### PR TITLE
chore: scaffold Equibles.FunctionalTests (Playwright + Testcontainers)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
         run: dotnet build Equibles.sln --no-restore -c Release
 
       - name: Test
-        run: dotnet test Equibles.sln --no-build -c Release --logger "trx;LogFileName=results.trx" --collect:"XPlat Code Coverage" --settings coverage.runsettings --results-directory ./coverage
+        # Functional tests need Playwright + a ParadeDB container and live in functional.yml.
+        run: dotnet test Equibles.sln --no-build -c Release --filter "Category!=Functional" --logger "trx;LogFileName=results.trx" --collect:"XPlat Code Coverage" --settings coverage.runsettings --results-directory ./coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -1,0 +1,54 @@
+name: Functional Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  functional:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Restore
+        run: dotnet restore Equibles.sln
+
+      - name: Build functional test project
+        run: dotnet build tests/Equibles.FunctionalTests/Equibles.FunctionalTests.csproj --no-restore -c Release
+
+      - name: Install Playwright browsers
+        # Pre-install Chromium so the first test doesn't pay the download cost.
+        # PlaywrightFixture has a fallback for local runs without this step.
+        run: pwsh tests/Equibles.FunctionalTests/bin/Release/net10.0/playwright.ps1 install chromium --with-deps
+
+      - name: Run functional tests
+        run: dotnet test tests/Equibles.FunctionalTests/Equibles.FunctionalTests.csproj --no-build -c Release --logger "trx;LogFileName=results.trx" --results-directory ./functional-results
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: tests/Equibles.FunctionalTests/bin/Release/net10.0/playwright-traces
+          if-no-files-found: ignore
+
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: Functional Test Results
+          path: functional-results/**/*.trx
+          reporter: dotnet-trx

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,5 +77,9 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="FluentAssertions" Version="8.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+    <PackageVersion Include="Testcontainers" Version="4.8.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.8.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.5" />
   </ItemGroup>
 </Project>

