### PR TITLE
test(mcp): pin SimpleApiKeyValidator returns true for correct enabled key

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/SimpleApiKeyValidatorTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/SimpleApiKeyValidatorTests.cs
@@ -21,6 +21,33 @@ public class SimpleApiKeyValidatorTests {
     }
 
     [Fact]
+    public async Task IsValid_EnabledWithMatchingKey_ReturnsTrue() {
+        // Sibling pins exist for the two rejection paths: mismatched key → false,
+        // and disabled mode (no key configured) → true. The remaining branch — the
+        // actual success path, where IsEnabled is true AND the supplied key matches
+        // the configured one — is the load-bearing one for production: every real
+        // MCP client request hits this branch. Pin it explicitly so a regression
+        // that breaks the equality comparison (e.g. a refactor that swaps the
+        // argument order of FixedTimeEquals to compare against an uninitialized
+        // buffer, or that accidentally hashes the candidate twice while leaving
+        // _configuredKeyHash single-hashed) is caught at test time.
+        //
+        // The mismatched-key sibling alone can't prove the success path works:
+        // both "comparison always returns false" and "comparison works correctly"
+        // produce the same false result on a mismatched input. Only an explicit
+        // match-success assertion distinguishes the two failure modes — and the
+        // production consequence (every valid MCP client being locked out) is
+        // exactly the kind of silent regression CI must catch.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { ["McpApiKey"] = "correct-secret" })
+            .Build();
+        var sut = new SimpleApiKeyValidator(config);
+
+        sut.IsEnabled.Should().BeTrue();
+        (await sut.IsValid("correct-secret")).Should().BeTrue();
+    }
+
+    [Fact]
     public async Task IsValid_DisabledModeWithMissingApiKeyConfig_AcceptsAnyToken() {
         // When McpApiKey is unset (typical for local dev / docker-compose
         // without auth), IsEnabled is false and IsValid must short-circuit to


### PR DESCRIPTION
## Summary

- Pins the success path of `SimpleApiKeyValidator.IsValid`: when `IsEnabled` is true and the supplied API key matches the configured one, it must return `true`.
- Complements the two existing tests (mismatched-key → false, disabled-mode → true) by covering the third (and load-bearing) branch — every real MCP client request hits this path.

## Code changes

- `tests/Equibles.UnitTests/Mcp/SimpleApiKeyValidatorTests.cs` — adds `IsValid_EnabledWithMatchingKey_ReturnsTrue`. The mismatched-key sibling alone cannot distinguish "comparison always returns false" from "comparison works correctly"; this test makes that distinction explicit so a regression that locks every valid client out is caught at test time.