### PR TITLE
test(cftc): add tests for CftcImportService legacy date format

### DIFF
--- a/tests/Equibles.UnitTests/Cftc/CftcImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Cftc/CftcImportServiceTests.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using Equibles.Cftc.HostedService.Services;
+
+namespace Equibles.UnitTests.Cftc;
+
+/// <summary>
+/// Tests for <see cref="CftcImportService"/>. The public entry point pulls ZIPs from
+/// cftc.gov and writes to the database, so we exercise the pure-logic private
+/// date parser via reflection.
+/// </summary>
+public class CftcImportServiceTests {
+    private static readonly MethodInfo ParseDateMethod = typeof(CftcImportService)
+        .GetMethod("ParseDate", BindingFlags.NonPublic | BindingFlags.Static);
+
+    [Fact]
+    public void ParseDate_LegacyYyMmDdFormat_Parses() {
+        // CFTC history files mix two date encodings: modern "Report_Date_as_YYYY-MM-DD"
+        // and legacy "As_of_Date_In_Form_YYMMDD". ParseDate must fall back to the
+        // legacy yyMMdd format after the yyyy-MM-dd attempt — without the fallback,
+        // every historical row that only carries the legacy date silently parses as
+        // null and gets dropped by the importer. Pin the legacy path so a refactor
+        // that removes it doesn't lose decades of COT history.
+        var result = (DateOnly?)ParseDateMethod.Invoke(null, ["250115"]);
+
+        result.Should().Be(new DateOnly(2025, 1, 15));
+    }
+}

--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -77,6 +77,7 @@
     <ProjectReference Include="..\..\src\Equibles.Cboe.Repositories\Equibles.Cboe.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.Cboe\Equibles.Integrations.Cboe.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.Cftc\Equibles.Integrations.Cftc.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Cftc.HostedService\Equibles.Cftc.HostedService.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Adds the first test coverage for `CftcImportService` by pinning the `ParseDate` legacy-format fallback (`yyMMdd`).
- CFTC history files mix two date columns: modern `Report_Date_as_YYYY-MM-DD` and legacy `As_of_Date_In_Form_YYMMDD`. Without the fallback, every historical row that only carries the legacy date silently parses as `null` and gets dropped by the importer — a stealth data-loss regression no other test would catch.
- Adds a `ProjectReference` from `Equibles.UnitTests` to `Equibles.Cftc.HostedService` so the service is visible to the unit-test project.

## Code changes

- `tests/Equibles.UnitTests/Cftc/CftcImportServiceTests.cs` — new unit test `ParseDate_LegacyYyMmDdFormat_Parses`. Invokes the private static helper via reflection.
- `tests/Equibles.UnitTests/Equibles.UnitTests.csproj` — adds `ProjectReference` to `Equibles.Cftc.HostedService`.