### PR TITLE
test(integration): add tests for SecEdgarClient recent/archive DistinctBy

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/SecEdgarClientTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/SecEdgarClientTests.cs
@@ -291,6 +291,68 @@ public class SecEdgarClientTests {
         filings[0].AccessionNumber.Should().Be("0001-24-JAN");
     }
 
+    [Fact]
+    public async Task GetCompanyFilings_SameAccessionInRecentAndArchive_DistinctByCollapsesToOneRow() {
+        // SEC paginates older filings into archive files but the boundaries occasionally
+        // overlap — the same `accessionNumber` can appear in both `filings.recent` and a
+        // listed archive. `GetCompanyFilings` runs `.DistinctBy(f => f.AccessionNumber)`
+        // before applying the per-row filters; without it, the same Form 4 would be
+        // inserted twice into the result list and (downstream) cause the unique-index
+        // violation in `InsiderTransactionRepository` on the next save.
+        //
+        // This `[Fact]` ships TWO responses: the main `recent` block carrying one Form 4
+        // row, plus an archive whose filingFrom/filingTo overlaps the recent date and
+        // which carries the SAME accession (different primaryDocument string to make
+        // sure the test is comparing accessions, not whole rows). Asserts the result
+        // collapses to exactly one filing.
+        var mainJson = """
+            {
+              "cik": "1234567",
+              "name": "Test Co",
+              "filings": {
+                "recent": {
+                  "accessionNumber": ["0001-20-DUP"],
+                  "filingDate":      ["2020-06-15"],
+                  "reportDate":      ["2020-06-14"],
+                  "form":            ["4"],
+                  "primaryDocument": ["recent-form4.xml"],
+                  "primaryDocDescription": [""]
+                },
+                "files": [
+                  {
+                    "name": "CIK0001234567-submissions-001.json",
+                    "filingCount": 1,
+                    "filingFrom": "2020-01-01",
+                    "filingTo": "2020-12-31"
+                  }
+                ]
+              }
+            }
+            """;
+        var archiveJson = """
+            {
+              "accessionNumber": ["0001-20-DUP"],
+              "filingDate":      ["2020-06-15"],
+              "reportDate":      ["2020-06-14"],
+              "form":            ["4"],
+              "primaryDocument": ["archive-form4.xml"],
+              "primaryDocDescription": [""]
+            }
+            """;
+
+        var handler = new ScriptedHandler(mainJson, archiveJson);
+        var httpClient = new HttpClient(handler);
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { ["Sec:ContactEmail"] = "test@example.com" })
+            .Build();
+        var sut = new SecEdgarClient(httpClient, Substitute.For<ILogger<SecEdgarClient>>(), config);
+
+        var filings = await sut.GetCompanyFilings("1234567");
+
+        filings.Should().ContainSingle();
+        filings[0].AccessionNumber.Should().Be("0001-20-DUP");
+    }
+
     private sealed class ScriptedHandler : HttpMessageHandler {
         private readonly Queue<string> _responses;
 


### PR DESCRIPTION
## Summary

- Adds a `[Fact]` covering the `.DistinctBy(f => f.AccessionNumber)` line in `SecEdgarClient.GetCompanyFilings`. SEC paginates older filings into archive JSONs and occasionally the date boundaries overlap, so the same `accessionNumber` shows up in both `filings.recent` and the listed archive. A regression that removed `DistinctBy` would let the duplicate row reach `InsiderTransactionRepository`, which would then crash on its own unique index — by which point the actual bug (overlap, not a duplicate insert) is many call frames away.
- The `[Fact]` ships two ScriptedHandler responses with the same `accessionNumber` in both the `recent` block and the archive payload (different `primaryDocument` so we know the test is comparing accessions, not whole rows). Asserts the result collapses to exactly one filing.
- Together with the earlier archive-skip (#108), archive-fetch (#109), Form-4 filter (#94), and toDate filter (#128) `[Fact]`s, this completes the side-by-side coverage of every per-row path through `GetCompanyFilings`.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/SecEdgarClientTests.cs` — appends one `[Fact]` (`GetCompanyFilings_SameAccessionInRecentAndArchive_DistinctByCollapsesToOneRow`). Reuses the existing `ScriptedHandler`.