### PR TITLE
test(congress): pin SenateDisclosureClient rejects cross-origin absolute report URL

### DIFF
--- a/tests/Equibles.UnitTests/Congress/SenateDisclosureClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateDisclosureClientTests.cs
@@ -15,6 +15,34 @@ public class SenateDisclosureClientTests {
         .GetMethod("ParseReportRow", BindingFlags.NonPublic | BindingFlags.Instance);
 
     [Fact]
+    public void ParseReportRow_AbsoluteUrlOutsideSenateBase_IsRejectedAndReturnsNull() {
+        // The Senate disclosure feed delivers report links inside row HTML. Most are
+        // relative paths (`/search/view/...`) that ParseReportRow prefixes with BaseUrl,
+        // but the parser also accepts already-absolute URLs (`reportPath.StartsWith("http")`).
+        // That branch trusts the source HTML's domain — an attacker who could feed the
+        // importer a row whose href pointed at `https://evil.com/phish` would otherwise
+        // get downstream code calling Playwright + the HTTP client against an arbitrary
+        // origin, exfiltrating any cookie or credential the runtime might attach.
+        // The guard is `if (!IsValidDisclosureUrl(reportUrl, BaseUrl)) return null;`
+        // — drop it (or weaken the prefix check) and that cross-origin call goes through.
+        // Pin the rejection on an attacker-controlled absolute URL so a refactor that
+        // collapses the if/else into "always prepend BaseUrl" (which would silently
+        // mangle absolute URLs but ALSO accept them) is caught.
+        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var row = new List<string> {
+            "Jane",
+            "Doe",
+            "filed",
+            "<a href=\"https://evil.example/phish/report\">link</a>",
+            "2024-01-15",
+        };
+
+        var result = ParseReportRowMethod.Invoke(sut, [row]);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public void ParseReportRow_PaperFilingUrl_ReturnsNull() {
         // Senate disclosures come in two flavours: HTML electronic filings (parseable) and
         // scanned-PDF "paper" filings (unparseable). ParseReportRow skips paper filings by


### PR DESCRIPTION
## Summary

- Pin the cross-origin guard in `SenateDisclosureClient.ParseReportRow`. The parser accepts already-absolute report URLs from the source HTML, then validates them against `BaseUrl` via `IsValidDisclosureUrl`. Without that check, an attacker who fed a row whose href pointed at `https://evil.example/...` would have downstream code call Playwright + HTTP against an arbitrary origin, exfiltrating any cookie or credential attached at the runtime layer. The existing test only covered the paper-filing skip path.

## Code changes

- `tests/Equibles.UnitTests/Congress/SenateDisclosureClientTests.cs` — added one `[Fact]` (`ParseReportRow_AbsoluteUrlOutsideSenateBase_IsRejectedAndReturnsNull`) using reflection on the private parser (matching the existing pattern), feeding an `https://evil.example/phish/report` href, and asserting the parser returns `null` instead of forwarding the malicious URL into the fetch pipeline.