### PR TITLE
test(mcp): pin ShortDataTools empty-DB snapshot message

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
@@ -34,4 +34,28 @@ public class ShortDataToolsTests {
 
         result.Should().Be("Stock 'ZZZZ' not found.");
     }
+
+    [Fact]
+    public async Task GetShortInterestSnapshot_EmptyDatabase_ReturnsNoDataAvailableMessage() {
+        // GetShortInterestSnapshot has two distinct empty-state messages — one for an
+        // entirely empty table ("No short interest data available.") and one for an
+        // empty filtered result inside an existing settlement period. The first message
+        // matters because it tells an MCP client the FINRA scraper hasn't run yet at all
+        // (vs. "ran but nothing met your filter"). If a refactor consolidated both branches
+        // into the filtered message, the agent would mis-diagnose a never-scraped database
+        // as a too-strict filter. Pin the empty-table path.
+        using var ctx = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new FinraModuleConfiguration(),
+            new ErrorsModuleConfiguration());
+        var stockRepo = new CommonStockRepository(ctx);
+        var shortVolumeRepo = new DailyShortVolumeRepository(ctx);
+        var shortInterestRepo = new ShortInterestRepository(ctx);
+        var errorManager = new ErrorManager(new ErrorRepository(ctx));
+        var sut = new ShortDataTools(shortVolumeRepo, shortInterestRepo, stockRepo, errorManager, Substitute.For<ILogger<ShortDataTools>>());
+
+        var result = await sut.GetShortInterestSnapshot();
+
+        result.Should().Be("No short interest data available.");
+    }
 }


### PR DESCRIPTION
## Summary

- Extends `ShortDataToolsTests` with `GetShortInterestSnapshot_EmptyDatabase_ReturnsNoDataAvailableMessage` to pin the unique empty-table reply on the snapshot endpoint.
- `GetShortInterestSnapshot` has two distinct empty-state messages — one for an entirely empty table (`"No short interest data available."`) and one for an empty filtered result inside an existing settlement period. The first tells an MCP client the FINRA scraper hasn't run yet at all, versus "ran but nothing met your filter". Folding the two branches together would mis-diagnose a never-scraped database as a too-strict filter.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs` — adds one new `[Fact]` exercising `GetShortInterestSnapshot()` against an empty in-memory DB; asserts the exact `"No short interest data available."` message.