### PR TITLE
test(web): cover AuthController.Login redirect-when-auth-disabled

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/AuthLoginTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/AuthLoginTests.cs
@@ -1,0 +1,38 @@
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class AuthLoginTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public AuthLoginTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Login_GetWhenAuthDisabled_RedirectsToHomeInsteadOfRenderingLoginForm() {
+        // The fixture configures no "Auth" section, so AuthSettings.IsEnabled is false and the
+        // EnvAuthHandler signs every request in as the anonymous principal. AuthController.Login
+        // (GET) must short-circuit to Home in that mode — otherwise instances that intentionally
+        // run open would expose a non-functional login form. The browser is followed end-to-end so
+        // the 302 chain, lowercase-URL routing, anti-forgery cookie issuance, and Home/Index view
+        // rendering are all exercised against the real Kestrel host.
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        var response = await page.GotoAsync("/auth/login");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+        page.Url.Should().EndWith("/",
+            "Login (GET) must redirect to Home when AuthSettings.IsEnabled is false");
+        await Assertions.Expect(page.Locator("h1")).ToHaveTextAsync("Equibles");
+        await Assertions.Expect(page.Locator("form[action*='/auth/login']")).ToHaveCountAsync(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Add a Playwright functional test pinning the production behavior that `AuthController.Login` (GET) redirects to Home whenever `AuthSettings.IsEnabled` is false, instead of rendering a non-working login form.
- Drives the real Kestrel host + browser so the 302 chain, lowercase-URL routing, antiforgery cookie issuance, and Home view rendering are all exercised end-to-end.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/AuthLoginTests.cs` — new test class `AuthLoginTests` with one `[Fact]` (`Login_GetWhenAuthDisabled_RedirectsToHomeInsteadOfRenderingLoginForm`) that navigates to `/auth/login` on the shared `WebAppFixture` (no `Auth` section configured, so `IsEnabled` is false) and asserts the final URL ends with `/`, the page renders the `Equibles` h1, and no login form is present.