### PR TITLE
refactor+test(holdings): RetryDelays seam + pin TryProcessDataSet retry arms

### DIFF
--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -13,12 +13,12 @@ namespace Equibles.Holdings.HostedService;
 public class HoldingsScraperWorker : BaseScraperWorker
 {
     private const int MaxRetries = 3;
-    private static readonly TimeSpan[] RetryDelays =
-    [
-        TimeSpan.FromSeconds(30),
-        TimeSpan.FromMinutes(2),
-        TimeSpan.FromMinutes(10),
-    ];
+
+    // Per-attempt backoff before retrying a transient data-set failure.
+    // Exposed as a protected virtual seam so tests can collapse the waits
+    // without changing production behaviour (the defaults are unchanged).
+    protected virtual TimeSpan[] RetryDelays =>
+        [TimeSpan.FromSeconds(30), TimeSpan.FromMinutes(2), TimeSpan.FromMinutes(10)];
 
     private readonly WorkerOptions _workerOptions;
     private readonly IConfiguration _configuration;

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRetryArmsTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRetryArmsTests.cs
@@ -1,0 +1,120 @@
+using System.Reflection;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Holdings.HostedService;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Pins <c>TryProcessDataSet</c>'s transient-retry arms. The download throws a
+/// transient exception on every attempt, so the per-attempt backoff block, the
+/// HttpRequestException / IOException catch arms, and the "failed all attempts"
+/// return-false are all exercised across the full MaxRetries loop. The backoff
+/// is collapsed via the <c>RetryDelays</c> seam so the loop runs in
+/// milliseconds rather than minutes.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsScraperWorkerRetryArmsTests : ParadeDbMcpTestBase
+{
+    private const string FileName = "2024q3_form13f.zip";
+
+    public HoldingsScraperWorkerRetryArmsTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    // Production HoldingsScraperWorker with the retry backoff collapsed to ~0.
+    private sealed class FastRetryWorker : HoldingsScraperWorker
+    {
+        public FastRetryWorker(
+            ILogger<HoldingsScraperWorker> logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            IOptions<WorkerOptions> workerOptions,
+            IConfiguration configuration
+        )
+            : base(logger, scopeFactory, errorReporter, workerOptions, configuration) { }
+
+        protected override TimeSpan[] RetryDelays =>
+            [
+                TimeSpan.FromMilliseconds(1),
+                TimeSpan.FromMilliseconds(1),
+                TimeSpan.FromMilliseconds(1),
+            ];
+    }
+
+    private HoldingsDataSetClient ThrowingDataSetClient(Exception toThrow)
+    {
+        var secEdgar = Substitute.For<ISecEdgarClient>();
+        secEdgar.DownloadStream(Arg.Any<string>()).Returns<Task<Stream>>(_ => throw toThrow);
+        return new HoldingsDataSetClient(
+            secEdgar,
+            Substitute.For<ILogger<HoldingsDataSetClient>>()
+        );
+    }
+
+    // Resolved by TryProcessDataSet before the (failing) download; never invoked.
+    private HoldingsImportService BuildImporter() =>
+        new(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            Substitute.For<IStockPriceProvider>()
+        );
+
+    private FastRetryWorker BuildWorker(Exception downloadException)
+    {
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(ProcessedDataSetRepository), new ProcessedDataSetRepository(DbContext)),
+            (typeof(HoldingsDataSetClient), ThrowingDataSetClient(downloadException)),
+            (typeof(HoldingsImportService), BuildImporter())
+        );
+
+        var config = Substitute.For<IConfiguration>();
+        config["Sec:ContactEmail"].Returns("test@example.com");
+
+        return new FastRetryWorker(
+            Substitute.For<ILogger<HoldingsScraperWorker>>(),
+            scopeFactory,
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions()),
+            config
+        );
+    }
+
+    public static IEnumerable<object[]> TransientExceptions =>
+        [
+            [new HttpRequestException("network down")],
+            [new IOException("disk error")],
+        ];
+
+    [Theory]
+    [MemberData(nameof(TransientExceptions))]
+    public async Task TryProcessDataSet_TransientFailureEveryAttempt_RetriesThenReturnsFalse(
+        Exception transient
+    )
+    {
+        var worker = BuildWorker(transient);
+
+        var method = typeof(HoldingsScraperWorker).GetMethod(
+            "TryProcessDataSet",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var result = await (Task<bool>)
+            method.Invoke(worker, [FileName, new DateOnly(2024, 1, 1), CancellationToken.None]);
+
+        result.Should().BeFalse("every attempt failed transiently — the file is deferred");
+    }
+}


### PR DESCRIPTION
## Summary
`HoldingsScraperWorker.TryProcessDataSet`'s transient-retry arms were the largest persistent coverage gap, blocked by a hardcoded `RetryDelays = [30s, 2m, 10m]` that made the retry loop untestable in reasonable time.

## Code changes
- **src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs** (`refactor:`) — `private static readonly TimeSpan[] RetryDelays` → `protected virtual TimeSpan[] RetryDelays` with **identical default durations**. Zero production behaviour change; provides a minimal test seam (the magic durations are also now a named, documented member).
- **tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRetryArmsTests.cs** (`test:`) — a subclass collapses the backoff to ~0; a download that throws `HttpRequestException` / `IOException` on every attempt exercises the per-attempt backoff block, both transient catch arms, and the failed-all-attempts return-false across the full MaxRetries loop (runs in ~90 ms).

## Verification
Full Holdings suite green: 69 integration + 106 unit, 0 failed — the seam refactor is regression-free. `TryProcessDataSet` 48% → 71% (merged with existing pins). Remaining lines: MarkAsProcessed catch + the non-transient arm (covered by a separate existing test) + the success-path 10s delay.