### PR TITLE
fix(insider): preserve all transactions in multi-tranche Form 4

### DIFF
--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -8,7 +8,9 @@ namespace Equibles.InsiderTrading.Data.Models;
 [Index(nameof(InsiderOwnerId), nameof(TransactionDate))]
 [Index(nameof(AccessionNumber))]
 [Index(nameof(CommonStockId), nameof(InsiderOwnerId), nameof(TransactionDate),
-    nameof(TransactionCode), nameof(SecurityTitle), nameof(AccessionNumber), IsUnique = true)]
+    nameof(TransactionCode), nameof(SecurityTitle), nameof(AccessionNumber),
+    nameof(OwnershipNature), nameof(Shares), nameof(PricePerShare), nameof(SharesOwnedAfter),
+    IsUnique = true)]
 [Index(nameof(FilingDate))]
 [Index(nameof(TransactionDate))]
 public class InsiderTransaction {

--- a/src/Equibles.Migrations/Migrations/20260512222451_WidenInsiderTransactionUniqueIndexForMultiTxPerFiling.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260512222451_WidenInsiderTransactionUniqueIndexForMultiTxPerFiling.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260512222451_WidenInsiderTransactionUniqueIndexForMultiTxPerFiling")]
+    partial class WidenInsiderTransactionUniqueIndexForMultiTxPerFiling
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260512222451_WidenInsiderTransactionUniqueIndexForMultiTxPerFiling.cs
+++ b/src/Equibles.Migrations/Migrations/20260512222451_WidenInsiderTransactionUniqueIndexForMultiTxPerFiling.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class WidenInsiderTransactionUniqueIndexForMultiTxPerFiling : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_CommonStockId_InsiderOwnerId_Transaction~",
+                table: "InsiderTransaction");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderTransaction_CommonStockId_InsiderOwnerId_Transaction~",
+                table: "InsiderTransaction",
+                columns: new[] { "CommonStockId", "InsiderOwnerId", "TransactionDate", "TransactionCode", "SecurityTitle", "AccessionNumber", "OwnershipNature", "Shares", "PricePerShare", "SharesOwnedAfter" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_CommonStockId_InsiderOwnerId_Transaction~",
+                table: "InsiderTransaction");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderTransaction_CommonStockId_InsiderOwnerId_Transaction~",
+                table: "InsiderTransaction",
+                columns: new[] { "CommonStockId", "InsiderOwnerId", "TransactionDate", "TransactionCode", "SecurityTitle", "AccessionNumber" },
+                unique: true);
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -169,13 +169,19 @@ public class InsiderTradingFilingProcessor : IFilingProcessor {
             return true;
         }
 
-        // Deduplicate within the batch — a single filing can have multiple holdings with the
-        // same (stock, owner, date, code, title, accession) e.g. direct vs indirect ownership.
-        var seen = new HashSet<(Guid, Guid, DateOnly, TransactionCode, string, string)>();
+        // Deduplicate within the batch — only collapse rows that are byte-identical along
+        // every persisted dimension. A Form 4 can legitimately carry multiple non-derivative
+        // transactions on the same date with the same code and security (e.g. open-market
+        // purchases split across price tranches) — those differ in Shares / PricePerShare /
+        // SharesOwnedAfter and must survive. Direct + Indirect rows are distinct beneficial
+        // ownerships and must also survive (OwnershipNature differentiates them).
+        var seen = new HashSet<(Guid, Guid, DateOnly, TransactionCode, string, string,
+            OwnershipNature, long, decimal, long)>();
         var uniqueTransactions = new List<InsiderTransaction>();
         foreach (var tx in transactions) {
             var key = (tx.CommonStockId, tx.InsiderOwnerId, tx.TransactionDate,
-                tx.TransactionCode, tx.SecurityTitle, tx.AccessionNumber);
+                tx.TransactionCode, tx.SecurityTitle, tx.AccessionNumber,
+                tx.OwnershipNature, tx.Shares, tx.PricePerShare, tx.SharesOwnedAfter);
             if (seen.Add(key)) {
                 uniqueTransactions.Add(tx);
             }

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -616,23 +616,12 @@ public class InsiderTradingFilingProcessorTests {
     }
 
     [Fact]
