### PR TITLE
test(cftc): pin CuratedContractRegistry contains E-mini S&P 500 with code 13874A

### DIFF
--- a/tests/Equibles.UnitTests/Cftc/CuratedContractRegistryTests.cs
+++ b/tests/Equibles.UnitTests/Cftc/CuratedContractRegistryTests.cs
@@ -22,4 +22,33 @@ public class CuratedContractRegistryTests {
 
         duplicates.Should().BeEmpty();
     }
+
+    [Fact]
+    public void Contracts_ContainsEminiSP500WithExactCftcMarketCode13874A() {
+        // CFTC publishes Commitments of Traders position data keyed by exact MarketCode
+        // strings — these are immutable identifiers like SEC CIKs. The E-mini S&P 500
+        // (CME) market code is "13874A" specifically — the trailing "A" distinguishes
+        // it from the full-size S&P 500 contract and is part of the wire format. A
+        // typo regression (e.g. "13874" or "13874a" — case-insensitive lookup makes
+        // the latter trickier to catch) would cause CftcImportService.ImportYear to
+        // never match any rows for this contract code, silently dropping the highest-
+        // volume CFTC-reported equity-index future from the import.
+        //
+        // The risk: E-mini S&P 500 positioning is THE primary signal on the CFTC
+        // equity-index dashboard. Speculative long/short open interest in this single
+        // contract drives the "speculator positioning" narrative across financial
+        // press. Silently losing it would empty out the dashboard's main column
+        // while every other contract continues working — exactly the partial-failure
+        // mode that operator inspection misses.
+        //
+        // Pin both the MarketCode literal AND the DisplayName so a regression that
+        // typo'd either field is caught. The display name flows into the dashboard's
+        // contract-picker dropdown; a regression there would mis-label the contract
+        // for analysts.
+        var contract = CuratedContractRegistry.Contracts
+            .SingleOrDefault(c => c.MarketCode == "13874A");
+
+        contract.Should().NotBeNull();
+        contract!.DisplayName.Should().Be("E-mini S&P 500 (CME)");
+    }
 }


### PR DESCRIPTION
## Summary

- Pins the E-mini S&P 500 (CME) entry with its exact CFTC market code "13874A" — the trailing "A" distinguishes it from the full-size S&P 500 contract.
- A typo regression would cause `CftcImportService.ImportYear` to never match rows for this contract, silently dropping the highest-volume CFTC equity-index future from the import. Asserts both MarketCode and DisplayName.

## Code changes

- `tests/Equibles.UnitTests/Cftc/CuratedContractRegistryTests.cs` — adds `Contracts_ContainsEminiSP500WithExactCftcMarketCode13874A`.