### PR TITLE
test(cboe): add tests for CboeImportService empty-download skip

### DIFF
--- a/tests/Equibles.UnitTests/Cboe/CboeImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Cboe/CboeImportServiceTests.cs
@@ -1,0 +1,40 @@
+using Equibles.Cboe.HostedService.Services;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Cboe.Contracts;
+using Equibles.Integrations.Cboe.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Cboe;
+
+public class CboeImportServiceTests {
+    [Fact]
+    public async Task Import_AllDownloadsEmpty_DoesNotCreateDbScope() {
+        // Each ImportPutCallRatio call short-circuits at `if (records.Count == 0) return`
+        // before touching _scopeFactory.CreateScope(). Same pattern in ImportVixHistory.
+        // The early-return matters because the scraper runs on a schedule against CBOE's
+        // public CDN — if the CDN serves an empty CSV (cache miss, weekend, holiday),
+        // we want the worker to do nothing rather than open a DB scope just to query
+        // the latest date. Pin the contract so a refactor that moves the GetLatestDate
+        // query above the count-check can't turn every CDN miss into a DB round-trip.
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        var cboeClient = Substitute.For<ICboeClient>();
+        cboeClient.DownloadPutCallRatios(Arg.Any<CboePutCallCsvType>())
+            .Returns(new List<CboePutCallRecord>());
+        cboeClient.DownloadVixHistory().Returns(new List<CboeVixRecord>());
+        var errorReporter = Substitute.For<ErrorReporter>(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<ErrorReporter>>());
+
+        var sut = new CboeImportService(
+            scopeFactory,
+            Substitute.For<ILogger<CboeImportService>>(),
+            cboeClient,
+            errorReporter);
+
+        await sut.Import(CancellationToken.None);
+
+        scopeFactory.DidNotReceive().CreateScope();
+    }
+}

--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -79,6 +79,7 @@
     <ProjectReference Include="..\..\src\Equibles.Integrations.Cftc\Equibles.Integrations.Cftc.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cftc.HostedService\Equibles.Cftc.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Plugins\Equibles.Plugins.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Cboe.HostedService\Equibles.Cboe.HostedService.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Adds the first test coverage for `CboeImportService` by pinning the contract that an empty CSV download short-circuits before opening a DB scope.
- CBOE's public CDN can serve empty files on cache misses, weekends, and holidays. The scraper must do nothing rather than open a scope just to query the latest stored date. A refactor that moves the `GetLatestDate` query above the count-check would turn every CDN miss into a DB round-trip on every put/call type.
- Adds a `ProjectReference` from `Equibles.UnitTests` to `Equibles.Cboe.HostedService` so the service is visible to the unit-test project.

## Code changes

- `tests/Equibles.UnitTests/Cboe/CboeImportServiceTests.cs` — new unit test `Import_AllDownloadsEmpty_DoesNotCreateDbScope`. Mocks `ICboeClient` to return empty lists and asserts the scope factory was never invoked.
- `tests/Equibles.UnitTests/Equibles.UnitTests.csproj` — adds `ProjectReference` to `Equibles.Cboe.HostedService`.