### PR TITLE
test(functional): add unknown-ticker 404 coverage for /stocks/{ticker}

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/StocksShowTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksShowTests.cs
@@ -50,4 +50,23 @@ public class StocksShowTests
         page.Url.Should()
             .EndWith("/stocks/aapl/price", "Show must redirect bare-ticker URLs to the Price tab");
     }
+
+    [Fact]
+    public async Task Show_GetBareTickerUrlForUnknownStock_FollowsRedirectAnd404s()
+    {
+        // /stocks/{ticker} unconditionally 302s to .../Price; the Price action then runs
+        // `LoadStock(ticker)` and returns NotFound() for an unknown ticker. The existing redirect
+        // test doesn't exercise the null-stock branch — and the same `if (stock == null) return
+        // NotFound()` pattern is repeated across every tab action in StocksController. Pins the
+        // bare-URL flow on the unknown-ticker side: the redirect runs AND the destination 404s.
+        await _web.ResetAndSeedAsync(); // empty DB — no CommonStock rows
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/stocks/unknown");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(404);
+        page.Url.Should()
+            .EndWith("/stocks/unknown/price", "Show must still 302 to the Price tab even when the stock is missing");
+    }
 }

--- a/tests/Equibles.FunctionalTests/Tests/StocksShowTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksShowTests.cs
@@ -67,6 +67,9 @@ public class StocksShowTests
         response.Should().NotBeNull();
         response!.Status.Should().Be(404);
         page.Url.Should()
-            .EndWith("/stocks/unknown/price", "Show must still 302 to the Price tab even when the stock is missing");
+            .EndWith(
+                "/stocks/unknown/price",
+                "Show must still 302 to the Price tab even when the stock is missing"
+            );
     }
 }


### PR DESCRIPTION
## Summary

- Adds the unknown-ticker functional test for the bare-URL `/stocks/{ticker}` flow. The existing redirect test only covered the happy path with a seeded ticker; the shared `if (stock == null) return NotFound()` branch — replicated across every `StocksController` tab action — was untested end-to-end.
- Pins both behaviours of the unknown-ticker flow: the Show 302 still runs, and the destination Price action returns 404.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/StocksShowTests.cs` — adds `Show_GetBareTickerUrlForUnknownStock_FollowsRedirectAnd404s`, navigating to `/stocks/unknown` against an empty DB and asserting both the final 404 and that the URL landed on the price tab.