### PR TITLE
test(integration): add tests for HoldingsParsingHelper SEC date parsing

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class HoldingsParsingHelperTests {
+    [Fact]
+    public void TryParseDateOnly_SecDdMmmYyyyFormat_ParsesCorrectlyAfterIsoLegRejects() {
+        // 13F SUBMISSION.tsv routinely emits dates in SEC's classic `dd-MMM-yyyy` form
+        // (`30-SEP-2024`) — not the ISO format `DateOnly.TryParse` natively recognises. The
+        // parser tries the ISO leg first, falls back to `dd-MMM-yyyy` (invariant culture),
+        // and only then gives up. If the fallback ever regresses (e.g. someone removes it
+        // thinking ISO is enough, or the invariant-culture parse switches to ordinal-month
+        // matching), the entire 13F import silently drops every submission row because
+        // PERIODOFREPORT/FILING_DATE parses to `default(DateOnly)`.
+        //
+        // This `[Fact]` exercises the SEC-format leg specifically with an uppercase month
+        // abbreviation — that's what real SEC TSVs ship — and asserts the resulting DateOnly
+        // matches the calendar date. Uses September because no other 3-letter month
+        // abbreviation collides with it; if the parser accidentally matched on prefix or did
+        // something culture-sensitive (e.g. Portuguese "Set"), the test would catch it.
+
+        var success = HoldingsParsingHelper.TryParseDateOnly("30-SEP-2024", out var result);
+
+        success.Should().BeTrue();
+        result.Should().Be(new DateOnly(2024, 9, 30));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `HoldingsParsingHelper`, the static parsing helper bundle used by `HoldingsImportService` to lift fields out of 13F SUBMISSION.tsv / COVERPAGE.tsv / INFOTABLE.tsv rows. Targets `TryParseDateOnly` because it carries the SEC-specific `dd-MMM-yyyy` fallback that nothing else exercises — `DateOnly.TryParse` covers ISO out of the box, but a regression on the fallback would silently default every 13F submission row's `PeriodOfReport` and `FilingDate` to `default(DateOnly)`, taking the whole import down with no exception.
- One `[Fact]` proves the SEC leg with an uppercase month abbreviation (`30-SEP-2024`) — that's what real SEC TSVs ship — and asserts the resulting `DateOnly` matches the calendar date. September is chosen deliberately: no other 3-letter month prefix collides with `SEP` and Portuguese/other-culture matches on `Set` would not equal `SEP`, so a culture-sensitive accident would surface here.
- Pinning this dual-format guarantee here means a future refactor (e.g. removing the fallback because "ISO covers everything now") will fail loudly instead of dropping submissions silently.

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs` — new test file. Single `[Fact]` (`TryParseDateOnly_SecDdMmmYyyyFormat_ParsesCorrectlyAfterIsoLegRejects`). Uses the existing `Equibles.IntegrationTests` ↔ `Equibles.Holdings.HostedService` `InternalsVisibleTo` to call the `internal static` method on the `internal static class`.