### PR TITLE
test(web): pin BaseController.InitSseStream sets SSE headers including X-Accel-Buffering

### DIFF
--- a/tests/Equibles.UnitTests/Web/BaseControllerTests.cs
+++ b/tests/Equibles.UnitTests/Web/BaseControllerTests.cs
@@ -43,9 +43,33 @@ public class BaseControllerTests {
         result.Should().BeNull();
     }
 
+    [Fact]
+    public void InitSseStream_SetsContentTypeAndDisablesNginxBuffering() {
+        // InitSseStream prepares a response for Server-Sent Events. The three
+        // headers it sets are load-bearing: text/event-stream is the SSE
+        // content type, no-cache prevents downstream caches from holding
+        // the stream, and X-Accel-Buffering: no tells nginx (and other
+        // reverse proxies that honour the header) NOT to buffer the
+        // response — without it, the proxy holds bytes until the
+        // connection closes and SSE clients see nothing until then. Pin
+        // all three so a refactor that "simplifies" the helper to a
+        // single ContentType set can't silently break streaming.
+        var sut = new TestableBaseController();
+        var httpContext = new DefaultHttpContext();
+        sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        sut.InvokeInitSseStream();
+
+        httpContext.Response.ContentType.Should().Be("text/event-stream");
+        httpContext.Response.Headers.CacheControl.ToString().Should().Be("no-cache");
+        httpContext.Response.Headers["X-Accel-Buffering"].ToString().Should().Be("no");
+    }
+
     private sealed class TestableBaseController : BaseController {
         public TestableBaseController() : base(Substitute.For<ILogger<BaseController>>()) { }
 
         public string InvokeGetReturnUrl() => GetReturnUrl();
+
+        public void InvokeInitSseStream() => InitSseStream();
     }
 }


### PR DESCRIPTION
## Summary

- `BaseController.InitSseStream` sets three load-bearing headers for Server-Sent Events: `text/event-stream` content type, `Cache-Control: no-cache`, and `X-Accel-Buffering: no`. None of them were exercised.
- Without `X-Accel-Buffering: no`, nginx (and similar reverse proxies) buffer the response until the connection closes — SSE clients receive nothing until then. Pin all three so a refactor that "simplifies" the helper to a single ContentType set can't silently break streaming.

## Code changes

- `tests/Equibles.UnitTests/Web/BaseControllerTests.cs` — adds `InitSseStream_SetsContentTypeAndDisablesNginxBuffering` exercising the previously uncovered `InitSseStream` helper. Extends the local `TestableBaseController` with an invoker for the protected method.