### PR TITLE
chore: add Dependabot for nuget, github-actions, docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,82 @@
+version: 2
+
+updates:
+  # NuGet packages — versions live in Directory.Packages.props (centralised).
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    # Default NuGet commit messages don't include the `build` prefix, which would
+    # break the conventional-commits PR-title-lint workflow. Force it here.
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    labels:
+      - "type: dependencies"
+    groups:
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+      entity-framework:
+        patterns:
+          - "Microsoft.EntityFrameworkCore*"
+          - "Npgsql.EntityFrameworkCore*"
+          - "Pgvector.EntityFrameworkCore"
+          - "FlexLabs.EntityFrameworkCore.Upsert"
+      aspnetcore:
+        patterns:
+          - "Microsoft.AspNetCore.*"
+      ai:
+        patterns:
+          - "Microsoft.Extensions.AI*"
+          - "Microsoft.ML.*"
+          - "ModelContextProtocol*"
+      testing:
+        patterns:
+          - "xunit*"
+          - "Microsoft.NET.Test.Sdk"
+          - "coverlet.*"
+          - "Testcontainers*"
+          - "Microsoft.AspNetCore.Mvc.Testing"
+          - "Bogus"
+          - "FluentAssertions"
+          - "Moq"
+          - "Microsoft.Playwright"
+      serilog:
+        patterns:
+          - "Serilog*"
+      masstransit:
+        patterns:
+          - "MassTransit*"
+
+  # GitHub Actions referenced from .github/workflows/.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    labels:
+      - "type: dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Docker base images in docker-compose.yml / Dockerfiles.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    labels:
+      - "type: dependencies"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so dependency updates land as grouped, weekly PRs instead of festering until something breaks.

## Code changes

- **NuGet ecosystem** (Directory.Packages.props is centralised, so root path is correct)
  - Weekly on Monday 06:00 UTC
  - 5 open PR cap
  - `commit-message.prefix: "build"` is **required** for NuGet: Dependabot's default for NuGet omits the conventional-commit prefix (unlike npm/github-actions which include it), which would fail the new PR-title-lint workflow (#486)
  - Groups: `microsoft-extensions`, `entity-framework`, `aspnetcore`, `ai` (MCP/ML), `testing`, `serilog`, `masstransit`
- **GitHub Actions ecosystem** — single `*` group; 3 open PR cap
- **Docker ecosystem** — `docker-compose.yml` base images; 3 open PR cap

## Verification

- YAML schema matches Dependabot's [v2 reference](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
- Group patterns cross-checked against Directory.Packages.props package names
- First run fires within ~24h of merge; the `type: dependencies` label is referenced — create it once via `gh label create "type: dependencies" --color FFC107` if it doesn't already exist