### PR TITLE
test(functional): add populated-data coverage for /market index page

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/MarketIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/MarketIndexTests.cs
@@ -1,3 +1,4 @@
+using Equibles.Cboe.Data.Models;
 using Equibles.FunctionalTests.Fixtures;
 using FluentAssertions;
 using Microsoft.Playwright;
@@ -41,5 +42,54 @@ public class MarketIndexTests
                 page.Locator("h2.card-title").Filter(new() { HasTextString = "Put/Call Ratios" })
             )
             .ToHaveCountAsync(1);
+    }
+
+    [Fact]
+    public async Task Index_GetWithSeededPutCallAndVixRows_RendersLatestDateOnPage()
+    {
+        // MarketController.Index has populated arithmetic branches the empty-state test cannot
+        // exercise: `latestVix.Count > 0/1` selects LatestClose/PreviousClose, and `vixRange.Max()/
+        // Min()` over the 52-week window throws on an empty sequence — so the absence of a
+        // populated test would have let a regression that drops the `Count > 0` guards slip in.
+        // Asserts the seeded date renders on the page (PCR row + VIX tile both consume it).
+        var settlementDate = new DateOnly(2025, 1, 2);
+        await _web.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CboePutCallRatio
+                {
+                    Date = settlementDate,
+                    RatioType = CboePutCallRatioType.Equity,
+                    CallVolume = 1_000_000,
+                    PutVolume = 750_000,
+                    TotalVolume = 1_750_000,
+                    PutCallRatio = 0.75m,
+                }
+            );
+            db.Add(
+                new CboeVixDaily
+                {
+                    Date = settlementDate,
+                    Open = 15m,
+                    High = 16m,
+                    Low = 14m,
+                    Close = 15.5m,
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/market");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("h1")).ToHaveTextAsync("Market Indicators");
+        // The seeded date appears in both the PCR table row's Date column AND the VIX summary
+        // tile's Date field — a stable signal that BOTH controller code paths populated.
+        await Assertions
+            .Expect(page.Locator("body"))
+            .ToContainTextAsync(settlementDate.ToString("yyyy-MM-dd"));
     }
 }


### PR DESCRIPTION
## Summary

- Adds the populated-data functional test for `/market`. The existing test only covered the empty-state branch — `MarketController.Index` has populated-only paths the empty test cannot exercise (the `latestVix.Count > 0/1` guards selecting LatestClose/PreviousClose, and the `vixRange.Max()`/`Min()` calls over the 52-week window, which throw on an empty sequence).
- A regression dropping either guard would not be caught by the empty test.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/MarketIndexTests.cs` — adds `Index_GetWithSeededPutCallAndVixRows_RendersLatestDateOnPage`, seeding one CboePutCallRatio and one CboeVixDaily then asserting the seeded date renders on the page (appears in both the PCR row's Date column and the VIX summary tile).