### PR TITLE
test(functional): add observations-populated coverage for /economicdata/{seriesId}

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/EconomicDataShowTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/EconomicDataShowTests.cs
@@ -57,4 +57,48 @@ public class EconomicDataShowTests
             .Expect(page.Locator("body"))
             .ToContainTextAsync("Market Yield on U.S. Treasury Securities");
     }
+
+    [Fact]
+    public async Task Show_GetForSeededSeriesWithObservations_RendersStatisticsAndChart()
+    {
+        // EconomicDataController.Show has a populated-only block `if (values.Length > 0)` that
+        // composes DescriptiveStatistics, Median, LatestValue/PreviousValue, and the SMA20/50
+        // arrays. The existing test (series only, no observations) skips this entire block, and
+        // the view's `if (chronological.Count > 0)` branch (stats cards + #economy-chart) is
+        // therefore also untested. Seeds three observations so the populated branch runs and
+        // `observations.Count > 1` also sets PreviousValue.
+        var seriesId = Guid.NewGuid();
+        await _web.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new FredSeries
+                {
+                    Id = seriesId,
+                    SeriesId = "DGS10",
+                    Title = "Market Yield on U.S. Treasury Securities at 10-Year Constant Maturity",
+                    Category = FredSeriesCategory.InterestRates,
+                    Frequency = "Daily",
+                    Units = "Percent",
+                    SeasonalAdjustment = "Not Seasonally Adjusted",
+                }
+            );
+            db.Add(new FredObservation { FredSeriesId = seriesId, Date = new DateOnly(2025, 1, 2), Value = 4.55m });
+            db.Add(new FredObservation { FredSeriesId = seriesId, Date = new DateOnly(2025, 1, 3), Value = 4.60m });
+            db.Add(new FredObservation { FredSeriesId = seriesId, Date = new DateOnly(2025, 1, 6), Value = 4.58m });
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/economicdata/dgs10");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        // Stats card heading appears only inside the `chronological.Count > 0` branch.
+        await Assertions
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "Statistics" }))
+            .ToHaveCountAsync(1);
+        // Chart canvas only renders when chronological is non-empty.
+        await Assertions.Expect(page.Locator("#economy-chart")).ToHaveCountAsync(1);
+    }
 }

--- a/tests/Equibles.FunctionalTests/Tests/EconomicDataShowTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/EconomicDataShowTests.cs
@@ -82,9 +82,30 @@ public class EconomicDataShowTests
                     SeasonalAdjustment = "Not Seasonally Adjusted",
                 }
             );
-            db.Add(new FredObservation { FredSeriesId = seriesId, Date = new DateOnly(2025, 1, 2), Value = 4.55m });
-            db.Add(new FredObservation { FredSeriesId = seriesId, Date = new DateOnly(2025, 1, 3), Value = 4.60m });
-            db.Add(new FredObservation { FredSeriesId = seriesId, Date = new DateOnly(2025, 1, 6), Value = 4.58m });
+            db.Add(
+                new FredObservation
+                {
+                    FredSeriesId = seriesId,
+                    Date = new DateOnly(2025, 1, 2),
+                    Value = 4.55m,
+                }
+            );
+            db.Add(
+                new FredObservation
+                {
+                    FredSeriesId = seriesId,
+                    Date = new DateOnly(2025, 1, 3),
+                    Value = 4.60m,
+                }
+            );
+            db.Add(
+                new FredObservation
+                {
+                    FredSeriesId = seriesId,
+                    Date = new DateOnly(2025, 1, 6),
+                    Value = 4.58m,
+                }
+            );
             await Task.CompletedTask;
         });
 


### PR DESCRIPTION
## Summary

- Adds the observations-populated functional test for `EconomicDataController.Show`. The existing test seeded only a `FredSeries` with zero observations — the controller's `if (values.Length > 0)` block (DescriptiveStatistics, Median, Latest/PreviousValue, SMA20/50) and the view's `chronological.Count > 0` branch (stats cards + `#economy-chart`) were therefore untested.
- A regression in the MathNet stats pipeline or the chart rendering would not be caught by the existing test.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/EconomicDataShowTests.cs` — adds `Show_GetForSeededSeriesWithObservations_RendersStatisticsAndChart`, seeding the series plus three observations and asserting on the Statistics H2 and `#economy-chart` canvas counts.