### PR TITLE
chore: scaffold Equibles.Benchmarks with first baseline benchmark

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -135,6 +135,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Yahoo.Mcp", "src\E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FunctionalTests", "tests\Equibles.FunctionalTests\Equibles.FunctionalTests.csproj", "{618EBD42-DF65-4048-AB48-71CD08B87CD9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Benchmarks", "tests\Equibles.Benchmarks\Equibles.Benchmarks.csproj", "{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -913,6 +915,18 @@ Global
 		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Release|x64.Build.0 = Release|Any CPU
 		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Release|x86.ActiveCfg = Release|Any CPU
 		{618EBD42-DF65-4048-AB48-71CD08B87CD9}.Release|x86.Build.0 = Release|Any CPU
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}.Debug|x64.Build.0 = Debug|Any CPU
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}.Debug|x86.Build.0 = Debug|Any CPU
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}.Release|x64.ActiveCfg = Release|Any CPU
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}.Release|x64.Build.0 = Release|Any CPU
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}.Release|x86.ActiveCfg = Release|Any CPU
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -982,6 +996,7 @@ Global
 		{A07E8FC4-C113-425A-B033-E3780044BB30} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{1715A6E7-C5E7-43D6-9FCA-8752040FD3B7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{618EBD42-DF65-4048-AB48-71CD08B87CD9} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/tests/Equibles.Benchmarks/Benchmarks/HoldingsDataSetClientBenchmarks.cs
+++ b/tests/Equibles.Benchmarks/Benchmarks/HoldingsDataSetClientBenchmarks.cs
@@ -1,0 +1,23 @@
+using BenchmarkDotNet.Attributes;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Baseline benchmark for the holdings scraper's quarterly-period enumerator.
+/// <see cref="HoldingsDataSetClient.GetDataSetFileNames"/> runs once per scraper cycle, and
+/// the list it produces drives every SEC EDGAR 13F download. The function is pure and
+/// allocation-shaped (one string per period, ~50 entries for a 2013-onward backfill), so
+/// it's a clean baseline for tracking allocation regressions as new format periods are added.
+/// </summary>
+[MemoryDiagnoser]
+public class HoldingsDataSetClientBenchmarks {
+    private static readonly DateTime FullBackfillStart = new(2013, 1, 1);
+    private static readonly DateTime IncrementalStart = DateTime.UtcNow.AddYears(-1);
+
+    [Benchmark(Baseline = true)]
+    public List<string> FullBackfill() => HoldingsDataSetClient.GetDataSetFileNames(FullBackfillStart);
+
+    [Benchmark]
+    public List<string> IncrementalSync() => HoldingsDataSetClient.GetDataSetFileNames(IncrementalStart);
+}

--- a/tests/Equibles.Benchmarks/Equibles.Benchmarks.csproj
+++ b/tests/Equibles.Benchmarks/Equibles.Benchmarks.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <!-- BenchmarkDotNet projects are executables, not test projects — dotnet test skips them. -->
+    <IsTestProject>false</IsTestProject>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <RootNamespace>Equibles.Benchmarks</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Equibles.Holdings.HostedService\Equibles.Holdings.HostedService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Equibles.Benchmarks/Program.cs
+++ b/tests/Equibles.Benchmarks/Program.cs
@@ -1,0 +1,9 @@
+using BenchmarkDotNet.Running;
+
+namespace Equibles.Benchmarks;
+
+public static class Program {
+    // Pass --list flat / --filter "*HoldingsDataSet*" / --filter "*" to BenchmarkSwitcher.
+    public static void Main(string[] args) =>
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+}


### PR DESCRIPTION
## Summary

- Adds the performance tier: a BenchmarkDotNet console project for tracking time and allocation regressions on hot paths
- First baseline subject is `HoldingsDataSetClient.GetDataSetFileNames` — runs once per scraper cycle, drives every SEC EDGAR 13F download, has a clean static signature and predictable allocation shape (~50 strings per full backfill)
- Project uses `IsTestProject=false` so `dotnet test Equibles.sln` ignores it; no CI workflow — benchmarks need stable hardware to produce comparable numbers, run manually

## Code changes

- `tests/Equibles.Benchmarks/Equibles.Benchmarks.csproj` — new project, `OutputType=Exe`, `ServerGarbageCollection=true`, references Equibles.Holdings.HostedService and BenchmarkDotNet
- `tests/Equibles.Benchmarks/Program.cs` — `BenchmarkSwitcher.FromAssembly(...).Run(args)` entry point
- `tests/Equibles.Benchmarks/Benchmarks/HoldingsDataSetClientBenchmarks.cs` — two benchmarks: `FullBackfill` (baseline, 2013-onward) and `IncrementalSync` (one year back); `[MemoryDiagnoser]` enabled
- `Equibles.sln` — register the new project

## Run locally

```
dotnet run --project tests/Equibles.Benchmarks -c Release -- --filter "*"
dotnet run --project tests/Equibles.Benchmarks -c Release -- --list flat
```