### PR TITLE
test(sec): pin DocumentTypeConverter ConvertTo emits Value not DisplayName

### DIFF
--- a/tests/Equibles.UnitTests/Sec/DocumentTypeConverterTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeConverterTests.cs
@@ -7,6 +7,23 @@ public class DocumentTypeConverterTests {
     private readonly DocumentTypeConverter _sut = new();
 
     [Fact]
+    public void ConvertTo_DocumentTypeToString_ReturnsValueNotDisplayName() {
+        // MVC tag helpers and Url.Action pass a `DocumentType` as a route value through
+        // this converter to produce URL segments like `/Sec/Filings/TenK`. The wire form
+        // is the stable internal `Value` (e.g. "TenK"), NOT the human-friendly DisplayName
+        // ("10-K") — the slash in "10-K/A" would otherwise break route parsing entirely.
+        // A regression that returns DisplayName instead of Value would generate
+        // user-visible URLs that 404 on every typed-route action AND break round-tripping
+        // through `ConvertFrom` (which looks up by Value via DocumentType.FromValue). Pin
+        // ConvertTo on a name with a slash in the DisplayName so the distinction is loud
+        // — if a refactor swapped the two properties, the test would fail with a clearly
+        // wrong "10-K/A" output instead of the expected "TenKa".
+        var result = _sut.ConvertTo(null, CultureInfo.InvariantCulture, DocumentType.TenKa, typeof(string));
+
+        result.Should().Be("TenKa");
+    }
+
+    [Fact]
     public void ConvertFrom_UnknownStringValue_ThrowsFormatException() {
         var act = () => _sut.ConvertFrom(null, CultureInfo.InvariantCulture, "NotARealDocumentType");
 


### PR DESCRIPTION
## Summary

- Pin `DocumentTypeConverter.ConvertTo`. MVC tag helpers and `Url.Action` route a `DocumentType` through this converter to produce URL segments — the wire form must be the stable internal `Value` (e.g. `TenKa`), never the human-friendly `DisplayName` (`10-K/A`), or the embedded slash would break route parsing and every typed-route action would 404. The existing test only covered the inverse failure path (`ConvertFrom` of an unknown string).

## Code changes

- `tests/Equibles.UnitTests/Sec/DocumentTypeConverterTests.cs` — added one `[Fact]` (`ConvertTo_DocumentTypeToString_ReturnsValueNotDisplayName`) deliberately using `DocumentType.TenKa` (whose `DisplayName` is `"10-K/A"`) so any regression that swaps the two properties fails loudly with a clearly wrong slash-bearing output.