### PR TITLE
test(media): pin FileManager.DeleteFile actually removes the saved file

### DIFF
--- a/tests/Equibles.IntegrationTests/Media/FileManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/FileManagerTests.cs
@@ -89,4 +89,23 @@ public class FileManagerTests {
 
         act.Should().NotThrow();
     }
+
+    [Fact]
+    public async Task DeleteFile_SavedFile_RemovesItFromRepository() {
+        // The companion DeleteFile_Null test only exercises the early
+        // null guard. Without this, the actual delete branch is unpinned —
+        // a refactor that "simplifies" DeleteFile to a no-op (or
+        // mis-routes it to a different repository) would leak files and
+        // the existing tests wouldn't catch it. Round-trip through
+        // SaveFile → SaveChanges → DeleteFile → SaveChanges to assert
+        // the file is actually removed.
+        var file = await _sut.SaveFile([0x01, 0x02], "to-delete.pdf");
+        await _repository.SaveChanges();
+        _repository.GetAll().Should().ContainSingle();
+
+        _sut.DeleteFile(file);
+        await _repository.SaveChanges();
+
+        _repository.GetAll().Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
## Summary

- The existing `DeleteFile_Null_DoesNotThrow` test only exercises the early null guard. The real delete branch (lines 72-73 in `FileManager`) was unpinned.
- This adds one integration test that round-trips a saved file through `DeleteFile` and asserts the repository is empty afterward, so a refactor that turns `DeleteFile` into a no-op or mis-routes it to a different repository surfaces immediately.

## Code changes

- `tests/Equibles.IntegrationTests/Media/FileManagerTests.cs` — adds `DeleteFile_SavedFile_RemovesItFromRepository` exercising the previously uncovered non-null delete path.