### PR TITLE
test(yahoo): add tests for YahooPriceImportService overflow guard rejects negative-side overflow

### DIFF
--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Equibles.Integrations.Yahoo.Models;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Tests for <see cref="YahooPriceImportService"/>. The public entry point pulls
+/// quotes from Yahoo Finance and writes them to the database; we exercise the
+/// pure-logic private static guard <c>HasOverflowPrice</c> via reflection.
+/// </summary>
+public class YahooPriceImportServiceTests {
+    private static readonly MethodInfo HasOverflowPriceMethod = typeof(YahooPriceImportService)
+        .GetMethod("HasOverflowPrice", BindingFlags.NonPublic | BindingFlags.Static);
+
+    [Fact]
+    public void HasOverflowPrice_AbsValueExceedsNumeric18_4Ceiling_ReturnsTrue() {
+        // The Yahoo importer batches into a numeric(18,4) column; values that exceed
+        // 99_999_999_999_999.9999 will throw on SaveChanges and abort the entire
+        // batch. HasOverflowPrice is the filter that keeps a single garbage quote —
+        // Yahoo occasionally returns absurd values for thinly traded tickers — from
+        // poisoning the day's import for every other stock. Pin the abs() comparison
+        // so a refactor that drops the absolute-value check (allowing large negative
+        // values through) doesn't silently re-enable the overflow path.
+        var price = new HistoricalPrice {
+            Open = -200_000_000_000_000m, // |value| > MaxPriceValue, negative side
+            High = 1m,
+            Low = 1m,
+            Close = 1m,
+            AdjustedClose = 1m
+        };
+
+        var result = (bool)HasOverflowPriceMethod.Invoke(null, [price]);
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Pins the absolute-value comparison inside `YahooPriceImportService.HasOverflowPrice`, the guard that keeps a single absurd Yahoo quote from poisoning a whole day's batch insert against the `numeric(18,4)` price column. Yahoo occasionally returns garbage values for thinly traded tickers; without `Math.Abs(...)`, a large negative quote would slip through the `> MaxPriceValue` check, EF Core would throw on `SaveChanges`, and the entire ticker batch would be lost. A refactor that drops the `Math.Abs` would silently re-enable that path.

## Code changes

- `tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceTests.cs` (new) — one `[Fact]` (`HasOverflowPrice_AbsValueExceedsNumeric18_4Ceiling_ReturnsTrue`) that invokes the private static helper via reflection (same pattern as `CftcImportServiceTests`) with a negative value beyond `99_999_999_999_999.9999m` and asserts `true`.

## Test plan

- [x] `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj --filter "FullyQualifiedName~Equibles.UnitTests.Yahoo.YahooPriceImportServiceTests"` — 1/1 passed locally