### PR TITLE
test(benchmarks): add TechnicalIndicatorServiceEmaBenchmarks

### DIFF
--- a/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceEmaBenchmarks.cs
+++ b/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceEmaBenchmarks.cs
@@ -1,0 +1,36 @@
+using BenchmarkDotNet.Attributes;
+using Equibles.Web.Services;
+
+namespace Equibles.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Per-stock cost of <see cref="TechnicalIndicatorService.ComputeEma"/>. EMA is the building
+/// block <see cref="TechnicalIndicatorService.ComputeMacd"/> composes three times (fast EMA,
+/// slow EMA, signal EMA over the difference), so having a standalone EMA number alongside the
+/// already-benchmarked MACD lets us reason about how that composition cost decomposes — if EMA
+/// regresses, MACD will regress; if MACD regresses but EMA doesn't, the diff is in the glue.
+/// Price fixture matches the MACD and RSI benchmarks byte-for-byte for direct cost comparison
+/// across all three indicators.
+/// </summary>
+[MemoryDiagnoser]
+public class TechnicalIndicatorServiceEmaBenchmarks {
+    private const int PriceCount = 1_008;
+    private const int Period = 26;
+    private List<decimal> _prices;
+
+    [GlobalSetup]
+    public void Setup() {
+        // Identical shape to TechnicalIndicatorServiceBenchmarks/TechnicalIndicatorServiceRsiBenchmarks:
+        // ~4 trading years of slow drift plus a sinusoidal component. The 26-period matches
+        // MACD's slow EMA, so this benchmark measures one of the exact instances MACD composes.
+        _prices = new List<decimal>(PriceCount);
+        for (var i = 0; i < PriceCount; i++) {
+            var drift = i * 0.05m;
+            var wave = (decimal)Math.Sin(i / 12.0) * 3m;
+            _prices.Add(100m + drift + wave);
+        }
+    }
+
+    [Benchmark]
+    public int ComputeEma() => TechnicalIndicatorService.ComputeEma(_prices, Period).Count;
+}


### PR DESCRIPTION
## Summary

- Adds a standalone benchmark for `TechnicalIndicatorService.ComputeEma` to complete the indicator-family coverage (MACD and RSI already benchmarked).
- EMA is the building block MACD composes three times (fast, slow, signal), so an isolated EMA number lets us decompose regression signals — if EMA regresses, MACD will too; if MACD moves but EMA does not, the delta is in the glue.

## Code changes

- `tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceEmaBenchmarks.cs` — new `[MemoryDiagnoser]` benchmark `ComputeEma`. Uses the same 1,008-day drift + sinusoidal price fixture as MACD and RSI byte-for-byte; period = 26 to match MACD's slow EMA. Dry-run reports ~2.8 ms on this hardware.