### PR TITLE
test(sec): pin DocumentProcessor.GenerateEmbeddings short-circuits on cancelled token

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
@@ -21,6 +21,31 @@ public class DocumentProcessorTests {
     }
 
     [Fact]
+    public async Task GenerateEmbeddings_AlreadyCancelledToken_DoesNotCallEmbeddingClient() {
+        // GenerateEmbeddings groups chunks by document, then checks the
+        // cancellation token at the top of each group. With a pre-cancelled
+        // token it must break BEFORE calling _embeddingClient — the embedding
+        // server sits behind an expensive Polly retry pipeline; firing even
+        // one request after the worker was told to stop wastes budget and
+        // can race the shutdown. Pin the early-exit so a refactor that
+        // moves the cancellation check after the embedding call (or drops
+        // it entirely) surfaces here instead of in production logs.
+        var documentId = Guid.NewGuid();
+        var chunks = new List<Chunk> {
+            new() { DocumentId = documentId, Content = "first" },
+        };
+
+        var embeddingClient = Substitute.For<IEmbeddingClient>();
+        var sut = CreateSut(embeddingClient);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await sut.GenerateEmbeddings(chunks, cts.Token);
+
+        await embeddingClient.DidNotReceiveWithAnyArgs().GenerateEmbeddings(default);
+    }
+
+    [Fact]
     public async Task GenerateEmbeddings_EmbeddingCountMismatch_Throws() {
         var documentId = Guid.NewGuid();
         var chunks = new List<Chunk> {


### PR DESCRIPTION
## Summary

- `DocumentProcessor.GenerateEmbeddings` checks the cancellation token at the top of each per-document group and breaks before calling `_embeddingClient`. That early-exit wasn't pinned.
- The embedding server sits behind an expensive Polly retry pipeline. Firing even one request after the worker was told to stop wastes budget and races shutdown. A refactor that moves the cancellation check after the embedding call (or drops it entirely) would surface here instead of in production logs.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs` — adds `GenerateEmbeddings_AlreadyCancelledToken_DoesNotCallEmbeddingClient` exercising the previously unpinned cancellation early-exit.