### PR TITLE
test(yahoo): pin AddYahooWorker auto-wires IYahooFinanceClient from Integrations.Yahoo assembly

### DIFF
--- a/tests/Equibles.UnitTests/Yahoo/YahooServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooServiceCollectionExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Equibles.Core.Contracts;
+using Equibles.Integrations.Yahoo.Contracts;
 using Equibles.Yahoo.HostedService.Extensions;
 using Equibles.Yahoo.HostedService.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -6,6 +7,51 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Equibles.UnitTests.Yahoo;
 
 public class YahooServiceCollectionExtensionsTests {
+    [Fact]
+    public void AddYahooWorker_AutoWiresIYahooFinanceClientFromIntegrationsAssembly() {
+        // Sibling to `AddYahooWorker_RegistersIStockPriceProviderAsYahooStockPriceProviderScoped`.
+        // The existing pin covers the EXPLICIT `services.AddScoped<IStockPriceProvider, ...>`
+        // binding — the cross-module contract the Holdings valuation
+        // pipeline depends on. This pin covers the OTHER half of the
+        // composition: the auto-wire scan of `Equibles.Integrations.Yahoo`
+        // that registers IYahooFinanceClient → YahooFinanceClient (the
+        // HTTP client behind YahooPriceImportService's daily-close
+        // downloads and YahooStockPriceProvider's per-ticker lookups).
+        //
+        // AddYahooWorker has TWO auto-wire calls — one for the
+        // hosted-service assembly (covered indirectly by the existing
+        // explicit binding pin), one for the Integrations.Yahoo
+        // assembly. This pin protects the Integrations.Yahoo scan
+        // specifically:
+        //   • A refactor that drops the second AutoWireServicesFrom
+        //     (under the false intuition that "the explicit
+        //     IStockPriceProvider binding is enough") would compile,
+        //     pass the existing IStockPriceProvider pin, and silently
+        //     leave IYahooFinanceClient unresolvable.
+        //     YahooPriceScraperWorker.DoWork's first iteration would
+        //     throw InvalidOperationException; the worker's
+        //     BaseScraperWorker catch-all routes it to ErrorReporter
+        //     and the daily-price ingest silently halts.
+        //   • The complementary risk: pointing the second scan at the
+        //     wrong assembly (typing `<Equibles.Integrations.Sec.SecEdgarClient>`
+        //     during a copy-paste refactor) would also pass the
+        //     IStockPriceProvider pin while registering the wrong
+        //     client — IYahooFinanceClient would not appear in the
+        //     descriptor list. This pin catches both via the explicit
+        //     `typeof(IYahooFinanceClient)` lookup.
+        //
+        // Pin: `services.Should().Contain(d => d.ServiceType ==
+        // typeof(IYahooFinanceClient))`. YahooFinanceClient is
+        // registered with `[Service(ServiceLifetime.Scoped,
+        // typeof(IYahooFinanceClient))]`, so the descriptor's
+        // ServiceType IS the interface.
+        var services = new ServiceCollection();
+
+        services.AddYahooWorker();
+
+        services.Should().Contain(d => d.ServiceType == typeof(IYahooFinanceClient));
+    }
+
     [Fact]
     public void AddYahooWorker_RegistersIStockPriceProviderAsYahooStockPriceProviderScoped() {
         // AddYahooWorker is the host's seam into auto-wiring for daily price


### PR DESCRIPTION
## Summary

- Sibling to the existing IStockPriceProvider explicit-binding pin. Covers the SECOND `AutoWireServicesFrom` call in AddYahooWorker — the `Equibles.Integrations.Yahoo` assembly scan that registers IYahooFinanceClient → YahooFinanceClient.
- Existing pin only verifies the cross-module IStockPriceProvider binding. A dropped Integrations.Yahoo scan would silently leave IYahooFinanceClient unresolvable; YahooPriceScraperWorker.DoWork would throw on first iteration.
- Also catches wrong-assembly-scan refactors (e.g., copy-paste typo pointing at Integrations.Sec instead).

## Code changes

- `tests/Equibles.UnitTests/Yahoo/YahooServiceCollectionExtensionsTests.cs` — new `AddYahooWorker_AutoWiresIYahooFinanceClientFromIntegrationsAssembly` fact and import for `Equibles.Integrations.Yahoo.Contracts`.