### PR TITLE
test(web): pin MarkdownExtensions DisableHtml XSS guard

### DIFF
--- a/tests/Equibles.UnitTests/Web/MarkdownExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Web/MarkdownExtensionsTests.cs
@@ -8,6 +8,34 @@ namespace Equibles.UnitTests.Web;
 
 public class MarkdownExtensionsTests {
     [Fact]
+    public void MarkdownToHtml_RawHtmlInInput_IsStrippedByDisableHtmlPipeline() {
+        // The markdown rendered through this extension can originate from SEC filings,
+        // earnings-call transcripts, and other ingested content that may contain raw
+        // HTML — including potentially malicious payloads. The pipeline builder calls
+        // `.DisableHtml()` specifically to prevent any `<script>`, `<iframe>`, or other
+        // raw-HTML content in the source markdown from being passed through to the
+        // page DOM. Markdig honours that flag by escaping HTML angle brackets at
+        // render time. A regression that drops `.DisableHtml()` (e.g. someone copying
+        // a different pipeline preset) would re-enable raw HTML passthrough, turning
+        // any ingested document into a vector for stored XSS the next time it
+        // renders in the Web project. Pin the strip on a `<script>` payload — assert
+        // the rendered HTML does NOT contain a live `<script` tag (only the escaped
+        // form `&lt;script&gt;` which is inert).
+        string captured = null;
+        var htmlHelper = Substitute.For<IHtmlHelper>();
+        htmlHelper.Raw(Arg.Do<string>(s => captured = s))
+            .Returns(callInfo => new HtmlString(callInfo.Arg<string>()));
+
+        var markdown = "Hello <script>alert('xss')</script> world";
+
+        htmlHelper.MarkdownToHtml(markdown);
+
+        captured.Should().NotBeNull();
+        captured.Should().NotContain("<script>");
+        captured.Should().Contain("&lt;script&gt;");
+    }
+
+    [Fact]
     public void MarkdownToHtml_PipeTableWithBlankLineBetweenRows_RendersAsSingleTable() {
         string captured = null;
         var htmlHelper = Substitute.For<IHtmlHelper>();


### PR DESCRIPTION
## Summary

- Pin the security guard in `MarkdownExtensions.MarkdownToHtml`. The Markdig pipeline calls `.DisableHtml()` specifically to prevent raw HTML (including `<script>`, `<iframe>`, etc.) from being passed through into the rendered DOM when the source markdown originates from ingested SEC filings, earnings-call transcripts, or other untrusted content. Without that flag, any malicious payload in the source would become stored XSS the next time it renders. The existing test only covers the pipe-table-blank-line normaliser.

## Code changes

- `tests/Equibles.UnitTests/Web/MarkdownExtensionsTests.cs` — added one `[Fact]` (`MarkdownToHtml_RawHtmlInInput_IsStrippedByDisableHtmlPipeline`) feeding a `<script>alert('xss')</script>` payload and asserting the rendered output contains the escaped `&lt;script&gt;` form but NOT the live `<script>` tag. A regression that swaps the pipeline preset (or copies one that omits `DisableHtml`) would be caught at test time.