### PR TITLE
test(sec): pin SecEdgarClient.ParseCompaniesFromResponse malformed-row skips

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientParseCompaniesFromResponseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientParseCompaniesFromResponseTests.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Reflection;
+using Equibles.Integrations.Sec;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins <see cref="SecEdgarClient"/>'s private static ParseCompaniesFromResponse
+/// malformed-row resilience. The two skip guards (short row, empty cik/ticker)
+/// are zero-hit by every existing test — yet a regression removing the short-row
+/// guard throws IndexOutOfRange and aborts the entire SEC company sync, and
+/// removing the empty-cik/ticker guard poisons the CIK-keyed dictionary with
+/// blank-key "companies". Same reflection pattern as the sibling SecEdgarClient
+/// pins (the internal CompanyTickersResponse has no InternalsVisibleTo).
+/// </summary>
+public class SecEdgarClientParseCompaniesFromResponseTests
+{
+    private static readonly MethodInfo ParseCompaniesFromResponseMethod =
+        typeof(SecEdgarClient).GetMethod(
+            "ParseCompaniesFromResponse",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    [Fact]
+    public void ParseCompaniesFromResponse_RowsTooShortOrMissingCikTicker_AreSkippedNotThrownOrEmitted()
+    {
+        var responseType = typeof(SecEdgarClient).Assembly.GetType(
+            "Equibles.Integrations.Sec.Models.Responses.CompanyTickersResponse"
+        );
+        var response = Activator.CreateInstance(responseType);
+        responseType
+            .GetProperty("Fields")!
+            .SetValue(response, new List<string> { "cik", "name", "ticker", "exchange" });
+        responseType
+            .GetProperty("Data")!
+            .SetValue(
+                response,
+                new List<List<object>>
+                {
+                    new() { "0000320193" }, // too short — must skip, not IndexOutOfRange
+                    new() { "", "Empty Co", "EMP", "Nasdaq" }, // empty cik — must skip
+                    new() { "0000789019", "Microsoft Corp", "MSFT", "Nasdaq" }, // valid
+                }
+            );
+
+        var result = (IEnumerable)ParseCompaniesFromResponseMethod.Invoke(null, [response]);
+        var companies = result.Cast<CompanyInfo>().ToList();
+
+        companies.Should().ContainSingle();
+        companies[0].Cik.Should().Be("0000789019");
+        companies[0].Tickers.Should().ContainSingle().Which.Should().Be("MSFT");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one unit test pinning `SecEdgarClient.ParseCompaniesFromResponse`'s malformed-row resilience. Lines 454 (too-short-row `continue`) and 461 (empty-cik/ticker `continue`) were zero-hit by the entire merged suite (unit + integration + functional); the existing file even notes these private static parsers are uncovered.
- Verified by filtered re-run: both lines go 0 → 1 driven by this test alone.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecEdgarClientParseCompaniesFromResponseTests.cs` — new file, one `[Fact]`. Feeds a `CompanyTickersResponse` (constructed via reflection — the model is `internal` with no `InternalsVisibleTo`) containing a too-short row, an empty-CIK row, and one valid row; asserts only the valid company survives. Catches: dropping the short-row guard → `IndexOutOfRangeException` aborting the whole SEC company sync; dropping the empty guard → blank-key entries poisoning the CIK-keyed dictionary. Mirrors the established reflection pattern of the sibling `SecEdgarClient*Tests` files.