### PR TITLE
refactor(yahoo): move YahooStockPriceProvider to HostedService

### DIFF
--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -83,8 +83,5 @@ builder.Services.AddCboeWorker();
 builder.Services.AddCongressWorker();
 builder.Services.AddHoldingsWorker();
 
-// Cross-module services (interface-based, need manual registration)
-builder.Services.AddScoped<Equibles.Core.Contracts.IStockPriceProvider, Equibles.Yahoo.Repositories.YahooStockPriceProvider>();
-
 var host = builder.Build();
 host.Run();

--- a/src/Equibles.Yahoo.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Yahoo.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Equibles.Core.AutoWiring;
+using Equibles.Core.Contracts;
 using Equibles.Yahoo.HostedService.Services;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +9,9 @@ public static class ServiceCollectionExtensions {
     public static IServiceCollection AddYahooWorker(this IServiceCollection services) {
         services.AutoWireServicesFrom<YahooPriceImportService>();
         services.AutoWireServicesFrom<Equibles.Integrations.Yahoo.YahooFinanceClient>();
+
+        // Yahoo is the OSS source of stock prices for Holdings valuation.
+        services.AddScoped<IStockPriceProvider, YahooStockPriceProvider>();
 
         services.AddHostedService<YahooPriceScraperWorker>();
 

--- a/src/Equibles.Yahoo.HostedService/Services/YahooStockPriceProvider.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooStockPriceProvider.cs
@@ -3,7 +3,7 @@ using Equibles.Data;
 using Equibles.Yahoo.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
-namespace Equibles.Yahoo.Repositories;
+namespace Equibles.Yahoo.HostedService.Services;
 
 public class YahooStockPriceProvider : IStockPriceProvider {
     private const int LookbackDays = 7;

--- a/tests/Equibles.Tests/Yahoo/YahooRepositoryTests.cs
+++ b/tests/Equibles.Tests/Yahoo/YahooRepositoryTests.cs
@@ -4,6 +4,7 @@ using Equibles.Data;
 using Equibles.Tests.Helpers;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.HostedService.Services;
 using Equibles.Yahoo.Repositories;
 using Microsoft.EntityFrameworkCore;
 


### PR DESCRIPTION
## Summary

Architecture-review finding #9: `YahooStockPriceProvider` was sitting inside `Equibles.Yahoo.Repositories` even though it isn't a repository — it's a strategy adapter implementing `IStockPriceProvider`. That mis-classification forced `Worker.Host` to do a manual cross-module DI registration that no other module needs.

## Code changes

- `src/Equibles.Yahoo.Repositories/YahooStockPriceProvider.cs` → `src/Equibles.Yahoo.HostedService/Services/YahooStockPriceProvider.cs` (`git mv`, preserves history; namespace updated to `Equibles.Yahoo.HostedService.Services`)
- `src/Equibles.Yahoo.HostedService/Extensions/ServiceCollectionExtensions.cs` — `AddYahooWorker()` now registers `IStockPriceProvider → YahooStockPriceProvider` itself, so the price-provider wiring travels with the Yahoo worker
- `src/Equibles.Worker.Host/Program.cs` — drops the ad-hoc `services.AddScoped<IStockPriceProvider, YahooStockPriceProvider>()` line and the now-stale "Cross-module services (interface-based, need manual registration)" comment
- `tests/Equibles.Tests/Yahoo/YahooRepositoryTests.cs` — `using` updated to the new namespace

## How to test

- [ ] `dotnet build Equibles.sln` — clean (0 errors)
- [ ] `dotnet test tests/Equibles.Tests/` — all tests pass; the 30 Yahoo-scoped tests in particular
- [ ] Start `Equibles.Worker.Host` and confirm Holdings valuation still finds `IStockPriceProvider` at runtime — should resolve to the new registration inside `AddYahooWorker()`