### PR TITLE
ci: rename PR-title lint job to avoid name collision

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -8,7 +8,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  lint:
+  pr-title:
+    name: PR title (Conventional Commits)
     runs-on: ubuntu-latest
     steps:
       - name: Validate Conventional Commit format


### PR DESCRIPTION
## Summary

Renames the PR-title lint job so it no longer shares the `lint` context name with `ci.yml`'s lint job — needed before branch protection can require both independently.

## Code changes

- **`.github/workflows/lint-pr-title.yml`** — job key `lint` → `pr-title`, with display name `PR title (Conventional Commits)`.

## Verification

- The job runs on PRs (same trigger as before, just with a distinct name)
- This PR's title self-tests the rename