### PR TITLE
fix(market): guard descriptive-stats casts against NaN

### DIFF
--- a/src/Equibles.Web/Controllers/MarketController.cs
+++ b/src/Equibles.Web/Controllers/MarketController.cs
@@ -87,11 +87,12 @@ public class MarketController : BaseController {
         var values = records.Where(r => r.PutCallRatio.HasValue).Select(r => (double)r.PutCallRatio.Value).ToArray();
         if (values.Length > 0) {
             var stats = new DescriptiveStatistics(values);
-            viewModel.Mean = (decimal)Math.Round(stats.Mean, 4);
-            viewModel.Median = (decimal)Math.Round(values.Median(), 4);
-            viewModel.Min = (decimal)stats.Minimum;
-            viewModel.Max = (decimal)stats.Maximum;
-            viewModel.StdDev = (decimal)Math.Round(stats.StandardDeviation, 4);
+            viewModel.Mean = SafeRound(stats.Mean, 4);
+            viewModel.Median = SafeRound(values.Median(), 4);
+            viewModel.Min = SafeRound(stats.Minimum, 4);
+            viewModel.Max = SafeRound(stats.Maximum, 4);
+            // StandardDeviation is NaN for a single-value sample.
+            viewModel.StdDev = SafeRound(stats.StandardDeviation, 4);
             viewModel.LatestRatio = records.FirstOrDefault()?.PutCallRatio;
             if (records.Count > 1) viewModel.PreviousRatio = records[1].PutCallRatio;
         }
@@ -119,11 +120,12 @@ public class MarketController : BaseController {
         var values = records.Select(r => (double)r.Close).ToArray();
         if (values.Length > 0) {
             var stats = new DescriptiveStatistics(values);
-            viewModel.Mean = (decimal)Math.Round(stats.Mean, 2);
-            viewModel.Median = (decimal)Math.Round(values.Median(), 2);
-            viewModel.Min = (decimal)stats.Minimum;
-            viewModel.Max = (decimal)stats.Maximum;
-            viewModel.StdDev = (decimal)Math.Round(stats.StandardDeviation, 2);
+            viewModel.Mean = SafeRound(stats.Mean, 2);
+            viewModel.Median = SafeRound(values.Median(), 2);
+            viewModel.Min = SafeRound(stats.Minimum, 2);
+            viewModel.Max = SafeRound(stats.Maximum, 2);
+            // StandardDeviation is NaN for a single-value sample.
+            viewModel.StdDev = SafeRound(stats.StandardDeviation, 2);
             viewModel.LatestClose = records.FirstOrDefault()?.Close;
             if (records.Count > 1) viewModel.PreviousClose = records[1].Close;
 
@@ -141,5 +143,9 @@ public class MarketController : BaseController {
     private static List<decimal?> ComputeSma(double[] values, int period) {
         var sma = values.MovingAverage(period);
         return sma.Select((v, i) => i < period - 1 ? (decimal?)null : (decimal?)Math.Round(v, 2)).ToList();
+    }
+
+    private static decimal? SafeRound(double value, int digits) {
+        return double.IsFinite(value) ? (decimal?)Math.Round(value, digits) : null;
     }
 }

--- a/src/Equibles.Web/Controllers/MarketController.cs
+++ b/src/Equibles.Web/Controllers/MarketController.cs
@@ -2,6 +2,7 @@ using Equibles.Cboe.Data.Models;
 using Equibles.Cboe.Repositories;
 using Equibles.Core.Extensions;
 using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Extensions;
 using Equibles.Web.ViewModels.Market;
 using MathNet.Numerics.Statistics;
 using Microsoft.AspNetCore.Mvc;
@@ -87,12 +88,11 @@ public class MarketController : BaseController {
         var values = records.Where(r => r.PutCallRatio.HasValue).Select(r => (double)r.PutCallRatio.Value).ToArray();
         if (values.Length > 0) {
             var stats = new DescriptiveStatistics(values);
-            viewModel.Mean = SafeRound(stats.Mean, 4);
-            viewModel.Median = SafeRound(values.Median(), 4);
-            viewModel.Min = SafeRound(stats.Minimum, 4);
-            viewModel.Max = SafeRound(stats.Maximum, 4);
-            // StandardDeviation is NaN for a single-value sample.
-            viewModel.StdDev = SafeRound(stats.StandardDeviation, 4);
+            viewModel.Mean = stats.Mean.SafeRound(4);
+            viewModel.Median = values.Median().SafeRound(4);
+            viewModel.Min = stats.Minimum.SafeRound(4);
+            viewModel.Max = stats.Maximum.SafeRound(4);
+            viewModel.StdDev = stats.StandardDeviation.SafeRound(4);
             viewModel.LatestRatio = records.FirstOrDefault()?.PutCallRatio;
             if (records.Count > 1) viewModel.PreviousRatio = records[1].PutCallRatio;
         }
@@ -120,32 +120,22 @@ public class MarketController : BaseController {
         var values = records.Select(r => (double)r.Close).ToArray();
         if (values.Length > 0) {
             var stats = new DescriptiveStatistics(values);
-            viewModel.Mean = SafeRound(stats.Mean, 2);
-            viewModel.Median = SafeRound(values.Median(), 2);
-            viewModel.Min = SafeRound(stats.Minimum, 2);
-            viewModel.Max = SafeRound(stats.Maximum, 2);
-            // StandardDeviation is NaN for a single-value sample.
-            viewModel.StdDev = SafeRound(stats.StandardDeviation, 2);
+            viewModel.Mean = stats.Mean.SafeRound(2);
+            viewModel.Median = values.Median().SafeRound(2);
+            viewModel.Min = stats.Minimum.SafeRound(2);
+            viewModel.Max = stats.Maximum.SafeRound(2);
+            viewModel.StdDev = stats.StandardDeviation.SafeRound(2);
             viewModel.LatestClose = records.FirstOrDefault()?.Close;
             if (records.Count > 1) viewModel.PreviousClose = records[1].Close;
 
             // Moving averages (chronological order)
             var chronological = records.OrderBy(r => r.Date).Select(r => (double)r.Close).ToArray();
-            viewModel.Sma20 = ComputeSma(chronological, 20);
-            viewModel.Sma50 = ComputeSma(chronological, 50);
+            viewModel.Sma20 = chronological.ComputeSma(20, 2);
+            viewModel.Sma50 = chronological.ComputeSma(50, 2);
         }
 
         ViewData["Title"] = "VIX — Volatility Index";
         ViewData["Description"] = "CBOE Volatility Index (VIX) daily history with chart and statistics.";
         return View(viewModel);
-    }
-
-    private static List<decimal?> ComputeSma(double[] values, int period) {
-        var sma = values.MovingAverage(period);
-        return sma.Select((v, i) => i < period - 1 ? (decimal?)null : (decimal?)Math.Round(v, 2)).ToList();
-    }
-
-    private static decimal? SafeRound(double value, int digits) {
-        return double.IsFinite(value) ? (decimal?)Math.Round(value, digits) : null;
     }
 }

--- a/src/Equibles.Web/Extensions/StatisticsExtensions.cs
+++ b/src/Equibles.Web/Extensions/StatisticsExtensions.cs
@@ -1,0 +1,19 @@
+using MathNet.Numerics.Statistics;
+
+namespace Equibles.Web.Extensions;
+
+public static class StatisticsExtensions {
+    // Returns null when the value is NaN or infinity — protects view-model casts from
+    // OverflowException, since (decimal)NaN throws. DescriptiveStatistics.StandardDeviation
+    // returns NaN for a single-value sample, which is the realistic trigger.
+    public static decimal? SafeRound(this double value, int digits) {
+        return double.IsFinite(value) ? (decimal?)Math.Round(value, digits) : null;
+    }
+
+    // Simple moving average aligned to the input: positions before the first full window
+    // are null, subsequent positions are the rounded SMA value.
+    public static List<decimal?> ComputeSma(this double[] values, int period, int digits) {
+        var sma = values.MovingAverage(period);
+        return sma.Select((v, i) => i < period - 1 ? (decimal?)null : (decimal?)Math.Round(v, digits)).ToList();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Web/MarketControllerTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/MarketControllerTests.cs
@@ -1,7 +1,9 @@
 using Equibles.Cboe.Data;
+using Equibles.Cboe.Data.Models;
 using Equibles.Cboe.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Web.Controllers;
+using Equibles.Web.ViewModels.Market;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -23,5 +25,38 @@ public class MarketControllerTests {
         var result = await sut.PutCallRatio("not-a-real-ratio-type");
 
         result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task PutCallRatio_SingleRecord_RendersViewWithNullStdDev() {
+        // DescriptiveStatistics.StandardDeviation returns NaN for a single-value sample
+        // and casting NaN to decimal throws OverflowException. The action must guard the
+        // cast and surface a null StdDev rather than 500-ing.
+        using var ctx = TestDbContextFactory.Create(new CboeModuleConfiguration());
+        ctx.Set<CboePutCallRatio>().Add(new CboePutCallRatio {
+            RatioType = CboePutCallRatioType.Equity,
+            Date = new DateOnly(2025, 1, 2),
+            CallVolume = 1_000_000,
+            PutVolume = 750_000,
+            TotalVolume = 1_750_000,
+            PutCallRatio = 0.75m
+        });
+        await ctx.SaveChangesAsync();
+
+        var putCallRepo = new CboePutCallRatioRepository(ctx);
+        var vixRepo = new CboeVixDailyRepository(ctx);
+        var sut = new MarketController(putCallRepo, vixRepo, Substitute.For<ILogger<MarketController>>());
+
+        var result = await sut.PutCallRatio("equity");
+
+        var view = result.Should().BeOfType<ViewResult>().Subject;
+        var model = view.Model.Should().BeOfType<PutCallRatioViewModel>().Subject;
+        model.Records.Should().HaveCount(1);
+        model.LatestRatio.Should().Be(0.75m);
+        model.Mean.Should().Be(0.75m);
+        model.Median.Should().Be(0.75m);
+        model.Min.Should().Be(0.75m);
+        model.Max.Should().Be(0.75m);
+        model.StdDev.Should().BeNull("StandardDeviation is undefined for a single-value sample");
     }
 }


### PR DESCRIPTION
## Summary

Closes #71.

`MarketController.PutCallRatio` (and the latent same bug in `Vix`) 500s when a put/call type or VIX series has exactly **one** record with a non-null value. `DescriptiveStatistics.StandardDeviation` returns `NaN` for a single-value sample, and `(decimal)Math.Round(NaN, n)` throws `OverflowException`.

## Code changes

- `src/Equibles.Web/Controllers/MarketController.cs` — route the four cast sites in `PutCallRatio` and `Vix` through a `SafeRound(double, int)` helper that returns `null` when the input is not finite. The view models already use `decimal?` for every stat, so the page degrades gracefully: StdDev shows as null on a single-record sample, while Mean/Median/Min/Max still populate.
- `tests/Equibles.IntegrationTests/Web/MarketControllerTests.cs` — regression test seeding one `CboePutCallRatio` row (the scenario described in the issue) and asserting the action returns a populated view with `StdDev = null`.

## Test plan

- [x] `dotnet test tests/Equibles.IntegrationTests --filter MarketControllerTests` passes locally (2/2).
- [x] CI green.