### PR TITLE
test(core): add tests for BatchPersister

### DIFF
--- a/tests/Equibles.Tests/Core/BatchPersisterTests.cs
+++ b/tests/Equibles.Tests/Core/BatchPersisterTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Worker;
+
+namespace Equibles.Tests.Core;
+
+public class BatchPersisterTests {
+    [Fact]
+    public async Task Persist_ItemsNotDivisibleByBatchSize_FlushesEveryItemAndReturnsCorrectTotal() {
+        var items = Enumerable.Range(1, 7).ToList();
+        var flushed = new List<List<int>>();
+
+        var total = await BatchPersister.Persist(items, batchSize: 3, flushBatch: batch => {
+            flushed.Add([..batch]);
+            return Task.CompletedTask;
+        });
+
+        total.Should().Be(7);
+        flushed.Should().HaveCount(3);
+        flushed[0].Should().Equal(1, 2, 3);
+        flushed[1].Should().Equal(4, 5, 6);
+        flushed[2].Should().Equal(7);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `BatchPersister.Persist`, locking in correct behavior when the item count isn't divisible by `batchSize` — the partial last batch must still be flushed and counted.
- A regression here would silently drop the tail items of every import run, so this is high-value coverage despite the small surface.

## Code changes

- `tests/Equibles.Tests/Core/BatchPersisterTests.cs` — new xUnit test class with `Persist_ItemsNotDivisibleByBatchSize_FlushesEveryItemAndReturnsCorrectTotal`, asserting that 7 items with `batchSize: 3` produce three flushes (`[1,2,3]`, `[4,5,6]`, `[7]`) and return total `7`.