### PR TITLE
test(congress): fill partial-coverage branches in Congress.HostedService.Services

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTests.cs
@@ -728,4 +728,280 @@ public class DisclosureParsingHelperTests {
         result.Should().HaveCount(1);
         result[0].OwnerType.Should().Be("Joint");
     }
+
+    // ── Partial-branch fills ────────────────────────────────────────────
+    // Each test below pins the false/null arm of a `?.` / `??` / `&&` / `||`
+    // / pattern-match branch that the existing happy-path fixtures don't
+    // currently traverse. Identified from coverlet's cobertura
+    // `condition-coverage` attribute over the production code.
+
+    [Fact]
+    public void ParseTransactionsFromHtml_TableWithNoTheadAndNoLeadingThRow_SkipsTableSilently() {
+        // Pins ExtractHeaderTexts' null-coalesce + null-conditional fallthrough:
+        //   var headers = SelectNodes(".//thead//th") ?? SelectNodes(".//tr[1]//th");
+        //   return headers?.Select(...).ToList();
+        // and the caller's `headerTexts == null ||` short-circuit. Existing pins
+        // cover thead-present (happy path) and thead-less-but-first-row-th
+        // (TableWithoutTheadButFirstRowTh) — neither hits the case where BOTH
+        // selectors miss, which is what a malformed HTML scrape would produce.
+        // Without the `==null` guard in the caller, IsTransactionTable would NRE
+        // on a null headerTexts.
+        var html = """
+            <html><body>
+            <table>
+              <tbody>
+                <tr>
+                  <td>2024-06-15</td>
+                  <td>AAPL</td>
+                  <td>Purchase</td>
+                </tr>
+              </tbody>
+            </table>
+            </body></html>
+            """;
+
+        var result = DisclosureParsingHelper.ParseTransactionsFromHtml(
+            html, "Test", CongressPosition.Representative,
+            new DateOnly(2024, 7, 1), Substitute.For<ILogger>());
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseTransactionsFromHtml_OnlyNotificationDateColumnNoTransactionDate_UsesNotificationDateAsTxDate() {
+        // Pins MapColumnIndices' first dateCol fallback:
+        //   if (dateCol == -1) dateCol = FindIndex(h.Contains("notification") && h.Contains("date"));
+        // The existing BothTransactionAndNotificationDateColumns pin includes a
+        // Transaction Date column, so the first FindIndex succeeds and this
+        // fallback never fires. Pin a table with ONLY a "Notification Date"
+        // so the helper has to fall through to the second tier; the parsed
+        // TransactionDate must come from that column.
+        var html = """
+            <html><body>
+            <table>
+              <thead><tr>
+                <th>Notification Date</th>
+                <th>Ticker</th>
+                <th>Asset Name</th>
+                <th>Transaction Type</th>
+                <th>Amount</th>
+              </tr></thead>
+              <tbody>
+                <tr>
+                  <td>2024-07-01</td>
+                  <td>AAPL</td>
+                  <td>Apple Inc</td>
+                  <td>Purchase</td>
+                  <td>$1,001 - $15,000</td>
+                </tr>
+              </tbody>
+            </table>
+            </body></html>
+            """;
+
+        var result = DisclosureParsingHelper.ParseTransactionsFromHtml(
+            html, "Test", CongressPosition.Senator,
+            new DateOnly(2024, 7, 5), Substitute.For<ILogger>());
+
+        result.Should().HaveCount(1);
+        result[0].TransactionDate.Should().Be(new DateOnly(2024, 7, 1));
+    }
+
+    [Fact]
+    public void ParseTransactionsFromHtml_OnlyGenericDateColumn_UsesItAsTxDate() {
+        // Pins MapColumnIndices' SECOND dateCol fallback:
+        //   if (dateCol == -1) dateCol = FindIndex(h.Contains("date"));
+        // — the most permissive arm. Fires for legacy / hand-rolled tables that
+        // use a bare "Date" header. Together with the notification-only sibling
+        // above and the existing transaction-date primary pin, the three-tier
+        // chain is fully exercised.
+        var html = """
+            <html><body>
+            <table>
+              <thead><tr>
+                <th>Date</th>
+                <th>Ticker</th>
+                <th>Asset Name</th>
+                <th>Transaction Type</th>
+                <th>Amount</th>
+              </tr></thead>
+              <tbody>
+                <tr>
+                  <td>2024-06-15</td>
+                  <td>AAPL</td>
+                  <td>Apple Inc</td>
+                  <td>Purchase</td>
+                  <td>$1,001 - $15,000</td>
+                </tr>
+              </tbody>
+            </table>
+            </body></html>
+            """;
+
+        var result = DisclosureParsingHelper.ParseTransactionsFromHtml(
+            html, "Test", CongressPosition.Representative,
+            new DateOnly(2024, 7, 1), Substitute.For<ILogger>());
+
+        result.Should().HaveCount(1);
+        result[0].TransactionDate.Should().Be(new DateOnly(2024, 6, 15));
+    }
+
+    [Fact]
+    public void ParseTransactionsFromHtml_BareTypeHeaderWithoutTransactionPrefix_ResolvesTypeColumn() {
+        // Pins MapColumnIndices' typeCol fallback:
+        //   if (typeCol == -1) typeCol = FindIndex(h == "type");
+        // Without the fallback, tables that label the transaction column simply
+        // "Type" (older House PTR exports, hand-coded staff submissions) would
+        // never resolve cols.Type — every row would skip on the type==null
+        // guard in ParseTransactionRow. The exact-match `h == "type"` (NOT
+        // `Contains("type")`) is load-bearing: it must distinguish "Type" from
+        // "Asset Type" which is a different column entirely.
+        var html = """
+            <html><body>
+            <table>
+              <thead><tr>
+                <th>Transaction Date</th>
+                <th>Ticker</th>
+                <th>Asset Name</th>
+                <th>Type</th>
+                <th>Amount</th>
+              </tr></thead>
+              <tbody>
+                <tr>
+                  <td>2024-06-15</td>
+                  <td>AAPL</td>
+                  <td>Apple Inc</td>
+                  <td>Sale</td>
+                  <td>$1,001 - $15,000</td>
+                </tr>
+              </tbody>
+            </table>
+            </body></html>
+            """;
+
+        var result = DisclosureParsingHelper.ParseTransactionsFromHtml(
+            html, "Test", CongressPosition.Representative,
+            new DateOnly(2024, 7, 1), Substitute.For<ILogger>());
+
+        result.Should().HaveCount(1);
+        result[0].TransactionType.Should().Be(CongressTransactionType.Sale);
+    }
+
+    [Fact]
+    public void ParseTransactionsFromHtml_RowWithNoCellElements_IsSilentlySkipped() {
+        // Pins ParseTransactionRow's first null guard:
+        //   var cells = row.SelectNodes(".//td");
+        //   if (cells == null) return null;
+        // HtmlAgilityPack's SelectNodes returns null (not empty) when no match.
+        // A `<tr>` with no `<td>` descendants — common in real-world disclosure
+        // HTML where the body contains `<tr><th>...</th></tr>` separator rows
+        // alongside actual data rows — would NRE on the next `.Select` without
+        // the guard.
+        var html = """
+            <html><body>
+            <table>
+              <thead><tr>
+                <th>Transaction Date</th>
+                <th>Ticker</th>
+                <th>Asset Name</th>
+                <th>Transaction Type</th>
+                <th>Amount</th>
+              </tr></thead>
+              <tbody>
+                <tr><th>Section header — no td cells</th></tr>
+              </tbody>
+            </table>
+            </body></html>
+            """;
+
+        var result = DisclosureParsingHelper.ParseTransactionsFromHtml(
+            html, "Test", CongressPosition.Representative,
+            new DateOnly(2024, 7, 1), Substitute.For<ILogger>());
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseTransactionsFromHtml_RowWithValidDateButEmptyTickerAndEmptyAsset_IsSkipped() {
+        // Pins ParseTransactionRow's both-empty short-circuit:
+        //   if (string.IsNullOrEmpty(ticker) && string.IsNullOrEmpty(assetName)) return null;
+        // Existing tests always have at least one of ticker/asset populated,
+        // so the `&&`-true arm has never fired. Without it, downstream
+        // ExtractTickerFromAssetName would dereference a null asset and the
+        // emitted transaction would carry both an empty ticker and an empty
+        // asset name — useless for analytics but not invalid enough for any
+        // later filter to drop.
+        var html = """
+            <html><body>
+            <table>
+              <thead><tr>
+                <th>Transaction Date</th>
+                <th>Ticker</th>
+                <th>Asset Name</th>
+                <th>Transaction Type</th>
+                <th>Amount</th>
+              </tr></thead>
+              <tbody>
+                <tr>
+                  <td>2024-06-15</td>
+                  <td></td>
+                  <td></td>
+                  <td>Purchase</td>
+                  <td>$1,001 - $15,000</td>
+                </tr>
+              </tbody>
+            </table>
+            </body></html>
+            """;
+
+        var result = DisclosureParsingHelper.ParseTransactionsFromHtml(
+            html, "Test", CongressPosition.Representative,
+            new DateOnly(2024, 7, 1), Substitute.For<ILogger>());
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseTransactionsFromHtml_AssetNameWithoutParenthesizedTicker_RecordsTransactionWithNullTicker() {
+        // Pins the `Ticker = ticker?.ToUpperInvariant()` null-conditional on
+        // the final DisclosureTransaction. Reaches it via the path where:
+        //   - ticker cell is empty (CleanSentinel returns null)
+        //   - asset cell is populated (so the both-empty guard doesn't trip)
+        //   - asset name has no parenthesized ticker pattern, so
+        //     ExtractTickerFromAssetName returns null
+        // Without the `?.`, calling ToUpperInvariant on a null ticker would
+        // NRE at row-construction time. Existing tests always derive a ticker
+        // (either from the column or from the asset name's parens), so the
+        // null arm has never fired.
+        var html = """
+            <html><body>
+            <table>
+              <thead><tr>
+                <th>Transaction Date</th>
+                <th>Ticker</th>
+                <th>Asset Name</th>
+                <th>Transaction Type</th>
+                <th>Amount</th>
+              </tr></thead>
+              <tbody>
+                <tr>
+                  <td>2024-06-15</td>
+                  <td></td>
+                  <td>Apple Inc common stock with no ticker symbol</td>
+                  <td>Purchase</td>
+                  <td>$1,001 - $15,000</td>
+                </tr>
+              </tbody>
+            </table>
+            </body></html>
+            """;
+
+        var result = DisclosureParsingHelper.ParseTransactionsFromHtml(
+            html, "Test", CongressPosition.Representative,
+            new DateOnly(2024, 7, 1), Substitute.For<ILogger>());
+
+        result.Should().HaveCount(1);
+        result[0].Ticker.Should().BeNull();
+        result[0].AssetName.Should().Be("Apple Inc common stock with no ticker symbol");
+    }
 }

--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs
@@ -673,6 +673,75 @@ public class HouseDisclosureClientTests {
         result.Should().Be("GOOGLE LLC - CLASS A COMMON");
     }
 
+    // ── Partial-branch fills ────────────────────────────────────────────
+
+    [Fact]
+    public void ExtractTransactionType_TextThatMatchesNeitherSaleNorPurchase_ReturnsNull() {
+        // Pins the fall-through `return null` in ExtractTransactionType. Existing
+        // pins cover only the Sale and Purchase return paths; neither evaluates
+        // the second `if (PurchaseTypeRegex().IsMatch(text))` to false. Without
+        // the fall-through, a regression that "tightens" PurchaseTypeRegex (or
+        // re-orders the two ifs) could silently classify garbage text as a
+        // Purchase by leaning on a default value.
+        var result = (CongressTransactionType?)ExtractTransactionTypeMethod.Invoke(
+            null, ["ACME WIDGETS COMMON STOCK"]);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseTransactionLines_LineWithNoAssetOrTickerAfterStrip_SkipsSilently() {
+        // Pins the both-empty short-circuit:
+        //   if (string.IsNullOrEmpty(assetName) && string.IsNullOrEmpty(ticker)) continue;
+        // Existing reflection pin has both populated, so the AND=true arm never
+        // fires. Trigger here: a House PTR line with no asset description at all
+        // — owner code + transaction type + date + amount. RemoveTrailingTransactionType
+        // strips the trailing "P", assetName becomes empty, ticker stays null,
+        // the continue fires, and no transaction is recorded. Without the
+        // guard, the row would persist with both AssetName and Ticker empty.
+        var parseTransactionLines = typeof(HouseDisclosureClient).GetMethod(
+            "ParseTransactionLines", BindingFlags.NonPublic | BindingFlags.Instance);
+        var houseFilingType = typeof(HouseDisclosureClient).GetNestedType(
+            "HouseFiling", BindingFlags.NonPublic);
+        var filing = houseFilingType.GetConstructors()[0].Invoke([
+            "Jane Doe", "20251234", new DateOnly(2025, 2, 1), "CA01"
+        ]);
+        using var httpClient = new HttpClient();
+        var client = new HouseDisclosureClient(httpClient, Substitute.For<ILogger<HouseDisclosureClient>>());
+        var lines = new[] { "SP P 01/14/2025 $1,001 - $15,000" };
+
+        var result = (List<DisclosureTransaction>)parseTransactionLines.Invoke(client, [lines, filing]);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseTransactionLines_AssetWithoutParenthesizedTicker_RecordsTransactionWithNullTicker() {
+        // Pins the `Ticker = ticker?.ToUpperInvariant()` null-conditional. The
+        // null arm fires when the asset description carries no parenthesized
+        // ticker — ExtractTickerFromAssetName returns null and the ticker
+        // variable stays null all the way through to the property assignment.
+        // The existing "realistic" pin always supplies "APPLE INC (AAPL)" so the
+        // ticker is never null at row-construction time.
+        var parseTransactionLines = typeof(HouseDisclosureClient).GetMethod(
+            "ParseTransactionLines", BindingFlags.NonPublic | BindingFlags.Instance);
+        var houseFilingType = typeof(HouseDisclosureClient).GetNestedType(
+            "HouseFiling", BindingFlags.NonPublic);
+        var filing = houseFilingType.GetConstructors()[0].Invoke([
+            "Jane Doe", "20251234", new DateOnly(2025, 2, 1), "CA01"
+        ]);
+        using var httpClient = new HttpClient();
+        var client = new HouseDisclosureClient(httpClient, Substitute.For<ILogger<HouseDisclosureClient>>());
+        // No parens anywhere — ExtractTickerFromAssetName regex won't match.
+        var lines = new[] { "SP APPLE INC COMMON STOCK P 01/14/2025 $1,001 - $15,000" };
+
+        var result = (List<DisclosureTransaction>)parseTransactionLines.Invoke(client, [lines, filing]);
+
+        result.Should().HaveCount(1);
+        result[0].Ticker.Should().BeNull();
+        result[0].AssetName.Should().Be("APPLE INC COMMON STOCK");
+    }
+
     [Fact]
     public void ParsePtrPdf_MalformedPdfBytes_ReturnsEmptyListWithoutThrowing() {
         // ParsePtrPdf is the only callsite that wraps `PdfDocument.Open(pdfBytes)`

--- a/tests/Equibles.UnitTests/Congress/SenateDisclosureClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateDisclosureClientTests.cs
@@ -273,4 +273,80 @@ public class SenateDisclosureClientTests {
 
         result.Should().BeNull();
     }
+
+    // ── Partial-branch fills ────────────────────────────────────────────
+
+    [Fact]
+    public void ParseReportRow_NullFirstAndLastNameCells_HandlesNullsAndReturnsNull() {
+        // Pins the null arms of:
+        //   var firstName = row[0]?.Trim() ?? "";
+        //   var lastName  = row[1]?.Trim() ?? "";
+        // Every existing pin (including the both-empty sibling) supplies non-null
+        // strings, so the `?.` short-circuit's null path and the `??` left-null
+        // path have never executed. Drop either operator and the next line throws
+        // NRE on a Trim invocation against null. Asserts the method returns null
+        // (via the memberName="" guard) AND, by completing the invocation
+        // without exception, proves the two null-safe operators handled the
+        // null inputs without dereferencing.
+        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var row = new List<string> {
+            null,
+            null,
+            "filed",
+            "<a href=\"/search/view/ptr/abc-123/\">link</a>",
+            "2024-01-15",
+        };
+
+        var act = () => ParseReportRowMethod.Invoke(sut, [row]);
+
+        act.Should().NotThrow();
+        ParseReportRowMethod.Invoke(sut, [row]).Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseReportRow_NullLinkCell_HandlesNullAndReturnsNull() {
+        // Pins the null arm of `var linkHtml = row[3] ?? "";`. Existing pins
+        // always supply a string for row[3] (whether or not it contains an
+        // anchor), so the `??` right-side has never fired. With the row[3]
+        // value null, the coalesce yields an empty string, HrefRegex.Match("")
+        // succeeds=false, and the method returns null at the !Success guard.
+        // Without the `?? ""`, HrefRegex.Match(null) throws ArgumentNullException.
+        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var row = new List<string> {
+            "Jane",
+            "Doe",
+            "filed",
+            null,
+            "2024-01-15",
+        };
+
+        var act = () => ParseReportRowMethod.Invoke(sut, [row]);
+
+        act.Should().NotThrow();
+        ParseReportRowMethod.Invoke(sut, [row]).Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseReportRow_NullDateCell_HandlesNullAndReturnsNull() {
+        // Pins the null arm of `row[4]?.Trim()` inside
+        //   if (!DateOnly.TryParse(row[4]?.Trim(), out var dateSubmitted)) { ... }
+        // The unparseable-date sibling supplies a non-null garbage string so
+        // TryParse returns false but `?.Trim()` never sees a null input. With
+        // row[4] null, `?.Trim()` short-circuits to null, TryParse(null)
+        // returns false, the method logs the debug message and returns null.
+        // Without the `?.`, Trim() would NRE on the null reference.
+        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var row = new List<string> {
+            "Jane",
+            "Doe",
+            "filed",
+            "<a href=\"/search/view/ptr/abc-123/\">link</a>",
+            null,
+        };
+
+        var act = () => ParseReportRowMethod.Invoke(sut, [row]);
+
+        act.Should().NotThrow();
+        ParseReportRowMethod.Invoke(sut, [row]).Should().BeNull();
+    }
 }


### PR DESCRIPTION
## Summary

- Cobertura branch-coverage analysis flagged **17 partial-coverage lines** in `Equibles.Congress.HostedService/Services/` (`DisclosureParsingHelper.cs`, `HouseDisclosureClient.cs`, `SenateDisclosureClient.cs`). 13 new targeted tests exercise the previously-untraversed false/null arms.
- Partial count for these three files drops from **17 → 2** without modifying any production code. Remaining two (`HouseDisclosureClient.cs:L42`, `L82`) need a coordinated ZIP+XML test fixture and will be a follow-up PR.
- All 157 Congress-area unit tests pass (was 144).

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTests.cs` — 7 tests for `ParseTransactionsFromHtml` covering: thead-less table (L24/L42), `Notification Date`-only fallback (L54), generic `Date`-only fallback (L55), bare `Type` header (L67), row with no `<td>` cells (L80), row with both ticker and asset empty (L90), transaction recorded with null ticker (L114).
- `tests/Equibles.UnitTests/Congress/HouseDisclosureClientTests.cs` — 3 tests: `ExtractTransactionType` fall-through `return null` (L214), `ParseTransactionLines` both-empty short-circuit (L188), `ParseTransactionLines` records transaction with null ticker via `?.ToUpperInvariant()` (L194).
- `tests/Equibles.UnitTests/Congress/SenateDisclosureClientTests.cs` — 3 tests for `ParseReportRow` exercising the null arms of `row[0]?.Trim() ?? ""` / `row[1]?.Trim() ?? ""` (L174/L175), `row[3] ?? ""` (L179), and `row[4]?.Trim()` inside the `DateOnly.TryParse` guard (L191).