### PR TITLE
test(integration): add tests for HoldingsParsingHelper.ResolveManagerName

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs
@@ -1,3 +1,4 @@
+using Equibles.Holdings.HostedService.Models;
 using Equibles.Holdings.HostedService.Services;
 
 namespace Equibles.IntegrationTests.Holdings;
@@ -39,5 +40,34 @@ public class HoldingsParsingHelperTests {
         var result = HoldingsParsingHelper.ParseInvestmentDiscretion("DFND");
 
         result.Should().Be(Equibles.Holdings.Data.Models.InvestmentDiscretion.Defined);
+    }
+
+    [Fact]
+    public void ResolveManagerName_AccessionAndSequenceFoundInOtherManagers_ReturnsMappedName() {
+        // 13F-HR filings can carry multiple managers per accession — the primary filing
+        // manager from SUBMISSION.tsv plus zero-or-more "other managers" listed in
+        // OTHERMANAGER2.tsv keyed by `(ACCESSION_NUMBER, SEQUENCENUMBER)`. During INFOTABLE
+        // processing, each holding row points to a manager via its OTHERMANAGER index;
+        // ResolveManagerName walks the nested `OtherManagers[accession][seq]` dictionary to
+        // turn that index back into a human-readable name. A regression that lost the inner
+        // dictionary or keyed by the wrong tuple would leave every multi-manager holding
+        // attributed to "null" — silently flattening real co-advisor relationships.
+        //
+        // This `[Fact]` pins the happy-path lookup at minimum size: one accession with two
+        // sequence-numbered managers, asks for sequence 2, asserts the second name comes
+        // back. Covers (a) the outer dictionary hit, (b) the inner dictionary hit, (c) the
+        // exact sequence-number selection (not e.g. first-in-iteration order).
+        var context = new ImportContext {
+            OtherManagers = new Dictionary<string, Dictionary<int, string>>(StringComparer.OrdinalIgnoreCase) {
+                ["ACC-001"] = new() {
+                    [1] = "Capital Group Companies, Inc.",
+                    [2] = "Capital Research Global Investors",
+                },
+            },
+        };
+
+        var result = HoldingsParsingHelper.ResolveManagerName(context, "ACC-001", managerNumber: 2);
+
+        result.Should().Be("Capital Research Global Investors");
     }
 }


### PR DESCRIPTION
## Summary

- Adds a third `[Fact]` to `HoldingsParsingHelperTests` covering `ResolveManagerName`, the 13F multi-manager lookup. Each `INFOTABLE.tsv` row may name an OTHERMANAGER index that points into `OTHERMANAGER2.tsv` for the same accession — `ResolveManagerName(ctx, accession, idx)` walks the nested `OtherManagers[accession][idx]` dictionary to turn that index back into the manager's display name.
- The nested dictionary structure is easy to get subtly wrong — a refactor that flattened the outer map, or keyed the inner map by accession instead of sequence, would leave every multi-manager holding silently attributed to `null` and collapse real co-advisor relationships at ingestion time.
- The `[Fact]` pins all three layers in one shot at minimum size: outer hit (accession key exists), inner hit (sequence key exists), exact selection (sequence 2 returns the SECOND name, not the first).

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs` — appends one `[Fact]` (`ResolveManagerName_AccessionAndSequenceFoundInOtherManagers_ReturnsMappedName`) and adds a `using Equibles.Holdings.HostedService.Models;` to reach `ImportContext`. Uses real `Capital Group` / `Capital Research Global Investors` names so the assertion message reads like real SEC data rather than `m1`/`m2` placeholders.