### PR TITLE
test(sec): pin DocumentScraper HttpRequestException catch branches

### DIFF
--- a/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
@@ -340,6 +340,65 @@ public class DocumentScraperTests
         result.DocumentsAdded.Should().Be(0);
     }
 
+    [Fact]
+    public async Task ScrapeDocuments_GetCompanyFilingsThrowsHttp_RecordsPerCikErrorAndContinues()
+    {
+        // Covers ProcessDocumentTypeForCompany's per-CIK HttpRequestException
+        // catch (zero-hit): one CIK's filing fetch failing must be logged +
+        // counted, not abort the company — the loop continues to the next CIK.
+        var harness = new Harness();
+        await using var dbContext = harness.CreateDbContext();
+        SeedCompany(dbContext, ticker: "ACME", cik: "0000123456");
+
+        harness
+            .SecEdgarClient.GetCompanyFilings("0000123456", DocumentTypeFilter.TenK, null)
+            .Returns<List<FilingData>>(_ => throw new HttpRequestException("SEC EDGAR 503"));
+
+        var options = new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.TenK] };
+        var result = await harness.BuildScraper(dbContext, options: options).ScrapeDocuments();
+
+        result.CompaniesProcessed.Should().Be(1);
+        result.DocumentsFound.Should().Be(0);
+        result.Errors.Should().Be(1);
+        result.ErrorMessages.Should().ContainSingle().Which.Should().Contain("0000123456");
+    }
+
+    [Fact]
+    public async Task ScrapeDocuments_PersistenceExistsThrowsHttp_HitsHttpCatchAndRecordsError()
+    {
+        // Covers ProcessFiling's HttpRequestException catch (zero-hit), distinct
+        // from the generic catch: Exists throws BEFORE CreateDocument so the
+        // Polly pipeline is never entered — the HTTP-specific branch records the
+        // error without the deferred-retry path.
+        var harness = new Harness();
+        await using var dbContext = harness.CreateDbContext();
+        SeedCompany(dbContext, ticker: "ACME", cik: "0000123456");
+
+        harness
+            .SecEdgarClient.GetCompanyFilings("0000123456", DocumentTypeFilter.TenK, null)
+            .Returns([BuildFiling("0000123456", "0000123456-25-000011", "10-K")]);
+        harness
+            .Persistence.Exists(
+                Arg.Any<CommonStock>(),
+                Arg.Any<DocumentType>(),
+                Arg.Any<DateOnly>(),
+                Arg.Any<DateOnly>()
+            )
+            .Returns<bool>(_ => throw new HttpRequestException("persistence HTTP fault"));
+
+        var options = new DocumentScraperOptions { DocumentTypesToSync = [DocumentType.TenK] };
+        var result = await harness.BuildScraper(dbContext, options: options).ScrapeDocuments();
+
+        result.DocumentsFound.Should().Be(1);
+        result.Errors.Should().Be(1);
+        result
+            .ErrorMessages.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("0000123456-25-000011");
+        result.DocumentsAdded.Should().Be(0);
+    }
+
     // ── helpers ──
 
     private static FilingData BuildFiling(string cik, string accession, string form) =>


### PR DESCRIPTION
## Summary

- Two zero-hit fault-isolation branches in `DocumentScraper`: `ProcessDocumentTypeForCompany`'s per-CIK `HttpRequestException` catch (277–291) and `ProcessFiling`'s `HttpRequestException` catch (410–421, distinct from the generic catch pinned in #624).
- Adds 2 `[Fact]`s to the existing `DocumentScraperTests` (reuses its private `Harness`, no new infra, no production change).
- Verified: 26 previously-zero-hit lines go 0 → covered. Both fast — `Exists` throws *before* `CreateDocument` so the Polly retry pipeline (3× exponential from 2s) is never entered.

## Code changes

- `tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs` — +2 `[Fact]`s:
  - `SecEdgarClient.GetCompanyFilings` throws `HttpRequestException` → the per-CIK catch logs + increments `Errors` and the loop continues (no aborted company).
  - `Persistence.Exists` throws `HttpRequestException` → `ProcessFiling`'s HTTP-specific catch records the error without entering the deferred-retry/Polly path.