### PR TITLE
test(mcp): add tests for StockPriceTools 25-ticker abuse cap

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs
@@ -1,0 +1,37 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Mcp.Tools;
+using Equibles.Yahoo.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+public class StockPriceToolsTests {
+    [Fact]
+    public async Task GetLatestPrices_OverMaxTickers_ReturnsLimitMessage() {
+        // GetLatestPrices runs one DB lookup per ticker — without an upper bound an
+        // agent could trigger a 25× amplification by passing a long ticker list. The
+        // tool short-circuits at >25 with a user-facing instruction to split. Pin
+        // the limit so a regression that removes it (or bumps it silently) can't
+        // turn this endpoint into a database-amplification DoS vector.
+        using var ctx = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new YahooModuleConfiguration(),
+            new ErrorsModuleConfiguration());
+        var stockRepo = new CommonStockRepository(ctx);
+        var priceRepo = new DailyStockPriceRepository(ctx);
+        var errorManager = new ErrorManager(new ErrorRepository(ctx));
+        var sut = new StockPriceTools(priceRepo, stockRepo, errorManager, Substitute.For<ILogger<StockPriceTools>>());
+
+        var tickers = string.Join(",", Enumerable.Range(1, 26).Select(i => $"T{i:D3}"));
+        var result = await sut.GetLatestPrices(tickers);
+
+        result.Should().Be("Maximum 25 tickers per request. Please split into multiple calls.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test coverage for `StockPriceTools` (Yahoo MCP tools) by pinning the `GetLatestPrices` defensive guard that rejects requests with more than 25 tickers.
- The method runs one DB lookup per ticker, so without the cap an agent could trigger 25× amplification per call. A regression that silently removes or bumps the limit turns this endpoint into a DB-amplification vector for MCP clients.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs` — new integration test `GetLatestPrices_OverMaxTickers_ReturnsLimitMessage`. Builds a 26-ticker comma-separated input and asserts the exact user-facing limit message. Uses `TestDbContextFactory` with `CommonStocks`, `Yahoo`, and `Errors` modules; mirrors the existing MCP-tool integration-test pattern.