### PR TITLE
refactor(congress): extract ISenateBrowserSession seam, unit-test SenateDisclosureClient

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/ISenateBrowserSession.cs
+++ b/src/Equibles.Congress.HostedService/Services/ISenateBrowserSession.cs
@@ -1,0 +1,27 @@
+namespace Equibles.Congress.HostedService.Services;
+
+/// <summary>
+/// Browser-mediated transport for Senate eFD. Reusing a real browser's TLS
+/// fingerprint and session cookies is what bypasses Akamai bot detection, so
+/// this concern is isolated here; <see cref="SenateDisclosureClient"/> owns the
+/// retry, pagination, and parsing logic on top of it.
+/// </summary>
+public interface ISenateBrowserSession : IAsyncDisposable
+{
+    /// <summary>
+    /// Launches the browser (once), navigates to Senate eFD, and accepts the
+    /// prohibition-agreement disclaimer. Idempotent.
+    /// </summary>
+    Task EnsureAuthenticated(CancellationToken ct);
+
+    /// <summary>
+    /// Issues a request through the authenticated browser context. Pass
+    /// <paramref name="formFields"/> for a POST, or null for a GET. Throws
+    /// <see cref="SenateBrowserException"/> on a transport failure.
+    /// </summary>
+    Task<SenateFetchResult> Fetch(
+        string url,
+        Dictionary<string, string> formFields,
+        CancellationToken ct
+    );
+}

