### PR TITLE
test(functional): add populated-render coverage for /futures/{marketCode}

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/CftcShowTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/CftcShowTests.cs
@@ -1,3 +1,4 @@
+using Equibles.Cftc.Data.Models;
 using Equibles.FunctionalTests.Fixtures;
 using FluentAssertions;
 using Microsoft.Playwright;
@@ -32,5 +33,73 @@ public class CftcShowTests
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task Show_GetWithKnownMarketCodeAndReports_RendersMarketHeaderAndLatestPositioning()
+    {
+        // CftcController.Show with a matching contract goes through repository.GetByMarketCode +
+        // reports load + viewmodel composition + view render. The 404-only test cannot exercise
+        // any of that. Seeds two reports so the controller's `latest.CommLong - latest.CommShort`
+        // arithmetic runs and the view's `if (latest != null)` Latest-Positioning block renders.
+        var contractId = Guid.NewGuid();
+        await _web.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CftcContract
+                {
+                    Id = contractId,
+                    MarketCode = "TEST_ES_FUT",
+                    MarketName = "Test E-Mini S&P 500",
+                    Category = CftcContractCategory.EquityIndices,
+                }
+            );
+            db.Add(
+                new CftcPositionReport
+                {
+                    CftcContractId = contractId,
+                    ReportDate = new DateOnly(2025, 1, 14),
+                    OpenInterest = 2_400_000,
+                    NonCommLong = 500_000,
+                    NonCommShort = 400_000,
+                    NonCommSpreads = 80_000,
+                    CommLong = 1_200_000,
+                    CommShort = 1_100_000,
+                    TotalRptLong = 1_700_000,
+                    TotalRptShort = 1_500_000,
+                    NonRptLong = 200_000,
+                    NonRptShort = 100_000,
+                }
+            );
+            db.Add(
+                new CftcPositionReport
+                {
+                    CftcContractId = contractId,
+                    ReportDate = new DateOnly(2025, 1, 7),
+                    OpenInterest = 2_300_000,
+                    NonCommLong = 480_000,
+                    NonCommShort = 410_000,
+                    NonCommSpreads = 70_000,
+                    CommLong = 1_180_000,
+                    CommShort = 1_120_000,
+                    TotalRptLong = 1_660_000,
+                    TotalRptShort = 1_530_000,
+                    NonRptLong = 190_000,
+                    NonRptShort = 90_000,
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/futures/TEST_ES_FUT");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("h1")).ToHaveTextAsync("Test E-Mini S&P 500");
+        await Assertions
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "Latest Positioning" }))
+            .ToHaveCountAsync(1);
     }
 }


### PR DESCRIPTION
## Summary

- Adds the populated-render functional test for `CftcController.Show`. The existing `CftcShowTests` file only covered the 404 path for an unknown market code — the success branch (repo lookup, reports load, view-model composition, view render) had zero functional coverage.
- The new test seeds a contract plus two reports so the view-model's `latest.CommLong - latest.CommShort` arithmetic runs and the view's `if (latest != null)` Latest-Positioning block renders.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/CftcShowTests.cs` — adds `Show_GetWithKnownMarketCodeAndReports_RendersMarketHeaderAndLatestPositioning`, asserting 200 OK, the H1 market name, and the Latest-Positioning H2.