### PR TITLE
test(cftc): pin AddCftcWorker auto-wires ICftcClient from Integrations.Cftc assembly

### DIFF
--- a/tests/Equibles.UnitTests/Cftc/CftcServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Cftc/CftcServiceCollectionExtensionsTests.cs
@@ -1,10 +1,58 @@
 using Equibles.Cftc.HostedService.Extensions;
 using Equibles.Cftc.HostedService.Services;
+using Equibles.Integrations.Cftc.Contracts;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Equibles.UnitTests.Cftc;
 
 public class CftcServiceCollectionExtensionsTests {
+    [Fact]
+    public void AddCftcWorker_AutoWiresICftcClientFromIntegrationsAssembly() {
+        // Sibling to `AddCftcWorker_AutoWiresCftcImportService`. The
+        // existing pin covers the FIRST `AutoWireServicesFrom` call —
+        // the hosted-service assembly scan that registers
+        // CftcImportService. AddCftcWorker has a SECOND
+        // `AutoWireServicesFrom` call that scans
+        // `Equibles.Integrations.Cftc` to wire ICftcClient →
+        // CftcClient (the HTTP client behind the COT-report
+        // downloader).
+        //
+        // The two scans are structurally distinct: separate assemblies,
+        // and ICftcClient is registered via an interface contract
+        // (`[Service(ServiceLifetime.Scoped, typeof(ICftcClient))]`),
+        // not via implementation type. The existing CftcImportService
+        // pin tests the implementation-is-concrete-class registration
+        // pattern; this pin exercises the interface-binding scan.
+        //
+        // The risk this catches that the CftcImportService sibling
+        // cannot:
+        //   • A refactor that drops the second AutoWireServicesFrom
+        //     (under the false intuition that the import service is
+        //     the only thing AddCftcWorker registers) would compile,
+        //     pass the existing CftcImportService pin, and silently
+        //     leave ICftcClient unresolvable at startup.
+        //     CftcScraperWorker's first DoWork iteration would throw
+        //     InvalidOperationException from
+        //     `GetRequiredService<ICftcClient>()` — the worker logs the
+        //     critical exception and the entire COT ingest stalls.
+        //   • A wrong-assembly scan (typing
+        //     `<Equibles.Integrations.Cboe.CboeClient>` — adjacent
+        //     module, easy copy-paste) would also pass the existing
+        //     pin but silently register the CBOE client instead.
+        //
+        // Mirror the existing Cboe pin's pattern: assert presence of
+        // the interface descriptor via `services.Should().Contain(d =>
+        // d.ServiceType == typeof(ICftcClient))`. ICftcClient is
+        // registered via the Service attribute's explicit interface
+        // parameter, so the descriptor's ServiceType IS the interface
+        // (not the concrete CftcClient).
+        var services = new ServiceCollection();
+
+        services.AddCftcWorker();
+
+        services.Should().Contain(d => d.ServiceType == typeof(ICftcClient));
+    }
+
     [Fact]
     public void AddCftcWorker_AutoWiresCftcImportService() {
         // AddCftcWorker is the host's seam into auto-wiring for the COT


### PR DESCRIPTION
## Summary

- Sibling to the existing CftcImportService pin. Covers the SECOND `AutoWireServicesFrom` call — the Integrations.Cftc assembly scan that registers ICftcClient.
- A dropped second scan would silently leave ICftcClient unresolvable; CftcScraperWorker.DoWork would NRE on first iteration with no clean error trail beyond the worker's catch-all.
- Mirrors the Cboe/Yahoo Integrations-assembly-scan pin pattern from earlier iterations — completes the family for the three Integrations.*-aware workers.

## Code changes

- `tests/Equibles.UnitTests/Cftc/CftcServiceCollectionExtensionsTests.cs` — new `AddCftcWorker_AutoWiresICftcClientFromIntegrationsAssembly` fact and import for `Equibles.Integrations.Cftc.Contracts`.