### PR TITLE
test(holdings): add tests for HoldingsParsingHelper PRN to Principal mapping

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTests.cs
@@ -1,3 +1,4 @@
+using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.HostedService.Services;
 
 namespace Equibles.UnitTests.Holdings;
@@ -9,5 +10,20 @@ public class HoldingsParsingHelperTests {
 
         success.Should().BeTrue();
         result.Should().Be(new DateOnly(2024, 3, 15));
+    }
+
+    [Fact]
+    public void ParseShareType_PrincipalAbbreviation_ReturnsPrincipal() {
+        // SEC 13F filings use abbreviated wire values: "SH" for Shares, "PRN" for Principal.
+        // The C# enum uses full descriptive names per project standards. ParseShareType is
+        // the bridge that translates the wire abbreviation to the domain enum. The default
+        // arm of the switch falls back to ShareType.Shares — so if the "PRN" → Principal
+        // case were ever dropped (or the SEC-side abbreviation refactored to lowercase
+        // without an `.ToUpperInvariant()` review), every Principal holding (typically
+        // bond positions) would silently mis-classify as Shares. Pin the PRN mapping so
+        // the wire-to-domain contract survives a switch-statement refactor.
+        var result = HoldingsParsingHelper.ParseShareType("PRN");
+
+        result.Should().Be(ShareType.Principal);
     }
 }


### PR DESCRIPTION
## Summary

Pins the `"PRN" → ShareType.Principal` mapping inside `HoldingsParsingHelper.ParseShareType`. SEC 13F filings use abbreviated wire values (`"SH"`, `"PRN"`); the project's enums use full descriptive names. This helper is the wire-to-domain bridge. The switch's default arm falls back to `ShareType.Shares`, so dropping the `"PRN"` case (or breaking the case-insensitive match) would silently mis-classify every Principal holding — typically bond positions inside 13F filings — as Shares, with no exception or log to flag it.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTests.cs` — one new `[Fact]` (`ParseShareType_PrincipalAbbreviation_ReturnsPrincipal`) that asserts `ParseShareType("PRN") == ShareType.Principal`. Same direct-call style as the pre-existing `TryParseDateOnly` test (the project has `InternalsVisibleTo` for the test assembly, so no reflection is needed).

## Test plan

- [x] `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj --filter "FullyQualifiedName~Equibles.UnitTests.Holdings.HoldingsParsingHelperTests"` — 2/2 passed locally