### PR TITLE
test(sec): pin EmbeddingClient.GenerateEmbeddings short-circuits on empty texts list

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/EmbeddingClientTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/EmbeddingClientTests.cs
@@ -17,4 +17,28 @@ public class EmbeddingClientTests {
 
         result.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task GenerateEmbeddings_EmptyTextList_ShortCircuitsBeforeConfigCheck() {
+        // The companion DisabledConfig test exercises the `!_config.IsConfigured`
+        // half of the early-return OR. This sibling exercises the OTHER half —
+        // `!texts.Any()` — so the regression "both halves were collapsed to the
+        // config check only" is caught. An empty texts list with a fully
+        // configured client must still short-circuit to an empty result and
+        // skip the Ollama HTTP call (which on a working setup would otherwise
+        // POST an empty payload and waste a request). Pin the empty-texts
+        // path so the regression surfaces here.
+        var httpFactory = Substitute.For<IHttpClientFactory>();
+        httpFactory.CreateClient(Arg.Any<string>()).Returns(new HttpClient());
+        var config = Options.Create(new EmbeddingConfig {
+            Enabled = true,
+            BaseUrl = "http://localhost:11434",
+            ModelName = "nomic-embed-text",
+        });
+        var sut = new EmbeddingClient(httpFactory, config, Substitute.For<ILogger<EmbeddingClient>>());
+
+        var result = await sut.GenerateEmbeddings([]);
+
+        result.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
## Summary

- The companion `DisabledConfig` test exercises the `!_config.IsConfigured` half of the early-return OR. The OTHER half — `!texts.Any()` — wasn't pinned.
- This adds the missing-half pin so the regression "both halves were collapsed to the config check only" is caught. An empty texts list with a fully configured client must still short-circuit to an empty result and skip the Ollama HTTP call.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/EmbeddingClientTests.cs` — adds `GenerateEmbeddings_EmptyTextList_ShortCircuitsBeforeConfigCheck` exercising the previously unpinned half.