### PR TITLE
test(sec): pin FtdScraperWorker.ValidateConfiguration returns true when SEC contact email is configured

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FtdScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdScraperWorkerTests.cs
@@ -31,6 +31,41 @@ public class FtdScraperWorkerTests {
         sut.InvokeValidateConfiguration().Should().BeFalse();
     }
 
+    [Fact]
+    public void ValidateConfiguration_SecContactEmailConfigured_ReturnsTrue() {
+        // Sibling to the false-case pin above. The risk this catches is asymmetric and
+        // unreachable from the empty-email sibling alone: a regression that hard-codes
+        // `ValidateConfiguration => false` (defensive default during a refactor, or
+        // copy-paste from a perpetually-disabled worker) passes the empty-email test
+        // and only shows up here. Without this pin, an "always-false" regression would
+        // silently disable the FTD scraper — failure-to-deliver imports would stop
+        // and the failure mode is invisible (no exception, no Warning log from the
+        // worker once it cleanly exits ExecuteAsync).
+        //
+        // FtdScraperWorker is one of three workers gated on Sec:ContactEmail (alongside
+        // SecScraperWorker pinned in PR #227 and HoldingsScraperWorker pinned in PR #225).
+        // FTD coverage feeds the short-data dashboard and is a load-bearing signal for
+        // settlement-failure analytics — a silent disable here means stale FTD data
+        // accumulates with no operator alert.
+        //
+        // The pair (empty → false, configured → true) distinguishes a working
+        // `IsNullOrEmpty` check from BOTH inversion (caught by the false sibling) AND
+        // constant-return regressions (caught only here).
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> {
+                ["Sec:ContactEmail"] = "equibles-bot@example.com"
+            })
+            .Build();
+        var sut = new TestableFtdScraperWorker(
+            Substitute.For<ILogger<FtdScraperWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(Substitute.For<IServiceScopeFactory>(), Substitute.For<ILogger<ErrorReporter>>()),
+            Options.Create(new FtdScraperOptions()),
+            config);
+
+        sut.InvokeValidateConfiguration().Should().BeTrue();
+    }
+
     private sealed class TestableFtdScraperWorker : FtdScraperWorker {
         public TestableFtdScraperWorker(
             ILogger<FtdScraperWorker> logger,


### PR DESCRIPTION
## Summary

- Pins the success path of `FtdScraperWorker.ValidateConfiguration`: when `Sec:ContactEmail` is set, the guard must return `true`.
- Mirrors the sibling pattern added for `HoldingsScraperWorker` (PR #225) and `SecScraperWorker` (PR #227). FTD coverage feeds short-data analytics; an "always-false" regression here silently stops failure-to-deliver imports without exception or Warning log.

## Code changes

- `tests/Equibles.UnitTests/Sec/FtdScraperWorkerTests.cs` — adds `ValidateConfiguration_SecContactEmailConfigured_ReturnsTrue`. Pair (empty → false, configured → true) distinguishes a working `IsNullOrEmpty` check from both inversion AND constant-return regressions.