### PR TITLE
test(functional): add tests for HomeErrorPage

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/HomeErrorTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HomeErrorTests.cs
@@ -1,0 +1,34 @@
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class HomeErrorTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public HomeErrorTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Error_GetWith404_ReturnsNotFoundStatusAndPageNotFoundCopy() {
+        // HomeController.Error sets Response.StatusCode from the route value and switches
+        // ViewData["Title"]/["Description"] on the same value. This pins the 404 branch:
+        // both the wire status and the rendered copy must match the switch arms. A regression
+        // that returns 500 by default or strips the switch would only surface here.
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        var response = await page.GotoAsync("/home/error/404");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(404);
+
+        await Assertions.Expect(page.Locator("h1")).ToHaveTextAsync("Page Not Found");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Playwright functional test for `/home/error/404`. Drives the endpoint through Kestrel and asserts both the wire-level status (`Response.StatusCode = 404`) and the rendered copy (`<h1>Page Not Found</h1>` from the controller's status-code switch).
- A regression that defaults to 500, strips a switch arm, or breaks the `_Layout`/`Home/Error.cshtml` view would not surface in unit tests — the response code is set on the real `HttpContext` and the title comes from `ViewData` on the rendered view. This is the only check that catches both at once.
- Verified locally: passes against the Kestrel-backed `WebAppFixture` + ParadeDB container in under a second.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/HomeErrorTests.cs` — new functional test class with one `[Fact]` exercising the `/home/error/{statusCode}` action end-to-end for the 404 branch.