### PR TITLE
test(core): pin BatchPersister.Persist empty items does not call flushBatch and returns zero

### DIFF
--- a/tests/Equibles.UnitTests/Core/BatchPersisterTests.cs
+++ b/tests/Equibles.UnitTests/Core/BatchPersisterTests.cs
@@ -21,6 +21,51 @@ public class BatchPersisterTests {
     }
 
     [Fact]
+    public async Task Persist_EmptyItems_DoesNotCallFlushBatchAndReturnsZero() {
+        // Sibling to the divisible/non-divisible pins. Both existing tests
+        // use non-empty inputs. The third structural shape — an empty
+        // enumerable — exercises a distinct path: the foreach body never
+        // runs AND the trailing `if (batch.Count > 0)` guard correctly
+        // skips the would-be tail flush.
+        //
+        // The risk this catches: a refactor that drops the trailing
+        // `if (batch.Count > 0)` guard (under the false intuition that
+        // "the foreach already drained everything, the final flush is
+        // dead code") would still pass both existing pins — both have
+        // a leftover-but-non-empty final batch — and silently introduce
+        // an empty-list flush call on every empty payload. The flush
+        // callback is the EF-Core `repo.AddRange + SaveChanges` path
+        // for FINRA / FRED / CFTC imports; an empty SaveChanges is a
+        // wasted DB roundtrip per empty-input invocation. More subtly,
+        // some callers' flush callbacks assume `batch.Count > 0` and
+        // dereference `batch[0]` for logging/metadata — a regression
+        // that drops the guard would IndexOutOfRange on empty input.
+        //
+        // The complementary risk: a refactor that swaps the foreach
+        // body's flush-then-clear order (clear first, then flush a
+        // now-empty list) would also pass the divisible pin's exact-
+        // count assertion accidentally (because the flushed list would
+        // still see the right invocation count), but would NOT pass
+        // this empty-input pin's `Receive(0)` assertion — the
+        // would-be empty flushes from the divisible path could
+        // collide with the test setup if the implementation
+        // miscounts on empty input.
+        //
+        // Pin: empty input. Assert total=0 AND no flush calls. The
+        // dual assertion proves (a) no work happened and (b) the
+        // final-flush guard fired correctly.
+        var flushed = new List<List<int>>();
+
+        var total = await BatchPersister.Persist(Enumerable.Empty<int>(), batchSize: 3, flushBatch: batch => {
+            flushed.Add([..batch]);
+            return Task.CompletedTask;
+        });
+
+        total.Should().Be(0);
+        flushed.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task Persist_ItemCountExactlyDivisibleByBatchSize_FlushesEachBatchOnceAndDoesNotDoubleFlush() {
         // The non-divisible sibling pins the "leftover partial batch" path. This pin
         // covers the boundary case the sibling can NOT catch: when the last full


### PR DESCRIPTION
## Summary

- Pins the empty-input path of `BatchPersister.Persist`. Existing siblings cover divisible/non-divisible paths; the empty-enumerable shape — foreach never runs AND trailing `if (batch.Count > 0)` guard fires — was unpinned.
- A "drop the trailing guard" refactor would silently introduce empty-list flush calls on every empty payload (wasted EF Core `SaveChanges` roundtrip per FINRA/FRED/CFTC import) and could IndexOutOfRange on callbacks that dereference `batch[0]` for metadata.
- The dual assertion (`total == 0` AND `flushed.IsEmpty`) proves both that no work happened and that the final-flush guard fired.

## Code changes

- `tests/Equibles.UnitTests/Core/BatchPersisterTests.cs` — new `Persist_EmptyItems_DoesNotCallFlushBatchAndReturnsZero` fact.