### PR TITLE
test(functional): add tests for CftcShowPage not-found path

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/CftcShowTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/CftcShowTests.cs
@@ -1,0 +1,33 @@
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class CftcShowTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public CftcShowTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Show_GetWithUnknownMarketCode_Returns404() {
+        // CftcController.Show has two not-found branches: empty/whitespace marketCode, and a
+        // valid code that doesn't match any contract. With no seed rows, every code falls into
+        // the second branch. This test pins the wire-level NotFound contract — a regression
+        // that returns a 200 with an empty view (e.g., a controller refactor that drops the
+        // null-check on the contract lookup) would only surface here.
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        var response = await page.GotoAsync("/futures/NOT_A_REAL_MARKET_CODE");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(404);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Playwright functional test for `/futures/{marketCode}` driving a non-existent market code against the empty fixture. Pins the wire-level 404 contract — `CftcController.Show`'s null-check on the contract lookup must return `NotFound`, not 200 with an empty view.
- Distinct from the CftcIndex test (covers the list page); this one exercises the parameterised detail route and its missing-entity branch — a refactor that drops the null-guard would silently render an empty page and only surface here.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/CftcShowTests.cs` — new functional test class with one `[Fact]` exercising `/futures/{marketCode}` with an unknown code.