### PR TITLE
test(mcp): pin Equibles.Mcp.AddEquiblesMcp invokes configure callback with EquiblesMcpBuilder

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/EquiblesMcpServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/EquiblesMcpServiceCollectionExtensionsTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Mcp;
+using Equibles.Mcp.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class EquiblesMcpServiceCollectionExtensionsTests {
+    [Fact]
+    public void AddEquiblesMcp_InvokesConfigureCallbackWithNonNullBuilder() {
+        // AddEquiblesMcp is the composition root's entry point for wiring
+        // MCP tooling — it bootstraps the underlying IMcpServerBuilder
+        // (with HTTP transport) and exposes an EquiblesMcpBuilder to the
+        // caller via a configure callback. The caller chains
+        // AddSec/AddCongress/... onto that builder. A regression that
+        // skips invoking the callback (or passes a null builder) would
+        // silently strip every MCP module registration at startup,
+        // leaving the server with no tools to expose. Pin that the
+        // callback runs and receives a non-null builder so the
+        // regression surfaces here.
+        var services = new ServiceCollection();
+        EquiblesMcpBuilder captured = null;
+
+        services.AddEquiblesMcp(b => captured = b);
+
+        captured.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `Equibles.Mcp.Extensions.ServiceCollectionExtensions.AddEquiblesMcp` invokes the caller-supplied configure callback with a non-null `EquiblesMcpBuilder`.
- Subject is the composition root's entry point for wiring MCP tooling — every `Add{Module}()` chain in the host depends on this callback firing with a real builder.

## Code changes

- `tests/Equibles.UnitTests/Mcp/EquiblesMcpServiceCollectionExtensionsTests.cs` — new unit test that calls `AddEquiblesMcp` against a real `ServiceCollection` and captures the builder passed to the configure delegate, asserting it is not null.