### PR TITLE
test(integration): add tests for FtdImportService.IsRecentFtdFile

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceTests.cs
@@ -33,4 +33,27 @@ public class FtdImportServiceTests {
         result.Should().HaveElementAt(1, "cnsfails201707a.zip");
         result.Should().HaveElementAt(2, "cnsfails201707b.zip");
     }
+
+    [Fact]
+    public void IsRecentFtdFile_FilenameForYear2000_ReturnsFalseRegardlessOfClock() {
+        // Companion to GetFileNames coverage: IsRecentFtdFile decides whether a 404 on an
+        // FTD download is "expected" (file not yet published — log INFO) or "anomalous"
+        // (URL pattern may have shifted — log WARNING and report). The recency cutoff is
+        // 2 months ago by wall clock, so the function is partially clock-dependent — BUT for
+        // any filename old enough that the cutoff cannot reach it, the answer is `false`
+        // unconditionally. Year 2000 is 20+ years before any plausible execution clock; the
+        // earliest FTD data SEC actually publishes is 2017-06.
+        //
+        // This `[Fact]` pins three things in one shot without depending on the clock:
+        //   (1) the filename guard accepts a well-formed `cnsfailsYYYYMMa.zip` length+chars,
+        //   (2) the inner date math runs (year/month parse to a valid DateOnly), and
+        //   (3) the recency comparison correctly classifies a very-old date as not-recent.
+        // A regression that swapped `>= twoMonthsAgo` for `<= twoMonthsAgo` (the easiest
+        // sign-flip mistake) would surface here: year-2000 would become "recent" and FTD
+        // 404s for ancient files would start firing the WARNING + error-report path.
+
+        var result = FtdImportService.IsRecentFtdFile("cnsfails200001a.zip");
+
+        result.Should().BeFalse();
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a second `[Fact]` to `FtdImportServiceTests` covering `IsRecentFtdFile`. The first one (#94) covered the URL generator; this one covers the 404-classification helper that decides whether a missing FTD download is "expected" (SEC has 45 days to publish — log INFO) or "anomalous" (URL pattern may have shifted — log WARNING and fire an error report).
- The comparison is clock-relative (`>= twoMonthsAgo`), so most inputs depend on `DateTime.UtcNow`. The `[Fact]` uses a year-2000 filename — far older than any plausible execution clock and well before SEC's actual 2017-06 FTD-data epoch — so the answer is deterministic regardless of when the test runs.
- The single fact pins three things together: (a) the filename guard accepts a well-formed `cnsfailsYYYYMMa.zip`, (b) the inner year/month parse and `DateOnly` build succeed, (c) the recency comparison correctly classifies that very-old date as not-recent. A sign-flipped `<= twoMonthsAgo` regression would surface here.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/FtdImportServiceTests.cs` — appends one `[Fact]` (`IsRecentFtdFile_FilenameForYear2000_ReturnsFalseRegardlessOfClock`). Uses the existing `Equibles.IntegrationTests` ↔ `Equibles.Sec.HostedService` `InternalsVisibleTo` to reach the `internal static` method directly.