### PR TITLE
test(functional): add tests for CftcIndexPage

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/CftcIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/CftcIndexTests.cs
@@ -1,0 +1,38 @@
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class CftcIndexTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public CftcIndexTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Index_GetWithEmptyCftcData_RendersFuturesHeaderAndZeroCategoriesDescription() {
+        // CftcController.Index queries every CftcContract, groups by Category, and joins each row
+        // with the latest CftcPositionReport. The view interpolates Categories.Sum/Count into the
+        // description. With no seed rows, the group-by yields zero categories and zero contracts —
+        // and the description text must reflect that without nulling out. Catches view regressions
+        // where the Sum/Count over an empty IEnumerable wouldn't survive a missing null-guard, or
+        // a category enum's NameForHumans is invoked before the empty check.
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        var response = await page.GotoAsync("/futures");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("h1")).ToHaveTextAsync("Futures");
+        await Assertions.Expect(page.Locator("p").Filter(new() { HasTextString = "contracts from" }))
+            .ToContainTextAsync("0 contracts from");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Playwright functional test for `/futures` against the empty fixture database. Pins the empty-state shape — 200 status, `Futures` h1, and a description paragraph containing `0 contracts from` (the view's `Categories.Sum/Count` aggregate must yield zero on an empty group-by, not throw or render `null`).
- Catches view-rendering regressions where a missing null-guard around the empty IEnumerable, or a premature `NameForHumans` call on a non-existent category, would surface as a YSOD when the system has no CFTC data yet.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/CftcIndexTests.cs` — new functional test class with one `[Fact]` exercising the `/futures` action end-to-end against an empty database.