### PR TITLE
fix(web): show option type (Put/Call) in holdings views

### DIFF
--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -110,7 +110,14 @@
                                         <span>—</span>
                                     }
                                 </td>
-                                <td class="hidden lg:table-cell">@h.ShareType</td>
+                                <td class="hidden lg:table-cell">
+                                    @if (h.OptionType.HasValue) {
+                                        <span class="badge badge-sm @(h.OptionType.Value == Equibles.Holdings.Data.Models.OptionType.Call ? "badge-success" : "badge-error")">@h.OptionType.Value</span>
+                                        <span class="text-base-content/60 text-xs">@h.ShareType</span>
+                                    } else {
+                                        @h.ShareType
+                                    }
+                                </td>
                                 <td class="hidden lg:table-cell">@h.InvestmentDiscretion</td>
                                 <td class="hidden lg:table-cell text-base-content/60">@h.FilingDate.ToString("yyyy-MM-dd")</td>
                             </tr>

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -73,7 +73,14 @@
                                     <span>—</span>
                                 }
                             </td>
-                            <td class="hidden lg:table-cell">@h.ShareType</td>
+                            <td class="hidden lg:table-cell">
+                                @if (h.OptionType.HasValue) {
+                                    <span class="badge badge-sm @(h.OptionType.Value == Equibles.Holdings.Data.Models.OptionType.Call ? "badge-success" : "badge-error")">@h.OptionType.Value</span>
+                                    <span class="text-base-content/60 text-xs">@h.ShareType</span>
+                                } else {
+                                    @h.ShareType
+                                }
+                            </td>
                             <td class="hidden lg:table-cell">@h.InvestmentDiscretion</td>
                             <td class="hidden lg:table-cell text-base-content/60">@h.FilingDate.ToString("yyyy-MM-dd")</td>
                             <td class="text-right">


### PR DESCRIPTION
## Summary

The holdings tab (`/stocks/{ticker}/holdings`) and the holder detail view (`/stocks/{ticker}/holder/{cik}`) only rendered `ShareType` (Shares/Principal). The `OptionType` field on `InstitutionalHolding` was silently ignored, so options positions in 13F filings looked identical to stock positions in the UI.

## Code changes

- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml` — Type cell now renders a colored badge (green `Call`, red `Put`) when `OptionType` is set, with `ShareType` shown as muted secondary text. Falls back to plain `ShareType` otherwise.
- `src/Equibles.Web/Views/Stocks/ShowHolder.cshtml` — Same change applied to the per-holder history table.

## How to test

- [ ] Navigate to a stock with known options activity in its 13F filings (e.g. `/stocks/aapl/holdings`).
- [ ] Verify rows representing puts/calls show a `Put` or `Call` badge in the Type column.
- [ ] Verify rows representing share positions still show `Shares` (no badge).
- [ ] Click "View" into a holder that filed options positions and confirm the per-quarter history table also displays the badge.