### PR TITLE
test(web): add tests for MarketController

### DIFF
--- a/tests/Equibles.Tests/Web/MarketControllerTests.cs
+++ b/tests/Equibles.Tests/Web/MarketControllerTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Cboe.Data;
+using Equibles.Cboe.Repositories;
+using Equibles.Tests.Helpers;
+using Equibles.Web.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.Tests.Web;
+
+public class MarketControllerTests {
+    [Fact]
+    public async Task PutCallRatio_UnknownTypeString_ReturnsNotFound() {
+        // The route accepts {type} as a raw string and converts to CboePutCallRatioType
+        // via Enum.TryParse. A regression that drops the TryParse guard would either
+        // throw or fall through to a 200 with empty data — both are worse than 404
+        // for an unknown ratio type.
+        using var ctx = TestDbContextFactory.Create(new CboeModuleConfiguration());
+        var putCallRepo = new CboePutCallRatioRepository(ctx);
+        var vixRepo = new CboeVixDailyRepository(ctx);
+        var sut = new MarketController(putCallRepo, vixRepo, Substitute.For<ILogger<MarketController>>());
+
+        var result = await sut.PutCallRatio("not-a-real-ratio-type");
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the unknown-type guard in `MarketController.PutCallRatio` — the route takes a raw string and converts via `Enum.TryParse`; dropping that guard would either throw or render empty data instead of 404
- Test wires real `CboePutCallRatioRepository`/`CboeVixDailyRepository` against an InMemory `EquiblesDbContext` so the controller's parsing path is exercised end-to-end

## Code changes

- `tests/Equibles.Tests/Web/MarketControllerTests.cs` — new test asserting `NotFoundResult` for an unknown ratio-type segment