### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners — automatically requested as reviewers when matching files change.
+# Reference: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customizations/customizing-your-repository/about-code-owners
+#
+# Order is significant — the last matching pattern wins.
+
+# Default owner for everything in the repo.
+*                              @daniel3303


### PR DESCRIPTION
## Summary

Adds a `CODEOWNERS` file so future external PRs auto-request `@daniel3303` as the reviewer.

## Code changes

- **`.github/CODEOWNERS`** — wildcard owner: `* @daniel3303`. Solo maintainer for now; per-area lines can layer on later (`/src/Equibles.Sec.* @sec-team` etc.).

## Verification

- File location matches the canonical `.github/CODEOWNERS` path GitHub looks for
- Branch protection (final PR in this hardening series) will be configured with `require_code_owner_reviews: false` for now, so this just drives auto-assignment, not gating