### PR TITLE
test(functional): add tests for EconomicDataIndexPage

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/EconomicDataIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/EconomicDataIndexTests.cs
@@ -1,0 +1,38 @@
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class EconomicDataIndexTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public EconomicDataIndexTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Index_GetWithEmptyFredData_RendersEconomicDataHeaderAndZeroIndicatorsDescription() {
+        // EconomicDataController.Index queries every FredSeries, groups by Category, and joins each
+        // series with its latest observation. The view interpolates Categories.Sum(Series.Count)
+        // and Categories.Count into the description. With no seed rows both aggregates must yield
+        // 0 — not throw on a nested empty Sum. Catches view regressions where a premature
+        // NameForHumans on a missing category, or a missing null-guard on the latest-observation
+        // join, would only surface on a clean install with no FRED data yet.
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        var response = await page.GotoAsync("/economicdata");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("h1")).ToHaveTextAsync("Economic Data");
+        await Assertions.Expect(page.Locator("p").Filter(new() { HasTextString = "indicators from" }))
+            .ToContainTextAsync("0 indicators from");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Playwright functional test for `/economicdata` against the empty fixture (no FRED series, no observations). Pins the empty-state shape — 200 status, `Economic Data` h1, and a description containing `0 indicators from` (the nested `Categories.Sum(Series.Count)` aggregate must yield zero on an empty group-by, not throw).
- Catches view regressions where a premature `NameForHumans` on a missing category, or a null-unguarded latest-observation join, would only surface on a clean install with no FRED data yet.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/EconomicDataIndexTests.cs` — new functional test class with one `[Fact]` exercising the `/economicdata` action end-to-end against an empty database.