### PR TITLE
test(sec): add tests for DocumentTypeConverter

### DIFF
--- a/tests/Equibles.Tests/Sec/DocumentTypeConverterTests.cs
+++ b/tests/Equibles.Tests/Sec/DocumentTypeConverterTests.cs
@@ -1,0 +1,16 @@
+using System.Globalization;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Tests.Sec;
+
+public class DocumentTypeConverterTests {
+    private readonly DocumentTypeConverter _sut = new();
+
+    [Fact]
+    public void ConvertFrom_UnknownStringValue_ThrowsFormatException() {
+        var act = () => _sut.ConvertFrom(null, CultureInfo.InvariantCulture, "NotARealDocumentType");
+
+        act.Should().Throw<FormatException>()
+            .WithMessage("*NotARealDocumentType*");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `DocumentTypeConverter`, the `TypeConverter` registered on `DocumentType` and used by ASP.NET model binding to coerce query/form strings.
- Locks in the explicit fail-fast contract: an unknown string raises `FormatException` instead of silently returning `null`, which would propagate as a misbound model.

## Code changes

- `tests/Equibles.Tests/Sec/DocumentTypeConverterTests.cs` — new xUnit test class with `ConvertFrom_UnknownStringValue_ThrowsFormatException`, asserting the throw and that the exception message includes the offending input.