### PR TITLE
test(holdings): pin HoldingsScraperWorker.SleepInterval at 24 hours

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsScraperWorkerTests.cs
@@ -63,6 +63,33 @@ public class HoldingsScraperWorkerTests {
         sut.InvokeValidateConfiguration().Should().BeTrue();
     }
 
+    [Fact]
+    public void SleepInterval_IsTwentyFourHours() {
+        // The Holdings scraper pulls SEC EDGAR's quarterly 13F filing data sets —
+        // by SEC mandate institutions report quarterly within 45 days of quarter
+        // end, so new data lands at most a few times per quarter. The 24-hour
+        // `SleepInterval` matches that cadence: a once-daily check catches every
+        // newly published data set with minutes-to-hours latency at worst, with
+        // plenty of margin for SEC's 10 req/s outbound cap shared across all
+        // SEC scrapers. The risk this pins: a refactor that lowered the interval
+        // (a copy-paste of `FromSeconds(15)` from a sibling worker, or a casual
+        // `FromHours(1)` "let's check more often") would silently 24× the
+        // outbound load against SEC EDGAR. Each Holdings pass also walks every
+        // ProcessedDataSet row to compute the "to fetch" list — that's a real
+        // DB query — and a tighter interval would burn DB time + SEC quota
+        // for zero benefit (no new 13Fs to fetch). Pin the literal value so any
+        // future cadence change is a deliberate test update.
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()).Build();
+        var sut = new TestableHoldingsScraperWorker(
+            Substitute.For<ILogger<HoldingsScraperWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(Substitute.For<IServiceScopeFactory>(), Substitute.For<ILogger<ErrorReporter>>()),
+            Options.Create(new WorkerOptions()),
+            config);
+
+        sut.InvokeSleepInterval().Should().Be(TimeSpan.FromHours(24));
+    }
+
     private sealed class TestableHoldingsScraperWorker : HoldingsScraperWorker {
         public TestableHoldingsScraperWorker(
             ILogger<HoldingsScraperWorker> logger,
@@ -73,5 +100,7 @@ public class HoldingsScraperWorkerTests {
             : base(logger, scopeFactory, errorReporter, workerOptions, configuration) { }
 
         public bool InvokeValidateConfiguration() => ValidateConfiguration();
+
+        public TimeSpan InvokeSleepInterval() => SleepInterval;
     }
 }


### PR DESCRIPTION
## Summary

- Pins the hardcoded `SleepInterval` on `HoldingsScraperWorker` at `TimeSpan.FromHours(24)`.
- SEC mandates quarterly 13F reporting within 45 days of quarter end, so new data lands at most a few times per quarter — a once-daily check has plenty of margin. A regression to a shorter interval (e.g. `FromHours(1)` or a copy-paste of `FromSeconds(15)` from a sibling worker) would 24× the outbound load against SEC EDGAR (shared with every other SEC scraper) AND walk the ProcessedDataSet table that often for zero benefit.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsScraperWorkerTests.cs` — adds `SleepInterval_IsTwentyFourHours` and an `InvokeSleepInterval` accessor on the existing `TestableHoldingsScraperWorker` subclass.