### PR TITLE
test(sec): pin June 2017 'a'-file omission in FtdImportService.GetFileNames

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceTests.cs
@@ -57,6 +57,26 @@ public class FtdImportServiceTests {
         fileNames.Should().BeEmpty();
     }
 
+    [Fact]
+    public void GetFileNames_StartBeforeOldestAvailableDate_OmitsJune2017AFile() {
+        // June 2017 is the oldest month SEC publishes FTD data for, and uniquely has
+        // only the second-half ("b") file — cnsfails201706a.zip does not exist on
+        // sec.gov. Any backfill from the earliest history must skip the 'a' file
+        // for June 2017 specifically; otherwise the very first download in the
+        // sequence 404s and gets logged as "URL change" (per the >2-months check),
+        // which would noisily mask a known, permanent SEC quirk.
+        //
+        // Passing a start date earlier than the clamp date (here: 2015) exercises
+        // both the clamp branch and the June-2017 special case. Without the
+        // `if (current != OldestAvailableDate)` guard, the first generated name
+        // would be cnsfails201706a.zip and break the backfill.
+        var fileNames = FtdImportService.GetFileNames(new DateOnly(2015, 1, 1));
+
+        fileNames.Should().NotContain("cnsfails201706a.zip");
+        fileNames.Should().StartWith("cnsfails201706b.zip");
+        fileNames.Should().Contain("cnsfails201707a.zip");
+    }
+
     // ── IsRecentFtdFile ──
 
     [Fact]


### PR DESCRIPTION
## Summary

- Pins the SEC-specific quirk that `cnsfails201706a.zip` does not exist: June 2017 is the oldest FTD month, and only the `b` (second-half) file is published.
- A backfill starting before that date currently relies on `if (current != OldestAvailableDate)` to skip the `a` file. Without the guard, the first download of every full backfill 404s and gets logged as "URL change" (per the >2-months check), masking the real, permanent SEC behavior.
- New test also exercises the start-date clamp branch (pre-2017 input clamped to the oldest available date).

## Code changes

- `tests/Equibles.UnitTests/Sec/FtdImportServiceTests.cs` — new `[Fact]` `GetFileNames_StartBeforeOldestAvailableDate_OmitsJune2017AFile`: passes `2015-01-01`, asserts the result does **not** contain `cnsfails201706a.zip`, starts with `cnsfails201706b.zip`, and does contain the next month's `cnsfails201707a.zip` (proving the special case is localized to June 2017).