### PR TITLE
test(integrations): add tests for CftcClient BuildColumnIndex quote-strip

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CftcClientTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientTests.cs
@@ -14,6 +14,29 @@ public class CftcClientTests {
     private static readonly MethodInfo ParseLongMethod = typeof(CftcClient)
         .GetMethod("ParseLong", BindingFlags.NonPublic | BindingFlags.Static);
 
+    private static readonly MethodInfo BuildColumnIndexMethod = typeof(CftcClient)
+        .GetMethod("BuildColumnIndex", BindingFlags.NonPublic | BindingFlags.Static);
+
+    [Fact]
+    public void BuildColumnIndex_QuotedHeaderName_IndexedWithoutQuotes() {
+        // CFTC's COT history CSVs ship header rows in two flavours that vary by year:
+        // bare (`Open_Interest_All`) and double-quoted (`"Open_Interest_All"`). The
+        // downstream ParseLine looks up each column by its bare-string name through
+        // GetField, so the index built here must strip surrounding quotes — drop the
+        // `.Trim('"')` and every quoted-header file's GetField calls miss, falling
+        // through to `idx >= fields.Length` returning null, and every numeric column
+        // silently parses to zero. Pin the quote-strip path on a single quoted header
+        // and a follow-on case-insensitive lookup (the index uses OrdinalIgnoreCase),
+        // so a regression that swaps the comparer or removes the trim is caught.
+        var headerLine = "\"Open_Interest_All\",Some_Other";
+
+        var index = (Dictionary<string, int>)BuildColumnIndexMethod.Invoke(null, [headerLine]);
+
+        index.Should().ContainKey("Open_Interest_All").WhoseValue.Should().Be(0);
+        // OrdinalIgnoreCase: bare lookup with different casing must still hit.
+        index.Should().ContainKey("open_interest_all");
+    }
+
     [Fact]
     public void ParseLong_ValueWithThousandSeparatorCommas_StripsAndParses() {
         // CFTC's legacy COT history files format every numeric position column


### PR DESCRIPTION
## Summary

- Pin `CftcClient.BuildColumnIndex` quote-strip behavior. CFTC's COT history CSVs ship two header flavours by year: bare (`Open_Interest_All`) and double-quoted (`"Open_Interest_All"`). The downstream `GetField` lookups use bare column names — drop the `.Trim('"')` and every quoted-header file silently parses to zero across all numeric columns.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CftcClientTests.cs` — added one `[Fact]` (`BuildColumnIndex_QuotedHeaderName_IndexedWithoutQuotes`) plus a reflection handle for the private static. Asserts a quoted header `"Open_Interest_All"` lands at index 0 keyed by the bare name, and an OrdinalIgnoreCase lookup with different casing still hits.