### PR TITLE
fix(deps): remediate Bcl.Memory high-sev vuln + drop redundant refs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,6 +40,10 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Equibles.ParadeDB.EntityFrameworkCore" Version="2.1.0" />
     <PackageVersion Include="Pgvector.EntityFrameworkCore" Version="0.3.0" />
+    <!-- Pinned to remediate the transitive 9.0.4 high-severity advisory
+         GHSA-73j8-2gch-69rq (NU1903); referenced directly in
+         Equibles.Sec.BusinessLogic to override the vulnerable transitive. -->
+    <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.16" />
     <!-- Microsoft.Extensions -->
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />

--- a/src/Equibles.Data/Equibles.Data.csproj
+++ b/src/Equibles.Data/Equibles.Data.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" />
     <PackageReference Include="Equibles.ParadeDB.EntityFrameworkCore" />

--- a/src/Equibles.Mcp/Equibles.Mcp.csproj
+++ b/src/Equibles.Mcp/Equibles.Mcp.csproj
@@ -7,6 +7,5 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Sec.BusinessLogic/Equibles.Sec.BusinessLogic.csproj
+++ b/src/Equibles.Sec.BusinessLogic/Equibles.Sec.BusinessLogic.csproj
@@ -7,6 +7,11 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="Equibles.Core.AutoWiring" />
+    <!-- Direct reference pins the otherwise-transitive Microsoft.Bcl.Memory
+         (pulled via the ML.Tokenizers / PdfPig graph) off the vulnerable
+         9.0.4 (NU1903 / GHSA-73j8-2gch-69rq) to the centrally-managed
+         patched version. -->
+    <PackageReference Include="Microsoft.Bcl.Memory" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />


### PR DESCRIPTION
## Summary
Clears the NuGet build lints, including a high-severity dependency vulnerability.

- **NU1903 (high severity):** `Microsoft.Bcl.Memory` 9.0.4 — transitive via the ML.Tokenizers / PdfPig graph in `Equibles.Sec.BusinessLogic` — has advisory [GHSA-73j8-2gch-69rq](https://github.com/advisories/GHSA-73j8-2gch-69rq). Pinned to the patched **9.0.16** with a direct PackageReference in Sec.BusinessLogic + a central PackageVersion (CPM).
- **NU1510:** removed the redundant `Microsoft.Extensions.DependencyInjection.Abstractions` PackageReference from `Equibles.Mcp` (provided by the AspNetCore FrameworkReference) and `Equibles.Data` (provided by EF Core).

## Verification
Solution builds with 0 errors; NU1903 and NU1510 no longer emitted. Full non-functional suite green (1155 passed, 1 pre-existing skip, 0 failed) — the dependency bump and ref removals are regression-free.