### PR TITLE
test(sec): pin FtdImportService GetFileNames June-2017 skip-a quirk

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceTests.cs
@@ -49,6 +49,28 @@ public class FtdImportServiceTests {
     }
 
     [Fact]
+    public void GetFileNames_StartBeforeOldestAvailable_ClampsAndSkipsJune2017AFile() {
+        // SEC's failure-to-deliver history begins June 2017, but the FIRST month is special:
+        // only the second-half file `cnsfails201706b.zip` exists — there is no
+        // `cnsfails201706a.zip` on sec.gov. GetFileNames encodes this asymmetry with
+        // `if (current != OldestAvailableDate) fileNames.Add($"...a.zip")`. Without
+        // that guard, every import would request the non-existent 201706a file, the
+        // download would 404, and (per the IsRecentFtdFile check) a stale 404 from
+        // 2017 would be reported as an error every single scrape cycle — burning
+        // log volume and triggering false ErrorReporter pages. Pin the clamp-to-
+        // 2017-06 AND the no-'a'-for-June-2017 rule with a deliberately ancient
+        // start date.
+        var startDate = new DateOnly(2010, 1, 1);
+
+        var fileNames = FtdImportService.GetFileNames(startDate);
+
+        fileNames[0].Should().Be("cnsfails201706b.zip");
+        fileNames[1].Should().Be("cnsfails201707a.zip");
+        fileNames[2].Should().Be("cnsfails201707b.zip");
+        fileNames.Should().NotContain("cnsfails201706a.zip");
+    }
+
+    [Fact]
     public void GetFileNames_FutureDate_ReturnsEmptyList() {
         var futureDate = DateOnly.FromDateTime(DateTime.UtcNow).AddYears(1);
 


### PR DESCRIPTION
## Summary

- Pin a real production quirk that the existing `GetFileNames` test set doesn't cover: SEC's failure-to-deliver history begins with **only** the second-half file `cnsfails201706b.zip` — there is no `cnsfails201706a.zip` on sec.gov. The production guard (`if (current != OldestAvailableDate) fileNames.Add($"...a.zip")`) encodes this asymmetry; without it the import would 404 on a non-existent file every cycle and trip the error reporter forever.

## Code changes

- `tests/Equibles.UnitTests/Sec/FtdImportServiceTests.cs` — added one `[Fact]` (`GetFileNames_StartBeforeOldestAvailable_ClampsAndSkipsJune2017AFile`) that uses a deliberately ancient start date to exercise both the clamp-to-2017-06 path AND the skip-`a`-for-June-2017 rule, asserting the first three emitted file names and the absence of `cnsfails201706a.zip`.