### PR TITLE
test(sec): add skipped repro for GH-700 — DocumentTextTools.HighlightKeyword empty-keyword loop

### DIFF
--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsEmptyKeywordTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsEmptyKeywordTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Equibles.Sec.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class DocumentTextToolsEmptyKeywordTests
+{
+    private static readonly MethodInfo HighlightKeywordMethod = typeof(DocumentTextTools).GetMethod(
+        "HighlightKeyword",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    // Contract: HighlightKeyword wraps every occurrence of `keyword` in a line.
+    // An empty keyword has no meaningful occurrence, so the only safe behaviour
+    // a caller can rely on is termination returning the line unchanged. The
+    // public SearchDocumentKeyword MCP tool passes its unvalidated keyword arg
+    // straight here, so an empty keyword is reachable and must not hang.
+    // (Ambiguity: empty keyword could be argued a caller error — but it must
+    // never produce an unbounded loop / DoS.) Timeout-bounded so the harness
+    // can't hang; exceeding it is the failure signal.
+    [Fact(Timeout = 2000, Skip = "GH-700 — HighlightKeyword infinite-loops on empty keyword")]
+    public async Task HighlightKeyword_EmptyKeyword_ReturnsLineUnchangedWithoutHanging()
+    {
+        var result = await Task.Run(() => (string)HighlightKeywordMethod.Invoke(null, ["abc", ""]));
+
+        result.Should().Be("abc");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `DocumentTextTools.HighlightKeyword` found a real availability bug: an empty `keyword` causes an unbounded loop (`IndexOf("", i)` returns `i`, `index` never advances), allocating until the process OOMs/hangs.
- Reachable from untrusted input — the `SearchDocumentKeyword` MCP tool passes its unvalidated `keyword` straight through, and `Contains("", …)` makes every line "match", flowing into the loop.
- Bug filed as GH-700. The test is committed **skipped** (`[Fact(Timeout = 2000, Skip = "GH-700 …")]`) so it documents expected behavior without hanging CI — un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Sec/DocumentTextToolsEmptyKeywordTests.cs` — new test `HighlightKeyword_EmptyKeyword_ReturnsLineUnchangedWithoutHanging`, skipped — see GH-700. Test-only; no production code touched. Timeout-bounded (`Task.Run` + `[Fact(Timeout = 2000)]`) so the repro cannot hang the harness; asserts `HighlightKeyword("abc", "")` returns `"abc"`. Currently the call never returns (verified: 2000ms timeout). Uses the same private-static reflection pattern as the existing `DocumentTextToolsTests`.