### PR TITLE
test(functional): add tests for StocksIndexPage

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/StocksIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksIndexTests.cs
@@ -1,0 +1,41 @@
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class StocksIndexTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public StocksIndexTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Index_GetWithEmptyDatabase_RendersZeroCountAndSearchForm() {
+        // The /stocks page runs the EF Search query against the real ParadeDB container, paginates,
+        // and renders the result list. The functional fixture seeds no rows, so the test pins the
+        // empty-state shape: 200 status, "Stocks" h1, total count of 0, and a search input named
+        // "search" so the query-string parameter round-trips through asp-for. A renamed parameter
+        // on the controller or a broken tag helper would change the rendered name attribute and
+        // silently break URL-based searching.
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        var response = await page.GotoAsync("/stocks");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("h1")).ToHaveTextAsync("Stocks");
+        await Assertions.Expect(page.Locator("p").Filter(new() { HasTextString = "Browse" }))
+            .ToContainTextAsync("0");
+
+        var searchInput = page.Locator("input[name='search']");
+        await Assertions.Expect(searchInput).ToHaveCountAsync(1);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Playwright-driven functional test for `/stocks`, the data browser's main list page. With no seed rows in the fixture the page should render the empty-state shape: 200 status, `<h1>Stocks</h1>`, total count of 0, and a search input named `search` so the query-string parameter round-trips through `asp-for`.
- Covers the EF Search query, view rendering, pagination wiring, and the tag-helper-driven form-input name. A renamed controller parameter or broken tag helper changes the rendered `name` attribute and silently breaks URL-based searching — this is the only check that catches it.
- Verified locally: passes against the Kestrel-backed `WebAppFixture` (PR #47) + a fresh ParadeDB container in under a second.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/StocksIndexTests.cs` — new functional test class with one `[Fact]` exercising `/stocks` end-to-end through a real browser.