### PR TITLE
test(benchmarks): add TechnicalIndicatorServiceRsiBenchmarks

### DIFF
--- a/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceRsiBenchmarks.cs
+++ b/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceRsiBenchmarks.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using Equibles.Web.Services;
+
+namespace Equibles.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Per-stock cost of <see cref="TechnicalIndicatorService.ComputeRsi"/>. RSI sits on the same
+/// per-chart-render hot path as MACD (already covered by <see cref="TechnicalIndicatorServiceBenchmarks"/>),
+/// but its allocation shape is different — two pre-sized <see cref="decimal"/> arrays for the
+/// gain/loss series, no nested EMA recurrence — so its cost should be tracked on its own.
+/// The price fixture matches the MACD benchmark byte-for-byte so the two numbers are
+/// directly comparable across commits.
+/// </summary>
+[MemoryDiagnoser]
+public class TechnicalIndicatorServiceRsiBenchmarks {
+    private const int PriceCount = 1_008;
+    private List<decimal> _prices;
+
+    [GlobalSetup]
+    public void Setup() {
+        // Identical shape to TechnicalIndicatorServiceBenchmarks: ~4 trading years of slow
+        // drift plus a sinusoidal component. Flat input would push every change to zero and
+        // hit the avgLoss == 0 branch every step; pure random would make cross-commit deltas
+        // dominated by noise.
+        _prices = new List<decimal>(PriceCount);
+        for (var i = 0; i < PriceCount; i++) {
+            var drift = i * 0.05m;
+            var wave = (decimal)Math.Sin(i / 12.0) * 3m;
+            _prices.Add(100m + drift + wave);
+        }
+    }
+
+    [Benchmark]
+    public int ComputeRsi() => TechnicalIndicatorService.ComputeRsi(_prices).Count;
+}


### PR DESCRIPTION
## Summary

- Adds a sibling benchmark for `TechnicalIndicatorService.ComputeRsi` alongside the existing MACD benchmark.
- Both indicators run on the per-chart-render hot path, but RSI's allocation shape is different (two pre-sized decimal arrays for the gain/loss series, no nested EMA recurrence) and worth tracking on its own.

## Code changes

- `tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceRsiBenchmarks.cs` — new `[MemoryDiagnoser]` benchmark `ComputeRsi`. Uses the same 1,008-day drift + sinusoidal price fixture as the existing MACD benchmark byte-for-byte, so the two numbers compare directly across commits. Dry-run reports ~5 ms / ~55 KB allocations on this hardware.