### PR TITLE
test(congress): pin CongressionalTradeSyncService null MinSyncDate default lookback

### DIFF
--- a/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceTests.cs
@@ -56,10 +56,73 @@ public class CongressionalTradeSyncServiceTests {
             Arg.Any<Func<object, Exception, string>>());
     }
 
+    [Fact]
+    public async Task SyncAll_NullMinSyncDate_DefaultsToNinetyDayLookback() {
+        // Sibling to the STOCK-Act-clamp pin above. The risk this catches is the
+        // PRODUCTION-DEFAULT branch of the same expression:
+        //   var fromDate = _workerOptions.MinSyncDate.HasValue
+        //       ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
+        //       : DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-90));
+        // Most deployments DON'T set MinSyncDate (it's an optional override for
+        // backfills and tests), so the else-branch is the path that 99% of
+        // production runs hit. The existing pin only exercises the HasValue path
+        // with a pre-STOCK-Act date — it has nothing to say about the null path.
+        //
+        // A regression that swapped the `-90` for `-30`, `-7`, or `-365` would
+        // silently shrink (or stretch) the backfill window with no test, no log
+        // warning, and no CI signal. The user-visible failure mode is asymmetric
+        // and slow: with a `-30` regression, every congressional trade between
+        // 30 and 90 days back goes un-imported on a fresh deploy or after any
+        // outage longer than 30 days; with a `-365` overshoot, the Senate and
+        // House endpoints would be hit with a year-wide query that triggers
+        // their rate limits and partial responses. The 90-day window is
+        // explicitly load-bearing: it spans the SEC's typical 45-day STOCK-Act
+        // filing-deadline plus margin for late filers.
+        //
+        // Construction mirrors the sibling test: substituted scope factory
+        // returns no Senate/House clients, the Fetch helpers throw, both
+        // catches degrade cleanly, and SyncAll returns after the startup
+        // "Starting congressional trade sync" log line fires with the resolved
+        // From. Tolerance of ±1 day handles test execution that crosses
+        // midnight UTC between the test setup and the log assertion.
+        var logger = Substitute.For<ILogger<CongressionalTradeSyncService>>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        var scope = Substitute.For<IServiceScope>();
+        scope.ServiceProvider.Returns(serviceProvider);
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+        var errorReporter = Substitute.For<ErrorReporter>(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<ErrorReporter>>());
+        var workerOptions = Options.Create(new WorkerOptions { MinSyncDate = null });
+
+        var expectedFromUpper = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-90));
+        var expectedFromLower = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-91));
+
+        var sut = new CongressionalTradeSyncService(scopeFactory, workerOptions, logger, errorReporter);
+
+        await sut.SyncAll(CancellationToken.None);
+
+        logger.Received().Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(state => StateContainsFromInRange(state, expectedFromLower, expectedFromUpper)),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<object, Exception, string>>());
+    }
+
     private static bool StateContainsFrom(object state, DateOnly expected) {
         if (state is not IReadOnlyList<KeyValuePair<string, object>> values) return false;
         foreach (var kv in values) {
             if (kv.Key == "From" && kv.Value is DateOnly d && d == expected) return true;
+        }
+        return false;
+    }
+
+    private static bool StateContainsFromInRange(object state, DateOnly lower, DateOnly upper) {
+        if (state is not IReadOnlyList<KeyValuePair<string, object>> values) return false;
+        foreach (var kv in values) {
+            if (kv.Key == "From" && kv.Value is DateOnly d && d >= lower && d <= upper) return true;
         }
         return false;
     }


### PR DESCRIPTION
## Summary

- Adds a sibling pin for `CongressionalTradeSyncService.SyncAll` covering the production-default branch of the `MinSyncDate.HasValue ? ... : DateTime.UtcNow.AddDays(-90)` expression. The existing test only exercises the `HasValue` path (with a pre-STOCK-Act date that clamps to 2012-04-01); the else-branch — the path 99% of deployments hit — was unpinned. A regression that swapped `-90` for `-30`, `-7`, or `-365` would silently shrink or stretch the backfill window with no test, log, or CI signal: a `-30` regression silently drops congressional trades between 30 and 90 days back on every fresh deploy or post-outage recovery; a `-365` overshoot triggers rate-limit / partial-response failures on both Senate and House endpoints.

## Code changes

- `tests/Equibles.UnitTests/Congress/CongressionalTradeSyncServiceTests.cs` — add `SyncAll_NullMinSyncDate_DefaultsToNinetyDayLookback` `[Fact]` plus a `StateContainsFromInRange` helper. Asserts the resolved From-date in the structured "Starting congressional trade sync" log line is within `[today-91d, today-90d]` (±1 day tolerance for tests crossing midnight UTC).