### PR TITLE
test(web): add skipped repro for GH-718 — EconomicDataController.Show single observation

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/EconomicDataControllerShowSingleObservationTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/EconomicDataControllerShowSingleObservationTests.cs
@@ -1,0 +1,56 @@
+using Equibles.Fred.Data;
+using Equibles.Fred.Data.Models;
+using Equibles.Fred.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Web.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Web;
+
+public class EconomicDataControllerShowSingleObservationTests
+{
+    [Fact(Skip = "GH-718 — EconomicData.Show OverflowExceptions on single-observation series (NaN StdDev cast)")]
+    public async Task Show_SeriesWithExactlyOneObservation_RendersViewInsteadOfThrowing()
+    {
+        // Contract: a valid series detail page must render. Show casts
+        // DescriptiveStatistics.StandardDeviation straight to decimal (no SafeRound
+        // guard, unlike MarketController); for one sample StdDev is NaN -> overflow.
+        using var ctx = TestDbContextFactory.Create(new FredModuleConfiguration());
+        var series = new FredSeries
+        {
+            SeriesId = "DGS10",
+            Title = "10-Year Treasury Constant Maturity Rate",
+            Category = FredSeriesCategory.InterestRates,
+            Frequency = "Daily",
+            Units = "Percent",
+            SeasonalAdjustment = "Not Seasonally Adjusted",
+        };
+        ctx.Add(series);
+        ctx.Add(
+            new FredObservation
+            {
+                FredSeriesId = series.Id,
+                Date = new DateOnly(2025, 1, 2),
+                Value = 4.55m,
+            }
+        );
+        await ctx.SaveChangesAsync();
+
+        var sut = new EconomicDataController(
+            new FredSeriesRepository(ctx),
+            new FredObservationRepository(ctx),
+            Substitute.For<ILogger<EconomicDataController>>()
+        );
+
+        var result = await sut.Show("dgs10");
+
+        result
+            .Should()
+            .BeOfType<ViewResult>(
+                "a valid series with a single observation must still render — the "
+                    + "StandardDeviation cast must not OverflowException on NaN"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for `EconomicDataController.Show` discovered a real bug: a FRED series with a single observation 500s its detail page.
- Root cause: `(decimal)Math.Round(stats.StandardDeviation, 4)` — StdDev is `NaN` for one sample, `(decimal)NaN` overflows. This controller never uses the NaN-safe `SafeRound` that `MarketController` does. Tracked in GH-718 (distinct subject from GH-698).
- Test is committed `[Skip]` — un-skip it as part of the fix for GH-718. No production code changed.

## Code changes

- `tests/Equibles.IntegrationTests/Web/EconomicDataControllerShowSingleObservationTests.cs` — new integration test (direct controller + EF test context, mirroring `MarketControllerTests`) asserting `Show("dgs10")` for a one-observation series returns a `ViewResult`. Skipped (`GH-718`) because it currently fails by exposing the bug — see GH-718.