### PR TITLE
refactor(insider): replace 10-col unique index with (AccessionNumber, TransactionOrder)

### DIFF
--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -6,11 +6,7 @@ namespace Equibles.InsiderTrading.Data.Models;
 
 [Index(nameof(CommonStockId), nameof(TransactionDate))]
 [Index(nameof(InsiderOwnerId), nameof(TransactionDate))]
-[Index(nameof(AccessionNumber))]
-[Index(nameof(CommonStockId), nameof(InsiderOwnerId), nameof(TransactionDate),
-    nameof(TransactionCode), nameof(SecurityTitle), nameof(AccessionNumber),
-    nameof(OwnershipNature), nameof(Shares), nameof(PricePerShare), nameof(SharesOwnedAfter),
-    IsUnique = true)]
+[Index(nameof(AccessionNumber), nameof(TransactionOrder), IsUnique = true)]
 [Index(nameof(FilingDate))]
 [Index(nameof(TransactionDate))]
 public class InsiderTransaction {
@@ -38,6 +34,12 @@ public class InsiderTransaction {
 
     [MaxLength(32)]
     public string AccessionNumber { get; set; }
+
+    /// <summary>
+    /// Ordinal position of this row within its Form 3/4 filing (0-based). Form 4 XML
+    /// has no per-transaction identifier — uniqueness is by (AccessionNumber, position).
+    /// </summary>
+    public int TransactionOrder { get; set; }
 
     public bool IsAmendment { get; set; }
 

--- a/src/Equibles.Migrations/Migrations/20260513110630_AddTransactionOrderToInsiderTransaction.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260513110630_AddTransactionOrderToInsiderTransaction.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260513110630_AddTransactionOrderToInsiderTransaction")]
+    partial class AddTransactionOrderToInsiderTransaction
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260513110630_AddTransactionOrderToInsiderTransaction.cs
+++ b/src/Equibles.Migrations/Migrations/20260513110630_AddTransactionOrderToInsiderTransaction.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTransactionOrderToInsiderTransaction : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_AccessionNumber",
+                table: "InsiderTransaction");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_CommonStockId_InsiderOwnerId_Transaction~",
+                table: "InsiderTransaction");
+
+            migrationBuilder.AddColumn<int>(
+                name: "TransactionOrder",
+                table: "InsiderTransaction",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderTransaction_AccessionNumber_TransactionOrder",
+                table: "InsiderTransaction",
+                columns: new[] { "AccessionNumber", "TransactionOrder" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_AccessionNumber_TransactionOrder",
+                table: "InsiderTransaction");
+
+            migrationBuilder.DropColumn(
+                name: "TransactionOrder",
+                table: "InsiderTransaction");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderTransaction_AccessionNumber",
+                table: "InsiderTransaction",
+                column: "AccessionNumber");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderTransaction_CommonStockId_InsiderOwnerId_Transaction~",
+                table: "InsiderTransaction",
+                columns: new[] { "CommonStockId", "InsiderOwnerId", "TransactionDate", "TransactionCode", "SecurityTitle", "AccessionNumber", "OwnershipNature", "Shares", "PricePerShare", "SharesOwnedAfter" },
+                unique: true);
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -121,37 +121,43 @@ public class InsiderTradingFilingProcessor : IFilingProcessor {
         // postTransactionAmounts, ownershipNature). The SecurityTitle distinguishes the instrument
         // type (e.g., "Common Stock" vs "Stock Option (Right to Buy)"). For derivatives, Shares
         // and PricePerShare refer to the derivative instrument, not the underlying security.
+        //
+        // TransactionOrder is the 0-based position of the row within its filing — assigned as
+        // we parse so the (AccessionNumber, TransactionOrder) unique index has a stable key.
+        // The XML's document order is the only natural identity Form 4 transactions have.
         var transactions = new List<InsiderTransaction>();
+
+        void AddParsed(InsiderTransaction tx) {
+            if (tx == null) return;
+            tx.TransactionOrder = transactions.Count;
+            transactions.Add(tx);
+        }
 
         var nonDerivTable = root.Element("nonDerivativeTable");
         if (nonDerivTable != null) {
             foreach (var txElement in nonDerivTable.Elements("nonDerivativeTransaction")) {
-                var transaction = ParseTransaction(txElement, owner, companyId, filing, isAmendment);
-                if (transaction != null) transactions.Add(transaction);
+                AddParsed(ParseTransaction(txElement, owner, companyId, filing, isAmendment));
             }
 
             foreach (var holdingElement in nonDerivTable.Elements("nonDerivativeHolding")) {
-                var transaction = ParseHolding(holdingElement, owner, companyId, filing, isAmendment);
-                if (transaction != null) transactions.Add(transaction);
+                AddParsed(ParseHolding(holdingElement, owner, companyId, filing, isAmendment));
             }
         }
 
         var derivTable = root.Element("derivativeTable");
         if (derivTable != null) {
             foreach (var txElement in derivTable.Elements("derivativeTransaction")) {
-                var transaction = ParseTransaction(txElement, owner, companyId, filing, isAmendment);
-                if (transaction != null) transactions.Add(transaction);
+                AddParsed(ParseTransaction(txElement, owner, companyId, filing, isAmendment));
             }
 
             foreach (var holdingElement in derivTable.Elements("derivativeHolding")) {
-                var transaction = ParseHolding(holdingElement, owner, companyId, filing, isAmendment);
-                if (transaction != null) transactions.Add(transaction);
+                AddParsed(ParseHolding(holdingElement, owner, companyId, filing, isAmendment));
             }
         }
 
         if (transactions.Count == 0) {
-            // Form 3 with noSecuritiesOwned — save a 0-shares record so the accession number
-            // dedup prevents re-fetching this filing on every scraper cycle.
+            // Form 3 with noSecuritiesOwned — save a 0-shares record so the accession-number
+            // short-circuit at the top of Process() prevents re-fetching this filing every cycle.
             _logger.LogDebug("No transactions found for {Ticker} - {AccessionNumber}, saving 0-shares holding",
                 companyTicker, filing.AccessionNumber);
 
@@ -162,41 +168,26 @@ public class InsiderTradingFilingProcessor : IFilingProcessor {
                 TransactionDate = filing.ReportDate,
                 TransactionCode = TransactionCode.Other,
                 AccessionNumber = filing.AccessionNumber,
-                SecurityTitle = "No Securities Owned"
+                SecurityTitle = "No Securities Owned",
+                TransactionOrder = 0,
             });
             await transactionRepository.SaveChanges();
 
             return true;
         }
 
