### PR TITLE
test(sec): pin RagManager.BuildContext excerpt ordering by StartPosition

### DIFF
--- a/tests/Equibles.UnitTests/Sec/RagManagerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RagManagerTests.cs
@@ -1,0 +1,53 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.BusinessLogic.Search;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Data.Models.Chunks;
+
+namespace Equibles.UnitTests.Sec;
+
+public class RagManagerTests {
+    [Fact]
+    public async Task BuildContext_ChunksFromSameDocumentOutOfOrder_OutputsByStartPositionAscending() {
+        // RagManager.BuildContext groups chunks per (Ticker, DocumentType, ReportingDate) and
+        // emits each group's excerpts ordered by Chunk.StartPosition. The order matters: the
+        // assembled string is fed to an LLM, and disordered excerpts produce non-sequential
+        // narrative — e.g. the Risk Factors discussion appearing AFTER its dependent forward-
+        // looking-statements section. HybridSearch returns chunks ranked by relevance, NOT
+        // by position, so this OrderBy is the only thing keeping output sequential.
+        //
+        // The risk this test pins: a "tidy-up" refactor that drops the OrderBy (or replaces
+        // it with .OrderBy(c => c.Index)) would silently scramble every multi-chunk RAG
+        // response. Index and StartPosition are usually monotonic together — but Index can
+        // be reassigned during chunk-table backfills, while StartPosition is the source of
+        // truth from the original document offsets. Pinning StartPosition specifically
+        // catches the OrderBy → OrderBy(Index) substitution.
+        //
+        // Construction: three chunks from the same document, fed in deliberately wrong order
+        // (StartPositions 500, 100, 300 in that sequence). Output should be "Excerpt 1 (line ~10)",
+        // "Excerpt 3 (line ~30)", "Excerpt 2 (line ~50)" — but importantly the *content* must
+        // appear at positions matching StartPosition ascending: "FIRST" → "SECOND" → "THIRD".
+        var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
+        var document = new Document {
+            CommonStock = stock,
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2024, 12, 31),
+        };
+        var chunks = new List<Chunk> {
+            new() { Index = 0, StartPosition = 500, StartLineNumber = 50, Content = "THIRD excerpt", Document = document },
+            new() { Index = 1, StartPosition = 100, StartLineNumber = 10, Content = "FIRST excerpt", Document = document },
+            new() { Index = 2, StartPosition = 300, StartLineNumber = 30, Content = "SECOND excerpt", Document = document },
+        };
+
+        var sut = new RagManager(chunkRepository: null, commonStockRepository: null, logger: null);
+
+        var result = await sut.BuildContext(chunks);
+
+        var firstIdx = result.IndexOf("FIRST", StringComparison.Ordinal);
+        var secondIdx = result.IndexOf("SECOND", StringComparison.Ordinal);
+        var thirdIdx = result.IndexOf("THIRD", StringComparison.Ordinal);
+
+        firstIdx.Should().BePositive();
+        secondIdx.Should().BeGreaterThan(firstIdx);
+        thirdIdx.Should().BeGreaterThan(secondIdx);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `RagManager.BuildContext` ordering excerpts within a (Ticker, DocumentType, ReportingDate) group by `Chunk.StartPosition` ascending. `HybridSearch` returns chunks ranked by relevance, not by position — this `OrderBy` is the only thing keeping the LLM-facing context sequential.
- The risk: a refactor that drops the OrderBy or replaces it with `OrderBy(Index)` would silently scramble every multi-chunk RAG response. `Index` and `StartPosition` are usually monotonic together, but `Index` can be reassigned during chunk backfills while `StartPosition` is the source of truth from original document offsets — so substituting one for the other passes happy-path tests but breaks under backfill conditions.
- First unit test for `RagManager`; existing coverage was integration-only and exercised the happy path, not the ordering invariant.

## Code changes

- `tests/Equibles.UnitTests/Sec/RagManagerTests.cs` — new `[Fact]` `BuildContext_ChunksFromSameDocumentOutOfOrder_OutputsByStartPositionAscending`. Constructs three chunks for the same document with `StartPosition` 500/100/300 fed in that wrong order, then asserts the output string contains "FIRST" before "SECOND" before "THIRD" by `IndexOf` position. Direct ctor instantiation (null repos/logger) since `BuildContext` is pure-logic and doesn't touch them.