### PR TITLE
fix(functional-tests): boot WebAppFixture against real Kestrel

### DIFF
--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -10,89 +10,96 @@ using Microsoft.EntityFrameworkCore;
 using Serilog;
 using Serilog.Events;
 
-var builder = WebApplication.CreateBuilder(args);
+namespace Equibles.Web;
 
-builder.Services.AddSerilog(config => {
-    config.ReadFrom.Configuration(builder.Configuration);
-    var minLevel = builder.Configuration["MinimumLogLevel"];
-    if (!string.IsNullOrEmpty(minLevel) && Enum.TryParse<LogEventLevel>(minLevel, true, out var level)) {
-        config.MinimumLevel.Is(level);
+public partial class Program {
+    public static async Task Main(string[] args) {
+        var builder = WebApplication.CreateBuilder(args);
+        ConfigureServices(builder);
+        var app = builder.Build();
+        await ApplyMigrationsAsync(app);
+        ConfigurePipeline(app);
+        await app.RunAsync();
     }
-});
 
-Equibles.Plugins.PluginLoader.LoadAll();
+    public static void ConfigureServices(WebApplicationBuilder builder) {
+        builder.Services.AddSerilog(config => {
+            config.ReadFrom.Configuration(builder.Configuration);
+            var minLevel = builder.Configuration["MinimumLogLevel"];
+            if (!string.IsNullOrEmpty(minLevel) && Enum.TryParse<LogEventLevel>(minLevel, true, out var level)) {
+                config.MinimumLevel.Is(level);
+            }
+        });
 
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
-builder.Services.AddEquiblesDbContext(connectionString,
-    modules => modules.AddAllModules(),
-    migrationsAssembly: typeof(Equibles.Migrations.DesignTimeDbContextFactory).Assembly);
-builder.Services.AddAllRepositories();
+        Equibles.Plugins.PluginLoader.LoadAll();
 
-builder.Services.AutoWireServicesFrom<Equibles.Errors.BusinessLogic.ErrorManager>();
-builder.Services.AutoWireServicesFrom<Equibles.Web.Services.StockTabService>();
+        var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+        builder.Services.AddEquiblesDbContext(connectionString,
+            modules => modules.AddAllModules(),
+            migrationsAssembly: typeof(Equibles.Migrations.DesignTimeDbContextFactory).Assembly);
+        builder.Services.AddAllRepositories();
 
-var authSettings = builder.Configuration.GetSection("Auth").Get<AuthSettings>() ?? new AuthSettings();
-builder.Services.Configure<AuthSettings>(builder.Configuration.GetSection("Auth"));
+        builder.Services.AutoWireServicesFrom<Equibles.Errors.BusinessLogic.ErrorManager>();
+        builder.Services.AutoWireServicesFrom<Equibles.Web.Services.StockTabService>();
 
-builder.Services.AddAuthentication(EnvAuthHandler.SchemeName)
-    .AddScheme<AuthenticationSchemeOptions, EnvAuthHandler>(EnvAuthHandler.SchemeName, null);
+        var authSettings = builder.Configuration.GetSection("Auth").Get<AuthSettings>() ?? new AuthSettings();
+        builder.Services.Configure<AuthSettings>(builder.Configuration.GetSection("Auth"));
 
-if (authSettings.IsEnabled) {
-    builder.Services.AddAuthorization(options => {
-        options.FallbackPolicy = new AuthorizationPolicyBuilder()
-            .RequireAuthenticatedUser()
-            .Build();
-    });
-} else {
-    builder.Services.AddAuthorization();
-}
+        builder.Services.AddAuthentication(EnvAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, EnvAuthHandler>(EnvAuthHandler.SchemeName, null);
 
-builder.Services.Configure<RouteOptions>(options => {
-    options.LowercaseUrls = true;
-});
+        if (authSettings.IsEnabled) {
+            builder.Services.AddAuthorization(options => {
+                options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                    .RequireAuthenticatedUser()
+                    .Build();
+            });
+        } else {
+            builder.Services.AddAuthorization();
+        }
 
-builder.Services.AddScoped<Equibles.Web.Filters.StatusBadgeFilter>();
-builder.Services.AddControllersWithViews(options => {
-        options.Filters.AddService<Equibles.Web.Filters.StatusBadgeFilter>();
-    })
-    .AddRazorRuntimeCompilation();
+        builder.Services.Configure<RouteOptions>(options => {
+            options.LowercaseUrls = true;
+        });
 
-var keysDirectory = builder.Configuration["DataProtection:KeysDirectory"] ?? "/app/keys";
-builder.Services.AddDataProtection()
-    .PersistKeysToFileSystem(new DirectoryInfo(keysDirectory));
+        builder.Services.AddScoped<Equibles.Web.Filters.StatusBadgeFilter>();
+        builder.Services.AddControllersWithViews(options => {
+                options.Filters.AddService<Equibles.Web.Filters.StatusBadgeFilter>();
+            })
+            .AddRazorRuntimeCompilation();
 
-builder.Services.AddHttpContextAccessor();
-builder.Services.AddSession();
-builder.Services.AddFlashMessage();
-builder.Services.AddHealthChecks();
+        var keysDirectory = builder.Configuration["DataProtection:KeysDirectory"] ?? "/app/keys";
+        builder.Services.AddDataProtection()
+            .PersistKeysToFileSystem(new DirectoryInfo(keysDirectory));
 
-var app = builder.Build();
+        builder.Services.AddHttpContextAccessor();
+        builder.Services.AddSession();
+        builder.Services.AddFlashMessage();
+        builder.Services.AddHealthChecks();
+    }
 
-// Apply pending EF Core migrations on startup (extended timeout for index rebuilds)
-using (var scope = app.Services.CreateScope()) {
-    var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
-    dbContext.Database.SetCommandTimeout(TimeSpan.FromHours(1));
-    await dbContext.Database.MigrateAsync();
-}
+    public static async Task ApplyMigrationsAsync(WebApplication app) {
+        // Extended timeout for index rebuilds.
+        using var scope = app.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
+        dbContext.Database.SetCommandTimeout(TimeSpan.FromHours(1));
+        await dbContext.Database.MigrateAsync();
+    }
 
-if (!app.Environment.IsDevelopment()) {
-    app.UseExceptionHandler("/Home/Error");
-}
+    public static void ConfigurePipeline(WebApplication app) {
+        if (!app.Environment.IsDevelopment()) {
+            app.UseExceptionHandler("/Home/Error");
+        }
 
-app.UseStaticFiles();
-app.UseRouting();
-app.UseSession();
-app.UseAuthentication();
-app.UseAuthorization();
+        app.UseStaticFiles();
+        app.UseRouting();
+        app.UseSession();
+        app.UseAuthentication();
+        app.UseAuthorization();
 
-app.MapHealthChecks("/healthz").AllowAnonymous();
-app.MapControllerRoute(
-    name: "default",
-    pattern: "{controller=Home}/{action=Index}/{id?}");
-
-app.Run();
-
-namespace Equibles.Web {
-    // Exposed for WebApplicationFactory<Equibles.Web.Program> in the functional test project.
-    public partial class Program;
+        app.MapHealthChecks("/healthz").AllowAnonymous();
+        app.MapControllerRoute(
+            name: "default",
+            pattern: "{controller=Home}/{action=Index}/{id?}");
+    }
 }

--- a/tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs
@@ -1,10 +1,6 @@
-using System.Net;
+using Equibles.Web;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.Hosting.Server.Features;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Testcontainers.PostgreSql;
 using Xunit;
 
@@ -15,11 +11,14 @@ namespace Equibles.FunctionalTests.Fixtures;
 /// ParadeDB instance (PostgreSQL + pgvector + pg_search) so EF Core migrations apply against
 /// the same engine as production. One container per fixture; shared across the whole functional
 /// collection to amortise the ~15-30s container boot cost.
+///
+/// Builds the host directly via <see cref="WebApplication.CreateBuilder()"/> rather than
+/// inheriting from <c>WebApplicationFactory&lt;T&gt;</c>. <c>WebApplicationFactory</c> hardcodes
+/// its IServer as a <c>TestServer</c> — accessing its <c>Server</c> or <c>Services</c> property
+/// throws <c>InvalidCastException</c> when the underlying server is Kestrel, so it cannot drive
+/// the real HTTP listener Playwright needs.
 /// </summary>
-public class WebAppFixture : WebApplicationFactory<Equibles.Web.Program>, IAsyncLifetime {
-    // ParadeDB ships PostgreSQL with both `pg_search` and `vector` extensions, which the
-    // initial migration declares via Npgsql:PostgresExtension annotations. Plain postgres images
-    // don't have these and the migration fails on first run.
+public class WebAppFixture : IAsyncLifetime {
     private readonly PostgreSqlContainer _db = new PostgreSqlBuilder()
         .WithImage("paradedb/paradedb:latest")
         .WithDatabase("equibles_functional")
@@ -27,44 +26,62 @@ public class WebAppFixture : WebApplicationFactory<Equibles.Web.Program>, IAsync
         .WithPassword("postgres")
         .Build();
 
+    private WebApplication _app;
+    private string _keysDirectory;
+
     public string BaseUrl { get; private set; }
 
     public async Task InitializeAsync() {
         await _db.StartAsync();
-        // Trigger app build so WebApplicationFactory boots Kestrel and runs migrations.
-        // Reading Server.Features pins the bound URL after Kestrel has chosen its port.
-        var _ = Server;
-        var addresses = Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>();
-        BaseUrl = addresses?.Addresses.FirstOrDefault() ?? throw new InvalidOperationException(
-            "Kestrel did not expose a bound address — IServerAddressesFeature returned no entries.");
-    }
 
-    public new async Task DisposeAsync() {
-        await base.DisposeAsync();
-        await _db.DisposeAsync();
-    }
+        // Per-fixture ephemeral keys directory. The production default (/app/keys) doesn't exist
+        // on dev/CI hosts and would crash AddDataProtection at startup.
+        _keysDirectory = Path.Combine(Path.GetTempPath(), $"equibles-functional-keys-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_keysDirectory);
 
-    protected override IHost CreateHost(IHostBuilder builder) {
-        // Force Kestrel onto a random loopback port. WebApplicationFactory's default in-memory
-        // TestServer can't accept browser traffic; Playwright drives a real browser, so we
-        // need a real socket.
-        builder.ConfigureWebHost(webHost => {
-            webHost.UseUrls("http://127.0.0.1:0");
-            webHost.UseKestrel();
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions {
+            ApplicationName = "Equibles.Web",
+            // Content root must point at the Web project's source dir so Views/, wwwroot/, and
+            // AddRazorRuntimeCompilation can find their files relative to it.
+            ContentRootPath = ResolveWebContentRoot(),
+            EnvironmentName = "Development",
         });
-        return base.CreateHost(builder);
+
+        builder.Configuration["ConnectionStrings:DefaultConnection"] = _db.GetConnectionString();
+        builder.Configuration["DataProtection:KeysDirectory"] = _keysDirectory;
+
+        Program.ConfigureServices(builder);
+        _app = builder.Build();
+        await Program.ApplyMigrationsAsync(_app);
+        Program.ConfigurePipeline(_app);
+
+        _app.Urls.Add("http://127.0.0.1:0");
+        await _app.StartAsync();
+        BaseUrl = _app.Urls.First();
     }
 
-    protected override void ConfigureWebHost(IWebHostBuilder builder) {
-        // Override the production DefaultConnection so EF Core points at the test container.
-        builder.UseSetting("ConnectionStrings:DefaultConnection", _db.GetConnectionString());
+    public async Task DisposeAsync() {
+        if (_app is not null) {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+        await _db.DisposeAsync();
+        if (_keysDirectory is not null && Directory.Exists(_keysDirectory)) {
+            try { Directory.Delete(_keysDirectory, recursive: true); } catch { /* best-effort */ }
+        }
+    }
 
-        // Production Program.cs writes data-protection keys to /app/keys (the container path).
-        // On dev/CI hosts that directory doesn't exist; override to a temp directory per fixture.
-        var keysDir = Path.Combine(Path.GetTempPath(), $"equibles-functional-keys-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(keysDir);
-        builder.UseSetting("DataProtection:KeysDirectory", keysDir);
-
-        builder.UseEnvironment("Development");
+    private static string ResolveWebContentRoot() {
+        // Walk up from the test bin directory until we find Equibles.sln, then resolve the Web
+        // project's source root. Works under both `dotnet test` and `dotnet test --output …`.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Equibles.sln"))) {
+            dir = dir.Parent;
+        }
+        if (dir is null) {
+            throw new InvalidOperationException(
+                "Could not locate Equibles.sln from test bin directory — fixture cannot resolve ContentRootPath.");
+        }
+        return Path.Combine(dir.FullName, "src", "Equibles.Web");
     }
 }

--- a/tests/Equibles.FunctionalTests/Tests/HomeIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HomeIndexTests.cs
@@ -16,7 +16,7 @@ public class HomeIndexTests {
         _playwright = playwright;
     }
 
-    [Fact(Skip = "GH-45 — WebAppFixture casts IServer to TestServer; cannot boot Kestrel-backed functional fixture")]
+    [Fact]
     public async Task Index_Get_RendersDataBrowserLandingWithResolvedStocksLink() {
         // Drives the full Kestrel + MVC + Razor pipeline against the real app. Catches
         // regressions in routing, _Layout, the home view, and — crucially — the
@@ -34,7 +34,8 @@ public class HomeIndexTests {
 
         var stocksLink = page.Locator("a.btn-primary").First;
         var href = await stocksLink.GetAttributeAsync("href");
-        href.Should().StartWith("/Stocks",
+        // Production sets RouteOptions.LowercaseUrls = true, so the resolved href is lowercase.
+        href.Should().StartWith("/stocks",
             "the Stocks button uses asp-action/asp-controller; a broken tag helper renders href=\"\"");
     }
 }


### PR DESCRIPTION
## Summary

- `WebApplicationFactory<T>` wraps whatever `IServer` it finds as a `TestServer` and casts unconditionally — accessing `Server` (or `Services`) throws `InvalidCastException` once the host is Kestrel. The previous fixture overrode `CreateHost` to use Kestrel but still read `Server` to trigger build, blowing up startup. The entire `Equibles.FunctionalTests` project has been failing on every push since PR #34 (the "Functional Tests" CI job has been red).
- Build the `WebApplication` host directly per the `dotnet-testing` skill's recipe instead of inheriting from `WebApplicationFactory`. `Program.cs` now exposes `ConfigureServices`, `ApplyMigrationsAsync`, and `ConfigurePipeline` helpers — production `Main` and the fixture call into the same code so they cannot drift.
- Un-skip `HomeIndexTests` (PR #46). The test now exercises the full Kestrel + MVC + Razor pipeline end-to-end through a real browser. Verified locally: `HealthCheckTests` + `HomeIndexTests` both pass, all 1594 unit tests still pass.

Closes #45.

## Code changes

- `src/Equibles.Web/Program.cs` — converted top-level statements into `partial class Program { Main, ConfigureServices, ApplyMigrationsAsync, ConfigurePipeline }`. No behaviour change in the production startup path; the helpers exist so the fixture can share them.
- `tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs` — rewritten as `IAsyncLifetime` over a self-built `WebApplication` on a random Kestrel port. Resolves `ContentRootPath` by walking up to `Equibles.sln` so Razor runtime compilation and `UseStaticFiles` find the right files. Per-fixture ephemeral data-protection keys directory.
- `tests/Equibles.FunctionalTests/Tests/HomeIndexTests.cs` — dropped `Skip = "GH-45 …"`. Updated the asserted href prefix to `/stocks` (production sets `RouteOptions.LowercaseUrls = true`).