### PR TITLE
test(finra): pin AddFinraWorker auto-wires IFinraClient from Integrations.Finra assembly

### DIFF
--- a/tests/Equibles.UnitTests/Finra/FinraServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraServiceCollectionExtensionsTests.cs
@@ -1,10 +1,61 @@
 using Equibles.Finra.HostedService.Extensions;
 using Equibles.Finra.HostedService.Services;
+using Equibles.Integrations.Finra.Contracts;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Equibles.UnitTests.Finra;
 
 public class FinraServiceCollectionExtensionsTests {
+    [Fact]
+    public void AddFinraWorker_AutoWiresIFinraClientFromIntegrationsAssembly() {
+        // Sibling to `AddFinraWorker_AutoWiresShortVolumeImportService`.
+        // The existing pin covers the FIRST `AutoWireServicesFrom` call
+        // — the hosted-service assembly scan that registers
+        // ShortVolumeImportService. AddFinraWorker has a SECOND
+        // `AutoWireServicesFrom` call that scans
+        // `Equibles.Integrations.Finra` to wire IFinraClient →
+        // FinraClient (the OAuth2-authenticated HTTP client behind
+        // FINRA's short-volume + short-interest downloads).
+        //
+        // The two scans are structurally distinct: separate assemblies,
+        // and IFinraClient is registered via interface contract
+        // (`[Service(ServiceLifetime.Scoped, typeof(IFinraClient))]`),
+        // NOT via the implementation-type-equals-service-type pattern.
+        // The existing ShortVolumeImportService pin tests the latter;
+        // this pin exercises the interface-binding scan.
+        //
+        // The risk this catches that the ShortVolumeImportService
+        // sibling cannot:
+        //   • A refactor that drops the second AutoWireServicesFrom
+        //     (under the false intuition that "the import service is
+        //     all we need") would compile, pass the existing
+        //     ShortVolumeImportService pin, and silently leave
+        //     IFinraClient unresolvable at startup. FinraScraperWorker's
+        //     ValidateConfiguration's call into IFinraClient.IsConfigured
+        //     would NRE — the defensive validation step pinned by the
+        //     existing `ValidateConfiguration_FinraClientNotConfigured`
+        //     test depends on this binding.
+        //   • A wrong-assembly scan (typing
+        //     `<Equibles.Integrations.Fred.FredClient>` during a
+        //     copy-paste refactor) would also pass the
+        //     ShortVolumeImportService sibling but silently register
+        //     the FRED client instead.
+        //
+        // FINRA's OAuth2 flow is the most fragile of the integration
+        // clients (token refresh, scope handling, multi-step auth) —
+        // a regression here breaks the daily short-volume ingest with
+        // no obvious error trail (the worker logs and continues, no
+        // 401 surfaces to the operator dashboard).
+        //
+        // Mirror the Cboe/Cftc/Yahoo/Fred Integrations-assembly-scan
+        // pin pattern.
+        var services = new ServiceCollection();
+
+        services.AddFinraWorker();
+
+        services.Should().Contain(d => d.ServiceType == typeof(IFinraClient));
+    }
+
     [Fact]
     public void AddFinraWorker_AutoWiresShortVolumeImportService() {
         // AddFinraWorker is the host's seam into auto-wiring for the


### PR DESCRIPTION
## Summary

- Sibling to the existing ShortVolumeImportService pin. Covers the SECOND `AutoWireServicesFrom` call — the Integrations.Finra assembly scan that registers IFinraClient (the OAuth2-authenticated HTTP client).
- Completes the Integrations-assembly-scan family across all five integration workers (CBOE, CFTC, Yahoo, FRED, FINRA).
- The existing `ValidateConfiguration_FinraClientNotConfigured_ReturnsFalse` worker pin depends on IFinraClient being resolvable. A dropped second scan would silently NRE at first DoWork's IsConfigured check; FINRA's OAuth2 flow makes the regression hardest to diagnose without an explicit binding pin.

## Code changes

- `tests/Equibles.UnitTests/Finra/FinraServiceCollectionExtensionsTests.cs` — new `AddFinraWorker_AutoWiresIFinraClientFromIntegrationsAssembly` fact and import for `Equibles.Integrations.Finra.Contracts`.