### PR TITLE
test(web): pin HeroIconTagHelper solid attribute emits inline SVG without wrapper

### DIFF
--- a/tests/Equibles.UnitTests/Web/HeroIconTagHelperTests.cs
+++ b/tests/Equibles.UnitTests/Web/HeroIconTagHelperTests.cs
@@ -6,6 +6,36 @@ namespace Equibles.UnitTests.Web;
 
 public class HeroIconTagHelperTests {
     [Fact]
+    public void Process_SolidAttributeOnKnownIcon_RendersInlineSvgWithoutSurroundingIconTag() {
+        // The companion UnknownIconName test only exercises the outline-default
+        // suppress path. This pins three things the tag helper must do for a
+        // known icon when `solid="true"` is set: (1) take the Solid branch of
+        // the Outline/Solid ternary, (2) wipe `output.TagName` so the rendered
+        // SVG isn't wrapped in a stray <icon> element the browser would treat
+        // as a custom tag, and (3) inject the SVG via SetHtmlContent. A
+        // refactor that drops the ternary or keeps the wrapper element would
+        // emit broken markup, but only on solid-style usages — easy to miss
+        // visually until a page renders.
+        var sut = new HeroIconTagHelper { Name = "plus", Solid = true };
+        var context = new TagHelperContext(
+            new TagHelperAttributeList(),
+            new Dictionary<object, object>(),
+            uniqueId: "test");
+        var output = new TagHelperOutput(
+            "icon",
+            new TagHelperAttributeList(),
+            getChildContentAsync: (useCachedResult, encoder) =>
+                Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+        sut.Process(context, output);
+
+        output.TagName.Should().BeNull();
+        var content = output.Content.GetContent(HtmlEncoder.Default);
+        content.Should().Contain("<svg");
+        content.Should().Contain("fill=\"currentColor\"");
+    }
+
+    [Fact]
     public void Process_UnknownIconName_SuppressesOutput() {
         var sut = new HeroIconTagHelper { Name = "this-icon-does-not-exist" };
         var context = new TagHelperContext(


### PR DESCRIPTION
## Summary

- The existing `Process_UnknownIconName_SuppressesOutput` test only exercises the outline-default suppress path. Three behaviors weren't pinned: the `solid="true"` ternary branch, wiping `output.TagName` so the SVG isn't wrapped in a stray `<icon>` element, and injecting the SVG via `SetHtmlContent`.
- This adds one test that drives Process with `Solid=true` on a known icon and asserts the rendered output is an inline `<svg fill="currentColor" ...>` with no surrounding `<icon>` element. A refactor that drops the ternary or keeps the wrapper would emit broken markup, but only on solid-style usages — easy to miss visually.

## Code changes

- `tests/Equibles.UnitTests/Web/HeroIconTagHelperTests.cs` — adds `Process_SolidAttributeOnKnownIcon_RendersInlineSvgWithoutSurroundingIconTag` exercising the previously unpinned solid-render emission path.