### PR TITLE
test(sec): pin RagManager.BuildContext friendly empty-list message

### DIFF
--- a/tests/Equibles.UnitTests/Sec/RagManagerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RagManagerTests.cs
@@ -50,4 +50,37 @@ public class RagManagerTests {
         secondIdx.Should().BeGreaterThan(firstIdx);
         thirdIdx.Should().BeGreaterThan(secondIdx);
     }
+
+    [Fact]
+    public async Task BuildContext_EmptyChunkList_ReturnsNoDocumentsFoundMessage() {
+        // Sibling to the StartPosition-ordering pin above. The risk this catches is
+        // asymmetric and unreachable from the existing test: `BuildContext` begins
+        // with an early guard
+        //   if (!chunks.Any()) return Task.FromResult("No relevant financial documents found.");
+        // EVERY downstream line (the GroupBy on `c.Document.CommonStock.Ticker`, the
+        // `group.First()` enumerator, the `chunks.OrderBy` inside the inner foreach)
+        // would NRE on an empty list because Document navigation is fetched lazily —
+        // not because of empty enumeration itself, but because the very first chunk
+        // touch in `groupedChunks.First()` would crash if the guard were dropped.
+        //
+        // The user-visible failure mode is a generic "An error occurred while
+        // searching the document. Please try again." message from McpToolExecutor's
+        // outer catch, with no signal to the operator about WHY the empty-results
+        // case suddenly started erroring. The friendly "No relevant financial
+        // documents found." string is the contract the LLM consumer relies on to
+        // distinguish "we searched and found nothing" from "the search itself
+        // failed". A regression here corrupts that distinction silently — every
+        // legitimate zero-result query starts looking like a server failure, and
+        // the LLM either retries (wasting tokens) or surfaces a misleading error
+        // to the user.
+        //
+        // The pair (non-empty → ordered excerpts, empty → friendly empty-message)
+        // distinguishes a working guard from BOTH guard-dropped (NRE catchpath)
+        // AND guard-inverted (wrong message for non-empty case) regressions.
+        var sut = new RagManager(chunkRepository: null, commonStockRepository: null, logger: null);
+
+        var result = await sut.BuildContext(new List<Chunk>());
+
+        result.Should().Be("No relevant financial documents found.");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a sibling pin for `RagManager.BuildContext` covering the early-return guard `if (!chunks.Any()) return "No relevant financial documents found."`. The existing `BuildContext_ChunksFromSameDocumentOutOfOrder_OutputsByStartPositionAscending` test only exercises the non-empty path. A regression that drops the guard NREs on `chunks.First()` enumeration and is swallowed by McpToolExecutor's outer catch, surfacing to the LLM consumer as the generic "An error occurred…" message — operationally indistinguishable from a real server failure, and corrupting the contract that lets the LLM consumer distinguish "zero results" from "search failed". An inverted-condition regression returns the wrong message for non-empty results.

## Code changes

- `tests/Equibles.UnitTests/Sec/RagManagerTests.cs` — add `BuildContext_EmptyChunkList_ReturnsNoDocumentsFoundMessage` `[Fact]`. Constructs `RagManager` with null repositories/logger (safe — the empty-list path returns before touching them) and asserts the exact friendly message.