### PR TITLE
test(web): pin FlashMessage.Error sets Type=Error not default Success

### DIFF
--- a/tests/Equibles.UnitTests/Web/FlashMessageClassTests.cs
+++ b/tests/Equibles.UnitTests/Web/FlashMessageClassTests.cs
@@ -8,6 +8,40 @@ namespace Equibles.UnitTests.Web;
 
 public class FlashMessageClassTests {
     [Fact]
+    public void Error_QueuesMessageWithErrorTypeNotDefaultSuccess() {
+        // FlashMessageModel's default `Type` is `FlashMessageType.Success` — pinned by
+        // FlashMessageModelTests.Constructor_DefaultType_IsSuccess. Every convenience
+        // helper (Success / Error / Info / Warning) constructs a FlashMessageModel and
+        // sets `Type = ...` explicitly to override that default. The risk this test
+        // pins: a copy-paste regression that drops the explicit `Type =` assignment
+        // from `FlashMessage.Error`, or that mistakenly sets it to the wrong enum
+        // value, would silently render every error toast as a green success toast.
+        // The UI renders toast color/icon strictly from this enum value, so the
+        // visual error (forms claiming success on failure, error pages showing the
+        // success affordance) is invisible to compilers and integration tests.
+        //
+        // Distinguish "intentional Error" from "default Success" by capturing the
+        // serialized payload from TempData[KeyName] and asserting Type=Error after
+        // round-tripping through the real serializer — a test that only checks
+        // "some message was queued" wouldn't catch the type-swap regression.
+        var serializer = new JsonFlashMessageSerializer();
+        string captured = null;
+        var tempData = Substitute.For<ITempDataDictionary>();
+        tempData.WhenForAnyArgs(t => t[FlashMessage.KeyName] = default)
+            .Do(callInfo => captured = (string)callInfo.Arg<object>());
+        var factory = Substitute.For<ITempDataDictionaryFactory>();
+        factory.GetTempData(Arg.Any<HttpContext>()).Returns(tempData);
+        var sut = new FlashMessage(factory, Substitute.For<IHttpContextAccessor>(), serializer);
+
+        sut.Error("Something broke");
+
+        captured.Should().NotBeNull();
+        var roundTripped = serializer.Deserialize(captured);
+        roundTripped.Should().ContainSingle()
+            .Which.Type.Should().Be(FlashMessageType.Error);
+    }
+
+    [Fact]
     public void Retrieve_WhenEntryExists_RemovesItFromTempData() {
         var serializer = new JsonFlashMessageSerializer();
         var serialized = serializer.Serialize(new List<IFlashMessageModel> {


### PR DESCRIPTION
## Summary

- Pins `FlashMessage.Error` queuing a `FlashMessageModel` with `Type = FlashMessageType.Error` specifically. `FlashMessageModel`'s default `Type` is `Success`, so the convenience helpers (`Success`/`Error`/`Info`/`Warning`) each explicitly override that default.
- The risk: a copy-paste regression in `Error` (dropping the `Type =` assignment, or setting it to the wrong enum) would silently render every error toast green. The UI renders toast color/icon strictly from this enum value; the visual error (forms claiming success on failure, error pages showing the success affordance) is invisible to compilers and integration tests.

## Code changes

- `tests/Equibles.UnitTests/Web/FlashMessageClassTests.cs` — new `[Fact]` `Error_QueuesMessageWithErrorTypeNotDefaultSuccess`. Captures the serialized payload that `Error("Something broke")` writes to `TempData[KeyName]` via NSubstitute's `WhenForAnyArgs` on the indexer set, round-trips it back through `JsonFlashMessageSerializer.Deserialize`, and asserts the resulting `Type` is `Error` (not the default `Success`).