### PR TITLE
test(integration): add tests for SecEdgarClient Form 4 filing filter

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/SecEdgarClientTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/SecEdgarClientTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Equibles.Integrations.Sec;
+using Equibles.Integrations.Sec.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -37,6 +38,52 @@ public class SecEdgarClientTests {
         companies[0].Cik.Should().Be("1652044");
         companies[0].Name.Should().Be("Alphabet Inc.");
         companies[0].Tickers.Should().Equal("GOOGL", "GOOG");
+    }
+
+    [Fact]
+    public async Task GetCompanyFilings_DocumentTypeFilterFormFour_KeepsOnlyForm4FilingsFromRecentList() {
+        // The SEC `submissions/CIK{n}.json` payload returns filings as parallel column-arrays
+        // (`form`, `accessionNumber`, `filingDate`, …) mixing every form type the company has
+        // ever filed. Insider-trading ingestion only wants Form 4 filings out of that bag.
+        // GetCompanyFilings runs the SEC payload through MapToFilingData → FilterFilings,
+        // where the form filter compares against `DocumentTypeFilter.FormFour.GetFormName()` —
+        // which goes through `[Display(Name = "4")]` reflection on the enum value. A
+        // regression in any of those three layers (column zip, reflection-based form-name
+        // lookup, equality check) would either drop the Form 4 row or smuggle in the 10-K /
+        // 13F-HR neighbours. This `[Fact]` pins exactly that path: three mixed-type filings
+        // in `recent`, one of them Form 4, only the Form 4 survives the filter — and the
+        // returned `FilingData.Form` is the SEC string `"4"`, not `"FormFour"` (the C#
+        // enum name) — distinguishing the display-name leg from the value leg.
+        var json = """
+            {
+              "cik": "1234567",
+              "name": "Test Co",
+              "filings": {
+                "recent": {
+                  "accessionNumber": ["0001-24-000001", "0001-24-000002", "0001-24-000003"],
+                  "filingDate":      ["2024-03-15",     "2024-03-20",     "2024-03-25"],
+                  "reportDate":      ["2024-03-14",     "2023-12-31",     "2023-12-31"],
+                  "form":            ["4",              "10-K",           "13F-HR"],
+                  "primaryDocument": ["wf-form4.xml",   "tenk.htm",       "13fhr.xml"],
+                  "primaryDocDescription": ["",         "",               ""]
+                },
+                "files": []
+              }
+            }
+            """;
+
+        var handler = new ScriptedHandler(json);
+        var httpClient = new HttpClient(handler);
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { ["Sec:ContactEmail"] = "test@example.com" })
+            .Build();
+        var sut = new SecEdgarClient(httpClient, Substitute.For<ILogger<SecEdgarClient>>(), config);
+
+        var filings = await sut.GetCompanyFilings("1234567", documentType: DocumentTypeFilter.FormFour);
+
+        filings.Should().ContainSingle();
+        filings[0].Form.Should().Be("4");
+        filings[0].AccessionNumber.Should().Be("0001-24-000001");
     }
 
     private sealed class ScriptedHandler : HttpMessageHandler {


### PR DESCRIPTION
## Summary

- Adds a second `[Fact]` to `SecEdgarClientTests`. The first one covered `GetActiveCompanies` (company-tickers JSON); this one covers the much hotter path: `GetCompanyFilings` with a `DocumentTypeFilter`.
- The Form 4 filter is the entry point for insider-trading ingestion — `InsiderTradingFilingProcessor` only runs on filings that survive this filter. Three layers can silently break it: the SEC payload is parallel column-arrays so `MapToFilingData` has to zip them correctly; the form filter compares `f.Form` against `DocumentTypeFilter.FormFour.GetFormName()`, which goes through `[Display(Name = "4")]` reflection on the enum value; the equality check is a plain string compare. The fact pins all three at once by mixing a Form 4 row in with a 10-K and a 13F-HR and asserting only the Form 4 survives.
- Asserts the surviving filing's `Form` is `"4"` (the SEC display name), not `"FormFour"` (the C# enum name) — that distinguishes the display-name leg from the value leg of the reflection lookup.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/SecEdgarClientTests.cs` — appends a single `[Fact]` (`GetCompanyFilings_DocumentTypeFilterFormFour_KeepsOnlyForm4FilingsFromRecentList`) and adds `using Equibles.Integrations.Sec.Models;` to reach `DocumentTypeFilter`. Reuses the existing `ScriptedHandler` for the HTTP mock, mirroring the file's existing convention.