### PR TITLE
test(mcp): add tests for CboeTools invalid-type enumeration

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/CboeToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CboeToolsTests.cs
@@ -1,0 +1,33 @@
+using Equibles.Cboe.Data;
+using Equibles.Cboe.Mcp.Tools;
+using Equibles.Cboe.Repositories;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+public class CboeToolsTests {
+    [Fact]
+    public async Task GetPutCallRatios_InvalidType_ReturnsErrorWithValidTypesList() {
+        // The invalid-type message hard-codes the list of accepted enum values
+        // ("Total, Equity, Index, Vix, Etp"). When CboePutCallRatioType gains a
+        // new variant, this string must be updated in lockstep — without a pin
+        // an MCP client sees a stale enumeration and can't discover the new
+        // type. Lock the exact message so a drift forces a deliberate change.
+        using var ctx = TestDbContextFactory.Create(
+            new CboeModuleConfiguration(),
+            new ErrorsModuleConfiguration());
+        var putCallRepo = new CboePutCallRatioRepository(ctx);
+        var vixRepo = new CboeVixDailyRepository(ctx);
+        var errorManager = new ErrorManager(new ErrorRepository(ctx));
+        var sut = new CboeTools(putCallRepo, vixRepo, errorManager, Substitute.For<ILogger<CboeTools>>());
+
+        var result = await sut.GetPutCallRatios(type: "Bogus");
+
+        result.Should().Be("Invalid type 'Bogus'. Valid types: Total, Equity, Index, Vix, Etp");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test coverage for `CboeTools` (CBOE MCP tools) by pinning the `GetPutCallRatios` invalid-type error message that hard-codes the accepted `CboePutCallRatioType` values.
- When the enum gains a new variant this string must be updated in lockstep. Without a pin, an MCP client sees a stale enumeration and can't discover the new type — a real drift risk because the enum and the message live in different files.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/CboeToolsTests.cs` — new integration test `GetPutCallRatios_InvalidType_ReturnsErrorWithValidTypesList`. Uses `TestDbContextFactory` with `Cboe` and `Errors` modules; mirrors the existing MCP-tool integration-test pattern.