### PR TITLE
test(sec): pin DocumentTextTools.ReadDocumentLines catch arm

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesErrorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesErrorTests.cs
@@ -1,0 +1,49 @@
+using Equibles.Errors.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Mcp.Tools;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Sibling to <see cref="DocumentTextToolsSearchKeywordErrorTests"/>. Pins
+/// <c>ReadDocumentLines</c>'s catch arm: a repository failure (here, a disposed
+/// DbContext) must be logged, persisted via the error manager, and returned as
+/// the safe fallback message — never propagated to the MCP caller.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class DocumentTextToolsReadLinesErrorTests : ParadeDbMcpTestBase
+{
+    public DocumentTextToolsReadLinesErrorTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task ReadDocumentLines_RepositoryThrows_LogsReportsAndReturnsFallback()
+    {
+        // A repository over a disposed context throws on first access, driving
+        // the catch arm. The error manager uses the live base context.
+        var disposedContext = Fixture.CreateDbContext();
+        disposedContext.Dispose();
+
+        var sut = new DocumentTextTools(
+            new DocumentRepository(disposedContext),
+            ErrorManager,
+            Substitute.For<ILogger<DocumentTextTools>>()
+        );
+
+        var output = await sut.ReadDocumentLines(Guid.NewGuid(), startLine: 1, endLine: 10);
+
+        output.Should().Be("An error occurred while reading document lines. Please try again.");
+
+        await using var verify = Fixture.CreateDbContext();
+        var reported = await verify
+            .Set<Error>()
+            .AsNoTracking()
+            .AnyAsync(e => e.Context == "ReadDocumentLines");
+        reported.Should().BeTrue("the catch arm must persist the failure via the error manager");
+    }
+}


### PR DESCRIPTION
## Summary
`DocumentTextTools.ReadDocumentLines`'s catch arm (log + persist Error + safe fallback) was uncovered — there's no nullable string param or unclamped int to throw via inputs, so it was abandoned earlier. Cracked with the disposed-context fault-injection technique (#665).

## Code changes
- **tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadLinesErrorTests.cs** (new) — a `DocumentRepository` over a disposed context throws on first access; asserts `ReadDocumentLines` returns the fallback message and persists an Error (Context "ReadDocumentLines") via the live ErrorManager.

## Verification
Passes. `ReadDocumentLines` 65% → 90% (29/32, combined with the existing ReadLines pins). Remaining 3 lines are the invalid-range return and the defensive empty `catch {}` (error manager itself throwing). Test-only.