### PR TITLE
test(sec): add tests for HtmlElementExtensions

### DIFF
--- a/tests/Equibles.Tests/Sec/Normalizers/HtmlElementExtensionsTests.cs
+++ b/tests/Equibles.Tests/Sec/Normalizers/HtmlElementExtensionsTests.cs
@@ -1,0 +1,19 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.Tests.Sec.Normalizers;
+
+public class HtmlElementExtensionsTests {
+    [Fact]
+    public void InsertAfter_RefNodeIsLastChild_AppendsAtEnd() {
+        var doc = new HtmlParser().ParseDocument("<html><body><div id=\"p\"><span id=\"first\"></span></div></body></html>");
+        var parent = doc.GetElementById("p")!;
+        var refNode = doc.GetElementById("first")!;
+        var newNode = doc.CreateElement("em");
+        newNode.SetAttribute("id", "added");
+
+        HtmlElementExtensions.InsertAfter(parent, newNode, refNode);
+
+        parent.LastElementChild!.GetAttribute("id").Should().Be("added");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test for the `InsertAfter` helper used by the HTML normalization pipeline.
- Pins the subtle "refNode is last child" behavior — `InsertBefore(node, NextSibling)` with a null `NextSibling` must still append, which is the contract callers rely on when restructuring tables and headings.

## Code changes

- `tests/Equibles.Tests/Sec/Normalizers/HtmlElementExtensionsTests.cs` — new test class with `InsertAfter_RefNodeIsLastChild_AppendsAtEnd`. Uses AngleSharp to build a small DOM, inserts after the last element, and asserts the new node becomes `LastElementChild`.