### PR TITLE
test(web): pin Program.cs branches + carryforward Codecov flags

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,18 @@ coverage:
     patch:
       default:
         target: 60%
+
+# Flag carryforward keeps the merged "All flags" view stable when one upload is
+# missing or delayed. ci.yml uploads `unit-integration` (UnitTests +
+# IntegrationTests); functional.yml uploads `functional` (FunctionalTests, which
+# is what exercises Program.cs and the Razor views). Without carryforward, if
+# functional.yml fails (Playwright flake, container hiccup), every web-only file
+# silently reports 0% on the dashboard.
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: unit-integration
+      carryforward: true
+    - name: functional
+      carryforward: true

--- a/tests/Equibles.IntegrationTests/Web/ProgramConfigurationTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProgramConfigurationTests.cs
@@ -1,0 +1,128 @@
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Tests the three branches of <see cref="Equibles.Web.Program"/> that the FunctionalTests
+/// project's <c>WebAppFixture</c> never exercises:
+///   • <c>if (authSettings.IsEnabled)</c> — WebAppFixture leaves Auth disabled
+///   • <c>?? "/app/keys"</c> — WebAppFixture always sets DataProtection:KeysDirectory
+///   • <c>if (!app.Environment.IsDevelopment())</c> — WebAppFixture pins Development
+/// Builds the same composition pipeline as production (ConfigureServices → Build →
+/// ApplyMigrationsAsync → ConfigurePipeline) against the shared ParadeDB container,
+/// varying one knob per test.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class ProgramConfigurationTests {
+    private readonly ParadeDbFixture _db;
+
+    public ProgramConfigurationTests(ParadeDbFixture db) => _db = db;
+
+    [Fact]
+    public async Task ConfigureServices_AuthIsEnabled_RegistersAuthenticatedUserFallbackPolicy() {
+        // Pins the `if (authSettings.IsEnabled) { … FallbackPolicy.RequireAuthenticatedUser … }`
+        // TRUE branch. WebAppFixture (FunctionalTests) doesn't set Auth credentials, so
+        // AuthSettings.IsEnabled (a computed `Username AND Password set` property) is false
+        // and only the `else AddAuthorization()` arm runs end-to-end. Setting both credentials
+        // flips IsEnabled to true; the fallback policy is then expected to deny anonymous —
+        // the production safeguard for every endpoint not explicitly [AllowAnonymous].
+        await using var app = BuildHost("Development", overrides: new() {
+            ["Auth:Username"] = "test-user",
+            ["Auth:Password"] = "test-pass",
+        });
+
+        var policyProvider = app.Services.GetRequiredService<IAuthorizationPolicyProvider>();
+        var fallback = await policyProvider.GetFallbackPolicyAsync();
+
+        fallback.Should().NotBeNull();
+        fallback.Requirements.Should().Contain(r => r is DenyAnonymousAuthorizationRequirement);
+    }
+
+    [Fact]
+    public async Task ConfigureServices_DataProtectionKeysDirectoryNotConfigured_FallsBackToAppKeysPath() {
+        // Pins the `?? "/app/keys"` fallback. WebAppFixture always sets
+        // DataProtection:KeysDirectory to a temp dir to avoid touching /app/keys on macOS/CI,
+        // so the right-hand `??` arm is unexercised. Omit the config entirely and assert the
+        // registered FileSystemXmlRepository points at the production default — proves the
+        // line ran AND the fallback string survives the null-coalesce + DirectoryInfo wrap.
+        //
+        // The build is safe even though /app/keys doesn't exist: AddDataProtection's
+        // KeyRing initialization is lazy (only the first IDataProtector resolution triggers
+        // directory access), and this test never resolves one or starts the host's hosted
+        // services — Build() composes the IServiceProvider without running app.Run.
+        await using var app = BuildHost("Development", omitKeysDirectoryConfig: true);
+
+        var options = app.Services.GetRequiredService<IOptions<KeyManagementOptions>>();
+        var repo = options.Value.XmlRepository as FileSystemXmlRepository;
+        repo.Should().NotBeNull();
+        repo!.Directory.FullName.Should().Be("/app/keys");
+    }
+
+    [Fact]
+    public async Task ConfigurePipeline_NonDevelopmentEnvironment_RunsProductionExceptionHandlerBranch() {
+        // Pins the `if (!app.Environment.IsDevelopment()) { app.UseExceptionHandler("/Home/Error"); }`
+        // branch. WebAppFixture hardcodes EnvironmentName="Development" so the production-side
+        // middleware registration never runs. Driving Production explicitly and running
+        // ConfigurePipeline hits the line; the environment assertion below proves the host was
+        // actually wired in Production mode (vs. silently defaulting to Development from a
+        // config typo, which would leave the branch unexercised).
+        await using var app = BuildHost("Production");
+
+        app.Environment.IsDevelopment().Should().BeFalse();
+        app.Environment.EnvironmentName.Should().Be("Production");
+    }
+
+    private WebApplication BuildHost(
+        string environment,
+        Dictionary<string, string> overrides = null,
+        bool omitKeysDirectoryConfig = false) {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions {
+            ApplicationName = "Equibles.Web",
+            EnvironmentName = environment,
+            ContentRootPath = ResolveWebContentRoot(),
+        });
+        builder.Configuration["ConnectionStrings:DefaultConnection"] = _db.ConnectionString;
+        if (!omitKeysDirectoryConfig) {
+            builder.Configuration["DataProtection:KeysDirectory"] = Path.Combine(
+                Path.GetTempPath(), $"equibles-keys-{Guid.NewGuid():N}");
+        }
+        if (overrides != null) {
+            foreach (var kvp in overrides) {
+                builder.Configuration[kvp.Key] = kvp.Value;
+            }
+        }
+
+        Equibles.Web.Program.ConfigureServices(builder);
+        var app = builder.Build();
+        // ApplyMigrationsAsync is intentionally skipped — ParadeDbFixture has already applied
+        // the schema against the shared container, and the full production EF model wired up
+        // here triggers a PendingModelChangesWarning that's tangential to the branches under
+        // test. The lines we want to cover sit in ConfigureServices and ConfigurePipeline.
+        Equibles.Web.Program.ConfigurePipeline(app);
+        return app;
+    }
+
+    private static string ResolveWebContentRoot() {
+        // Walks up from the test bin directory until it finds the solution file, then
+        // returns the Web project's source root. Matches WebAppFixture's resolution so the
+        // same Razor/wwwroot contents are visible to both fixtures.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Equibles.sln"))) {
+            dir = dir.Parent;
+        }
+        if (dir is null) {
+            throw new InvalidOperationException(
+                "Could not locate Equibles.sln from test bin directory — cannot resolve ContentRootPath.");
+        }
+        return Path.Combine(dir.FullName, "src", "Equibles.Web");
+    }
+}


