### PR TITLE
test(functional): add empty-state coverage for Stocks Short Volume tab

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/StocksShortVolumeTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksShortVolumeTests.cs
@@ -86,4 +86,35 @@ public class StocksShortVolumeTests
             .Expect(rows.First.Locator("td").First)
             .ToHaveTextAsync(endDate.ToString("yyyy-MM-dd"));
     }
+
+    [Fact]
+    public async Task ShortVolume_GetForSeededStockWithNoShortVolume_RendersNoShortVolumeDataEmptyState()
+    {
+        // /stocks/{ticker}/shortvolume runs StockTabService.LoadShortVolumeTab against the
+        // seeded stock. With no DailyShortVolume rows, the view takes the explicit empty-state
+        // branch ("No Short Volume Data"). Pins both the route + LoadStock lookup AND the
+        // empty-state copy — the other test in this file only covers the populated branch.
+        await _web.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/stocks/aapl/shortvolume");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions
+            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Short Volume Data" }))
+            .ToHaveCountAsync(1);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds the missing empty-state functional test for the Stocks Short Volume tab — Short Volume was the only Stocks tab (alongside Short Interest, addressed by PR #501) without separate coverage for the empty-state branch.
- Pins the empty-state view path end-to-end: `/stocks/{ticker}/shortvolume` returns 200 for a seeded stock with zero `DailyShortVolume` rows and the view renders the explicit "No Short Volume Data" heading.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/StocksShortVolumeTests.cs` — adds `ShortVolume_GetForSeededStockWithNoShortVolume_RendersNoShortVolumeDataEmptyState`, mirroring `StocksHoldingsTests` and the new Short Interest empty-state test.