### PR TITLE
test(sec): add skipped repro for GH-693 — SecDocumentEnvelopeParser URL-encoded traversal

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserEncodedTraversalTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserEncodedTraversalTests.cs
@@ -1,0 +1,39 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentEnvelopeParserEncodedTraversalTests
+{
+    // Contract (documented in IsSafeFilename, SecDocumentEnvelopeParser.cs:61-63):
+    // "EDGAR filenames are always bare names ([A-Za-z0-9._-]+); reject anything
+    // that could traverse paths or escape the expected directory even though the
+    // host is already locked." The candidate flows into
+    // /Archives/edgar/data/{cik}/{accession}/{filename}; a URL-encoded `../../`
+    // (%2e%2e%2f) is not a bare name and the server decodes it back to a real
+    // traversal. Literal `../` and `\` are already pinned — the encoded form
+    // (the classic allowlist-bypass) is not. Per the stated contract this must
+    // be rejected: TryExtractPaperPdfFilename returns false, filename empty.
+    [Fact(Skip = "GH-693 — IsSafeFilename accepts URL-encoded path traversal (%2e%2e%2f)")]
+    public void TryExtractPaperPdfFilename_UrlEncodedPathTraversal_RejectsAndReturnsFalse()
+    {
+        var envelope = """
+            <SEC-DOCUMENT>
+            <DOCUMENT>
+            <TYPE>6-K
+            <SEQUENCE>1
+            <FILENAME>report%2e%2e%2f%2e%2e%2fadmin.pdf
+            <TEXT>
+            </TEXT>
+            </DOCUMENT>
+            </SEC-DOCUMENT>
+            """;
+
+        var success = SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(
+            envelope,
+            out var filename
+        );
+
+        success.Should().BeFalse();
+        filename.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `SecDocumentEnvelopeParser.TryExtractPaperPdfFilename` found a real bug: it accepts a `<FILENAME>` containing URL-encoded path traversal (`%2e%2e%2f` = `../`), violating its own documented allowlist (bare names `[A-Za-z0-9._-]+`, "reject anything that could traverse paths").
- Bug filed as GH-693. The test is committed **skipped** (`[Fact(Skip = "GH-693 …")]`) so it documents the expected behavior without breaking the build — un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserEncodedTraversalTests.cs` — new test `TryExtractPaperPdfFilename_UrlEncodedPathTraversal_RejectsAndReturnsFalse`, skipped — see GH-693. Test-only; no production code touched. Asserts the parser rejects an envelope whose `<FILENAME>` is `report%2e%2e%2f%2e%2e%2fadmin.pdf`; currently it returns `true` because `IsSafeFilename` only blocklists literal `/`, `\`, and a leading `.`.