### PR TITLE
test(web): pin Stocks holdings/insider/holder seeded view rendering

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/StocksTabsViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksTabsViewRenderingTests.cs
@@ -1,0 +1,130 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Completes the in-process Razor coverage seam for the Stocks area: the
+/// holdings tab, insider-trading tab and holder-detail views render only when
+/// their tab data is present, so they were 0%. Each test seeds the minimum
+/// graph (stock + holder/holding or insider owner/transaction), GETs the route,
+/// and asserts on the row HTML the populated path emits.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class StocksTabsViewRenderingTests
+{
+    private const string Ticker = "AAPL";
+    private const string HolderCik = "0001067983";
+
+    private readonly WebHostFixture _fixture;
+
+    public StocksTabsViewRenderingTests(WebHostFixture fixture) => _fixture = fixture;
+
+    private async Task SeedHoldingsGraph()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            var stock = new CommonStock
+            {
+                Cik = "0000320193",
+                Ticker = Ticker,
+                Name = "Apple Inc.",
+            };
+            var holder = new InstitutionalHolder { Cik = HolderCik, Name = "Berkshire Hathaway" };
+            db.AddRange(stock, holder);
+            db.AddRange(
+                new InstitutionalHolding
+                {
+                    CommonStockId = stock.Id,
+                    InstitutionalHolderId = holder.Id,
+                    FilingDate = new DateOnly(2026, 1, 31),
+                    ReportDate = new DateOnly(2025, 12, 31),
+                    Shares = 1_000_000,
+                    Value = 50_000_000,
+                },
+                new InstitutionalHolding
+                {
+                    CommonStockId = stock.Id,
+                    InstitutionalHolderId = holder.Id,
+                    FilingDate = new DateOnly(2025, 10, 31),
+                    ReportDate = new DateOnly(2025, 9, 30),
+                    Shares = 900_000,
+                    Value = 42_000_000,
+                }
+            );
+            await Task.CompletedTask;
+        });
+    }
+
+    [Fact]
+    public async Task GetStocksHoldings_WithSeededInstitutionalHolding_RendersHoldingsTab()
+    {
+        await SeedHoldingsGraph();
+
+        var response = await _fixture.Client.GetAsync($"/Stocks/{Ticker}/Holdings");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Berkshire Hathaway", "the holdings tab lists the holder");
+    }
+
+    [Fact]
+    public async Task GetStocksHolderDetail_WithSeededHolding_RendersHolderView()
+    {
+        await SeedHoldingsGraph();
+
+        var response = await _fixture.Client.GetAsync($"/Stocks/{Ticker}/Holders/{HolderCik}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Berkshire Hathaway", "the holder-detail view renders the holder");
+        html.Should().Contain(Ticker, "the holder-detail view renders the stock ticker");
+    }
+
+    [Fact]
+    public async Task GetStocksInsiderTrading_WithSeededTransaction_RendersInsiderTab()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            var stock = new CommonStock
+            {
+                Cik = "0000320193",
+                Ticker = Ticker,
+                Name = "Apple Inc.",
+            };
+            var owner = new InsiderOwner
+            {
+                OwnerCik = "0001214156",
+                Name = "Cook Timothy D",
+                IsOfficer = true,
+                OfficerTitle = "CEO",
+            };
+            db.AddRange(stock, owner);
+            db.Add(
+                new InsiderTransaction
+                {
+                    CommonStockId = stock.Id,
+                    InsiderOwnerId = owner.Id,
+                    FilingDate = new DateOnly(2026, 1, 5),
+                    TransactionDate = new DateOnly(2026, 1, 2),
+                    Shares = 50_000,
+                    PricePerShare = 190.25m,
+                    SharesOwnedAfter = 3_000_000,
+                    SecurityTitle = "Common Stock",
+                    AccessionNumber = "0001214156-26-000001",
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync($"/Stocks/{Ticker}/InsiderTrading");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Cook Timothy D", "the insider-trading tab lists the insider");
+    }
+}


### PR DESCRIPTION
## Summary
Completes the WebHostFixture (#634) view-coverage seam for the Stocks area — the last cluster of high-line 0% Razor views.

## Code changes
- **tests/Equibles.IntegrationTests/Web/StocksTabsViewRenderingTests.cs** (new), seeding the minimum graph and GETting each route:
  - `/Stocks/AAPL/Holdings` → `Views_Stocks__HoldingsTab` **0% → 82%** (14/17)
  - `/Stocks/AAPL/Holders/{cik}` → `Views_Stocks_ShowHolder` **0% → 92%** (23/25)
  - `/Stocks/AAPL/InsiderTrading` → `Views_Stocks__InsiderTradingTab` **0% → 56%** (13/23)

50 previously-uncovered view lines + incidental StockTabService loader path coverage (LoadHoldingsTab / LoadInsiderTradingTab / LoadHolderDetail populated paths). Remaining lines are conditional fragments (prior-quarter change %, alternate transaction codes). Test-only; reuses the validated WebHostCollection container.