### PR TITLE
test(cboe): pin CboeScraperWorker.ErrorSource at CboeScraper

### DIFF
--- a/tests/Equibles.UnitTests/Cboe/CboeScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Cboe/CboeScraperWorkerTests.cs
@@ -1,6 +1,7 @@
 using Equibles.Cboe.HostedService;
 using Equibles.Cboe.HostedService.Configuration;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -31,6 +32,30 @@ public class CboeScraperWorkerTests {
         sut.InvokeSleepInterval().Should().Be(TimeSpan.FromHours(6));
     }
 
+    [Fact]
+    public void ErrorSource_IsCboeScraper() {
+        // CboeScraperWorker pulls VIX history and put/call ratios from cboe.com —
+        // a different upstream and data product from every other scraper. The
+        // base `BaseScraperWorker` hands this enum value to `ErrorReporter.Report`
+        // as the routing key for the issue-tracker queue. The Errors.Data.Models
+        // namespace defines a long list of visually-similar ErrorSource members
+        // (CftcScraper, FinraScraper, FredScraper, YahooScraper, etc.) all sitting
+        // alongside CboeScraper, so a copy-paste regression that picks the wrong
+        // sibling is the obvious failure mode — and it has no test signal from
+        // the existing SleepInterval pin. Pin the literal enum value so any
+        // future routing change must update this test deliberately.
+        var options = Options.Create(new CboeScraperOptions { SleepIntervalHours = 24 });
+        var sut = new TestableCboeScraperWorker(
+            Substitute.For<ILogger<CboeScraperWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()),
+            options);
+
+        sut.InvokeErrorSource().Should().Be(ErrorSource.CboeScraper);
+    }
+
     private sealed class TestableCboeScraperWorker : CboeScraperWorker {
         public TestableCboeScraperWorker(
             ILogger<CboeScraperWorker> logger,
@@ -40,5 +65,7 @@ public class CboeScraperWorkerTests {
             : base(logger, scopeFactory, errorReporter, options) { }
 
         public TimeSpan InvokeSleepInterval() => SleepInterval;
+
+        public ErrorSource InvokeErrorSource() => ErrorSource;
     }
 }


### PR DESCRIPTION
## Summary

- Pins that `CboeScraperWorker.ErrorSource` returns `ErrorSource.CboeScraper` — the routing key the base `BaseScraperWorker` hands to `ErrorReporter.Report` for every VIX / put-call-ratio scrape failure.
- A copy-paste regression that picked a sibling member (CftcScraper, FinraScraper, FredScraper, YahooScraper) would silently misroute every Cboe failure into the wrong on-call queue. The existing SleepInterval pin doesn't touch this property.

## Code changes

- `tests/Equibles.UnitTests/Cboe/CboeScraperWorkerTests.cs` — adds `ErrorSource_IsCboeScraper`, an `InvokeErrorSource` accessor on the existing `TestableCboeScraperWorker` subclass, and a `using Equibles.Errors.Data.Models;` import for the enum.