### PR TITLE
fix(sec): make UpdateExistingStock obsolete-holder removal reachable + pin it

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -210,9 +210,13 @@ public class CompanySyncService : ICompanySyncService
             && state.ExistingPrimaryTickers.Contains(primaryTicker)
         )
         {
-            var tickerHolder = state.ExistingStocks.FirstOrDefault(cs =>
-                cs.Ticker == primaryTicker
-            );
+            // Resolve the holder over every row, not just SEC-feed-scoped
+            // ExistingStocks: the holder we need to displace is precisely the
+            // one whose own CIK dropped out of the feed, so a feed-scoped lookup
+            // would never find it and the obsolete-removal arm below would be
+            // unreachable. PrimaryTickerToStock exists for exactly this (see its
+            // construction comment) and is what ReplaceObsoleteStock uses.
+            state.PrimaryTickerToStock.TryGetValue(primaryTicker, out var tickerHolder);
             if (tickerHolder != null && !state.SecCiks.Contains(tickerHolder.Cik))
             {
                 // Old holder is no longer in SEC data - remove it

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs
@@ -1,0 +1,182 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.HostedService.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// <see cref="CompanySyncServiceUpdateExistingTests"/> pins only the collision-free
+/// in-place update. This pins the two primary-ticker collision arms of
+/// <c>UpdateExistingStock</c> plus the no-op early return:
+///
+/// <list type="bullet">
+/// <item>The ticker the SEC now assigns to an existing CIK is held by another
+/// company whose own CIK has dropped out of the SEC feed → that obsolete holder
+/// is deleted and the update proceeds.</item>
+/// <item>The ticker is held by a company still active in the SEC feed → the
+/// update is skipped (the active holder keeps the ticker) and the stale row is
+/// left untouched.</item>
+/// <item>The SEC payload matches the stored row exactly → no write at all.</item>
+/// </list>
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class CompanySyncServiceUpdateExistingCollisionTests : ParadeDbMcpTestBase
+{
+    public CompanySyncServiceUpdateExistingCollisionTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private CompanySyncService BuildService(ISecEdgarClient secEdgarClient)
+    {
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
+            (
+                typeof(CommonStockManager),
+                new CommonStockManager(new CommonStockRepository(DbContext))
+            ),
+            (typeof(EquiblesDbContext), DbContext)
+        );
+
+        return new CompanySyncService(
+            scopeFactory,
+            secEdgarClient,
+            Options.Create(new WorkerOptions { TickersToSync = [] }),
+            Substitute.For<ILogger<CompanySyncService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+    }
+
+    [Fact]
+    public async Task SyncCompaniesFromSecApi_TickerHeldByCompanyNotInSecFeed_DeletesObsoleteHolderThenUpdates()
+    {
+        // Holder owns ticker "NEW" but its CIK is absent from the SEC payload —
+        // it is obsolete and must be removed so the updating company can take
+        // the ticker.
+        var obsoleteHolder = new CommonStock
+        {
+            Cik = "0000000001",
+            Ticker = "NEW",
+            Name = "Obsolete Holder Inc.",
+            Description = "Holds the ticker the updater wants",
+        };
+        var updating = new CommonStock
+        {
+            Cik = "0001067983",
+            Ticker = "OLD",
+            Name = "Old Name Inc.",
+            Description = "Will move from OLD to NEW",
+        };
+        DbContext.AddRange(obsoleteHolder, updating);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient
+            .GetActiveCompanies()
+            .Returns(
+                new List<CompanyInfo>
+                {
+                    new()
+                    {
+                        Cik = "0001067983",
+                        Name = "Berkshire Hathaway Inc.",
+                        Tickers = ["NEW"],
+                        EntityType = "operating",
+                    },
+                }
+            );
+
+        await BuildService(secEdgarClient).SyncCompaniesFromSecApi();
+
+        await using var verify = Fixture.CreateDbContext();
+        var stocks = await verify.Set<CommonStock>().AsNoTracking().ToListAsync();
+        stocks.Should().ContainSingle("the obsolete holder must be deleted");
+        stocks[0].Id.Should().Be(updating.Id);
+        stocks[0].Ticker.Should().Be("NEW");
+        stocks[0].Name.Should().Be("Berkshire Hathaway Inc.");
+    }
+
+    [Fact]
+    public async Task SyncCompaniesFromSecApi_TickerHeldByActiveCompany_SkipsUpdateAndLeavesRowStale()
+    {
+        // Holder owns ticker "NEW" AND its CIK is still in the SEC payload — it
+        // is active, keeps the ticker, and the updating company must be skipped.
+        // The holder's own payload matches its stored row exactly, exercising
+        // the needsUpdate==false early return on its iteration.
+        var activeHolder = new CommonStock
+        {
+            Cik = "0000000001",
+            Ticker = "NEW",
+            Name = "Active Holder Inc.",
+            Description = "Keeps the ticker",
+        };
+        var updating = new CommonStock
+        {
+            Cik = "0001067983",
+            Ticker = "OLD",
+            Name = "Old Name Inc.",
+            Description = "Wants NEW but is blocked",
+        };
+        DbContext.AddRange(activeHolder, updating);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient
+            .GetActiveCompanies()
+            .Returns(
+                new List<CompanyInfo>
+                {
+                    // Updating company processed first, then the active holder
+                    // (whose payload is identical to its stored row).
+                    new()
+                    {
+                        Cik = "0001067983",
+                        Name = "Berkshire Hathaway Inc.",
+                        Tickers = ["NEW"],
+                        EntityType = "operating",
+                    },
+                    new()
+                    {
+                        Cik = "0000000001",
+                        Name = "Active Holder Inc.",
+                        Tickers = ["NEW"],
+                        EntityType = "operating",
+                    },
+                }
+            );
+
+        await BuildService(secEdgarClient).SyncCompaniesFromSecApi();
+
+        await using var verify = Fixture.CreateDbContext();
+        var stocks = await verify
+            .Set<CommonStock>()
+            .AsNoTracking()
+            .OrderBy(s => s.Cik)
+            .ToListAsync();
+        stocks.Should().HaveCount(2, "neither row may be deleted");
+
+        var holder = stocks.Single(s => s.Cik == "0000000001");
+        holder.Ticker.Should().Be("NEW");
+        holder.Name.Should().Be("Active Holder Inc.");
+
+        var blocked = stocks.Single(s => s.Cik == "0001067983");
+        blocked.Ticker.Should().Be("OLD", "the update is skipped — ticker is in active use");
+        blocked.Name.Should().Be("Old Name Inc.");
+    }
+}


### PR DESCRIPTION
## Summary
`CompanySyncService.UpdateExistingStock` was the largest remaining in-process-testable coverage gap (45/93 lines). Investigating it surfaced a latent scoping bug: the obsolete-holder arm (delete a company that still holds the ticker our updating CIK now wants, when that holder's own CIK has dropped out of the SEC feed) was **unreachable** — `tickerHolder` was resolved over the SEC-feed-scoped `ExistingStocks`, so a holder absent from the feed could never be found.

## Code changes
- **src/Equibles.Sec.HostedService/Services/CompanySyncService.cs** — resolve `tickerHolder` via `state.PrimaryTickerToStock` (all rows), matching `ReplaceObsoleteStock` and that map's own construction comment ("so [we] can find a ticker holder whose own CIK dropped out of SEC's feed"). Minimal change; the obsolete-removal behaviour the code already intended is now actually reached.
- **tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs** (new) — pins both collision arms end-to-end via the ParadeDB harness:
  - ticker held by a company **not** in the SEC feed → obsolete holder deleted, update proceeds;
  - ticker held by a company **still active** in the feed → update skipped, stale row left untouched (also exercises the `needsUpdate==false` early return).

## Verification
All 12 `CompanySyncService` integration tests pass (10 pre-existing + 2 new) — no regression. `UpdateExistingStock` coverage 48% → 62%.