### PR TITLE
chore: add pre-commit hooks for csharpier, markdownlint, codespell

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,2 @@
+# Words codespell should not flag. Add one per line, lowercase.
+# Format: <misspelling>  → use the word verbatim, no replacement column.

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+skip = .git,bin,obj,.idea,.vs,node_modules,*.lock,*.svg,*.min.js,*.min.css,Migrations,coverage,functional-results,worktrees,LICENSE
+ignore-words = .codespellignore
+check-filenames =
+check-hidden =

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,20 @@
+# Markdownlint rules.
+# Reference: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+default: true
+
+# MD013 — line length. Long URLs and tables routinely exceed limits; not worth
+# the noise.
+MD013: false
+
+# MD024 — duplicate headings. CHANGELOG.md repeats "### Added", "### Fixed"
+# under each version section by design.
+MD024: false
+
+# MD033 — inline HTML. We use <details>/<summary> in PR templates and the
+# occasional <kbd>/<sub> in docs.
+MD033: false
+
+# MD041 — first line must be a top-level heading. PR/issue templates start with
+# H2 by convention.
+MD041: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+# Run these locally before pushing. Install once with `prek install -f`
+# (https://prek.j178.dev) or the Python `pre-commit` tool.
+#
+# Run on demand with `prek run --all-files`.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: no-commit-to-branch
+        args: ["--branch", "main"]
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+      - id: end-of-file-fixer
+        exclude: '\.(svg|min\.js|min\.css)$'
+      - id: trailing-whitespace
+        exclude: '\.(svg|min\.js|min\.css|md)$'
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-json
+        exclude: '\.idea/.*'
+      - id: detect-private-key
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.45.0
+    hooks:
+      - id: markdownlint
+        args: ["--config", ".markdownlint.yaml"]
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies: ["tomli"]
+
+  - repo: local
+    hooks:
+      - id: csharpier
+        name: csharpier check
+        entry: dotnet csharpier check
+        language: system
+        types: [c#]
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,20 @@ Thanks for your interest in contributing! This guide covers how to get started, 
 
    EF Core migrations run automatically on startup.
 
+5. **Install the pre-commit hooks** (recommended). They run CSharpier, markdownlint, codespell, and a few hygiene checks before every commit:
+
+   ```bash
+   # Restore CSharpier (and other .NET tools)
+   dotnet tool restore
+
+   # Install hooks — pick whichever tool you prefer
+   prek install -f       # https://prek.j178.dev — Rust port, faster
+   # or: pre-commit install --install-hooks
+
+   # Run once across the repo
+   prek run --all-files
+   ```
+
 ## Submitting Changes
 
 1. Create a feature branch from `main`:


### PR DESCRIPTION
## Summary

Adds local pre-commit hooks so style and hygiene violations get caught before they hit CI.

## Code changes

- **`.pre-commit-config.yaml`** — orchestrates four sources:
  - `pre-commit/pre-commit-hooks v5.0.0` — `no-commit-to-branch` (main), `mixed-line-ending`, `end-of-file-fixer`, `trailing-whitespace`, `check-added-large-files` (500KB), `check-merge-conflict`, `check-yaml`, `check-json`, `detect-private-key`
  - `markdownlint-cli v0.45.0`
  - `codespell v2.4.1`
  - Local hook: `dotnet csharpier check` for C# files
- **`.markdownlint.yaml`** — disables MD013 (line length), MD024 (duplicate headings — CHANGELOG by design), MD033 (inline HTML — `<details>` in PR templates), MD041 (first-line H1 — templates start with H2).
- **`.codespellrc` + `.codespellignore`** — skip configuration and empty ignore list ready for false positives.
- **`CONTRIBUTING.md`** — `prek install -f` / `prek run --all-files` instructions in the development setup.

This is purely developer tooling — no CI workflow runs the hooks; they're opt-in once contributors run `prek install -f`.

## Verification

- All four config files parse (yaml/toml syntax verified)
- CSharpier already clean on `main` (verified by lint job in #485)
- Run `prek run --all-files` locally after this merges to surface any false positives — entries land in `.codespellignore`