### PR TITLE
chore(coverage): exclude entire Equibles.Migrations project from code coverage

### DIFF
--- a/coverage.runsettings
+++ b/coverage.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <ExcludeByFile>**/Migrations/**</ExcludeByFile>
+          <ExcludeByFile>**/Equibles.Migrations/**</ExcludeByFile>
           <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>


### PR DESCRIPTION
## Summary

- The previous `ExcludeByFile` glob `**/Migrations/**` matched only the EF-generated migration files under `src/Equibles.Migrations/Migrations/`, but missed `src/Equibles.Migrations/DesignTimeDbContextFactory.cs` (sits directly at the project root, not inside a `Migrations/` subfolder).
- The whole `Equibles.Migrations` project is a design-time tool with no runtime code — it should be excluded from coverage as a unit.

## Code changes

- `coverage.runsettings` — replace `**/Migrations/**` with `**/Equibles.Migrations/**`. Single pattern now covers every file in the migrations project, including the design-time factory.