### PR TITLE
test(yahoo): pin HasOverflowPrice returns false for prices within numeric ceiling

### DIFF
--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -34,4 +34,38 @@ public class YahooPriceImportServiceTests {
 
         result.Should().BeTrue();
     }
+
+    [Fact]
+    public void HasOverflowPrice_AllFieldsWithinNumericCeiling_ReturnsFalse() {
+        // Sibling to the overflow-true pin above. The risk this catches is
+        // asymmetric and unreachable from the existing sibling: a regression
+        // that hard-codes `HasOverflowPrice => true` (defensive default during
+        // a refactor, or copy-paste from an "always-filter" path) passes the
+        // overflow-case test and only shows up here. Without this pin, an
+        // "always-true" regression silently filters EVERY price quote out of
+        // every batch — all Yahoo imports would import zero rows per cycle,
+        // and the failure mode is invisible because HasOverflowPrice doesn't
+        // log (the filter is applied silently inside a LINQ Where on a per-
+        // row basis). Operators discover days later when historical-price
+        // dashboards show flatlines on every active ticker.
+        //
+        // The pair (overflow → true, normal → false) distinguishes a working
+        // OR-chain from BOTH negation (`Math.Abs(p.Open) <= MaxPriceValue ||
+        // ...` → normal-case returns true, caught here) AND constant-true
+        // collapse (also caught here). Use realistic stock-price magnitudes
+        // (sub-$10K) far inside the numeric(18,4) ceiling so a refactor that
+        // tightened the threshold by a factor of 10⁹ or 10¹⁰ (still wildly
+        // above realistic prices) wouldn't accidentally trigger.
+        var price = new HistoricalPrice {
+            Open = 150.25m,
+            High = 152.80m,
+            Low = 149.10m,
+            Close = 151.45m,
+            AdjustedClose = 151.45m
+        };
+
+        var result = (bool)HasOverflowPriceMethod.Invoke(null, [price]);
+
+        result.Should().BeFalse();
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a sibling pin for `YahooPriceImportService.HasOverflowPrice` covering the false (normal-prices) case. The existing test pins only the true-on-overflow direction. A regression to `=> true` (defensive default, or "always-filter" copy-paste from a different path) would pass the existing test and silently filter EVERY price quote out of every batch — `Where(p => !HasOverflowPrice(p))` evaluates to empty, every cycle imports zero rows, and the failure mode is invisible because the filter doesn't log. Historical-price dashboards flatline on every ticker.
- The pair (overflow → true, normal → false) distinguishes a working OR-chain from BOTH negation (`<=` swap → normal returns true) AND constant-true collapse.

## Code changes

- `tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceTests.cs` — add `HasOverflowPrice_AllFieldsWithinNumericCeiling_ReturnsFalse` `[Fact]`. Constructs a realistic stock-price `HistoricalPrice` (~$150 across all 5 fields, well within the numeric(18,4) ceiling) and asserts `HasOverflowPrice` returns `false` via reflection — mirroring the existing private-static-via-reflection pattern.