### PR TITLE
test(cboe): pin Cboe.Mcp.AddCboe registers AssemblyMcpModule with CboeTools marker

### DIFF
--- a/tests/Equibles.UnitTests/Cboe/CboeMcpBuilderExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Cboe/CboeMcpBuilderExtensionsTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Cboe.Mcp.Extensions;
+using Equibles.Cboe.Mcp.Tools;
+using Equibles.Mcp;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Cboe;
+
+public class CboeMcpBuilderExtensionsTests {
+    [Fact]
+    public void AddCboe_RegistersAssemblyMcpModuleForCboeTools() {
+        // AddCboe wires the CBOE VIX + put/call-ratio MCP tools into the
+        // EquiblesMcpBuilder via AssemblyMcpModule<CboeTools>. The marker
+        // type drives the AutoWiring assembly scan; a regression that
+        // swaps it for a non-Cboe type would silently miss every CBOE
+        // MCP tool at runtime. Pin the marker so the regression surfaces
+        // here.
+        var services = new ServiceCollection();
+        var mcpServerBuilder = Substitute.For<IMcpServerBuilder>();
+        var builder = new EquiblesMcpBuilder(services, mcpServerBuilder);
+
+        builder.AddCboe();
+
+        builder.Modules.Should().ContainSingle()
+            .Which.Should().BeOfType<AssemblyMcpModule<CboeTools>>();
+    }
+}


### PR DESCRIPTION
## Summary

- `AddCboe` wires the CBOE VIX + put/call-ratio MCP tools into the EquiblesMcpBuilder via `AssemblyMcpModule<CboeTools>`. The marker type drives the AutoWiring assembly scan. The extension was at 0% coverage.
- A regression that swaps the marker for a non-Cboe type would silently miss every CBOE MCP tool at runtime; this pins the marker so the regression surfaces here.

## Code changes

- `tests/Equibles.UnitTests/Cboe/CboeMcpBuilderExtensionsTests.cs` — new test file pinning the marker registration.