### PR TITLE
test(web): pin Stocks/ShowHolder view — holder header + no-holdings empty state

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/StocksShowHolderViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksShowHolderViewRenderingTests.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// <c>StocksControllerShowHolderNotFoundTests</c> pins only the 404 guard via a
+/// directly-instantiated controller, so <c>Views/Stocks/ShowHolder.cshtml</c>
+/// is never rendered — 0% on its populated path. Pins the happy render: a
+/// resolvable ticker + holder CIK returns 200 with the holder header and the
+/// no-holdings empty-state branch (`Model.Holdings.Count == 0`).
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class StocksShowHolderViewRenderingTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public StocksShowHolderViewRenderingTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetShowHolder_ResolvableTickerAndCik_RendersHolderHeaderAndEmptyState()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(new CommonStock { Ticker = "AAPL", Name = "Apple Inc." });
+            db.Add(new InstitutionalHolder { Cik = "0001067983", Name = "BERKSHIRE HATHAWAY INC" });
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Stocks/AAPL/Holders/0001067983");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("BERKSHIRE HATHAWAY INC", "the holder name header must render");
+        html.Should()
+            .Contain(
+                "No Holdings History",
+                "with no seeded holdings the empty-state branch must render"
+            );
+        html.Should()
+            .Contain(
+                "No holdings records found for this institution in AAPL",
+                "the empty-state must interpolate the stock ticker"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Integration-tier Lane B coverage pin for the previously-0% `Stocks/ShowHolder` view (`~/Stocks/{ticker}/Holders/{cik}`). The existing `StocksControllerShowHolderNotFoundTests` only pins the 404 guard via a directly-instantiated controller, so the view itself was never rendered.
- Seeds a `CommonStock` + `InstitutionalHolder` (no holdings), GETs `/Stocks/AAPL/Holders/0001067983`, asserts: 200, the holder name header, and the `Model.Holdings.Count == 0` empty-state branch (including the interpolated ticker).
- Reuses the existing `WebHostFixture` / `WebHostCollection` — no new infrastructure. Passes; not a bug.

## Code changes

- `tests/Equibles.IntegrationTests/Web/StocksShowHolderViewRenderingTests.cs` — new test `GetShowHolder_ResolvableTickerAndCik_RendersHolderHeaderAndEmptyState`, `[Collection(WebHostCollection.Name)]`, mirroring the existing `SeededViewRenderingTests` pattern. Test-only; no production code touched.