### PR TITLE
test(web): add skipped repro for GH-703 — MarkdownToHtml javascript: link XSS

### DIFF
--- a/tests/Equibles.UnitTests/Web/MarkdownExtensionsJavascriptUriTests.cs
+++ b/tests/Equibles.UnitTests/Web/MarkdownExtensionsJavascriptUriTests.cs
@@ -1,0 +1,34 @@
+using Equibles.Web.Extensions;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Web;
+
+public class MarkdownExtensionsJavascriptUriTests
+{
+    // Contract (security intent established by the sibling raw-<script> pin's own
+    // comment): MarkdownToHtml renders untrusted ingested content (SEC filings,
+    // earnings transcripts) via htmlHelper.Raw() — unencoded — and uses
+    // .DisableHtml() so "potentially malicious payloads" never reach the DOM.
+    // .DisableHtml() neutralizes raw HTML tags but NOT link destinations:
+    // `[x](javascript:…)` is a well-known XSS bypass the existing tests don't
+    // cover. Per the stated anti-XSS purpose, the output must not carry an
+    // active javascript: href. (Ambiguity: contract is implicit security intent,
+    // not an XML-doc — but Raw() + DisableHtml + ingested input make it the
+    // behaviour a caller must rely on.)
+    [Fact(Skip = "GH-703 — MarkdownToHtml emits active javascript: link href (stored XSS)")]
+    public void MarkdownToHtml_JavascriptUriInLink_DoesNotEmitActiveJavascriptHref()
+    {
+        string captured = null;
+        var htmlHelper = Substitute.For<IHtmlHelper>();
+        htmlHelper
+            .Raw(Arg.Do<string>(s => captured = s))
+            .Returns(callInfo => new HtmlString(callInfo.Arg<string>()));
+
+        htmlHelper.MarkdownToHtml("[click me](javascript:alert(document.cookie))");
+
+        captured.Should().NotBeNull();
+        captured.Should().NotContain("href=\"javascript:");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `MarkdownExtensions.MarkdownToHtml` found a stored-XSS bug: the method renders untrusted ingested content via `htmlHelper.Raw(...)` and relies on `.DisableHtml()`, but that flag does not sanitize link destinations — `[x](javascript:…)` produces an active `javascript:` href in the page.
- This is the exact threat model the sibling raw-`<script>` test documents; the four existing tests don't cover the link-URI vector. Bug filed as GH-703.
- The test is committed **skipped** (`[Fact(Skip = "GH-703 …")]`) so it documents the expected behavior without breaking the build — un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Web/MarkdownExtensionsJavascriptUriTests.cs` — new test `MarkdownToHtml_JavascriptUriInLink_DoesNotEmitActiveJavascriptHref`, skipped — see GH-703. Test-only; no production code touched. Asserts the rendered output for `[click me](javascript:alert(document.cookie))` does not contain `href="javascript:`; current output is `<a href="javascript:alert(document.cookie)">click me</a>`. Uses the same NSubstitute `IHtmlHelper` / captured-`Raw` harness as the existing `MarkdownExtensionsTests`.