### PR TITLE
test(holdings): add tests for HoldingsDataSetClient

### DIFF
--- a/tests/Equibles.Tests/Holdings/HoldingsDataSetClientTests.cs
+++ b/tests/Equibles.Tests/Holdings/HoldingsDataSetClientTests.cs
@@ -1,0 +1,13 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.Tests.Holdings;
+
+public class HoldingsDataSetClientTests {
+    [Fact]
+    public void GetDataSetFileNames_StartDateBeforeEarliestAvailable_ClampsToQ2_2013() {
+        var result = HoldingsDataSetClient.GetDataSetFileNames(new DateTime(2010, 1, 1));
+
+        result.Should().Contain("2013q2_form13f.zip");
+        result.Should().NotContain("2013q1_form13f.zip");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test pinning the SEC 13F earliest-available clamp in `HoldingsDataSetClient.GetDataSetFileNames`.
- Locks in that callers asking for dates before Q2 2013 still get a valid file list starting at the actual earliest-published period (Q1 2013 doesn't exist on SEC's side).

## Code changes

- `tests/Equibles.Tests/Holdings/HoldingsDataSetClientTests.cs` — new test class with `GetDataSetFileNames_StartDateBeforeEarliestAvailable_ClampsToQ2_2013`. Passes `2010-01-01`, asserts `2013q2_form13f.zip` is present and `2013q1_form13f.zip` is not.