### PR TITLE
test(integration): add tests for HoldingsParsingHelper DFND discretion mapping

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs
@@ -24,4 +24,20 @@ public class HoldingsParsingHelperTests {
         success.Should().BeTrue();
         result.Should().Be(new DateOnly(2024, 9, 30));
     }
+
+    [Fact]
+    public void ParseInvestmentDiscretion_DfndAbbreviation_ReturnsDefined() {
+        // 13F INFOTABLE.tsv encodes the discretion column as a four-character SEC
+        // abbreviation: SOLE / DFND / OTR. The first two map 1:1 (`Sole`, `Other`) but `DFND`
+        // is the surprising one — it expands to `Defined`, not `Default` (a developer
+        // refactoring the parser by autocomplete is far more likely to type `Default`).
+        // Pinning this here means a rename that flips the mapping silently — every 13F row
+        // with `INVESTMENTDISCRETION=DFND` would land on the fallback (`Sole`) and the
+        // entire defined-discretion fleet would misrepresent — fails loudly instead. The
+        // production reading runs through `value?.ToUpperInvariant()` first, so the
+        // assertion uses uppercase to match what real SEC TSVs ship.
+        var result = HoldingsParsingHelper.ParseInvestmentDiscretion("DFND");
+
+        result.Should().Be(Equibles.Holdings.Data.Models.InvestmentDiscretion.Defined);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a second `[Fact]` to `HoldingsParsingHelperTests`, this time covering `ParseInvestmentDiscretion`. Of the three SEC abbreviations the parser maps (`SOLE`, `DFND`, `OTR`), only `DFND` → `Defined` is non-obvious — a developer refactoring by autocomplete is far more likely to type `Default` than `Defined`. Pinning this mapping protects every 13F-HR row whose `INVESTMENTDISCRETION` is `DFND` from silently falling through to the `Sole` default and being misrepresented in the holdings ingestion.
- One `[Fact]` exercises the `DFND` branch in isolation, mirroring the file's existing convention for the `dd-MMM-yyyy` date fallback (cover one surprising leg, leave the obvious ones alone).
- Both legs of the parser run input through `ToUpperInvariant()` first; the assertion uses `DFND` (already uppercase) to match what real SEC TSVs ship.

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs` — appends a single `[Fact]` (`ParseInvestmentDiscretion_DfndAbbreviation_ReturnsDefined`). No other changes; the existing `TryParseDateOnly_SecDdMmmYyyyFormat_ParsesCorrectlyAfterIsoLegRejects` is untouched.