### PR TITLE
test(holdings): pin HoldingsScraperWorker.ValidateConfiguration returns true when SEC contact email is configured

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsScraperWorkerTests.cs
@@ -30,6 +30,39 @@ public class HoldingsScraperWorkerTests {
         sut.InvokeValidateConfiguration().Should().BeFalse();
     }
 
+    [Fact]
+    public void ValidateConfiguration_SecContactEmailConfigured_ReturnsTrue() {
+        // Sibling to the false-case pin above. The risk this pin catches is asymmetric
+        // and unreachable from the empty-email sibling alone: a regression that hard-codes
+        // `ValidateConfiguration => false` (defensive default during refactor, or copy-paste
+        // from another worker that's perpetually off) passes the empty-email test and only
+        // shows up here. Without this pin, an "always-false" regression would silently
+        // disable the entire Holdings scraper — 13F filings would stop importing, and the
+        // failure mode is invisible because `return false` cleanly exits ExecuteAsync (no
+        // exception, no log at Warning+ from the worker itself once it stops looping).
+        //
+        // The pair (empty → false, configured → true) distinguishes a working
+        // `IsNullOrEmpty` check from BOTH inversion (`!IsNullOrEmpty` — caught by the
+        // false sibling) AND constant-return regressions (caught only here). Pick a
+        // realistic SEC-compliant contact email so a future refactor that adds format
+        // validation (RFC 5321 syntax, domain whitelist) won't silently invalidate this
+        // pin without a clear failure mode — the SEC actually inspects User-Agent strings
+        // and rejects implausible contact emails.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> {
+                ["Sec:ContactEmail"] = "equibles-bot@example.com"
+            })
+            .Build();
+        var sut = new TestableHoldingsScraperWorker(
+            Substitute.For<ILogger<HoldingsScraperWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(Substitute.For<IServiceScopeFactory>(), Substitute.For<ILogger<ErrorReporter>>()),
+            Options.Create(new WorkerOptions()),
+            config);
+
+        sut.InvokeValidateConfiguration().Should().BeTrue();
+    }
+
     private sealed class TestableHoldingsScraperWorker : HoldingsScraperWorker {
         public TestableHoldingsScraperWorker(
             ILogger<HoldingsScraperWorker> logger,


### PR DESCRIPTION
## Summary

- Pins the success path of `HoldingsScraperWorker.ValidateConfiguration`: when `Sec:ContactEmail` is configured, the guard must return `true`.
- Complements the existing false-case pin (empty email → false). Without this, a regression that hard-codes `ValidateConfiguration => false` silently disables the entire 13F scraper — no exception, no Warning log, just a worker that exits ExecuteAsync and never imports again.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsScraperWorkerTests.cs` — adds `ValidateConfiguration_SecContactEmailConfigured_ReturnsTrue`. Pair (empty → false, configured → true) distinguishes a working `IsNullOrEmpty` check from both inversion AND constant-return regressions.