### PR TITLE
test(web): add tests for HeroIconTagHelper

### DIFF
--- a/tests/Equibles.Tests/Web/HeroIconTagHelperTests.cs
+++ b/tests/Equibles.Tests/Web/HeroIconTagHelperTests.cs
@@ -1,0 +1,27 @@
+using System.Text.Encodings.Web;
+using Equibles.Web.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.Tests.Web;
+
+public class HeroIconTagHelperTests {
+    [Fact]
+    public void Process_UnknownIconName_SuppressesOutput() {
+        var sut = new HeroIconTagHelper { Name = "this-icon-does-not-exist" };
+        var context = new TagHelperContext(
+            new TagHelperAttributeList(),
+            new Dictionary<object, object>(),
+            uniqueId: "test");
+        var output = new TagHelperOutput(
+            "icon",
+            new TagHelperAttributeList(),
+            getChildContentAsync: (useCachedResult, encoder) =>
+                Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+        sut.Process(context, output);
+
+        output.TagName.Should().BeNull();
+        output.IsContentModified.Should().BeTrue();
+        output.Content.GetContent(HtmlEncoder.Default).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test pinning `HeroIconTagHelper.Process` suppression for unknown icon names.
- Locks in the fail-soft behavior: an `<icon name="...">` that doesn't match any glyph in `HeroIcons` is removed from the rendered output rather than leaving an empty `<icon>` element or a broken `<svg>`.

## Code changes

- `tests/Equibles.Tests/Web/HeroIconTagHelperTests.cs` — new test class with `Process_UnknownIconName_SuppressesOutput`. Constructs a real `TagHelperContext`/`TagHelperOutput` (no DI), passes a bogus name, and asserts the output's `TagName` is null, content was modified, and the rendered content string is empty.