### PR TITLE
test(sec): pin ListConversionStep span-fallback when no inline content div

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepTests.cs
@@ -117,6 +117,27 @@ public class ListConversionStepTests {
     }
 
     [Fact]
+    public void WrapperWithoutInlineDisplayDiv_FallsBackToCloningContentSpans() {
+        // When the item wrapper has no <div style="display:inline"> content
+        // container, the converter falls back to cloning the non-bullet
+        // spans into the <li>. This pins the fallback path so SEC filings
+        // that put item content directly in spans still produce a list.
+        var input = """
+            <div class="item-list-element-wrapper">
+              <span>•</span>
+              <span>Span-based item</span>
+            </div>
+            """;
+
+        var result = Execute(input);
+
+        result.Should().Contain("<ul>");
+        result.Should().Contain("<li>");
+        result.Should().Contain("<span>Span-based item</span>");
+        result.Should().NotContain("•");
+    }
+
+    [Fact]
     public void EmptyDocument_NoError() {
         var result = Execute(string.Empty);
 


### PR DESCRIPTION
## Summary

- The `ListConversionStep.ConvertItemToListItem` fallback branch (lines 84-88) — used when an `item-list-element-wrapper` div has no `<div style="display:inline">` content container — was not covered.
- This adds one test pinning the fallback path so SEC filings that place item content directly in non-bullet spans still get converted to `<ul>`/`<li>` with the content spans cloned in.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepTests.cs` — adds `WrapperWithoutInlineDisplayDiv_FallsBackToCloningContentSpans` exercising the previously uncovered span-clone fallback branch.