### PR TITLE
test(sec): pin SecDocumentEnvelopeParser IsSafeFilename path-traversal reject

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserTests.cs
@@ -4,6 +4,39 @@ namespace Equibles.UnitTests.Sec;
 
 public class SecDocumentEnvelopeParserTests {
     [Fact]
+    public void TryExtractPaperPdfFilename_FilenameWithPathTraversal_RejectsAndReturnsFalse() {
+        // The parser pulls the candidate filename out of an SGML envelope body and the
+        // caller uses it to compose an EDGAR URL (`/Archives/edgar/data/{cik}/{accession}/{filename}`).
+        // The envelope is hostile-by-default: if SEC's CDN ever served — or a man-in-the-middle
+        // ever crafted — a filing whose <FILENAME> contained `..` or a path separator, the
+        // composed URL could traverse out of the per-filing directory. IsSafeFilename is the
+        // guard that rejects anything starting with `.` or containing `/` `\` — drop it and the
+        // URL composition is the only remaining defence. Pin the rejection on a `..` traversal
+        // pattern; even though `.endswith(".pdf")` passes, the leading-`.` and embedded `/`
+        // checks must both fire to return false. The companion happy-path [Fact] covers the
+        // permissive side, this one covers the security side.
+        var envelope = """
+            <SEC-DOCUMENT>
+            <SEC-HEADER>
+            </SEC-HEADER>
+            <DOCUMENT>
+            <TYPE>6-K
+            <SEQUENCE>1
+            <FILENAME>../etc/passwd.pdf
+            <DESCRIPTION>Form 6-K
+            <TEXT>
+            </TEXT>
+            </DOCUMENT>
+            </SEC-DOCUMENT>
+            """;
+
+        var success = SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(envelope, out var filename);
+
+        success.Should().BeFalse();
+        filename.Should().BeEmpty();
+    }
+
+    [Fact]
     public void TryExtractPaperPdfFilename_EnvelopeWrappingPdfDocument_ReturnsFilename() {
         var envelope = """
             <SEC-DOCUMENT>


### PR DESCRIPTION
## Summary

- Pin the security guard inside `SecDocumentEnvelopeParser.TryExtractPaperPdfFilename`. The filename it returns is concatenated into an EDGAR URL by the caller, so an envelope whose `<FILENAME>` contained `../` or a path separator could traverse out of the per-filing directory. `IsSafeFilename` rejects anything starting with `.` or containing `/`/`\`; the existing tests only covered the permissive happy path.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserTests.cs` — added one `[Fact]` (`TryExtractPaperPdfFilename_FilenameWithPathTraversal_RejectsAndReturnsFalse`) that feeds an envelope containing `<FILENAME>../etc/passwd.pdf` and asserts the method returns `false` with an empty out-filename. Pins the leading-dot and embedded-slash checks together.