### PR TITLE
test(mcp): add tests for SimpleApiKeyValidator key-rejection path

### DIFF
--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\src\Equibles.Core\Equibles.Core.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Data\Equibles.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Mcp\Equibles.Mcp.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Mcp.Server\Equibles.Mcp.Server.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.Common\Equibles.Integrations.Common.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Sec.Data\Equibles.Sec.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Sec.BusinessLogic\Equibles.Sec.BusinessLogic.csproj" />

--- a/tests/Equibles.UnitTests/Mcp/SimpleApiKeyValidatorTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/SimpleApiKeyValidatorTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Mcp.Server;
+using Microsoft.Extensions.Configuration;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class SimpleApiKeyValidatorTests {
+    [Fact]
+    public async Task IsValid_EnabledWithMismatchedKey_ReturnsFalse() {
+        // The validator hashes the configured key on construction and compares
+        // it to the hashed candidate via FixedTimeEquals. Pin the rejection
+        // path so a regression that bypasses the comparison (or swaps the
+        // equality direction) can't silently accept arbitrary tokens.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { ["McpApiKey"] = "correct-secret" })
+            .Build();
+        var sut = new SimpleApiKeyValidator(config);
+
+        var result = await sut.IsValid("wrong-secret");
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the security guarantee that a mismatched MCP API key is rejected by `SimpleApiKeyValidator` — a regression that bypasses or inverts the SHA-256 + `FixedTimeEquals` check would silently authenticate arbitrary tokens, and the file currently has no test coverage.
- Adds a project reference from `Equibles.UnitTests` to `Equibles.Mcp.Server` so the validator can be exercised in the unit-test tier.

## Code changes

- `tests/Equibles.UnitTests/Mcp/SimpleApiKeyValidatorTests.cs` — new unit test `IsValid_EnabledWithMismatchedKey_ReturnsFalse`: constructs the validator with a configured `McpApiKey` and asserts a different candidate is rejected.
- `tests/Equibles.UnitTests/Equibles.UnitTests.csproj` — adds `ProjectReference` to `Equibles.Mcp.Server` so its types are visible from the unit-test project.