### PR TITLE
test(cftc): add tests for CftcImportService unparseable date fall-through

### DIFF
--- a/tests/Equibles.UnitTests/Cftc/CftcImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Cftc/CftcImportServiceTests.cs
@@ -24,4 +24,16 @@ public class CftcImportServiceTests {
 
         result.Should().Be(new DateOnly(2025, 1, 15));
     }
+
+    [Fact]
+    public void ParseDate_UnparseableValue_ReturnsNull() {
+        // ImportYear's foreach skips malformed rows via `if (date == null) continue;`,
+        // so returning null on bad input — rather than throwing — is the contract that
+        // keeps the importer from crashing an entire year on a single bad row. A
+        // refactor that swapped TryParseExact for DateOnly.Parse would throw
+        // FormatException and break that contract silently.
+        var result = (DateOnly?)ParseDateMethod.Invoke(null, ["not-a-date"]);
+
+        result.Should().BeNull();
+    }
 }


### PR DESCRIPTION
## Summary

Pins the contract that `CftcImportService.ParseDate` returns `null` (rather than throwing) when an input matches neither the modern `yyyy-MM-dd` nor the legacy `yyMMdd` format. `ImportYear`'s foreach uses `if (date == null) continue;` to skip malformed CFTC rows — a refactor that swapped `TryParseExact` for `DateOnly.Parse` would throw `FormatException` and crash the entire year-import on a single bad row, silently breaking that contract.

## Code changes

- `tests/Equibles.UnitTests/Cftc/CftcImportServiceTests.cs` — one new `[Fact]` (`ParseDate_UnparseableValue_ReturnsNull`) that invokes the private static `ParseDate` via reflection (same pattern as the existing legacy-format test) and asserts `null` for the input `"not-a-date"`.

## Test plan

- [x] `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj --filter "FullyQualifiedName~CftcImportServiceTests"` — 2/2 passed locally