### PR TITLE
test(functional): add empty-state coverage for Market VIX page

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/MarketVixTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/MarketVixTests.cs
@@ -66,4 +66,30 @@ public class MarketVixTests
         // thread culture which the fixture doesn't pin, so anchor on the row count instead).
         await Assertions.Expect(page.Locator("tbody tr")).ToHaveCountAsync(2);
     }
+
+    [Fact]
+    public async Task Vix_GetWithNoVixRows_RendersEmptyStateAndHidesChart()
+    {
+        // /market/vix with zero CboeVixDaily rows must (a) still return 200 and render the
+        // breadcrumb (MarketController must not 404), (b) take the `Records.Count == 0`
+        // branch of Views/Market/Vix.cshtml that emits "No data yet", and (c) skip the
+        // chronological-chart branch so the #vix-chart canvas is absent. The existing test
+        // only covers the populated path; this pins the empty path including the chart skip.
+        await _web.ResetAndSeedAsync(_ => Task.CompletedTask);
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/market/vix");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions
+            .Expect(page.Locator(".breadcrumbs li").Filter(new() { HasTextString = "VIX" }))
+            .ToHaveCountAsync(1);
+        await Assertions
+            .Expect(page.Locator("p").Filter(new() { HasTextString = "No data yet" }))
+            .ToHaveCountAsync(1);
+        await Assertions.Expect(page.Locator("#vix-chart")).ToHaveCountAsync(0);
+        await Assertions.Expect(page.Locator("tbody tr")).ToHaveCountAsync(0);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds the missing empty-state functional test for `/market/vix`. The existing test only covered the populated path; the view has an explicit `Records.Count == 0` branch rendering "No data yet" and a separate `chronological.Count > 0` chart branch — neither path was covered.
- Pins three behaviours: the route still returns 200 + renders the breadcrumb with zero rows, the empty-state copy appears, and the `#vix-chart` canvas is absent when there are no records.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/MarketVixTests.cs` — adds `Vix_GetWithNoVixRows_RendersEmptyStateAndHidesChart`, mirroring the empty-state tests being added for the Stocks tabs.