### PR TITLE
test(finra): pin FinraClient.SendWithRetry 5xx retry-then-succeed

### DIFF
--- a/tests/Equibles.IntegrationTests/Finra/FinraClientServerErrorRetryTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraClientServerErrorRetryTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using Equibles.Integrations.Finra;
+using Equibles.Integrations.Finra.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Finra;
+
+/// <summary>
+/// Sibling to <see cref="FinraClientTokenRefreshTests"/>, which pins the 401
+/// branch of SendWithRetry. This pins the 5xx branch (lines 362-373, zero-hit):
+/// FINRA's data API intermittently 500s under load; that response must trigger
+/// a transparent retry, not abort the whole short-volume import. A regression
+/// moving 5xx into the EnsureSuccessStatusCode path would fail every nightly
+/// scrape the moment FINRA hiccups once.
+/// </summary>
+public class FinraClientServerErrorRetryTests
+{
+    [Fact]
+    public async Task GetDailyShortVolume_FirstDataCallServerError_RetriesThenSucceeds()
+    {
+        var dataResponse =
+            "[{\"tradeReportDate\":\"2024-12-31\","
+            + "\"securitiesInformationProcessorSymbolIdentifier\":\"AAPL\","
+            + "\"totalParQuantity\":1000}]";
+
+        var handler = new ServerErrorThenOkHandler(
+            tokenBody: "{\"access_token\":\"tok\",\"expires_in\":3600}",
+            dataBody: dataResponse
+        );
+        var sut = new FinraClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<FinraClient>>(),
+            Options.Create(new FinraOptions { ClientId = "id", ClientSecret = "secret" })
+        );
+
+        var result = await sut.GetDailyShortVolume(new DateOnly(2024, 12, 31));
+
+        // Two data calls + a parsed record prove the 500 drove a retry that then
+        // succeeded — a broken 5xx branch would throw on the first response.
+        result.Should().ContainSingle();
+        result[0].Symbol.Should().Be("AAPL");
+        handler.DataRequestCount.Should().Be(2);
+    }
+
+    private sealed class ServerErrorThenOkHandler : HttpMessageHandler
+    {
+        private readonly string _tokenBody;
+        private readonly string _dataBody;
+        public int DataRequestCount { get; private set; }
+
+        public ServerErrorThenOkHandler(string tokenBody, string dataBody)
+        {
+            _tokenBody = tokenBody;
+            _dataBody = dataBody;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            if (request.RequestUri!.AbsoluteUri.Contains("oauth2/access_token"))
+            {
+                return Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(_tokenBody),
+                    }
+                );
+            }
+
+            DataRequestCount++;
+            if (DataRequestCount == 1)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+            }
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_dataBody),
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one integration test pinning `FinraClient.SendWithRetry`'s 5xx-retry branch (lines 363–373), zero-hit by the whole suite — the sibling `FinraClientTokenRefreshTests` only covers the 401 branch.
- Verified by filtered re-run: 11 previously-zero-hit lines (the entire server-error retry block) go 0 → covered, driven by this test alone.

## Code changes

- `tests/Equibles.IntegrationTests/Finra/FinraClientServerErrorRetryTests.cs` — new file, one `[Fact]`. Fake `HttpMessageHandler` serves the OAuth token, then returns `500` on the first data call and `200` with a valid short-volume payload on the retry; drives it through `GetDailyShortVolume`. Asserts two data calls + a parsed record — proving the 500 triggered a transparent retry. A regression moving 5xx into the `EnsureSuccessStatusCode` path would fail the nightly short-volume import on the first FINRA hiccup. Mirrors the established `FinraClientTokenRefreshTests` handler pattern (token-count deliberately not asserted — the token cache is static/cross-test).