### PR TITLE
chore(coverage): drop assembly-level excludes, keep migrations filter

### DIFF
--- a/coverage.runsettings
+++ b/coverage.runsettings
@@ -7,16 +7,6 @@
           <Format>cobertura</Format>
           <ExcludeByFile>**/Migrations/**</ExcludeByFile>
           <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
-          <Exclude>
-            [Equibles.Migrations]*,
-            [Equibles.Mcp.Server]*,
-            [Equibles.Worker.Host]*,
-            [Equibles.Integrations.*]*,
-            [Equibles.*.Mcp]*.Extensions.*,
-            [Equibles.Mcp]*.Extensions.*,
-            [Equibles.Data]*PluginLoader,
-            [Equibles.Data]*EquiblesModuleBuilder
-          </Exclude>
         </Configuration>
       </DataCollector>
     </DataCollectors>


### PR DESCRIPTION
## Summary

- Coverage was excluding far more than migrations: MCP server host, Worker host, all integration packages, MCP extension classes, `PluginLoader`, and `EquiblesModuleBuilder`. Only migrations should be excluded.
- `<ExcludeByFile>**/Migrations/**</ExcludeByFile>` already covers migration source files, so the assembly-level `<Exclude>` block is redundant for migrations and overreaching for everything else.

## Code changes

- `coverage.runsettings` — removed the `<Exclude>` block entirely; `<ExcludeByFile>` continues to exclude migrations.