### PR TITLE
test(worker): pin Worker.ServiceCollectionExtensions AddWorkerServices auto-wires TickerMapService

### DIFF
--- a/tests/Equibles.UnitTests/Worker/ServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Worker/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,26 @@
+using Equibles.Worker;
+using Equibles.Worker.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.UnitTests.Worker;
+
+public class ServiceCollectionExtensionsTests {
+    [Fact]
+    public void AddWorkerServices_RegistersTickerMapServiceViaAutoWiring() {
+        // AddWorkerServices is the host's seam into auto-wiring — it scans
+        // the Equibles.Worker assembly and registers every [Service]-
+        // attributed type. The composition root (Equibles.Worker.Host)
+        // depends on this side-effect: if the scan stops finding services
+        // the host boots without ScraperWorker dependencies and silently
+        // does no work. TickerMapService carries [Service] and is the
+        // canonical worker-assembly type; pin it as the smoke test so a
+        // refactor that swaps AutoWireServicesFrom for a different scanner
+        // (or accidentally points at the wrong assembly marker) surfaces
+        // here.
+        var services = new ServiceCollection();
+
+        services.AddWorkerServices();
+
+        services.Should().Contain(d => d.ServiceType == typeof(TickerMapService));
+    }
+}


### PR DESCRIPTION
## Summary

- `AddWorkerServices` is the host's seam into auto-wiring — it scans the `Equibles.Worker` assembly and registers every `[Service]`-attributed type. The composition root (`Equibles.Worker.Host`) depends on this side-effect; without it the host boots with no ScraperWorker dependencies and silently does no work. The extension wasn't pinned.
- This adds one test asserting that after `AddWorkerServices`, `TickerMapService` (a `[Service]`-attributed worker-assembly type) is registered. A refactor that swaps `AutoWireServicesFrom` for a different scanner or points at the wrong assembly marker would surface here.

## Code changes

- `tests/Equibles.UnitTests/Worker/ServiceCollectionExtensionsTests.cs` — new test file with `AddWorkerServices_RegistersTickerMapServiceViaAutoWiring` exercising the previously unpinned extension.