### PR TITLE
test(yahoo): pin YahooFinanceClient.GetHistoricalPrices empty chart returns []

### DIFF
--- a/tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalEmptyResultTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalEmptyResultTests.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using System.Text;
+using Equibles.Integrations.Yahoo;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Yahoo;
+
+/// <summary>
+/// Sibling to <see cref="YahooFinanceClientHistoricalTests"/>, which pins the
+/// populated chart path. This pins the empty path: Yahoo returns
+/// <c>{"chart":{"result":[]}}</c> for a delisted or invalid ticker, so
+/// <c>result?.Chart?.Result?.FirstOrDefault()</c> is null. <c>GetHistoricalPrices</c>
+/// must return an empty list via the <c>result?.Timestamp == null</c> guard, not
+/// NRE walking <c>result.Timestamp</c>. The daily price scrape iterates every
+/// tracked stock; dropping that guard would crash the whole run on the first
+/// ticker Yahoo no longer charts.
+/// </summary>
+public class YahooFinanceClientHistoricalEmptyResultTests
+{
+    [Fact]
+    public async Task GetHistoricalPrices_EmptyChartResult_ReturnsEmptyList()
+    {
+        var json = "{\"chart\":{\"result\":[]}}";
+
+        var sut = new YahooFinanceClient(
+            new HttpClient(new StubHandler(json)),
+            Substitute.For<ILogger<YahooFinanceClient>>()
+        );
+
+        var prices = await sut.GetHistoricalPrices(
+            "DELISTED",
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2024, 1, 31)
+        );
+
+        prices.Should().BeEmpty();
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+
+        public StubHandler(string body) => _body = body;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+                }
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- `YahooFinanceClientHistoricalTests` pins the populated chart path; the empty path (Yahoo returns `{"chart":{"result":[]}}` for a delisted/invalid ticker) had no coverage.
- Adds one integration test asserting `GetHistoricalPrices` returns an empty list via the `result?.Timestamp == null` guard rather than NRE-ing. Pins against a regression that would crash the entire daily price scrape on the first ticker Yahoo no longer charts.

## Code changes

- `tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalEmptyResultTests.cs` — new integration test `GetHistoricalPrices_EmptyChartResult_ReturnsEmptyList` using a stub `HttpMessageHandler`.