### PR TITLE
style: apply csharpier formatting to StatusController test backlog

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/StatusControllerDeleteAllTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerDeleteAllTests.cs
@@ -1,4 +1,7 @@
+using Equibles.Cboe.Repositories;
+using Equibles.Cftc.Repositories;
 using Equibles.CommonStocks.Repositories;
+using Equibles.Congress.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Errors.Repositories;
@@ -7,9 +10,6 @@ using Equibles.Fred.Repositories;
 using Equibles.Holdings.Repositories;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
-using Equibles.Cboe.Repositories;
-using Equibles.Cftc.Repositories;
-using Equibles.Congress.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
 using Equibles.Web.FlashMessage.Contracts;
@@ -46,24 +46,36 @@ public class StatusControllerDeleteAllTests : ParadeDbMcpTestBase
     [Fact]
     public async Task DeleteAll_ThreeErrorsAcrossSources_WipesEveryRowAndRedirectsToIndex()
     {
-        DbContext.Set<Error>().Add(new Error
-        {
-            Source = ErrorSource.Other,
-            Context = "C1",
-            Message = "M1",
-        });
-        DbContext.Set<Error>().Add(new Error
-        {
-            Source = ErrorSource.DocumentScraper,
-            Context = "C2",
-            Message = "M2",
-        });
-        DbContext.Set<Error>().Add(new Error
-        {
-            Source = ErrorSource.CongressScraper,
-            Context = "C3",
-            Message = "M3",
-        });
+        DbContext
+            .Set<Error>()
+            .Add(
+                new Error
+                {
+                    Source = ErrorSource.Other,
+                    Context = "C1",
+                    Message = "M1",
+                }
+            );
+        DbContext
+            .Set<Error>()
+            .Add(
+                new Error
+                {
+                    Source = ErrorSource.DocumentScraper,
+                    Context = "C2",
+                    Message = "M2",
+                }
+            );
+        DbContext
+            .Set<Error>()
+            .Add(
+                new Error
+                {
+                    Source = ErrorSource.CongressScraper,
+                    Context = "C3",
+                    Message = "M3",
+                }
+            );
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerDeleteHappyTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerDeleteHappyTests.cs
@@ -123,6 +123,8 @@ public class StatusControllerDeleteHappyTests : IDisposable
         flashMessage.Received(1).Success("Error deleted.");
         // The row must be gone — a regression that called Detach instead of
         // Remove would still pass the redirect assertion but leak the row.
-        (await _dbContext.Set<Error>().AnyAsync(e => e.Id == error.Id)).Should().BeFalse();
+        (await _dbContext.Set<Error>().AnyAsync(e => e.Id == error.Id))
+            .Should()
+            .BeFalse();
     }
 }

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerMarkAsSeenHappyTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerMarkAsSeenHappyTests.cs
@@ -124,7 +124,10 @@ public class StatusControllerMarkAsSeenHappyTests : IDisposable
         redirect.ActionName.Should().Be(nameof(StatusController.Show));
         redirect.RouteValues!["id"].Should().Be(error.Id);
         flashMessage.Received(1).Success("Error marked as seen.");
-        var refreshed = await _dbContext.Set<Error>().AsNoTracking().SingleAsync(e => e.Id == error.Id);
+        var refreshed = await _dbContext
+            .Set<Error>()
+            .AsNoTracking()
+            .SingleAsync(e => e.Id == error.Id);
         refreshed.Seen.Should().BeTrue();
     }
 }


### PR DESCRIPTION
## Summary

`main` has been lint-failing for several consecutive merges (#573, #574). The StatusController test PRs landed unformatted, so every downstream PR's `lint` job fails. This applies `dotnet csharpier format .` to clear the backlog.

## Code changes

| File | Change |
|---|---|
| `tests/Equibles.IntegrationTests/Web/StatusControllerMarkAsSeenHappyTests.cs` | csharpier-format |
| `tests/Equibles.IntegrationTests/Web/StatusControllerDeleteHappyTests.cs` | csharpier-format |
| `tests/Equibles.IntegrationTests/Web/StatusControllerDeleteAllTests.cs` | csharpier-format |

## Test plan

- [x] `dotnet csharpier check .` — passes locally.