### PR TITLE
test(integration): add tests for HoldingsParsingHelper.ParseShareType PRN mapping

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs
@@ -70,4 +70,23 @@ public class HoldingsParsingHelperTests {
 
         result.Should().Be("Capital Research Global Investors");
     }
+
+    [Fact]
+    public void ParseShareType_PrnAbbreviation_ReturnsPrincipal() {
+        // 13F INFOTABLE.tsv encodes the share-quantity unit in column SSHPRNAMTTYPE with
+        // exactly two valid values: `SH` (equity share count) and `PRN` (principal amount —
+        // bond face value). PRN is the surprising one — a developer expanding the
+        // abbreviation by guess is more likely to read it as `Principal` (✓) than as
+        // `Print`, `Premium`, or anything else, but the real risk is a refactor that
+        // accidentally types `Default` or simply drops the branch (causing every bond
+        // holding to be classified as `Shares`, which then double-counts when totals are
+        // computed as `Shares × price` rather than `Principal × price-per-100`). Pinning
+        // PRN→Principal here protects every bond holding in 13F filings from silently
+        // falling through to the share-count default. Production reads the value through
+        // `ToUpperInvariant()` first, so the assertion uses uppercase to match the SEC TSV
+        // wire format.
+        var result = HoldingsParsingHelper.ParseShareType("PRN");
+
+        result.Should().Be(Equibles.Holdings.Data.Models.ShareType.Principal);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a fourth `[Fact]` to `HoldingsParsingHelperTests` covering `ParseShareType`. The SEC INFOTABLE.tsv column `SSHPRNAMTTYPE` has exactly two valid values — `SH` (equity share count) and `PRN` (principal amount, i.e. bond face value). `PRN → Principal` is the non-obvious mapping the test pins.
- The fallback branch (`_ => ShareType.Shares`) is the danger: a refactor that dropped or renamed the PRN arm would silently reclassify every bond holding as shares, and downstream value calculations (`Shares × price` vs. `Principal × price/100`) would double-count the entire fixed-income side of every 13F filing.
- Production runs the input through `ToUpperInvariant()` first, so the assertion uses uppercase to match what real SEC TSVs ship.

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/HoldingsParsingHelperTests.cs` — appends one `[Fact]` (`ParseShareType_PrnAbbreviation_ReturnsPrincipal`). No other changes; existing tests untouched.