### PR TITLE
test(sec): pin EmbeddingClient.ProcessBatch multi-text branch

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/EmbeddingClientMultiTextBatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/EmbeddingClientMultiTextBatchTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Text;
+using Equibles.Sec.BusinessLogic.Embeddings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Sibling to <see cref="EmbeddingClientGenerateTests"/>, which pins the
+/// <c>batch.Count == 1</c> shortcut. This pins the multi-text branch of
+/// ProcessBatch (lines 113-137, zero-hit): Ollama's /api/embed takes one input
+/// at a time, so a batch of N must POST N times and collect one vector each. A
+/// regression that broke the per-text loop (e.g. posted the whole batch once or
+/// dropped <c>Embeddings[0]</c>) would silently shrink every multi-chunk
+/// document's embedding set with no exception.
+/// </summary>
+public class EmbeddingClientMultiTextBatchTests
+{
+    [Fact]
+    public async Task GenerateEmbeddings_MultipleTextsInOneBatch_PostsPerTextAndReturnsVectorEach()
+    {
+        var responseBody = "{\"model\":\"nomic-embed-text\",\"embeddings\":[[0.5,0.6]]}";
+        var handler = new CountingHandler(responseBody);
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(handler));
+
+        var sut = new EmbeddingClient(
+            factory,
+            Options.Create(
+                new EmbeddingConfig
+                {
+                    Enabled = true,
+                    BaseUrl = "http://ollama.test",
+                    ModelName = "nomic-embed-text",
+                    BatchSize = 10,
+                }
+            ),
+            Substitute.For<ILogger<EmbeddingClient>>()
+        );
+
+        var vectors = await sut.GenerateEmbeddings(["first chunk", "second chunk"]);
+
+        // Two inputs in one batch → two separate /api/embed POSTs → two vectors.
+        handler.CallCount.Should().Be(2);
+        vectors.Should().HaveCount(2);
+        vectors[0].Should().Equal(0.5f, 0.6f);
+        vectors[1].Should().Equal(0.5f, 0.6f);
+    }
+
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+        public int CallCount { get; private set; }
+
+        public CountingHandler(string body) => _body = body;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            CallCount++;
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one integration test pinning `EmbeddingClient.ProcessBatch`'s multi-text branch (lines 113–137), zero-hit by the whole suite — the sibling `EmbeddingClientGenerateTests` only covers the `batch.Count == 1` shortcut.
- Verified by filtered re-run: all 20 previously-zero-hit lines (the entire per-text loop) go 0 → covered, driven by this test alone.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/EmbeddingClientMultiTextBatchTests.cs` — new file, one `[Fact]`. Fake `IHttpClientFactory` + counting handler; two texts in one batch (`BatchSize=10`) force the multi-text path. Asserts two separate `/api/embed` POSTs and two returned vectors. Ollama's `/api/embed` is one-input-at-a-time; a regression that posted the whole batch once or dropped `Embeddings[0]` would silently shrink every multi-chunk document's embedding set with no exception. Mirrors the established `EmbeddingClientGenerateTests` fake-factory pattern.