### PR TITLE
test(web): add tests for MarkdownExtensions

### DIFF
--- a/tests/Equibles.Tests/Web/MarkdownExtensionsTests.cs
+++ b/tests/Equibles.Tests/Web/MarkdownExtensionsTests.cs
@@ -1,0 +1,24 @@
+using System.Text.RegularExpressions;
+using Equibles.Web.Extensions;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using NSubstitute;
+
+namespace Equibles.Tests.Web;
+
+public class MarkdownExtensionsTests {
+    [Fact]
+    public void MarkdownToHtml_PipeTableWithBlankLineBetweenRows_RendersAsSingleTable() {
+        string captured = null;
+        var htmlHelper = Substitute.For<IHtmlHelper>();
+        htmlHelper.Raw(Arg.Do<string>(s => captured = s))
+            .Returns(callInfo => new HtmlString(callInfo.Arg<string>()));
+
+        var markdown = "| H1 | H2 |\n|----|----|\n| a  | b  |\n\n| c  | d  |\n";
+
+        htmlHelper.MarkdownToHtml(markdown);
+
+        captured.Should().NotBeNull();
+        Regex.Matches(captured, "<table").Count.Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test pinning `MarkdownExtensions.MarkdownToHtml`'s pipe-table blank-line collapse.
- Locks in the workaround that keeps tables stored with blank lines between rows (from older filings) rendering as a single contiguous table instead of fracturing.

## Code changes

- `tests/Equibles.Tests/Web/MarkdownExtensionsTests.cs` — new test class with `MarkdownToHtml_PipeTableWithBlankLineBetweenRows_RendersAsSingleTable`. Substitutes `IHtmlHelper`, captures what is passed to `Raw`, and asserts the rendered HTML contains exactly one `<table>` element.