### PR TITLE
ci: lint PR titles for Conventional Commits

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,36 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Conventional Commit format
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed prefixes. Keep aligned with CONTRIBUTING.md examples.
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            revert
+          # Subject must start lowercase to stay consistent with the rest of git log.
+          subjectPattern: ^[a-z].+$
+          subjectPatternError: |
+            The PR title subject must start with a lowercase letter.
+            Got: "{subject}"


### PR DESCRIPTION
## Summary

Adds a tiny workflow that validates every PR title against the [Conventional Commits](https://www.conventionalcommits.org/) spec via [amannn/action-semantic-pull-request@v5](https://github.com/amannn/action-semantic-pull-request).

## Code changes

- **`.github/workflows/lint-pr-title.yml`** — runs on `pull_request: opened/edited/synchronize/reopened`. Allowed prefixes match what already shows up in `git log`: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `revert`. Subject must start with a lowercase letter.

## Verification

- Workflow YAML is syntactically valid (matches action's documented options)
- This PR's own title (`ci: lint PR titles for Conventional Commits`) is itself compliant