-        // Deduplicate within the batch — only collapse rows that are byte-identical along
-        // every persisted dimension. A Form 4 can legitimately carry multiple non-derivative
-        // transactions on the same date with the same code and security (e.g. open-market
-        // purchases split across price tranches) — those differ in Shares / PricePerShare /
-        // SharesOwnedAfter and must survive. Direct + Indirect rows are distinct beneficial
-        // ownerships and must also survive (OwnershipNature differentiates them).
-        var seen = new HashSet<(Guid, Guid, DateOnly, TransactionCode, string, string,
-            OwnershipNature, long, decimal, long)>();
-        var uniqueTransactions = new List<InsiderTransaction>();
+        // No in-memory dedup needed: every parsed row got a unique TransactionOrder from its
+        // XML position, so the (AccessionNumber, TransactionOrder) unique index can't collide
+        // within a single filing. Duplicate full-filing re-imports are stopped by the
+        // GetByAccessionNumber(...).AnyAsync() check at the top of Process().
         foreach (var tx in transactions) {
-            var key = (tx.CommonStockId, tx.InsiderOwnerId, tx.TransactionDate,
-                tx.TransactionCode, tx.SecurityTitle, tx.AccessionNumber,
-                tx.OwnershipNature, tx.Shares, tx.PricePerShare, tx.SharesOwnedAfter);
-            if (seen.Add(key)) {
-                uniqueTransactions.Add(tx);
-            }
-        }
-
-        // The unique index (which includes AccessionNumber) allows the same transaction
-        // data from different filings to coexist.
-        foreach (var tx in uniqueTransactions) {
             transactionRepository.Add(tx);
         }
 
         await transactionRepository.SaveChanges();
 
         _logger.LogInformation("Imported {Count} insider transactions for {Ticker} from {Form} - {AccessionNumber}",
-            uniqueTransactions.Count, companyTicker, filing.Form, filing.AccessionNumber);
+            transactions.Count, companyTicker, filing.Form, filing.AccessionNumber);
 
         return true;
     }

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -777,6 +777,17 @@ public class InsiderTradingFilingProcessorTests {
         transactions[2].Shares.Should().Be(3832);
         transactions[2].PricePerShare.Should().Be(42.76m);
         transactions[2].SharesOwnedAfter.Should().Be(578618);
+
+        // TransactionOrder is assigned from the XML document order (0, 1, 2). The unique
+        // index on (AccessionNumber, TransactionOrder) relies on each row in a filing
+        // getting a distinct ordinal — if the parser ever stopped assigning it (or assigned
+        // the same value twice), this filing would fail to insert in prod with a duplicate-
+        // key violation. Order by Shares above is incidental — assert on the ORDINAL contract.
+        var byOrder = transactions.OrderBy(t => t.TransactionOrder).ToList();
+        byOrder.Select(t => t.TransactionOrder).Should().Equal(0, 1, 2);
+        byOrder[0].Shares.Should().Be(2062);   // first tranche in the XML
+        byOrder[1].Shares.Should().Be(3832);
+        byOrder[2].Shares.Should().Be(1606);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Follow-up to #134. The unique index on `InsiderTransaction` had grown to **ten columns** — `(stock, owner, date, code, security, accession, ownership, shares, price, after)` — to keep multi-tranche Form 4 rows distinct, because Form 4 XML offers no per-transaction identifier. That's the index doing *value-uniqueness*, not *identity*: bloated B-tree entries (incl. two `MaxLength` strings), write amplification on every insert, and still no real identity guarantee (two tranches with coincidentally identical shares/price/after would still collide).

Introduce `TransactionOrder`: the 0-based position of each row within its parsing filing. XML document order is the only natural identity these transactions have. Narrow the unique index to `(AccessionNumber, TransactionOrder)` — two columns, semantically meaningful.

## Code changes

- **`InsiderTransaction.cs`** — added `TransactionOrder` int property; replaced the 10-col `[Index(..., IsUnique = true)]` with `[Index(nameof(AccessionNumber), nameof(TransactionOrder), IsUnique = true)]`. Also dropped the standalone `[Index(nameof(AccessionNumber))]` since the new compound index is leftmost-prefix usable for `AccessionNumber` lookups.
- **`InsiderTradingFilingProcessor.cs`** — assigns `TransactionOrder = transactions.Count` via a small local `AddParsed` helper as the four XML loops walk (`nonDerivativeTransaction` → `nonDerivativeHolding` → `derivativeTransaction` → `derivativeHolding`). The in-memory HashSet dedup that protected the old wide index is now removed — the per-row ordinal makes intra-filing collisions impossible. Full-filing re-imports remain guarded by the existing `GetByAccessionNumber(...).AnyAsync()` short-circuit at the top of `Process()`.
- **Migration** `20260513110630_AddTransactionOrderToInsiderTransaction` — drops the wide unique index + standalone `IX_InsiderTransaction_AccessionNumber`, adds the column (default 0), creates the narrow unique index.
- **Tests** — extended `Process_Form4WithMultiplePurchasesSameDay_PersistsAllTransactions` to assert `TransactionOrder` is the sequence `0, 1, 2` matching XML document order.

## Deploy note ⚠️

Existing rows get `TransactionOrder = 0` from the column default. Two regimes:

- **Pre-#134 accessions** (most of prod): the old wide index collapsed multi-tranche rows, so every accession has at most 1 row → the new unique index applies cleanly.
- **Post-#134 accessions** (filings imported between 2026-05-12 and this deploy): the wide index allowed multi-row accessions, so some have N rows that would all default to `TransactionOrder = 0` → unique-key violation on migration apply.

If the migration reports a duplicate-key violation, run a one-time backfill that assigns sequential `TransactionOrder` per `AccessionNumber`:

```sql
WITH ranked AS (
    SELECT "Id",
           row_number() OVER (PARTITION BY "AccessionNumber" ORDER BY "CreationTime", "Id") - 1 AS rn
    FROM "InsiderTransaction"
)
UPDATE "InsiderTransaction" t
SET "TransactionOrder" = ranked.rn
FROM ranked
WHERE t."Id" = ranked."Id";
```

Then re-run the migration. Per project standards we don't ship `migrationBuilder.Sql(...)`; the backfill is operator-run.

## Test plan

- [x] `dotnet build Equibles.sln` — clean
- [x] `dotnet test tests/Equibles.IntegrationTests/...InsiderTradingFilingProcessor` — 65/65 pass
- [x] `dotnet test tests/Equibles.UnitTests/...~InsiderTrading` — 43/43 pass
- [x] Manual verification via SEC EDGAR confirmed the multi-tranche test pin matches the real Marcus/ARE 2026-05-05 filing (accession 0001216955-26-000015)