### PR DESCRIPTION
## Summary

- Two complementary fixes for the dashboard view that reports `src/Equibles.Web/Program.cs` at 0% under the `unit-integration` flag (the `functional` flag's run exercises Program.cs but lives on a different upload — when functional.yml fails or is delayed, the merged "All flags" dashboard silently drops to 0%).
- **#1 — codecov.yml**: declares the `unit-integration` and `functional` flags with `carryforward: true`. Codecov reuses each flag's most-recent prior coverage when a fresh upload is missing, keeping the merged view stable.
- **#2 — three integration tests in `Equibles.IntegrationTests`**: pins the three Program.cs branches `WebAppFixture` (FunctionalTests) doesn't cross — `if (authSettings.IsEnabled)`, `?? "/app/keys"`, and `if (!app.Environment.IsDevelopment())`. Reuses the shared `ParadeDbFixture` container; skips `ApplyMigrationsAsync` since the schema is already applied and the full production EF model triggers a tangential `PendingModelChangesWarning`.

## Code changes

- `codecov.yml` — adds a `flag_management` block declaring both flags with `carryforward: true` and a default rule mirroring them.
- `tests/Equibles.IntegrationTests/Web/ProgramConfigurationTests.cs` — three `[Fact]` methods sharing a `BuildHost(environment, overrides, omitKeysDirectoryConfig)` helper that mirrors `Program.Main`'s composition pipeline (ConfigureServices → Build → ConfigurePipeline). Test 1 sets `Auth:Username`/`Auth:Password` (`IsEnabled` is computed from those, not a settable bool) and asserts the fallback policy denies anonymous. Test 2 omits `DataProtection:KeysDirectory` and asserts the registered `FileSystemXmlRepository.Directory.FullName == "/app/keys"`. Test 3 drives `EnvironmentName = "Production"` and asserts the host's environment is wired non-development.