### PR TITLE
test(data): tests for ServiceCollectionExtensions repository auto-reg

### DIFF
--- a/tests/Equibles.Tests/Data/RepositoryRegistrationTests.cs
+++ b/tests/Equibles.Tests/Data/RepositoryRegistrationTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Data.Extensions;
+using Equibles.Errors.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.Tests.Data;
+
+public class RepositoryRegistrationTests {
+    [Fact]
+    public void AddRepositoriesFrom_AssemblyContainingBaseRepositorySubclass_RegistersItAsScoped() {
+        // AddRepositoriesFrom auto-discovers every concrete BaseRepository<T> subclass in the
+        // given assembly and binds it to itself with Scoped lifetime. The lifetime is the
+        // load-bearing part — Singleton would leak DbContext across requests, Transient would
+        // break the unit-of-work guarantee within a single request. Pin it here so a careless
+        // change in the registration shape can't silently downgrade the lifetime.
+        var services = new ServiceCollection();
+
+        services.AddRepositoriesFrom(typeof(ErrorRepository).Assembly);
+
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(ErrorRepository));
+        descriptor.Should().NotBeNull();
+        descriptor!.Lifetime.Should().Be(ServiceLifetime.Scoped);
+        descriptor.ImplementationType.Should().Be(typeof(ErrorRepository));
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the Scoped lifetime on `AddRepositoriesFrom` — auto-discovered `BaseRepository<T>` subclasses must register as Scoped so DbContext isn't leaked across requests (Singleton) or fragmented within a request (Transient)
- Existing `ServiceCollectionExtensionsTests` in `DataLayerTests.cs` covers `AddEquiblesDbContext`, but the repository-scanning path was uncovered

## Code changes

- `tests/Equibles.Tests/Data/RepositoryRegistrationTests.cs` — new test calling `AddRepositoriesFrom(typeof(ErrorRepository).Assembly)` and asserting the descriptor's `Lifetime == ServiceLifetime.Scoped` and `ImplementationType == typeof(ErrorRepository)`