### PR TITLE
test(yahoo): add tests for YahooFinanceClient ToUnixTimestamp UTC anchor

### DIFF
--- a/tests/Equibles.UnitTests/Yahoo/YahooFinanceClientTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooFinanceClientTests.cs
@@ -1,8 +1,27 @@
+using System.Reflection;
 using Equibles.Integrations.Yahoo;
 
 namespace Equibles.UnitTests.Yahoo;
 
 public class YahooFinanceClientTests {
+    private static readonly MethodInfo ToUnixTimestampMethod = typeof(YahooFinanceClient)
+        .GetMethod("ToUnixTimestamp", BindingFlags.NonPublic | BindingFlags.Static);
+
+    [Fact]
+    public void ToUnixTimestamp_KnownUtcDate_ReturnsCorrectUnixSeconds() {
+        // GetHistoricalPrices builds the chart URL with `?period1={ToUnixTimestamp(start)}`,
+        // and Yahoo treats those parameters as Unix epoch seconds in UTC. ToUnixTimestamp
+        // anchors the conversion by explicitly constructing the DateTime with
+        // DateTimeKind.Utc — drop the kind and the subtraction against the UTC-offset
+        // UnixEpoch silently uses the host's local timezone, shifting every requested
+        // range by the local offset and pulling the wrong day's prices. Pin the UTC
+        // anchor by asserting the exact epoch seconds for a known calendar date.
+        var result = (long)ToUnixTimestampMethod.Invoke(null, [new DateOnly(2024, 1, 1)]);
+
+        result.Should().Be(1704067200L);
+    }
+
+
     [Fact]
     public async Task GetHistoricalPrices_NullTicker_ThrowsArgumentException() {
         var client = CreateClient();


### PR DESCRIPTION
## Summary

Pins the UTC anchor in `YahooFinanceClient.ToUnixTimestamp`. `GetHistoricalPrices` builds the Yahoo chart URL with `?period1={ToUnixTimestamp(start)}&period2={ToUnixTimestamp(end)}`, and Yahoo interprets those query parameters as Unix epoch seconds in UTC. The implementation explicitly constructs the `DateTime` with `DateTimeKind.Utc` so the subtraction against the UTC-offset `UnixEpoch` is timezone-stable. A refactor that drops the kind (defaulting to `Unspecified`) would silently use the host's local timezone, shifting every requested range by the local offset and pulling the wrong calendar day's prices. This test would catch that on any non-UTC CI runner.

## Code changes

- `tests/Equibles.UnitTests/Yahoo/YahooFinanceClientTests.cs` — one new `[Fact]` (`ToUnixTimestamp_KnownUtcDate_ReturnsCorrectUnixSeconds`). The method is `private static`, so it's invoked via reflection (same pattern as the other reflection-based unit tests in this repo). Asserts `ToUnixTimestamp(new DateOnly(2024, 1, 1)) == 1704067200L`.

## Test plan

- [x] `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj --filter "FullyQualifiedName~Equibles.UnitTests.Yahoo.YahooFinanceClientTests"` — 6/6 passed locally