### PR TITLE
test(functional): add tests for StatusIndexPage

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/StatusIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StatusIndexTests.cs
@@ -1,0 +1,37 @@
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class StatusIndexTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public StatusIndexTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Index_GetWithEmptyData_RendersSystemStatusHeaderAndAutoRefreshControls() {
+        // StatusController.Index composes worker statuses, MCP key state, and the recent-errors
+        // list. With no workers registered and no errors in the database the page must still
+        // render the header and the auto-refresh control surface — both are static UI scaffolding
+        // that depend on the view model being non-null. A regression that throws on Workers.Count
+        // or RecentErrors enumeration (because some sub-collection was null instead of empty)
+        // would surface here, not in any unit test.
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        var response = await page.GotoAsync("/status");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("h1")).ToHaveTextAsync("System Status");
+        await Assertions.Expect(page.Locator("[data-status-interval='5']")).ToHaveCountAsync(1);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Playwright functional test for `/status` against the empty fixture (no workers registered, no errors in the DB). Pins the static scaffolding — 200 status, `System Status` h1, and the auto-refresh `5s` interval button present (the JS-driven control surface every dashboard view ships with).
- Catches regressions where `Workers.Count` or `RecentErrors` enumeration would NRE on an unexpectedly null sub-collection — a failure unit tests don't surface because they pre-populate the view model.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/StatusIndexTests.cs` — new functional test class with one `[Fact]` exercising the `/status` action end-to-end against an empty database.