### PR TITLE
test(web): pin StatusController.Show missing-error redirect with flash error

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
@@ -973,4 +973,17 @@ public class StatusControllerTests : IDisposable {
         totalErrorCount.Should().Be(1);
         unseenErrorCount.Should().Be(1);
     }
+
+    // ── Show ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Show_MissingError_RedirectsToIndexWithFlashError() {
+        var controller = CreateController();
+
+        var result = await controller.Show(Guid.NewGuid());
+
+        var redirect = result.Should().BeOfType<RedirectToActionResult>().Subject;
+        redirect.ActionName.Should().Be(nameof(StatusController.Index));
+        _flashMessage.Received(1).Error("Error not found.", Arg.Any<string>(), Arg.Any<bool>());
+    }
 }


### PR DESCRIPTION
## Summary

- Pins the not-found branch of `StatusController.Show(Guid id)` so the contract — redirect to `Index` and surface "Error not found." via flash — can't silently drift.
- Closes the gap left by existing `StatusControllerTests`, which cover `Index` and `Data` but never exercise `Show`.

## Code changes

- `tests/Equibles.IntegrationTests/Web/ControllersTests.cs` — adds `Show_MissingError_RedirectsToIndexWithFlashError` to `StatusControllerTests`. Calls `Show(Guid.NewGuid())` against an empty in-memory DB, asserts a `RedirectToActionResult` targeting `nameof(StatusController.Index)`, and verifies `IFlashMessage.Error("Error not found.", ...)` was called once via NSubstitute.