### PR TITLE
test(congress): pin transaction-date column priority over notification-date

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTests.cs
@@ -284,6 +284,58 @@ public class DisclosureParsingHelperTests {
     }
 
     [Fact]
+    public void ParseTransactionsFromHtml_BothTransactionAndNotificationDateColumns_UsesTransactionDate() {
+        // Senate HTML disclosures regularly carry BOTH a "Transaction Date" (when the
+        // member traded) AND a "Notification Date" (when the filing was acknowledged) —
+        // the two can differ by weeks. MapColumnIndices' priority chain (transaction →
+        // notification → any-date) hinges on this distinction: every analyst-facing
+        // metric (timing relative to legislation, frontrunning windows) is computed from
+        // the transaction date, never the notification date.
+        //
+        // The risk this test pins: a refactor that simplifies to a single
+        // `FindIndex(h => h.Contains("date"))` would pick the FIRST date-matching column.
+        // Because Senate often renders Notification first, the helper would silently
+        // record FilingDate-ish values as TransactionDate, blowing up every "trades
+        // within N days of a hearing" query downstream. The existing positive test only
+        // has one date column — neither this nor the integration tests catch the
+        // priority regression.
+        //
+        // Notification Date 2024-07-01 is deliberately placed BEFORE Transaction Date
+        // 2024-06-15 so the simplified fallback would pick the wrong column.
+        var html = """
+            <html><body>
+            <table>
+              <thead><tr>
+                <th>Notification Date</th>
+                <th>Transaction Date</th>
+                <th>Ticker</th>
+                <th>Asset Name</th>
+                <th>Transaction Type</th>
+                <th>Amount</th>
+              </tr></thead>
+              <tbody>
+                <tr>
+                  <td>2024-07-01</td>
+                  <td>2024-06-15</td>
+                  <td>AAPL</td>
+                  <td>Apple Inc</td>
+                  <td>Purchase</td>
+                  <td>$1,001 - $15,000</td>
+                </tr>
+              </tbody>
+            </table>
+            </body></html>
+            """;
+
+        var result = DisclosureParsingHelper.ParseTransactionsFromHtml(
+            html, "Test Senator", CongressPosition.Senator,
+            new DateOnly(2024, 7, 1), Substitute.For<ILogger>());
+
+        result.Should().HaveCount(1);
+        result[0].TransactionDate.Should().Be(new DateOnly(2024, 6, 15));
+    }
+
+    [Fact]
     public void ParseTransactionsFromHtml_TickerExtractedFromAssetName() {
         var html = """
             <html><body>


### PR DESCRIPTION
## Summary

- Pins the priority chain in `DisclosureParsingHelper.MapColumnIndices`: "transaction date" → "notification date" → any "date" column. Senate disclosures regularly carry both columns, and every downstream analytic (frontrunning windows, trade timing relative to legislation) depends on `TransactionDate` being the day of the trade, not the day the filing was acknowledged.
- A refactor that simplifies to a single `FindIndex(h => h.Contains("date"))` would silently pick the first date-like column. Because Senate often renders "Notification Date" first, the helper would record acknowledgement dates as transaction dates. Existing happy-path tests only include one date column, so this regression has no coverage today.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTests.cs` — new `[Fact]` `ParseTransactionsFromHtml_BothTransactionAndNotificationDateColumns_UsesTransactionDate`. HTML deliberately puts "Notification Date" before "Transaction Date" with distinct values, then asserts the parsed `TransactionDate` matches the transaction column, not the notification column.