### PR TITLE
test(holdings): pin TsvParser.ParseEntry more-values-than-headers row mapping

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/TsvParserExtraValuesTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/TsvParserExtraValuesTests.cs
@@ -1,0 +1,54 @@
+using System.IO.Compression;
+using System.Text;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class TsvParserExtraValuesTests
+{
+    private readonly TsvParser _sut = new();
+
+    // Adversarial: a row carrying MORE tab-separated values than there are
+    // headers is malformed input. The contract is positional header→value
+    // mapping, so every declared header must still receive its own correct
+    // value, the surplus value must not leak in under any key, and parsing
+    // must not throw. (Sibling "fewer values than headers" is already pinned.)
+    [Fact]
+    public async Task ParseEntry_MoreValuesThanHeaders_MapsHeadersAndDropsSurplus()
+    {
+        var tsv = "NAME\tAGE\nAlice\t30\tLONDON";
+        using var archive = CreateZipArchive(tsv);
+
+        var rows = await CollectRows(archive.Entries[0]);
+
+        rows.Should().ContainSingle();
+        rows[0].Should().HaveCount(2);
+        rows[0]["NAME"].Should().Be("Alice");
+        rows[0]["AGE"].Should().Be("30");
+        rows[0].Values.Should().NotContain("LONDON");
+    }
+
+    private static ZipArchive CreateZipArchive(string content)
+    {
+        var stream = new MemoryStream();
+        using (var writeArchive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = writeArchive.CreateEntry("data.tsv");
+            using var writer = new StreamWriter(entry.Open(), Encoding.UTF8);
+            writer.Write(content);
+        }
+
+        stream.Position = 0;
+        return new ZipArchive(stream, ZipArchiveMode.Read);
+    }
+
+    private async Task<List<Dictionary<string, string>>> CollectRows(ZipArchiveEntry entry)
+    {
+        var rows = new List<Dictionary<string, string>>();
+        await foreach (var row in _sut.ParseEntry(entry))
+        {
+            rows.Add(row);
+        }
+        return rows;
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `TsvParser.ParseEntry`: a malformed row carrying more tab-separated values than there are headers.
- The contract is positional header→value mapping; the test pins that every declared header still gets its correct value, the surplus value is dropped, and parsing does not throw.
- Complements the existing "fewer values than headers" test — this is the previously-untested inverse boundary.

## Code changes

- `tests/Equibles.UnitTests/Holdings/TsvParserExtraValuesTests.cs` — new test `ParseEntry_MoreValuesThanHeaders_MapsHeadersAndDropsSurplus`. Test-only; no production code touched. Guards against a regression where the `i < headers.Length && i < values.Length` loop bound is changed.