### PR TITLE
test(congress): pin HouseDisclosureClient RemoveTrailingTransactionType strip

### DIFF
--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
@@ -12,6 +12,9 @@ public class HouseDisclosureClientTests {
     private static readonly MethodInfo ExtractTransactionTypeMethod = typeof(HouseDisclosureClient)
         .GetMethod("ExtractTransactionType", BindingFlags.NonPublic | BindingFlags.Static);
 
+    private static readonly MethodInfo RemoveTrailingTransactionTypeMethod = typeof(HouseDisclosureClient)
+        .GetMethod("RemoveTrailingTransactionType", BindingFlags.NonPublic | BindingFlags.Static);
+
     [Fact]
     public void ExtractTransactionType_SaleWithPartialQualifier_ReturnsSale() {
         // House PTRs encode partial sales as "S (partial)" rather than bare "S".
@@ -23,5 +26,20 @@ public class HouseDisclosureClientTests {
         var result = (CongressTransactionType?)ExtractTransactionTypeMethod.Invoke(null, ["AAPL S (partial)"]);
 
         result.Should().Be(CongressTransactionType.Sale);
+    }
+
+    [Fact]
+    public void RemoveTrailingTransactionType_SaleWithPartialQualifier_StripsSuffixAndQualifier() {
+        // After ExtractTransactionType recognises the trailing "S (partial)" marker,
+        // RemoveTrailingTransactionType has to strip it cleanly so the asset name
+        // ("APPLE INC - COMMON STOCK") doesn't carry a dangling " S (partial)" tail
+        // into the persisted AssetName column. The two regexes (Sale/Purchase) must
+        // be applied in sequence and the result trimmed — without this, downstream
+        // consumers (UI, MCP tools) display garbled asset names. Pin the
+        // parenthetical-qualifier strip so the regex can't be loosened to a bare
+        // "S" matcher that would leave the "(partial)" tail behind.
+        var result = (string)RemoveTrailingTransactionTypeMethod.Invoke(null, ["APPLE INC - COMMON STOCK S (partial)"]);
+
+        result.Should().Be("APPLE INC - COMMON STOCK");
     }
 }


### PR DESCRIPTION
## Summary

- Extends `HouseDisclosureClientTests` with `RemoveTrailingTransactionType_SaleWithPartialQualifier_StripsSuffixAndQualifier` to pin the asset-name cleanup that runs after `ExtractTransactionType` recognises the trailing marker.
- The two regexes (`SaleTypeRegex`, `PurchaseTypeRegex`) must be applied in sequence and the result trimmed. If `SaleTypeRegex` were loosened to a bare `S` matcher, the `"(partial)"` qualifier would survive into the persisted `AssetName` and flow downstream into UI / MCP tools as a garbled string.

## Code changes

- `tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs` — adds one new `[Fact]` invoking the private static `RemoveTrailingTransactionType` via reflection; asserts that `"APPLE INC - COMMON STOCK S (partial)"` strips to `"APPLE INC - COMMON STOCK"`.