### PR TITLE
test(functional): add empty-state coverage for Stocks Short Interest tab

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/StocksShortInterestTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksShortInterestTests.cs
@@ -87,4 +87,35 @@ public class StocksShortInterestTests
             .Expect(rows.First.Locator("td").First)
             .ToHaveTextAsync(newestSettlement.ToString("yyyy-MM-dd"));
     }
+
+    [Fact]
+    public async Task ShortInterest_GetForSeededStockWithNoShortInterest_RendersNoShortInterestDataEmptyState()
+    {
+        // /stocks/{ticker}/shortinterest runs StockTabService.LoadShortInterestTab against the
+        // seeded stock. With no ShortInterest rows, the view takes the explicit empty-state
+        // branch ("No Short Interest Data"). Pins both the route + LoadStock lookup AND the
+        // empty-state copy — the other test in this file only covers the populated branch.
+        await _web.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/stocks/aapl/shortinterest");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions
+            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Short Interest Data" }))
+            .ToHaveCountAsync(1);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds the missing empty-state functional test for the Stocks Short Interest tab — every other Stocks tab (Holdings, Ftd, InsiderTrading, CongressionalTrades, Price) already has separate coverage for both the populated and the empty-state branch; Short Interest only covered the populated branch.
- Pins the empty-state view path end-to-end: `/stocks/{ticker}/shortinterest` returns 200 for a seeded stock with zero `ShortInterest` rows and the view renders the explicit "No Short Interest Data" heading.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/StocksShortInterestTests.cs` — adds `ShortInterest_GetForSeededStockWithNoShortInterest_RendersNoShortInterestDataEmptyState`, modeled after the equivalent `StocksHoldingsTests` empty-state test.