### PR TITLE
chore: add FUNDING.yml with GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,8 @@
+# These are supported funding model platforms
+
+github: [daniel3303]
+# patreon: # Replace with a single Patreon username
+# open_collective: # Replace with a single Open Collective username
+# ko_fi: # Replace with a single Ko-fi username
+# tidelift: # Replace with a single Tidelift platform-name/package-name
+# custom: # Replace with up to 4 custom sponsorship URLs (e.g. https://example.com)


### PR DESCRIPTION
## Summary

Adds `.github/FUNDING.yml` so the repository shows a Sponsor button on its profile.

## Code changes

- **`.github/FUNDING.yml`** — single entry: `github: [daniel3303]`. Other platforms (Patreon, Open Collective, Ko-fi, Tidelift, custom URLs) left commented out as templates if you decide to add them.

If GitHub Sponsors isn't enabled for the account yet, the button still won't render until the account is approved — but the file is correctly placed and the YAML schema is valid, so it'll activate the moment Sponsors is live.

## Verification

- YAML matches GitHub's [FUNDING.yml schema](https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customizations/customizing-your-repository/displaying-a-sponsor-button-in-your-repository)