### PR TITLE
test(sec): pin DocumentProcessor.ProcessDocuments logs and continues when a document has null Content

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
@@ -1,6 +1,8 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Sec.BusinessLogic.Embeddings;
 using Equibles.Sec.BusinessLogic.Processing;
 using Equibles.Sec.BusinessLogic.Tokenization;
+using Equibles.Sec.Data.Models;
 using Equibles.Sec.Data.Models.Chunks;
 using Equibles.Sec.Repositories;
 using Microsoft.Extensions.Logging;
@@ -10,14 +12,15 @@ using NSubstitute;
 namespace Equibles.IntegrationTests.Sec;
 
 public class DocumentProcessorTests {
-    private static DocumentProcessor CreateSut(IEmbeddingClient embeddingClient) {
+    private static DocumentProcessor CreateSut(IEmbeddingClient embeddingClient,
+        ILogger<DocumentProcessor> logger = null) {
         return new DocumentProcessor(
             Substitute.For<ChunkRepository>((Equibles.Data.EquiblesDbContext)null),
             Substitute.For<EmbeddingRepository>((Equibles.Data.EquiblesDbContext)null),
             embeddingClient,
             new ChunkingStrategy(new TokenCounter()),
             Options.Create(new EmbeddingConfig { ModelName = "test-model" }),
-            Substitute.For<ILogger<DocumentProcessor>>());
+            logger ?? Substitute.For<ILogger<DocumentProcessor>>());
     }
 
     [Fact]
@@ -43,6 +46,50 @@ public class DocumentProcessorTests {
         await sut.GenerateEmbeddings(chunks, cts.Token);
 
         await embeddingClient.DidNotReceiveWithAnyArgs().GenerateEmbeddings(default);
+    }
+
+    [Fact]
+    public async Task ProcessDocuments_DocumentWithNullContent_LogsErrorAndContinuesBatch() {
+        // DocumentProcessor.ProcessDocuments is the worker's main loop —
+        // SecScraperWorker hands it the whole queue of newly-fetched filings
+        // each cycle. If a single document is missing its File envelope
+        // (Content == null), GetDocumentContent throws Exception("Document
+        // content is null"); ProcessDocuments catches that under `catch
+        // (Exception ex)` and logs an error so the rest of the batch can
+        // proceed. The risk this pins: a refactor that narrows the catch
+        // (e.g. `catch (IOException ex)` because someone thought only IO
+        // exceptions occur here) would let the bare Exception propagate up
+        // to BaseScraperWorker's outer handler — which marks the entire
+        // cycle as failed and skips every following document in the batch,
+        // silently stalling SEC ingest until the bad row is removed by
+        // hand. The catch block AND the log call together are the
+        // resilience contract; both must remain to keep the worker
+        // forward-progressing past data anomalies (incomplete uploads,
+        // corrupted blobs, FK orphans).
+        //
+        // Setup: one Document with a CommonStock populated (so the leading
+        // LogInformation in ChunkDocument doesn't NRE before reaching the
+        // throw) but Content == null. Assert that ProcessDocuments
+        // completes without throwing AND that ILogger received exactly one
+        // Error call mentioning that document's Id.
+        var logger = Substitute.For<ILogger<DocumentProcessor>>();
+        var sut = CreateSut(Substitute.For<IEmbeddingClient>(), logger);
+        var documentId = Guid.NewGuid();
+        var documents = new List<Document> {
+            new() {
+                Id = documentId,
+                CommonStock = new CommonStock { Name = "Test Co", Ticker = "TEST" },
+                Content = null,
+            },
+        };
+
+        var act = () => sut.ProcessDocuments(documents, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        logger.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == "Log"
+                && c.GetArguments().OfType<LogLevel>().FirstOrDefault() == LogLevel.Error)
+            .Should().ContainSingle();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Pins the resilience contract on `DocumentProcessor.ProcessDocuments`: a document whose `Content` is null must surface as a logged Error, not propagate up and stall the whole SEC ingest cycle.
- The catch block + log call together are what keeps SecScraperWorker moving past data anomalies (incomplete uploads, corrupted blobs, FK orphans). A refactor that narrowed `catch (Exception)` to a specific type would let the bare `Exception("Document content is null")` from `GetDocumentContent` propagate up to BaseScraperWorker, marking the whole batch failed with no signal beyond "scrape errored out."

## Code changes

- `tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs` — adds `ProcessDocuments_DocumentWithNullContent_LogsErrorAndContinuesBatch`. Builds a `Document` with `CommonStock` populated and `Content = null`, asserts the call does not throw and that the substituted `ILogger<DocumentProcessor>` received exactly one `LogLevel.Error` call. Extends `CreateSut` to accept an optional logger so the assertion can target a specific substitute.