### PR TITLE
test(web): pin Stocks/Index browser list — seeded stock row + resolved Show link

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/StocksIndexViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksIndexViewRenderingTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// The Stocks tab partials and Show pages are pinned elsewhere, but the Stocks
+/// browser/search list (<c>~/Stocks</c>, <c>Views/Stocks/Index.cshtml</c>) is
+/// never rendered through the host — its compiled view stays 0% on the
+/// populated path. Pins it: a seeded stock must render in the list with its
+/// ticker, name, and a resolved (lowercased) Show link.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class StocksIndexViewRenderingTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public StocksIndexViewRenderingTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetStocks_WithSeededStock_RendersStockRowWithResolvedShowLink()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(new CommonStock { Ticker = "AAPL", Name = "Apple Inc." });
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Stocks");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("AAPL", "the seeded ticker must render in the browser list");
+        html.Should().Contain("Apple Inc.", "the seeded company name must render");
+        html.Should()
+            .Contain(
+                "/stocks/aapl",
+                "the list row's asp-action=\"Show\" must resolve to the lowercased Show route"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Integration-tier Lane B coverage pin for the previously-0% `Stocks/Index` browser/search list (`~/Stocks`, `Views/Stocks/Index.cshtml`). The Stocks tab partials and Show pages are pinned elsewhere, but the list view itself was never rendered through the host.
- Seeds a `CommonStock`, GETs `/Stocks`, asserts: 200, the ticker + company name render in the list, and a resolved (lowercased) `Show` link from the list row.
- Reuses the existing `WebHostFixture` / `WebHostCollection` — no new infrastructure. Passes; not a bug.

## Code changes

- `tests/Equibles.IntegrationTests/Web/StocksIndexViewRenderingTests.cs` — new test `GetStocks_WithSeededStock_RendersStockRowWithResolvedShowLink`, `[Collection(WebHostCollection.Name)]`, mirroring the existing `SeededViewRenderingTests` pattern. Test-only; no production code touched.