### PR TITLE
test(cboe): add tests for CboeClient ParseVixCsv decimal-skip

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CboeClientTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientTests.cs
@@ -12,6 +12,9 @@ public class CboeClientTests {
     private static readonly MethodInfo ParsePutCallCsvMethod = typeof(CboeClient)
         .GetMethod("ParsePutCallCsv", BindingFlags.NonPublic | BindingFlags.Static);
 
+    private static readonly MethodInfo ParseVixCsvMethod = typeof(CboeClient)
+        .GetMethod("ParseVixCsv", BindingFlags.NonPublic | BindingFlags.Static);
+
     [Fact]
     public void ParsePutCallCsv_RowWithUnparseableDate_IsSkipped() {
         // The CBOE CSV occasionally carries narrative rows ("Disclaimer:...") between
@@ -28,5 +31,34 @@ public class CboeClientTests {
 
         records.Should().ContainSingle()
             .Which.Date.Should().Be(new DateOnly(2025, 1, 15));
+    }
+
+    [Fact]
+    public void ParseVixCsv_RowWithUnparseableOhlcDecimal_IsSkipped() {
+        // The CBOE VIX history CSV occasionally carries rows where one of the
+        // OHLC columns is blank or "N/A" (early history before VIX listed
+        // intraday open/high/low — only close was published). ParseVixCsv
+        // walks decimal.TryParse for Open/High/Low/Close and must skip the
+        // entire row if any of the four fails, otherwise an unparseable Open
+        // would leave a default-zero OHLC row in the VIX history table and
+        // silently corrupt volatility analytics. The unique branch here is
+        // not the date skip (already covered by ParsePutCallCsv's test) but
+        // the decimal-skip fall-through — pin it on a row whose High column
+        // is non-numeric while the date is valid, and assert the next valid
+        // row still parses so we know we hit `continue` and not `return`.
+        var csv = "DATE,OPEN,HIGH,LOW,CLOSE\n" +
+                  "01/02/2020,13.46,N/A,13.20,12.47\n" +
+                  "01/03/2020,13.72,14.49,13.51,14.02\n";
+
+        var records = (List<CboeVixRecord>)ParseVixCsvMethod.Invoke(null, [csv]);
+
+        records.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new CboeVixRecord {
+                Date = new DateOnly(2020, 1, 3),
+                Open = 13.72m,
+                High = 14.49m,
+                Low = 13.51m,
+                Close = 14.02m
+            });
     }
 }


### PR DESCRIPTION
## Summary

- Adds a single `[Fact]` covering `CboeClient.ParseVixCsv` — the VIX history parser whose decimal-skip fall-through was uncovered (`CboeClient.cs` was at 31.1% line coverage, with only `ParsePutCallCsv` exercised by the existing test).
- The test feeds a CSV where the first row has `High = "N/A"` and the second row is fully valid. It asserts only the second row lands in the output, proving the parser executes `continue` on the unparseable decimal rather than `return`-ing or emitting a default-zero OHLC row.
- Why this branch matters: without the guard, an unparseable Open/High/Low/Close would silently insert `0m` OHLC rows into the VIX history table and corrupt volatility analytics downstream.

## Test plan

- [x] `dotnet test tests/Equibles.UnitTests --filter "CboeClientTests" -c Release` passes locally (2/2).
- [x] No production code touched (`git status --porcelain src/` empty).
- [x] CI must stay green.