### PR TITLE
fix(test): wait for first worker cycle instead of 100ms blind delay

### DIFF
--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerTests.cs
@@ -130,10 +130,13 @@ public class BaseScraperWorkerTests {
     [Fact]
     public async Task ExecuteAsync_LogsStartAndCompletionMessages() {
         using var worker = CreateWorker();
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 
         await worker.StartAsync(cts.Token);
-        await Task.Delay(100);
+        // Wait until at least one full cycle has executed rather than a blind delay —
+        // a 100ms wait races on slow CI runners where ExecuteAsync may not be scheduled
+        // before the assertion runs, even though DoWork eventually fires.
+        await WaitUntilAsync(() => worker.DoWorkCallCount >= 1, TimeSpan.FromSeconds(2));
         await worker.StopAsync(CancellationToken.None);
 
         // "running at" log on start of each cycle
@@ -153,6 +156,14 @@ public class BaseScraperWorkerTests {
             Arg.Any<Exception?>(),
             Arg.Any<Func<object, Exception?, string>>()
         );
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout) {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline) {
+            if (condition()) return;
+            await Task.Delay(10);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

`ExecuteAsync_LogsStartAndCompletionMessages` failed intermittently on Linux CI (PR #101 build is the most recent example: https://github.com/daniel3303/Equibles/runs/75671221306) because it used `Task.Delay(100)` to let the `BackgroundService` run before asserting on logger receipts. On a loaded runner that 100ms isn't always enough for `ExecuteAsync`'s first iteration to fire, so the assertion sees no matching `Log<Object>(Information, ..., "running at", ...)` call. Locally it passes 5/5.

## Code changes

- `tests/Equibles.UnitTests/Worker/BaseScraperWorkerTests.cs` — replace the blind `Task.Delay(100)` with `WaitUntilAsync(() => worker.DoWorkCallCount >= 1, TimeSpan.FromSeconds(2))`. The assertions now only run after the worker has demonstrably completed at least one cycle, so the "running at" and "cycle complete" logs are guaranteed to have been emitted. CTS timeout bumped to 2s to give the wait headroom on slow runners.

## Test plan

- [x] All 7 tests in `BaseScraperWorkerTests` pass locally.
- [ ] CI green on this PR.