### PR TITLE
test(holdings): cover DownloadDataSet and ImportDataSet early-exit branches

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceTests.cs
@@ -1,5 +1,20 @@
+using System.IO.Compression;
+using System.Text;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data;
 using Equibles.Holdings.HostedService.Models;
 using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
 
 namespace Equibles.IntegrationTests.Holdings;
 
@@ -107,5 +122,167 @@ public class HoldingsImportServiceTests {
 
         context.Submissions.Should().HaveCount(3);
         context.Submissions.Should().ContainKeys("ACC-NO-CIK", "ACC-NO-PERIOD", "ACC-BOTH-EMPTY");
+    }
+
+    // ── ImportDataSet orchestrator: early-exit branches ──────────────────
+    //
+    // The four pins below pin the four return points BEFORE the heavy
+    // StreamAndInsertHoldings + FlushBatch + UpsertRange path that the
+    // EF Core InMemory provider can't execute. Together they cover every
+    // structural / data-shape early-exit ImportDataSet can take, which is
+    // exactly the region most likely to silently change shape during a
+    // refactor of the orchestrator's bool/null return signaling.
+
+    private static readonly IModuleConfiguration[] Modules = [
+        new CommonStocksModuleConfiguration(),
+        new HoldingsModuleConfiguration(),
+    ];
+
+    private static EquiblesDbContext CreateDb() => TestDbContextFactory.Create(Modules);
+
+    private static IServiceScopeFactory ScopeFactoryFor(EquiblesDbContext db) {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(_ => {
+            var sp = Substitute.For<IServiceProvider>();
+            sp.GetService(typeof(CommonStockRepository)).Returns(new CommonStockRepository(db));
+            sp.GetService(typeof(InstitutionalHolderRepository)).Returns(new InstitutionalHolderRepository(db));
+            sp.GetService(typeof(InstitutionalHoldingRepository)).Returns(new InstitutionalHoldingRepository(db));
+            sp.GetService(typeof(EquiblesDbContext)).Returns(db);
+            var scope = Substitute.For<IServiceScope>();
+            scope.ServiceProvider.Returns(sp);
+            return scope;
+        });
+        return scopeFactory;
+    }
+
+    private static HoldingsImportService CreateImporter(EquiblesDbContext db) {
+        return new HoldingsImportService(
+            ScopeFactoryFor(db),
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            Substitute.For<IStockPriceProvider>());
+    }
+
+    private static ZipArchive BuildArchive(params (string Name, string Body)[] entries) {
+        var buffer = new MemoryStream();
+        using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true)) {
+            foreach (var (name, body) in entries) {
+                var entry = writer.CreateEntry(name);
+                using var stream = entry.Open();
+                var bytes = Encoding.UTF8.GetBytes(body);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+        buffer.Position = 0;
+        return new ZipArchive(buffer, ZipArchiveMode.Read);
+    }
+
+    [Fact]
+    public async Task ImportDataSet_ArchiveMissingSubmissionTsv_ReturnsZeroSubmissionsNotComplete() {
+        // ParseSubmissions returns null when SUBMISSION.tsv is absent. The
+        // ImportDataSet orchestrator must convert that null into
+        // (SubmissionCount: 0, IsComplete: false) so the scraper schedules
+        // the file for retry next cycle rather than marking it processed.
+        // A regression that flipped IsComplete to true on the null path
+        // (a "simplification" treating no-submissions and no-archive as
+        // equivalent) would silently consume the SEC dataset's
+        // ProcessedDataSet slot without importing a single holding —
+        // the gap would persist forever once marked.
+        using var db = CreateDb();
+        using var archive = BuildArchive(("UNRELATED.tsv", "header\nbody"));
+        var sut = CreateImporter(db);
+
+        var result = await sut.ImportDataSet(archive, new DateOnly(2020, 1, 1), CancellationToken.None);
+
+        result.SubmissionCount.Should().Be(0);
+        result.IsComplete.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ImportDataSet_SubmissionTsvWithNoMatching13FHRRows_ReturnsZeroSubmissionsComplete() {
+        // Structurally distinct from the missing-tsv path: here SUBMISSION.tsv
+        // exists but contains only filings the importer filters out (wrong
+        // form type, missing accession, or PeriodOfReport < MinReportDate).
+        // ParseSubmissions returns false on the empty-after-filter path and
+        // ImportDataSet maps that to IsComplete:true — the dataset really
+        // contained nothing for us, and a retry would only fetch the same
+        // empty filter result. Pinning this distinguishes "no data here,
+        // mark done" (false) from "structurally broken, retry" (null —
+        // sibling pin above).
+        var tsv = "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n" +
+                  // Wrong form type → filtered
+                  "10-K\tACC-001\t2024-01-15\t2024-09-30\t0001234567\n" +
+                  // Empty accession → filtered
+                  "13F-HR\t\t2024-01-15\t2024-09-30\t0001234567\n" +
+                  // PeriodOfReport before MinReportDate → filtered
+                  "13F-HR\tACC-002\t2024-01-15\t2019-09-30\t0001234567\n";
+
+        using var db = CreateDb();
+        using var archive = BuildArchive(("SUBMISSION.tsv", tsv));
+        var sut = CreateImporter(db);
+
+        var result = await sut.ImportDataSet(archive, new DateOnly(2024, 1, 1), CancellationToken.None);
+
+        result.SubmissionCount.Should().Be(0);
+        result.IsComplete.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ImportDataSet_SubmissionsParseButCoverPageTsvMissing_ReturnsParsedCountNotComplete() {
+        // ParseCoverPages returns false when COVERPAGE.tsv is absent. The
+        // orchestrator must propagate that as (count, IsComplete:false) —
+        // we already know how many submissions parsed, but without cover
+        // pages we can't enrich institutional holders, so the dataset is
+        // half-imported and must retry. A regression here is the most
+        // dangerous of the four: marking IsComplete:true would persist
+        // the submission count to ProcessedDataSet but skip the entire
+        // cover-page enrichment step on every future cycle for that file.
+        var tsv = "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n" +
+                  "13F-HR\tACC-001\t2024-10-15\t2024-09-30\t0001234567\n";
+
+        using var db = CreateDb();
+        using var archive = BuildArchive(("SUBMISSION.tsv", tsv));
+        var sut = CreateImporter(db);
+
+        var result = await sut.ImportDataSet(archive, new DateOnly(2024, 1, 1), CancellationToken.None);
+
+        result.SubmissionCount.Should().Be(1);
+        result.IsComplete.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ImportDataSet_NoCusipsInInfoTableMatchTrackedStocks_ReturnsParsedCountComplete() {
+        // BuildCusipMapping returns false when none of the CUSIPs in
+        // INFOTABLE.tsv match a tracked CommonStock. ImportDataSet maps
+        // this to (count, IsComplete:true) — the file was structurally
+        // sound and we just don't track any of its issuers, so retrying
+        // would produce the same empty mapping. This is the inverse of
+        // the COVERPAGE.tsv-missing pin above (true vs false IsComplete
+        // for the same SubmissionCount), and a swap regression between
+        // them would corrupt ProcessedDataSet bookkeeping in opposite
+        // directions for opposite root causes.
+        var submissionTsv = "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n" +
+                            "13F-HR\tACC-001\t2024-10-15\t2024-09-30\t0001234567\n";
+        var coverPageTsv = "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\n" +
+                           "ACC-001\tN\tTest Manager\n";
+        var infoTableTsv = "ACCESSION_NUMBER\tCUSIP\n" +
+                           "ACC-001\t999999999\n"; // CUSIP not in DB
+
+        using var db = CreateDb();
+        db.Set<CommonStock>().Add(new CommonStock {
+            Id = Guid.NewGuid(), Ticker = "AAPL", Name = "Apple", Cusip = "037833100",
+        });
+        await db.SaveChangesAsync();
+
+        using var archive = BuildArchive(
+            ("SUBMISSION.tsv", submissionTsv),
+            ("COVERPAGE.tsv", coverPageTsv),
+            ("INFOTABLE.tsv", infoTableTsv));
+        var sut = CreateImporter(db);
+
+        var result = await sut.ImportDataSet(archive, new DateOnly(2024, 1, 1), CancellationToken.None);
+
+        result.SubmissionCount.Should().Be(1);
+        result.IsComplete.Should().BeTrue();
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/HoldingsDataSetClientTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsDataSetClientTests.cs
@@ -1,9 +1,66 @@
+using System.IO.Compression;
 using System.Reflection;
 using Equibles.Holdings.HostedService.Services;
+using Equibles.Integrations.Sec.Contracts;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
 
 namespace Equibles.UnitTests.Holdings;
 
 public class HoldingsDataSetClientTests {
+    [Fact]
+    public async Task DownloadDataSet_ProducedStream_BuildsRequestUrlFromBaseAndOpensReturnedStreamAsZipArchive() {
+        // The whole `DownloadDataSet` body is a tight three-step contract:
+        //   1. Compose the request URL as `{BaseUrl}/{fileName}`
+        //   2. Pump the SEC-returned Stream into a MemoryStream so the caller
+        //      can dispose it without breaking the ZipArchive
+        //   3. Open that buffer as a read-mode ZipArchive
+        // Each step is a regression risk that no other pin defends:
+        //   • URL composition — a refactor that swaps the order
+        //     ($"{fileName}/{BaseUrl}") or hard-codes the wrong CDN host
+        //     would silently 404 every download. SEC's data-set CDN does
+        //     NOT redirect partial-match URLs, so the failure mode is a
+        //     permanent 404 with no recovery path.
+        //   • Stream pump — dropping the CopyToAsync to MemoryStream (e.g.
+        //     "just return new ZipArchive(stream, Read)") compiles cleanly
+        //     and works for in-process tests, but in production the
+        //     SecEdgarClient's HttpClient response stream is a
+        //     forward-only network stream that the ZipArchive's central-
+        //     directory seek-back at end-of-stream cannot navigate —
+        //     `new ZipArchive(networkStream)` throws InvalidDataException
+        //     ("End of Central Directory record could not be found").
+        //   • ZipArchiveMode — using Update or Create instead of Read would
+        //     either fail (stream not writable) or rebuild the archive,
+        //     silently mutating the downloaded bytes.
+        //
+        // Pin: substitute ISecEdgarClient.DownloadStream to return a
+        // pre-built ZIP byte sequence, capture the URL argument, and
+        // assert (a) the URL matches `{BaseUrl}/{fileName}` AND (b) the
+        // returned ZipArchive surfaces the entry we put in the fixture.
+        // The pair of assertions catches all three regression classes above.
+        var fileName = "2024q3_form13f.zip";
+        var expectedUrl = $"https://www.sec.gov/files/structureddata/data/form-13f-data-sets/{fileName}";
+
+        var zipBytes = new MemoryStream();
+        using (var archive = new ZipArchive(zipBytes, ZipArchiveMode.Create, leaveOpen: true)) {
+            archive.CreateEntry("SUBMISSION.tsv");
+        }
+        zipBytes.Position = 0;
+
+        var capturedUrl = (string)null;
+        var sec = Substitute.For<ISecEdgarClient>();
+        sec.DownloadStream(Arg.Do<string>(url => capturedUrl = url))
+            .Returns(_ => Task.FromResult<Stream>(new MemoryStream(zipBytes.ToArray())));
+
+        var sut = new HoldingsDataSetClient(sec, Substitute.For<ILogger<HoldingsDataSetClient>>());
+
+        using var result = await sut.DownloadDataSet(fileName, CancellationToken.None);
+
+        capturedUrl.Should().Be(expectedUrl);
+        result.Entries.Should().ContainSingle()
+            .Which.Name.Should().Be("SUBMISSION.tsv");
+    }
+
     [Fact]
     public void GetDataSetFileNames_StartDateBeforeEarliestAvailable_ClampsToQ2_2013() {
         var result = HoldingsDataSetClient.GetDataSetFileNames(new DateTime(2010, 1, 1));


### PR DESCRIPTION
## Summary

Lift coverage on `src/Equibles.Holdings.HostedService/Services/`:
- `HoldingsDataSetClient.DownloadDataSet` was untested (the existing unit tests only cover the static `GetDataSetFileNames` URL builders).
- `HoldingsImportService.ImportDataSet` was untested as an orchestrator — only the static `DeduplicateSubmissions` helper had coverage. The four early-exit branches that drive the scraper's `IsComplete` / retry decision were all unverified.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsDataSetClientTests.cs` — add `DownloadDataSet_ProducedStream_BuildsRequestUrlFromBaseAndOpensReturnedStreamAsZipArchive`. Substitutes `ISecEdgarClient` to capture the request URL and serve a pre-built ZIP, then asserts both the URL composition (`{BaseUrl}/{fileName}`) and that the returned `ZipArchive` surfaces the seeded entry — covers the URL build, the `CopyToAsync(MemoryStream)` pump (required because the production stream isn't seekable), and the `ZipArchiveMode.Read` open.
- `tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceTests.cs` — add four `ImportDataSet_*` integration tests pinning each early-exit branch:
  - missing `SUBMISSION.tsv` → `(0, IsComplete: false)`
  - `SUBMISSION.tsv` present but no matching 13F-HR rows → `(0, IsComplete: true)`
  - submissions parse but `COVERPAGE.tsv` missing → `(count, IsComplete: false)`
  - submissions and cover pages parse but no `INFOTABLE` CUSIPs match a tracked stock → `(count, IsComplete: true)`

  Each test builds a synthetic in-memory ZIP, wires `IServiceScopeFactory` to an in-memory `EquiblesDbContext`, and exercises the orchestrator end-to-end up to the early-exit return. The four pins cover every branch before the heavy `StreamAndInsertHoldings` + `FlushBatch` + `UpsertRange` path (which the EF Core in-memory provider can't execute), so they're tractable without Testcontainers while still defending the IsComplete signaling that drives the scraper's mark-processed decision.

All 7 tests in `HoldingsDataSetClientTests` and 6 tests in `HoldingsImportServiceTests` pass.