### PR TITLE
chore: disable Codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,7 @@
+# Disable Codecov's automatic PR comment. Coverage status checks still run;
+# only the bot comment is suppressed.
+comment: false
+
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary

- Stop the Codecov bot from commenting on every PR (requested). Coverage status checks are unaffected — only the automatic comment is suppressed.

## Code changes

- `codecov.yml` — add top-level `comment: false`.