### PR TITLE
test(holdings): pin HoldingsScraperWorker DoWork + TryProcessDataSet

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkTests.cs
@@ -1,0 +1,106 @@
+using System.Reflection;
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// The existing Holdings worker tests only invoke single private helpers in
+/// isolation. This pins the two largest uncovered methods end-to-end via the
+/// real scope/DB harness: the <c>DoWork</c> per-cycle orchestration with no
+/// data sets in window, and <c>TryProcessDataSet</c>'s non-transient failure
+/// path (a dependency that can't be resolved must be reported and skipped, not
+/// crash the scraper).
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsScraperWorkerDoWorkTests : ParadeDbMcpTestBase
+{
+    public HoldingsScraperWorkerDoWorkTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private static ErrorReporter BuildErrorReporter() =>
+        new(Substitute.For<IServiceScopeFactory>(), Substitute.For<ILogger<ErrorReporter>>());
+
+    private static IConfiguration ConfigWithContactEmail()
+    {
+        var configuration = Substitute.For<IConfiguration>();
+        configuration["Sec:ContactEmail"].Returns("test@example.com");
+        return configuration;
+    }
+
+    [Fact]
+    public async Task DoWork_NoDataSetsInWindow_CompletesWithoutProcessingOrThrowing()
+    {
+        // MinSyncDate far in the future → GetDataSetFileNames yields nothing,
+        // so the cycle backfills nothing, processes nothing, and falls through
+        // to RecalculatePendingValues (whose recalculator is intentionally not
+        // registered → its own catch swallows, proving the cycle is resilient).
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(ProcessedDataSetRepository), new ProcessedDataSetRepository(DbContext))
+        );
+
+        var worker = new HoldingsScraperWorker(
+            Substitute.For<ILogger<HoldingsScraperWorker>>(),
+            scopeFactory,
+            BuildErrorReporter(),
+            Options.Create(new WorkerOptions { MinSyncDate = new DateTime(2099, 1, 1) }),
+            ConfigWithContactEmail()
+        );
+
+        var doWork = typeof(HoldingsScraperWorker).GetMethod(
+            "DoWork",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+        await (Task)doWork.Invoke(worker, [CancellationToken.None]);
+
+        var processed = await DbContext
+            .Set<ProcessedDataSet>()
+            .AsNoTracking()
+            .CountAsync(CancellationToken.None);
+        processed.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task TryProcessDataSet_HoldingsClientNotResolvable_ReportsErrorAndReturnsFalse()
+    {
+        // Scope has the ProcessedDataSet repo but NOT HoldingsDataSetClient, so
+        // GetRequiredService throws inside the try — the non-transient catch must
+        // report via ErrorReporter and return false (skip), not bubble up.
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(ProcessedDataSetRepository), new ProcessedDataSetRepository(DbContext))
+        );
+
+        var worker = new HoldingsScraperWorker(
+            Substitute.For<ILogger<HoldingsScraperWorker>>(),
+            scopeFactory,
+            BuildErrorReporter(),
+            Options.Create(new WorkerOptions()),
+            ConfigWithContactEmail()
+        );
+
+        var tryProcess = typeof(HoldingsScraperWorker).GetMethod(
+            "TryProcessDataSet",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+        var result = await (Task<bool>)
+            tryProcess.Invoke(
+                worker,
+                ["2024q1_form13f.zip", new DateOnly(2024, 1, 1), CancellationToken.None]
+            );
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- `HoldingsScraperWorker.DoWork` (53 zero-hit, the per-cycle orchestration) and `TryProcessDataSet` (100 zero-hit, the import core) were essentially uncovered — existing tests only invoke isolated private helpers in isolation.
- Adds 2 `[Fact]`s covering ~63 `HoldingsScraperWorker` lines via the existing `ServiceScopeSubstitute` + `ParadeDbMcpTestBase` harness — no new infra, no production change.

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkTests.cs` — new file, 2 `[Fact]`s:
  - `DoWork` with `MinSyncDate` in the far future → empty sync window → backfills nothing, processes nothing, falls through `RecalculatePendingValues` resiliently (recalculator intentionally unregistered → its own catch swallows). Pins the steady-state no-op cycle.
  - `TryProcessDataSet` with `HoldingsDataSetClient` unresolvable → the non-transient catch reports via `ErrorReporter` and returns `false` (skip), not bubbling up and crashing the scraper.
- Both fast/deterministic: the failure path returns before any retry/`Task.Delay`.