### PR TITLE
test(web): pin Status/Show view — unseen error renders New badge + antiforgery forms

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/StatusShowViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusShowViewRenderingTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using Equibles.Errors.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Sibling to <see cref="SeededViewRenderingTests"/>, which renders Status/Index
+/// but never follows through to Status/Show — its compiled Razor view stays 0%.
+/// Pins the Show contract for an unseen error: 200, the error Message rendered,
+/// the "New" badge (because <c>!Model.Seen</c>), and an antiforgery token in the
+/// MarkAsSeen/Delete POST forms — a missing token silently breaks both actions.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class StatusShowViewRenderingTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public StatusShowViewRenderingTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetStatusShow_UnseenSeededError_RendersNewBadgeAndAntiforgeryForms()
+    {
+        var errorId = new Guid("11111111-2222-3333-4444-555555555555");
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new Error
+                {
+                    Id = errorId,
+                    Source = ErrorSource.HoldingsScraper,
+                    Context = "Holdings.ProcessDataSet",
+                    Message = "Seeded unseen error for Status/Show rendering",
+                    CreationTime = DateTime.UtcNow,
+                    Seen = false,
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        // BaseController's [Route("{controller=Home}/{action=Index}")] combines with
+        // Show's [HttpGet("{id:guid}")] → /Status/Show/{id} (no ~/ override).
+        var response = await _fixture.Client.GetAsync($"/Status/Show/{errorId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should()
+            .Contain(
+                "Seeded unseen error for Status/Show rendering",
+                "the error message must render in the Show view"
+            );
+        html.Should().Contain("New", "an unseen error must show the 'New' badge, not 'Seen'");
+        html.Should()
+            .Contain(
+                "__RequestVerificationToken",
+                "the MarkAsSeen/Delete POST forms must carry an antiforgery token"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Integration-tier Lane B coverage pin for the previously-0% `Status/Show` Razor view. `SeededViewRenderingTests` renders `Status/Index` but never follows through to `Show`, so its compiled view stayed uncovered.
- Seeds an unseen `Error` with a known id, GETs `/Status/Show/{id}` through the in-process host, and asserts: 200, the error Message rendered, the "New" badge (the `!Model.Seen` branch), and `__RequestVerificationToken` present (the MarkAsSeen/Delete POST forms — a missing token silently breaks both actions).
- Reuses the existing `WebHostFixture` / `WebHostCollection` — no new infrastructure. Passes; not a bug.

## Code changes

- `tests/Equibles.IntegrationTests/Web/StatusShowViewRenderingTests.cs` — new test `GetStatusShow_UnseenSeededError_RendersNewBadgeAndAntiforgeryForms`, `[Collection(WebHostCollection.Name)]`, mirroring the existing `SeededViewRenderingTests` pattern. Test-only; no production code touched. Comment documents the `BaseController` route composition (`/Status/Show/{id}`, no `~/` override) that determines the correct URL.