### PR TITLE
test(sec): pin HeadingConversionStep parent-center-aligned span to H3

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepTests.cs
@@ -68,6 +68,18 @@ public class HeadingConversionStepTests {
     }
 
     [Fact]
+    public void SpanInsideParentWithCenterAlignment_IsConvertedToH3() {
+        // SEC filings frequently mark section labels by centering them at the
+        // parent level (<div style="text-align:center"><span>Label</span></div>)
+        // rather than on the span itself. IsCenterAligned reads both span and
+        // parent styles; the parent-only path was previously unexercised — pin
+        // it so centered section labels without bold/uppercase still get H3.
+        var result = Execute("<div style=\"text-align:center\"><span>Section Title</span></div>");
+
+        result.Should().Contain("<h3>Section Title</h3>");
+    }
+
+    [Fact]
     public void ParentheticalText_DoesNotTriggerHeading() {
         var result = Execute("<div><span>(continued)</span></div>");
 


### PR DESCRIPTION
## Summary

- `HeadingConversionStep.IsCenterAligned` checks both the span's `style` AND its parent's `style` for `text-align:center`. The parent-only path was previously unexercised.
- This adds one test pinning that a span whose parent (but not itself) has `text-align:center` still gets promoted to `<h3>` — matching the common SEC pattern of centering section labels at the wrapping div.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepTests.cs` — adds `SpanInsideParentWithCenterAlignment_IsConvertedToH3` exercising the previously uncovered parent-style branch of `IsCenterAligned`.