-    public async Task Process_Form4WithDirectAndIndirectOwnershipOfSameSecurity_DedupsToOneRecordWithinBatch() {
-        // A single Form 4 routinely reports the same (security, date, code) twice when an
-        // insider holds the position both directly (their own account) and indirectly
-        // (through a trust, joint account, etc.). The DB unique index would only catch
-        // those AFTER they hit the wire — `InsiderTradingFilingProcessor.Process` dedupes
-        // earlier, inside the parse batch, using `(stock, owner, date, code, title,
-        // accession)` as the key. Critically the key does NOT include `OwnershipNature`,
-        // so D + I rows for the same security collapse into one persisted record (the
-        // first one seen wins).
-        //
-        // A regression that added OwnershipNature to the dedup key — or dropped the dedup
-        // step altogether — would let both rows reach SaveChanges and the unique index
-        // would throw at insert time, aborting the entire filing. This `[Fact]` ships a
-        // Form 4 with two non-derivative transactions identical except for the
-        // directOrIndirectOwnership value ("D" vs "I"), and asserts: (a) Process returns
-        // true (didn't abort), (b) exactly one row was persisted (in-batch dedup fired),
-        // (c) the surviving row's OwnershipNature is `Direct` — the first one parsed.
+    public async Task Process_Form4WithDirectAndIndirectOwnershipOfSameSecurity_PersistsBothRecords() {
+        // A single Form 4 can report the same (security, date, code) twice when an insider
+        // holds the position both directly (own account) and indirectly (through a trust,
+        // joint account, etc.). Under SEC rules these are distinct beneficial ownerships
+        // with their own running balances, so both rows must persist — the dedup key
+        // must include OwnershipNature (and SharesOwnedAfter) to keep them apart.
         var dualOwnershipForm4Xml = """
             <ownershipDocument>
                 <reportingOwner>
@@ -687,9 +676,106 @@ public class InsiderTradingFilingProcessorTests {
         var result = await processor.Process(MakeFiling(), MakeCompany());
 
         result.Should().BeTrue();
-        var transactions = txRepo.GetAll().ToList();
-        transactions.Should().ContainSingle();
-        // First-seen wins: the D row is processed before the I row in document order.
+        var transactions = txRepo.GetAll().OrderBy(t => t.OwnershipNature).ToList();
+        // Direct and Indirect are separate beneficial ownerships under SEC rules — they
+        // must be persisted as two distinct rows (their SharesOwnedAfter balances and
+        // OwnershipNature differ).
+        transactions.Should().HaveCount(2);
         transactions[0].OwnershipNature.Should().Be(OwnershipNature.Direct);
+        transactions[0].SharesOwnedAfter.Should().Be(1000);
+        transactions[1].OwnershipNature.Should().Be(OwnershipNature.Indirect);
+        transactions[1].SharesOwnedAfter.Should().Be(2000);
+    }
+
+    [Fact]
+    public async Task Process_Form4WithMultiplePurchasesSameDay_PersistsAllTransactions() {
+        // Real-world filing: Joel Marcus (ARE) 2026-05-05, accession 0001216955-26-000015
+        // reports three open-market purchases on the same day, broken out by price tranche.
+        // All three share (insider, security, date, code P, accession, ownership Direct);
+        // they differ only in Shares, PricePerShare, and the running SharesOwnedAfter.
+        // A dedup key that collapses on the narrow tuple silently drops the 2nd and 3rd
+        // tranches — the user-visible bug on https://equibles.com/stocks/are/insidertrading.
+        var multiPurchaseXml = """
+            <ownershipDocument>
+                <reportingOwner>
+                    <reportingOwnerId>
+                        <rptOwnerCik>0001216955</rptOwnerCik>
+                        <rptOwnerName>MARCUS JOEL S</rptOwnerName>
+                    </reportingOwnerId>
+                    <reportingOwnerRelationship>
+                        <isDirector>1</isDirector>
+                        <isOfficer>1</isOfficer>
+                        <officerTitle>Executive Chairman</officerTitle>
+                    </reportingOwnerRelationship>
+                </reportingOwner>
+                <nonDerivativeTable>
+                    <nonDerivativeTransaction>
+                        <securityTitle><value>Common Stock</value></securityTitle>
+                        <transactionDate><value>2026-05-05</value></transactionDate>
+                        <transactionCoding><transactionCode>P</transactionCode></transactionCoding>
+                        <transactionAmounts>
+                            <transactionShares><value>2062</value></transactionShares>
+                            <transactionPricePerShare><value>41.89</value></transactionPricePerShare>
+                            <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+                        </transactionAmounts>
+                        <postTransactionAmounts>
+                            <sharesOwnedFollowingTransaction><value>574786</value></sharesOwnedFollowingTransaction>
+                        </postTransactionAmounts>
+                        <ownershipNature>
+                            <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+                        </ownershipNature>
+                    </nonDerivativeTransaction>
+                    <nonDerivativeTransaction>
+                        <securityTitle><value>Common Stock</value></securityTitle>
+                        <transactionDate><value>2026-05-05</value></transactionDate>
+                        <transactionCoding><transactionCode>P</transactionCode></transactionCoding>
+                        <transactionAmounts>
+                            <transactionShares><value>3832</value></transactionShares>
+                            <transactionPricePerShare><value>42.76</value></transactionPricePerShare>
+                            <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+                        </transactionAmounts>
+                        <postTransactionAmounts>
+                            <sharesOwnedFollowingTransaction><value>578618</value></sharesOwnedFollowingTransaction>
+                        </postTransactionAmounts>
+                        <ownershipNature>
+                            <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+                        </ownershipNature>
+                    </nonDerivativeTransaction>
+                    <nonDerivativeTransaction>
+                        <securityTitle><value>Common Stock</value></securityTitle>
+                        <transactionDate><value>2026-05-05</value></transactionDate>
+                        <transactionCoding><transactionCode>P</transactionCode></transactionCoding>
+                        <transactionAmounts>
+                            <transactionShares><value>1606</value></transactionShares>
+                            <transactionPricePerShare><value>43.70</value></transactionPricePerShare>
+                            <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+                        </transactionAmounts>
+                        <postTransactionAmounts>
+                            <sharesOwnedFollowingTransaction><value>580224</value></sharesOwnedFollowingTransaction>
+                        </postTransactionAmounts>
+                        <ownershipNature>
+                            <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+                        </ownershipNature>
+                    </nonDerivativeTransaction>
+                </nonDerivativeTable>
+            </ownershipDocument>
+            """;
+        var (processor, _, txRepo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(multiPurchaseXml);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var transactions = txRepo.GetAll().OrderBy(t => t.Shares).ToList();
+        transactions.Should().HaveCount(3);
+        transactions[0].Shares.Should().Be(1606);
+        transactions[0].PricePerShare.Should().Be(43.70m);
+        transactions[0].SharesOwnedAfter.Should().Be(580224);
+        transactions[1].Shares.Should().Be(2062);
+        transactions[1].PricePerShare.Should().Be(41.89m);
+        transactions[1].SharesOwnedAfter.Should().Be(574786);
+        transactions[2].Shares.Should().Be(3832);
+        transactions[2].PricePerShare.Should().Be(42.76m);
+        transactions[2].SharesOwnedAfter.Should().Be(578618);
     }
 }


### PR DESCRIPTION
## Summary

- Form 4 filings can report a single day's trade across multiple price tranches (e.g. MARCUS JOEL S / ARE on 2026-05-05 split a purchase across three prices). The in-memory dedup key in `InsiderTradingFilingProcessor` and the matching DB unique index were both keyed on `(stock, owner, date, code, security, accession)` — too narrow — so the 2nd+ rows were silently dropped and the page at `/stocks/are/insidertrading` showed only the first tranche per filing.
- Direct + Indirect ownership rows of the same security were also collapsing despite being distinct beneficial ownerships under SEC rules.
- Widen both the in-memory dedup key and the unique index to additionally include `OwnershipNature`, `Shares`, `PricePerShare`, `SharesOwnedAfter`.

Verified by fetching the source XML for the 2026-05-04/05/06 ARE filings on EDGAR and asserting each filing's transaction count matches what gets persisted. Note: already-imported buggy filings won't auto-reprocess (accession-number short-circuit at `InsiderTradingFilingProcessor.cs:49`); existing rows for the affected ARE filings need a separate re-import.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — widen in-memory dedup tuple to include `OwnershipNature`, `Shares`, `PricePerShare`, `SharesOwnedAfter`; refresh the explanatory comment.
- `src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs` — extend the unique `[Index]` with the same four columns so the DB constraint matches the dedup contract.
- `src/Equibles.Migrations/Migrations/20260512222451_WidenInsiderTransactionUniqueIndexForMultiTxPerFiling.cs` — drop + recreate the wider unique index. Also touches the snapshot.
- `tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs`:
  - New `Process_Form4WithMultiplePurchasesSameDay_PersistsAllTransactions` using the real 2026-05-05 Marcus XML (3 purchases → 3 rows).
  - Renamed `…OfSameSecurity_DedupsToOneRecordWithinBatch` → `…_PersistsBothRecords` and updated its assertions: Direct and Indirect now persist as 2 separate rows with their own `SharesOwnedAfter` balances.