### PR TITLE
chore(deps): ignore SixLabors.ImageSharp major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
       include: "scope"
     labels:
       - "type: dependencies"
+    ignore:
+      # SixLabors.ImageSharp 4.x requires a paid commercial license.
+      # Stay on the 3.x line, which remains under the Six Labors Split License.
+      - dependency-name: "SixLabors.ImageSharp"
+        update-types: ["version-update:semver-major"]
     groups:
       microsoft-extensions:
         patterns:


### PR DESCRIPTION
## Summary

- Dependabot opened #512 to bump SixLabors.ImageSharp 3.1.12 → 4.0.0. ImageSharp 4.x moved to a paid commercial license (build fails with `error : No Six Labors license found. … Please obtain a license from https://sixlabors.com/pricing/`), so it isn't viable on an OSS project.
- The 3.x line is still under the open-source-friendly Six Labors Split License. This change tells dependabot to stop proposing major-version upgrades for `SixLabors.ImageSharp` so #512-style PRs don't keep reappearing weekly.

## Code changes

- `.github/dependabot.yml` — add an `ignore` entry under the `nuget` ecosystem: `SixLabors.ImageSharp` with `update-types: ["version-update:semver-major"]`. Patch and minor bumps within the 3.x line continue to flow through.

Closes #512.