### PR TITLE
docs: add CHANGELOG following Keep a Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project tries to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+once the first tagged release ships.
+
+## [Unreleased]
+
+### Added
+
+- Initial CHANGELOG. Past changes are recoverable from `git log` and merged PRs.
+
+[Unreleased]: https://github.com/daniel3303/Equibles/commits/main


### PR DESCRIPTION
## Summary

Adds `CHANGELOG.md` so user-visible changes have a single home instead of being scattered across PR descriptions.

## Code changes

- **`CHANGELOG.md`** — Keep a Changelog 1.1.0 format with an empty `## [Unreleased]` section. No historical entries since the repo has no tagged releases yet; back-fabricating from `git log` would be lossy.
- The PR template (#488) already includes a "CHANGELOG.md updated under `## [Unreleased]`" checkbox to nudge contributors.

## Verification

- Format matches Keep a Changelog 1.1.0 spec
- Compare-link footer points at `commits/main` (will update to a real version compare once the first tag ships)