### PR TITLE
test(fred): pin FredScraperWorker.ValidateConfiguration returns true when IFredClient is configured

### DIFF
--- a/tests/Equibles.UnitTests/Fred/FredScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Fred/FredScraperWorkerTests.cs
@@ -38,6 +38,45 @@ public class FredScraperWorkerTests {
         sut.InvokeValidateConfiguration().Should().BeFalse();
     }
 
+    [Fact]
+    public void ValidateConfiguration_FredClientConfigured_ReturnsTrue() {
+        // Sibling to the false-case pin above. The risk this catches is asymmetric
+        // and unreachable from the not-configured sibling alone: a regression that
+        // hard-codes `ValidateConfiguration => false` (defensive default during a
+        // refactor) passes the not-configured test and only shows up here.
+        //
+        // FredScraperWorker delegates the check to `IFredClient.IsConfigured` resolved
+        // through a DI scope — same indirection pattern as FinraScraperWorker (pinned
+        // in PR #231). A regression that swaps the DI lookup for a hard-coded default,
+        // or that drops the wire entirely, would slip past the false sibling (mocking
+        // IsConfigured = false matches the default) and only this true-case pin catches
+        // the regression by exercising the live wire from `_scopeFactory.CreateScope()
+        // → GetRequiredService<IFredClient>() → IsConfigured` through to a true return.
+        //
+        // Without this pin, FRED economic-indicator imports would silently stop —
+        // every macro dashboard relying on FEDFUNDS / CPIAUCSL / UNRATE / etc. would
+        // freeze with no exception or Warning log. The pair (not-configured → false,
+        // configured → true) distinguishes a working IsConfigured wire from BOTH
+        // inversion AND constant-return regressions.
+        var fredClient = Substitute.For<IFredClient>();
+        fredClient.IsConfigured.Returns(true);
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IFredClient)).Returns(fredClient);
+        var scope = Substitute.For<IServiceScope>();
+        scope.ServiceProvider.Returns(serviceProvider);
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+
+        var sut = new TestableFredScraperWorker(
+            Substitute.For<ILogger<FredScraperWorker>>(),
+            scopeFactory,
+            Substitute.For<ErrorReporter>(Substitute.For<IServiceScopeFactory>(), Substitute.For<ILogger<ErrorReporter>>()),
+            Options.Create(new FredScraperOptions()));
+
+        sut.InvokeValidateConfiguration().Should().BeTrue();
+    }
+
     private sealed class TestableFredScraperWorker : FredScraperWorker {
         public TestableFredScraperWorker(
             ILogger<FredScraperWorker> logger,


### PR DESCRIPTION
## Summary

- Pins the success path of `FredScraperWorker.ValidateConfiguration`: when the resolved `IFredClient.IsConfigured` returns `true`, the guard must return `true`.
- Completes the worker-validate-true sibling sweep started with Holdings (#225), SEC (#227), FTD (#229), and FINRA (#231). FRED feeds macro indicators (FEDFUNDS, CPIAUCSL, UNRATE, etc.); an "always-false" regression silently freezes the entire economic-indicator pipeline.

## Code changes

- `tests/Equibles.UnitTests/Fred/FredScraperWorkerTests.cs` — adds `ValidateConfiguration_FredClientConfigured_ReturnsTrue`. Exercises the full DI scope → `GetRequiredService<IFredClient>` → `IsConfigured` → true wire, catching both inversion AND constant-return regressions that the false sibling alone can't distinguish.