### PR TITLE
test(functional): add skipped repro for GH-45 — HomeIndex page

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/HomeIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HomeIndexTests.cs
@@ -1,0 +1,40 @@
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class HomeIndexTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public HomeIndexTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact(Skip = "GH-45 — WebAppFixture casts IServer to TestServer; cannot boot Kestrel-backed functional fixture")]
+    public async Task Index_Get_RendersDataBrowserLandingWithResolvedStocksLink() {
+        // Drives the full Kestrel + MVC + Razor pipeline against the real app. Catches
+        // regressions in routing, _Layout, the home view, and — crucially — the
+        // asp-action/asp-controller tag helpers on the Stocks button. A broken tag helper
+        // renders href="" with no static check anywhere, so asserting on the resolved href
+        // is the only thing that catches it.
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        var response = await page.GotoAsync("/");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("h1")).ToHaveTextAsync("Equibles");
+
+        var stocksLink = page.Locator("a.btn-primary").First;
+        var href = await stocksLink.GetAttributeAsync("href");
+        href.Should().StartWith("/Stocks",
+            "the Stocks button uses asp-action/asp-controller; a broken tag helper renders href=\"\"");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Playwright-driven functional test for the homepage `/`, covering the data browser's entry point: 200 status, `<h1>Equibles</h1>`, and a Stocks button whose `href` resolves to `/Stocks` (the only check that catches broken `asp-action` / `asp-controller` tag helpers — those render `href=""` with no static gate).
- Currently `[Skip]` — see GH-45. `WebAppFixture` overrides `CreateHost` to use Kestrel but then reads `WebApplicationFactory<T>.Server`, which internally tries to cast the host's `IServer` to `TestServer` and throws. The existing `HealthCheckTests` hits the same exception; the entire functional project is unbootable on `main`. Dropping the `Skip` argument is part of the fix in GH-45.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/HomeIndexTests.cs` — new functional test, skipped pending GH-45. Captures expected homepage shape so it starts catching regressions the moment the fixture is repaired.