### PR TITLE
test(web): pin Cftc/Futures Show view — stats card, report row, chart canvas

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/CftcShowViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/CftcShowViewRenderingTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using Equibles.Cftc.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Sibling to <see cref="SeededViewRenderingTests"/>: no test renders the Cftc
+/// (Futures) Show view, so its compiled Razor view stays 0% along the populated
+/// path. Pins it: a seeded contract + report must render the latest-stats cards
+/// (OpenInterest N0), the reports table row, and the chart canvas the inline JS
+/// binds to (a missing #cftc-chart silently breaks the visualization).
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class CftcShowViewRenderingTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public CftcShowViewRenderingTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetFuturesShow_WithSeededContractAndReport_RendersStatsTableAndChartCanvas()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            var contract = new CftcContract
+            {
+                MarketCode = "067651",
+                MarketName = "CRUDE OIL, LIGHT SWEET-WTI",
+                Category = CftcContractCategory.Energy,
+            };
+            db.Add(contract);
+            db.Add(
+                new CftcPositionReport
+                {
+                    CftcContract = contract,
+                    ReportDate = new DateOnly(2026, 1, 6),
+                    OpenInterest = 250_000,
+                    CommLong = 300_000,
+                    CommShort = 100_000,
+                    NonCommLong = 150_000,
+                    NonCommShort = 120_000,
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Futures/067651");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("CRUDE OIL, LIGHT SWEET-WTI", "the market name must render");
+        html.Should()
+            .Contain("250&#xA0;000", "the latest OpenInterest stat must render formatted N0");
+        html.Should().Contain("2026-01-06", "the seeded report row date must render in the table");
+        html.Should()
+            .Contain(
+                "id=\"cftc-chart\"",
+                "the chart canvas the inline JS binds to must be present"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Integration-tier Lane B coverage pin for the previously-0% `Cftc` (Futures) Show Razor view. No test rendered it, so its compiled view stayed uncovered along the populated path.
- Seeds a `CftcContract` + `CftcPositionReport`, GETs `/Futures/067651` through the in-process host, and asserts: 200, MarketName renders, the latest OpenInterest stat (`N0`), the seeded report row date in the table, and the `#cftc-chart` canvas the inline JS binds to.
- Reuses the existing `WebHostFixture` / `WebHostCollection` — no new infrastructure. Passes; not a bug.

## Code changes

- `tests/Equibles.IntegrationTests/Web/CftcShowViewRenderingTests.cs` — new test `GetFuturesShow_WithSeededContractAndReport_RendersStatsTableAndChartCanvas`, `[Collection(WebHostCollection.Name)]`, mirroring the existing `SeededViewRenderingTests` pattern. Test-only; no production code touched. Accounts for the host culture's non-breaking-space `N0` group separator (`&#xA0;`).