### PR TITLE
test(web): pin FlashMessage.Clear delegates to TempData.Clear (full wipe)

### DIFF
--- a/tests/Equibles.UnitTests/Web/FlashMessageClassTests.cs
+++ b/tests/Equibles.UnitTests/Web/FlashMessageClassTests.cs
@@ -96,6 +96,26 @@ public class FlashMessageClassTests {
     }
 
     [Fact]
+    public void Clear_DelegatesToTempDataClear_WipingAllEntriesNotJustFlashKey() {
+        // FlashMessage.Clear() calls TempData.Clear() — which wipes EVERY key in
+        // TempData, not just the flash-message entry. That semantic is load-
+        // bearing: a refactor that "narrows" it to TempData.Remove(KeyName)
+        // would silently change behavior for controllers that read other
+        // TempData entries (PRG-pattern form repopulation, return URLs).
+        // Pin the broad-clear contract so any future change must be explicit.
+        var tempData = Substitute.For<ITempDataDictionary>();
+        var factory = Substitute.For<ITempDataDictionaryFactory>();
+        factory.GetTempData(Arg.Any<HttpContext>()).Returns(tempData);
+        var sut = new FlashMessage(factory, Substitute.For<IHttpContextAccessor>(),
+            Substitute.For<IFlashMessageSerializer>());
+
+        sut.Clear();
+
+        tempData.Received(1).Clear();
+        tempData.DidNotReceiveWithAnyArgs().Remove(default);
+    }
+
+    [Fact]
     public void Retrieve_WhenEntryExists_RemovesItFromTempData() {
         var serializer = new JsonFlashMessageSerializer();
         var serialized = serializer.Serialize(new List<IFlashMessageModel> {


### PR DESCRIPTION
## Summary

- `FlashMessage.Clear()` was unpinned. It calls `TempData.Clear()` — wiping EVERY key in TempData, not just the flash-message entry. That semantic is load-bearing: a refactor that narrowed it to `TempData.Remove(KeyName)` would silently change behavior for controllers that store other state in TempData (PRG-pattern form repopulation, return URLs).
- This adds one test asserting `Clear()` invokes `TempData.Clear()` and does NOT invoke `Remove(...)`, so any future change to the contract must be deliberate.

## Code changes

- `tests/Equibles.UnitTests/Web/FlashMessageClassTests.cs` — adds `Clear_DelegatesToTempDataClear_WipingAllEntriesNotJustFlashKey` exercising the previously uncovered `Clear()` method.