### PR TITLE
test(sec): pin SecDocumentEnvelopeParser short-circuits on empty envelope

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserTests.cs
@@ -37,6 +37,21 @@ public class SecDocumentEnvelopeParserTests {
     }
 
     [Fact]
+    public void TryExtractPaperPdfFilename_EmptyEnvelope_ReturnsFalseWithoutScanning() {
+        // DocumentScraper invokes the parser on whatever the SEC EDGAR fetch
+        // returned. A 404 or empty-body response yields an empty string —
+        // the parser must short-circuit on null/empty BEFORE entering the
+        // index-walking loop, otherwise IndexOf is invoked on an empty
+        // string in a tight loop. Pin the guard so a refactor that removes
+        // it surfaces immediately. The companion happy-path and traversal
+        // tests don't reach this branch.
+        var success = SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(string.Empty, out var filename);
+
+        success.Should().BeFalse();
+        filename.Should().BeEmpty();
+    }
+
+    [Fact]
     public void TryExtractPaperPdfFilename_EnvelopeWrappingPdfDocument_ReturnsFilename() {
         var envelope = """
             <SEC-DOCUMENT>


### PR DESCRIPTION
## Summary

- `DocumentScraper` invokes `TryExtractPaperPdfFilename` on whatever the SEC EDGAR fetch returned. A 404 or empty-body response yields an empty string. The parser short-circuits on null/empty BEFORE entering the index-walking loop — that guard wasn't pinned.
- This adds one test asserting the empty-envelope path returns `false` with empty `filename`, so a refactor that removes the guard (and runs `IndexOf` in a tight loop on an empty string) surfaces immediately.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserTests.cs` — adds `TryExtractPaperPdfFilename_EmptyEnvelope_ReturnsFalseWithoutScanning` exercising the previously unpinned null/empty short-circuit.