### PR TITLE
test(sec): pin SecDocumentHtmlNormalizer filters EX-* with non-numeric suffix

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerTests.cs
@@ -78,6 +78,61 @@ public class SecDocumentHtmlNormalizerTests {
     }
 
     [Fact]
+    public void Normalize_ExhibitTypeWithNonNumericSuffix_IsFilteredWithoutThrowing() {
+        // IsAllowedDocumentType's exhibit branch:
+        //   if (documentType.StartsWith("EX-")) {
+        //       var exNumberPart = documentType.Substring(3);
+        //       var exNumberPartClean = exNumberPart.Split('.')[0];
+        //       if (int.TryParse(exNumberPartClean, out var exNumber) && exNumber < 100) {
+        //           return true;
+        //       }
+        //   }
+        //   return false;
+        // The existing `Normalize_ExhibitTypeOver100_IsFiltered` pin exercises the
+        // path where TryParse succeeds (999 parses fine) but `< 100` fails — falls
+        // through to `return false`. The TryParse=FALSE branch is structurally
+        // distinct and unpinned: when the suffix is non-numeric (e.g. an aggregator
+        // adds a metadata suffix, or a malformed EDGAR upload labels an exhibit
+        // "EX-A1" or "EX-foo"), TryParse returns false, the short-circuit AND
+        // skips the < 100 comparison, and the method falls through to `return false`.
+        //
+        // The risk this catches: a refactor that "modernizes" `int.TryParse` to
+        // `int.Parse` (assuming SEC always sends a valid number) would throw
+        // FormatException on the first non-numeric EX-* code. There's no try/catch
+        // around the steps in Normalize, so the exception would bubble up through
+        // ExtractAndFilterDocuments → Normalize → the caller (typically the
+        // DocumentScraper.CreateDocument path), aborting the import of that filing
+        // and potentially affecting the whole batch.
+        //
+        // Pin: an EX-* document with a non-numeric suffix. Result must be empty
+        // (filtered), not thrown. The trailing valid 10-K confirms Normalize
+        // continues past the malformed exhibit and processes the next document
+        // — proving the loop's break didn't fire and the catch-less code path
+        // returned cleanly.
+        var sgml = """
+            <DOCUMENT>
+            <TYPE>EX-foo
+            <FILENAME>exhibit.htm
+            <TEXT>
+            <html><body><p>Malformed exhibit code</p></body></html>
+            </TEXT>
+            </DOCUMENT>
+            <DOCUMENT>
+            <TYPE>10-K
+            <FILENAME>filing.htm
+            <TEXT>
+            <html><body><p>Real filing follows</p></body></html>
+            </TEXT>
+            </DOCUMENT>
+            """;
+
+        var result = _sut.Normalize(sgml);
+
+        result.Should().NotContain("Malformed exhibit code");
+        result.Should().Contain("Real filing follows");
+    }
+
+    [Fact]
     public void Normalize_ExhibitTypeOver100_IsFiltered() {
         var sgml = """
             <DOCUMENT>


### PR DESCRIPTION
## Summary

- Pins the `int.TryParse=false` branch of `IsAllowedDocumentType`. Existing EX-999 pin exercises TryParse=success but `< 100` fails; the non-numeric suffix case is structurally distinct.
- A refactor to `int.Parse` would throw `FormatException` on the first malformed EX-* code. No try/catch surrounds the normalize steps, so the exception bubbles up and aborts the filing.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerTests.cs` — adds `Normalize_ExhibitTypeWithNonNumericSuffix_IsFilteredWithoutThrowing`.