### PR TITLE
test(web): add tests for FlashMessage

### DIFF
--- a/tests/Equibles.Tests/Web/FlashMessageClassTests.cs
+++ b/tests/Equibles.Tests/Web/FlashMessageClassTests.cs
@@ -1,0 +1,29 @@
+using Equibles.Web.FlashMessage;
+using Equibles.Web.FlashMessage.Contracts;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using NSubstitute;
+
+namespace Equibles.Tests.Web;
+
+public class FlashMessageClassTests {
+    [Fact]
+    public void Retrieve_WhenEntryExists_RemovesItFromTempData() {
+        var serializer = new JsonFlashMessageSerializer();
+        var serialized = serializer.Serialize(new List<IFlashMessageModel> {
+            new FlashMessageModel { Message = "Saved", Type = FlashMessageType.Success },
+        });
+
+        var tempData = Substitute.For<ITempDataDictionary>();
+        tempData[FlashMessage.KeyName].Returns(serialized);
+
+        var factory = Substitute.For<ITempDataDictionaryFactory>();
+        factory.GetTempData(Arg.Any<HttpContext>()).Returns(tempData);
+        var sut = new FlashMessage(factory, Substitute.For<IHttpContextAccessor>(), serializer);
+
+        var result = sut.Retrieve();
+
+        result.Should().ContainSingle().Which.Message.Should().Be("Saved");
+        tempData.Received(1).Remove(FlashMessage.KeyName);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test pinning `FlashMessage.Retrieve`'s "read once, then remove" contract.
- The existing FlashMessageTests.cs covers the model, type, serializer and DI extensions but not the `FlashMessage` orchestrator itself — `Retrieve` differs from `Peek` precisely in that it removes the entry, and that distinction was untested.

## Code changes

- `tests/Equibles.Tests/Web/FlashMessageClassTests.cs` — new test class with `Retrieve_WhenEntryExists_RemovesItFromTempData`. Substitutes `ITempDataDictionary`/`Factory`/`IHttpContextAccessor`, stubs a pre-serialized entry, calls `Retrieve()`, and asserts both the deserialized payload and `Remove(KeyName)` invocation.