### PR TITLE
test(sec): pin PdfTextExtractor empty-bytes early-return is silent

### DIFF
--- a/tests/Equibles.UnitTests/Sec/PdfTextExtractorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/PdfTextExtractorTests.cs
@@ -21,6 +21,25 @@ public class PdfTextExtractorTests {
     }
 
     [Fact]
+    public void Extract_EmptyBytes_ReturnsEmptyWithoutLogging() {
+        // The guard at the top of Extract short-circuits on BOTH null and
+        // Length == 0. Without the Length == 0 branch, an empty byte[] would
+        // reach PdfPig, throw, hit the catch handler, and log a warning on
+        // every empty filing artifact. Pin the silent early-return so a
+        // refactor that simplifies the guard to `pdfBytes == null` surfaces
+        // as log spam in the warning-count assertion below.
+        var logger = Substitute.For<ILogger<PdfTextExtractor>>();
+        var sut = new PdfTextExtractor(logger);
+
+        var result = sut.Extract([]);
+
+        result.Should().BeEmpty();
+        logger.ReceivedCalls()
+            .Any(c => c.GetMethodInfo().Name == "Log")
+            .Should().BeFalse();
+    }
+
+    [Fact]
     public void Extract_NullBytes_ReturnsEmptyWithoutLogging() {
         // Extract is called from the SEC paper-PDF fallback in DocumentScraper:
         // when SecDocumentEnvelopeParser locates a PDF filename but the artifact


### PR DESCRIPTION
## Summary

- Adds a pin asserting `PdfTextExtractor.Extract([])` returns empty AND emits zero log calls — same shape as the existing null pin, but for the second OR-branch of the guard.
- Without `Length == 0` in the guard, an empty byte[] reaches PdfPig, throws, hits the catch handler, and logs a warning on every empty filing artifact. This test separates the silent early-return from the warning-logging catch path.

## Code changes

- `tests/Equibles.UnitTests/Sec/PdfTextExtractorTests.cs` — adds `Extract_EmptyBytes_ReturnsEmptyWithoutLogging`, asserting empty result and zero log calls.