### PR TITLE
test(yahoo): pin YahooPriceImportService overflow guard + key-stats update

### DIFF
--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -500,4 +500,64 @@ public class YahooPriceImportServiceTests : IDisposable
         var prices = _priceRepo.GetAll().ToList();
         prices.Should().HaveCount(600);
     }
+
+    // ── Overflow guard + key-statistics update (zero-hit branches) ─────
+
+    [Fact]
+    public async Task Import_PriceExceedsNumericLimit_SkipsOverflowRowButInsertsValidOnes()
+    {
+        var stock = CreateStock("OVR", "Overflow Co.");
+        await SeedStocks(stock);
+
+        var valid = new HistoricalPrice
+        {
+            Date = new DateOnly(2024, 1, 2),
+            Open = 100m,
+            High = 102m,
+            Low = 99m,
+            Close = 101m,
+            AdjustedClose = 101m,
+            Volume = 1_000_000,
+        };
+        var overflow = new HistoricalPrice
+        {
+            Date = new DateOnly(2024, 1, 3),
+            // Above the numeric(18,4) ceiling → HasOverflowPrice true.
+            Open = 100_000_000_000_000m,
+            High = 100_000_000_000_000m,
+            Low = 100_000_000_000_000m,
+            Close = 100_000_000_000_000m,
+            AdjustedClose = 100_000_000_000_000m,
+            Volume = 1,
+        };
+        _yahooClient
+            .GetHistoricalPrices("OVR", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns([valid, overflow]);
+
+        await _service.Import(CancellationToken.None);
+
+        var prices = _priceRepo.GetAll().ToList();
+        prices.Should().ContainSingle("the overflow row must be skipped, the valid one kept");
+        prices[0].Date.Should().Be(new DateOnly(2024, 1, 2));
+    }
+
+    [Fact]
+    public async Task Import_KeyStatisticsSharesDiffer_UpdatesStockSharesOutstanding()
+    {
+        var stock = CreateStock("KST", "KeyStat Co.");
+        await SeedStocks(stock);
+
+        // No prices → ImportTicker returns early; SyncKeyStatistics still runs.
+        _yahooClient
+            .GetHistoricalPrices("KST", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns([]);
+        _yahooClient
+            .GetKeyStatistics("KST")
+            .Returns(new KeyStatistics { SharesOutstanding = 5_000_000 });
+
+        await _service.Import(CancellationToken.None);
+
+        var updated = _stockRepo.GetAll().Single(s => s.Ticker == "KST");
+        updated.SharesOutStanding.Should().Be(5_000_000);
+    }
 }


### PR DESCRIPTION
## Summary

- Two zero-hit branches in `YahooPriceImportService`: `ImportTicker`'s `numeric(18,4)` overflow-price warning (116–134) and `SyncKeyStatistics`' shares-outstanding update path (176–195).
- Adds 2 `[Fact]`s to the existing `YahooPriceImportServiceTests` (reuses its `TestDbContextFactory` + `ServiceScopeSubstitute` harness — no new infra, no production change).
- Verified: ~27 net-new genuinely-zero lines covered.

## Code changes

- `tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs` — +2 `[Fact]`s:
  - a price exceeding the `numeric(18,4)` ceiling → logged and skipped while the valid same-batch row is still inserted (guards the DB against an overflow insert that would fail the whole batch).
  - `GetKeyStatistics` returns a `SharesOutstanding` differing from the stored value → the stock row is updated and saved.