### PR TITLE
test(benchmarks): add TechnicalIndicatorServiceBenchmarks for MACD

### DIFF
--- a/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceBenchmarks.cs
+++ b/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceBenchmarks.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using Equibles.Web.Services;
+
+namespace Equibles.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Per-stock cost of the MACD calculation in <see cref="TechnicalIndicatorService"/>. MACD
+/// is the most expensive of the indicator family — it composes two EMAs plus a signal EMA
+/// over their difference — and it runs over the full daily price history every time a stock's
+/// chart view is rendered. The fixture is a 1 008-day series (~four trading years) shaped as a
+/// slow drift plus a sinusoidal component, so the EMA recurrence stays non-degenerate.
+/// </summary>
+[MemoryDiagnoser]
+public class TechnicalIndicatorServiceBenchmarks {
+    private const int PriceCount = 1_008;
+    private List<decimal> _prices;
+
+    [GlobalSetup]
+    public void Setup() {
+        // 100 + small daily drift + sinusoidal oscillation. Flat input would degenerate the
+        // EMA recurrence; pure random would make cross-commit comparisons too noisy.
+        _prices = new List<decimal>(PriceCount);
+        for (var i = 0; i < PriceCount; i++) {
+            var drift = i * 0.05m;
+            var wave = (decimal)Math.Sin(i / 12.0) * 3m;
+            _prices.Add(100m + drift + wave);
+        }
+    }
+
+    [Benchmark]
+    public int ComputeMacd() {
+        var (line, signal, histogram) = TechnicalIndicatorService.ComputeMacd(_prices);
+        return line.Count + signal.Count + histogram.Count;
+    }
+}

--- a/tests/Equibles.Benchmarks/Equibles.Benchmarks.csproj
+++ b/tests/Equibles.Benchmarks/Equibles.Benchmarks.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\src\Equibles.Congress.HostedService\Equibles.Congress.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Holdings.HostedService\Equibles.Holdings.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Sec.BusinessLogic\Equibles.Sec.BusinessLogic.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Web\Equibles.Web.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Adds a BenchmarkDotNet baseline for `TechnicalIndicatorService.ComputeMacd`, the most expensive of the indicator family — two EMAs plus a signal EMA over their difference, run over the full daily price history for every stock chart view.
- Fixture is a 1,008-day series (~four trading years) shaped as a slow drift + sinusoid so the EMA recurrence stays non-degenerate. Dry-run measures ~1.65 ms / 174 KB allocated.
- Adds a `ProjectReference` to `Equibles.Web` in the benchmark project so the Web service is reachable from BDN — matches the dotnet-testing skill's pattern of referencing web from benchmarks for view/service work.

## Code changes

- `tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceBenchmarks.cs` — new `[MemoryDiagnoser]` benchmark class with one `[Benchmark]` (`ComputeMacd`) and a `[GlobalSetup]` that builds the synthetic price series.
- `tests/Equibles.Benchmarks/Equibles.Benchmarks.csproj` — adds `ProjectReference` to `Equibles.Web` so the benchmark can resolve `TechnicalIndicatorService`.