### PR TITLE
test(web): cover StatusController.Show not-found redirect + flash error

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/StatusShowNotFoundTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StatusShowNotFoundTests.cs
@@ -1,0 +1,42 @@
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class StatusShowNotFoundTests {
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public StatusShowNotFoundTests(WebAppFixture web, PlaywrightFixture playwright) {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Show_GetForUnknownErrorId_RedirectsToIndexAndRendersFlashError() {
+        // StatusController.Show returns RedirectToAction(Index) + flash error when the id
+        // resolves to no Error row. The redirect happens via 302 and the flash message
+        // round-trips through Session — dropping the IFlashMessage call or returning a bare
+        // 404 instead would silently take users to an empty page without explanation. The
+        // browser follows the redirect so we can assert both the landed URL and the
+        // rendered .alert-error toast in one shot.
+        await _web.ResetAndSeedAsync();
+        var missingId = Guid.NewGuid();
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync($"/status/show/{missingId}");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+        page.Url.Should().EndWith("/status",
+            "Show must redirect missing-error lookups to the Index action");
+        await Assertions.Expect(page.Locator(".alert-error").Filter(new() {
+                HasTextString = "Error not found.",
+            }))
+            .ToHaveCountAsync(1);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin StatusController.Show's missing-id branch: a Guid that resolves to no Error row must redirect to Index *and* surface an `Error not found.` flash toast. Dropping the `IFlashMessage` call or swapping the redirect for a bare 404 would silently take users to an empty page without explanation.
- Functional tier — drives the 302 chain + Session-backed flash through Kestrel and Playwright, so the cookie-context round-trip that delivers the flash to the redirected page is part of the regression surface.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/StatusShowNotFoundTests.cs` — new `StatusShowNotFoundTests` with one `[Fact]` (`Show_GetForUnknownErrorId_RedirectsToIndexAndRendersFlashError`) that resets the DB, GETs `/status/show/{random-guid}`, and asserts the final URL ends at `/status` and a `.alert-error` toast containing `Error not found.` is rendered.