### PR TITLE
docs(changelog): backfill 1.0.0 section for v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,29 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project tries to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
-once the first tagged release ships.
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-05-15
+
+First tagged release.
+
 ### Added
 
-- Initial CHANGELOG. Past changes are recoverable from `git log` and merged PRs.
+- SEC filings ingestion with full-text search — 10-K, 10-Q, 8-K from SEC EDGAR.
+- Institutional holdings (SEC 13F-HR) — top holders, ownership history, institution portfolios.
+- Insider trading (SEC Form 3/4) — director, officer, and 10% owner transactions.
+- Congressional trading from House and Senate disclosures.
+- Short data — fails-to-deliver (SEC), daily short volume and short interest (FINRA).
+- Economic indicators from FRED (Federal Reserve).
+- Futures positioning — CFTC Commitments of Traders for 30+ contracts.
+- Market indicators — CBOE VIX history and put/call ratios.
+- Daily stock prices with technical indicators (SMA, RSI, MACD) from Yahoo Finance.
+- MCP server exposing all data as tools for Claude, ChatGPT, Cursor, and other MCP-compatible clients.
+- Web portal for browsing stocks, holdings, filings, economy, futures, and market data.
+- Background worker — scrapers and document processor.
+- Docker Compose stack (ParadeDB + web + MCP + worker), with an optional vector-embedding profile.
 
-[Unreleased]: https://github.com/daniel3303/Equibles/commits/main
+[Unreleased]: https://github.com/daniel3303/Equibles/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/daniel3303/Equibles/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary

The `v1.0.0` tag and GitHub release were cut, but the CHANGELOG was not updated as part of that. This backfills the CHANGELOG to document the already-published v1.0.0 release.

No re-tag and no new release — `v1.0.0` (tagged at 6a2a5d2) and its GitHub release stay as published. This is a documentation-only change.

## Code changes

- `CHANGELOG.md`
  - `## [Unreleased]` → `## [1.0.0] — 2026-05-15` with an itemized `### Added` list covering the full feature set (SEC filings, 13F holdings, insider/congressional trades, short data, FRED, CFTC, CBOE, prices, MCP server, web portal, worker, Docker Compose).
  - Added a fresh empty `## [Unreleased]` section.
  - Footer links: `[Unreleased]` now compares `v1.0.0...HEAD`; added `[1.0.0]` pointing at the release tag.
  - Tightened the SemVer header line (dropped the pre-release qualifier now that v1.0.0 has shipped).