### PR TITLE
test(sec): add tests for SecDocumentEnvelopeParser

### DIFF
--- a/tests/Equibles.Tests/Sec/SecDocumentEnvelopeParserTests.cs
+++ b/tests/Equibles.Tests/Sec/SecDocumentEnvelopeParserTests.cs
@@ -1,0 +1,32 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.Tests.Sec;
+
+public class SecDocumentEnvelopeParserTests {
+    [Fact]
+    public void TryExtractPaperPdfFilename_EnvelopeWrappingPdfDocument_ReturnsFilename() {
+        var envelope = """
+            <SEC-DOCUMENT>
+            <SEC-HEADER>
+            <ACCEPTANCE-DATETIME>20251201170000
+            </SEC-HEADER>
+            <DOCUMENT>
+            <TYPE>6-K
+            <SEQUENCE>1
+            <FILENAME>form6k.pdf
+            <DESCRIPTION>Form 6-K
+            <TEXT>
+            begin 644 form6k.pdf
+            (uuencoded body)
+            end
+            </TEXT>
+            </DOCUMENT>
+            </SEC-DOCUMENT>
+            """;
+
+        var success = SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(envelope, out var filename);
+
+        success.Should().BeTrue();
+        filename.Should().Be("form6k.pdf");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `SecDocumentEnvelopeParser` covering the happy path: a valid `<DOCUMENT>` envelope wrapping an uuencoded PDF resolves to the embedded `FILENAME`.
- Exercises the document block walker, SGML tag parser, `.pdf` extension check, and `IsSafeFilename` guard in one round-trip.

## Code changes

- `tests/Equibles.Tests/Sec/SecDocumentEnvelopeParserTests.cs` — new xUnit test class with `TryExtractPaperPdfFilename_EnvelopeWrappingPdfDocument_ReturnsFilename` asserting `success == true` and `filename == "form6k.pdf"` against a representative PAPER 6-K envelope.