### PR TITLE
test(congress): pin HouseDisclosureClient bare 'S' classifies as Sale

### DIFF
--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
@@ -63,6 +63,35 @@ public class HouseDisclosureClientTests {
     }
 
     [Fact]
+    public void ExtractTransactionType_BareSaleNoQualifier_ReturnsSale() {
+        // Completes the Sale/Purchase pin family. Existing pins cover:
+        //   • bare "P"        → Purchase  (ExtractTransactionType_PurchaseTrailingP_…)
+        //   • "S (partial)"   → Sale      (existing partial pin)
+        //   • "S (full)"      → Sale      (existing full pin)
+        // The bare "S" form — `S` at line end with NO parenthetical qualifier — is
+        // the most common House PTR sale encoding (used for ordinary whole-position
+        // sells where no partial/full qualifier applies), and it's the ONLY form
+        // currently unpinned in the family.
+        //
+        // The SaleTypeRegex pattern is `\bS\s*(\((?:partial|full)\))?\s*$` — the
+        // `?` modifier on the parenthetical group is what makes bare S match. A
+        // regression that drops the `?` (someone "tightening" the pattern under
+        // the false assumption that every Sale must carry a qualifier) would still
+        // pass BOTH the partial AND the full sibling pins — those rows have the
+        // parenthetical present — while silently classifying every bare-S row as
+        // null, dropping them from the import via the `if (txType == null) continue;`
+        // guard in ParseTransactionLines. The failure mode is invisible: the import
+        // succeeds, just with a fraction of the expected row count, and the
+        // dashboard quietly shows fewer insider sales than reality.
+        //
+        // Pin the bare-S case specifically so the optional-qualifier `?` modifier
+        // can't be removed without a test failure.
+        var result = (CongressTransactionType?)ExtractTransactionTypeMethod.Invoke(null, ["AAPL S"]);
+
+        result.Should().Be(CongressTransactionType.Sale);
+    }
+
+    [Fact]
     public void RemoveTrailingTransactionType_SaleWithPartialQualifier_StripsSuffixAndQualifier() {
         // After ExtractTransactionType recognises the trailing "S (partial)" marker,
         // RemoveTrailingTransactionType has to strip it cleanly so the asset name


### PR DESCRIPTION
## Summary

- Pins bare `S` (no parenthetical qualifier) → `Sale`. Completes the family alongside the existing `P` → Purchase, `S (partial)` → Sale, `S (full)` → Sale pins.
- Bare S is the most common House PTR sale encoding (ordinary whole-position sells). SaleTypeRegex's `?` modifier on the parenthetical group is what makes bare S match. A regression that drops the `?` would still pass partial and full pins while silently classifying every bare-S row as null and dropping it from import.

## Code changes

- `tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs` — adds `ExtractTransactionType_BareSaleNoQualifier_ReturnsSale`.