### PR TITLE
test(cboe): pin CboeImportService idempotency + VIX catch arms

### DIFF
--- a/tests/Equibles.IntegrationTests/Cboe/CboeImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Cboe/CboeImportServiceFullPipelineTests.cs
@@ -3,6 +3,7 @@ using Equibles.Cboe.HostedService.Services;
 using Equibles.Cboe.Repositories;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Cboe.Contracts;
 using Equibles.Integrations.Cboe.Models;
 using Equibles.IntegrationTests.Helpers;
@@ -163,5 +164,177 @@ public class CboeImportServiceFullPipelineTests : IAsyncLifetime
         var persistedVix = await verify.Set<CboeVixDaily>().ToListAsync();
         persistedVix.Should().ContainSingle();
         persistedVix[0].Close.Should().Be(14.95m);
+    }
+
+    // ── Idempotency + per-source resilience (zero-hit branches) ─────────
+
+    private static ICboeClient NoPutCallClient()
+    {
+        var client = Substitute.For<ICboeClient>();
+        foreach (var t in Enum.GetValues<CboePutCallCsvType>())
+            client.DownloadPutCallRatios(t).Returns([]);
+        return client;
+    }
+
+    [Fact]
+    public async Task Import_VixHistoryAlreadyUpToDate_InsertsNothing()
+    {
+        using (var seed = FreshContext())
+        {
+            seed.Set<CboeVixDaily>()
+                .Add(
+                    new CboeVixDaily
+                    {
+                        Date = new DateOnly(2026, 4, 10),
+                        Open = 14m,
+                        High = 15m,
+                        Low = 13m,
+                        Close = 14.5m,
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var client = NoPutCallClient();
+        client
+            .DownloadVixHistory()
+            .Returns([
+                new CboeVixRecord
+                {
+                    Date = new DateOnly(2026, 4, 1), // older than stored → filtered out
+                    Open = 1m,
+                    High = 1m,
+                    Low = 1m,
+                    Close = 1m,
+                },
+            ]);
+
+        var sut = new CboeImportService(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<CboeImportService>>(),
+            client,
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+
+        await sut.Import(CancellationToken.None);
+
+        using var verify = FreshContext();
+        var rows = await verify.Set<CboeVixDaily>().ToListAsync();
+        rows.Should().ContainSingle("the only row is the pre-seeded one — nothing new inserted");
+        rows[0].Close.Should().Be(14.5m);
+    }
+
+    [Fact]
+    public async Task Import_VixDownloadThrowsHttp_SwallowsAndPersistsNothing()
+    {
+        var client = NoPutCallClient();
+        client
+            .DownloadVixHistory()
+            .Returns<Task<List<CboeVixRecord>>>(_ => throw new HttpRequestException("CBOE 503"));
+
+        var sut = new CboeImportService(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<CboeImportService>>(),
+            client,
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+
+        await sut.Import(CancellationToken.None);
+
+        using var verify = FreshContext();
+        (await verify.Set<CboeVixDaily>().CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Import_VixDownloadThrowsGeneric_ReportsToErrorReporter()
+    {
+        var client = NoPutCallClient();
+        client
+            .DownloadVixHistory()
+            .Returns<Task<List<CboeVixRecord>>>(_ => throw new InvalidOperationException("boom"));
+
+        var errorReporter = Substitute.For<ErrorReporter>(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+
+        var sut = new CboeImportService(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<CboeImportService>>(),
+            client,
+            errorReporter
+        );
+
+        await sut.Import(CancellationToken.None);
+
+        await errorReporter
+            .Received()
+            .Report(
+                ErrorSource.CboeScraper,
+                "CboeImport.ImportVixHistory",
+                Arg.Any<string>(),
+                Arg.Any<string>()
+            );
+    }
+
+    [Fact]
+    public async Task Import_PutCallRatioAlreadyUpToDate_InsertsNothingForThatType()
+    {
+        using (var seed = FreshContext())
+        {
+            seed.Set<CboePutCallRatio>()
+                .Add(
+                    new CboePutCallRatio
+                    {
+                        RatioType = CboePutCallRatioType.Equity,
+                        Date = new DateOnly(2026, 4, 10),
+                        CallVolume = 1,
+                        PutVolume = 1,
+                        TotalVolume = 2,
+                        PutCallRatio = 1m,
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var client = NoPutCallClient();
+        client
+            .DownloadPutCallRatios(CboePutCallCsvType.Equity)
+            .Returns([
+                new CboePutCallRecord
+                {
+                    Date = new DateOnly(2026, 4, 1), // older than stored → filtered out
+                    CallVolume = 5,
+                    PutVolume = 5,
+                    TotalVolume = 10,
+                    PutCallRatio = 1m,
+                },
+            ]);
+        client.DownloadVixHistory().Returns([]);
+
+        var sut = new CboeImportService(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<CboeImportService>>(),
+            client,
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+
+        await sut.Import(CancellationToken.None);
+
+        using var verify = FreshContext();
+        var rows = await verify
+            .Set<CboePutCallRatio>()
+            .Where(r => r.RatioType == CboePutCallRatioType.Equity)
+            .ToListAsync();
+        rows.Should().ContainSingle("the stored Equity row is current — no newer record inserted");
     }
 }


### PR DESCRIPTION
## Summary

- Adds 4 `[Fact]`s to the existing `CboeImportServiceFullPipelineTests` (reuses its ParadeDB scope harness — no new infra, no production change) covering zero-hit branches:
  - `ImportVixHistory` already-up-to-date early return (186–188)
  - `ImportVixHistory` `HttpRequestException` catch (224–227) and non-HTTP catch → `ErrorReporter` (228–237)
  - `ImportPutCallRatio` already-up-to-date early return (116–118)
- Verified: ~26 net-new genuinely-zero lines covered. The `>= InsertBatchSize` flush branches (208–212 / 139–143) are deliberately left — they need 1000+ synthetic records for marginal value.

## Code changes

- `tests/Equibles.IntegrationTests/Cboe/CboeImportServiceFullPipelineTests.cs` — +4 `[Fact]`s + a small `NoPutCallClient()` helper:
  - seed a recent `CboeVixDaily`/`CboePutCallRatio`, client returns an older record → filtered out → idempotent no-op insert.
  - `DownloadVixHistory` throws `HttpRequestException` → swallowed, nothing persisted.
  - `DownloadVixHistory` throws `InvalidOperationException` → `ErrorReporter.Report("CboeImport.ImportVixHistory", …)` asserted via a substituted reporter.