### PR TITLE
fix(finra): validate CommonStockIds before persisting short interest

### DIFF
--- a/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Finra.Data.Models;
@@ -151,8 +152,30 @@ public class ShortInterestImportService {
 
                 var inserted = await BatchPersister.Persist(items, InsertBatchSize, async batch => {
                     using var scope = _scopeFactory.CreateScope();
+                    var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
                     var repo = scope.ServiceProvider.GetRequiredService<ShortInterestRepository>();
-                    repo.AddRange(batch);
+
+                    // tickerMap was built at the start of Import and goes stale if CompanySyncService
+                    // hard-deletes a stock in parallel (PR #5's ReplaceObsoleteStock path). Re-validate
+                    // each batch against the current set of CommonStockIds so dangling-FK inserts can't
+                    // poison the whole batch.
+                    var batchStockIds = batch.Select(b => b.CommonStockId).Distinct().ToList();
+                    var liveStockIds = await stockRepo.GetAll()
+                        .Where(s => batchStockIds.Contains(s.Id))
+                        .Select(s => s.Id)
+                        .ToHashSetAsync(cancellationToken);
+
+                    var validBatch = batch.Where(b => liveStockIds.Contains(b.CommonStockId)).ToList();
+                    var dropped = batch.Count - validBatch.Count;
+                    if (dropped > 0) {
+                        _logger.LogWarning(
+                            "Dropped {Dropped} short interest rows for {Date} referencing CommonStockIds no longer in the database",
+                            dropped, date);
+                    }
+
+                    if (validBatch.Count == 0) return;
+
+                    repo.AddRange(validBatch);
                     await repo.SaveChanges();
                 });
 


### PR DESCRIPTION
## Summary

Production worker has been crashing nightly on `ShortInterest` inserts with `Npgsql.PostgresException 23503: insert or update on table \"ShortInterest\" violates foreign key constraint`. Geekom logs show the same stale `CommonStockId` (`52ea9e95-…`) failing every settlement date from 2020 onward.

Root cause: `CompanySyncService.ReplaceObsoleteStock` (introduced in #5) hard-deletes `CommonStock` rows whose CIK fell out of SEC's feed. The FK on `ShortInterest` cascades existing rows away, but the in-memory `tickerMap` that `ShortInterestImportService` built at the start of `Import()` still references the deleted `CommonStockId`. Once that happens every batch carrying the stale id throws `23503` and `BatchPersister` rolls back the whole batch — losing every row for that date, not just the bad one.

## Code changes

- `src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs` — inside the `BatchPersister.Persist` callback, query `CommonStockRepository` for which of the batch's `CommonStockId`s still exist. Drop dangling rows with a `WRN` log so operators can see the rate of stale-id churn. EF Core query, no raw SQL.

## How to test

- [ ] `dotnet build Equibles.sln` — clean (0 errors)
- [ ] `dotnet test tests/Equibles.Tests/` — all 1570 tests pass
- [ ] On the worker, watch logs for `Dropped N short interest rows for {Date} referencing CommonStockIds no longer in the database` — confirms the guard kicks in and the batch still completes
- [ ] Confirm the `[ERR] Error importing short interest for "2020-…"` spam stops on the next FinraScraper cycle