### PR TITLE
test(yahoo): pin YahooPriceScraperWorker.ErrorSource at YahooPriceScraper

### DIFF
--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceScraperWorkerTests.cs
@@ -1,4 +1,5 @@
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
 using Equibles.Yahoo.HostedService;
 using Equibles.Yahoo.HostedService.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,6 +33,36 @@ public class YahooPriceScraperWorkerTests {
         sut.InvokeSleepInterval().Should().Be(TimeSpan.FromHours(8));
     }
 
+    [Fact]
+    public void ErrorSource_IsYahooPriceScraper() {
+        // YahooPriceScraperWorker pulls daily-close prices from Yahoo Finance —
+        // a different upstream, auth model (browser-impersonation cookies/crumb),
+        // and rate-limit envelope from every other scraper in the system. When
+        // BaseScraperWorker's catch-all reports a failure, it tags the error
+        // with this enum value as the routing key for the issue-tracker queue.
+        // The Errors.Data.Models namespace defines a row of visually-similar
+        // ErrorSource members (CftcScraper, FinraScraper, FredScraper,
+        // CboeScraper) alongside YahooPriceScraper, and there's also a
+        // YahooFundamentalsScraper sibling that could plausibly be copy-pasted
+        // here by accident — both come from the same `yahoo.com` upstream. A
+        // routing typo would silently misroute every price-feed failure into
+        // the wrong on-call queue, pointing the responder at the wrong Yahoo
+        // endpoint's outage page or worse, at an entirely different vendor.
+        // The existing SleepInterval pin doesn't touch this property. Pin
+        // the literal enum value so any future routing change must update
+        // this test deliberately.
+        var options = Options.Create(new YahooPriceScraperOptions { SleepIntervalHours = 24 });
+        var sut = new TestableYahooPriceScraperWorker(
+            Substitute.For<ILogger<YahooPriceScraperWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()),
+            options);
+
+        sut.InvokeErrorSource().Should().Be(ErrorSource.YahooPriceScraper);
+    }
+
     private sealed class TestableYahooPriceScraperWorker : YahooPriceScraperWorker {
         public TestableYahooPriceScraperWorker(
             ILogger<YahooPriceScraperWorker> logger,
@@ -41,5 +72,7 @@ public class YahooPriceScraperWorkerTests {
             : base(logger, scopeFactory, errorReporter, options) { }
 
         public TimeSpan InvokeSleepInterval() => SleepInterval;
+
+        public ErrorSource InvokeErrorSource() => ErrorSource;
     }
 }


### PR DESCRIPTION
## Summary

- Pins that `YahooPriceScraperWorker.ErrorSource` returns `ErrorSource.YahooPriceScraper` — the routing key the base `BaseScraperWorker` hands to `ErrorReporter.Report` for every daily-close-price scrape failure.
- The `Errors.Data.Models` namespace defines visually-similar sibling members (CftcScraper, FinraScraper, FredScraper, CboeScraper) plus a `YahooFundamentalsScraper` sibling from the same Yahoo upstream — a copy-paste regression here would silently misroute price-feed failures into the wrong on-call queue. The existing SleepInterval pin doesn't touch this property.

## Code changes

- `tests/Equibles.UnitTests/Yahoo/YahooPriceScraperWorkerTests.cs` — adds `ErrorSource_IsYahooPriceScraper`, an `InvokeErrorSource` accessor on the existing `TestableYahooPriceScraperWorker` subclass, and a `using Equibles.Errors.Data.Models;` import for the enum.