### PR TITLE
test(worker): replace Task.Delay with deterministic polling in BaseScraperWorker tests

### DIFF
--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerTests.cs
@@ -36,10 +36,12 @@ public class BaseScraperWorkerTests {
     [Fact]
     public async Task ExecuteAsync_CallsDoWork_WhenNotCancelled() {
         using var worker = CreateWorker();
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        using var cts = new CancellationTokenSource();
 
         await worker.StartAsync(cts.Token);
-        await Task.Delay(100);
+        // Poll instead of a blind Task.Delay — on slow CI runners the BackgroundService
+        // may not schedule ExecuteAsync within 100ms, leaving DoWorkCallCount at 0.
+        await WaitUntilAsync(() => worker.DoWorkCallCount >= 1, TimeSpan.FromSeconds(5));
         await worker.StopAsync(CancellationToken.None);
 
         worker.DoWorkCallCount.Should().BeGreaterThanOrEqualTo(1);
@@ -49,10 +51,13 @@ public class BaseScraperWorkerTests {
     public async Task ExecuteAsync_CatchesAndLogsCriticalException_WhenDoWorkThrows() {
         var exception = new InvalidOperationException("Something broke");
         using var worker = CreateWorker(doWorkOverride: _ => throw exception);
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        using var cts = new CancellationTokenSource();
 
         await worker.StartAsync(cts.Token);
-        await Task.Delay(100);
+        // Once DoWork has been entered twice, iteration 1's catch block (LogCritical
+        // + ErrorReporter.Report + post-cycle log + sleep) has fully completed —
+        // deterministic proof the log assertion below has a value to match.
+        await WaitUntilAsync(() => worker.DoWorkCallCount >= 2, TimeSpan.FromSeconds(5));
         await worker.StopAsync(CancellationToken.None);
 
         _logger.Received().Log(
@@ -68,10 +73,10 @@ public class BaseScraperWorkerTests {
     public async Task ExecuteAsync_ReportsErrorViaErrorReporter_WhenDoWorkThrows() {
         var exception = new InvalidOperationException("Report this error");
         using var worker = CreateWorker(doWorkOverride: _ => throw exception);
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        using var cts = new CancellationTokenSource();
 
         await worker.StartAsync(cts.Token);
-        await Task.Delay(100);
+        await WaitUntilAsync(() => worker.DoWorkCallCount >= 2, TimeSpan.FromSeconds(5));
         await worker.StopAsync(CancellationToken.None);
 
         // ErrorReporter.Report internally calls CreateAsyncScope which will throw


### PR DESCRIPTION
## Summary

- `BaseScraperWorkerTests.ExecuteAsync_CallsDoWork_WhenNotCancelled` failed in CI on #162 (https://github.com/daniel3303/Equibles/runs/75684344174). The race: `Task.Delay(100)` is not long enough on slow CI runners for `BackgroundService.ExecuteAsync` to be scheduled, so `DoWorkCallCount` stayed at `0` and the assertion failed.
- The same race pattern existed in two sibling tests (`ExecuteAsync_CatchesAndLogsCriticalException_WhenDoWorkThrows`, `ExecuteAsync_ReportsErrorViaErrorReporter_WhenDoWorkThrows`) — they happened to pass on this run but would flake the same way.
- Replaced the blind sleeps with the file's existing `WaitUntilAsync` polling helper (already used by `ExecuteAsync_LogsStartAndCompletionMessages`). For the throw tests, polling for `DoWorkCallCount >= 2` is deterministic proof that iteration 1's catch block (LogCritical + ErrorReporter.Report) ran to completion.
- Verified the fix by running the suite 20 times in a loop locally — 20/20 passes.

## Code changes

- `tests/Equibles.UnitTests/Worker/BaseScraperWorkerTests.cs`
  - `ExecuteAsync_CallsDoWork_WhenNotCancelled`: dropped the 200ms auto-cancel and the 100ms sleep; poll until `DoWorkCallCount >= 1` (timeout 5s).
  - `ExecuteAsync_CatchesAndLogsCriticalException_WhenDoWorkThrows`: same change, polling until `DoWorkCallCount >= 2` so iteration 1's catch+log is guaranteed to have fired before the `Received().Log` assertion runs.
  - `ExecuteAsync_ReportsErrorViaErrorReporter_WhenDoWorkThrows`: same as above.