### PR TITLE
test(web): pin AuthController session-cookie HttpOnly and SameSite=Strict flags

### DIFF
--- a/tests/Equibles.UnitTests/Web/AuthControllerTests.cs
+++ b/tests/Equibles.UnitTests/Web/AuthControllerTests.cs
@@ -162,6 +162,30 @@ public class AuthControllerTests {
     }
 
     [Fact]
+    public void LoginPost_ValidCredentials_CookieSetsHttpOnlyAndSameSiteStrictFlags() {
+        // The session cookie carries the only credential the browser will replay on every
+        // subsequent request, so its two hardening flags are load-bearing:
+        //   - HttpOnly: blocks document.cookie access from injected JS, the difference
+        //     between "someone planted a stored XSS in a markdown filing" and "someone
+        //     planted a stored XSS in a markdown filing AND now has every operator's
+        //     session token".
+        //   - SameSite=Strict: blocks third-party-context cookie attachment, which is the
+        //     only thing keeping a cross-origin form-POST attacker from logging an admin
+        //     in to operations of the attacker's choice.
+        // The existing `*_SetsCookie` test only asserts the cookie's *name* appears in
+        // Set-Cookie — a regression that removed either flag would still pass it. Pin
+        // both flags together: a single Set-Cookie header must carry `httponly` and
+        // `samesite=strict` (case-insensitive — the framework emits in mixed-case).
+        var controller = CreateController(EnabledAuthSettings());
+
+        controller.Login(ValidUsername, ValidPassword, returnUrl: null!);
+
+        var cookies = controller.HttpContext.Response.Headers["Set-Cookie"].ToString();
+        cookies.ToLowerInvariant().Should().Contain("httponly");
+        cookies.ToLowerInvariant().Should().Contain("samesite=strict");
+    }
+
+    [Fact]
     public void LoginPost_ValidCredentials_CookieContainsExpectedToken() {
         var controller = CreateController(EnabledAuthSettings());
         var expectedToken = EnvAuthHandler.GenerateToken(ValidUsername, SessionSecret);


### PR DESCRIPTION
## Summary

- Pin the two load-bearing hardening flags on the session cookie set by `AuthController.LoginPost`: `HttpOnly` (blocks document.cookie from injected JS — without it a stored-XSS in any rendered filing would also exfiltrate every operator's session token) and `SameSite=Strict` (blocks third-party-context cookie attachment — without it a cross-origin form POST can ride the operator's session). The existing `*_SetsCookie` test only asserts the cookie's *name* — a regression that dropped either flag would pass it.

## Code changes

- `tests/Equibles.UnitTests/Web/AuthControllerTests.cs` — added one `[Fact]` (`LoginPost_ValidCredentials_CookieSetsHttpOnlyAndSameSiteStrictFlags`) inspecting the Set-Cookie header for both `httponly` and `samesite=strict` substrings (case-insensitive — ASP.NET Core emits in mixed-case).