### PR TITLE
fix(stocks): show option type on holder detail page

### DIFF
--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -60,7 +60,10 @@
             </div>
         </div>
     } else {
-        var chartHoldings = Model.Holdings.OrderBy(h => h.ReportDate).ToList();
+        var chartHoldings = Model.Holdings
+            .Where(h => h.OptionType == null)
+            .OrderBy(h => h.ReportDate)
+            .ToList();
 
         <h2 class="text-lg font-semibold mb-3">Holdings in @stock.Ticker</h2>
 
@@ -111,11 +114,16 @@
                                     }
                                 </td>
                                 <td class="hidden lg:table-cell">
-                                    @if (h.OptionType.HasValue) {
-                                        <span class="badge badge-sm @(h.OptionType.Value == Equibles.Holdings.Data.Models.OptionType.Call ? "badge-success" : "badge-error")">@h.OptionType.Value</span>
-                                        <span class="text-base-content/60 text-xs">@h.ShareType</span>
-                                    } else {
-                                        @h.ShareType
+                                    @switch (h.OptionType) {
+                                        case Equibles.Holdings.Data.Models.OptionType.Call:
+                                            <span class="badge badge-sm badge-success">Call</span>
+                                            break;
+                                        case Equibles.Holdings.Data.Models.OptionType.Put:
+                                            <span class="badge badge-sm badge-error">Put</span>
+                                            break;
+                                        default:
+                                            @h.ShareType
+                                            break;
                                     }
                                 </td>
                                 <td class="hidden lg:table-cell">@h.InvestmentDiscretion</td>

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -76,10 +76,10 @@
                             <td class="hidden lg:table-cell">
                                 @switch (h.OptionType) {
                                     case Equibles.Holdings.Data.Models.OptionType.Call:
-                                        <span class="badge badge-sm badge-success">Call Options</span>
+                                        <span class="badge badge-sm badge-success">Call</span>
                                         break;
                                     case Equibles.Holdings.Data.Models.OptionType.Put:
-                                        <span class="badge badge-sm badge-error">Put Options</span>
+                                        <span class="badge badge-sm badge-error">Put</span>
                                         break;
                                     default:
                                         @h.ShareType


### PR DESCRIPTION
## Summary

- The holder detail page rendered only `ShareType` in its Type column, so a holder with direct shares plus call and put positions in the same 13F filing appeared as three identical "Shares" rows.
- The Position Over Time chart also plotted every row, so the line bounced between values within a single quarter when option positions were present.
- Holdings tab badges shortened from `Call Options` / `Put Options` to `Call` / `Put` for consistency.

## Code changes

- `src/Equibles.Web/Views/Stocks/ShowHolder.cshtml`
  - Type cell now renders `Call` / `Put` badges or plain `ShareType` fallback (same switch as the holdings tab).
  - Position chart now filters to `OptionType == null` so each quarter contributes exactly one point.
- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml`
  - Badge labels shortened to `Call` / `Put`.

## How to test

- [ ] Build: `dotnet build src/Equibles.Web/Equibles.Web.csproj`.
- [ ] Visit any holder detail page for a stock where the holder reports calls/puts in addition to direct shares.
- [ ] Confirm the table shows distinct `Call` / `Put` / `Shares` rows.
- [ ] Confirm the Position Over Time chart no longer bounces within a quarter and shows a single point per report date.