### PR TITLE
test(mcp): add tests for FailToDeliverTools

### DIFF
--- a/tests/Equibles.Tests/Mcp/FailToDeliverToolsTests.cs
+++ b/tests/Equibles.Tests/Mcp/FailToDeliverToolsTests.cs
@@ -1,0 +1,37 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.Media.Data;
+using Equibles.Sec.Mcp.Tools;
+using Equibles.Sec.Repositories;
+using Equibles.Tests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.Tests.Mcp;
+
+public class FailToDeliverToolsTests {
+    [Fact]
+    public async Task GetFailsToDeliver_UnknownTicker_ReturnsStockNotFoundMessage() {
+        // FailToDeliverTools must short-circuit when the ticker doesn't match any stock —
+        // otherwise the subsequent `GetByStock(null)` call dereferences the missing entity
+        // and the tool returns the generic McpToolExecutor error string, masking the real
+        // (user-facing) "stock not found" feedback. Pinning the early-return path keeps the
+        // MCP client message specific.
+        using var ctx = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new MediaModuleConfiguration(),
+            new SecTestModuleConfiguration(),
+            new ErrorsModuleConfiguration());
+        var stockRepo = new CommonStockRepository(ctx);
+        var ftdRepo = new FailToDeliverRepository(ctx);
+        var errorManager = new ErrorManager(new ErrorRepository(ctx));
+        var sut = new FailToDeliverTools(ftdRepo, stockRepo, errorManager, Substitute.For<ILogger<FailToDeliverTools>>());
+
+        var result = await sut.GetFailsToDeliver("ZZZZ");
+
+        result.Should().Be("Stock 'ZZZZ' not found.");
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the unknown-ticker short-circuit in `FailToDeliverTools.GetFailsToDeliver` — the tool must return the specific "Stock '<ticker>' not found." string before any `GetByStock(null)` call, otherwise the generic McpToolExecutor error message replaces the user-facing feedback
- Test wires real repositories and `ErrorManager` against an InMemory `EquiblesDbContext` (CommonStocks + Media + Sec + Errors modules)

## Code changes

- `tests/Equibles.Tests/Mcp/FailToDeliverToolsTests.cs` — new test asserting the exact not-found message for ticker "ZZZZ" with an empty database