### PR TITLE
test(cboe): cover CboeClient HTTP entry points and retry branches

### DIFF
--- a/tests/Equibles.IntegrationTests/Cboe/CboeClientTests.cs
+++ b/tests/Equibles.IntegrationTests/Cboe/CboeClientTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using Equibles.Integrations.Cboe;
+using Equibles.Integrations.Cboe.Models;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Cboe;
+
+public class CboeClientTests {
+    private const string PutCallBaseUrl = "https://cdn.cboe.com/resources/options/volume_and_call_put_ratios";
+    private const string VixUrl = "https://cdn.cboe.com/api/global/us_indices/daily_prices/VIX_History.csv";
+
+    [Theory]
+    [InlineData(CboePutCallCsvType.Total, "totalpc.csv")]
+    [InlineData(CboePutCallCsvType.Equity, "equitypc.csv")]
+    [InlineData(CboePutCallCsvType.Index, "indexpc.csv")]
+    [InlineData(CboePutCallCsvType.Vix, "vixpc.csv")]
+    [InlineData(CboePutCallCsvType.Etp, "etppc.csv")]
+    public async Task DownloadPutCallRatios_EachCsvType_FetchesMatchingCdnFileAndReturnsParsedRecords(
+        CboePutCallCsvType csvType, string expectedFileName) {
+        // The CsvFileNames dictionary maps each CboePutCallCsvType to its CDN file name.
+        // A swapped or typo'd entry would point one consumer (e.g. Total ratios) at
+        // another file's data (e.g. Equity), and the import would silently land wrong
+        // values under the wrong type. Pin every enum->file mapping end-to-end.
+        var csv = "Date,Call Volume,Put Volume,Total Volume,P/C Ratio\n" +
+                  "01/15/2025,100000,80000,200000,0.80\n";
+        var handler = new ScriptedHandler((HttpStatusCode.OK, csv));
+        var sut = new CboeClient(new HttpClient(handler), Substitute.For<ILogger<CboeClient>>());
+
+        var result = await sut.DownloadPutCallRatios(csvType);
+
+        handler.Requests.Should().ContainSingle()
+            .Which.RequestUri!.ToString().Should().Be($"{PutCallBaseUrl}/{expectedFileName}");
+        result.Should().ContainSingle()
+            .Which.Date.Should().Be(new DateOnly(2025, 1, 15));
+    }
+
+    [Fact]
+    public async Task DownloadVixHistory_OkResponse_FetchesVixHistoryUrlAndReturnsParsedRecords() {
+        // Pin the VIX endpoint URL and confirm the full DownloadVixHistory -> ParseVixCsv
+        // flow on a well-formed feed. The constant VixUrl is hardcoded; a typo or
+        // a future change to a different CBOE CDN path would silently break the
+        // VIX ingest in production. Asserting on the requested URL fixes the contract.
+        var csv = "DATE,OPEN,HIGH,LOW,CLOSE\n" +
+                  "01/03/2020,13.72,14.49,13.51,14.02\n";
+        var handler = new ScriptedHandler((HttpStatusCode.OK, csv));
+        var sut = new CboeClient(new HttpClient(handler), Substitute.For<ILogger<CboeClient>>());
+
+        var result = await sut.DownloadVixHistory();
+
+        handler.Requests.Should().ContainSingle()
+            .Which.RequestUri!.ToString().Should().Be(VixUrl);
+        result.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new CboeVixRecord {
+                Date = new DateOnly(2020, 1, 3),
+                Open = 13.72m,
+                High = 14.49m,
+                Low = 13.51m,
+                Close = 14.02m
+            });
+    }
+
+    [Fact]
+    public async Task DownloadWithRetry_TooManyRequestsThenOk_RetriesAndReturnsParsedContent() {
+        // 429 path: the loop must back off (RateLimiter.PauseFor + Task.Delay) and
+        // try again, returning the eventual success body. Without the retry the
+        // first CBOE 429 of the day would abort the whole ingest. The initial
+        // delay is 2^(0+1) = 2s, so this test pays a real 2s wait — keep it to
+        // a single retry. The success on attempt #2 also proves the loop EXITS
+        // the retry branch instead of looping forever.
+        var csv = "Date,Call Volume,Put Volume,Total Volume,P/C Ratio\n" +
+                  "01/15/2025,100000,80000,200000,0.80\n";
+        var handler = new ScriptedHandler(
+            (HttpStatusCode.TooManyRequests, ""),
+            (HttpStatusCode.OK, csv));
+        var sut = new CboeClient(new HttpClient(handler), Substitute.For<ILogger<CboeClient>>());
+
+        var result = await sut.DownloadPutCallRatios(CboePutCallCsvType.Total);
+
+        handler.Requests.Should().HaveCount(2);
+        result.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task DownloadWithRetry_ServerErrorThenOk_RetriesAndReturnsParsedContent() {
+        // 5xx path is structurally distinct from the 429 path: it does NOT call
+        // RateLimiter.PauseFor (server errors aren't a rate-limit signal), only
+        // Task.Delay. Pin the retry-on-5xx -> success flow so a refactor that
+        // collapses both branches into one or drops the 5xx retry is caught.
+        var csv = "DATE,OPEN,HIGH,LOW,CLOSE\n" +
+                  "01/03/2020,13.72,14.49,13.51,14.02\n";
+        var handler = new ScriptedHandler(
+            (HttpStatusCode.BadGateway, ""),
+            (HttpStatusCode.OK, csv));
+        var sut = new CboeClient(new HttpClient(handler), Substitute.For<ILogger<CboeClient>>());
+
+        var result = await sut.DownloadVixHistory();
+
+        handler.Requests.Should().HaveCount(2);
+        result.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task DownloadWithRetry_NonRetryableStatus_ThrowsImmediately() {
+        // 404 (and any other non-2xx, non-429, non-5xx) is not retryable —
+        // EnsureSuccessStatusCode throws on the first attempt. Pin the
+        // single-request behavior so a refactor that broadens the retry
+        // window (e.g. "retry on any error") isn't shipped silently:
+        // retrying a permanent 404 burns the rate-limit budget for nothing.
+        var handler = new ScriptedHandler((HttpStatusCode.NotFound, ""));
+        var sut = new CboeClient(new HttpClient(handler), Substitute.For<ILogger<CboeClient>>());
+
+        var act = async () => await sut.DownloadPutCallRatios(CboePutCallCsvType.Total);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        handler.Requests.Should().ContainSingle();
+    }
+
+    private sealed class ScriptedHandler : HttpMessageHandler {
+        private readonly Queue<(HttpStatusCode Status, string Body)> _responses;
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        public ScriptedHandler(params (HttpStatusCode Status, string Body)[] responses) {
+            _responses = new Queue<(HttpStatusCode, string)>(responses);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            Requests.Add(request);
+            if (_responses.Count == 0) {
+                throw new InvalidOperationException("ScriptedHandler exhausted — retry loop made more calls than expected.");
+            }
+            var (status, body) = _responses.Dequeue();
+            return Task.FromResult(new HttpResponseMessage(status) {
+                Content = new StringContent(body),
+            });
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
+++ b/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
@@ -82,6 +82,7 @@
     <ProjectReference Include="..\..\src\Equibles.Cftc.Repositories\Equibles.Cftc.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cboe.Data\Equibles.Cboe.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cboe.Repositories\Equibles.Cboe.Repositories.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Integrations.Cboe\Equibles.Integrations.Cboe.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Migrations\Equibles.Migrations.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Mcp.Server\Equibles.Mcp.Server.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- Lift `src/Equibles.Integrations.Cboe/CboeClient.cs` from 68.85% to full reachable coverage.
- The existing `tests/Equibles.UnitTests/Integrations/CboeClientTests.cs` covers the private CSV parsers via reflection. This PR adds an integration-test sibling that exercises the public download surface end-to-end through a scripted `HttpMessageHandler`, matching the pattern used by `FredClient` / `FinraClient` tests.

## Code changes

- `tests/Equibles.IntegrationTests/Cboe/CboeClientTests.cs` (new) — 9 tests:
  - `[Theory]` over every `CboePutCallCsvType` asserts the URL hit is `…/{expected-csv-name}` and the response is parsed.
  - `DownloadVixHistory` happy path pins the hardcoded VIX history URL.
  - `DownloadWithRetry` 429-then-OK and 5xx-then-OK pins both retry branches (they diverge — only 429 calls `RateLimiter.PauseFor`).
  - 404 → `HttpRequestException` pins the non-retryable path so the retry window can't be silently broadened.
- `tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj` — add `Equibles.Integrations.Cboe` project reference (the IntegrationTests project didn't reference it yet).

Note: the `throw new HttpRequestException("Max retries exceeded for CBOE download")` at the end of `DownloadWithRetry` is unreachable in the current loop structure (the final attempt always returns or throws inside the loop) and is left untouched.