### PR TITLE
fix(ci): drop pinned LogFileName so multi-project TRX results merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,11 @@ jobs:
 
       - name: Test
         # Functional tests need Playwright + a ParadeDB container and live in functional.yml.
-        run: dotnet test Equibles.sln --no-build -c Release --filter "Category!=Functional" --logger "trx;LogFileName=results.trx" --collect:"XPlat Code Coverage" --settings coverage.runsettings --results-directory ./coverage
+        # Do not pin LogFileName: with multiple test projects in the sln, a fixed
+        # filename makes each project overwrite the previous TRX so only the last
+        # project's results survive. Letting dotnet test auto-name produces one
+        # TRX per project for dorny/test-reporter's coverage/**/*.trx glob.
+        run: dotnet test Equibles.sln --no-build -c Release --filter "Category!=Functional" --logger trx --collect:"XPlat Code Coverage" --settings coverage.runsettings --results-directory ./coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary

The Test Results check showed **854** tests after the test-project refactor (#79), but the repo actually has 1,500+. Root cause: `.github/workflows/ci.yml` passed `--logger "trx;LogFileName=results.trx"` to `dotnet test Equibles.sln`. With three test projects (UnitTests, IntegrationTests, FunctionalTests-filtered-out) all writing to the same `coverage/results.trx`, each project overwrote the previous one — only the last project's results survived. Before the refactor there was a single `Equibles.Tests` project so the bug was invisible.

## Code changes

- `.github/workflows/ci.yml` — replace `--logger "trx;LogFileName=results.trx"` with `--logger trx` so each project gets its own auto-named TRX in the shared results directory. `dorny/test-reporter`'s existing `coverage/**/*.trx` glob already handles multiple files. Comment added inline explaining why `LogFileName` must not be pinned.

`functional.yml` is unaffected — it runs a single test project so the fixed filename is safe.

## Test plan

- [ ] CI green on this PR.
- [ ] Test Results check on this PR reports ~1,500+ tests rather than ~854.