### PR TITLE
test(sec): pin SecDocumentEnvelopeParser scans past non-PDF first DOCUMENT in multi-block envelope

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserTests.cs
@@ -52,6 +52,52 @@ public class SecDocumentEnvelopeParserTests {
     }
 
     [Fact]
+    public void TryExtractPaperPdfFilename_MultiDocumentEnvelopeWithPdfInSecondBlock_ReturnsPdfFilename() {
+        // SEC envelopes regularly bundle several DOCUMENT blocks — a primary HTML/XML
+        // submission followed by exhibit attachments. When a paper filing's PDF is
+        // attached as a later DOCUMENT (e.g. SEQUENCE 2 EX-99 alongside a SEQUENCE 1
+        // 6-K cover form), the parser must advance past the first block and keep
+        // scanning. The loop does this by setting `pos = blockEnd + DocumentEndTag.Length`
+        // after each iteration and re-entering at the `while (pos < envelope.Length)`
+        // check. A refactor that short-circuits on the first non-PDF FILENAME (e.g.
+        // returning false instead of `continue`) would compile cleanly and pass the
+        // single-document happy-path test, while silently dropping every paper
+        // attachment that isn't the first document in its envelope. Pin the
+        // multi-block scan with a second-position PDF so that regression surfaces here.
+        var envelope = """
+            <SEC-DOCUMENT>
+            <SEC-HEADER>
+            </SEC-HEADER>
+            <DOCUMENT>
+            <TYPE>6-K
+            <SEQUENCE>1
+            <FILENAME>cover.htm
+            <DESCRIPTION>Cover page
+            <TEXT>
+            <html><body>Cover page body</body></html>
+            </TEXT>
+            </DOCUMENT>
+            <DOCUMENT>
+            <TYPE>EX-99
+            <SEQUENCE>2
+            <FILENAME>exhibit99.pdf
+            <DESCRIPTION>Exhibit 99
+            <TEXT>
+            begin 644 exhibit99.pdf
+            (uuencoded body)
+            end
+            </TEXT>
+            </DOCUMENT>
+            </SEC-DOCUMENT>
+            """;
+
+        var success = SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(envelope, out var filename);
+
+        success.Should().BeTrue();
+        filename.Should().Be("exhibit99.pdf");
+    }
+
+    [Fact]
     public void TryExtractPaperPdfFilename_EnvelopeWrappingPdfDocument_ReturnsFilename() {
         var envelope = """
             <SEC-DOCUMENT>


### PR DESCRIPTION
## Summary

- Pins that `SecDocumentEnvelopeParser.TryExtractPaperPdfFilename` keeps scanning subsequent `<DOCUMENT>` blocks after a non-PDF one — SEC envelopes bundle multiple documents (cover form + exhibits), and the PDF is often not the first.
- Without this pin, a refactor that swapped `continue` for `return false` on a non-`.pdf` FILENAME would silently drop every paper attachment in a multi-document envelope and still pass the existing single-document happy-path test.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserTests.cs` — adds `TryExtractPaperPdfFilename_MultiDocumentEnvelopeWithPdfInSecondBlock_ReturnsPdfFilename`. The envelope contains a SEQUENCE 1 6-K cover `cover.htm` and a SEQUENCE 2 EX-99 `exhibit99.pdf`; asserts the parser returns `true` with `exhibit99.pdf`.