### PR TITLE
test(sec): pin DocumentProcessor.GenerateEmbeddings throws when embeddings > chunks

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs
@@ -112,4 +112,47 @@ public class DocumentProcessorTests {
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("Embedding count mismatch: expected 3, got 2");
     }
+
+    [Fact]
+    public async Task GenerateEmbeddings_EmbeddingCountExceedsChunkCount_Throws() {
+        // Sibling to the count-too-low pin above. The risk this catches is asymmetric
+        // and unreachable from the existing sibling alone: the guard is
+        // `if (embeddings.Count != chunks.Count) throw;` — a regression that swaps `!=`
+        // for `<` (or for `embeddings.Count < chunks.Count`, a "defensive" check someone
+        // might write to "tolerate extra embeddings") would still throw on the too-low
+        // case (3 chunks, 2 embeddings) and pass the existing test, but would silently
+        // let the too-high case through. The for-loop below the guard then runs only
+        // `chunks.Count` iterations, so the extra embedding gets dropped on the floor
+        // and no exception, no log, no CI signal surfaces.
+        //
+        // That partial-drop is a real data-integrity hazard: the embedding service
+        // could return more vectors than chunks under several plausible failure modes
+        // — a hosted batching bug where one chunk's payload tokenises into two,
+        // a transient duplicate-response retry, or a misconfigured model that emits
+        // multiple vectors per input. In every case, the surviving chunks would still
+        // be persisted with their intended embeddings, but the dropped vector
+        // represents a chunk that DID exist on the wire and now silently doesn't —
+        // future search hits against the dropped vector are simply impossible, and
+        // no recovery path exists because the loss is unobservable.
+        //
+        // The pair (2-vs-3 → throws, 3-vs-2 → throws) distinguishes a working `!=`
+        // guard from BOTH `<` AND `>` collapses; only one direction is caught by the
+        // existing test.
+        var documentId = Guid.NewGuid();
+        var chunks = new List<Chunk> {
+            new() { DocumentId = documentId, Content = "first" },
+            new() { DocumentId = documentId, Content = "second" },
+        };
+
+        var embeddingClient = Substitute.For<IEmbeddingClient>();
+        embeddingClient.GenerateEmbeddings(Arg.Any<List<string>>())
+            .Returns(new List<float[]> { new float[] { 0.1f }, new float[] { 0.2f }, new float[] { 0.3f } });
+
+        var sut = CreateSut(embeddingClient);
+
+        var act = () => sut.GenerateEmbeddings(chunks, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Embedding count mismatch: expected 2, got 3");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a sibling pin for `DocumentProcessor.GenerateEmbeddings` covering the `embeddings.Count > chunks.Count` direction of the count-mismatch guard. The existing `GenerateEmbeddings_EmbeddingCountMismatch_Throws` test exercises only the too-low direction (3 chunks, 2 embeddings); a regression that swaps `!=` for `<` would still throw on the too-low case (existing test passes) but silently let the too-high case through — the for-loop below the guard only iterates `chunks.Count` times, dropping the extra vector on the floor with no exception, log, or CI signal. That partial-drop is a real data-integrity hazard (hosted batching bugs, duplicate-response retries, mis-configured models).

## Code changes

- `tests/Equibles.IntegrationTests/Sec/DocumentProcessorTests.cs` — add `GenerateEmbeddings_EmbeddingCountExceedsChunkCount_Throws` `[Fact]` with a `// Why this matters` block explaining the asymmetry and how the pair (low → throws, high → throws) distinguishes a working `!=` guard from BOTH `<` AND `>` collapses.