### PR TITLE
test(web): pin StatisticsExtensions.ComputeSma aligns first (period-1) slots to null

### DIFF
--- a/tests/Equibles.UnitTests/Web/StatisticsExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Web/StatisticsExtensionsTests.cs
@@ -21,4 +21,27 @@ public class StatisticsExtensionsTests {
 
         result.Should().BeNull();
     }
+
+    [Fact]
+    public void ComputeSma_AlignsToInput_FirstWindowSlotsAreNullThenRoundedSma() {
+        // ComputeSma is consumed by view models that overlay SMA series on price
+        // charts; alignment to the original prices array matters because the
+        // chart's x-axis is indexed by trading day. The first (period-1)
+        // entries MUST be null so the SMA line starts only when a full window
+        // has accumulated — otherwise the chart shows a misleading non-null
+        // value at day 0 that's actually computed from incomplete data. A
+        // refactor that drops the alignment (e.g. returns the raw
+        // MovingAverage sequence without the null prefix) would silently
+        // shift every SMA point one period to the left.
+        var values = new[] { 1.0, 2.0, 3.0, 4.0, 5.0 };
+
+        var result = values.ComputeSma(period: 3, digits: 2);
+
+        result.Should().HaveCount(5);
+        result[0].Should().BeNull();
+        result[1].Should().BeNull();
+        result[2].Should().Be(2.00m);
+        result[3].Should().Be(3.00m);
+        result[4].Should().Be(4.00m);
+    }
 }


### PR DESCRIPTION
## Summary

- `ComputeSma` is consumed by view models that overlay SMA series on price charts; alignment to the original prices array matters because the chart's x-axis is indexed by trading day. The first `(period-1)` entries MUST be null so the SMA line starts only when a full window has accumulated. The alignment wasn't pinned.
- A refactor that drops the alignment (returns the raw `MovingAverage` sequence without the null prefix) would silently shift every SMA point one period to the left — a misleading chart value at day 0 computed from incomplete data.

## Code changes

- `tests/Equibles.UnitTests/Web/StatisticsExtensionsTests.cs` — adds `ComputeSma_AlignsToInput_FirstWindowSlotsAreNullThenRoundedSma` exercising the previously unpinned `ComputeSma` extension.