### PR TITLE
test(plugins): add tests for PluginLoader defensive catch

### DIFF
--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -77,6 +77,7 @@
     <ProjectReference Include="..\..\src\Equibles.Cboe.Repositories\Equibles.Cboe.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.Cboe\Equibles.Integrations.Cboe.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.Cftc\Equibles.Integrations.Cftc.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Plugins\Equibles.Plugins.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Equibles.UnitTests/Plugins/PluginLoaderTests.cs
+++ b/tests/Equibles.UnitTests/Plugins/PluginLoaderTests.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Equibles.Plugins;
+
+namespace Equibles.UnitTests.Plugins;
+
+/// <summary>
+/// Tests for <see cref="PluginLoader"/>. The public <c>LoadAll</c> entry point caches
+/// statically and walks <c>AppContext.BaseDirectory</c>, so we exercise the pure-logic
+/// private metadata probe via reflection.
+/// </summary>
+public class PluginLoaderTests {
+    private static readonly MethodInfo HasPluginAttributeMethod = typeof(PluginLoader)
+        .GetMethod("HasPluginAttribute", BindingFlags.NonPublic | BindingFlags.Static);
+
+    [Fact]
+    public void HasPluginAttribute_NonExistentFile_ReturnsFalse() {
+        // PluginLoader walks every DLL in AppContext.BaseDirectory. Native libraries,
+        // permission-blocked files, and DLLs deleted between Directory.GetFiles and
+        // the metadata read are all real failure modes — the defensive try/catch
+        // around the PE-reader path is the only thing preventing one bad file from
+        // crashing the whole plugin-discovery pass at startup. Pin the
+        // exception-swallowing contract on a path that does not exist so a refactor
+        // can't narrow the catch (or remove it) without a test failure.
+        var nonExistent = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.dll");
+
+        var result = (bool)HasPluginAttributeMethod.Invoke(null, [nonExistent]);
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test coverage for `PluginLoader` by pinning `HasPluginAttribute` on a non-existent path: returns false without throwing.
- `PluginLoader` walks every DLL in `AppContext.BaseDirectory` at startup. The defensive `try/catch` around the PE-reader path is the only thing preventing one bad file — native library, permission-blocked, or deleted mid-scan — from crashing the entire plugin-discovery pass and bringing down app startup.
- Adds a `ProjectReference` from `Equibles.UnitTests` to `Equibles.Plugins` so `PluginLoader` is visible to the unit-test project.

## Code changes

- `tests/Equibles.UnitTests/Plugins/PluginLoaderTests.cs` — new unit test `HasPluginAttribute_NonExistentFile_ReturnsFalse`. Invokes the private static helper via reflection.
- `tests/Equibles.UnitTests/Equibles.UnitTests.csproj` — adds `ProjectReference` to `Equibles.Plugins`.