### PR TITLE
test(yahoo): pin FromUnixTimestamp UTC-date contract at sub-midnight instant

### DIFF
--- a/tests/Equibles.UnitTests/Yahoo/YahooFinanceClientUtcDateTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooFinanceClientUtcDateTests.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using Equibles.Integrations.Yahoo;
+
+namespace Equibles.UnitTests.Yahoo;
+
+public class YahooFinanceClientUtcDateTests
+{
+    private static readonly MethodInfo FromUnixTimestampMethod =
+        typeof(YahooFinanceClient).GetMethod(
+            "FromUnixTimestamp",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // Contract: FromUnixTimestamp returns the UTC calendar date of the instant
+    // (anchored on UnixEpoch ... .UtcDateTime). 1704067199 = 2023-12-31T23:59:59Z,
+    // whose UTC date is 2023-12-31 but whose LOCAL date is 2024-01-01 on any
+    // UTC+ machine. The existing pin uses exact-midnight 1704067200 where UTC
+    // and local dates coincide, so it cannot catch a local-time regression;
+    // this instant can. Yahoo daily candles are not midnight-aligned.
+    [Fact]
+    public void FromUnixTimestamp_OneSecondBeforeMidnightUtc_ReturnsUtcCalendarDateNotLocal()
+    {
+        var result = (DateOnly)FromUnixTimestampMethod.Invoke(null, [1704067199L]);
+
+        result.Should().Be(new DateOnly(2023, 12, 31));
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial pin for `YahooFinanceClient.FromUnixTimestamp`: its contract is to return the **UTC** calendar date of the instant (anchored on `UnixEpoch … .UtcDateTime`).
- The existing pin uses the exact-midnight timestamp `1704067200`, where the UTC date and a UTC+offset local date coincide — so it cannot detect a regression to local time. This test uses `1704067199` (2023-12-31T23:59:59Z), whose UTC date is `2023-12-31` but whose local date is `2024-01-01` on any UTC+ machine. Yahoo daily candle timestamps are not midnight-aligned, so this edge is real.
- Test passes against current code; it guards against a `.UtcDateTime`→`.DateTime`/`.LocalDateTime` regression.

## Code changes

- `tests/Equibles.UnitTests/Yahoo/YahooFinanceClientUtcDateTests.cs` — new test `FromUnixTimestamp_OneSecondBeforeMidnightUtc_ReturnsUtcCalendarDateNotLocal`, invoking the private method via the same reflection pattern the existing tests use. Test-only; no production code touched.