--- a/src/Equibles.Congress.HostedService/Services/PlaywrightSenateBrowserSession.cs
+++ b/src/Equibles.Congress.HostedService/Services/PlaywrightSenateBrowserSession.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using Equibles.Core.AutoWiring;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Playwright;
+
+namespace Equibles.Congress.HostedService.Services;
+
+/// <summary>
+/// Playwright/Firefox implementation of <see cref="ISenateBrowserSession"/>.
+/// This is the only Senate code that touches a real browser; the testable
+/// retry/pagination/parsing logic lives in <see cref="SenateDisclosureClient"/>.
+/// </summary>
+[Service(ServiceLifetime.Scoped, typeof(ISenateBrowserSession))]
+public class PlaywrightSenateBrowserSession : ISenateBrowserSession
+{
+    private const string BaseUrl = "https://efdsearch.senate.gov";
+    private const string HomeUrl = BaseUrl + "/search/home/";
+    private const int BrowserFetchTimeoutMs = 30_000;
+
+    private readonly ILogger<PlaywrightSenateBrowserSession> _logger;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+
+    private IPlaywright _playwright;
+    private IBrowser _browser;
+    private IPage _page;
+    private bool _authenticated;
+
+    // JavaScript executed in the browser context to make HTTP requests.
+    // Reuses the browser's TLS fingerprint and session cookies to bypass Akamai bot detection.
+    // For POST requests, extracts the CSRF token from cookies and includes it in headers and form data.
+    private const string BrowserFetchScript = """
+        async ({url, formFields}) => {
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 30000);
+            try {
+                const options = { signal: controller.signal };
+                if (formFields) {
+                    const csrfToken = document.cookie.split(';')
+                        .map(c => c.trim())
+                        .find(c => c.startsWith('csrftoken='))
+                        ?.split('=')[1] ?? '';
+                    formFields['csrftoken'] = csrfToken;
+                    options.method = 'POST';
+                    options.headers = {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                        'X-CSRFToken': csrfToken,
+                        'Referer': location.origin + '/search/',
+                    };
+                    options.body = new URLSearchParams(formFields).toString();
+                }
+                const resp = await fetch(url, options);
+                return { status: resp.status, body: await resp.text() };
+            } finally {
+                clearTimeout(timeoutId);
+            }
+        }
+        """;
+
+    public PlaywrightSenateBrowserSession(ILogger<PlaywrightSenateBrowserSession> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task EnsureAuthenticated(CancellationToken ct)
+    {
+        if (_authenticated)
+            return;
+
+        await _initLock.WaitAsync(ct);
+        try
+        {
+            if (_authenticated)
+                return;
+
+            _playwright = await Playwright.CreateAsync();
+            _browser = await _playwright.Firefox.LaunchAsync(
+                new BrowserTypeLaunchOptions { Headless = true }
+            );
+
+            var context = await _browser.NewContextAsync();
+            context.SetDefaultTimeout(BrowserFetchTimeoutMs);
+            _page = await context.NewPageAsync();
+
+            _logger.LogDebug("Navigating to Senate eFD via Playwright Firefox");
+
+            var response = await _page.GotoAsync(
+                HomeUrl,
+                new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 30_000 }
+            );
+
+            if (response?.Status != 200)
+                throw new HttpRequestException(
+                    $"Senate eFD home page returned HTTP {response?.Status}"
+                );
+
+            // Accept the prohibition agreement disclaimer
+            var checkbox = _page.Locator("#agree_statement");
+            if (await checkbox.IsVisibleAsync())
+            {
+                await checkbox.CheckAsync();
+                await _page.Locator("button[type='submit'], input[type='submit']").ClickAsync();
+                await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            }
+
+            _authenticated = true;
+            _logger.LogDebug("Senate eFD disclaimer accepted via Playwright Firefox");
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    public async Task<SenateFetchResult> Fetch(
+        string url,
+        Dictionary<string, string> formFields,
+        CancellationToken ct
+    )
+    {
+        JsonElement result;
+        try
+        {
+            result = await _page.EvaluateAsync<JsonElement>(
+                BrowserFetchScript,
+                new { url, formFields }
+            );
+        }
+        catch (PlaywrightException) when (ct.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(ct);
+        }
+        catch (PlaywrightException ex)
+        {
+            throw new SenateBrowserException($"Browser fetch failed for {url}", ex);
+        }
+
+        return new SenateFetchResult
+        {
+            Status = result.GetProperty("status").GetInt32(),
+            Body = result.GetProperty("body").GetString(),
+        };
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+
+        try
+        {
+            if (_page != null)
+            {
+                await _page.Context.CloseAsync();
+                _page = null;
+            }
+        }
+        catch (PlaywrightException)
+        {
+            _page = null;
+        }
+
+        try
+        {
+            if (_browser != null)
+            {
+                await _browser.CloseAsync();
+                _browser = null;
+            }
+        }
+        catch (PlaywrightException)
+        {
+            _browser = null;
+        }
+
+        _playwright?.Dispose();
+        _playwright = null;
+        _initLock.Dispose();
+    }
+}

--- a/src/Equibles.Congress.HostedService/Services/SenateBrowserException.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateBrowserException.cs
@@ -1,0 +1,13 @@
+namespace Equibles.Congress.HostedService.Services;
+
+/// <summary>
+/// Thrown by <see cref="ISenateBrowserSession"/> when the underlying browser
+/// transport fails (timeout, navigation error, evaluation failure). Lets
+/// <see cref="SenateDisclosureClient"/> own the retry/backoff policy without a
+/// hard dependency on the Playwright exception types.
+/// </summary>
+public class SenateBrowserException : Exception
+{
+    public SenateBrowserException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
@@ -1,9 +1,7 @@
-using System.Text.Json;
 using Equibles.Congress.Data.Models;
 using Equibles.Congress.HostedService.Models;
 using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Common.RateLimiter;
-using Microsoft.Playwright;
 using Newtonsoft.Json;
 using static Equibles.Congress.HostedService.Services.DisclosureParsingHelper;
 
@@ -19,52 +17,18 @@ public class SenateDisclosureClient : IAsyncDisposable
     private const int MaxRetries = 3;
 
     private const string BaseUrl = "https://efdsearch.senate.gov";
-    private const string HomeUrl = BaseUrl + "/search/home/";
     private const string SearchDataUrl = BaseUrl + "/search/report/data/";
     private const string PtrReportTypeFilter = "[11]"; // Periodic Transaction Report
-    private const int BrowserFetchTimeoutMs = 30_000;
 
+    private readonly ISenateBrowserSession _session;
     private readonly ILogger<SenateDisclosureClient> _logger;
-    private readonly SemaphoreSlim _initLock = new(1, 1);
 
-    private IPlaywright _playwright;
-    private IBrowser _browser;
-    private IPage _page;
-    private bool _authenticated;
-
-    // JavaScript executed in the browser context to make HTTP requests.
-    // Reuses the browser's TLS fingerprint and session cookies to bypass Akamai bot detection.
-    // For POST requests, extracts the CSRF token from cookies and includes it in headers and form data.
-    private const string BrowserFetchScript = """
-        async ({url, formFields}) => {
-            const controller = new AbortController();
-            const timeoutId = setTimeout(() => controller.abort(), 30000);
-            try {
-                const options = { signal: controller.signal };
-                if (formFields) {
-                    const csrfToken = document.cookie.split(';')
-                        .map(c => c.trim())
-                        .find(c => c.startsWith('csrftoken='))
-                        ?.split('=')[1] ?? '';
-                    formFields['csrftoken'] = csrfToken;
-                    options.method = 'POST';
-                    options.headers = {
-                        'Content-Type': 'application/x-www-form-urlencoded',
-                        'X-CSRFToken': csrfToken,
-                        'Referer': location.origin + '/search/',
-                    };
-                    options.body = new URLSearchParams(formFields).toString();
-                }
-                const resp = await fetch(url, options);
-                return { status: resp.status, body: await resp.text() };
-            } finally {
-                clearTimeout(timeoutId);
-            }
-        }
-        """;
-
-    public SenateDisclosureClient(ILogger<SenateDisclosureClient> logger)
+    public SenateDisclosureClient(
+        ISenateBrowserSession session,
+        ILogger<SenateDisclosureClient> logger
+    )
     {
+        _session = session;
         _logger = logger;
     }
 
@@ -74,7 +38,7 @@ public class SenateDisclosureClient : IAsyncDisposable
         CancellationToken ct
     )
     {
-        await EnsureAuthenticated(ct);
+        await _session.EnsureAuthenticated(ct);
 
         var reports = await SearchPtrReports(fromDate, toDate, ct);
         _logger.LogInformation(
@@ -115,56 +79,6 @@ public class SenateDisclosureClient : IAsyncDisposable
             reports.Count
         );
         return transactions;
-    }
-
-    private async Task EnsureAuthenticated(CancellationToken ct)
-    {
-        if (_authenticated)
-            return;
-
-        await _initLock.WaitAsync(ct);
-        try
-        {
-            if (_authenticated)
-                return;
-
-            _playwright = await Playwright.CreateAsync();
-            _browser = await _playwright.Firefox.LaunchAsync(
-                new BrowserTypeLaunchOptions { Headless = true }
-            );
-
-            var context = await _browser.NewContextAsync();
-            context.SetDefaultTimeout(BrowserFetchTimeoutMs);
-            _page = await context.NewPageAsync();
-
-            _logger.LogDebug("Navigating to Senate eFD via Playwright Firefox");
-
-            var response = await _page.GotoAsync(
-                HomeUrl,
-                new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 30_000 }
-            );
-
-            if (response?.Status != 200)
-                throw new HttpRequestException(
-                    $"Senate eFD home page returned HTTP {response?.Status}"
-                );
-
-            // Accept the prohibition agreement disclaimer
-            var checkbox = _page.Locator("#agree_statement");
-            if (await checkbox.IsVisibleAsync())
-            {
-                await checkbox.CheckAsync();
-                await _page.Locator("button[type='submit'], input[type='submit']").ClickAsync();
-                await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-            }
-
-            _authenticated = true;
-            _logger.LogDebug("Senate eFD disclaimer accepted via Playwright Firefox");
-        }
-        finally
-        {
-            _initLock.Release();
-        }
     }
 
     private async Task<List<SenateReport>> SearchPtrReports(
@@ -273,9 +187,8 @@ public class SenateDisclosureClient : IAsyncDisposable
     }
 
     /// <summary>
-    /// Makes an HTTP request via the Playwright browser's fetch() API with retry logic.
-    /// Bypasses Akamai bot detection by reusing the browser's TLS fingerprint and session cookies.
-    /// Pass formFields for POST, or null for GET.
+    /// Issues a request through the browser session with retry logic. Pass
+    /// formFields for POST, or null for GET.
     /// </summary>
     private async Task<string> FetchWithRetry(
         string url,
@@ -288,25 +201,18 @@ public class SenateDisclosureClient : IAsyncDisposable
             ct.ThrowIfCancellationRequested();
             await RateLimiter.WaitAsync();
 
-            JsonElement result;
+            SenateFetchResult result;
             try
             {
-                result = await _page.EvaluateAsync<JsonElement>(
-                    BrowserFetchScript,
-                    new { url, formFields }
-                );
+                result = await _session.Fetch(url, formFields, ct);
             }
-            catch (PlaywrightException) when (ct.IsCancellationRequested)
-            {
-                throw new OperationCanceledException(ct);
-            }
-            catch (PlaywrightException ex)
+            catch (SenateBrowserException ex)
             {
                 if (attempt >= MaxRetries)
                 {
                     _logger.LogError(
                         ex,
-                        "Playwright failed for {Url} after {Attempts} attempt(s)",
+                        "Browser fetch failed for {Url} after {Attempts} attempt(s)",
                         url,
                         attempt + 1
                     );
@@ -314,7 +220,7 @@ public class SenateDisclosureClient : IAsyncDisposable
                 }
                 var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
                 _logger.LogWarning(
-                    "Playwright timeout for {Url}, retrying in {Delay}s (attempt {Attempt}/{MaxRetries}): {Message}",
+                    "Browser fetch error for {Url}, retrying in {Delay}s (attempt {Attempt}/{MaxRetries}): {Message}",
                     url,
                     delay.TotalSeconds,
                     attempt + 1,
@@ -324,8 +230,9 @@ public class SenateDisclosureClient : IAsyncDisposable
                 await Task.Delay(delay, ct);
                 continue;
             }
-            var status = result.GetProperty("status").GetInt32();
-            var body = result.GetProperty("body").GetString();
+
+            var status = result.Status;
+            var body = result.Body;
 
             var isRetryable = status == 429 || status >= 500;
             if (isRetryable && attempt < MaxRetries)
@@ -371,36 +278,7 @@ public class SenateDisclosureClient : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         GC.SuppressFinalize(this);
-
-        try
-        {
-            if (_page != null)
-            {
-                await _page.Context.CloseAsync();
-                _page = null;
-            }
-        }
-        catch (PlaywrightException)
-        {
-            _page = null;
-        }
-
-        try
-        {
-            if (_browser != null)
-            {
-                await _browser.CloseAsync();
-                _browser = null;
-            }
-        }
-        catch (PlaywrightException)
-        {
-            _browser = null;
-        }
-
-        _playwright?.Dispose();
-        _playwright = null;
-        _initLock.Dispose();
+        await _session.DisposeAsync();
     }
 
     private record SenateReport(string MemberName, string ReportUrl, DateOnly DateSubmitted);

--- a/src/Equibles.Congress.HostedService/Services/SenateFetchResult.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateFetchResult.cs
@@ -1,0 +1,12 @@
+namespace Equibles.Congress.HostedService.Services;
+
+/// <summary>
+/// Outcome of a single browser-mediated HTTP request to Senate eFD: the HTTP
+/// status code and the raw response body.
+/// </summary>
+public class SenateFetchResult
+{
+    public int Status { get; set; }
+
+    public string Body { get; set; }
+}

--- a/tests/Equibles.UnitTests/Congress/SenateDisclosureClientFetchTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateDisclosureClientFetchTests.cs
@@ -1,0 +1,188 @@
+using Equibles.Congress.HostedService.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Pins SenateDisclosureClient's fetch/retry/pagination orchestration, now
+/// testable after extracting the Playwright transport behind
+/// <see cref="ISenateBrowserSession"/>. Covers the search→report flow,
+/// multi-page pagination, the 429 and SenateBrowserException retry branches,
+/// the non-2xx hard-fail, and disposal delegation. The HTML transaction parser
+/// has its own dedicated tests; these assert the orchestration only.
+/// </summary>
+public class SenateDisclosureClientFetchTests
+{
+    private const string ReportUrl = "https://efdsearch.senate.gov/search/view/ptr/abc123/";
+
+    private static string SearchJson(int recordsTotal, int rowCount)
+    {
+        var rows = string.Join(
+            ",",
+            Enumerable
+                .Range(0, rowCount)
+                .Select(_ =>
+                    "[\"John\",\"Doe\",\"x\","
+                    + "\"<a href=\\\"/search/view/ptr/abc123/\\\">View</a>\","
+                    + "\"2024-01-15\"]"
+                )
+        );
+        return $"{{\"draw\":1,\"recordsTotal\":{recordsTotal},"
+            + $"\"recordsFiltered\":{recordsTotal},\"data\":[{rows}],\"result\":\"ok\"}}";
+    }
+
+    private static SenateFetchResult Ok(string body) => new() { Status = 200, Body = body };
+
+    private sealed class FakeSenateBrowserSession : ISenateBrowserSession
+    {
+        public Queue<Func<SenateFetchResult>> Script { get; } = new();
+        public List<string> FetchedUrls { get; } = [];
+        public bool Disposed { get; private set; }
+
+        public Task EnsureAuthenticated(CancellationToken ct) => Task.CompletedTask;
+
+        public Task<SenateFetchResult> Fetch(
+            string url,
+            Dictionary<string, string> formFields,
+            CancellationToken ct
+        )
+        {
+            FetchedUrls.Add(url);
+            return Task.FromResult(Script.Dequeue()());
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static SenateDisclosureClient Sut(FakeSenateBrowserSession session) =>
+        new(session, Substitute.For<ILogger<SenateDisclosureClient>>());
+
+    [Fact]
+    public async Task GetRecentTransactions_SearchThenReport_FetchesEachReportUrl()
+    {
+        var session = new FakeSenateBrowserSession();
+        session.Script.Enqueue(() => Ok(SearchJson(recordsTotal: 1, rowCount: 1)));
+        session.Script.Enqueue(() => Ok("<html><body>no transactions</body></html>"));
+
+        var result = await Sut(session)
+            .GetRecentTransactions(
+                new DateOnly(2024, 1, 1),
+                new DateOnly(2024, 1, 31),
+                CancellationToken.None
+            );
+
+        result.Should().NotBeNull();
+        session.FetchedUrls.Should().Contain(ReportUrl);
+    }
+
+    private static string SearchJsonInvalidRows(int recordsTotal, int rowCount)
+    {
+        // Rows with no href → ParseReportRow rejects them, so pagination is
+        // exercised without triggering a report fetch per row.
+        var rows = string.Join(
+            ",",
+            Enumerable
+                .Range(0, rowCount)
+                .Select(_ => "[\"John\",\"Doe\",\"x\",\"no-link-here\",\"2024-01-15\"]")
+        );
+        return $"{{\"draw\":1,\"recordsTotal\":{recordsTotal},"
+            + $"\"recordsFiltered\":{recordsTotal},\"data\":[{rows}],\"result\":\"ok\"}}";
+    }
+
+    [Fact]
+    public async Task GetRecentTransactions_RecordsTotalSpansTwoPages_PaginatesUntilExhausted()
+    {
+        const string searchUrl = "https://efdsearch.senate.gov/search/report/data/";
+        var session = new FakeSenateBrowserSession();
+        // recordsTotal 150 with pageSize 100 → exactly two search pages.
+        session.Script.Enqueue(() => Ok(SearchJsonInvalidRows(recordsTotal: 150, rowCount: 100)));
+        session.Script.Enqueue(() => Ok(SearchJsonInvalidRows(recordsTotal: 150, rowCount: 50)));
+
+        await Sut(session)
+            .GetRecentTransactions(
+                new DateOnly(2024, 1, 1),
+                new DateOnly(2024, 1, 31),
+                CancellationToken.None
+            );
+
+        // Two search pages fetched, zero reports (all rows rejected).
+        session.FetchedUrls.Should().AllBe(searchUrl);
+        session.FetchedUrls.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetRecentTransactions_FirstSearchReturns429ThenSucceeds_RetriesTransparently()
+    {
+        var session = new FakeSenateBrowserSession();
+        session.Script.Enqueue(() => new SenateFetchResult { Status = 429, Body = "" });
+        session.Script.Enqueue(() => Ok(SearchJson(1, 1)));
+        session.Script.Enqueue(() => Ok("<html></html>"));
+
+        var result = await Sut(session)
+            .GetRecentTransactions(
+                new DateOnly(2024, 1, 1),
+                new DateOnly(2024, 1, 31),
+                CancellationToken.None
+            );
+
+        result.Should().NotBeNull();
+        session.FetchedUrls.Should().Contain(ReportUrl);
+    }
+
+    [Fact]
+    public async Task GetRecentTransactions_FirstSearchThrowsBrowserExceptionThenSucceeds_Retries()
+    {
+        var session = new FakeSenateBrowserSession();
+        var thrown = false;
+        session.Script.Enqueue(() =>
+        {
+            thrown = true;
+            throw new SenateBrowserException("boom", new InvalidOperationException());
+        });
+        session.Script.Enqueue(() => Ok(SearchJson(1, 1)));
+        session.Script.Enqueue(() => Ok("<html></html>"));
+
+        var result = await Sut(session)
+            .GetRecentTransactions(
+                new DateOnly(2024, 1, 1),
+                new DateOnly(2024, 1, 31),
+                CancellationToken.None
+            );
+
+        thrown.Should().BeTrue();
+        result.Should().NotBeNull();
+        session.FetchedUrls.Should().Contain(ReportUrl);
+    }
+
+    [Fact]
+    public async Task GetRecentTransactions_SearchReturnsNonRetryable404_ThrowsHttpRequestException()
+    {
+        var session = new FakeSenateBrowserSession();
+        session.Script.Enqueue(() => new SenateFetchResult { Status = 404, Body = "missing" });
+
+        var act = () =>
+            Sut(session)
+                .GetRecentTransactions(
+                    new DateOnly(2024, 1, 1),
+                    new DateOnly(2024, 1, 31),
+                    CancellationToken.None
+                );
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DelegatesToSession()
+    {
+        var session = new FakeSenateBrowserSession();
+
+        await Sut(session).DisposeAsync();
+
+        session.Disposed.Should().BeTrue();
+    }
+}

--- a/tests/Equibles.UnitTests/Congress/SenateDisclosureClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateDisclosureClientTests.cs
@@ -33,7 +33,10 @@ public class SenateDisclosureClientTests
         // Pin the rejection on an attacker-controlled absolute URL so a refactor that
         // collapses the if/else into "always prepend BaseUrl" (which would silently
         // mangle absolute URLs but ALSO accept them) is caught.
-        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var sut = new SenateDisclosureClient(
+            Substitute.For<ISenateBrowserSession>(),
+            Substitute.For<ILogger<SenateDisclosureClient>>()
+        );
         var row = new List<string>
         {
             "Jane",
@@ -75,7 +78,10 @@ public class SenateDisclosureClientTests
         // Together with the two rejection siblings, ParseReportRow's contract
         // is fully pinned: rejects cross-origin, rejects paper, accepts valid
         // electronic Senate filings.
-        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var sut = new SenateDisclosureClient(
+            Substitute.For<ISenateBrowserSession>(),
+            Substitute.For<ILogger<SenateDisclosureClient>>()
+        );
         var row = new List<string>
         {
             "Jane",
@@ -125,7 +131,10 @@ public class SenateDisclosureClientTests
         // URL) both have a valid <a href=...> tag. Neither exercises the .Success guard.
         // Pin the no-anchor case with a plain-text link cell so a refactor that drops
         // the guard surfaces here rather than as silent home-page fetches in production.
-        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var sut = new SenateDisclosureClient(
+            Substitute.For<ISenateBrowserSession>(),
+            Substitute.For<ILogger<SenateDisclosureClient>>()
+        );
         var row = new List<string>
         {
             "John",
@@ -166,7 +175,10 @@ public class SenateDisclosureClientTests
         // (the malformed bit is the URL or anchor). None exercises the date-parse
         // branch. Pin with a clearly-unparseable value ("not-a-date") so a regex/
         // culture-flexibility regression doesn't accidentally parse it.
-        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var sut = new SenateDisclosureClient(
+            Substitute.For<ISenateBrowserSession>(),
+            Substitute.For<ILogger<SenateDisclosureClient>>()
+        );
         var row = new List<string>
         {
             "Jane",
@@ -190,7 +202,10 @@ public class SenateDisclosureClientTests
         // (or used a wrong path segment), the importer would forward scanned PDFs into
         // FetchAndParseReport, fail mid-flight, and either flood the error log or crash
         // the scrape. Pin the skip so a refactor can't quietly let paper filings through.
-        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var sut = new SenateDisclosureClient(
+            Substitute.For<ISenateBrowserSession>(),
+            Substitute.For<ILogger<SenateDisclosureClient>>()
+        );
         var row = new List<string>
         {
             "John",
@@ -240,7 +255,10 @@ public class SenateDisclosureClientTests
         // TargetInvocationException wrapping IndexOutOfRangeException, which
         // .Should().BeNull() can't observe (it asserts on a return value the
         // exception prevents from existing).
-        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var sut = new SenateDisclosureClient(
+            Substitute.For<ISenateBrowserSession>(),
+            Substitute.For<ILogger<SenateDisclosureClient>>()
+        );
         var row = new List<string>
         {
             "Jane",
@@ -279,7 +297,10 @@ public class SenateDisclosureClientTests
         // to an empty member. Pin with both first AND last name as empty
         // strings (the JSON-likely shape; nulls are also possible but ?.Trim
         // on "" is the same as ?.Trim on null after the ?? "" coalesce).
-        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var sut = new SenateDisclosureClient(
+            Substitute.For<ISenateBrowserSession>(),
+            Substitute.For<ILogger<SenateDisclosureClient>>()
+        );
         var row = new List<string>
         {
             "",
@@ -309,7 +330,10 @@ public class SenateDisclosureClientTests
         // (via the memberName="" guard) AND, by completing the invocation
         // without exception, proves the two null-safe operators handled the
         // null inputs without dereferencing.
-        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var sut = new SenateDisclosureClient(
+            Substitute.For<ISenateBrowserSession>(),
+            Substitute.For<ILogger<SenateDisclosureClient>>()
+        );
         var row = new List<string>
         {
             null,
@@ -334,7 +358,10 @@ public class SenateDisclosureClientTests
         // value null, the coalesce yields an empty string, HrefRegex.Match("")
         // succeeds=false, and the method returns null at the !Success guard.
         // Without the `?? ""`, HrefRegex.Match(null) throws ArgumentNullException.
-        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var sut = new SenateDisclosureClient(
+            Substitute.For<ISenateBrowserSession>(),
+            Substitute.For<ILogger<SenateDisclosureClient>>()
+        );
         var row = new List<string> { "Jane", "Doe", "filed", null, "2024-01-15" };
 
         var act = () => ParseReportRowMethod.Invoke(sut, [row]);
@@ -353,7 +380,10 @@ public class SenateDisclosureClientTests
         // row[4] null, `?.Trim()` short-circuits to null, TryParse(null)
         // returns false, the method logs the debug message and returns null.
         // Without the `?.`, Trim() would NRE on the null reference.
-        var sut = new SenateDisclosureClient(Substitute.For<ILogger<SenateDisclosureClient>>());
+        var sut = new SenateDisclosureClient(
+            Substitute.For<ISenateBrowserSession>(),
+            Substitute.For<ILogger<SenateDisclosureClient>>()
+        );
         var row = new List<string>
         {
             "Jane",


### PR DESCRIPTION
## Summary

- `SenateDisclosureClient` newed up Playwright/Firefox internally (constructor took only `ILogger`), so its ~226 lines of fetch/retry/pagination logic were structurally untestable — the single largest uncovered class and the blocker to ~95%.
- Extracts the browser transport behind `ISenateBrowserSession` (real impl: `PlaywrightSenateBrowserSession`). The client now depends on the abstraction and retains all retry/pagination/parse logic. A new `SenateBrowserException` decouples the retry policy from Playwright's exception types.
- **Behavior-preserving**: the sole consumer (`CongressionalTradeSyncService`) resolves the client identically; `AutoWireServicesFrom<CongressionalTradeSyncService>` already scans the assembly, so the new impl auto-registers as `ISenateBrowserSession` — no DI-wiring file change. Verified: 164 Congress unit + 52 Congress integration tests green.
- **Local coverage 88.33% → 89.27%** (biggest single-PR jump); `SenateDisclosureClient.cs` ~0/226 → 167/191.

## Code changes

- `src/Equibles.Congress.HostedService/Services/ISenateBrowserSession.cs` — new transport abstraction (`EnsureAuthenticated`, `Fetch`, `IAsyncDisposable`).
- `PlaywrightSenateBrowserSession.cs` — new; the Firefox launch + disclaimer + JS-fetch (moved verbatim from the client), `[Service(Scoped, typeof(ISenateBrowserSession))]`.
- `SenateFetchResult.cs`, `SenateBrowserException.cs` — new; strongly-typed result + domain transport exception.
- `SenateDisclosureClient.cs` — constructor now `(ISenateBrowserSession, ILogger)`; Playwright removed; `FetchWithRetry` retries on `SenateBrowserException`/429/5xx exactly as before; `DisposeAsync` delegates to the session.
- `SenateDisclosureClientTests.cs` — updated existing `ParseReportRow` reflection tests to the new ctor.
- `SenateDisclosureClientFetchTests.cs` — new 6-`[Fact]` suite via a fake `ISenateBrowserSession`: search→report flow, two-page pagination, 429-retry, browser-exception-retry, non-2xx hard-fail, dispose delegation.