### PR TITLE
test(sec): pin FtdImportService.Import early-exit against SEC EDGAR rate-limit burn

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceTests.cs
@@ -1,4 +1,15 @@
+using Equibles.CommonStocks.Data;
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
 
 namespace Equibles.IntegrationTests.Sec;
 
@@ -32,6 +43,84 @@ public class FtdImportServiceTests {
         // that exact order, immediately after June's 'b'.
         result.Should().HaveElementAt(1, "cnsfails201707a.zip");
         result.Should().HaveElementAt(2, "cnsfails201707b.zip");
+    }
+
+    [Fact]
+    public async Task Import_WhenLatestSettlementDateIsBeyondCurrentMonth_LogsUpToDateAndDoesNotCallSecEdgar() {
+        // FtdImportService.Import is the entry point of the FTD scraper — invoked on every
+        // worker tick. Before fetching anything it resolves the next unsynced month via
+        // SyncDateResolver + GetFileNames, and if that resolution yields no files (i.e. we're
+        // caught up) Import must short-circuit BEFORE hitting SEC EDGAR (no zip download) AND
+        // before BuildTickerMap (no DB scan of CommonStock). Every existing test on this
+        // service exercises the two static helpers (GetFileNames, IsRecentFtdFile); none
+        // exercise the instance Import flow at all — so the entire early-exit branch
+        // currently survives any regression silently.
+        //
+        // The risk this pins is the blast radius of an order-of-operations regression:
+        //   • A refactor that swaps `var tickerMap = await BuildTickerMap(...)` and the
+        //     `if (fileNames.Count == 0) return;` early-exit would compile cleanly, pass
+        //     every static-method pin in this file and its UnitTests sibling, and silently
+        //     start scanning every CommonStock row on every tick of a caught-up scraper —
+        //     a wasted ToDictionaryAsync per tick across thousands of rows on a daily
+        //     schedule.
+        //   • Worse, a refactor that moves the SEC download out of the
+        //     `foreach (var fileName in fileNames)` loop (or that doesn't guard against an
+        //     empty fileNames list) would issue a request to sec.gov even when there's
+        //     nothing to download. SEC EDGAR enforces a 10 req/s budget per User-Agent
+        //     across the whole deployment and returns 429s when exceeded; burning that
+        //     budget on a no-op is exactly the kind of "small per-tick, daily forever"
+        //     leak that doesn't surface in any monitor until something else also gets
+        //     throttled.
+        //
+        // Setup: seed the in-memory DB with ONE FailToDeliver row whose SettlementDate is
+        // a year in the future. SyncDateResolver.Resolve returns latestDate+1 (also future),
+        // GetFileNames clamps `current` to the first of that future month, the while-loop
+        // condition `current <= now` fails on the first iteration, and Import takes the
+        // empty-list early-exit. The assertion is two-sided:
+        //   (a) ISecEdgarClient.DownloadStream was NEVER invoked — the rate-limit-burning
+        //       regression surfaces here as a Received(>0) call.
+        //   (b) The seed row is unchanged and no new FailToDeliver rows were written —
+        //       proves the loop body never ran. Had the import attempted to "import" the
+        //       future-dated row we'd see a delta.
+        var dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration());
+
+        var futureSettlementDate = DateOnly.FromDateTime(DateTime.UtcNow).AddYears(1);
+        dbContext.Set<FailToDeliver>().Add(new FailToDeliver {
+            CommonStockId = Guid.NewGuid(),
+            SettlementDate = futureSettlementDate,
+            Quantity = 0,
+            Price = 0m,
+        });
+        await dbContext.SaveChangesAsync();
+
+        var failToDeliverRepo = new FailToDeliverRepository(dbContext);
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(FailToDeliverRepository), failToDeliverRepo));
+        var errorReporter = new ErrorReporter(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<ErrorReporter>>());
+
+        var sut = new FtdImportService(
+            scopeFactory,
+            secEdgarClient,
+            Substitute.For<ILogger<FtdImportService>>(),
+            errorReporter,
+            Options.Create(new WorkerOptions { TickersToSync = [] }));
+
+        await sut.Import(CancellationToken.None);
+
+        // SEC EDGAR was never hit — the early-exit ran before BuildTickerMap and before
+        // the download loop. A regression that moves the DownloadStream call upstream of
+        // the empty-fileNames check would flip this to a Received(1+) and fail here.
+        await secEdgarClient.DidNotReceive().DownloadStream(Arg.Any<string>());
+
+        // The seed row is intact and no new rows were persisted — the loop body never ran.
+        var rows = dbContext.Set<FailToDeliver>().ToList();
+        rows.Should().ContainSingle();
+        rows[0].SettlementDate.Should().Be(futureSettlementDate);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Adds the first test that exercises the instance `FtdImportService.Import` flow. Existing coverage only targets the two static helpers (`GetFileNames`, `IsRecentFtdFile`), leaving the Import method body — including the "FTD data is up to date" early-exit — entirely unpinned at 61.76% line coverage.
- Pins the order-of-operations contract: when the next unsynced month resolves to a future date and `GetFileNames` returns empty, `Import` must short-circuit before any call to `ISecEdgarClient.DownloadStream` and before `BuildTickerMap` scans `CommonStock`.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/FtdImportServiceTests.cs` — adds `Import_WhenLatestSettlementDateIsBeyondCurrentMonth_LogsUpToDateAndDoesNotCallSecEdgar`. Seeds a `FailToDeliver` row dated one year in the future via the in-memory `EquiblesDbContext`, wires a `FailToDeliverRepository` into a `ServiceScopeSubstitute`-built scope factory, and substitutes `ISecEdgarClient`. Asserts (a) `DownloadStream` was never invoked and (b) no new FTD rows were persisted — pinning both the rate-limit-protection and the no-work-on-empty-fileNames invariants in a single `[Fact]`.