### PR TITLE
test(web): add skipped repro for GH-698 — StatisticsExtensions.SafeRound overflow

### DIFF
--- a/tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundOverflowTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class StatisticsExtensionsSafeRoundOverflowTests
+{
+    // Contract: SafeRound is named "Safe" and its doc-comment states its purpose
+    // is to "protect view-model casts from OverflowException" on the (decimal)
+    // cast. A finite double larger than decimal.MaxValue (~7.9e28) also throws
+    // OverflowException on that cast — IsFinite(1e29) is true, so the guard lets
+    // it through. (Ambiguity: the literal comment only names NaN/infinity; the
+    // method name + stated purpose imply no OverflowException for any double.)
+    // A caller relying on "Safe" must get null, not a crashed view render.
+    [Fact(
+        Skip = "GH-698 — SafeRound throws OverflowException for finite double exceeding decimal range"
+    )]
+    public void SafeRound_FiniteValueExceedingDecimalRange_ReturnsNullInsteadOfThrowing()
+    {
+        var result = 1e29.SafeRound(2);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `StatisticsExtensions.SafeRound` found a real bug: despite being named "Safe" and documented as protecting the view-model `(decimal)` cast from `OverflowException`, it still throws `OverflowException` for a **finite** double larger than `decimal.MaxValue` (~7.9e28) — `double.IsFinite` lets it through to the throwing cast.
- Bug filed as GH-698. The test is committed **skipped** (`[Fact(Skip = "GH-698 …")]`) so it documents the expected behavior without breaking the build — un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundOverflowTests.cs` — new test `SafeRound_FiniteValueExceedingDecimalRange_ReturnsNullInsteadOfThrowing`, skipped — see GH-698. Test-only; no production code touched. Asserts `1e29.SafeRound(2)` returns `null`; currently throws `System.OverflowException` at the `(decimal)Math.Round(...)` cast. All four existing `SafeRound` tests cover only `NaN`/`±∞`/small-finite, leaving this edge uncovered.