### PR TITLE
test(web): pin HeroIcons.Render solid style emits filled currentColor without stroke

### DIFF
--- a/tests/Equibles.UnitTests/Web/HeroIconsTests.cs
+++ b/tests/Equibles.UnitTests/Web/HeroIconsTests.cs
@@ -11,4 +11,21 @@ public class HeroIconsTests {
         outline.Should().NotBeEmpty();
         solid.Should().Be(outline);
     }
+
+    [Fact]
+    public void Render_SolidStyle_EmitsFilledCurrentColorWithoutStrokeAttributes() {
+        // Render's solid path differs from outline at three points: fill, stroke,
+        // and the path's stroke-linecap/stroke-linejoin attrs. Outline icons use
+        // a transparent fill with a colored stroke; solid icons use a colored
+        // fill and no stroke at all. A refactor that flips the ternaries (or
+        // merges the two styles into one render path) would silently change
+        // every solid icon to render as an outline glyph, breaking the visual
+        // affordance for filled-state buttons. Pin the solid attribute shape
+        // so the regression fails at test time.
+        var svg = HeroIcons.Render("plus", HeroIcons.IconStyle.Solid);
+
+        svg.Should().Contain("fill=\"currentColor\"");
+        svg.Should().NotContain("stroke=\"currentColor\"");
+        svg.Should().NotContain("stroke-linecap");
+    }
 }


### PR DESCRIPTION
## Summary

- `HeroIcons.Render` differs between outline and solid at three points: the SVG `fill` attribute, the `stroke` attribute, and the path's `stroke-linecap`/`stroke-linejoin` attrs. The solid branch was unpinned.
- A refactor that flips the ternaries (or merges the styles into one render path) would silently render every solid icon as an outline glyph, breaking the visual affordance for filled-state buttons.

## Code changes

- `tests/Equibles.UnitTests/Web/HeroIconsTests.cs` — adds `Render_SolidStyle_EmitsFilledCurrentColorWithoutStrokeAttributes` exercising the previously unpinned solid-render branch.