### PR TITLE
test(sec): add skipped repro for GH-481 — FlexLabs UpsertRange WhenMatched no-op

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/FailToDeliverUpsertWhenMatchedTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FailToDeliverUpsertWhenMatchedTests.cs
@@ -1,0 +1,61 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using FlexLabs.EntityFrameworkCore.Upsert;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Isolated repro for the FlexLabs <c>UpsertRange(...).On(...).WhenMatched(...)</c> path
+/// FtdImportService relies on. The Postgres backend should compile this into
+/// <c>INSERT ... ON CONFLICT (cols) DO UPDATE SET ...</c> and update the matched row.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FailToDeliverUpsertWhenMatchedTests : ParadeDbMcpTestBase {
+    public FailToDeliverUpsertWhenMatchedTests(ParadeDbFixture fixture) : base(fixture) { }
+
+    [Fact(Skip = "GH-481 — UpsertRange WhenMatched silently no-ops on existing FailToDeliver rows against ParadeDB (FtdImportService cannot correct stale Quantity/Price on re-import)")]
+    public async Task UpsertRange_OnCommonStockIdAndSettlementDate_WhenMatched_OverwritesExistingRowQuantityAndPrice() {
+        var stock = new CommonStock {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var settlementDate = new DateOnly(2026, 4, 1);
+        var existing = new FailToDeliver {
+            CommonStockId = stock.Id,
+            SettlementDate = settlementDate,
+            Quantity = 999,
+            Price = 10.00m,
+        };
+
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<FailToDeliver>().Add(existing);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await DbContext.Set<FailToDeliver>()
+            .UpsertRange([new FailToDeliver {
+                CommonStockId = stock.Id,
+                SettlementDate = settlementDate,
+                Quantity = 12345,
+                Price = 187.50m,
+            }])
+            .On(f => new { f.CommonStockId, f.SettlementDate })
+            .WhenMatched(f => new FailToDeliver {
+                Quantity = f.Quantity,
+                Price = f.Price,
+            })
+            .RunAsync();
+
+        DbContext.ChangeTracker.Clear();
+        var rows = await DbContext.Set<FailToDeliver>().ToListAsync();
+
+        rows.Should().ContainSingle("conflict on the unique index must collapse INSERT+existing into one row");
+        rows[0].Quantity.Should().Be(12345, "WhenMatched projects Quantity = source.Quantity");
+        rows[0].Price.Should().Be(187.50m, "WhenMatched projects Price = source.Price");
+    }
+}


### PR DESCRIPTION
## Summary

- While writing a real-DB integration test for `FtdImportService.Import`, the upsert UPDATE path was discovered to be a silent no-op against the production ParadeDB stack — see GH-481.
- `FtdImportService.FlushBatch` calls `.UpsertRange(items).On(f => new { f.CommonStockId, f.SettlementDate }).WhenMatched(f => new FailToDeliver { Quantity = f.Quantity, Price = f.Price }).RunAsync()`. The INSERT path of that call works; for already-existing `(CommonStockId, SettlementDate)` rows, the `WhenMatched` SET clause never runs and the row keeps its stale `Quantity`/`Price`. The real-world impact: when SEC republishes a corrected FTD figure, the worker keeps serving the old value forever — no log line, no exception.
- The same `UpsertRange().On(...).WhenMatched(...)` shape is used by `HoldingsImportService` and `CongressionalTradeSyncService`, which should be audited for the same regression once the root cause is identified.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/FailToDeliverUpsertWhenMatchedTests.cs` — new isolated repro: seeds one `FailToDeliver` row, runs the same `UpsertRange(...).On(...).WhenMatched(...)` shape used by production with new `Quantity`/`Price`, and asserts the row was updated. Currently fails against the shared ParadeDB fixture; committed as `[Fact(Skip = "GH-481 — ...")]` so the regression artifact lives in the repo until the fix lands. Un-skipping the test is part of the fix per the bug-found protocol.