### PR TITLE
test(cboe): pin AddCboeWorker auto-wires ICboeClient from Equibles.Integrations.Cboe assembly

### DIFF
--- a/tests/Equibles.UnitTests/Cboe/CboeServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Cboe/CboeServiceCollectionExtensionsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.Cboe.HostedService.Extensions;
 using Equibles.Cboe.HostedService.Services;
+using Equibles.Integrations.Cboe.Contracts;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Equibles.UnitTests.Cboe;
@@ -22,5 +23,49 @@ public class CboeServiceCollectionExtensionsTests {
         services.AddCboeWorker();
 
         services.Should().Contain(d => d.ServiceType == typeof(CboeImportService));
+    }
+
+    [Fact]
+    public void AddCboeWorker_AutoWiresICboeClientFromIntegrationsAssembly() {
+        // Sibling to `AddCboeWorker_AutoWiresCboeImportService`. The existing
+        // pin covers the first `AutoWireServicesFrom<CboeImportService>()`
+        // call — the hosted-service assembly scan. AddCboeWorker has a
+        // SECOND `AutoWireServicesFrom` call that scans the
+        // Equibles.Integrations.Cboe assembly to wire ICboeClient →
+        // CboeClient (the HTTP client behind the VIX and put/call-ratio
+        // downloaders). This second scan is structurally distinct: a
+        // separate assembly, a separate auto-wire seam, and the
+        // ICboeClient binding (NOT a service-type-matches-impl-type case
+        // like CboeImportService).
+        //
+        // The risk this pin catches that the CboeImportService sibling
+        // cannot: a refactor that drops the second AutoWireServicesFrom
+        // call (under the false intuition that "CboeImportService is the
+        // only service we need to register, the client is implicit") would
+        // compile, pass the existing CboeImportService pin, and silently
+        // leave ICboeClient unresolvable at startup. CboeScraperWorker's
+        // first DoWork iteration would throw InvalidOperationException
+        // from `GetRequiredService<ICboeClient>()` — the worker logs the
+        // critical exception and the entire CBOE ingest stalls.
+        //
+        // The complementary risk: a refactor that points the second scan
+        // at the WRONG assembly (e.g. typing `<Equibles.Integrations.Cftc.CftcClient>`
+        // — adjacent class, easy copy-paste) would also pass the
+        // CboeImportService sibling but silently register the CFTC
+        // client instead. CboeScraperWorker's GetRequiredService<ICboeClient>
+        // would still fail at runtime because the wrong-assembly scan
+        // would register ICftcClient, not ICboeClient.
+        //
+        // Pin: `services.Should().Contain(d => d.ServiceType ==
+        // typeof(ICboeClient))`. CboeClient is registered with the
+        // `[Service(ServiceLifetime.Scoped, typeof(ICboeClient))]`
+        // attribute, so the registered ServiceType IS the interface
+        // (not the concrete). Asserting on the interface presence
+        // catches all three regression classes above.
+        var services = new ServiceCollection();
+
+        services.AddCboeWorker();
+
+        services.Should().Contain(d => d.ServiceType == typeof(ICboeClient));
     }
 }


### PR DESCRIPTION
## Summary

- Sibling to the existing CboeImportService pin. Covers the SECOND `AutoWireServicesFrom` call in AddCboeWorker — the Equibles.Integrations.Cboe assembly scan that registers ICboeClient → CboeClient.
- A "we only need to wire the import service" refactor would compile, pass the existing CboeImportService pin, and silently leave ICboeClient unresolvable at startup. CboeScraperWorker's first DoWork would NRE on `GetRequiredService<ICboeClient>()`.
- Asserts on the interface (`typeof(ICboeClient)`) because the Service attribute registers via the interface type, not the concrete.

## Code changes

- `tests/Equibles.UnitTests/Cboe/CboeServiceCollectionExtensionsTests.cs` — new `AddCboeWorker_AutoWiresICboeClientFromIntegrationsAssembly` fact and import for `Equibles.Integrations.Cboe.Contracts`.