### PR TITLE
test(sec): add tests for PdfTextExtractor

### DIFF
--- a/tests/Equibles.Tests/Sec/PdfTextExtractorTests.cs
+++ b/tests/Equibles.Tests/Sec/PdfTextExtractorTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Sec.BusinessLogic;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.Tests.Sec;
+
+public class PdfTextExtractorTests {
+    [Fact]
+    public void Extract_MalformedBytes_ReturnsEmptyAndLogsWarning() {
+        var logger = Substitute.For<ILogger<PdfTextExtractor>>();
+        var sut = new PdfTextExtractor(logger);
+        var notAPdf = new byte[] { 0x47, 0x49, 0x46, 0x38, 0x39, 0x61 }; // "GIF89a" magic
+
+        var result = sut.Extract(notAPdf);
+
+        result.Should().BeEmpty();
+        logger.ReceivedCalls()
+            .Any(c => c.GetMethodInfo().Name == "Log"
+                && c.GetArguments().OfType<LogLevel>().FirstOrDefault() == LogLevel.Warning)
+            .Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test pinning `PdfTextExtractor.Extract`'s swallow-and-log contract for malformed input.
- Protects callers from PdfPig throwing on unreadable (non-PDF / encrypted / truncated) bytes — a real production scenario for SEC filings.

## Code changes

- `tests/Equibles.Tests/Sec/PdfTextExtractorTests.cs` — new test class with `Extract_MalformedBytes_ReturnsEmptyAndLogsWarning`. Feeds a GIF magic-header byte sequence (deliberately not a PDF), asserts the method returns empty and emits a `Warning`-level log.