### PR TITLE
test(web): add skipped repro for GH-716 — MarketController.PutCallRatio numeric type

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/MarketControllerPutCallRatioNumericTypeTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/MarketControllerPutCallRatioNumericTypeTests.cs
@@ -1,0 +1,37 @@
+using Equibles.Cboe.Data;
+using Equibles.Cboe.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Web.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Web;
+
+public class MarketControllerPutCallRatioNumericTypeTests
+{
+    [Fact(Skip = "GH-716 — PutCallRatio numeric type string slips past Enum.TryParse and 500s")]
+    public async Task PutCallRatio_NumericTypeStringNotADefinedEnum_ReturnsNotFound()
+    {
+        // Contract: an unknown ratio type must yield 404 (pinned for alphabetic input
+        // elsewhere). Enum.TryParse returns true for ANY numeric string in range, so
+        // "999" -> (CboePutCallRatioType)999, an undefined value, slips past the guard.
+        using var ctx = TestDbContextFactory.Create(new CboeModuleConfiguration());
+        var putCallRepo = new CboePutCallRatioRepository(ctx);
+        var vixRepo = new CboeVixDailyRepository(ctx);
+        var sut = new MarketController(
+            putCallRepo,
+            vixRepo,
+            Substitute.For<ILogger<MarketController>>()
+        );
+
+        var result = await sut.PutCallRatio("999");
+
+        result
+            .Should()
+            .BeOfType<NotFoundResult>(
+                "a type that is not a defined CboePutCallRatioType must 404, not pass "
+                    + "through Enum.TryParse's numeric-string acceptance as an undefined enum"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for `MarketController.PutCallRatio` discovered a real bug: `GET /Market/PutCallRatio/999` returns HTTP 500 instead of 404.
- Root cause: `Enum.TryParse` accepts any numeric string in range, so `"999"` becomes an undefined `CboePutCallRatioType`, slips past the `NotFound` guard, and crashes in `NameForHumans()`. Tracked in GH-716.
- Test is committed `[Skip]` — un-skip it as part of the fix for GH-716. No production code changed.

## Code changes

- `tests/Equibles.IntegrationTests/Web/MarketControllerPutCallRatioNumericTypeTests.cs` — new integration test (direct controller + EF test context, mirroring `MarketControllerTests`) asserting `PutCallRatio("999")` returns `NotFoundResult`. Skipped (`GH-716`) because it currently fails by exposing the bug — see GH-716.