### PR TITLE
ci: add CodeQL workflow for csharp

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,57 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan on Monday 04:17 UTC — off-peak so we don't race CI.
+    - cron: "17 4 * * 1"
+
+# Cancel superseded runs on the same PR / branch.
+concurrency:
+  group: codeql-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [csharp]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-and-quality is broader than the default `security` suite,
+          # picks up maintainability issues alongside vulnerabilities.
+          queries: security-and-quality
+
+      - name: Build
+        run: |
+          dotnet restore Equibles.sln
+          dotnet build Equibles.sln --no-restore -c Release
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Adds GitHub's CodeQL static analysis workflow so vulnerabilities and quality issues are surfaced in the Security tab.

## Code changes

- **`.github/workflows/codeql.yml`** — runs on push to `main`, PRs targeting `main`, and weekly on Monday 04:17 UTC. Single `csharp` language entry (multi-language matrix scaffolding is in place for future additions). Uses the `security-and-quality` query suite which picks up maintainability issues in addition to security findings. Concurrency group cancels superseded runs.

## Verification

- Workflow YAML matches GitHub's [Setup CodeQL](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning) reference
- CodeQL is free for public repos (no GitHub Advanced Security required)
- First scan kicks off on this PR — review the Security tab for findings before merging