### PR TITLE
test(sec): pin ListConversionStep removes middle-dot bullet spans

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepTests.cs
@@ -71,6 +71,46 @@ public class ListConversionStepTests {
     }
 
     [Fact]
+    public void MiddleDotBulletSpans_AreRemovedFromListItems() {
+        // ConvertItemToListItem's bullet matcher is the three-arm pattern
+        //   `s.TextContent.Trim() is "•" or "·" or "-"`
+        // The existing `BulletSpans_AreRemovedFromListItems` test only
+        // exercises the "•" (U+2022 BULLET) arm. The middle-arm "·"
+        // (U+00B7 MIDDLE DOT) is unpinned and structurally distinct: it's
+        // the *second* visually-similar bullet character that SEC filers
+        // routinely use, especially in proxy statements rendered from
+        // Donnelley Financial and DFS pipelines. A regression that
+        // "consolidates" the three-arm pattern to just `is "•"` (the
+        // dominant case) would compile, pass the existing bullet test,
+        // and silently leave every `·` in the rendered list items — a
+        // visible glyph baked into the persisted document text that
+        // would show up in the public document viewer and in MCP
+        // `SearchDocumentKeyword` results.
+        //
+        // The risk is asymmetric vs. the existing `•` pin: the `•` arm
+        // is the dominant case and would never be dropped accidentally;
+        // the `·` arm is the one that goes quiet first when someone
+        // "simplifies" the pattern. Pin it explicitly so the
+        // visually-similar-but-encoded-differently bullet survives.
+        //
+        // The hyphen `-` arm is the third (also unpinned) but is more
+        // ambiguous — hyphens legitimately appear inside list-item text
+        // ("non-GAAP", "Q4-2024"). The middle-dot arm is the cleaner pin
+        // because `·` is unambiguously decorative in this context.
+        var input = """
+            <div class="item-list-element-wrapper">
+              <span>·</span>
+              <div style="display:inline">Item with middle-dot bullet</div>
+            </div>
+            """;
+
+        var result = Execute(input);
+
+        result.Should().NotContain("·");
+        result.Should().Contain("Item with middle-dot bullet");
+    }
+
+    [Fact]
     public void ContentFromInlineDisplayDiv_IsPreservedInLi() {
         var input = """
             <div class="item-list-element-wrapper">


### PR DESCRIPTION
## Summary

- Pins the middle-arm of the three-arm bullet matcher in `ConvertItemToListItem`: `s.TextContent.Trim() is "•" or "·" or "-"`.
- The existing `BulletSpans_AreRemovedFromListItems` test only exercises the `•` (U+2022 BULLET) arm. A "consolidate to just `•`" refactor would silently leave every `·` (U+00B7 MIDDLE DOT) in the rendered list — visible glyph in the document viewer and indexed in keyword search.
- Middle-dot bullets are common in proxy statements rendered from Donnelley Financial and DFS pipelines. Hyphen arm intentionally left unpinned for now — hyphens legitimately appear inside list text ("non-GAAP", "Q4-2024"), so a clean isolation test is harder.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepTests.cs` — new `MiddleDotBulletSpans_AreRemovedFromListItems` fact mirroring the existing bullet test.