### PR TITLE
test(web): in-process WebHostFixture + Home Razor view-rendering coverage

### DIFF
--- a/tests/Equibles.IntegrationTests/Helpers/WebHostCollection.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/WebHostCollection.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace Equibles.IntegrationTests.Helpers;
+
+/// <summary>
+/// xUnit collection sharing one <see cref="WebHostFixture"/> (and its ParadeDB
+/// container) across every in-process Web view-rendering test class.
+/// </summary>
+[CollectionDefinition(Name)]
+public class WebHostCollection : ICollectionFixture<WebHostFixture>
+{
+    public const string Name = "WebHost";
+}

--- a/tests/Equibles.IntegrationTests/Helpers/WebHostFixture.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/WebHostFixture.cs
@@ -1,0 +1,173 @@
+using Equibles.Data;
+using Equibles.ParadeDB.EntityFrameworkCore;
+using Equibles.Web;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Respawn;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Helpers;
+
+/// <summary>
+/// In-process integration host for the real Equibles.Web app. Controller and tab
+/// service tests instantiate controllers directly, so no test exercises the Razor
+/// view pipeline — every compiled <c>AspNetCoreGeneratedDocument.Views_*</c> class
+/// is uncovered. This fixture boots the production host on a Kestrel loopback port
+/// backed by a Testcontainers ParadeDB instance and exposes an
+/// <see cref="HttpClient"/>, so a GET drives routing → controller → Razor view in
+/// the test process where coverage is captured.
+///
+/// Mirrors the functional <c>WebAppFixture</c> design (manual host build rather
+/// than <c>WebApplicationFactory&lt;T&gt;</c>, whose hardcoded TestServer and
+/// <c>DisposeAsync</c> signature clash with xUnit v2's <see cref="IAsyncLifetime"/>).
+/// One container per collection amortises the boot cost.
+/// </summary>
+public class WebHostFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _db = new PostgreSqlBuilder()
+        .WithImage("paradedb/paradedb:latest")
+        .WithDatabase("equibles_webint")
+        .WithUsername("postgres")
+        .WithPassword("postgres")
+        .Build();
+
+    private WebApplication _app;
+    private string _keysDirectory;
+    private Respawner _respawner;
+
+    public HttpClient Client { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        await _db.StartAsync();
+
+        // Production default (/app/keys) doesn't exist on dev/CI hosts and would
+        // crash AddDataProtection at startup.
+        _keysDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"equibles-webint-keys-{Guid.NewGuid():N}"
+        );
+        Directory.CreateDirectory(_keysDirectory);
+
+        var builder = WebApplication.CreateBuilder(
+            new WebApplicationOptions
+            {
+                ApplicationName = "Equibles.Web",
+                ContentRootPath = ResolveWebContentRoot(),
+                EnvironmentName = "Development",
+            }
+        );
+
+        builder.Configuration["ConnectionStrings:DefaultConnection"] = _db.GetConnectionString();
+        builder.Configuration["DataProtection:KeysDirectory"] = _keysDirectory;
+
+        Program.ConfigureServices(builder);
+
+        // Test-host relaxation: the Web module composition currently has EF model
+        // drift vs the migrations snapshot, so EF Core 9+ aborts MigrateAsync with
+        // PendingModelChangesWarning (thrown by default). Re-register the context
+        // ignoring only that warning so the schema still applies and views render.
+        // (Flagged for maintainers — the deployed Web host hits the same path.)
+        builder.Services.AddDbContext<EquiblesDbContext>(
+            (sp, options) =>
+            {
+                options.UseNpgsql(
+                    _db.GetConnectionString(),
+                    npgsql =>
+                        npgsql
+                            .UseVector()
+                            .UseParadeDb()
+                            .UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)
+                );
+                options.UseLazyLoadingProxies();
+                options.ConfigureWarnings(w =>
+                    w.Ignore(RelationalEventId.PendingModelChangesWarning)
+                );
+            }
+        );
+
+        _app = builder.Build();
+        await Program.ApplyMigrationsAsync(_app);
+        Program.ConfigurePipeline(_app);
+
+        _app.Urls.Add("http://127.0.0.1:0");
+        await _app.StartAsync();
+        Client = new HttpClient { BaseAddress = new Uri(_app.Urls.First()) };
+
+        await using var respawnConnection = new NpgsqlConnection(_db.GetConnectionString());
+        await respawnConnection.OpenAsync();
+        _respawner = await Respawner.CreateAsync(
+            respawnConnection,
+            new RespawnerOptions
+            {
+                DbAdapter = DbAdapter.Postgres,
+                SchemasToInclude = ["public"],
+                TablesToIgnore = [new Respawn.Graph.Table("__EFMigrationsHistory")],
+            }
+        );
+    }
+
+    public async Task DisposeAsync()
+    {
+        Client?.Dispose();
+        if (_app is not null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+        await _db.DisposeAsync();
+        if (_keysDirectory is not null && Directory.Exists(_keysDirectory))
+        {
+            try
+            {
+                Directory.Delete(_keysDirectory, recursive: true);
+            }
+            catch
+            { /* best-effort */
+            }
+        }
+    }
+
+    /// <summary>
+    /// Truncates all user tables in <c>public</c>, then runs <paramref name="seed"/>
+    /// against a fresh attached <see cref="EquiblesDbContext"/>. Call from the test
+    /// class constructor — xUnit instantiates the class once per test, so seeded
+    /// state never leaks across tests in the same class.
+    /// </summary>
+    public async Task ResetAndSeedAsync(Func<EquiblesDbContext, Task> seed = null)
+    {
+        await using (var resetConnection = new NpgsqlConnection(_db.GetConnectionString()))
+        {
+            await resetConnection.OpenAsync();
+            await _respawner.ResetAsync(resetConnection);
+        }
+
+        if (seed is null)
+            return;
+
+        using var scope = _app.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
+        await seed(dbContext);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static string ResolveWebContentRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Equibles.sln")))
+        {
+            dir = dir.Parent;
+        }
+        if (dir is null)
+        {
+            throw new InvalidOperationException(
+                "Could not locate Equibles.sln from test bin directory — cannot resolve ContentRootPath."
+            );
+        }
+        return Path.Combine(dir.FullName, "src", "Equibles.Web");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Web/HomeViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HomeViewRenderingTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// First in-process view-rendering coverage: the Home controller's views need
+/// no seed data and no auth, so they pin the Razor pipeline end-to-end (routing
+/// → controller → compiled view + shared layout + the FlashMessages partial that
+/// renders on every page) without database setup. Every assertion targets
+/// rendered HTML the view is responsible for emitting, so a broken view template
+/// fails the test rather than silently returning an empty body.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HomeViewRenderingTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HomeViewRenderingTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetIndex_RendersHomeViewWithLayout()
+    {
+        var response = await _fixture.Client.GetAsync("/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Equibles", "the home view sets and renders its title");
+        html.Should().Contain("<html", "the shared layout must wrap the view");
+    }
+
+    [Fact]
+    public async Task GetConnect_RendersConnectViewWithMcpUrl()
+    {
+        var response = await _fixture.Client.GetAsync("/Home/Connect");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        // Connect() computes an MCP URL from the request scheme/host and pushes it
+        // into ViewData — the view must render it, exercising the data-driven path.
+        html.Should().Contain("/mcp", "the connect view renders the computed MCP URL");
+    }
+
+    [Fact]
+    public async Task GetError404_RendersErrorViewWithNotFoundStatus()
+    {
+        var response = await _fixture.Client.GetAsync("/Home/Error/404");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Page Not Found", "the error view renders the 404 title");
+    }
+}


### PR DESCRIPTION
## Summary
Every compiled `AspNetCoreGeneratedDocument.Views_*` class was at 0% — the existing Web tests instantiate controllers directly and never drive the Razor pipeline. This adds reusable in-process Web host infrastructure and the first view-rendering tests.

## Code changes
- **WebHostFixture** (new) — boots the real Equibles.Web host on a Kestrel loopback port backed by a Testcontainers ParadeDB, exposing an `HttpClient`. Mirrors the proven functional `WebAppFixture` design (manual host build; `WebApplicationFactory<T>`'s TestServer + `DisposeAsync` clash with xUnit v2). Reusable by future iterations to cover the remaining 0% views with seeded GETs.
- **WebHostCollection** (new) — shares one fixture/container across Web view-rendering classes.
- **HomeViewRenderingTests** (new) — GET `/`, `/Home/Connect`, `/Home/Error/404` assert on rendered HTML; covers 7 previously-0% view classes (`Views_Home_Connect` fully 18/18, plus Index/Error/Layout/Head/FlashMessages/ViewStart).

## ⚠️ Latent issue surfaced (maintainers)
`Program.ApplyMigrationsAsync` aborts with EF Core's `PendingModelChangesWarning`: the Web module composition's model has drift vs the migrations snapshot. EF Core 9+ throws this from `MigrateAsync` by default, so the deployed Web host hits the same path. The fixture ignores **only** that warning as a documented test-host relaxation (see inline comment) so views can render — it does not fix the underlying drift, which needs a maintainer-generated migration.

## Verification
Full integration suite green: 1094 passed, 1 pre-existing skip, 0 failed — the added parallel container causes no contention. Test-only.