### PR TITLE
test(cftc): pin CftcImportService.ParseDate modern yyyy-MM-dd format

### DIFF
--- a/tests/Equibles.UnitTests/Cftc/CftcImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Cftc/CftcImportServiceTests.cs
@@ -26,6 +26,31 @@ public class CftcImportServiceTests {
     }
 
     [Fact]
+    public void ParseDate_ModernYyyyMmDdFormat_Parses() {
+        // Sibling pin to the legacy-format test above. The two tests together pin BOTH
+        // date-format branches of ParseDate. The risk this catches is asymmetric and
+        // unreachable from the legacy sibling alone: a regression that deletes (or
+        // breaks) the FIRST TryParseExact call — for the modern "yyyy-MM-dd" format —
+        // would slip past the existing tests:
+        //   - "250115" still matches the surviving yyMMdd branch → legacy test passes
+        //   - "not-a-date" still returns null → unparseable test passes
+        // …but every modern Report_Date_as_YYYY-MM-DD row would silently parse to null
+        // and get dropped by `if (date == null) continue;` in ImportYear. CFTC's recent
+        // history files (post-2010 or so) use the modern format exclusively, so an
+        // "always-legacy-only" regression would silently stop importing every recent
+        // year while the legacy fallback keeps the pre-2010 path working — exactly the
+        // sort of partial failure that looks healthy until someone audits coverage.
+        //
+        // Pin the modern format with a representative date that ONLY the yyyy-MM-dd
+        // branch can match (10 chars, dashes — yyMMdd's TryParseExact rejects it on
+        // length). The pair (legacy → date, modern → date) distinguishes a working
+        // two-branch parser from a refactor that collapses to a single branch.
+        var result = (DateOnly?)ParseDateMethod.Invoke(null, ["2025-01-15"]);
+
+        result.Should().Be(new DateOnly(2025, 1, 15));
+    }
+
+    [Fact]
     public void ParseDate_UnparseableValue_ReturnsNull() {
         // ImportYear's foreach skips malformed rows via `if (date == null) continue;`,
         // so returning null on bad input — rather than throwing — is the contract that


### PR DESCRIPTION
## Summary

- Adds a sibling pin for `CftcImportService.ParseDate` covering the modern `yyyy-MM-dd` branch. The existing two tests pin the legacy `yyMMdd` fallback and the null-on-unparseable path; both still pass even if a regression deletes or breaks the first `TryParseExact("yyyy-MM-dd", …)` branch — "250115" still matches the surviving yyMMdd branch and "not-a-date" still nulls — yet every modern CFTC row would silently drop. The new pin closes that asymmetric gap.

## Code changes

- `tests/Equibles.UnitTests/Cftc/CftcImportServiceTests.cs` — add `ParseDate_ModernYyyyMmDdFormat_Parses` `[Fact]` with a `// Why this matters` block explaining the asymmetry and how the pair (legacy → date, modern → date) distinguishes a working two-branch parser from a collapsed one-branch refactor.