### PR TITLE
test(holdings): add tests for HoldingsParsingHelper

### DIFF
--- a/tests/Equibles.Tests/Holdings/HoldingsParsingHelperTests.cs
+++ b/tests/Equibles.Tests/Holdings/HoldingsParsingHelperTests.cs
@@ -1,0 +1,13 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.Tests.Holdings;
+
+public class HoldingsParsingHelperTests {
+    [Fact]
+    public void TryParseDateOnly_SecFormat_ReturnsExpectedDate() {
+        var success = HoldingsParsingHelper.TryParseDateOnly("15-MAR-2024", out var result);
+
+        success.Should().BeTrue();
+        result.Should().Be(new DateOnly(2024, 3, 15));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test covering the SEC date-format fallback in `HoldingsParsingHelper.TryParseDateOnly`.
- Pins behavior of the dual ISO / SEC parser so the SEC path (`dd-MMM-yyyy`) doesn't regress to ISO-only.

## Code changes

- `tests/Equibles.Tests/Holdings/HoldingsParsingHelperTests.cs` — new test class with `TryParseDateOnly_SecFormat_ReturnsExpectedDate`. Asserts `"15-MAR-2024"` parses to `2024-03-15`.