### PR TITLE
test(sec): pin DocumentTypeConverter.ConvertFrom round-trips Value to DocumentType

### DIFF
--- a/tests/Equibles.UnitTests/Sec/DocumentTypeConverterTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeConverterTests.cs
@@ -24,6 +24,20 @@ public class DocumentTypeConverterTests {
     }
 
     [Fact]
+    public void ConvertFrom_KnownValueString_ReturnsMatchingDocumentType() {
+        // ConvertTo emits the stable Value ("TenKa"). ConvertFrom is the inverse:
+        // MVC route/query binding hands a string like "TenKa" back to this
+        // converter, which must round-trip it to the matching DocumentType.
+        // The companion ConvertTo test pins emit; this one pins parse. Without
+        // it a refactor that switched FromValue to a DisplayName lookup would
+        // silently break every route that takes a DocumentType (no exception —
+        // null would surface only at use time, far from the binding code).
+        var result = _sut.ConvertFrom(null, CultureInfo.InvariantCulture, "TenKa");
+
+        result.Should().Be(DocumentType.TenKa);
+    }
+
+    [Fact]
     public void ConvertFrom_UnknownStringValue_ThrowsFormatException() {
         var act = () => _sut.ConvertFrom(null, CultureInfo.InvariantCulture, "NotARealDocumentType");
 


### PR DESCRIPTION
## Summary

- The companion `ConvertTo_DocumentTypeToString_ReturnsValueNotDisplayName` test pins emit (DocumentType → Value); the parse direction (Value → DocumentType) wasn't pinned.
- MVC route/query binding feeds the stable Value back through this converter. Without a pin, a refactor that switched `FromValue` to a DisplayName lookup would silently break every route taking a DocumentType — no exception, just null at use time far from the binding site.

## Code changes

- `tests/Equibles.UnitTests/Sec/DocumentTypeConverterTests.cs` — adds `ConvertFrom_KnownValueString_ReturnsMatchingDocumentType` exercising the previously unpinned parse-happy-path.