### PR TITLE
test(finra): drop flaky token-count assertion sharing static cache

### DIFF
--- a/tests/Equibles.IntegrationTests/Finra/FinraClientTokenRefreshTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraClientTokenRefreshTests.cs
@@ -39,8 +39,12 @@ public class FinraClientTokenRefreshTests
 
         result.Should().ContainSingle();
         result[0].Symbol.Should().Be("AAPL");
-        // First data call 401 forced a token re-fetch (initial + refresh).
-        handler.TokenRequestCount.Should().BeGreaterThanOrEqualTo(2);
+        // The 401 path is fully proven by exactly two data calls plus a parsed
+        // record: the retry only returns data because GetAccessToken ran again
+        // after InvalidateToken — a broken branch would throw on the 401 instead.
+        // TokenRequestCount is deliberately NOT asserted: FinraClient caches the
+        // token in static fields, so a sibling Finra test running in parallel can
+        // warm that cache and make the initial fetch skip this handler.
         handler.DataRequestCount.Should().Be(2);
     }
 
@@ -48,7 +52,6 @@ public class FinraClientTokenRefreshTests
     {
         private readonly string _tokenBody;
         private readonly string _dataBody;
-        public int TokenRequestCount { get; private set; }
         public int DataRequestCount { get; private set; }
 
         public TokenRefreshHandler(string tokenBody, string dataBody)
@@ -64,7 +67,6 @@ public class FinraClientTokenRefreshTests
         {
             if (request.RequestUri!.AbsoluteUri.Contains("oauth2/access_token"))
             {
-                TokenRequestCount++;
                 return Task.FromResult(
                     new HttpResponseMessage(HttpStatusCode.OK)
                     {


### PR DESCRIPTION
## Summary

- CI on `main` (run for #609, which only touched `codecov.yml`) failed on `FinraClientTokenRefreshTests.GetDailyShortVolume_FirstDataCallUnauthorized_RefreshesTokenThenSucceeds`: `Expected handler.TokenRequestCount to be greater than or equal to 2, but found 1`.
- Root cause is test isolation, not the commit: `FinraClient` caches its access token in **static** fields (`_cachedToken`/`_tokenExpiry`). xUnit runs the 8 Finra integration test classes in parallel, all sharing that static cache. When a sibling test warms the cache first, this test's *initial* `GetAccessToken()` returns the cached token without hitting its own handler, so only the post-401 refresh is counted (`1`, not `>=2`). Passes in isolation, flakes under parallel load.
- The process-wide token reuse is intentional production behavior. The test over-specified an assertion dependent on global state set by other classes.

## Code changes

- `tests/Equibles.IntegrationTests/Finra/FinraClientTokenRefreshTests.cs` — removed the flaky `TokenRequestCount >= 2` assertion and the now-dead `TokenRequestCount` counter. The `401 -> InvalidateToken -> re-fetch -> retry` branch remains fully and deterministically proven by `DataRequestCount == 2` plus the parsed `AAPL` record (the retry only returns data because `GetAccessToken` ran again after invalidation; a broken branch would throw on the 401). Added a comment explaining why token count is not asserted.