### PR TITLE
chore: enable markdownlint --fix in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,10 @@ repos:
     rev: v0.45.0
     hooks:
       - id: markdownlint
-        args: ["--config", ".markdownlint.yaml"]
+        # --fix auto-corrects the safe rules (MD032 list spacing, MD009
+        # trailing-space variants) so we don't bounce every commit on rules
+        # the tool already knows how to repair.
+        args: ["--fix", "--config", ".markdownlint.yaml"]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1


### PR DESCRIPTION
## Summary

- The `markdownlint` pre-commit hook ran in report-only mode, so contributors had to fix every auto-fixable rule by hand before any commit touching markdown could land (e.g. PR #518 had to land just to clear pre-existing MD032 noise).
- `--fix` makes the safe rules (MD032 list spacing, MD009 trailing-space variants, MD031 blanks-around-fences) self-healing. Unfixable rules (MD040 missing code-block language, MD056 table column count) still report and block — surfaces real issues without manufacturing busywork.

## Code changes

- `.pre-commit-config.yaml` — add `--fix` to the markdownlint hook's args, with a comment explaining why.

## Follow-up

Running `prek run markdownlint --all-files` after this lands surfaces 5 residual issues that `--fix` can't repair:

- `CONTRIBUTING.md:74`, `:106`, `:131` — MD040 missing code-block language on fenced blocks
- `tests/README.md:25` — MD040 missing code-block language
- `tests/README.md:118` — MD056 table column count (the "Medium Value" table header declares 2 columns but row 118 has 3)

These are pre-existing and unrelated to this hook change, but would block any future commit that touches those files. Worth a small follow-up PR.