### PR TITLE
ci: add lint job, concurrency cancellation, blame-ignore SHA

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,4 +5,5 @@
 #
 # GitHub honors this file automatically in the web UI.
 
-# Add the squash-merge SHA of the csharpier mass-format PR here once merged.
+# PR #484 — chore: add csharpier and format codebase
+64c1514915ee2d0140b020bc9106868a5766c581

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,39 @@ permissions:
   contents: read
   checks: write
 
+# Cancel superseded runs on the same PR / branch so we don't burn CI minutes
+# on commits that have already been replaced.
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Restore tools
+        run: dotnet tool restore
+
+      - name: Restore
+        run: dotnet restore Equibles.sln
+
+      - name: Format check (CSharpier)
+        run: dotnet csharpier check .
+
+      - name: Build
+        run: dotnet build Equibles.sln --no-restore -c Release
+
   build-and-test:
     runs-on: ubuntu-latest
+    needs: lint
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -11,6 +11,11 @@ permissions:
   contents: read
   checks: write
 
+# Cancel superseded runs on the same PR / branch.
+concurrency:
+  group: functional-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   functional:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Hardens the CI workflows: separate lint job that runs before the test step, concurrency cancellation, and the post-merge bookkeeping for the CSharpier format pass.

## Code changes

- **`.github/workflows/ci.yml`** — new `lint` job runs `dotnet csharpier check .` then a Release build; `build-and-test` declares `needs: lint` so style failures short-circuit the longer test step. Added a `concurrency` block (`ci-${{ github.head_ref || github.ref }}`, `cancel-in-progress: true`) so superseded runs cancel automatically.
- **`.github/workflows/functional.yml`** — same concurrency block (`functional-*`).
- **`.git-blame-ignore-revs`** — records PR #484's squash SHA (`64c1514`) so `git blame` skips the mass format pass.

## Deliberately not in this PR

`-warnaserror` on the build step. The codebase currently has 35 pre-existing warnings (`NU1902`/`NU1904` for `System.IdentityModel.Tokens.Jwt` and `System.Drawing.Common`, `CA2017` log-template mismatch in `CompanySyncService`, `CS8632` nullable annotations in test files). Flipping the switch now would red-fail CI; tracked as a follow-up.

## Verification

- Lint job runs `dotnet csharpier check .` (verified locally: all 654 files clean post-#484)
- Build step builds `Equibles.sln` in Release without `--no-restore` issues
- Concurrency syntax verified against GitHub's spec