### PR TITLE
feat(sec): attach subsidiary CIKs as SecondaryCiks on the parent stock

### DIFF
--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -34,6 +34,11 @@ public class CommonStock {
         set;
     } = [];
 
+    public List<string> SecondaryCiks {
+        get => field ?? [];
+        set;
+    } = [];
+
     [MaxLength(9)]
     public string Cusip { get; set; }
 

--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -37,6 +37,25 @@ public class CommonStockRepository : BaseRepository<CommonStock> {
     }
 
     /// <summary>
+    /// Returns the stock whose primary <c>Cik</c> equals <paramref name="cik"/>, or whose
+    /// <c>SecondaryCiks</c> contains it. Primary matches are preferred so lookups remain
+    /// deterministic when a subsidiary CIK is attached to a parent that's also queryable
+    /// by its own primary CIK.
+    /// </summary>
+    public async Task<CommonStock> GetByAnyCik(string cik) {
+        return await GetAll()
+            .Where(cs => cs.Cik == cik || cs.SecondaryCiks.Contains(cik))
+            .OrderBy(cs => cs.Cik == cik ? 0 : 1)
+            .FirstOrDefaultAsync();
+    }
+
+    public IQueryable<string> GetAllSecondaryCiks() {
+        return GetAll()
+            .Where(cs => cs.SecondaryCiks.Count > 0)
+            .SelectMany(cs => cs.SecondaryCiks);
+    }
+
+    /// <summary>
     /// Returns the stock whose primary <c>Ticker</c> equals <paramref name="ticker"/>, or whose
     /// <c>SecondaryTickers</c> contains it. A single ticker symbol can legitimately appear on
     /// more than one company (e.g. a preferred-share ticker listed under both the parent REIT

