### PR TITLE
test(cboe): pin Cboe.HostedService.AddCboeWorker auto-wires CboeImportService

### DIFF
--- a/tests/Equibles.UnitTests/Cboe/CboeServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Cboe/CboeServiceCollectionExtensionsTests.cs
@@ -1,0 +1,26 @@
+using Equibles.Cboe.HostedService.Extensions;
+using Equibles.Cboe.HostedService.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.UnitTests.Cboe;
+
+public class CboeServiceCollectionExtensionsTests {
+    [Fact]
+    public void AddCboeWorker_AutoWiresCboeImportService() {
+        // AddCboeWorker is the host's seam into auto-wiring for the CBOE
+        // VIX + put/call-ratio import pipeline. It scans BOTH the
+        // hosted-service assembly AND Equibles.Integrations.Cboe (for the
+        // HTTP client), then adds CboeScraperWorker as a BackgroundService.
+        // A regression that swaps the AutoWireServicesFrom<CboeImportService>
+        // marker for a different type — or points at the wrong assembly —
+        // would silently strip the import service and leave the
+        // BackgroundService unable to resolve its primary collaborator at
+        // startup. Pin CboeImportService as the canonical scan-was-
+        // successful smoke test.
+        var services = new ServiceCollection();
+
+        services.AddCboeWorker();
+
+        services.Should().Contain(d => d.ServiceType == typeof(CboeImportService));
+    }
+}


### PR DESCRIPTION
## Summary

- `AddCboeWorker` is the host's seam into auto-wiring for the CBOE VIX + put/call-ratio import pipeline. It scans both the hosted-service assembly and `Equibles.Integrations.Cboe`, then adds `CboeScraperWorker` as a BackgroundService. The extension was at 0% coverage.
- A regression that swaps the `AutoWireServicesFrom<CboeImportService>` marker for a different type — or points at the wrong assembly — would silently strip the import service and leave the BackgroundService unable to resolve its primary collaborator.

## Code changes

- `tests/Equibles.UnitTests/Cboe/CboeServiceCollectionExtensionsTests.cs` — new test file with `AddCboeWorker_AutoWiresCboeImportService` smoke-test.