### PR TITLE
test(holdings): pin HoldingsDataSetClient lowercase-month in 2024+ filename format

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsDataSetClientTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsDataSetClientTests.cs
@@ -12,6 +12,25 @@ public class HoldingsDataSetClientTests {
     }
 
     [Fact]
+    public void GetDataSetFileNames_StartIn2024_EmitsLowercaseMonthInNewFormatFilename() {
+        // SEC switched the 13F structured data set naming in 2024 from `{year}q{quarter}_form13f.zip`
+        // to a date-range form `{ddMMMyyyy}-{ddMMMyyyy}_form13f.zip` where the month abbreviation
+        // MUST be lowercase (the SEC's CDN matches the URL case-sensitively — `01Jan2024-...`
+        // returns 404 where `01jan2024-...` is the published artifact). Production explicitly
+        // calls `.ToLower()` on the `MMM` format result because culture-dependent
+        // DateOnly.ToString("MMM") emits a leading-capital `Jan`/`Feb`/etc on every culture
+        // that ships, including invariant. Drop the `.ToLower()` (or refactor to a custom
+        // formatter that forgets case) and every 2024+ download 404s, silently halting the
+        // 13F ingest for the entire post-2023 dataset. The Jan-Feb 2024 transition period
+        // is the cleanest pin because it's the ONLY period in the table that uses both the
+        // shortest-month "Jan" and the leap-day "29feb" — a regression in either dimension
+        // (uppercase month OR wrong leap-day choice) fails the assertion.
+        var result = HoldingsDataSetClient.GetDataSetFileNames(new DateTime(2024, 1, 1));
+
+        result.Should().Contain("01jan2024-29feb2024_form13f.zip");
+    }
+
+    [Fact]
     public void GetDataSetFileNames_StartIn2014_ProducesOldQuarterlyFormatFilename() {
         // The SEC publishes Form 13F data sets under exact-cased filenames that the
         // downloader concatenates onto the BaseUrl verbatim. For 2013-2023 the format


### PR DESCRIPTION
## Summary

- Pin the lowercase-month requirement on `HoldingsDataSetClient.GetDataSetFileNames`'s 2024+ output. SEC's CDN matches data-set URLs case-sensitively — the published artifact is `01jan2024-29feb2024_form13f.zip`, and an upstream `01Jan2024-…` would 404. Production explicitly calls `.ToLower()` on `DateOnly.ToString("MMM")` because invariant culture emits a leading-capital `Jan`. A regression that drops the `.ToLower()` halts the entire post-2023 13F ingest silently. The existing test set only covered the 2013-2023 quarterly format and the boundary clamp.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsDataSetClientTests.cs` — added one `[Fact]` (`GetDataSetFileNames_StartIn2024_EmitsLowercaseMonthInNewFormatFilename`) asserting the Jan-Feb 2024 transition period emits `01jan2024-29feb2024_form13f.zip`. Catches both an uppercase-month regression AND a leap-day mismatch in a single assertion.