### PR TITLE
test(web): pin HeroIconTagHelper renders outline-styled SVG by default

### DIFF
--- a/tests/Equibles.UnitTests/Web/HeroIconTagHelperTests.cs
+++ b/tests/Equibles.UnitTests/Web/HeroIconTagHelperTests.cs
@@ -36,6 +36,71 @@ public class HeroIconTagHelperTests {
     }
 
     [Fact]
+    public void Process_KnownIconWithDefaultSolidFalse_RendersOutlineStyledSvgWithStrokeAndFillNone() {
+        // Sibling pin to Process_SolidAttributeOnKnownIcon. The existing solid pin
+        // asserts that with `solid="true"`, the rendered SVG carries
+        // `fill="currentColor"` — the marker of the Solid style. It says NOTHING
+        // about the DEFAULT path (Solid=false), which is the path every
+        // `<icon name="..."/>` tag in the codebase takes (no `solid` attribute is
+        // the norm — solid is the rare opt-in for inline accent icons in toasts
+        // and buttons).
+        //
+        // The Process method's branching is:
+        //   var style = Solid ? HeroIcons.IconStyle.Solid : HeroIcons.IconStyle.Outline;
+        // And HeroIcons.Render emits two completely different SVG attribute sets
+        // based on `isSolid = style == IconStyle.Solid`:
+        //   • Solid:   fill="currentColor", no stroke attributes
+        //   • Outline: fill="none", stroke="currentColor", stroke-width="1.5",
+        //              stroke-linecap="round", stroke-linejoin="round"
+        // These are visually meaningful: outline icons render as thin-line glyphs;
+        // solid icons render as filled shapes. A swap reskins the entire UI.
+        //
+        // The risk this catches is asymmetric and unreachable from the solid sibling
+        // alone: a refactor that hardcodes `var style = HeroIcons.IconStyle.Solid`
+        // (e.g. someone "cleaning up the Solid property" during a defaults review)
+        // compiles cleanly, passes the existing solid pin (Solid=true still
+        // resolves to Solid via hardcode), passes the Unknown pin (whose Render
+        // returns "" before the style check matters), and silently rebrands every
+        // outline icon — the entire site's icon set — as solid. The visual
+        // symptom is uniform but subtle: same icon shapes, but every header,
+        // nav-bar, button, and inline glyph gets a heavier filled appearance.
+        // Operators rarely notice because the change happens to every icon
+        // simultaneously and looks intentional.
+        //
+        // Equally, a regression that inverts the ternary
+        // (`Solid ? Outline : Solid`) would be caught by the existing solid pin
+        // (it asserts fill="currentColor" which would no longer appear) — so
+        // this isn't the case to protect against. The case THIS pin uniquely
+        // catches is the "always-solid" hardcode, which slips past every existing
+        // test in this file.
+        //
+        // Pin: known icon, no `Solid` set (defaults to false), assert that the
+        // rendered SVG carries the outline markers (fill="none" AND
+        // stroke="currentColor"). Both attributes are required because
+        // fill="none" alone could result from a constant-empty regression in
+        // Render, while stroke="currentColor" alone is the load-bearing visual
+        // signal — the stroke is what draws the visible outline shape.
+        var sut = new HeroIconTagHelper { Name = "plus" };
+        var context = new TagHelperContext(
+            new TagHelperAttributeList(),
+            new Dictionary<object, object>(),
+            uniqueId: "test");
+        var output = new TagHelperOutput(
+            "icon",
+            new TagHelperAttributeList(),
+            getChildContentAsync: (useCachedResult, encoder) =>
+                Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+        sut.Process(context, output);
+
+        output.TagName.Should().BeNull();
+        var content = output.Content.GetContent(HtmlEncoder.Default);
+        content.Should().Contain("<svg");
+        content.Should().Contain("fill=\"none\"");
+        content.Should().Contain("stroke=\"currentColor\"");
+    }
+
+    [Fact]
     public void Process_UnknownIconName_SuppressesOutput() {
         var sut = new HeroIconTagHelper { Name = "this-icon-does-not-exist" };
         var context = new TagHelperContext(


### PR DESCRIPTION
## Summary

- Adds a sibling pin for `HeroIconTagHelper.Process` exercising the default-outline path (no `solid` attribute, Solid=false).
- The existing solid pin asserts `fill="currentColor"` for Solid=true, but it doesn't catch a hardcode regression like `var style = HeroIcons.IconStyle.Solid;` — that change would pass the solid pin (Solid=true still resolves to Solid via hardcode) and silently rebrand every outline icon site-wide.
- Pins both `fill="none"` and `stroke="currentColor"` so a constant-empty regression in `Render` is also caught.

## Code changes

- `tests/Equibles.UnitTests/Web/HeroIconTagHelperTests.cs` — adds `Process_KnownIconWithDefaultSolidFalse_RendersOutlineStyledSvgWithStrokeAndFillNone`. Uses the same `<icon name="plus"/>` shape as the existing solid pin so the only difference is the Solid attribute.