### PR TITLE
test(web): pin StatisticsExtensions.SafeRound NaN guard against decimal overflow

### DIFF
--- a/tests/Equibles.UnitTests/Web/StatisticsExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Web/StatisticsExtensionsTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class StatisticsExtensionsTests {
+    [Fact]
+    public void SafeRound_NaN_ReturnsNullInsteadOfThrowingOnDecimalCast() {
+        // MathNet.Numerics.Statistics.DescriptiveStatistics.StandardDeviation returns
+        // double.NaN for any single-value sample — a realistic shape coming out of
+        // TechnicalIndicatorService when an instrument has only one closing price in
+        // the requested window (e.g. an IPO's first trading day, or a thinly-traded
+        // ticker over a short range). `SafeRound` exists specifically to protect the
+        // downstream `(decimal)` cast: casting `double.NaN` to `decimal` throws
+        // OverflowException at runtime, which would crash the view render and serve
+        // a 500 instead of a graceful empty-cell. The guard is a single
+        // `double.IsFinite(value)` check — drop it and every single-row indicator
+        // calculation becomes a runtime crash that escapes the test suite (since the
+        // existing TechnicalIndicatorService tests all use multi-point inputs).
+        // Pin the NaN path so a "simplify" refactor that removes IsFinite is caught.
+        var result = double.NaN.SafeRound(2);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pin `StatisticsExtensions.SafeRound` on its actual reason-for-existing: `MathNet.Numerics.Statistics.DescriptiveStatistics.StandardDeviation` returns `double.NaN` for single-value samples (realistic on IPO first-day or thinly-traded tickers), and `(decimal)double.NaN` throws `OverflowException` at runtime. The `double.IsFinite` guard is the only thing preventing a 500 on those view renders, but no existing test exercises the NaN path (the `TechnicalIndicatorService` tests all use multi-point inputs).

## Code changes

- `tests/Equibles.UnitTests/Web/StatisticsExtensionsTests.cs` — new test class with one `[Fact]` (`SafeRound_NaN_ReturnsNullInsteadOfThrowingOnDecimalCast`) asserting that `double.NaN.SafeRound(2)` returns `null`. A regression that "simplifies" the helper by dropping `IsFinite` would crash on the next single-row indicator view; this catches it at test time.