### PR TITLE
test(cftc): pin Cftc.Mcp.AddCftc registers AssemblyMcpModule with CftcTools marker

### DIFF
--- a/tests/Equibles.UnitTests/Cftc/CftcMcpBuilderExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Cftc/CftcMcpBuilderExtensionsTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Cftc.Mcp.Extensions;
+using Equibles.Cftc.Mcp.Tools;
+using Equibles.Mcp;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Cftc;
+
+public class CftcMcpBuilderExtensionsTests {
+    [Fact]
+    public void AddCftc_RegistersAssemblyMcpModuleForCftcTools() {
+        // AddCftc wires the COT (Commitment of Traders) MCP tools into the
+        // EquiblesMcpBuilder via AssemblyMcpModule<CftcTools>. The marker
+        // type drives the AutoWiring assembly scan; a regression that
+        // swaps it for a non-Cftc type would silently miss every CFTC
+        // MCP tool at runtime. Pin the marker so the regression surfaces
+        // here.
+        var services = new ServiceCollection();
+        var mcpServerBuilder = Substitute.For<IMcpServerBuilder>();
+        var builder = new EquiblesMcpBuilder(services, mcpServerBuilder);
+
+        builder.AddCftc();
+
+        builder.Modules.Should().ContainSingle()
+            .Which.Should().BeOfType<AssemblyMcpModule<CftcTools>>();
+    }
+}


### PR DESCRIPTION
## Summary

- `AddCftc` wires the COT (Commitment of Traders) MCP tools into the EquiblesMcpBuilder via `AssemblyMcpModule<CftcTools>`. The marker type drives the AutoWiring assembly scan. The extension was at 0% coverage.
- A regression that swaps the marker for a non-Cftc type would silently miss every CFTC MCP tool at runtime; this pins the marker so the regression surfaces here.

## Code changes

- `tests/Equibles.UnitTests/Cftc/CftcMcpBuilderExtensionsTests.cs` — new test file pinning the marker registration.