### PR TITLE
test(integrations): add tests for CboeClient CSV date-skip rule

### DIFF
--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -75,6 +75,7 @@
     <ProjectReference Include="..\..\src\Equibles.Cftc.Repositories\Equibles.Cftc.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cboe.Data\Equibles.Cboe.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cboe.Repositories\Equibles.Cboe.Repositories.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Integrations.Cboe\Equibles.Integrations.Cboe.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Equibles.UnitTests/Integrations/CboeClientTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Equibles.Integrations.Cboe;
+using Equibles.Integrations.Cboe.Models;
+
+namespace Equibles.UnitTests.Integrations;
+
+/// <summary>
+/// Tests for <see cref="CboeClient"/>. The public entry points hit cdn.cboe.com,
+/// so we exercise the pure-logic private CSV parser via reflection.
+/// </summary>
+public class CboeClientTests {
+    private static readonly MethodInfo ParsePutCallCsvMethod = typeof(CboeClient)
+        .GetMethod("ParsePutCallCsv", BindingFlags.NonPublic | BindingFlags.Static);
+
+    [Fact]
+    public void ParsePutCallCsv_RowWithUnparseableDate_IsSkipped() {
+        // The CBOE CSV occasionally carries narrative rows ("Disclaimer:...") between
+        // the header and real data. ParsePutCallCsv must skip any row whose first
+        // field doesn't match the MM/dd/yyyy exact-format date. If a regression
+        // loosened TryParseExact (e.g. switched to TryParse), narrative rows would
+        // be parsed as DateTime.MinValue and silently flood the database with junk
+        // ratio records. Pin the skip path on a non-date row.
+        var csv = "Date,Call Volume,Put Volume,Total Volume,P/C Ratio\n" +
+                  "Disclaimer: data provided by CBOE,,,,\n" +
+                  "01/15/2025,100000,80000,200000,0.80\n";
+
+        var records = (List<CboePutCallRecord>)ParsePutCallCsvMethod.Invoke(null, [csv]);
+
+        records.Should().ContainSingle()
+            .Which.Date.Should().Be(new DateOnly(2025, 1, 15));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test coverage for `CboeClient` by pinning the `ParsePutCallCsv` rule that skips rows whose first field isn't a valid `MM/dd/yyyy` date.
- CBOE occasionally publishes narrative rows (`Disclaimer:...`) between the header and real data. If `TryParseExact` were loosened to `TryParse`, those rows would parse as `DateTime.MinValue` and silently flood the put/call table with junk records — a stealth data-quality regression no other test would catch.
- Adds a `ProjectReference` from `Equibles.UnitTests` to `Equibles.Integrations.Cboe` so the client types are visible to the unit-test project.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CboeClientTests.cs` — new unit test `ParsePutCallCsv_RowWithUnparseableDate_IsSkipped`. Invokes the private static parser via reflection.
- `tests/Equibles.UnitTests/Equibles.UnitTests.csproj` — adds `ProjectReference` to `Equibles.Integrations.Cboe`.