### PR TITLE
test(congress): pin CongressMemberRepository Search ILike against Postgres

### DIFF
--- a/tests/Equibles.IntegrationTests/Congress/CongressMemberRepositoryPostgresSearchTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressMemberRepositoryPostgresSearchTests.cs
@@ -1,0 +1,41 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Congress;
+
+/// <summary>
+/// Pins <see cref="CongressMemberRepository.Search"/>: the production query uses
+/// <c>EF.Functions.ILike</c> (Postgres case-insensitive LIKE) so a lower-cased
+/// substring matches a TitleCased stored name. A regression that swapped to
+/// <c>EF.Functions.Like</c> (case-sensitive) or to <c>.Contains</c> on the
+/// in-memory side would silently miss matches on every non-exact-case query.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class CongressMemberRepositoryPostgresSearchTests : ParadeDbMcpTestBase
+{
+    public CongressMemberRepositoryPostgresSearchTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Search_LowercaseSubstringAgainstTitleCasedName_ReturnsMatchViaILike()
+    {
+        DbContext.Add(new CongressMember { Name = "Pelosi, Nancy", Position = CongressPosition.Representative });
+        DbContext.Add(new CongressMember { Name = "Tuberville, Tommy", Position = CongressPosition.Senator });
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new CongressMemberRepository(verify);
+
+        // Lowercase query against TitleCased seed names — would fail under
+        // case-sensitive LIKE. Both results show this is case-insensitive AND
+        // a substring (not whole-word) match.
+        var results = await sut.Search("nancy").ToListAsync();
+
+        results.Should().ContainSingle();
+        results[0].Name.Should().Be("Pelosi, Nancy");
+    }
+}


### PR DESCRIPTION
## Summary

- The existing `CongressMemberRepositoryTests` in `CongressRepositoryTests.cs` only asserts that the InMemory provider throws on `ILike` evaluation. The actual Postgres case-insensitive substring behaviour is uncovered.
- Pins that a lowercase query against a TitleCased seed name matches via `EF.Functions.ILike` — a regression to `EF.Functions.Like` (case-sensitive) or to `.Contains` would silently miss every non-exact-case query, breaking member-search endpoints.

## Code changes

- `tests/Equibles.IntegrationTests/Congress/CongressMemberRepositoryPostgresSearchTests.cs` — new file, distinct class name from the existing InMemory-throws test. Seeds two members against real ParadeDB and asserts the lowercase search returns the single matching member by name.