### PR TITLE
test(web): pin StocksController.CongressionalTrades renders Show view with tab

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/StocksControllerCongressionalTradesTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerCongressionalTradesTabTests.cs
@@ -1,0 +1,93 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Congress.Data;
+using Equibles.Congress.Repositories;
+using Equibles.Data;
+using Equibles.Finra.Data;
+using Equibles.Finra.Repositories;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Repositories;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.Data;
+using Equibles.Sec.Repositories;
+using Equibles.Web.Controllers;
+using Equibles.Web.Services;
+using Equibles.Web.ViewModels.Stocks;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Repositories;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Sibling to the Holdings-tab pin. ControllersTests still exercises none of the
+/// remaining tab actions. This pins <c>CongressionalTrades</c>: an existing
+/// ticker resolves, renders the shared "Show" view with
+/// <c>ActiveTab == "congressional-trades"</c>, and stashes a
+/// <see cref="CongressionalTradesTabViewModel"/> in <c>ViewData["TabViewModel"]</c>.
+/// The seven tab actions are copy-paste shaped; a regression that pasted the
+/// wrong tab slug or view name into this one is invisible to every other test.
+/// </summary>
+public class StocksControllerCongressionalTradesTabTests : IDisposable
+{
+    private readonly EquiblesDbContext _dbContext;
+
+    public StocksControllerCongressionalTradesTabTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new MediaModuleConfiguration(),
+            new SecTestModuleConfiguration(),
+            new HoldingsModuleConfiguration(),
+            new FinraModuleConfiguration(),
+            new InsiderTradingModuleConfiguration(),
+            new CongressModuleConfiguration(),
+            new YahooModuleConfiguration()
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task CongressionalTrades_ExistingTicker_ReturnsShowViewWithCongressionalTradesTab()
+    {
+        _dbContext.Set<CommonStock>().Add(new CommonStock { Ticker = "AAPL", Name = "Apple Inc." });
+        await _dbContext.SaveChangesAsync();
+
+        var stockTabService = new StockTabService(
+            new InstitutionalHoldingRepository(_dbContext),
+            new InstitutionalHolderRepository(_dbContext),
+            new DailyShortVolumeRepository(_dbContext),
+            new ShortInterestRepository(_dbContext),
+            new FailToDeliverRepository(_dbContext),
+            new DocumentRepository(_dbContext),
+            new InsiderTransactionRepository(_dbContext),
+            new CongressionalTradeRepository(_dbContext),
+            new DailyStockPriceRepository(_dbContext)
+        );
+        var controller = new StocksController(
+            new CommonStockRepository(_dbContext),
+            new InstitutionalHolderRepository(_dbContext),
+            new DocumentRepository(_dbContext),
+            stockTabService,
+            Substitute.For<ILogger<StocksController>>()
+        )
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+
+        var result = await controller.CongressionalTrades("aapl");
+
+        var view = result.Should().BeOfType<ViewResult>().Subject;
+        view.ViewName.Should().Be("Show");
+        var model = view.Model.Should().BeOfType<StockDetailViewModel>().Subject;
+        model.ActiveTab.Should().Be("congressional-trades");
+        controller.ViewData["TabViewModel"].Should().BeOfType<CongressionalTradesTabViewModel>();
+    }
+}


### PR DESCRIPTION
## Summary

- Sibling to the merged Holdings-tab pin. None of the other StocksController tab actions were exercised.
- Adds one integration test for `CongressionalTrades`: an existing ticker resolves, renders the shared "Show" view with `ActiveTab == "congressional-trades"`, and stashes a `CongressionalTradesTabViewModel` in `ViewData`. The seven tab actions are copy-paste shaped; this pins the right tab slug + view name for this one.

## Code changes

- `tests/Equibles.IntegrationTests/Web/StocksControllerCongressionalTradesTabTests.cs` — new integration test `CongressionalTrades_ExistingTicker_ReturnsShowViewWithCongressionalTradesTab` using `TestDbContextFactory` + a real `StockTabService`.