### PR TITLE
chore(codeql): fix real findings and scope analysis to first-party src

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,10 @@
+name: "Equibles CodeQL config"
+
+# security-and-quality picks up maintainability findings alongside vulnerabilities.
+queries:
+  - uses: security-and-quality
+
+paths-ignore:
+  - "**/obj/**"
+  - "**/bin/**"
+  - "tests/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,9 +42,7 @@ jobs:
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4
         with:
           languages: ${{ matrix.language }}
-          # security-and-quality is broader than the default `security` suite,
-          # picks up maintainability issues alongside vulnerabilities.
-          queries: security-and-quality
+          config-file: ./.github/codeql-config.yml
 
       - name: Build
         run: |

--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -140,8 +140,6 @@ public class CongressionalTradeSyncService
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
         var memberRepository = scope.ServiceProvider.GetRequiredService<CongressMemberRepository>();
-        var tradeRepository =
-            scope.ServiceProvider.GetRequiredService<CongressionalTradeRepository>();
         var commonStockRepository =
             scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
 

--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -1,6 +1,6 @@
 namespace Equibles.Errors.Data.Models;
 
-public class ErrorSource
+public sealed class ErrorSource
 {
     public string Value { get; }
 

--- a/src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingClient.cs
+++ b/src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingClient.cs
@@ -92,7 +92,7 @@ public class EmbeddingClient : IEmbeddingClient
             var singlePayload = new { model = _config.ModelName, input = batch[0] };
 
             var singleJson = JsonSerializer.Serialize(singlePayload);
-            var singleContent = new StringContent(
+            using var singleContent = new StringContent(
                 singleJson,
                 System.Text.Encoding.UTF8,
                 "application/json"
@@ -116,7 +116,11 @@ public class EmbeddingClient : IEmbeddingClient
             var payload = new { model = _config.ModelName, input = text };
 
             var json = JsonSerializer.Serialize(payload);
-            var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+            using var content = new StringContent(
+                json,
+                System.Text.Encoding.UTF8,
+                "application/json"
+            );
 
             var response = await _httpClient.PostAsync("/api/embed", content);
             response.EnsureSuccessStatusCode();

--- a/src/Equibles.Sec.Data/Models/DocumentType.cs
+++ b/src/Equibles.Sec.Data/Models/DocumentType.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 namespace Equibles.Sec.Data.Models;
 
 [TypeConverter(typeof(DocumentTypeConverter))]
-public class DocumentType
+public sealed class DocumentType
 {
     public string Value { get; }
     public string DisplayName { get; }

--- a/src/Equibles.Web/Controllers/Abstract/BaseController.cs
+++ b/src/Equibles.Web/Controllers/Abstract/BaseController.cs
@@ -16,13 +16,13 @@ public abstract class BaseController : Controller
     protected string GetReturnUrl()
     {
         string returnUrl = null;
-        if (Request.HasFormContentType && Request.Form.ContainsKey("ReturnUrl"))
+        if (Request.HasFormContentType && Request.Form.TryGetValue("ReturnUrl", out var formValue))
         {
-            returnUrl = Request.Form["ReturnUrl"].ToString();
+            returnUrl = formValue.ToString();
         }
-        else if (Request.Query.ContainsKey("ReturnUrl"))
+        else if (Request.Query.TryGetValue("ReturnUrl", out var queryValue))
         {
-            returnUrl = Request.Query["ReturnUrl"].ToString();
+            returnUrl = queryValue.ToString();
         }
 
         if (!string.IsNullOrEmpty(returnUrl) && Url.IsLocalUrl(returnUrl))

--- a/tests/Equibles.IntegrationTests/Cboe/CboePutCallRatioRepositoryGetLatestTests.cs
+++ b/tests/Equibles.IntegrationTests/Cboe/CboePutCallRatioRepositoryGetLatestTests.cs
@@ -23,32 +23,39 @@ public class CboePutCallRatioRepositoryGetLatestTests : ParadeDbMcpTestBase
     [Fact]
     public async Task GetLatestPerType_TotalAndEquityWithMultipleDates_ReturnsNewestPerRatioType()
     {
-        DbContext.Add(new CboePutCallRatio
-        {
-            RatioType = CboePutCallRatioType.Total,
-            Date = new DateOnly(2024, 12, 23),
-            PutCallRatio = 0.85m,
-        });
-        DbContext.Add(new CboePutCallRatio
-        {
-            RatioType = CboePutCallRatioType.Total,
-            Date = new DateOnly(2024, 12, 24),
-            PutCallRatio = 0.92m,
-        });
-        DbContext.Add(new CboePutCallRatio
-        {
-            RatioType = CboePutCallRatioType.Equity,
-            Date = new DateOnly(2024, 12, 20),
-            PutCallRatio = 0.65m,
-        });
+        DbContext.Add(
+            new CboePutCallRatio
+            {
+                RatioType = CboePutCallRatioType.Total,
+                Date = new DateOnly(2024, 12, 23),
+                PutCallRatio = 0.85m,
+            }
+        );
+        DbContext.Add(
+            new CboePutCallRatio
+            {
+                RatioType = CboePutCallRatioType.Total,
+                Date = new DateOnly(2024, 12, 24),
+                PutCallRatio = 0.92m,
+            }
+        );
+        DbContext.Add(
+            new CboePutCallRatio
+            {
+                RatioType = CboePutCallRatioType.Equity,
+                Date = new DateOnly(2024, 12, 20),
+                PutCallRatio = 0.65m,
+            }
+        );
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
         await using var verify = Fixture.CreateDbContext();
         var sut = new CboePutCallRatioRepository(verify);
 
-        var latest = (await sut.GetLatestPerType().AsNoTracking().ToListAsync())
-            .ToDictionary(r => r.RatioType);
+        var latest = (await sut.GetLatestPerType().AsNoTracking().ToListAsync()).ToDictionary(r =>
+            r.RatioType
+        );
 
         latest.Should().HaveCount(2);
         latest[CboePutCallRatioType.Total].Date.Should().Be(new DateOnly(2024, 12, 24));

--- a/tests/Equibles.IntegrationTests/Cftc/CftcContractRepositorySearchTests.cs
+++ b/tests/Equibles.IntegrationTests/Cftc/CftcContractRepositorySearchTests.cs
@@ -26,18 +26,22 @@ public class CftcContractRepositorySearchTests : ParadeDbMcpTestBase
         // Two contracts. The query "13874" matches only the first one's MarketCode.
         // The second contract's MarketName is "Crude Oil" — chosen so it cannot
         // accidentally match "13874" via the MarketName branch.
-        DbContext.Add(new CftcContract
-        {
-            MarketCode = "13874+",
-            MarketName = "E-MINI S&P 500",
-            Category = CftcContractCategory.EquityIndices,
-        });
-        DbContext.Add(new CftcContract
-        {
-            MarketCode = "06765A",
-            MarketName = "Crude Oil",
-            Category = CftcContractCategory.Energy,
-        });
+        DbContext.Add(
+            new CftcContract
+            {
+                MarketCode = "13874+",
+                MarketName = "E-MINI S&P 500",
+                Category = CftcContractCategory.EquityIndices,
+            }
+        );
+        DbContext.Add(
+            new CftcContract
+            {
+                MarketCode = "06765A",
+                MarketName = "Crude Oil",
+                Category = CftcContractCategory.Energy,
+            }
+        );
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 

--- a/tests/Equibles.IntegrationTests/Cftc/CftcPositionReportRepositoryGetLatestTests.cs
+++ b/tests/Equibles.IntegrationTests/Cftc/CftcPositionReportRepositoryGetLatestTests.cs
@@ -37,32 +37,39 @@ public class CftcPositionReportRepositoryGetLatestTests : ParadeDbMcpTestBase
         DbContext.Add(contractA);
         DbContext.Add(contractB);
 
-        DbContext.Add(new CftcPositionReport
-        {
-            CftcContractId = contractA.Id,
-            ReportDate = new DateOnly(2024, 11, 5),
-            OpenInterest = 2_400_000,
-        });
-        DbContext.Add(new CftcPositionReport
-        {
-            CftcContractId = contractA.Id,
-            ReportDate = new DateOnly(2024, 12, 24),
-            OpenInterest = 2_500_000,
-        });
-        DbContext.Add(new CftcPositionReport
-        {
-            CftcContractId = contractB.Id,
-            ReportDate = new DateOnly(2024, 12, 10),
-            OpenInterest = 1_800_000,
-        });
+        DbContext.Add(
+            new CftcPositionReport
+            {
+                CftcContractId = contractA.Id,
+                ReportDate = new DateOnly(2024, 11, 5),
+                OpenInterest = 2_400_000,
+            }
+        );
+        DbContext.Add(
+            new CftcPositionReport
+            {
+                CftcContractId = contractA.Id,
+                ReportDate = new DateOnly(2024, 12, 24),
+                OpenInterest = 2_500_000,
+            }
+        );
+        DbContext.Add(
+            new CftcPositionReport
+            {
+                CftcContractId = contractB.Id,
+                ReportDate = new DateOnly(2024, 12, 10),
+                OpenInterest = 1_800_000,
+            }
+        );
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
         await using var verify = Fixture.CreateDbContext();
         var sut = new CftcPositionReportRepository(verify);
 
-        var latest = (await sut.GetLatestPerContract().AsNoTracking().ToListAsync())
-            .ToDictionary(r => r.CftcContractId);
+        var latest = (await sut.GetLatestPerContract().AsNoTracking().ToListAsync()).ToDictionary(
+            r => r.CftcContractId
+        );
 
         latest.Should().HaveCount(2);
         latest[contractA.Id].ReportDate.Should().Be(new DateOnly(2024, 12, 24));

--- a/tests/Equibles.IntegrationTests/Congress/CongressMemberRepositoryPostgresSearchTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressMemberRepositoryPostgresSearchTests.cs
@@ -22,8 +22,16 @@ public class CongressMemberRepositoryPostgresSearchTests : ParadeDbMcpTestBase
     [Fact]
     public async Task Search_LowercaseSubstringAgainstTitleCasedName_ReturnsMatchViaILike()
     {
-        DbContext.Add(new CongressMember { Name = "Pelosi, Nancy", Position = CongressPosition.Representative });
-        DbContext.Add(new CongressMember { Name = "Tuberville, Tommy", Position = CongressPosition.Senator });
+        DbContext.Add(
+            new CongressMember
+            {
+                Name = "Pelosi, Nancy",
+                Position = CongressPosition.Representative,
+            }
+        );
+        DbContext.Add(
+            new CongressMember { Name = "Tuberville, Tommy", Position = CongressPosition.Senator }
+        );
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalTradeRepositoryDateRangeTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalTradeRepositoryDateRangeTests.cs
@@ -35,10 +35,10 @@ public class CongressionalTradeRepositoryDateRangeTests : ParadeDbMcpTestBase
         DbContext.Add(member);
 
         DbContext.Add(MakeTrade(stock, member, new DateOnly(2024, 11, 30))); // BEFORE start — excluded
-        DbContext.Add(MakeTrade(stock, member, new DateOnly(2024, 12, 1)));  // ON start — INCLUDED
+        DbContext.Add(MakeTrade(stock, member, new DateOnly(2024, 12, 1))); // ON start — INCLUDED
         DbContext.Add(MakeTrade(stock, member, new DateOnly(2024, 12, 15))); // INSIDE — INCLUDED
         DbContext.Add(MakeTrade(stock, member, new DateOnly(2024, 12, 31))); // ON end — INCLUDED
-        DbContext.Add(MakeTrade(stock, member, new DateOnly(2025, 1, 1)));   // AFTER end — excluded
+        DbContext.Add(MakeTrade(stock, member, new DateOnly(2025, 1, 1))); // AFTER end — excluded
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
@@ -46,34 +46,43 @@ public class CongressionalTradeRepositoryDateRangeTests : ParadeDbMcpTestBase
         var trackedStock = verify.Set<CommonStock>().Single(s => s.Ticker == "AAPL");
         var sut = new CongressionalTradeRepository(verify);
 
-        var trades = await sut
-            .GetByStock(trackedStock, new DateOnly(2024, 12, 1), new DateOnly(2024, 12, 31))
+        var trades = await sut.GetByStock(
+                trackedStock,
+                new DateOnly(2024, 12, 1),
+                new DateOnly(2024, 12, 31)
+            )
             .AsNoTracking()
             .ToListAsync();
 
         trades.Should().HaveCount(3);
-        trades.Select(t => t.TransactionDate).Should().BeEquivalentTo(new[]
-        {
-            new DateOnly(2024, 12, 1),
-            new DateOnly(2024, 12, 15),
-            new DateOnly(2024, 12, 31),
-        });
+        trades
+            .Select(t => t.TransactionDate)
+            .Should()
+            .BeEquivalentTo(
+                new[]
+                {
+                    new DateOnly(2024, 12, 1),
+                    new DateOnly(2024, 12, 15),
+                    new DateOnly(2024, 12, 31),
+                }
+            );
     }
 
     private static CongressionalTrade MakeTrade(
         CommonStock stock,
         CongressMember member,
         DateOnly transactionDate
-    ) => new()
-    {
-        CommonStock = stock,
-        CongressMember = member,
-        TransactionDate = transactionDate,
-        FilingDate = transactionDate.AddDays(10),
-        TransactionType = CongressTransactionType.Purchase,
-        OwnerType = "Self",
-        AssetName = "Apple Inc.",
-        AmountFrom = 1000,
-        AmountTo = 15000,
-    };
+    ) =>
+        new()
+        {
+            CommonStock = stock,
+            CongressMember = member,
+            TransactionDate = transactionDate,
+            FilingDate = transactionDate.AddDays(10),
+            TransactionType = CongressTransactionType.Purchase,
+            OwnerType = "Self",
+            AssetName = "Apple Inc.",
+            AmountFrom = 1000,
+            AmountTo = 15000,
+        };
 }

--- a/tests/Equibles.IntegrationTests/Finra/FinraClientSettlementDatesAfterTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraClientSettlementDatesAfterTests.cs
@@ -74,9 +74,10 @@ public class FinraClientSettlementDatesAfterTests
             }
             else
             {
-                LastDataRequestBody = request.Content != null
-                    ? await request.Content.ReadAsStringAsync(cancellationToken)
-                    : "";
+                LastDataRequestBody =
+                    request.Content != null
+                        ? await request.Content.ReadAsStringAsync(cancellationToken)
+                        : "";
                 body = _dataBody;
             }
             return new HttpResponseMessage(HttpStatusCode.OK)

--- a/tests/Equibles.IntegrationTests/Finra/FinraClientSettlementDatesAllTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraClientSettlementDatesAllTests.cs
@@ -66,9 +66,10 @@ public class FinraClientSettlementDatesAllTests
             }
             else
             {
-                LastDataRequestBody = request.Content != null
-                    ? await request.Content.ReadAsStringAsync(cancellationToken)
-                    : "";
+                LastDataRequestBody =
+                    request.Content != null
+                        ? await request.Content.ReadAsStringAsync(cancellationToken)
+                        : "";
                 body = _dataBody;
             }
             return new HttpResponseMessage(HttpStatusCode.OK)

--- a/tests/Equibles.IntegrationTests/Fred/FredObservationRepositoryGetLatestTests.cs
+++ b/tests/Equibles.IntegrationTests/Fred/FredObservationRepositoryGetLatestTests.cs
@@ -33,12 +33,40 @@ public class FredObservationRepositoryGetLatestTests : ParadeDbMcpTestBase
         // seriesA: two observations, the older one with a real value, the newer
         // one with null (FRED reports "." for missing dates). The query must
         // SKIP the null row and surface the older real value as "latest".
-        DbContext.Add(new FredObservation { FredSeriesId = seriesA.Id, Date = new DateOnly(2024, 12, 1), Value = 4.25m });
-        DbContext.Add(new FredObservation { FredSeriesId = seriesA.Id, Date = new DateOnly(2024, 12, 8), Value = null });
+        DbContext.Add(
+            new FredObservation
+            {
+                FredSeriesId = seriesA.Id,
+                Date = new DateOnly(2024, 12, 1),
+                Value = 4.25m,
+            }
+        );
+        DbContext.Add(
+            new FredObservation
+            {
+                FredSeriesId = seriesA.Id,
+                Date = new DateOnly(2024, 12, 8),
+                Value = null,
+            }
+        );
 
         // seriesB: two real values — must pick the newer one.
-        DbContext.Add(new FredObservation { FredSeriesId = seriesB.Id, Date = new DateOnly(2024, 11, 1), Value = 4.1m });
-        DbContext.Add(new FredObservation { FredSeriesId = seriesB.Id, Date = new DateOnly(2024, 12, 1), Value = 4.2m });
+        DbContext.Add(
+            new FredObservation
+            {
+                FredSeriesId = seriesB.Id,
+                Date = new DateOnly(2024, 11, 1),
+                Value = 4.1m,
+            }
+        );
+        DbContext.Add(
+            new FredObservation
+            {
+                FredSeriesId = seriesB.Id,
+                Date = new DateOnly(2024, 12, 1),
+                Value = 4.2m,
+            }
+        );
 
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
@@ -46,8 +74,9 @@ public class FredObservationRepositoryGetLatestTests : ParadeDbMcpTestBase
         await using var verify = Fixture.CreateDbContext();
         var sut = new FredObservationRepository(verify);
 
-        var latest = (await sut.GetLatestPerSeries().AsNoTracking().ToListAsync())
-            .ToDictionary(o => o.FredSeriesId);
+        var latest = (await sut.GetLatestPerSeries().AsNoTracking().ToListAsync()).ToDictionary(o =>
+            o.FredSeriesId
+        );
 
         latest.Should().HaveCount(2);
         latest[seriesA.Id].Date.Should().Be(new DateOnly(2024, 12, 1));

--- a/tests/Equibles.IntegrationTests/Fred/FredSeriesRepositorySearchTests.cs
+++ b/tests/Equibles.IntegrationTests/Fred/FredSeriesRepositorySearchTests.cs
@@ -23,16 +23,8 @@ public class FredSeriesRepositorySearchTests : ParadeDbMcpTestBase
     [Fact]
     public async Task Search_LowercaseQueryAgainstUppercaseSeriesId_MatchesViaSeriesIdBranchCaseInsensitive()
     {
-        DbContext.Add(new FredSeries
-        {
-            SeriesId = "GDP",
-            Title = "Gross Domestic Product",
-        });
-        DbContext.Add(new FredSeries
-        {
-            SeriesId = "UNRATE",
-            Title = "Unemployment Rate",
-        });
+        DbContext.Add(new FredSeries { SeriesId = "GDP", Title = "Gross Domestic Product" });
+        DbContext.Add(new FredSeries { SeriesId = "UNRATE", Title = "Unemployment Rate" });
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRecalculateTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRecalculateTests.cs
@@ -46,8 +46,7 @@ public class HoldingsScraperWorkerRecalculateTests
             BindingFlags.NonPublic | BindingFlags.Instance
         );
 
-        var act = async () =>
-            await (Task)method.Invoke(worker, [CancellationToken.None]);
+        var act = async () => await (Task)method.Invoke(worker, [CancellationToken.None]);
 
         // Reflection wraps user exceptions in TargetInvocationException, but the
         // catch in the production method should swallow this entirely — assert no

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHolderRepositoryPostgresSearchTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHolderRepositoryPostgresSearchTests.cs
@@ -23,7 +23,9 @@ public class InstitutionalHolderRepositoryPostgresSearchTests : ParadeDbMcpTestB
     [Fact]
     public async Task Search_LowercaseSubstringAcrossMultipleHolders_ReturnsOnlyTheMatchViaILike()
     {
-        DbContext.Add(new InstitutionalHolder { Cik = "0001067983", Name = "Berkshire Hathaway Inc." });
+        DbContext.Add(
+            new InstitutionalHolder { Cik = "0001067983", Name = "Berkshire Hathaway Inc." }
+        );
         DbContext.Add(new InstitutionalHolder { Cik = "0001364742", Name = "BlackRock Inc." });
         DbContext.Add(new InstitutionalHolder { Cik = "0000102909", Name = "Vanguard Group Inc." });
         await DbContext.SaveChangesAsync();

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioTests.cs
@@ -29,17 +29,31 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioTests : ParadeDbMc
     public async Task GetInstitutionPortfolio_BigValueLowSharesVsLowValueBigShares_RanksByValueDescending()
     {
         var holder = new InstitutionalHolder { Cik = "1", Name = "Berkshire Hathaway Inc." };
-        var bigDollar = new CommonStock { Ticker = "AAPL", Name = "Apple Inc.", Cik = "0000320193" };
-        var pennyStock = new CommonStock { Ticker = "PNY", Name = "Penny Stock Co.", Cik = "0001999999" };
+        var bigDollar = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var pennyStock = new CommonStock
+        {
+            Ticker = "PNY",
+            Name = "Penny Stock Co.",
+            Cik = "0001999999",
+        };
         DbContext.Add(holder);
         DbContext.Add(bigDollar);
         DbContext.Add(pennyStock);
 
         var reportDate = new DateOnly(2024, 12, 31);
         // AAPL: fewer shares, but each share is worth more → larger Value.
-        DbContext.Add(MakeHolding(holder, bigDollar, reportDate, shares: 1_000, value: 100_000_000));
+        DbContext.Add(
+            MakeHolding(holder, bigDollar, reportDate, shares: 1_000, value: 100_000_000)
+        );
         // Penny: many more shares, but each is worth far less → smaller Value.
-        DbContext.Add(MakeHolding(holder, pennyStock, reportDate, shares: 1_000_000, value: 1_000_000));
+        DbContext.Add(
+            MakeHolding(holder, pennyStock, reportDate, shares: 1_000_000, value: 1_000_000)
+        );
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
@@ -69,16 +83,17 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioTests : ParadeDbMc
         DateOnly reportDate,
         long shares,
         long value
-    ) => new()
-    {
-        CommonStockId = stock.Id,
-        InstitutionalHolderId = holder.Id,
-        FilingDate = reportDate.AddDays(45),
-        ReportDate = reportDate,
-        Shares = shares,
-        Value = value,
-        ShareType = ShareType.Shares,
-        InvestmentDiscretion = InvestmentDiscretion.Sole,
-        AccessionNumber = $"acc-{stock.Ticker}",
-    };
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stock.Ticker}",
+        };
 }

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopHoldersTests.cs
@@ -29,7 +29,12 @@ public class InstitutionalHoldingsToolsGetTopHoldersTests : ParadeDbMcpTestBase
     [Fact]
     public async Task GetTopHolders_TwoHoldersWithLargeRatio_RanksByShareCountWithCorrectPercentages()
     {
-        var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc.", Cik = "0000320193" };
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
         var bigHolder = new InstitutionalHolder { Cik = "1", Name = "Vanguard Group Inc." };
         var smallHolder = new InstitutionalHolder { Cik = "2", Name = "Tiny Capital LLC" };
         DbContext.Add(stock);
@@ -68,16 +73,17 @@ public class InstitutionalHoldingsToolsGetTopHoldersTests : ParadeDbMcpTestBase
         InstitutionalHolder holder,
         DateOnly reportDate,
         long shares
-    ) => new()
-    {
-        CommonStockId = stock.Id,
-        InstitutionalHolderId = holder.Id,
-        FilingDate = reportDate.AddDays(45),
-        ReportDate = reportDate,
-        Shares = shares,
-        Value = shares * 100,
-        ShareType = ShareType.Shares,
-        InvestmentDiscretion = InvestmentDiscretion.Sole,
-        AccessionNumber = $"acc-{holder.Cik}",
-    };
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = shares * 100,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}",
+        };
 }

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryTests.cs
@@ -28,7 +28,12 @@ public class InstitutionalHoldingsToolsOwnershipHistoryTests : ParadeDbMcpTestBa
     [Fact]
     public async Task GetOwnershipHistory_QuarterOverQuarterIncrease_RendersPlusSignedPercentChange()
     {
-        var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc.", Cik = "0000320193" };
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
         var holder = new InstitutionalHolder
         {
             Cik = "0001067983",
@@ -67,16 +72,17 @@ public class InstitutionalHoldingsToolsOwnershipHistoryTests : ParadeDbMcpTestBa
         InstitutionalHolder holder,
         DateOnly reportDate,
         long shares
-    ) => new()
-    {
-        CommonStockId = stock.Id,
-        InstitutionalHolderId = holder.Id,
-        FilingDate = reportDate.AddDays(45),
-        ReportDate = reportDate,
-        Shares = shares,
-        Value = shares * 100,
-        ShareType = ShareType.Shares,
-        InvestmentDiscretion = InvestmentDiscretion.Sole,
-        AccessionNumber = $"acc-{reportDate:yyyyMMdd}",
-    };
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = shares * 100,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{reportDate:yyyyMMdd}",
+        };
 }

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsSearchTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsSearchTests.cs
@@ -26,20 +26,24 @@ public class InstitutionalHoldingsToolsSearchTests : ParadeDbMcpTestBase
     [Fact]
     public async Task SearchInstitutions_LowercaseQuery_RendersMarkdownTableWithCikCityState()
     {
-        DbContext.Add(new InstitutionalHolder
-        {
-            Cik = "0001067983",
-            Name = "Berkshire Hathaway Inc.",
-            City = "Omaha",
-            StateOrCountry = "NE",
-        });
-        DbContext.Add(new InstitutionalHolder
-        {
-            Cik = "0001364742",
-            Name = "BlackRock Inc.",
-            City = "New York",
-            StateOrCountry = "NY",
-        });
+        DbContext.Add(
+            new InstitutionalHolder
+            {
+                Cik = "0001067983",
+                Name = "Berkshire Hathaway Inc.",
+                City = "Omaha",
+                StateOrCountry = "NE",
+            }
+        );
+        DbContext.Add(
+            new InstitutionalHolder
+            {
+                Cik = "0001364742",
+                Name = "BlackRock Inc.",
+                City = "New York",
+                StateOrCountry = "NY",
+            }
+        );
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
@@ -4,9 +4,9 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Configuration;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
-using Equibles.IntegrationTests.Helpers;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -52,16 +52,20 @@ public class CompanySyncServiceReplaceObsoleteTests : ParadeDbMcpTestBase
         // The obsolete CIK is not in the feed → its row is removed; the new one
         // takes the ticker.
         var secEdgarClient = Substitute.For<ISecEdgarClient>();
-        secEdgarClient.GetActiveCompanies().Returns(new List<CompanyInfo>
-        {
-            new()
-            {
-                Cik = "0000000111",
-                Name = "Acquirer Inc.",
-                Tickers = ["REUSED"],
-                EntityType = "operating",
-            },
-        });
+        secEdgarClient
+            .GetActiveCompanies()
+            .Returns(
+                new List<CompanyInfo>
+                {
+                    new()
+                    {
+                        Cik = "0000000111",
+                        Name = "Acquirer Inc.",
+                        Tickers = ["REUSED"],
+                        EntityType = "operating",
+                    },
+                }
+            );
 
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceResolveCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceResolveCollisionTests.cs
@@ -4,9 +4,9 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Configuration;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
-using Equibles.IntegrationTests.Helpers;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -54,38 +54,50 @@ public class CompanySyncServiceResolveCollisionTests : ParadeDbMcpTestBase
         // through UpdateExistingStock; the subsidiary then hits the
         // ReplaceObsolete branch which routes to ResolveTickerCollision.
         var secEdgarClient = Substitute.For<ISecEdgarClient>();
-        secEdgarClient.GetActiveCompanies().Returns(new List<CompanyInfo>
-        {
-            new()
-            {
-                Cik = "0001719395",
-                Name = "ATAI Life Sciences N.V.",
-                Tickers = ["ATAI"],
-                EntityType = "operating",
-            },
-            new()
-            {
-                Cik = "0001999999",
-                Name = "AtaiBeckley Subsidiary",
-                Tickers = ["ATAI"],
-                EntityType = "operating",
-            },
-        });
+        secEdgarClient
+            .GetActiveCompanies()
+            .Returns(
+                new List<CompanyInfo>
+                {
+                    new()
+                    {
+                        Cik = "0001719395",
+                        Name = "ATAI Life Sciences N.V.",
+                        Tickers = ["ATAI"],
+                        EntityType = "operating",
+                    },
+                    new()
+                    {
+                        Cik = "0001999999",
+                        Name = "AtaiBeckley Subsidiary",
+                        Tickers = ["ATAI"],
+                        EntityType = "operating",
+                    },
+                }
+            );
         // Both metadata records satisfy IsListed (a real exchange) and
         // IsOperatingCompany (entityType "operating"), so the priority chain
         // falls to the lower-CIK tiebreak — incumbent (lower) wins.
-        secEdgarClient.GetCompanyMetadata("0001719395").Returns(new CompanyMetadata
-        {
-            Cik = "0001719395",
-            EntityType = "operating",
-            Exchanges = ["Nasdaq"],
-        });
-        secEdgarClient.GetCompanyMetadata("0001999999").Returns(new CompanyMetadata
-        {
-            Cik = "0001999999",
-            EntityType = "operating",
-            Exchanges = ["Nasdaq"],
-        });
+        secEdgarClient
+            .GetCompanyMetadata("0001719395")
+            .Returns(
+                new CompanyMetadata
+                {
+                    Cik = "0001719395",
+                    EntityType = "operating",
+                    Exchanges = ["Nasdaq"],
+                }
+            );
+        secEdgarClient
+            .GetCompanyMetadata("0001999999")
+            .Returns(
+                new CompanyMetadata
+                {
+                    Cik = "0001999999",
+                    EntityType = "operating",
+                    Exchanges = ["Nasdaq"],
+                }
+            );
 
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingTests.cs
@@ -4,9 +4,9 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Configuration;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
-using Equibles.IntegrationTests.Helpers;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -48,16 +48,20 @@ public class CompanySyncServiceUpdateExistingTests : ParadeDbMcpTestBase
         DbContext.ChangeTracker.Clear();
 
         var secEdgarClient = Substitute.For<ISecEdgarClient>();
-        secEdgarClient.GetActiveCompanies().Returns(new List<CompanyInfo>
-        {
-            new()
-            {
-                Cik = "0001067983",
-                Name = "Berkshire Hathaway Inc.",
-                Tickers = ["BRK.A", "BRK.B"],
-                EntityType = "operating",
-            },
-        });
+        secEdgarClient
+            .GetActiveCompanies()
+            .Returns(
+                new List<CompanyInfo>
+                {
+                    new()
+                    {
+                        Cik = "0001067983",
+                        Name = "Berkshire Hathaway Inc.",
+                        Tickers = ["BRK.A", "BRK.B"],
+                        EntityType = "operating",
+                    },
+                }
+            );
 
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorGenerateEmbeddingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorGenerateEmbeddingsTests.cs
@@ -71,11 +71,13 @@ public class DocumentProcessorGenerateEmbeddingsTests
         addedEmbeddings[0].Chunk.Content.Should().Be("first");
         addedEmbeddings[1].Chunk.Content.Should().Be("second");
         addedEmbeddings[2].Chunk.Content.Should().Be("third");
-        addedEmbeddings.Should().AllSatisfy(e =>
-        {
-            e.Model.Should().Be("nomic-embed-text");
-            e.VectorDimension.Should().Be(2);
-        });
+        addedEmbeddings
+            .Should()
+            .AllSatisfy(e =>
+            {
+                e.Model.Should().Be("nomic-embed-text");
+                e.VectorDimension.Should().Be(2);
+            });
         await embeddingRepository.Received(1).SaveChanges();
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/DocumentRepositoryExistsTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentRepositoryExistsTests.cs
@@ -27,7 +27,10 @@ public class DocumentRepositoryExistsTests : ParadeDbMcpTestBase
         var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
         var file = new File
         {
-            Name = "10k", Extension = "htm", ContentType = "text/html", Size = 1,
+            Name = "10k",
+            Extension = "htm",
+            ContentType = "text/html",
+            Size = 1,
             FileContent = new FileContent { Bytes = new byte[] { 0x01 } },
         };
         var seeded = new Document

--- a/tests/Equibles.IntegrationTests/Sec/DocumentScraperCompanySyncFailureTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentScraperCompanySyncFailureTests.cs
@@ -27,7 +27,8 @@ public class DocumentScraperCompanySyncFailureTests
     public async Task ScrapeDocuments_CompanySyncThrows_RecordsErrorAndReportsToErrorReporter()
     {
         var companySync = Substitute.For<ICompanySyncService>();
-        companySync.SyncCompaniesFromSecApi()
+        companySync
+            .SyncCompaniesFromSecApi()
             .Returns<Task>(_ => throw new HttpRequestException("SEC EDGAR 503"));
 
         var errorReporter = Substitute.For<ErrorReporter>(
@@ -48,16 +49,17 @@ public class DocumentScraperCompanySyncFailureTests
         var result = await sut.ScrapeDocuments(CancellationToken.None);
 
         result.Errors.Should().Be(1);
-        result.ErrorMessages.Should().ContainSingle()
-            .Which.Should().Contain("SEC EDGAR 503");
+        result.ErrorMessages.Should().ContainSingle().Which.Should().Contain("SEC EDGAR 503");
         // ErrorReporter.Report must be invoked once with DocumentScraper source
         // and the operation name — pins the public-facing error contract.
-        await errorReporter.Received(1).Report(
-            ErrorSource.DocumentScraper,
-            "DocumentScraper.ScrapeDocuments",
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>()
-        );
+        await errorReporter
+            .Received(1)
+            .Report(
+                ErrorSource.DocumentScraper,
+                "DocumentScraper.ScrapeDocuments",
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>()
+            );
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesTests.cs
@@ -29,7 +29,7 @@ public class DocumentTextToolsReadLinesTests : ParadeDbMcpTestBase
     [Fact]
     public async Task ReadDocumentLines_EndLineExceedsDocumentLength_ClampsToTotalAndReturnsRemainingLines()
     {
-        var content = "Alpha\nBeta\nGamma";  // 3 lines total
+        var content = "Alpha\nBeta\nGamma"; // 3 lines total
         var stock = new CommonStock { Ticker = "MSFT", Name = "Microsoft Corp." };
         var file = new File
         {
@@ -66,6 +66,6 @@ public class DocumentTextToolsReadLinesTests : ParadeDbMcpTestBase
         output.Should().Contain("lines 2 to 3 of 3");
         output.Should().Contain("     2 │ Beta");
         output.Should().Contain("     3 │ Gamma");
-        output.Should().NotContain("Alpha");  // startLine=2 excludes line 1
+        output.Should().NotContain("Alpha"); // startLine=2 excludes line 1
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsSearchKeywordTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsSearchKeywordTests.cs
@@ -31,7 +31,8 @@ public class DocumentTextToolsSearchKeywordTests : ParadeDbMcpTestBase
     {
         // Three lines so the match on line 2 produces both "line before" + "line after"
         // context — pins the branches at L77 (i > 0) and L87 (i < lines.Length - 1).
-        var content = "First line of the filing.\n"
+        var content =
+            "First line of the filing.\n"
             + "Revenue grew 15% year-over-year.\n"
             + "Operating expenses remained stable.";
         var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
@@ -68,8 +69,8 @@ public class DocumentTextToolsSearchKeywordTests : ParadeDbMcpTestBase
         var output = await sut.SearchDocumentKeyword(document.Id, "revenue");
 
         output.Should().Contain("1 matches found");
-        output.Should().Contain("**Revenue**");          // preserves original casing inside markers
-        output.Should().Contain("First line of the filing.");      // line before
+        output.Should().Contain("**Revenue**"); // preserves original casing inside markers
+        output.Should().Contain("First line of the filing."); // line before
         output.Should().Contain("Operating expenses remained stable."); // line after
         // Gutter is right-aligned 6-wide — drop the padding and downstream MCP clients
         // lose the column alignment they rely on for jump-to-line navigation.

--- a/tests/Equibles.IntegrationTests/Sec/EmbeddingRepositorySearchWithThresholdTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/EmbeddingRepositorySearchWithThresholdTests.cs
@@ -80,24 +80,26 @@ public class EmbeddingRepositorySearchWithThresholdTests : ParadeDbMcpTestBase
         results[0].ChunkId.Should().Be(chunkX.Id);
     }
 
-    private static Chunk MakeChunk(Document document, string content, int index) => new()
-    {
-        DocumentId = document.Id,
-        Content = content,
-        Index = index,
-        StartPosition = index * 100,
-        EndPosition = (index + 1) * 100,
-        StartLineNumber = index + 1,
-        DocumentType = document.DocumentType,
-        Ticker = "AAPL",
-        ReportingDate = document.ReportingDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
-    };
+    private static Chunk MakeChunk(Document document, string content, int index) =>
+        new()
+        {
+            DocumentId = document.Id,
+            Content = content,
+            Index = index,
+            StartPosition = index * 100,
+            EndPosition = (index + 1) * 100,
+            StartLineNumber = index + 1,
+            DocumentType = document.DocumentType,
+            Ticker = "AAPL",
+            ReportingDate = document.ReportingDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+        };
 
-    private static Embedding MakeEmbedding(Guid chunkId, float[] vec) => new()
-    {
-        ChunkId = chunkId,
-        Model = Model,
-        Vector = new Vector(new ReadOnlyMemory<float>(vec)),
-        VectorDimension = vec.Length,
-    };
+    private static Embedding MakeEmbedding(Guid chunkId, float[] vec) =>
+        new()
+        {
+            ChunkId = chunkId,
+            Model = Model,
+            Vector = new Vector(new ReadOnlyMemory<float>(vec)),
+            VectorDimension = vec.Length,
+        };
 }

--- a/tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDocumentFileBytesTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDocumentFileBytesTests.cs
@@ -44,7 +44,8 @@ public class SecEdgarClientGetDocumentFileBytesTests
         bytes.Should().Equal(payload);
 
         // Expected: unpadded cik + accession-no-dashes + URL-escaped filename.
-        handler.LastUrl.Should()
+        handler
+            .LastUrl.Should()
             .Be("https://www.sec.gov/Archives/edgar/data/320193/000032019325000001/primary.htm");
     }
 


### PR DESCRIPTION
## Summary

CodeQL had 248 open alerts. Most were noise from generated code and test fixtures, with a handful of real but minor issues in production code. This PR:

- **Fixes the real production-code findings in source.**
- **Adds a CodeQL config** (`.github/codeql-config.yml`) so future scans don't re-surface the noisy ones — analysis now skips `**/obj/**` (generated Razor/Regex output), `**/bin/**`, and `tests/**`.
- **Bulk-dismisses the remaining 241 alerts** outside this PR (false-positive / won't-fix / used-in-tests), all categorized by rule and path. The 7 alerts still open are exactly the ones this PR fixes; the next scan will auto-close them.

## Code changes

| File | Change |
|---|---|
| `.github/codeql-config.yml` (new) | Scope analysis: paths-ignore `**/obj/**`, `**/bin/**`, `tests/**`; keep `security-and-quality` suite. |
| `.github/workflows/codeql.yml` | Wire the config in via `config-file`. |
| `src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingClient.cs` | Wrap `StringContent` in `using` (2 call sites in `ProcessBatch`) so the request body is disposed deterministically. |
| `src/Equibles.Web/Controllers/Abstract/BaseController.cs` | `GetReturnUrl`: switch `ContainsKey + indexer` to `TryGetValue` — one lookup instead of two against both `Request.Form` and `Request.Query`. |
| `src/Equibles.Sec.Data/Models/DocumentType.cs` | Mark class `sealed` — `Equals` uses `obj is DocumentType`, which is unsound with subclasses. No subclasses exist; sealing makes the cast pattern correct. |
| `src/Equibles.Errors.Data/Models/ErrorSource.cs` | Same — mark `sealed`. |
| `src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs` | Remove dead `tradeRepository` scoped resolve in `ProcessTransactions` (never read after assignment). |

## Test plan

- [x] `dotnet build Equibles.sln -c Release` — succeeds, 0 errors, 22 pre-existing warnings unrelated to this change.
- [ ] CodeQL workflow runs green on this PR and the 7 fix-tracked alerts auto-close.