### PR TITLE
test(integrations): add tests for CftcClient ParseLong thousand-separator strip

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CftcClientTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientTests.cs
@@ -11,6 +11,24 @@ public class CftcClientTests {
     private static readonly MethodInfo SplitCsvLineMethod = typeof(CftcClient)
         .GetMethod("SplitCsvLine", BindingFlags.NonPublic | BindingFlags.Static);
 
+    private static readonly MethodInfo ParseLongMethod = typeof(CftcClient)
+        .GetMethod("ParseLong", BindingFlags.NonPublic | BindingFlags.Static);
+
+    [Fact]
+    public void ParseLong_ValueWithThousandSeparatorCommas_StripsAndParses() {
+        // CFTC's legacy COT history files format every numeric position column
+        // (Open_Interest_All, NonComm_Positions_*, Comm_Positions_*, etc.) with
+        // thousand-separator commas: "1,234,567". ParseLong strips those commas
+        // before calling long.TryParse with InvariantCulture — drop the
+        // .Replace(",", "") and every multi-comma value falls back to null/0,
+        // silently writing zeros for the bulk of CFTC's position dataset. Pin
+        // the strip path on a multi-group thousand-separated value so a
+        // regression that simplifies the parse path is caught at test time.
+        var result = (long?)ParseLongMethod.Invoke(null, ["1,234,567"]);
+
+        result.Should().Be(1_234_567L);
+    }
+
     [Fact]
     public void SplitCsvLine_QuotedFieldWithEmbeddedComma_KeepsFieldIntact() {
         // CFTC market names routinely contain commas (e.g. the market name


### PR DESCRIPTION
## Summary

- Pin the comma-stripping branch of `CftcClient.ParseLong`. CFTC's legacy COT history files format every numeric position column with thousand-separator commas — drop the `Replace(",", "")` and the bulk of position records silently parse to zero.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CftcClientTests.cs` — added one `[Fact]` (`ParseLong_ValueWithThousandSeparatorCommas_StripsAndParses`) plus a reflection handle for the private static. Asserts `"1,234,567" → 1234567L` so a regression that simplifies the parser is caught at test time.