### PR TITLE
test(sec): pin Sec.HostedService.AddSecWorker registers IDocumentScraper as Scoped

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecHostedServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecHostedServiceCollectionExtensionsTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Sec.HostedService;
+using Equibles.Sec.HostedService.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecHostedServiceCollectionExtensionsTests {
+    [Fact]
+    public void AddSecWorker_RegistersIDocumentScraperAsScoped() {
+        // AddSecWorker is the host's composition entry point for the SEC
+        // scraping pipeline. It wires the auto-discovered repositories, the
+        // explicit IFilingProcessor / IDocumentPersistenceService /
+        // ICompanySyncService / IDocumentScraper bindings, and three
+        // BackgroundServices. A regression that drops or downgrades the
+        // IDocumentScraper -> DocumentScraper Scoped binding would cause
+        // SecScraperWorker to fail resolving its primary collaborator at
+        // startup — silent in tests, fatal in production. Pin the binding
+        // shape so the regression surfaces here.
+        var services = new ServiceCollection();
+
+        services.AddSecWorker();
+
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDocumentScraper));
+        descriptor.Should().NotBeNull();
+        descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
+    }
+}


### PR DESCRIPTION
## Summary

- `AddSecWorker` is the host's composition entry point for the SEC scraping pipeline. It wires auto-discovered repositories, explicit `IFilingProcessor` / `IDocumentPersistenceService` / `ICompanySyncService` / `IDocumentScraper` bindings, and three `BackgroundService`s. The extension was at 0% coverage.
- This pins the `IDocumentScraper → DocumentScraper` Scoped binding — the primary collaborator of `SecScraperWorker`. A regression that drops or downgrades the binding would cause startup failures in production (silent in tests that don't boot the host).

## Code changes

- `tests/Equibles.UnitTests/Sec/SecHostedServiceCollectionExtensionsTests.cs` — new test file with `AddSecWorker_RegistersIDocumentScraperAsScoped` exercising the previously uncovered extension.