### PR TITLE
docs: clear residual markdownlint findings (MD040, MD056)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,17 +62,21 @@ Thanks for your interest in contributing! This guide covers how to get started, 
 ## Submitting Changes
 
 1. Create a feature branch from `main`:
+
    ```bash
    git checkout -b feat/your-feature
    ```
+
 2. Make your changes, following the [code style](#code-style) guidelines below.
 3. Ensure the solution builds cleanly: `dotnet build Equibles.sln`
 4. Commit with a descriptive message using [Conventional Commits](https://www.conventionalcommits.org/):
-   ```
+
+   ```text
    feat(holdings): add quarterly comparison endpoint
    fix(sec): handle missing CIK in EDGAR response
    docs: update MCP connection instructions
    ```
+
 5. Push your branch and open a pull request against `main`.
 6. Keep PRs focused — one logical change per PR.
 
@@ -99,7 +103,7 @@ Equibles is a modular monolith. Each financial domain (Holdings, Insider Trading
 
 Every domain module follows a layered pattern. Not all layers are required — create only what the module needs:
 
-```
+```text
 Equibles.{Module}.Data            → Entity models, EF configuration, IModuleConfiguration
 Equibles.{Module}.Repositories    → Data access via BaseRepository<T>
 Equibles.{Module}.BusinessLogic   → Managers with business logic (when needed)
@@ -124,7 +128,7 @@ Modules declare their dependencies automatically — calling `modules.AddSec()` 
 
 ### Data Flow
 
-```
+```text
 Data (models) → Repositories (data access) → Managers (business logic) → Controllers / MCP Tools / HostedServices
 ```
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,7 +22,7 @@ dotnet test tests/Equibles.Tests
 
 Tests are organized by feature area, mirroring the `src/` project structure:
 
-```
+```text
 tests/Equibles.Tests/
 ├── Helpers/                 # TestDbContextFactory, ServiceScopeSubstitute
 ├── CommonStocks/            # CommonStockManager validation
@@ -50,10 +50,12 @@ tests/Equibles.Tests/
 ## What Is Tested
 
 ### Core & Infrastructure
+
 - `EnumExtensionsTests` — `NameForHumans()` extension across multiple enum types
 - `EquiblesModuleBuilderTests` — Module registration, deduplication, fluent API
 
 ### Data Models & Enums
+
 - `CommonStockModelTests` — Entity defaults, property initialization
 - `HoldingsEnumTests` — `[Display]` attributes on ShareType, OptionType, InvestmentDiscretion
 - `InsiderTradingEnumTests` — `[Display]` on TransactionCode, AcquiredDisposed, OwnershipNature
@@ -63,17 +65,20 @@ tests/Equibles.Tests/
 - `DocumentTypeTests` — Case-insensitive parsing, display names, custom registration
 
 ### Business Logic
+
 - `CommonStockManagerTests` — Create/Update validation (required fields, uniqueness, secondary ticker conflicts)
 - `ErrorManagerTests` — Create with truncation boundaries, null defaults, MarkAsSeen, Delete
 - `ErrorReporterTests` — Delegation to ErrorManager, exception suppression on failure
 - `FileManagerTests` — SaveFile with MIME type detection, extension parsing, size validation
 
 ### Holdings Module
+
 - `ValueNormalizerTests` — Passthrough and Thousands normalizer behavior
 - `TsvParserTests` — Tab-delimited parsing from zip archives, edge cases
 - `HoldingsImportServiceTests` — Static parsing helpers (dates, enums, lookups, deduplication), SelectNormalizer decision tree (pre/post-2023, amendment consensus)
 
 ### SEC Module
+
 - `ChunkingStrategyTests` — Document segmentation into token-limited chunks
 - `TokenCounterTests` — Tokenization utility
 - `SecDocumentHtmlNormalizerTests` — SGML parsing, document type filtering
@@ -84,13 +89,16 @@ tests/Equibles.Tests/
 - **Normalizer pipeline** (6 test classes): XBRL stripping, table normalization, heading conversion, list conversion, pagination removal, currency consolidation
 
 ### Congress Module
+
 - `DisclosureParsingHelperTests` — ParseTransactionType, ParseAmountRange, ParseDate, ExtractTickerFromAssetName, GetCell, CleanSentinel, Truncate, IsValidDisclosureUrl, ParseTransactionsFromHtml (end-to-end)
 
 ### MCP Infrastructure
+
 - `ApiKeyMiddlewareTests` — Valid/invalid Bearer tokens, disabled validator, missing headers, case-insensitive prefix
 - `EquiblesMcpBuilderTests` — AddModule registration/deduplication, UseMiddleware DI registration, fluent API
 
 ### Integrations
+
 - `RateLimiterTests` — Async rate limiting, pause behavior, concurrency
 
 ## What Could Be Tested Next
@@ -105,12 +113,12 @@ tests/Equibles.Tests/
 
 ### Medium Value
 
-| Component | What to Test |
-|-----------|-------------|
+| Component | What to Test | Notes |
+|-----------|-------------|-------|
 | `FredImportService.ImportSeries` | Series creation, observation import, deduplication | Requires making method internal |
-| `ShortInterestImportService` | Date filtering, ticker mapping, duplicate detection |
-| `YahooPriceImportService` | Date range calculation, price record mapping |
-| Integration clients (`SecEdgarClient`, `FredClient`, `FinraClient`) | Response parsing with `HttpMessageHandler` mocking |
+| `ShortInterestImportService` | Date filtering, ticker mapping, duplicate detection | |
+| `YahooPriceImportService` | Date range calculation, price record mapping | |
+| Integration clients (`SecEdgarClient`, `FredClient`, `FinraClient`) | Response parsing with `HttpMessageHandler` mocking | |
 
 ### Lower Priority (simple pass-through or IO-bound)
 


### PR DESCRIPTION
## Summary

- Follow-up to #530: `prek run markdownlint --all-files` against `main` was still surfacing 5 issues `--fix` can't repair. This PR clears them so the hook passes from a clean state.
- Auto-fixable surrounding noise (MD031/MD032 blank lines around fences and lists) was picked up by `--fix` as a side effect.

## Code changes

- `CONTRIBUTING.md` — add `text` language tag to 3 fenced blocks (Conventional Commits examples, module-folder tree, data-flow arrow). All ASCII content; `text` matches the existing JSON/bash/csharp tags elsewhere in the same file.
- `tests/README.md` — add `text` language tag to the `tests/Equibles.Tests/` folder tree (MD040). Extend the "Medium Value" table header with a `Notes` column to match the "High Value" table; existing third-cell content on the `FredImportService` row now matches the header, empty `Notes` cells filled for the other rows (MD056).