### PR TITLE
test(fred): pin Fred.HostedService.AddFredWorker auto-wires FredImportService

### DIFF
--- a/tests/Equibles.UnitTests/Fred/FredServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Fred/FredServiceCollectionExtensionsTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Fred.HostedService.Extensions;
+using Equibles.Fred.HostedService.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.UnitTests.Fred;
+
+public class FredServiceCollectionExtensionsTests {
+    [Fact]
+    public void AddFredWorker_AutoWiresFredImportService() {
+        // AddFredWorker is the host's seam into auto-wiring for the FRED
+        // macroeconomic series pipeline. It scans BOTH the hosted-service
+        // assembly AND Equibles.Integrations.Fred (for the HTTP client),
+        // then adds FredScraperWorker as a BackgroundService. A regression
+        // that swaps the AutoWireServicesFrom<FredImportService> marker
+        // for a different type — or points at the wrong assembly — would
+        // silently strip the import service and leave the BackgroundService
+        // unable to resolve its primary collaborator at startup. Pin
+        // FredImportService as the canonical scan-was-successful smoke test.
+        var services = new ServiceCollection();
+
+        services.AddFredWorker();
+
+        services.Should().Contain(d => d.ServiceType == typeof(FredImportService));
+    }
+}


### PR DESCRIPTION
## Summary

- `AddFredWorker` is the host's seam into auto-wiring for the FRED macroeconomic series pipeline. It scans both the hosted-service assembly and `Equibles.Integrations.Fred`, then adds `FredScraperWorker` as a BackgroundService. The extension was at 0% coverage.
- A regression that swaps the `AutoWireServicesFrom<FredImportService>` marker for a different type — or points at the wrong assembly — would silently strip the import service and leave the BackgroundService unable to resolve its primary collaborator.

## Code changes

- `tests/Equibles.UnitTests/Fred/FredServiceCollectionExtensionsTests.cs` — new test file with `AddFredWorker_AutoWiresFredImportService` smoke-test.