### PR TITLE
test(worker): pin SyncDateResolver operator-configured MinSyncDate branch

### DIFF
--- a/tests/Equibles.UnitTests/Core/SyncDateResolverTests.cs
+++ b/tests/Equibles.UnitTests/Core/SyncDateResolverTests.cs
@@ -14,6 +14,31 @@ public class SyncDateResolverTests {
     }
 
     [Fact]
+    public void Resolve_DefaultLatestAndConfiguredMinSyncDate_ReturnsOperatorValue() {
+        // Operators override the baked-in 2020-01-01 fallback by setting
+        // WorkerOptions.MinSyncDate — typically to either backfill further back
+        // (e.g. CFTC COT history from 1986) or to constrain a brand-new deployment
+        // to a recent window so the first sync doesn't drag in a decade of data.
+        //
+        // The risk this test pins: a refactor that collapses the null-check
+        // (`workerOptions.MinSyncDate.HasValue ? ... : DefaultMinDate`) into a
+        // bare `?? DefaultMinDate` on the wrong side, or that swaps the two
+        // branch bodies, would silently restart every empty-DB sync from
+        // 2020-01-01 regardless of operator config. The non-default-latest leg
+        // is covered above; the null-MinSyncDate leg is covered below; this
+        // covers the "configured" leg of the empty-DB branch — the third and
+        // final reachable branch in Resolve.
+        //
+        // Picking 2018-03-15 specifically — a date strictly distinct from both
+        // DefaultMinDate (2020-01-01) and from a default(DateOnly) so the
+        // wrong-branch regression can't pass by coincidence.
+        var minSync = new DateTime(2018, 3, 15);
+        var result = SyncDateResolver.Resolve(default, new WorkerOptions { MinSyncDate = minSync });
+
+        result.Should().Be(new DateOnly(2018, 3, 15));
+    }
+
+    [Fact]
     public void Resolve_DefaultLatestAndNullMinSyncDate_ReturnsBakedDefaultMinDate() {
         // Every domain worker that resolves its sync window through this helper
         // (Yahoo prices, FRED, CFTC, FTD) depends on the empty-DB fallback when


### PR DESCRIPTION
## Summary

- Covers the third and final branch of `SyncDateResolver.Resolve`: empty DB + operator-set `WorkerOptions.MinSyncDate`. Operators rely on this branch to override the baked 2020-01-01 fallback — either backfilling further (CFTC's 1986 history) or constraining a fresh deployment to a recent window.
- The other two branches (non-default latest date, and empty DB + null MinSyncDate) already had tests; without this one, a swap or collapse of the null-check would silently revert every operator-configured empty-DB sync to 2020-01-01.

## Code changes

- `tests/Equibles.UnitTests/Core/SyncDateResolverTests.cs` — new `[Fact]` `Resolve_DefaultLatestAndConfiguredMinSyncDate_ReturnsOperatorValue`. Passes `default(DateOnly)` as `latestDateInDb` and a deliberate `MinSyncDate = 2018-03-15` (distinct from both the baked default and `default(DateOnly)`), asserts the resolver returns the operator value.