### PR TITLE
test(functional): add tests for StocksDocumentsPage empty-state

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/StocksDocumentsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksDocumentsTests.cs
@@ -1,0 +1,46 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class StocksDocumentsTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public StocksDocumentsTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Documents_GetForSeededStockWithNoDocuments_RendersNoDocumentsAvailableEmptyState() {
+        // /stocks/{ticker}/documents goes through LoadStock + StockTabService.LoadDocumentsTab,
+        // which queries DocumentRepository.GetByCompany. With no Document rows the view takes
+        // the empty-state branch. Pins the explicit 'No Documents Available' h3 — distinct from
+        // the Insider/Holdings/Congressional empty-states because it covers SEC filings + earnings
+        // transcripts, a different repository join (DocumentRepository, not InsiderTransaction or
+        // CongressionalTrade).
+        await _web.ResetAndSeedAsync(async db => {
+            db.Add(new CommonStock {
+                Ticker = "AAPL",
+                Name = "Apple Inc.",
+                Cik = "0000320193",
+            });
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/stocks/aapl/documents");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("h3").Filter(new() { HasTextString = "No Documents Available" }))
+            .ToHaveCountAsync(1);
+    }
+}


### PR DESCRIPTION
## Summary

- Seeds a single `CommonStock`, hits `/stocks/aapl/documents`, pins the empty-state branch: 200 status + the `No Documents Available` h3 from `_DocumentsTab.cshtml`.
- Exercises `LoadStock` + `StockTabService.LoadDocumentsTab` (`DocumentRepository.GetByCompany`). Completes the per-tab empty-state coverage for the Stocks detail page alongside Holdings, InsiderTrading, and CongressionalTrades.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/StocksDocumentsTests.cs` — new functional test class with one `[Fact]` seeding a stock and asserting the empty-state h3.