--- a/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
@@ -5,6 +5,7 @@ namespace Equibles.Integrations.Sec.Contracts;
 public interface ISecEdgarClient {
     Task<List<CompanyInfo>> GetActiveCompanies();
     Task<string> GetEntityType(string cik);
+    Task<CompanyMetadata> GetCompanyMetadata(string cik);
     Task<List<FilingData>> GetCompanyFilings(string cik, DocumentTypeFilter? documentType = null, DateOnly? fromDate = null, DateOnly? toDate = null);
     Task<string> GetDocumentContent(string accessionNumber, string cik);
     Task<string> GetDocumentContent(FilingData filing);

--- a/src/Equibles.Integrations.Sec/Models/CompanyMetadata.cs
+++ b/src/Equibles.Integrations.Sec/Models/CompanyMetadata.cs
@@ -1,0 +1,19 @@
+namespace Equibles.Integrations.Sec.Models;
+
+public class CompanyMetadata {
+    public string Cik { get; set; }
+    public string EntityType { get; set; }
+    public List<string> Exchanges { get; set; } = [];
+
+    public bool IsOperatingCompany => string.Equals(EntityType, "operating", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True when SEC's submissions document lists at least one real stock exchange.
+    /// Subsidiaries that file with the SEC but aren't separately listed have an empty
+    /// or OTC-only exchanges list, which is the strongest signal that they don't own
+    /// the public ticker they share with their parent.
+    /// </summary>
+    public bool IsListed => Exchanges.Any(e =>
+        !string.IsNullOrWhiteSpace(e) &&
+        !string.Equals(e, "OTC", StringComparison.OrdinalIgnoreCase));
+}

--- a/src/Equibles.Integrations.Sec/Models/FillingData.cs
+++ b/src/Equibles.Integrations.Sec/Models/FillingData.cs
@@ -1,6 +1,13 @@
 namespace Equibles.Integrations.Sec.Models;
 
 public class FilingData {
+    /// <summary>
+    /// CIK of the <em>filer</em> of this document, which may be a subsidiary that shares
+    /// its parent's public ticker. Use this for retrieving the document content from
+    /// SEC's archive. For stock attribution, use the <c>CommonStock</c> instance the
+    /// filing is being processed under — that may be the parent even when this CIK is
+    /// the subsidiary.
+    /// </summary>
     public string Cik { get; set; }
     public string AccessionNumber { get; set; }
     public DateOnly FilingDate { get; set; }

--- a/src/Equibles.Integrations.Sec/Models/Responses/SecApiResponse.cs
+++ b/src/Equibles.Integrations.Sec/Models/Responses/SecApiResponse.cs
@@ -9,5 +9,7 @@ internal class SecApiResponse {
 
     [JsonProperty("entityType")] public string EntityType { get; set; }
 
+    [JsonProperty("exchanges")] public List<string> Exchanges { get; set; } = [];
+
     [JsonProperty("filings")] public FilingsContainer Filings { get; set; } = new();
 }

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -62,6 +62,11 @@ public class SecEdgarClient : ISecEdgarClient {
     }
 
     public async Task<string> GetEntityType(string cik) {
+        var metadata = await GetCompanyMetadata(cik);
+        return metadata?.EntityType;
+    }
+
+    public async Task<CompanyMetadata> GetCompanyMetadata(string cik) {
         try {
             var formattedCik = FormatCik(cik);
             var url = BuildUrl($"/submissions/CIK{formattedCik}.json");
@@ -72,14 +77,21 @@ public class SecEdgarClient : ISecEdgarClient {
             var content = await response.Content.ReadAsStringAsync();
             var apiResponse = JsonConvert.DeserializeObject<SecApiResponse>(content);
 
-            return apiResponse?.EntityType;
+            if (apiResponse == null)
+                return null;
+
+            return new CompanyMetadata {
+                Cik = cik,
+                EntityType = apiResponse.EntityType,
+                Exchanges = apiResponse.Exchanges ?? []
+            };
         } catch (HttpRequestException ex) {
             // HTTP errors (including exhausted 429 retries) propagate to caller
-            _logger.LogError(ex, "HTTP error retrieving entity type for CIK: {Cik}", cik);
+            _logger.LogError(ex, "HTTP error retrieving metadata for CIK: {Cik}", cik);
             throw;
         } catch (Exception ex) {
             // Non-HTTP errors (deserialization, etc.) — return null as "not found"
-            _logger.LogError(ex, "Error retrieving entity type for CIK: {Cik}", cik);
+            _logger.LogError(ex, "Error retrieving metadata for CIK: {Cik}", cik);
             return null;
         }
     }

--- a/src/Equibles.Migrations/Migrations/20260511231509_AddSecondaryCiksToCommonStock.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260511231509_AddSecondaryCiksToCommonStock.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260511231509_AddSecondaryCiksToCommonStock")]
+    partial class AddSecondaryCiksToCommonStock
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260511231509_AddSecondaryCiksToCommonStock.cs
+++ b/src/Equibles.Migrations/Migrations/20260511231509_AddSecondaryCiksToCommonStock.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSecondaryCiksToCommonStock : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<List<string>>(
+                name: "SecondaryCiks",
+                table: "CommonStock",
+                type: "text[]",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SecondaryCiks",
+                table: "CommonStock");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -173,24 +173,46 @@ public class DocumentScraper : IDocumentScraper {
         _logger.LogDebug("Fetching {DocumentType} filings for {Ticker}", documentType, company.Ticker);
 
         try {
-            var filings = await secEdgarClient.GetCompanyFilings(
-                company.Cik,
-                secFilter,
-                _workerOptions.MinSyncDate != null ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value) : null);
+            // Subsidiary CIKs share the parent's public ticker (e.g. parent + co-registrant
+            // operating sub). Their filings belong on the parent's stock page, so we fetch
+            // each CIK separately and dedupe by AccessionNumber (globally unique in SEC).
+            var ciks = new List<string> { company.Cik };
+            ciks.AddRange(company.SecondaryCiks);
 
-            _logger.LogDebug("Found {FilingCount} {DocumentType} filings for {Ticker}",
-                filings.Count, documentType, company.Ticker);
+            var fromDate = _workerOptions.MinSyncDate != null
+                ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
+                : (DateOnly?)null;
+
+            var filings = new List<FilingData>();
+            var seenAccessions = new HashSet<string>();
+
+            foreach (var cik in ciks) {
+                List<FilingData> cikFilings;
+                try {
+                    cikFilings = await secEdgarClient.GetCompanyFilings(cik, secFilter, fromDate);
+                } catch (HttpRequestException ex) {
+                    // One CIK failing shouldn't drop the others — log and continue.
+                    _logger.LogWarning(ex, "HTTP error fetching {DocumentType} filings for CIK {Cik} ({Ticker})",
+                        documentType, cik, company.Ticker);
+                    result.Errors++;
+                    result.ErrorMessages.Add($"Company {company.Ticker} CIK {cik} - {documentType}: {ex.Message}");
+                    continue;
+                }
+
+                foreach (var filing in cikFilings) {
+                    if (seenAccessions.Add(filing.AccessionNumber))
+                        filings.Add(filing);
+                }
+            }
+
+            _logger.LogDebug("Found {FilingCount} {DocumentType} filings for {Ticker} across {CikCount} CIK(s)",
+                filings.Count, documentType, company.Ticker, ciks.Count);
 
             result.DocumentsFound += filings.Count;
 
             foreach (var filing in filings) {
                 await ProcessFiling(company, filing, documentType, result, persistenceService);
             }
-        } catch (HttpRequestException ex) {
-            _logger.LogWarning(ex, "HTTP error processing {DocumentType} documents for company {Ticker}",
-                documentType, company.Ticker);
-            result.Errors++;
-            result.ErrorMessages.Add($"Company {company.Ticker} - {documentType}: {ex.Message}");
         } catch (Exception ex) {
             _logger.LogError(ex, "Error processing {DocumentType} documents for company {Ticker}",
                 documentType, company.Ticker);

--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -54,9 +54,36 @@ public class CompanySyncService : ICompanySyncService {
             // Get all CIKs from SEC companies
             var secCiks = secCompanies.Select(c => c.Cik).ToHashSet();
 
-            // Get existing companies from database
-            var existingStocks = await commonStockRepository.GetByCiks(secCiks).ToListAsync();
+            // Load every existing stock so we can detect subsidiaries already attached
+            // as SecondaryCiks on prior syncs. We can't filter by SEC CIKs alone because
+            // the subsidiary's CIK won't match any incoming primary CIK — it lives only
+            // inside another stock's SecondaryCiks list.
+            var allExistingStocks = await commonStockRepository.GetAll().ToListAsync();
+            var existingStocks = allExistingStocks.Where(cs => secCiks.Contains(cs.Cik)).ToList();
             var existingCiks = existingStocks.Select(cs => cs.Cik).ToHashSet();
+
+            // Build the ticker → stock lookup over every row so ReplaceObsoleteStock can find
+            // a ticker holder whose own CIK dropped out of SEC's feed but who still owns the
+            // primary ticker our incoming company wants.
+            var primaryTickerToStock = allExistingStocks
+                .ToDictionary(s => s.Ticker, s => s);
+
+            // Subsidiaries we already decided about: each entry maps a subsidiary CIK to
+            // its parent stock. Incoming SEC entries whose CIK appears here are silently
+            // skipped — without this filter every sync would re-evaluate the collision
+            // and re-log the warning. We build defensively to survive a data anomaly
+            // (the same subsidiary CIK attached to two parents) rather than throwing.
+            var secondaryCikToParent = new Dictionary<string, CommonStock>();
+            foreach (var stock in allExistingStocks) {
+                foreach (var subCik in stock.SecondaryCiks) {
+                    if (!secondaryCikToParent.TryAdd(subCik, stock)) {
+                        _logger.LogWarning(
+                            "Subsidiary CIK {Cik} is attached to multiple parents ({ExistingParent} and {DuplicateParent}); " +
+                            "keeping {ExistingParent}. Manual cleanup required.",
+                            subCik, secondaryCikToParent[subCik].Ticker, stock.Ticker);
+                    }
+                }
+            }
 
             // Primary tickers are globally unique — collisions on primary mean the incoming
             // company must replace or skip. Secondary tickers may legitimately overlap across
@@ -75,12 +102,21 @@ public class CompanySyncService : ICompanySyncService {
                 ExistingCiks = existingCiks,
                 ExistingPrimaryTickers = existingPrimaryTickers,
                 ExistingSecondaryTickers = existingSecondaryTickers,
+                PrimaryTickerToStock = primaryTickerToStock,
+                SecondaryCikToParent = secondaryCikToParent,
                 CommonStockRepository = commonStockRepository,
                 CommonStockManager = commonStockManager,
                 DbContext = dbContext
             };
 
             foreach (var secCompany in secCompanies) {
+                if (state.SecondaryCikToParent.TryGetValue(secCompany.Cik, out var parent)) {
+                    _logger.LogDebug(
+                        "Skipping subsidiary CIK {Cik} ({Name}) — already attached to parent {ParentTicker} (CIK: {ParentCik})",
+                        secCompany.Cik, secCompany.Name, parent.Ticker, parent.Cik);
+                    continue;
+                }
+
                 var primaryTicker = secCompany.Tickers.FirstOrDefault();
                 if (string.IsNullOrEmpty(primaryTicker)) {
                     _logger.LogWarning("Company {CompanyName} (CIK: {Cik}) has no tickers, skipping", secCompany.Name,
@@ -185,12 +221,23 @@ public class CompanySyncService : ICompanySyncService {
 
     private async Task ReplaceObsoleteStock(CompanyInfo secCompany, string primaryTicker,
         List<string> secondaryTickers, StockSyncState state) {
-        // Ticker exists - check if the current holder is still active in SEC data
-        var obsoleteStock = state.ExistingStocks.FirstOrDefault(cs => cs.Ticker == primaryTicker);
+        // The ticker holder may not be in state.ExistingStocks (which is scoped to CIKs in
+        // SEC's current feed). Look in the full in-memory map so we also see holders whose
+        // own CIK dropped out of the feed.
+        state.PrimaryTickerToStock.TryGetValue(primaryTicker, out var obsoleteStock);
 
-        if (obsoleteStock == null || state.SecCiks.Contains(obsoleteStock.Cik)) {
+        if (obsoleteStock != null && state.SecCiks.Contains(obsoleteStock.Cik)) {
+            // Both CIKs are active in SEC's feed — this is the legitimate parent/subsidiary
+            // case (e.g. ATAI Life Sciences + AtaiBeckley sharing ATAI). Resolve which one
+            // is the listed parent and attach the loser as a SecondaryCik on the winner
+            // so its filings still flow through, without re-warning on future syncs.
+            await ResolveTickerCollision(secCompany, obsoleteStock, primaryTicker, state);
+            return;
+        }
+
+        if (obsoleteStock == null) {
             _logger.LogWarning(
-                "Company {CompanyName} (CIK: {Cik}) has ticker {Ticker} already used by another active company, skipping",
+                "Company {CompanyName} (CIK: {Cik}) has ticker {Ticker} marked as taken but the holder could not be loaded, skipping",
                 secCompany.Name, secCompany.Cik, primaryTicker);
             return;
         }
@@ -276,12 +323,86 @@ public class CompanySyncService : ICompanySyncService {
         return company.IsOperatingCompany;
     }
 
+    /// <summary>
+    /// Handles the case where two CIKs in SEC's feed both claim the same primary ticker.
+    /// Decides the rightful owner via (listed-on-exchange &gt; operating &gt; older CIK) and
+    /// attaches the loser's CIK to the winner's <see cref="CommonStock.SecondaryCiks"/> so
+    /// the subsidiary's filings still flow through and we don't re-warn on every sync.
+    /// </summary>
+    private async Task ResolveTickerCollision(CompanyInfo incoming, CommonStock incumbent, string ticker, StockSyncState state) {
+        try {
+            var incumbentWins = await ShouldIncumbentWin(incoming, incumbent);
+
+            if (incumbentWins) {
+                if (incumbent.SecondaryCiks.Contains(incoming.Cik))
+                    return;
+
+                incumbent.SecondaryCiks = [..incumbent.SecondaryCiks, incoming.Cik];
+                // Save directly via the repository — manager.Update would re-run the full
+                // uniqueness validation against the incumbent's own Ticker/CIK, which is
+                // an unnecessary round-trip for a SecondaryCiks-only mutation.
+                await state.CommonStockRepository.SaveChanges();
+                state.SecondaryCikToParent[incoming.Cik] = incumbent;
+
+                _logger.LogInformation(
+                    "Attached subsidiary CIK {Cik} ({Name}) to parent {Ticker} (CIK: {ParentCik})",
+                    incoming.Cik, incoming.Name, ticker, incumbent.Cik);
+            } else {
+                // Authoritative signals say the incoming CIK is the rightful holder. We
+                // don't auto-swap (that would delete or rewrite the incumbent's history);
+                // surface a warning once and rely on operator intervention.
+                _logger.LogWarning(
+                    "Ticker {Ticker} appears to belong to incoming CIK {IncomingCik} ({IncomingName}) " +
+                    "rather than incumbent CIK {IncumbentCik} ({IncumbentName}). Manual review required.",
+                    ticker, incoming.Cik, incoming.Name, incumbent.Cik, incumbent.Name);
+            }
+        } catch (Exception ex) {
+            _logger.LogError(ex, "Error resolving ticker collision for {Ticker} between CIKs {IncomingCik} and {IncumbentCik}",
+                ticker, incoming.Cik, incumbent.Cik);
+            await _errorReporter.Report(ErrorSource.DocumentScraper, "CompanySync.ResolveTickerCollision",
+                ex.Message, ex.StackTrace,
+                $"ticker: {ticker}, incoming: {incoming.Cik}, incumbent: {incumbent.Cik}");
+        }
+    }
+
+    private async Task<bool> ShouldIncumbentWin(CompanyInfo incoming, CommonStock incumbent) {
+        var incomingMeta = await _secEdgarClient.GetCompanyMetadata(incoming.Cik);
+        var incumbentMeta = await _secEdgarClient.GetCompanyMetadata(incumbent.Cik);
+
+        // Without authoritative metadata for either side we have no evidence to override
+        // the existing assignment — keep the incumbent. Log so operators can investigate
+        // patterns of malformed SEC responses that silently force the fallback path.
+        if (incomingMeta == null || incumbentMeta == null) {
+            _logger.LogWarning(
+                "Cannot resolve ticker collision deterministically — metadata missing for {MissingSide}: " +
+                "incoming CIK {IncomingCik}, incumbent CIK {IncumbentCik}. Defaulting to incumbent.",
+                incomingMeta == null && incumbentMeta == null ? "both"
+                    : incomingMeta == null ? "incoming"
+                    : "incumbent",
+                incoming.Cik, incumbent.Cik);
+            return true;
+        }
+
+        if (incomingMeta.IsListed != incumbentMeta.IsListed)
+            return incumbentMeta.IsListed;
+        if (incomingMeta.IsOperatingCompany != incumbentMeta.IsOperatingCompany)
+            return incumbentMeta.IsOperatingCompany;
+
+        return ParseCik(incumbent.Cik) <= ParseCik(incoming.Cik);
+    }
+
+    private static long ParseCik(string cik) {
+        return long.TryParse(cik, out var n) ? n : long.MaxValue;
+    }
+
     private class StockSyncState {
         public HashSet<string> SecCiks { get; init; }
         public List<CommonStock> ExistingStocks { get; init; }
         public HashSet<string> ExistingCiks { get; init; }
         public HashSet<string> ExistingPrimaryTickers { get; init; }
         public HashSet<string> ExistingSecondaryTickers { get; init; }
+        public Dictionary<string, CommonStock> PrimaryTickerToStock { get; init; }
+        public Dictionary<string, CommonStock> SecondaryCikToParent { get; init; }
         public CommonStockRepository CommonStockRepository { get; init; }
         public CommonStockManager CommonStockManager { get; init; }
         public DbContext DbContext { get; init; }


### PR DESCRIPTION
## Summary

- SEC's `company_tickers_exchange.json` legitimately lists two CIKs per ticker when a subsidiary files separately under its parent's brand (e.g. ATAI Life Sciences + AtaiBeckley sharing `ATAI`, Datasea Inc. + Datasea Intelligent Technology Ltd. sharing `DTSS`). The losing CIK was being logged-and-skipped on every sync — 21×/day per collision.
- Subsidiaries are now attached to the parent stock via a new `SecondaryCiks: text[]` column. The document scraper fetches filings for every CIK on the stock and dedupes by `AccessionNumber`, so subsidiary filings (Form 4 / 13D / Form D / 8-K co-registrations) surface on the parent's stock page instead of being discarded.
- Resolution rule when two active CIKs claim the same ticker: **listed-on-exchange → operating entity → older CIK**. Sourced from SEC's `submissions/CIK*.json` (`exchanges` + `entityType`). If the incoming CIK appears to be the rightful holder, the sync logs a single review warning rather than auto-swapping.

## Code changes

- `src/Equibles.Integrations.Sec/` — new `CompanyMetadata` model + `ISecEdgarClient.GetCompanyMetadata` exposing `exchanges` and `entityType`; `FilingData.Cik` documented as the filer CIK (which may be a subsidiary).
- `src/Equibles.CommonStocks.Data/Models/CommonStock.cs` — adds `SecondaryCiks: List<string>` mirroring the `SecondaryTickers` pattern.
- `src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs` — `GetByAnyCik` (primary-or-secondary lookup) + `GetAllSecondaryCiks`.
- `src/Equibles.Migrations/Migrations/20260511231509_AddSecondaryCiksToCommonStock.*` — nullable `text[]` column add.
- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — pre-filters incoming feed against existing `SecondaryCiks`; replaces the skip-and-warn collision branch with `ResolveTickerCollision`/`ShouldIncumbentWin` that attaches the loser CIK; defensive dictionary build that survives data anomalies; logs when SEC metadata is missing.
- `src/Equibles.Sec.HostedService/DocumentScraper.cs` — iterates `[Cik, ...SecondaryCiks]` per company, per-CIK try/catch so one bad subsidiary call doesn't drop the rest, dedupe by `AccessionNumber`.

## How to test

- [ ] `dotnet build` from repo root succeeds with no new errors.
- [ ] `dotnet test tests/Equibles.Tests/Equibles.Tests.csproj --filter "FullyQualifiedName~CompanySyncServiceTests"` — all 17 pass.
- [ ] Apply the migration to a dev DB: `dotnet ef database update --project src/Equibles.Migrations`. Verify the `CommonStock` table has a `SecondaryCiks text[]` column, nullable.
- [ ] Run the worker against a fixture that includes a known collision (e.g. ATAI/AtaiBeckley). Verify: (a) AtaiBeckley does not get its own row, (b) ATAI Life Sciences's `SecondaryCiks` includes `2081043`, (c) the daily warning is gone, (d) any subsidiary filings appear under the parent's stock.
- [ ] Re-run the sync immediately. Verify no `"already used"` warning is re-logged for the same collision (subsidiary is filtered up-front).