### PR TITLE
test(sec): pin SecEdgarClient.GetEntityType null-safe on null submissions JSON

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetEntityTypeTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetEntityTypeTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using Equibles.Integrations.Sec;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// <c>GetEntityType</c> is the thin delegating wrapper CompanySyncService calls
+/// per CIK to decide operating-company vs non-issuer. It was only ever exercised
+/// through an NSubstitute mock — the real method (and the
+/// <c>apiResponse == null</c> branch of <c>GetCompanyMetadata</c> it sits on)
+/// had no coverage. This pins the null-safe path: when the SEC submissions
+/// endpoint returns a literal JSON <c>null</c>, <c>GetEntityType</c> must yield
+/// <c>null</c> via <c>metadata?.EntityType</c>, not NRE. Dropping the
+/// null-conditional would crash the entire company sync on the first CIK with
+/// an empty submissions document.
+/// </summary>
+public class SecEdgarClientGetEntityTypeTests
+{
+    [Fact]
+    public async Task GetEntityType_SubmissionsJsonIsLiteralNull_ReturnsNullWithoutThrowing()
+    {
+        var handler = new ConstantHandler("null");
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string> { ["Sec:ContactEmail"] = "test@example.com" }
+            )
+            .Build();
+        var sut = new SecEdgarClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<SecEdgarClient>>(),
+            config
+        );
+
+        var entityType = await sut.GetEntityType("1234567");
+
+        entityType.Should().BeNull();
+    }
+
+    private sealed class ConstantHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+
+        public ConstantHandler(string body) => _body = body;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_body) }
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- `GetEntityType` (the wrapper CompanySyncService calls per CIK) was only exercised through an NSubstitute mock — the real method and the `apiResponse == null` branch of `GetCompanyMetadata` it delegates to had no coverage.
- Adds one integration test serving a literal JSON `null` from the SEC submissions endpoint, asserting `GetEntityType` returns `null` via `metadata?.EntityType` instead of NRE-ing. Pins against a regression that would crash the entire company sync on the first CIK with an empty submissions document.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetEntityTypeTests.cs` — new integration test `GetEntityType_SubmissionsJsonIsLiteralNull_ReturnsNullWithoutThrowing` using a constant mock `HttpMessageHandler`.