### PR TITLE
test(integration): add tests for InsiderTradingFilingProcessor within-batch dedup

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -614,4 +614,82 @@ public class InsiderTradingFilingProcessorTests {
         // <transactionDate> element of its own.
         transactions[0].TransactionDate.Should().Be(filing.ReportDate);
     }
+
+    [Fact]
+    public async Task Process_Form4WithDirectAndIndirectOwnershipOfSameSecurity_DedupsToOneRecordWithinBatch() {
+        // A single Form 4 routinely reports the same (security, date, code) twice when an
+        // insider holds the position both directly (their own account) and indirectly
+        // (through a trust, joint account, etc.). The DB unique index would only catch
+        // those AFTER they hit the wire — `InsiderTradingFilingProcessor.Process` dedupes
+        // earlier, inside the parse batch, using `(stock, owner, date, code, title,
+        // accession)` as the key. Critically the key does NOT include `OwnershipNature`,
+        // so D + I rows for the same security collapse into one persisted record (the
+        // first one seen wins).
+        //
+        // A regression that added OwnershipNature to the dedup key — or dropped the dedup
+        // step altogether — would let both rows reach SaveChanges and the unique index
+        // would throw at insert time, aborting the entire filing. This `[Fact]` ships a
+        // Form 4 with two non-derivative transactions identical except for the
+        // directOrIndirectOwnership value ("D" vs "I"), and asserts: (a) Process returns
+        // true (didn't abort), (b) exactly one row was persisted (in-batch dedup fired),
+        // (c) the surviving row's OwnershipNature is `Direct` — the first one parsed.
+        var dualOwnershipForm4Xml = """
+            <ownershipDocument>
+                <reportingOwner>
+                    <reportingOwnerId>
+                        <rptOwnerCik>0008888888</rptOwnerCik>
+                        <rptOwnerName>Alice Roe</rptOwnerName>
+                    </reportingOwnerId>
+                    <reportingOwnerRelationship>
+                        <isOfficer>1</isOfficer>
+                        <officerTitle>CTO</officerTitle>
+                    </reportingOwnerRelationship>
+                </reportingOwner>
+                <nonDerivativeTable>
+                    <nonDerivativeTransaction>
+                        <securityTitle><value>Common Stock</value></securityTitle>
+                        <transactionDate><value>2024-05-10</value></transactionDate>
+                        <transactionCoding><transactionCode>S</transactionCode></transactionCoding>
+                        <transactionAmounts>
+                            <transactionShares><value>500</value></transactionShares>
+                            <transactionPricePerShare><value>150.00</value></transactionPricePerShare>
+                            <transactionAcquiredDisposedCode><value>D</value></transactionAcquiredDisposedCode>
+                        </transactionAmounts>
+                        <postTransactionAmounts>
+                            <sharesOwnedFollowingTransaction><value>1000</value></sharesOwnedFollowingTransaction>
+                        </postTransactionAmounts>
+                        <ownershipNature>
+                            <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+                        </ownershipNature>
+                    </nonDerivativeTransaction>
+                    <nonDerivativeTransaction>
+                        <securityTitle><value>Common Stock</value></securityTitle>
+                        <transactionDate><value>2024-05-10</value></transactionDate>
+                        <transactionCoding><transactionCode>S</transactionCode></transactionCoding>
+                        <transactionAmounts>
+                            <transactionShares><value>500</value></transactionShares>
+                            <transactionPricePerShare><value>150.00</value></transactionPricePerShare>
+                            <transactionAcquiredDisposedCode><value>D</value></transactionAcquiredDisposedCode>
+                        </transactionAmounts>
+                        <postTransactionAmounts>
+                            <sharesOwnedFollowingTransaction><value>2000</value></sharesOwnedFollowingTransaction>
+                        </postTransactionAmounts>
+                        <ownershipNature>
+                            <directOrIndirectOwnership><value>I</value></directOrIndirectOwnership>
+                        </ownershipNature>
+                    </nonDerivativeTransaction>
+                </nonDerivativeTable>
+            </ownershipDocument>
+            """;
+        var (processor, _, txRepo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(dualOwnershipForm4Xml);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var transactions = txRepo.GetAll().ToList();
+        transactions.Should().ContainSingle();
+        // First-seen wins: the D row is processed before the I row in document order.
+        transactions[0].OwnershipNature.Should().Be(OwnershipNature.Direct);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a `[Fact]` covering `InsiderTradingFilingProcessor.Process`'s in-memory dedup pass — the loop at lines 174-182 that collapses transactions sharing `(stock, owner, date, code, title, accession)`. Critically, the key does NOT include `OwnershipNature`, so direct + indirect ownership of the same security on the same day collapse into one persisted row (first-seen wins).
- A real-world Form 4 routinely emits exactly this pair: a single insider who holds shares both directly (own account) and indirectly (trust, joint account, family vehicle). Without the in-batch dedup, both rows would race for the DB unique index, the index would throw, and the entire filing would abort. The test pins the contract that the processor catches this earlier and lets the filing succeed.
- Asserts (a) `Process` returns true (didn't abort), (b) exactly one row was persisted (dedup fired), (c) the surviving row's `OwnershipNature` is `Direct` — the document-order first match.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs` — appends one `[Fact]` (`Process_Form4WithDirectAndIndirectOwnershipOfSameSecurity_DedupsToOneRecordWithinBatch`). Reuses the existing `CreateProcessorWithDeps` / `MakeFiling` / `MakeCompany` helpers.