### PR TITLE
test(congress): add skipped repro for GH-695 — ParseTransactionType S (partial)

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperPartialSaleTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperPartialSaleTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperPartialSaleTests
+{
+    // Contract (documented at DisclosureParsingHelper.cs, ParseTransactionType
+    // comment): "Handles both Senate full words ("Purchase", "Sale (Full)") and
+    // House abbreviations ("P", "S", "S (partial)")". "S (partial)" is an
+    // explicitly listed House abbreviation, so per the contract it must resolve
+    // to Sale. Existing tests pin "Sale (Partial)" and bare "S" but not this
+    // exact documented token.
+    [Fact(
+        Skip = "GH-695 — ParseTransactionType returns null for documented House abbreviation \"S (partial)\""
+    )]
+    public void ParseTransactionType_HouseAbbreviationSPartial_ReturnsSale()
+    {
+        var result = DisclosureParsingHelper.ParseTransactionType("S (partial)");
+
+        result.Should().Be(CongressTransactionType.Sale);
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `DisclosureParsingHelper.ParseTransactionType` found a real bug: it returns `null` for `"S (partial)"`, even though the method's own doc comment lists `"S (partial)"` as a handled House abbreviation that should map to `Sale`. Rows with this abbreviation are silently dropped by the caller.
- Bug filed as GH-695. The test is committed **skipped** (`[Fact(Skip = "GH-695 …")]`) so it documents the expected behavior without breaking the build — un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperPartialSaleTests.cs` — new test `ParseTransactionType_HouseAbbreviationSPartial_ReturnsSale`, skipped — see GH-695. Test-only; no production code touched. Asserts `ParseTransactionType("S (partial)")` returns `CongressTransactionType.Sale`; currently returns `null` because the Sale branch only matches `Contains("Sale"/"Sold")` or exact `Equals("S")`.