### PR TITLE
test(congress): pin PlaywrightSenateBrowserSession.DisposeAsync teardown

### DIFF
--- a/tests/Equibles.UnitTests/Congress/PlaywrightSenateBrowserSessionDisposeTests.cs
+++ b/tests/Equibles.UnitTests/Congress/PlaywrightSenateBrowserSessionDisposeTests.cs
@@ -1,0 +1,29 @@
+using Equibles.Congress.HostedService.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// <see cref="PlaywrightSenateBrowserSession.DisposeAsync"/> was 0% — the
+/// browser-driven methods need a real Firefox and aren't exercised. Disposing a
+/// never-authenticated session (page/browser/playwright all null) still must
+/// run the full teardown path: suppress finalize, skip the null page/browser
+/// closes, null-dispose Playwright, and dispose the init lock — without
+/// throwing.
+/// </summary>
+public class PlaywrightSenateBrowserSessionDisposeTests
+{
+    [Fact]
+    public async Task DisposeAsync_NeverAuthenticated_CompletesTeardownWithoutThrowing()
+    {
+        var session = new PlaywrightSenateBrowserSession(
+            Substitute.For<ILogger<PlaywrightSenateBrowserSession>>()
+        );
+
+        var dispose = async () => await session.DisposeAsync();
+
+        await dispose.Should().NotThrowAsync("the null-guarded teardown path must be safe");
+    }
+}


### PR DESCRIPTION
## Summary
`PlaywrightSenateBrowserSession.DisposeAsync` was 0% — the browser-driven methods need a real Firefox. But disposing a never-authenticated session is pure (page/browser/playwright null) and must still run the full teardown safely.

## Code changes
- **tests/Equibles.UnitTests/Congress/PlaywrightSenateBrowserSessionDisposeTests.cs** (new) — construct + `DisposeAsync()` with no authentication; asserts it completes without throwing.

## Verification
Passes (52ms). `DisposeAsync` 0% → 47% (9/19) — the entire null-guarded teardown path (suppress-finalize, null page/browser skips, Playwright null-dispose, init-lock dispose). The remaining 10 lines are the non-null close + PlaywrightException catch arms, which require a real Firefox (browser-bound by design). Test-only.