### PR TITLE
test(worker): pin SyncDateResolver empty-DB fallback to 2020-01-01

### DIFF
--- a/tests/Equibles.UnitTests/Core/SyncDateResolverTests.cs
+++ b/tests/Equibles.UnitTests/Core/SyncDateResolverTests.cs
@@ -12,4 +12,22 @@ public class SyncDateResolverTests {
 
         result.Should().Be(new DateOnly(2025, 6, 15));
     }
+
+    [Fact]
+    public void Resolve_DefaultLatestAndNullMinSyncDate_ReturnsBakedDefaultMinDate() {
+        // Every domain worker that resolves its sync window through this helper
+        // (Yahoo prices, FRED, CFTC, FTD) depends on the empty-DB fallback when
+        // the operator hasn't set WorkerOptions.MinSyncDate. The fallback is a
+        // hard-coded `new DateOnly(2020, 1, 1)` literal — drop the constant or
+        // flip the null-check inversion and a freshly-deployed instance would
+        // either crash on `default(DateOnly)` (year 0001) or start importing
+        // from a runtime "now", silently shortening the historical backfill.
+        // Pin the literal so a regression that changes the year (or the
+        // fallback path entirely) is caught at test time. The sibling [Fact]
+        // already covers the non-default-latest branch — this one covers the
+        // null-MinSyncDate leg of the "no data yet" branch.
+        var result = SyncDateResolver.Resolve(default, new WorkerOptions { MinSyncDate = null });
+
+        result.Should().Be(new DateOnly(2020, 1, 1));
+    }
 }


### PR DESCRIPTION
## Summary

- Pin the empty-DB / null-`MinSyncDate` leg of `SyncDateResolver.Resolve`. Every domain worker (Yahoo, FRED, CFTC, FTD) routes its sync window through this helper, and freshly-deployed instances rely on the hard-coded `new DateOnly(2020, 1, 1)` literal when no data exists yet and the operator hasn't overridden the start. The existing test only covered the non-default-latest branch.

## Code changes

- `tests/Equibles.UnitTests/Core/SyncDateResolverTests.cs` — added one `[Fact]` (`Resolve_DefaultLatestAndNullMinSyncDate_ReturnsBakedDefaultMinDate`) asserting that `Resolve(default, new WorkerOptions { MinSyncDate = null })` returns `2020-01-01`. Pinning the literal protects against a regression that changes the year or flips the null-check.