### PR TITLE
feat(sec): extract text from paper-filed PDF submissions

### DIFF
--- a/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
@@ -10,6 +10,12 @@ public interface ISecEdgarClient {
     Task<string> GetDocumentContent(FilingData filing);
 
     /// <summary>
+    /// Fetches a single artifact (e.g. an attached PDF) inside a filing by filename,
+    /// using the per-file URL pattern /Archives/edgar/data/{cik}/{accession-no-dashes}/{filename}.
+    /// </summary>
+    Task<byte[]> GetDocumentFileBytes(string cik, string accessionNumber, string filename, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Downloads a file from sec.gov with rate limiting, retries, and 429 handling.
     /// Use this for any SEC download (FTD files, 13F data sets, etc.).
     /// </summary>

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -191,21 +191,47 @@ public class SecEdgarClient : ISecEdgarClient {
     }
 
 
+    public async Task<byte[]> GetDocumentFileBytes(string cik, string accessionNumber, string filename, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrEmpty(cik) || string.IsNullOrEmpty(accessionNumber) || string.IsNullOrEmpty(filename))
+            throw new ArgumentException("cik, accessionNumber and filename are required");
+
+        // Per-file URL uses unpadded CIK and the accession number with dashes removed.
+        // Padded CIK works too but triggers a 301 redirect; skip the extra hop.
+        var unpaddedCik = cik.TrimStart('0');
+        var accessionNoDashes = accessionNumber.Replace("-", string.Empty);
+        var url = $"{FilesBaseUrl}/Archives/edgar/data/{unpaddedCik}/{accessionNoDashes}/{Uri.EscapeDataString(filename)}";
+
+        _logger.LogInformation("Requesting filing artifact: {Url}", url);
+
+        using var response = await SendWithRetryAsync(url, cancellationToken);
+
+        // 404 means the parsed filename does not match a published artifact (renamed, case
+        // mismatch, etc.). Return empty so the caller can warn-and-skip rather than retry-loop.
+        if (response.StatusCode == HttpStatusCode.NotFound) {
+            _logger.LogWarning("Filing artifact not found at {Url}", url);
+            return [];
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadAsByteArrayAsync(cancellationToken);
+    }
+
     public async Task<Stream> DownloadStream(string url) {
         var response = await SendWithRetryAsync(url, HttpCompletionOption.ResponseHeadersRead);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsStreamAsync();
     }
 
-    private Task<HttpResponseMessage> SendWithRetryAsync(string url) =>
-        SendWithRetryAsync(url, HttpCompletionOption.ResponseContentRead);
+    private Task<HttpResponseMessage> SendWithRetryAsync(string url, CancellationToken cancellationToken = default) =>
+        SendWithRetryAsync(url, HttpCompletionOption.ResponseContentRead, cancellationToken);
 
-    private async Task<HttpResponseMessage> SendWithRetryAsync(string url, HttpCompletionOption completionOption) {
+    private async Task<HttpResponseMessage> SendWithRetryAsync(string url, HttpCompletionOption completionOption, CancellationToken cancellationToken = default) {
         for (var attempt = 0; attempt <= MaxRetries; attempt++) {
             await RateLimiter.WaitAsync();
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
-            var response = await _httpClient.GetAsync(url, completionOption);
+            var response = await _httpClient.GetAsync(url, completionOption, cancellationToken);
             sw.Stop();
 
             _logger.LogDebug("SEC request {StatusCode} {Elapsed}ms {Url}",
@@ -222,7 +248,7 @@ public class SecEdgarClient : ISecEdgarClient {
 
                 if (attempt < MaxRetries) {
                     response.Dispose();
-                    await Task.Delay(delay);
+                    await Task.Delay(delay, cancellationToken);
                     continue;
                 }
             }
@@ -235,7 +261,7 @@ public class SecEdgarClient : ISecEdgarClient {
                     (int)response.StatusCode, url, delay.TotalSeconds, attempt + 1, MaxRetries);
 
                 response.Dispose();
-                await Task.Delay(delay);
+                await Task.Delay(delay, cancellationToken);
                 continue;
             }
 

--- a/src/Equibles.Sec.BusinessLogic/Equibles.Sec.BusinessLogic.csproj
+++ b/src/Equibles.Sec.BusinessLogic/Equibles.Sec.BusinessLogic.csproj
@@ -11,6 +11,7 @@
       <PackageReference Include="Microsoft.Extensions.Http" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
       <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" />
+      <PackageReference Include="PdfPig" />
       <PackageReference Include="ReverseMarkdown" />
     </ItemGroup>
 

--- a/src/Equibles.Sec.BusinessLogic/PdfTextExtractor.cs
+++ b/src/Equibles.Sec.BusinessLogic/PdfTextExtractor.cs
@@ -1,0 +1,40 @@
+using System.Text;
+using Equibles.Core.AutoWiring;
+using Microsoft.Extensions.Logging;
+using UglyToad.PdfPig;
+
+namespace Equibles.Sec.BusinessLogic;
+
+[Service]
+public class PdfTextExtractor {
+    private readonly ILogger<PdfTextExtractor> _logger;
+
+    public PdfTextExtractor(ILogger<PdfTextExtractor> logger) {
+        _logger = logger;
+    }
+
+    public string Extract(byte[] pdfBytes) {
+        if (pdfBytes == null || pdfBytes.Length == 0) return string.Empty;
+
+        try {
+            using var document = PdfDocument.Open(pdfBytes);
+
+            var result = new StringBuilder();
+
+            foreach (var page in document.GetPages()) {
+                var text = page.Text;
+                if (string.IsNullOrWhiteSpace(text)) continue;
+
+                result.AppendLine(text);
+                result.AppendLine();
+            }
+
+            return result.ToString();
+        } catch (Exception ex) {
+            // Encrypted, malformed, or otherwise unreadable PDF — treat as no extractable content.
+            // The caller logs a follow-up warning identifying the filing.
+            _logger.LogWarning(ex, "PdfPig could not read PDF ({Bytes} bytes)", pdfBytes.Length);
+            return string.Empty;
+        }
+    }
+}

--- a/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
@@ -1,0 +1,71 @@
+namespace Equibles.Sec.BusinessLogic;
+
+public static class SecDocumentEnvelopeParser {
+    private const string DocumentStartTag = "<DOCUMENT>";
+    private const string DocumentEndTag = "</DOCUMENT>";
+
+    /// <summary>
+    /// Some SEC filings (typically &lt;PAPER&gt; 6-K submissions and other digitized filings) are
+    /// stored as an SGML envelope wrapping a single uuencoded PDF rather than HTML. The HTML
+    /// normalizer rejects these by filename, leaving no extractable content. This method spots
+    /// the PDF so the caller can fetch the standalone PDF artifact directly from
+    /// /Archives/edgar/data/{cik}/{accession}/{filename}.
+    /// </summary>
+    /// <returns>True when a PDF filename was found; the filename is written to <paramref name="filename"/>.</returns>
+    public static bool TryExtractPaperPdfFilename(string envelope, out string filename) {
+        filename = string.Empty;
+        if (string.IsNullOrEmpty(envelope)) return false;
+
+        var pos = 0;
+        while (pos < envelope.Length) {
+            var blockStart = envelope.IndexOf(DocumentStartTag, pos, StringComparison.OrdinalIgnoreCase);
+            if (blockStart == -1) return false;
+
+            var blockEnd = envelope.IndexOf(DocumentEndTag, blockStart, StringComparison.OrdinalIgnoreCase);
+            if (blockEnd == -1) return false;
+
+            var block = envelope.Substring(blockStart, blockEnd - blockStart + DocumentEndTag.Length);
+            pos = blockEnd + DocumentEndTag.Length;
+
+            if (!TryExtractSgmlTagValue(block, "FILENAME", out var candidate)) continue;
+            if (!candidate.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase)) continue;
+            if (!IsSafeFilename(candidate)) continue;
+
+            filename = candidate;
+            return true;
+        }
+
+        return false;
+    }
+
+    // Filename flows from an untrusted envelope body into a URL. EDGAR filenames are always
+    // bare names ([A-Za-z0-9._-]+); reject anything that could traverse paths or escape the
+    // expected directory even though the host is already locked to www.sec.gov.
+    private static bool IsSafeFilename(string value) {
+        if (value.Length == 0) return false;
+        if (value[0] == '.') return false;
+        foreach (var ch in value) {
+            if (ch == '/' || ch == '\\') return false;
+        }
+        return true;
+    }
+
+    private static bool TryExtractSgmlTagValue(string block, string tagName, out string value) {
+        value = string.Empty;
+        var tagMarker = $"<{tagName}>";
+        var idx = block.IndexOf(tagMarker, StringComparison.OrdinalIgnoreCase);
+        if (idx == -1) return false;
+
+        var valueStart = idx + tagMarker.Length;
+        var end = valueStart;
+        while (end < block.Length && block[end] != '\n' && block[end] != '\r' && block[end] != '<') {
+            end++;
+        }
+
+        var raw = block.Substring(valueStart, end - valueStart).Trim();
+        if (raw.Length == 0) return false;
+
+        value = raw.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)[0];
+        return true;
+    }
+}

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -265,6 +265,7 @@ public class DocumentScraper : IDocumentScraper {
             var secEdgarClient = scope.ServiceProvider.GetRequiredService<ISecEdgarClient>();
             var normalizer = scope.ServiceProvider.GetRequiredService<ISecDocumentHtmlNormalizer>();
             var converter = scope.ServiceProvider.GetRequiredService<ISecDocumentHtmlToMarkdownConverter>();
+            var pdfTextExtractor = scope.ServiceProvider.GetRequiredService<PdfTextExtractor>();
             var persistenceService = scope.ServiceProvider.GetRequiredService<IDocumentPersistenceService>();
             var companyRepository = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
 
@@ -275,9 +276,28 @@ public class DocumentScraper : IDocumentScraper {
             var markdownDocument = converter.Convert(normalizedHtml);
 
             if (string.IsNullOrWhiteSpace(markdownDocument)) {
-                _logger.LogWarning("Skipping document for {Ticker} - {DocumentType} - {FilingDate}: no content after conversion. URL: {Url}",
-                    companyOutContext.Ticker, documentType, filing.FilingDate, filing.DocumentUrl);
-                return;
+                // Paper-filed submissions (typically older 6-K/20-F) wrap a uuencoded PDF
+                // and have no HTML for the normalizer to consume. Fetch the standalone PDF
+                // artifact and extract its text instead.
+                if (!SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(content, out var pdfFilename)) {
+                    _logger.LogWarning("Skipping document for {Ticker} - {DocumentType} - {FilingDate}: no content after conversion. URL: {Url}",
+                        companyOutContext.Ticker, documentType, filing.FilingDate, filing.DocumentUrl);
+                    return;
+                }
+
+                var pdfBytes = await secEdgarClient.GetDocumentFileBytes(filing.Cik, filing.AccessionNumber, pdfFilename, cancellationToken);
+                markdownDocument = pdfTextExtractor.Extract(pdfBytes);
+
+                if (string.IsNullOrWhiteSpace(markdownDocument)) {
+                    // PDF was located but yielded no extractable text — either the artifact was
+                    // missing (404, logged by the client), or it's an image-only scan needing OCR.
+                    _logger.LogWarning("Skipping document for {Ticker} - {DocumentType} - {FilingDate}: PDF {Filename} produced no text. URL: {Url}",
+                        companyOutContext.Ticker, documentType, filing.FilingDate, pdfFilename, filing.DocumentUrl);
+                    return;
+                }
+
+                _logger.LogInformation("Extracted PDF text for {Ticker} - {DocumentType} - {FilingDate} from paper filing artifact {Filename}",
+                    companyOutContext.Ticker, documentType, filing.FilingDate, pdfFilename);
             }
 
             await persistenceService.Save(company, Encoding.UTF8.GetBytes(markdownDocument),


### PR DESCRIPTION
## Summary

Older SEC submissions (typically `<PAPER>` 6-K and 20-F filings — e.g. Deutsche Bank's digitized 2019 annual report) wrap a uuencoded PDF inside the SGML envelope with no HTML for the existing normalizer to consume. The scraper was logging `no content after conversion` and silently re-fetching the same filings on every cycle — ~40 WRN lines per day for Deutsche Bank alone in production logs.

When the HTML pipeline yields empty content, this PR falls back to looking for a `.pdf` `<FILENAME>` in the envelope, fetches the standalone PDF artifact from SEC's per-file URL (`/Archives/edgar/data/{cik}/{accession-no-dashes}/{filename}`), and extracts text via PdfPig (already used in `HouseDisclosureClient`).

## Code changes

| File | Change |
|---|---|
| `Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs` (new) | Static `bool TryExtractPaperPdfFilename(envelope, out filename)` — scans `<DOCUMENT>` blocks for a `.pdf` filename, with `IsSafeFilename` allowlist guard (rejects `/`, `\`, leading `.`) to prevent path traversal from untrusted envelope content |
| `Equibles.Sec.BusinessLogic/PdfTextExtractor.cs` (new) | `[Service]`, wraps `PdfPig.PdfDocument` — concatenates per-page `page.Text` with blank-line separators; `try/catch` so encrypted/malformed PDFs log a warning and return empty rather than escalating to ERR |
| `Equibles.Sec.BusinessLogic.csproj` | + `PdfPig` package reference |
| `Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs` | + `GetDocumentFileBytes(cik, accession, filename, ct)` |
| `Equibles.Integrations.Sec/SecEdgarClient.cs` | Implements the new method; URL-encodes filename; returns empty `byte[]` on 404 with a distinct warning (instead of throwing, which would reintroduce the daily retry-loop); `CancellationToken` now threaded through `SendWithRetryAsync` (existing callers unchanged via default arg) |
| `Equibles.Sec.HostedService/DocumentScraper.cs` | When HTML pipeline produces empty content, fall back to the paper-PDF path; distinct WRN for "no PDF found" vs "PDF produced no text" so operators can spot image-only scans needing OCR |

## How to test

- [ ] `dotnet build Equibles.sln` — clean (0 errors)
- [ ] `dotnet test tests/Equibles.Tests/` — all 1570 tests pass
- [ ] On the worker, watch logs for `Extracted PDF text for DB - SixK - 2020-03-26 from paper filing artifact deutsche3262020.pdf` — the previously-skipped Deutsche Bank 6-K should now persist as a document
- [ ] Confirm the `Skipping document for DB - 6-K ... no content after conversion` WRN spam stops on the next scraper cycle
- [ ] Spot-check that non-PDF filings (regular HTML 10-Ks/10-Qs) still process normally — the fallback only fires when the HTML pipeline yields empty content