### PR TITLE
test(finra): pin FinraScraperWorker.ValidateConfiguration returns true when IFinraClient is configured

### DIFF
--- a/tests/Equibles.UnitTests/Finra/FinraScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraScraperWorkerTests.cs
@@ -45,6 +45,47 @@ public class FinraScraperWorkerTests {
         sut.InvokeValidateConfiguration().Should().BeFalse();
     }
 
+    [Fact]
+    public void ValidateConfiguration_FinraClientConfigured_ReturnsTrue() {
+        // Sibling to the false-case pin above. The risk this catches is asymmetric
+        // and unreachable from the not-configured sibling alone: a regression that
+        // hard-codes `ValidateConfiguration => false` (defensive default during a
+        // refactor) passes the not-configured test and only shows up here.
+        //
+        // Unlike the SEC-family workers (Sec/Ftd/Holdings) which gate on a direct
+        // IConfiguration read, FinraScraperWorker delegates to `IFinraClient.IsConfigured`
+        // via a resolved DI scope. That indirection adds an extra failure mode: a
+        // refactor that swaps the DI lookup for a hard-coded default would slip past
+        // the false sibling (mocking IsConfigured = false matches the default), and
+        // only this true-case pin catches the regression by exercising the live wire
+        // from `_scopeFactory.CreateScope() → GetRequiredService<IFinraClient>() → IsConfigured`
+        // through to a true return.
+        //
+        // Without this pin, the FINRA short-volume and short-interest scrapers would
+        // silently stop importing — short-data dashboards on the public site rely on
+        // both feeds, and an "always-false" regression here would freeze the data with
+        // no exception, no Warning log, no CI signal.
+        var finraClient = Substitute.For<IFinraClient>();
+        finraClient.IsConfigured.Returns(true);
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IFinraClient)).Returns(finraClient);
+
+        var scope = Substitute.For<IServiceScope>();
+        scope.ServiceProvider.Returns(serviceProvider);
+
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+
+        var sut = new TestableFinraScraperWorker(
+            Substitute.For<ILogger<FinraScraperWorker>>(),
+            scopeFactory,
+            Substitute.For<ErrorReporter>(Substitute.For<IServiceScopeFactory>(), Substitute.For<ILogger<ErrorReporter>>()),
+            Options.Create(new FinraScraperOptions()));
+
+        sut.InvokeValidateConfiguration().Should().BeTrue();
+    }
+
     private sealed class TestableFinraScraperWorker : FinraScraperWorker {
         public TestableFinraScraperWorker(
             ILogger<FinraScraperWorker> logger,


### PR DESCRIPTION
## Summary

- Pins the success path of `FinraScraperWorker.ValidateConfiguration`: when the resolved `IFinraClient.IsConfigured` returns `true`, the guard must return `true`.
- Mirrors the sibling pattern added for SEC/FTD/Holdings (#225, #227, #229). FINRA short-volume + short-interest scrapers go silent without exception or Warning log if an "always-false" regression slips in — the not-configured sibling alone can't distinguish a working IsConfigured wire from a constant-return.

## Code changes

- `tests/Equibles.UnitTests/Finra/FinraScraperWorkerTests.cs` — adds `ValidateConfiguration_FinraClientConfigured_ReturnsTrue`. Exercises the full DI scope → `GetRequiredService<IFinraClient>` → `IsConfigured` → true wire, catching both inversion AND constant-return regressions.