### PR TITLE
test(mcp): pin StockPriceTools GetLatestPrices empty-list guard

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs
@@ -34,4 +34,27 @@ public class StockPriceToolsTests {
 
         result.Should().Be("Maximum 25 tickers per request. Please split into multiple calls.");
     }
+
+    [Fact]
+    public async Task GetLatestPrices_OnlyCommasAndWhitespace_ReturnsNoTickersMessage() {
+        // GetLatestPrices splits the comma-separated input with RemoveEmptyEntries
+        // and TrimEntries, so a string of bare separators (",, , ,") collapses to
+        // an empty list. The guard that catches this returns "No tickers provided."
+        // — without it, the next branch would try to enforce the 25-ticker cap on
+        // an empty list (passes silently) and then emit a header-only Markdown
+        // table back to the MCP client, masking the input bug. Pin the
+        // explicit no-tickers reply so the agent gets a clear signal.
+        using var ctx = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new YahooModuleConfiguration(),
+            new ErrorsModuleConfiguration());
+        var stockRepo = new CommonStockRepository(ctx);
+        var priceRepo = new DailyStockPriceRepository(ctx);
+        var errorManager = new ErrorManager(new ErrorRepository(ctx));
+        var sut = new StockPriceTools(priceRepo, stockRepo, errorManager, Substitute.For<ILogger<StockPriceTools>>());
+
+        var result = await sut.GetLatestPrices(",, , ,");
+
+        result.Should().Be("No tickers provided.");
+    }
 }


### PR DESCRIPTION
## Summary

- Extends `StockPriceToolsTests` with `GetLatestPrices_OnlyCommasAndWhitespace_ReturnsNoTickersMessage` to pin the empty-list guard on the latest-prices endpoint.
- `GetLatestPrices` splits the comma-separated input with `RemoveEmptyEntries` and `TrimEntries`, so a string of bare separators (`",, , ,"`) collapses to an empty list. The `"No tickers provided."` guard is the only thing keeping the MCP client from receiving a header-only Markdown table — which would silently mask an input bug.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsTests.cs` — adds one new `[Fact]` exercising `GetLatestPrices(",, , ,")`; asserts the exact `"No tickers provided."` reply.