### PR TITLE
chore: bump NuGet dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,14 +7,14 @@
     <PackageVersion Include="Equibles.Core.AutoWiring" Version="1.0.1" />
     <!-- Browser Automation -->
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.58.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.59.0" />
     <!-- HTML / Markdown -->
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
     <PackageVersion Include="FlexLabs.EntityFrameworkCore.Upsert" Version="10.0.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="Markdig" Version="0.45.0" />
     <PackageVersion Include="PdfPig" Version="0.1.14" />
-    <PackageVersion Include="ReverseMarkdown" Version="5.0.0" />
+    <PackageVersion Include="ReverseMarkdown" Version="5.3.0" />
     <!-- Validation -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
@@ -27,38 +27,38 @@
     <!-- AI / ML -->
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.3.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
-    <PackageVersion Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.3" />
-    <PackageVersion Include="ModelContextProtocol" Version="1.0.0" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="2.0.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <!-- ASP.NET Core -->
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
     <!-- Entity Framework Core -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.3" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageVersion Include="Equibles.ParadeDB.EntityFrameworkCore" Version="1.1.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.8" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageVersion Include="Equibles.ParadeDB.EntityFrameworkCore" Version="2.1.0" />
     <PackageVersion Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
     <!-- Microsoft.Extensions -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
     <PackageVersion
       Include="Microsoft.Extensions.DependencyInjection.Abstractions"
-      Version="10.0.3"
+      Version="10.0.8"
     />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageVersion
       Include="Microsoft.Extensions.Options.ConfigurationExtensions"
-      Version="10.0.3"
+      Version="10.0.8"
     />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.8" />
     <!-- Logging -->
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
@@ -72,21 +72,21 @@
     <PackageVersion Include="MimeTypeMapOfficial" Version="1.0.17" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <!-- JSON -->
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <!-- Resilience -->
-    <PackageVersion Include="Polly" Version="8.6.5" />
+    <PackageVersion Include="Polly" Version="8.6.6" />
     <!-- Testing -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="FluentAssertions" Version="8.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-    <PackageVersion Include="Testcontainers" Version="4.8.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.8.0" />
-    <PackageVersion Include="Respawn" Version="6.2.1" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageVersion Include="Respawn" Version="7.0.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Bumps NuGet package versions across the solution. Includes the major bump of `Equibles.ParadeDB.EntityFrameworkCore` to v2.1.0 (the v2 line introduces a couple of breaking changes — `EF.Functions.Snippets` now returns `string[]` and `ParadeDbJsonQuery.Match(value)` was removed — but the codebase doesn't use either API, so no source changes were needed).

Held back per project policy (commercial license in newer versions):
- `FluentAssertions` stays at 8.3.0
- `SixLabors.ImageSharp` stays at 3.1.12
- `MassTransit` stays at 8.5.7 (already on the last permissively-licensed line)

## Code changes

`Directory.Packages.props` — single file. Notable bumps:

| Package | Old | New |
|---|---|---|
| Equibles.ParadeDB.EntityFrameworkCore | 1.1.0 | 2.1.0 |
| Microsoft.EntityFrameworkCore (+ Design, Proxies, InMemory) | 10.0.3 | 10.0.8 |
| Npgsql.EntityFrameworkCore.PostgreSQL | 10.0.0 | 10.0.1 |
| Microsoft.Extensions.* (Configuration, Hosting, Http, Logging, Options, DI) | 10.0.3 | 10.0.8 |
| Microsoft.AspNetCore.Mvc.* (NewtonsoftJson, Razor.RuntimeCompilation, Testing) | 10.0.3 | 10.0.8 |
| ModelContextProtocol(.AspNetCore) | 1.0.0 | 1.3.0 |
| Microsoft.NET.Test.Sdk | 17.13.0 | 18.5.1 |
| coverlet.collector | 6.0.4 | 10.0.0 |
| Respawn | 6.2.1 | 7.0.0 |
| Testcontainers(.PostgreSql) | 4.8.0 | 4.11.0 |
| xunit.runner.visualstudio | 3.0.2 | 3.1.5 |
| Microsoft.ML.Tokenizers.Data.O200kBase | 1.0.3 | 2.0.0 |
| BenchmarkDotNet | 0.15.5 | 0.15.8 |
| ReverseMarkdown | 5.0.0 | 5.3.0 |
| Microsoft.Playwright | 1.58.0 | 1.59.0 |
| Newtonsoft.Json | 13.0.3 | 13.0.4 |
| Polly | 8.6.5 | 8.6.6 |

## Test plan

- [x] `dotnet build Equibles.sln` — 0 errors
- [x] `dotnet test tests/Equibles.UnitTests` — 1092 passed
- [x] `dotnet test tests/Equibles.IntegrationTests` — 981 passed, 1 pre-existing skip (GH-481 FlexLabs UpsertRange repro)
- [x] `dotnet test tests/Equibles.FunctionalTests` — 42 passed
- [x] `dotnet csharpier check Directory.Packages.props` — clean