### PR TITLE
test(integrations): add tests for CftcClient quoted-comma CSV split

### DIFF
--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -76,6 +76,7 @@
     <ProjectReference Include="..\..\src\Equibles.Cboe.Data\Equibles.Cboe.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cboe.Repositories\Equibles.Cboe.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.Cboe\Equibles.Integrations.Cboe.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Integrations.Cftc\Equibles.Integrations.Cftc.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Equibles.UnitTests/Integrations/CftcClientTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientTests.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Equibles.Integrations.Cftc;
+
+namespace Equibles.UnitTests.Integrations;
+
+/// <summary>
+/// Tests for <see cref="CftcClient"/>. The public entry point downloads ZIPs from
+/// cftc.gov, so we exercise the pure-logic private CSV splitter via reflection.
+/// </summary>
+public class CftcClientTests {
+    private static readonly MethodInfo SplitCsvLineMethod = typeof(CftcClient)
+        .GetMethod("SplitCsvLine", BindingFlags.NonPublic | BindingFlags.Static);
+
+    [Fact]
+    public void SplitCsvLine_QuotedFieldWithEmbeddedComma_KeepsFieldIntact() {
+        // CFTC market names routinely contain commas (e.g. the market name
+        // "WHEAT-SRW - CHICAGO BOARD OF TRADE, CBOT"). The split must honour
+        // double quotes and keep the comma-bearing field as one cell —
+        // otherwise every subsequent column shifts by one, the column-index
+        // map mislabels OpenInterest, NonCommLong, etc., and the importer
+        // writes silently-mismatched numbers to the COT table. Pin the
+        // quoted-comma case so a regression in the inQuotes state machine
+        // can't slip in.
+        var line = "first,\"two, with comma\",third";
+
+        var fields = (string[])SplitCsvLineMethod.Invoke(null, [line]);
+
+        fields.Should().Equal("first", "two, with comma", "third");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test coverage for `CftcClient` by pinning the `SplitCsvLine` behavior on quoted fields with embedded commas.
- CFTC market names routinely contain commas (e.g. `"WHEAT-SRW - CHICAGO BOARD OF TRADE, CBOT"`). If the `inQuotes` state machine regressed, every subsequent column would shift by one — the column-index map would mislabel `OpenInterest`, `NonCommLong`, etc., and the importer would silently persist mismatched numbers to the COT table.
- Adds a `ProjectReference` from `Equibles.UnitTests` to `Equibles.Integrations.Cftc` so the client types are visible.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CftcClientTests.cs` — new unit test `SplitCsvLine_QuotedFieldWithEmbeddedComma_KeepsFieldIntact`. Invokes the private static helper via reflection.
- `tests/Equibles.UnitTests/Equibles.UnitTests.csproj` — adds `ProjectReference` to `Equibles.Integrations.Cftc`.