### PR TITLE
test(integration): add tests for ParseTransaction Disposed branch

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -857,4 +857,66 @@ public class InsiderTradingFilingProcessorTests {
         transactions.Should().ContainSingle();
         transactions[0].SecurityTitle.Should().Be("Common Stock B");
     }
+
+    [Fact]
+    public async Task Process_Form4WithDisposedTransaction_PersistsAsDisposedNotAcquired() {
+        // ParseTransaction encodes the SEC acquired-or-disposed code as a one-line ternary:
+        //   AcquiredDisposed = adCode == "A" ? Acquired : Disposed;
+        // The Acquired side is covered by Process_ValidForm4_InsertsTransactionsAndOwner
+        // (purchase with code "A"). The Disposed side — the `else` of the ternary — has
+        // never been exercised explicitly, even though it's exactly half of Form 4 payloads
+        // (every share sale flows through it).
+        //
+        // The risk is a refactor that swaps the ternary direction or drops the comparison
+        // (`?? Acquired` would always classify as Acquired). The resulting classification
+        // bug is silent — share counts and prices look right, only the direction of every
+        // sale is wrong, and downstream insider-sentiment signals derive purely from this
+        // flag.
+        //
+        // The `[Fact]` ships a Form 4 with a single sale: transaction code `S`,
+        // transactionAcquiredDisposedCode `D`. Asserts the persisted row's `AcquiredDisposed`
+        // is `Disposed` — pinning the "else" branch of the ternary.
+        var saleForm4Xml = """
+            <ownershipDocument>
+                <reportingOwner>
+                    <reportingOwnerId>
+                        <rptOwnerCik>0005555555</rptOwnerCik>
+                        <rptOwnerName>Carol Vu</rptOwnerName>
+                    </reportingOwnerId>
+                    <reportingOwnerRelationship>
+                        <isOfficer>1</isOfficer>
+                        <officerTitle>CFO</officerTitle>
+                    </reportingOwnerRelationship>
+                </reportingOwner>
+                <nonDerivativeTable>
+                    <nonDerivativeTransaction>
+                        <securityTitle><value>Common Stock</value></securityTitle>
+                        <transactionDate><value>2024-07-08</value></transactionDate>
+                        <transactionCoding><transactionCode>S</transactionCode></transactionCoding>
+                        <transactionAmounts>
+                            <transactionShares><value>1500</value></transactionShares>
+                            <transactionPricePerShare><value>200.00</value></transactionPricePerShare>
+                            <transactionAcquiredDisposedCode><value>D</value></transactionAcquiredDisposedCode>
+                        </transactionAmounts>
+                        <postTransactionAmounts>
+                            <sharesOwnedFollowingTransaction><value>8500</value></sharesOwnedFollowingTransaction>
+                        </postTransactionAmounts>
+                        <ownershipNature>
+                            <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+                        </ownershipNature>
+                    </nonDerivativeTransaction>
+                </nonDerivativeTable>
+            </ownershipDocument>
+            """;
+        var (processor, _, txRepo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(saleForm4Xml);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var transactions = txRepo.GetAll().ToList();
+        transactions.Should().ContainSingle();
+        transactions[0].AcquiredDisposed.Should().Be(AcquiredDisposed.Disposed);
+        transactions[0].TransactionCode.Should().Be(TransactionCode.Sale);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a `[Fact]` covering the `else` branch of `InsiderTradingFilingProcessor.ParseTransaction`'s acquired-or-disposed ternary: `adCode == "A" ? Acquired : Disposed`. The Acquired side flows through every existing test (purchase code `A`); the Disposed side — half of all Form 4 payloads, every share sale — was never pinned explicitly.
- The classification is silent: share counts, prices, and dates would all look right even if every sale were mis-classified as an acquisition. The downstream insider-sentiment signals derive purely from this flag, so a swap of the ternary direction (`Disposed : Acquired`) or a refactor that defaulted to Acquired would flip the meaning of every sale.
- The `[Fact]` ships a Form 4 with a single sale (`transactionCode = S`, `transactionAcquiredDisposedCode = D`) and asserts the persisted row's `AcquiredDisposed == Disposed` and `TransactionCode == Sale` — pinning both the ternary leg and the dependent `ParseTransactionCode` mapping.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs` — appends one `[Fact]` (`Process_Form4WithDisposedTransaction_PersistsAsDisposedNotAcquired`). Reuses the existing `CreateProcessorWithDeps` / `MakeFiling` / `MakeCompany` helpers.