### PR TITLE
test(holdings): add tests for HoldingsDataSetClient old-quarterly-format filename

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsDataSetClientTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsDataSetClientTests.cs
@@ -10,4 +10,19 @@ public class HoldingsDataSetClientTests {
         result.Should().Contain("2013q2_form13f.zip");
         result.Should().NotContain("2013q1_form13f.zip");
     }
+
+    [Fact]
+    public void GetDataSetFileNames_StartIn2014_ProducesOldQuarterlyFormatFilename() {
+        // The SEC publishes Form 13F data sets under exact-cased filenames that the
+        // downloader concatenates onto the BaseUrl verbatim. For 2013-2023 the format
+        // is `{year}q{quarter}_form13f.zip` (lowercase `q`). A refactor that changed
+        // the format string — uppercase Q, removing the underscore, dropping the
+        // four-digit year — would 404 every old-period download and silently halt
+        // the entire 13F ingest for the decade of historical data. The clamping
+        // test above only proves boundary behaviour; this one pins the literal
+        // filename SEC actually serves.
+        var result = HoldingsDataSetClient.GetDataSetFileNames(new DateTime(2014, 1, 15));
+
+        result.Should().Contain("2014q1_form13f.zip");
+    }
 }


### PR DESCRIPTION
## Summary

Pins the literal `{year}q{quarter}_form13f.zip` filename that `HoldingsDataSetClient.GetDataSetFileNames` produces for the 2013–2023 reporting periods. The downloader concatenates the result onto the SEC base URL verbatim — a refactor that changed the format string (uppercase `Q`, dropped underscore, two-digit year, etc.) would 404 every old-period download and silently halt the entire 13F holdings ingest for a decade of historical data. The pre-existing clamp test only proves the 2013 boundary; this one pins the SEC-served filename itself.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsDataSetClientTests.cs` — one new `[Fact]` (`GetDataSetFileNames_StartIn2014_ProducesOldQuarterlyFormatFilename`) calling `GetDataSetFileNames(new DateTime(2014, 1, 15))` and asserting `"2014q1_form13f.zip"` is contained in the result.

## Test plan

- [x] `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj --filter "FullyQualifiedName~Equibles.UnitTests.Holdings.HoldingsDataSetClientTests"` — 2/2 passed locally