### PR TITLE
test(functional): add tests for StocksFtdPage empty-state

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/StocksFtdTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksFtdTests.cs
@@ -1,0 +1,45 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class StocksFtdTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public StocksFtdTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Ftd_GetForSeededStockWithNoFails_RendersNoFailsToDeliverDataEmptyState() {
+        // /stocks/{ticker}/ftd goes through LoadStock + StockTabService.LoadFtdTab, which queries
+        // FailToDeliverRepository.GetByStock. With no FailToDeliver rows the view takes the
+        // empty-state branch. Pins the explicit 'No Fails to Deliver Data' h3 — distinct from
+        // the other Stocks-detail tab empty-states because it covers FINRA fails-to-deliver
+        // (a separate repository + view than holdings/insider/congressional/documents).
+        await _web.ResetAndSeedAsync(async db => {
+            db.Add(new CommonStock {
+                Ticker = "AAPL",
+                Name = "Apple Inc.",
+                Cik = "0000320193",
+            });
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/stocks/aapl/ftd");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("h3").Filter(new() { HasTextString = "No Fails to Deliver Data" }))
+            .ToHaveCountAsync(1);
+    }
+}


### PR DESCRIPTION
## Summary

- Seeds a single `CommonStock`, hits `/stocks/aapl/ftd`, pins the empty-state branch: 200 + the `No Fails to Deliver Data` h3 from `_FtdTab.cshtml`.
- Exercises `LoadStock` + `StockTabService.LoadFtdTab` against an empty `FailToDeliverRepository.GetByStock` result. Distinct from the other detail-tab empty-states because FINRA fails-to-deliver uses a separate repository and view.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/StocksFtdTests.cs` — new functional test class with one `[Fact]`.