### PR TITLE
fix(plugins): tolerate duplicate assembly names + drop dead skipped test

### DIFF
--- a/src/Equibles.Plugins/PluginLoader.cs
+++ b/src/Equibles.Plugins/PluginLoader.cs
@@ -19,8 +19,13 @@ public static class PluginLoader {
     public static Assembly[] LoadAll() {
         if (_loaded != null) return _loaded;
 
+        // The same simple name can appear more than once in AppDomain.CurrentDomain.GetAssemblies()
+        // — for example, the xunit visual studio adapter is loaded both as the VSTest host and
+        // again via the WebApplicationFactory bin folder during functional tests. ToDictionary
+        // without a duplicate-tolerant aggregation throws; keep the first instance and skip the rest.
         var alreadyLoaded = AppDomain.CurrentDomain.GetAssemblies()
-            .ToDictionary(a => a.GetName().Name);
+            .GroupBy(a => a.GetName().Name)
+            .ToDictionary(g => g.Key, g => g.First());
         var plugins = new List<Assembly>(alreadyLoaded.Values);
 
         foreach (var dll in Directory.GetFiles(AppContext.BaseDirectory, "*.dll")) {

--- a/tests/Equibles.Tests/Web/StockTabServiceTests.cs
+++ b/tests/Equibles.Tests/Web/StockTabServiceTests.cs
@@ -651,44 +651,6 @@ public class StockTabServiceTests : IDisposable {
         result.HolderCount.Should().Be(0);
     }
 
-    /// <summary>
-    /// The previous quarter lookup in LoadHoldingsTab uses GroupBy + ToDictionaryAsync which the
-    /// EF Core InMemory provider cannot translate when owned entities (HoldingManagerEntry) are
-    /// auto-included. This test verifies the behavior against a real PostgreSQL database and is
-    /// skipped in unit tests. The logic is implicitly validated: when only one report date exists,
-    /// PreviousSharesByHolder is empty (see NoPreviousQuarter test); the GroupBy path is
-    /// exercised in integration tests.
-    /// </summary>
-    [Fact(Skip = "InMemory provider cannot translate GroupBy with owned entity collections")]
-    public async Task LoadHoldingsTab_PreviousQuarterLookup_PopulatesPreviousSharesByHolder() {
-        var stock = CreateStock();
-        var holder = CreateInstitutionalHolder("State Street", "0001112223");
-
-        var q4Date = new DateOnly(2024, 12, 31);
-        var q1Date = new DateOnly(2025, 3, 31);
-
-        _dbContext.Set<InstitutionalHolding>().AddRange(
-            new InstitutionalHolding {
-                CommonStockId = stock.Id, InstitutionalHolderId = holder.Id,
-                FilingDate = new DateOnly(2025, 2, 14), ReportDate = q4Date,
-                Value = 400_000, Shares = 8_000, ShareType = ShareType.Shares,
-                TitleOfClass = "COM", AccessionNumber = "0001-25-000030",
-            },
-            new InstitutionalHolding {
-                CommonStockId = stock.Id, InstitutionalHolderId = holder.Id,
-                FilingDate = new DateOnly(2025, 5, 15), ReportDate = q1Date,
-                Value = 600_000, Shares = 12_000, ShareType = ShareType.Shares,
-                TitleOfClass = "COM", AccessionNumber = "0001-25-000031",
-            }
-        );
-        await _dbContext.SaveChangesAsync();
-
-        var result = await _service.LoadHoldingsTab(stock, q1Date);
-
-        result.PreviousSharesByHolder.Should().ContainKey(holder.Id);
-        result.PreviousSharesByHolder[holder.Id].Should().Be(8_000);
-    }
-
     [Fact]
     public async Task LoadHoldingsTab_NoPreviousQuarter_PreviousSharesByHolderIsEmpty() {
         var stock = CreateStock();


### PR DESCRIPTION
## Summary

- Fixes the functional-test CI failure on `main` (visible in PR #40's checks): `PluginLoader.LoadAll()` was using `ToDictionary(a => a.GetName().Name)` over `AppDomain.CurrentDomain.GetAssemblies()`, but in the WebApplicationFactory boot path the same simple name (`xunit.runner.visualstudio.testadapter`) appears twice, so the call threw `ArgumentException`. Switched to a duplicate-tolerant `GroupBy → ToDictionary` that keeps the first instance per simple name. Production runs are unaffected; the fix unblocks the functional workflow.
- Drops `LoadHoldingsTab_PreviousQuarterLookup_PopulatesPreviousSharesByHolder`, which has been `[Fact(Skip = "InMemory provider cannot translate GroupBy with owned entity collections")]` since it was written and never ran in CI. The branch is exercised by integration tests against real PostgreSQL, and the empty-result case is covered by `LoadHoldingsTab_NoPreviousQuarter_…`.

## Code changes

- `src/Equibles.Plugins/PluginLoader.cs` — `LoadAll()` now `.GroupBy(a => a.GetName().Name).ToDictionary(g => g.Key, g => g.First())` to swallow duplicate simple names in the AppDomain. Comment in source explains the xunit test-runner case the change actually unblocks.
- `tests/Equibles.Tests/Web/StockTabServiceTests.cs` — removed the permanently-skipped `LoadHoldingsTab_PreviousQuarterLookup_PopulatesPreviousSharesByHolder` test and its preceding doc comment.