--- a/Equibles.sln
+++ b/Equibles.sln
@@ -133,6 +133,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Finra.Mcp", "src\E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Yahoo.Mcp", "src\Equibles.Yahoo.Mcp\Equibles.Yahoo.Mcp.csproj", "{1715A6E7-C5E7-43D6-9FCA-8752040FD3B7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FunctionalTests", "tests\Equibles.FunctionalTests\Equibles.FunctionalTests.csproj", "{618EBD42-DF65-4048-AB48-71CD08B87CD9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -899,6 +901,18 @@ Global
 		{1715A6E7-C5E7-43D6-9FCA-8752040FD3B7}.Release|x64.Build.0 = Release|Any CPU
 		{1715A6E7-C5E7-43D6-9FCA-8752040FD3B7}.Release|x86.ActiveCfg = Release|Any CPU
 		{1715A6E7-C5E7-43D6-9FCA-8752040FD3B7}.Release|x86.Build.0 = Release|Any CPU
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Debug|x64.Build.0 = Debug|Any CPU
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Debug|x86.Build.0 = Debug|Any CPU
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Release|x64.ActiveCfg = Release|Any CPU
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Release|x64.Build.0 = Release|Any CPU
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Release|x86.ActiveCfg = Release|Any CPU
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -967,6 +981,7 @@ Global
 		{CCCD9620-0138-4911-B04E-9FD642E18018} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{A07E8FC4-C113-425A-B033-E3780044BB30} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{1715A6E7-C5E7-43D6-9FCA-8752040FD3B7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{618EBD42-DF65-4048-AB48-71CD08B87CD9} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -57,8 +57,9 @@ builder.Services.AddControllersWithViews(options => {
     })
     .AddRazorRuntimeCompilation();
 
+var keysDirectory = builder.Configuration["DataProtection:KeysDirectory"] ?? "/app/keys";
 builder.Services.AddDataProtection()
-    .PersistKeysToFileSystem(new DirectoryInfo("/app/keys"));
+    .PersistKeysToFileSystem(new DirectoryInfo(keysDirectory));
 
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddSession();
@@ -90,3 +91,8 @@ app.MapControllerRoute(
     pattern: "{controller=Home}/{action=Index}/{id?}");
 
 app.Run();
+
+namespace Equibles.Web {
+    // Exposed for WebApplicationFactory<Equibles.Web.Program> in the functional test project.
+    public partial class Program;
+}

--- a/tests/Equibles.FunctionalTests/Equibles.FunctionalTests.csproj
+++ b/tests/Equibles.FunctionalTests/Equibles.FunctionalTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <!-- Functional tests need ASP.NET Core to host the web app via WebApplicationFactory + Kestrel. -->
+    <RootNamespace>Equibles.FunctionalTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Playwright" />
+    <PackageReference Include="Testcontainers" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Equibles.Web\Equibles.Web.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Migrations\Equibles.Migrations.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Equibles.FunctionalTests/Fixtures/PlaywrightFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/PlaywrightFixture.cs
@@ -1,0 +1,55 @@
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Fixtures;
+
+/// <summary>
+/// Manages a single Chromium browser instance for the functional test collection.
+/// Each test creates its own browser context (cookies, storage) via <see cref="NewPageAsync"/>,
+/// so per-test state isolation is preserved without paying the browser-launch cost per test.
+///
+/// Browser binaries are installed lazily on first use — pulled by Microsoft.Playwright's
+/// own installer rather than the bundled playwright.ps1 script so contributors without
+/// PowerShell can still run the suite locally.
+/// </summary>
+public class PlaywrightFixture : IAsyncLifetime {
+    public IPlaywright Playwright { get; private set; }
+    public IBrowser Browser { get; private set; }
+
+    public async Task InitializeAsync() {
+        EnsureBrowserBinariesInstalled();
+        Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+        Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+    }
+
+    public async Task DisposeAsync() {
+        if (Browser != null) await Browser.CloseAsync();
+        Playwright?.Dispose();
+    }
+
+    public async Task<IPage> NewPageAsync(string baseUrl) {
+        var context = await Browser.NewContextAsync(new BrowserNewContextOptions {
+            BaseURL = baseUrl,
+            IgnoreHTTPSErrors = true,
+        });
+        return await context.NewPageAsync();
+    }
+
+    private static void EnsureBrowserBinariesInstalled() {
+        // Idempotent: exit code 0 if Chromium is already present.
+        // CI workflows usually pre-install via `playwright install chromium` to avoid the
+        // first-test latency, but this fallback keeps local runs working with no setup.
+        var exitCode = Microsoft.Playwright.Program.Main(["install", "chromium", "--with-deps"]);
+        if (exitCode != 0) {
+            throw new InvalidOperationException(
+                $"Playwright Chromium install returned exit code {exitCode}. " +
+                "Run `pwsh tests/Equibles.FunctionalTests/bin/Debug/net10.0/playwright.ps1 install chromium` " +
+                "or set PLAYWRIGHT_BROWSERS_PATH to use an existing installation.");
+        }
+    }
+}
+
+[CollectionDefinition(Name)]
+public class FunctionalTestCollection : ICollectionFixture<WebAppFixture>, ICollectionFixture<PlaywrightFixture> {
+    public const string Name = "Functional";
+}

--- a/tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Fixtures;
+
+/// <summary>
+/// Hosts the real Equibles.Web app on a Kestrel-bound random port, backed by a Testcontainers
+/// ParadeDB instance (PostgreSQL + pgvector + pg_search) so EF Core migrations apply against
+/// the same engine as production. One container per fixture; shared across the whole functional
+/// collection to amortise the ~15-30s container boot cost.
+/// </summary>
+public class WebAppFixture : WebApplicationFactory<Equibles.Web.Program>, IAsyncLifetime {
+    // ParadeDB ships PostgreSQL with both `pg_search` and `vector` extensions, which the
+    // initial migration declares via Npgsql:PostgresExtension annotations. Plain postgres images
+    // don't have these and the migration fails on first run.
+    private readonly PostgreSqlContainer _db = new PostgreSqlBuilder()
+        .WithImage("paradedb/paradedb:latest")
+        .WithDatabase("equibles_functional")
+        .WithUsername("postgres")
+        .WithPassword("postgres")
+        .Build();
+
+    public string BaseUrl { get; private set; }
+
+    public async Task InitializeAsync() {
+        await _db.StartAsync();
+        // Trigger app build so WebApplicationFactory boots Kestrel and runs migrations.
+        // Reading Server.Features pins the bound URL after Kestrel has chosen its port.
+        var _ = Server;
+        var addresses = Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>();
+        BaseUrl = addresses?.Addresses.FirstOrDefault() ?? throw new InvalidOperationException(
+            "Kestrel did not expose a bound address — IServerAddressesFeature returned no entries.");
+    }
+
+    public new async Task DisposeAsync() {
+        await base.DisposeAsync();
+        await _db.DisposeAsync();
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder) {
+        // Force Kestrel onto a random loopback port. WebApplicationFactory's default in-memory
+        // TestServer can't accept browser traffic; Playwright drives a real browser, so we
+        // need a real socket.
+        builder.ConfigureWebHost(webHost => {
+            webHost.UseUrls("http://127.0.0.1:0");
+            webHost.UseKestrel();
+        });
+        return base.CreateHost(builder);
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder) {
+        // Override the production DefaultConnection so EF Core points at the test container.
+        builder.UseSetting("ConnectionStrings:DefaultConnection", _db.GetConnectionString());
+
+        // Production Program.cs writes data-protection keys to /app/keys (the container path).
+        // On dev/CI hosts that directory doesn't exist; override to a temp directory per fixture.
+        var keysDir = Path.Combine(Path.GetTempPath(), $"equibles-functional-keys-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(keysDir);
+        builder.UseSetting("DataProtection:KeysDirectory", keysDir);
+
+        builder.UseEnvironment("Development");
+    }
+}

--- a/tests/Equibles.FunctionalTests/Tests/HealthCheckTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HealthCheckTests.cs
@@ -1,0 +1,35 @@
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class HealthCheckTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public HealthCheckTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Healthz_Get_ReturnsHealthyStatus() {
+        // Smoke test: drives a real browser through the full Kestrel + EF Core + ParadeDB stack
+        // to /healthz. Catches regressions that unit and integration tests can't:
+        //   - missing AddHealthChecks() / MapHealthChecks() wiring
+        //   - migration failures against the real schema
+        //   - DI graph that compiles but throws at first request
+        //   - data-protection key directory misconfiguration
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        var response = await page.GotoAsync("/healthz");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+        var body = await page.ContentAsync();
+        body.Should().Contain("Healthy");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the e2e tier: a new `Equibles.FunctionalTests` project that drives a real browser against the real Kestrel + EF Core + ParadeDB stack
- First test (`Healthz_Get_ReturnsHealthyStatus`) smoke-checks the full pipeline — catches regressions that unit/integration tests can't (migration failures against real schema, DI graphs that compile but throw at first request, missing health-check wiring)
- Functional tests are tagged `[Trait("Category", "Functional")]`; main CI excludes them via `--filter "Category!=Functional"`, and a dedicated `functional.yml` workflow runs them with Playwright Chromium pre-installed

## Code changes

- `src/Equibles.Web/Program.cs` — expose `Equibles.Web.Program` as `public partial` (required for `WebApplicationFactory<TEntryPoint>`); make `DataProtection:KeysDirectory` configurable so tests can redirect keys to a temp dir (default `/app/keys` unchanged for prod)
- `Directory.Packages.props` — add `Microsoft.AspNetCore.Mvc.Testing`, `Testcontainers`, `Testcontainers.PostgreSql` (and `BenchmarkDotNet`, queued for the follow-up benchmarks PR)
- `tests/Equibles.FunctionalTests/` — new project: `WebAppFixture` (Testcontainers `paradedb/paradedb:latest` + WebApplicationFactory bound to Kestrel on a random port), `PlaywrightFixture` (one Chromium browser, per-test contexts), `HealthCheckTests.Healthz_Get_ReturnsHealthyStatus`
- `Equibles.sln` — register the new project
- `.github/workflows/ci.yml` — filter out `Category=Functional` from the default test run
- `.github/workflows/functional.yml` — new workflow that installs Chromium via `playwright.ps1` and runs only the functional tests