### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
@@ -46,9 +46,9 @@ jobs:
     needs: lint
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
@@ -68,7 +68,7 @@ jobs:
         run: dotnet test Equibles.sln --no-build -c Release --filter "Category!=Functional" --logger trx --collect:"XPlat Code Coverage" --settings coverage.runsettings --results-directory ./coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/**/coverage.cobertura.xml
@@ -76,7 +76,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Test Report
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3
         if: success() || failure()
         with:
           name: Test Results

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,15 +31,15 @@ jobs:
         language: [csharp]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4
         with:
           languages: ${{ matrix.language }}
           # security-and-quality is broader than the default `security` suite,
@@ -52,6 +52,6 @@ jobs:
           dotnet build Equibles.sln --no-restore -c Release
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
@@ -44,14 +44,14 @@ jobs:
 
       - name: Upload Playwright traces on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: playwright-traces
           path: tests/Equibles.FunctionalTests/bin/Release/net10.0/playwright-traces
           if-no-files-found: ignore
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6
         if: success() || failure()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Test Report
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3
         if: success() || failure()
         with:
           name: Functional Test Results

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate Conventional Commit format
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

- Supply-chain hardening: pin every GitHub Action referenced from `.github/workflows/*.yml` to a commit SHA so a compromised tag cannot silently inject changes.
- Dependabot's `github-actions` ecosystem (configured weekly in `dependabot.yml`) will keep these SHAs current — the `# vX` trailing comment is what Dependabot uses to recognise the major version line.

## Code changes

Resolved each `@vX` tag to its current commit SHA and replaced it inline, keeping `# vX` as a trailing comment.

- `.github/workflows/ci.yml` — `actions/checkout`, `actions/setup-dotnet`, `codecov/codecov-action`, `dorny/test-reporter`.
- `.github/workflows/codeql.yml` — `actions/checkout`, `actions/setup-dotnet`, `github/codeql-action/init`, `github/codeql-action/analyze`.
- `.github/workflows/functional.yml` — `actions/checkout`, `actions/setup-dotnet`, `actions/upload-artifact`, `codecov/codecov-action`, `dorny/test-reporter`.
- `.github/workflows/lint-pr-title.yml` — `amannn/action-semantic-pull-request`.