### PR TITLE
test(mcp): add tests for CftcTools unknown-contract discovery hint

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/CftcToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CftcToolsTests.cs
@@ -1,0 +1,33 @@
+using Equibles.Cftc.Data;
+using Equibles.Cftc.Mcp.Tools;
+using Equibles.Cftc.Repositories;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+public class CftcToolsTests {
+    [Fact]
+    public async Task GetCftcPositioning_UnknownContract_ReturnsNotFoundMessageWithSearchHint() {
+        // The unknown-contract message specifically points at SearchCftcMarkets so an
+        // MCP client knows how to discover the right market code when the supplied one
+        // doesn't match. CFTC codes are opaque (e.g., "067651" = Crude Oil) — without
+        // the cross-reference, an MCP client has no path to recover from a typo.
+        // Pin the exact message so a refactor can't drop the discovery hint.
+        using var ctx = TestDbContextFactory.Create(
+            new CftcModuleConfiguration(),
+            new ErrorsModuleConfiguration());
+        var contractRepo = new CftcContractRepository(ctx);
+        var reportRepo = new CftcPositionReportRepository(ctx);
+        var errorManager = new ErrorManager(new ErrorRepository(ctx));
+        var sut = new CftcTools(contractRepo, reportRepo, errorManager, Substitute.For<ILogger<CftcTools>>());
+
+        var result = await sut.GetCftcPositioning("999999");
+
+        result.Should().Be("Contract '999999' not found. Use SearchCftcMarkets to find available contracts.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test coverage for `CftcTools` (CFTC MCP tools) by pinning the `GetCftcPositioning` unknown-contract message that cross-references `SearchCftcMarkets` as the recovery path.
- CFTC market codes are opaque (e.g., `067651` = Crude Oil), so without the discovery hint an MCP client stranded on a typo has no way to find a valid code. Pin the exact wording so a refactor can't drop the cross-reference.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/CftcToolsTests.cs` — new integration test `GetCftcPositioning_UnknownContract_ReturnsNotFoundMessageWithSearchHint`. Uses `TestDbContextFactory` with `Cftc` and `Errors` modules; mirrors the existing MCP-tool integration-test pattern.