### PR TITLE
test(mcp): pin CftcTools empty-database message on GetLatestCftcData

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/CftcToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CftcToolsTests.cs
@@ -30,4 +30,27 @@ public class CftcToolsTests {
 
         result.Should().Be("Contract '999999' not found. Use SearchCftcMarkets to find available contracts.");
     }
+
+    [Fact]
+    public async Task GetLatestCftcData_EmptyDatabase_ReturnsNoContractsMessage() {
+        // GetLatestCftcData uses a different empty-state message than GetCftcPositioning
+        // because it doesn't take a market code — it dumps the latest report per contract
+        // across all curated contracts. When the contracts table is empty (fresh install
+        // before EnsureContractsExist has run, or a misconfigured deployment), the user-
+        // facing message must say "No CFTC contracts found in the database." so the agent
+        // can distinguish a config problem from a "no data for this code" problem. Pin
+        // the exact text so a refactor that swaps in the generic positioning message
+        // can't hide a config gap behind a misleading reply.
+        using var ctx = TestDbContextFactory.Create(
+            new CftcModuleConfiguration(),
+            new ErrorsModuleConfiguration());
+        var contractRepo = new CftcContractRepository(ctx);
+        var reportRepo = new CftcPositionReportRepository(ctx);
+        var errorManager = new ErrorManager(new ErrorRepository(ctx));
+        var sut = new CftcTools(contractRepo, reportRepo, errorManager, Substitute.For<ILogger<CftcTools>>());
+
+        var result = await sut.GetLatestCftcData();
+
+        result.Should().Be("No CFTC contracts found in the database.");
+    }
 }


### PR DESCRIPTION
## Summary

- Extends `CftcToolsTests` with `GetLatestCftcData_EmptyDatabase_ReturnsNoContractsMessage` to pin the unique empty-state reply on the latest-snapshot endpoint.
- `GetLatestCftcData` doesn't take a market code — it dumps the latest report per contract across all curated contracts. When the contracts table is empty (fresh install before `EnsureContractsExist` has run, or a misconfigured deployment), the user-facing reply must distinguish "no data for this code" from "no contracts known at all" so the agent can surface a config problem rather than a content problem. A refactor that swaps in the generic positioning message would hide the config gap behind a misleading reply.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/CftcToolsTests.cs` — adds one new `[Fact]` exercising `GetLatestCftcData()` against an empty in-memory DB; asserts the exact `"No CFTC contracts found in the database."` message.