### PR TITLE
refactor(stocks): clarify call/put labels in holdings table

### DIFF
--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -74,11 +74,16 @@
                                 }
                             </td>
                             <td class="hidden lg:table-cell">
-                                @if (h.OptionType.HasValue) {
-                                    <span class="badge badge-sm @(h.OptionType.Value == Equibles.Holdings.Data.Models.OptionType.Call ? "badge-success" : "badge-error")">@h.OptionType.Value</span>
-                                    <span class="text-base-content/60 text-xs">@h.ShareType</span>
-                                } else {
-                                    @h.ShareType
+                                @switch (h.OptionType) {
+                                    case Equibles.Holdings.Data.Models.OptionType.Call:
+                                        <span class="badge badge-sm badge-success">Call Options</span>
+                                        break;
+                                    case Equibles.Holdings.Data.Models.OptionType.Put:
+                                        <span class="badge badge-sm badge-error">Put Options</span>
+                                        break;
+                                    default:
+                                        @h.ShareType
+                                        break;
                                 }
                             </td>
                             <td class="hidden lg:table-cell">@h.InvestmentDiscretion</td>


### PR DESCRIPTION
## Summary

- Replace the small `Call`/`Put` badge plus secondary share-type text with a single descriptive `Call Options` / `Put Options` badge.
- Direct share holdings continue to render the share type as plain text.
- Makes the three rows per holder (direct shares + calls + puts) visually distinct at a glance.

## Code changes

- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml` — switch-based rendering for the Type column:
  - `OptionType.Call` → green `Call Options` badge
  - `OptionType.Put` → red `Put Options` badge
  - `null` → plain `ShareType` text ("Shares" / "Principal")

## How to test

- [ ] Build the OSS web app: `dotnet build src/Equibles.Web/Equibles.Web.csproj`.
- [ ] Open any stock with option holdings (e.g. a heavily-traded ticker like IREN/NVDA) at `/Stocks/{ticker}/Holdings`.
- [ ] Confirm rows where the same holder appears multiple times now show distinct labels: `Shares` vs. `Call Options` vs. `Put Options`.
- [ ] Confirm Principal-amount holdings still render as `Principal`.