### PR TITLE
test(mcp): add tests for ShortDataTools unknown-ticker path

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
@@ -1,0 +1,37 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.Finra.Data;
+using Equibles.Finra.Mcp.Tools;
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+public class ShortDataToolsTests {
+    [Fact]
+    public async Task GetShortVolume_UnknownTicker_ReturnsStockNotFoundMessage() {
+        // ShortDataTools must short-circuit when the ticker doesn't match any stock —
+        // otherwise the subsequent `GetHistoryByStock(null)` call dereferences the
+        // missing entity and the tool returns the generic McpToolExecutor error
+        // string, masking the real (user-facing) "stock not found" feedback. Pinning
+        // the early-return path keeps the MCP client message specific.
+        using var ctx = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new FinraModuleConfiguration(),
+            new ErrorsModuleConfiguration());
+        var stockRepo = new CommonStockRepository(ctx);
+        var shortVolumeRepo = new DailyShortVolumeRepository(ctx);
+        var shortInterestRepo = new ShortInterestRepository(ctx);
+        var errorManager = new ErrorManager(new ErrorRepository(ctx));
+        var sut = new ShortDataTools(shortVolumeRepo, shortInterestRepo, stockRepo, errorManager, Substitute.For<ILogger<ShortDataTools>>());
+
+        var result = await sut.GetShortVolume("ZZZZ");
+
+        result.Should().Be("Stock 'ZZZZ' not found.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test coverage for `ShortDataTools` (FINRA MCP tools) by pinning the user-facing `Stock '{ticker}' not found.` early-return path on `GetShortVolume`.
- Without this short-circuit the tool would dereference `null` inside `GetHistoryByStock` and surface the generic `McpToolExecutor` error instead of the specific message, silently degrading the MCP client experience.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs` — new integration test `GetShortVolume_UnknownTicker_ReturnsStockNotFoundMessage`. Uses `TestDbContextFactory` with `CommonStocks`, `Finra`, and `Errors` module configurations, mirrors the existing `FailToDeliverToolsTests` pattern.