### PR TITLE
test(sec): pin PaginationRemovalStep comment-skip on after-HR side

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepTests.cs
@@ -125,6 +125,47 @@ public class PaginationRemovalStepTests {
     }
 
     [Fact]
+    public void WhitespaceAndCommentsBetweenHrAndPartHeader_StillRemovesPartHeader() {
+        // Sibling pin to WhitespaceAndCommentsBetweenHrAndPageNumber_StillRemoved.
+        // That test covers the BEFORE-HR skip-loop (comments/whitespace between an
+        // <hr> and the candidate page-number sibling). This pin covers the AFTER-HR
+        // skip-loop — structurally distinct, in a separate `while (nextSibling != null)`
+        // block inside PaginationRemovalStep.Execute.
+        //
+        // SEC 10-K HTML routinely interleaves `<!-- page break -->` comments and
+        // whitespace text nodes between page-separator `<hr>` and the following
+        // Part header — the upstream EDGAR-to-XBRL converters insert them as
+        // pagination annotations. The skip-loop on the after-side must walk past
+        // those non-substantive nodes to find the "Part I" / "Part II" textual
+        // sibling and add it to the elements-to-remove list. Without the skip-loop
+        // (or with it accidentally inverted), the loop's break would fire on the
+        // comment node, the Part header would not be detected, and the chunker
+        // downstream would treat the Part heading as continuation of the previous
+        // section — wrecking heading-based document outline extraction.
+        //
+        // Pin: an <hr> followed by a comment, then a `<p>Part III</p>`. Assert that
+        // Part III is removed (proving the skip-loop walked past the comment to
+        // find and recognize it) and that surrounding content survives.
+        var doc = _parser.ParseDocument("""
+            <html><body>
+              <p>Content before</p>
+              <hr>
+              <!-- page break -->
+              <p>Part III</p>
+              <p>Content after</p>
+            </body></html>
+            """);
+
+        _step.Execute(doc);
+
+        var bodyHtml = doc.Body!.InnerHtml;
+        bodyHtml.Should().NotContain("<hr");
+        bodyHtml.Should().NotContain("Part III");
+        bodyHtml.Should().Contain("Content before");
+        bodyHtml.Should().Contain("Content after");
+    }
+
+    [Fact]
     public void WhitespaceAndCommentsBetweenHrAndPageNumber_StillRemoved() {
         var doc = _parser.ParseDocument("""
             <html><body>


### PR DESCRIPTION
## Summary

- Sibling pin to the existing BEFORE-HR comment-skip test. Covers the AFTER-HR skip-loop — structurally distinct, in a separate `while (nextSibling != null)` block.
- SEC 10-K HTML interleaves `<!-- page break -->` comments between an `<hr>` and the following Part header. Without the skip-loop, the Part header is missed and downstream chunkers treat the Part heading as continuation of the previous section.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepTests.cs` — adds `WhitespaceAndCommentsBetweenHrAndPartHeader_StillRemovesPartHeader`.