### PR TITLE
test(insidertrading): pin InsiderTrading.Mcp.AddInsiderTrading marker registration

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingMcpBuilderExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingMcpBuilderExtensionsTests.cs
@@ -1,0 +1,28 @@
+using Equibles.InsiderTrading.Mcp.Extensions;
+using Equibles.InsiderTrading.Mcp.Tools;
+using Equibles.Mcp;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class InsiderTradingMcpBuilderExtensionsTests {
+    [Fact]
+    public void AddInsiderTrading_RegistersAssemblyMcpModuleForInsiderTradingTools() {
+        // AddInsiderTrading wires the SEC Form 3/4/5 insider-trading MCP
+        // tools into the EquiblesMcpBuilder via
+        // AssemblyMcpModule<InsiderTradingTools>. The marker type drives
+        // the AutoWiring assembly scan; a regression that swaps it for
+        // a non-InsiderTrading type would silently miss every insider
+        // MCP tool at runtime. Pin the marker so the regression surfaces
+        // here.
+        var services = new ServiceCollection();
+        var mcpServerBuilder = Substitute.For<IMcpServerBuilder>();
+        var builder = new EquiblesMcpBuilder(services, mcpServerBuilder);
+
+        builder.AddInsiderTrading();
+
+        builder.Modules.Should().ContainSingle()
+            .Which.Should().BeOfType<AssemblyMcpModule<InsiderTradingTools>>();
+    }
+}


### PR DESCRIPTION
## Summary

- `AddInsiderTrading` wires the SEC Form 3/4/5 insider-trading MCP tools into the EquiblesMcpBuilder via `AssemblyMcpModule<InsiderTradingTools>`. The marker type drives the AutoWiring assembly scan. The extension was at 0% coverage.
- A regression that swaps the marker for a non-InsiderTrading type would silently miss every insider MCP tool at runtime; this pins the marker so the regression surfaces here.

## Code changes

- `tests/Equibles.UnitTests/Mcp/InsiderTradingMcpBuilderExtensionsTests.cs` — new test file pinning the marker registration.