### PR TITLE
test(web): add skipped repro for GH-714 — HomeController.Error out-of-range status

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/HomeControllerErrorOutOfRangeStatusTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HomeControllerErrorOutOfRangeStatusTests.cs
@@ -1,0 +1,35 @@
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Contract: <c>HomeController.Error</c> backs the route
+/// <c>/Home/Error/{statusCode?}</c> and the global exception handler. As a
+/// user-facing endpoint it must emit a syntactically valid HTTP response —
+/// status codes are constrained to >= 100 (RFC 9110 / ASP.NET Core). The
+/// implementation sets <c>Response.StatusCode</c> verbatim from the route value,
+/// so <c>/Home/Error/0</c> (a valid int) produces an out-of-range status. Only
+/// the 404/500 arms are pinned elsewhere; the out-of-range boundary is not.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HomeControllerErrorOutOfRangeStatusTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HomeControllerErrorOutOfRangeStatusTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact(Skip = "GH-714 — Home/Error/0 emits malformed status line 'HTTP/1.1 0 '")]
+    public async Task Error_RouteStatusCodeIsZero_RespondsWithValidHttpStatus()
+    {
+        var response = await _fixture.Client.GetAsync("/Home/Error/0");
+
+        ((int)response.StatusCode)
+            .Should()
+            .BeGreaterThanOrEqualTo(
+                100,
+                "a user-facing error endpoint must emit a valid HTTP status (>= 100), "
+                    + "not echo an out-of-range route value straight onto Response.StatusCode"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for `HomeController.Error` discovered a real bug: `GET /Home/Error/0` makes Kestrel emit the malformed status line `HTTP/1.1 0 `, which HTTP clients reject as an invalid response.
- Root cause: the route value is written verbatim to `Response.StatusCode` with no range clamp. `/Home/Error` is also the configured exception handler. Tracked in GH-714.
- Test is committed `[Skip]` — un-skip it as part of the fix for GH-714. No production code changed.

## Code changes

- `tests/Equibles.IntegrationTests/Web/HomeControllerErrorOutOfRangeStatusTests.cs` — new in-process WebHost integration test asserting `GET /Home/Error/0` returns a valid HTTP status (>= 100). Skipped (`GH-714`) because it currently fails by exposing the bug — see GH-714.