### PR TITLE
test(functional): add tests for StocksHoldingsPage empty-state

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/StocksHoldingsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksHoldingsTests.cs
@@ -1,0 +1,45 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class StocksHoldingsTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public StocksHoldingsTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Holdings_GetForSeededStockWithNoHoldings_RendersNoHoldingsDataEmptyState() {
+        // /stocks/{ticker}/holdings runs StockTabService.LoadHoldingsTab against the seeded
+        // stock. With no InstitutionalHolding rows, AvailableDates is empty and the view takes
+        // the explicit empty-state branch ("No Holdings Data"). This pins both the route +
+        // LoadStock lookup AND the empty-state copy — distinct from StocksPriceTests, which
+        // does not have an empty-state branch (a no-prices chart still renders).
+        await _web.ResetAndSeedAsync(async db => {
+            db.Add(new CommonStock {
+                Ticker = "AAPL",
+                Name = "Apple Inc.",
+                Cik = "0000320193",
+            });
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/stocks/aapl/holdings");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("h3").Filter(new() { HasTextString = "No Holdings Data" }))
+            .ToHaveCountAsync(1);
+    }
+}


### PR DESCRIPTION
## Summary

- Seeds a single `CommonStock`, hits `/stocks/aapl/holdings`, pins the empty-state branch: 200 status + the explicit `No Holdings Data` h3 from `_HoldingsTab.cshtml`. Exercises `StockTabService.LoadHoldingsTab` against an empty `InstitutionalHolding` table where `AvailableDates` comes back empty.
- Distinct from `StocksPriceTests` — the price tab has no explicit empty branch (no-prices renders the same blank chart), so the regression surface is different. A refactor that drops the `AvailableDates.Count == 0` guard would silently render the date selector with no options instead of the empty-state card; only a rendered-view check catches that.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/StocksHoldingsTests.cs` — new functional test class with one `[Fact]` seeding a `CommonStock` and asserting the empty-state h3.