### PR TITLE
test(web): add tests for HeroIcons

### DIFF
--- a/tests/Equibles.Tests/Web/HeroIconsTests.cs
+++ b/tests/Equibles.Tests/Web/HeroIconsTests.cs
@@ -1,0 +1,14 @@
+using Equibles.Web.TagHelpers;
+
+namespace Equibles.Tests.Web;
+
+public class HeroIconsTests {
+    [Fact]
+    public void Get_SolidStyleMissingButOutlineExists_FallsBackToOutlinePath() {
+        var solid = HeroIcons.Get("circle-stack", HeroIcons.IconStyle.Solid);
+        var outline = HeroIcons.Get("circle-stack", HeroIcons.IconStyle.Outline);
+
+        outline.Should().NotBeEmpty();
+        solid.Should().Be(outline);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test for `HeroIcons.Get` covering the non-obvious outline-style fallback.
- Pins the contract that a `Solid` request for an icon that exists only as `Outline` returns the outline path (rather than empty or throwing).

## Code changes

- `tests/Equibles.Tests/Web/HeroIconsTests.cs` — new test class with `Get_SolidStyleMissingButOutlineExists_FallsBackToOutlinePath`. Uses `circle-stack` (present as outline, absent as solid in the icon dictionary) to verify the fallback returns the outline path.