### PR TITLE
chore(mcp): remove unused ApplyMigrationsAsync dead code

### DIFF
--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -25,7 +25,6 @@ using Equibles.Sec.Data.Extensions;
 using Equibles.Sec.Mcp.Extensions;
 using Equibles.Yahoo.Data.Extensions;
 using Equibles.Yahoo.Mcp.Extensions;
-using Microsoft.EntityFrameworkCore;
 using ModelContextProtocol.AspNetCore;
 using Serilog;
 using Serilog.Events;
@@ -81,14 +80,6 @@ public partial class Program
         });
 
         builder.Services.AddSingleton<IApiKeyValidator, SimpleApiKeyValidator>();
-    }
-
-    public static async Task ApplyMigrationsAsync(WebApplication app)
-    {
-        using var scope = app.Services.CreateScope();
-        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
-        dbContext.Database.SetCommandTimeout(TimeSpan.FromHours(1));
-        await dbContext.Database.MigrateAsync();
     }
 
     public static void ConfigurePipeline(WebApplication app)


### PR DESCRIPTION
## Summary
`Mcp.Server.Program.ApplyMigrationsAsync` is dead code: zero callers repo-wide. MCP `Program.Main` (unlike `Web.Program.Main`) never calls it, `McpServerFixture` doesn't, and no test does — the MCP server is a thin host running against a DB migrated by the Web/Worker hosts. Surfaced while auditing why it showed 0% coverage.

## Code changes
- **src/Equibles.Mcp.Server/Program.cs** — delete the uninvoked public `ApplyMigrationsAsync` and its now-orphaned `using Microsoft.EntityFrameworkCore;`.

## Verification
MCP server builds clean (0 errors); MCP integration suite green (165 passed, 0 failed) — nothing referenced the method. csharpier check passes on the changed file. No behaviour change (uninvoked code). Removes 5 permanently-uncoverable lines.