### PR TITLE
feat(functional-tests): add seedable WebAppFixture via Respawn

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -80,6 +80,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageVersion Include="Testcontainers" Version="4.8.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.8.0" />
+    <PackageVersion Include="Respawn" Version="6.2.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.5" />
   </ItemGroup>
 </Project>

--- a/tests/Equibles.FunctionalTests/Equibles.FunctionalTests.csproj
+++ b/tests/Equibles.FunctionalTests/Equibles.FunctionalTests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Playwright" />
     <PackageReference Include="Testcontainers" />
     <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Respawn" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs
@@ -1,6 +1,10 @@
+using Equibles.Data;
 using Equibles.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Respawn;
 using Testcontainers.PostgreSql;
 using Xunit;
 
@@ -17,6 +21,11 @@ namespace Equibles.FunctionalTests.Fixtures;
 /// its IServer as a <c>TestServer</c> — accessing its <c>Server</c> or <c>Services</c> property
 /// throws <c>InvalidCastException</c> when the underlying server is Kestrel, so it cannot drive
 /// the real HTTP listener Playwright needs.
+///
+/// Tests that need pre-existing data call <see cref="ResetAndSeedAsync"/> from their
+/// constructor — xUnit creates a fresh test class instance per test, so per-test isolation
+/// is automatic. Respawn truncates every user table in <c>public</c> between calls while
+/// keeping the migration history intact.
 /// </summary>
 public class WebAppFixture : IAsyncLifetime {
     private readonly PostgreSqlContainer _db = new PostgreSqlBuilder()
@@ -28,8 +37,16 @@ public class WebAppFixture : IAsyncLifetime {
 
     private WebApplication _app;
     private string _keysDirectory;
+    private Respawner _respawner;
 
     public string BaseUrl { get; private set; }
+
+    /// <summary>
+    /// Application root services. Use a scope (<c>Services.CreateScope()</c>) before resolving
+    /// scoped dependencies like <see cref="EquiblesDbContext"/>; never resolve them directly
+    /// from this provider.
+    /// </summary>
+    public IServiceProvider Services => _app.Services;
 
     public async Task InitializeAsync() {
         await _db.StartAsync();
@@ -58,6 +75,19 @@ public class WebAppFixture : IAsyncLifetime {
         _app.Urls.Add("http://127.0.0.1:0");
         await _app.StartAsync();
         BaseUrl = _app.Urls.First();
+
+        // Respawn snapshots the schema's user tables once and replays a TRUNCATE on every reset.
+        // Limit to the public schema so ParadeDB's pg_search / pgvector internal tables are not
+        // touched. The migrations history table is excluded so EF Core doesn't replay migrations
+        // on every test. Respawn's string overload defaults to SqlClient — for Postgres we open
+        // an explicit NpgsqlConnection and pass it through.
+        await using var respawnConnection = new NpgsqlConnection(_db.GetConnectionString());
+        await respawnConnection.OpenAsync();
+        _respawner = await Respawner.CreateAsync(respawnConnection, new RespawnerOptions {
+            DbAdapter = DbAdapter.Postgres,
+            SchemasToInclude = ["public"],
+            TablesToIgnore = [new Respawn.Graph.Table("__EFMigrationsHistory")],
+        });
     }
 
     public async Task DisposeAsync() {
@@ -69,6 +99,31 @@ public class WebAppFixture : IAsyncLifetime {
         if (_keysDirectory is not null && Directory.Exists(_keysDirectory)) {
             try { Directory.Delete(_keysDirectory, recursive: true); } catch { /* best-effort */ }
         }
+    }
+
+    /// <summary>
+    /// Truncates all user tables in <c>public</c> via Respawn, then runs <paramref name="seed"/>
+    /// against a fresh <see cref="EquiblesDbContext"/> scope. The seed delegate receives an
+    /// attached DbContext — add entities and the method will call <c>SaveChangesAsync</c> for
+    /// you. Pass <c>null</c> (or omit) to reset without seeding.
+    ///
+    /// Call this from the test class constructor so each test starts from a known state. xUnit
+    /// instantiates the class once per test, so seeding does not leak across tests in the same
+    /// class.
+    /// </summary>
+    public async Task ResetAndSeedAsync(Func<EquiblesDbContext, Task> seed = null) {
+        // Same Postgres caveat as fixture init — Respawn's string overload defaults to SqlClient.
+        await using (var resetConnection = new NpgsqlConnection(_db.GetConnectionString())) {
+            await resetConnection.OpenAsync();
+            await _respawner.ResetAsync(resetConnection);
+        }
+
+        if (seed is null) return;
+
+        using var scope = _app.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
+        await seed(dbContext);
+        await dbContext.SaveChangesAsync();
     }
 
     private static string ResolveWebContentRoot() {

--- a/tests/Equibles.FunctionalTests/Tests/CftcIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/CftcIndexTests.cs
@@ -24,6 +24,7 @@ public class CftcIndexTests {
         // and the description text must reflect that without nulling out. Catches view regressions
         // where the Sum/Count over an empty IEnumerable wouldn't survive a missing null-guard, or
         // a category enum's NameForHumans is invoked before the empty check.
+        await _web.ResetAndSeedAsync();   // guarantee empty DB regardless of test ordering
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
 
         var response = await page.GotoAsync("/futures");

--- a/tests/Equibles.FunctionalTests/Tests/EconomicDataIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/EconomicDataIndexTests.cs
@@ -24,6 +24,7 @@ public class EconomicDataIndexTests {
         // 0 — not throw on a nested empty Sum. Catches view regressions where a premature
         // NameForHumans on a missing category, or a missing null-guard on the latest-observation
         // join, would only surface on a clean install with no FRED data yet.
+        await _web.ResetAndSeedAsync();   // guarantee empty DB regardless of test ordering
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
 
         var response = await page.GotoAsync("/economicdata");

--- a/tests/Equibles.FunctionalTests/Tests/MarketIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/MarketIndexTests.cs
@@ -24,6 +24,7 @@ public class MarketIndexTests {
         // header renders, the Put/Call Ratios card shows the table shell (every enum value gets
         // a row even with no data), and the response is 200 — not the YSOD that would surface a
         // missing null-coalesce in the view.
+        await _web.ResetAndSeedAsync();   // guarantee empty DB regardless of test ordering
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
 
         var response = await page.GotoAsync("/market");

--- a/tests/Equibles.FunctionalTests/Tests/StatusIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StatusIndexTests.cs
@@ -24,6 +24,7 @@ public class StatusIndexTests {
         // that depend on the view model being non-null. A regression that throws on Workers.Count
         // or RecentErrors enumeration (because some sub-collection was null instead of empty)
         // would surface here, not in any unit test.
+        await _web.ResetAndSeedAsync();   // guarantee empty DB regardless of test ordering
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
 
         var response = await page.GotoAsync("/status");

--- a/tests/Equibles.FunctionalTests/Tests/StocksIndexSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksIndexSeededTests.cs
@@ -1,0 +1,46 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class StocksIndexSeededTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public StocksIndexSeededTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Index_GetWithSeededStock_RendersTickerAndCountOne() {
+        // Smoke test for WebAppFixture.ResetAndSeedAsync — proves the seed delegate's writes
+        // are visible to the running app's DbContext (same connection, same schema) and that
+        // Respawn doesn't accidentally truncate them between the seed call and the HTTP request.
+        // Stocks/Index runs CommonStockRepository.Search, which queries the live DB; a single
+        // seeded row must appear in the rendered list.
+        await _web.ResetAndSeedAsync(async db => {
+            db.Add(new CommonStock {
+                Ticker = "AAPL",
+                Name = "Apple Inc.",
+                Cik = "0000320193",
+            });
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/stocks");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("p").Filter(new() { HasTextString = "Browse" }))
+            .ToContainTextAsync("1 US common stocks");
+        await Assertions.Expect(page.Locator("text=AAPL")).ToBeVisibleAsync();
+    }
+}

--- a/tests/Equibles.FunctionalTests/Tests/StocksIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksIndexTests.cs
@@ -24,6 +24,7 @@ public class StocksIndexTests {
         // "search" so the query-string parameter round-trips through asp-for. A renamed parameter
         // on the controller or a broken tag helper would change the rendered name attribute and
         // silently break URL-based searching.
+        await _web.ResetAndSeedAsync();   // guarantee empty DB regardless of test ordering
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
 
         var response = await page.GotoAsync("/stocks");


### PR DESCRIPTION
## Summary

- Adds the infrastructure to functionally test data-bound pages. The existing `WebAppFixture` booted a real ParadeDB container but exposed no `DbContext` access, so every functional test asserted only against empty-state shape. Pages like `StocksController.Show`, holdings/insider/congressional tabs, document viewer, etc. were unreachable.
- `WebAppFixture` now exposes `Services` (application root provider) and a `ResetAndSeedAsync(Func<EquiblesDbContext, Task>)` helper. Respawn truncates every user table in `public` between resets while preserving the EF migration history; the seed delegate then runs against a fresh scoped DbContext with `SaveChangesAsync` handled for you.
- Existing empty-state tests now call `ResetAndSeedAsync()` with no seed so they remain green regardless of test ordering — the collection-shared fixture amortises the ~15-30s container boot but tests no longer leak state to each other.
- `StocksIndexSeededTests` ships as a working example: seeds an `AAPL` `CommonStock`, navigates `/stocks`, and asserts the rendered list shows the seeded ticker and a count of 1. Verified locally — all 11 functional tests pass.

## Code changes

- `Directory.Packages.props` — pin `Respawn 6.2.1` centrally.
- `tests/Equibles.FunctionalTests/Equibles.FunctionalTests.csproj` — reference `Respawn`.
- `tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs` — expose `Services`; create the `Respawner` against an `NpgsqlConnection` (the string overload defaults to SqlClient and aborts for Postgres) limited to the `public` schema, ignoring `__EFMigrationsHistory`; add `ResetAndSeedAsync` that truncates + invokes the seed delegate + saves.
- `tests/Equibles.FunctionalTests/Tests/StocksIndexSeededTests.cs` — new smoke test demonstrating the seed path.
- `tests/Equibles.FunctionalTests/Tests/{Stocks,Market,Cftc,Status,EconomicData}IndexTests.cs` — call `ResetAndSeedAsync()` at the top of each empty-state test so they survive a test ordering that seeds first.