### PR TITLE
test(congress): pin SenateDisclosureClient FetchWithRetry exhaustion arm

### DIFF
--- a/tests/Equibles.UnitTests/Congress/SenateDisclosureClientFetchTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateDisclosureClientFetchTests.cs
@@ -185,4 +185,31 @@ public class SenateDisclosureClientFetchTests
 
         session.Disposed.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task GetRecentTransactions_SearchThrowsBrowserExceptionEveryAttempt_ExhaustsRetriesAndRethrows()
+    {
+        // The "throws once then succeeds" pin covers the retry+continue arm;
+        // this covers the exhaustion arm: a SenateBrowserException on every
+        // attempt (0..MaxRetries) must, on the final attempt, log and rethrow
+        // rather than continue or swallow.
+        var session = new FakeSenateBrowserSession();
+        for (var attempt = 0; attempt <= 3; attempt++)
+        {
+            session.Script.Enqueue(() =>
+                throw new SenateBrowserException("down", new InvalidOperationException())
+            );
+        }
+
+        var act = async () =>
+            await Sut(session)
+                .GetRecentTransactions(
+                    new DateOnly(2024, 1, 1),
+                    new DateOnly(2024, 1, 31),
+                    CancellationToken.None
+                );
+
+        await act.Should().ThrowAsync<SenateBrowserException>();
+        session.FetchedUrls.Should().HaveCount(4, "every attempt (0..MaxRetries) was made");
+    }
 }


### PR DESCRIPTION
## Summary
`SenateDisclosureClient.FetchWithRetry`'s retry-exhaustion arm — a `SenateBrowserException` on every attempt (0..MaxRetries) must log and rethrow on the final attempt — was uncovered (the existing pins only cover throw-once-then-succeed and 429).

## Code changes
- **tests/Equibles.UnitTests/Congress/SenateDisclosureClientFetchTests.cs** — appended one [Fact] reusing the existing FakeSenateBrowserSession: scripts a SenateBrowserException on all 4 attempts, asserts GetRecentTransactions rethrows it and all 4 attempts were made.

## Verification
Passes (14s = 2+4+8s fixed backoffs). `FetchWithRetry` 82% → 94% (54/57). The 3 remaining lines are the post-loop `throw` — unreachable (every in-loop path returns/throws/continues; the final attempt cannot continue). Test-only.