### PR TITLE
test(core): add tests for SyncDateResolver

### DIFF
--- a/tests/Equibles.Tests/Core/SyncDateResolverTests.cs
+++ b/tests/Equibles.Tests/Core/SyncDateResolverTests.cs
@@ -1,0 +1,15 @@
+using Equibles.Core.Configuration;
+using Equibles.Worker;
+
+namespace Equibles.Tests.Core;
+
+public class SyncDateResolverTests {
+    [Fact]
+    public void Resolve_NonDefaultLatestDate_ReturnsNextDay() {
+        var latest = new DateOnly(2025, 6, 14);
+
+        var result = SyncDateResolver.Resolve(latest, new WorkerOptions());
+
+        result.Should().Be(new DateOnly(2025, 6, 15));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `SyncDateResolver.Resolve`, locking in the incremental-sync happy path: a non-default `latestDateInDb` yields `latestDateInDb + 1 day`.
- This is the production-hot path — every scraper resume calls into it — so the off-by-one regression risk is real.

## Code changes

- `tests/Equibles.Tests/Core/SyncDateResolverTests.cs` — new xUnit test class with `Resolve_NonDefaultLatestDate_ReturnsNextDay` asserting `Resolve(2025-06-14, new WorkerOptions())` returns `2025-06-15`.