### PR TITLE
test(holdings): pin ParseInvestmentDiscretion DFND→Defined wire mapping

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTests.cs
@@ -13,6 +13,27 @@ public class HoldingsParsingHelperTests {
     }
 
     [Fact]
+    public void ParseInvestmentDiscretion_DfndAbbreviation_ReturnsDefined() {
+        // SEC 13F filings use abbreviated wire values for investment discretion:
+        // "SOLE", "DFND" (defined investment discretion), and "OTR" (other). The C#
+        // enum follows project standards by using full descriptive names — Sole,
+        // Defined, Other — and `ParseInvestmentDiscretion` is the bridge that
+        // translates each wire abbreviation to its domain value. The default arm
+        // of the switch falls back to `InvestmentDiscretion.Sole`, so a regression
+        // that drops the "DFND" case (or that renames the wire abbreviation in a
+        // copy-paste edit) would silently reclassify every Defined-discretion
+        // holding as Sole — corrupting the analytics that distinguish how managers
+        // exercise authority over the holdings they report.
+        //
+        // The sibling [Fact] above pins the same wire-to-domain contract for the
+        // "PRN" → Principal case in ParseShareType; this one extends it to the
+        // structurally similar ParseInvestmentDiscretion switch.
+        var result = HoldingsParsingHelper.ParseInvestmentDiscretion("DFND");
+
+        result.Should().Be(InvestmentDiscretion.Defined);
+    }
+
+    [Fact]
     public void ParseShareType_PrincipalAbbreviation_ReturnsPrincipal() {
         // SEC 13F filings use abbreviated wire values: "SH" for Shares, "PRN" for Principal.
         // The C# enum uses full descriptive names per project standards. ParseShareType is


### PR DESCRIPTION
## Summary

- Pins the wire-to-domain bridge in `HoldingsParsingHelper.ParseInvestmentDiscretion`: SEC 13F filings emit the abbreviation `DFND` while the C# enum uses the full descriptive name `Defined` (per project standards). Without this test, a regression that drops the `DFND` case (or copy-pastes a typo into the switch) would silently fall through to the default `Sole` arm and reclassify every Defined-discretion holding as Sole.
- Mirrors the existing `ParseShareType("PRN") → Principal` pin for the structurally identical sibling switch in the same helper.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTests.cs` — new `[Fact]` `ParseInvestmentDiscretion_DfndAbbreviation_ReturnsDefined`. Calls the public helper directly and asserts the SEC wire value `"DFND"` maps to `InvestmentDiscretion.Defined`.