### PR TITLE
test(core): add skipped repro for GH-720 — EnumExtensions.NameForHumans undefined value

### DIFF
--- a/tests/Equibles.UnitTests/Core/EnumExtensionsUndefinedValueTests.cs
+++ b/tests/Equibles.UnitTests/Core/EnumExtensionsUndefinedValueTests.cs
@@ -1,0 +1,26 @@
+using Equibles.Core.Extensions;
+using Equibles.Fred.Data.Models;
+
+namespace Equibles.UnitTests.Core;
+
+public class EnumExtensionsUndefinedValueTests
+{
+    [Fact(Skip = "GH-720 — NameForHumans throws on undefined enum value instead of ToString() fallback")]
+    public void NameForHumans_UndefinedEnumValue_FallsBackToToStringInsteadOfThrowing()
+    {
+        // Contract: NameForHumans is a total Enum helper — its own `?? enumValue.ToString()`
+        // fallback proves the intent to never fail. Undefined values are legal C# enums
+        // (any cast int), so it must fall back to ToString(), not throw.
+        var undefined = (FredSeriesCategory)999;
+
+        var result = undefined.NameForHumans();
+
+        result
+            .Should()
+            .Be(
+                "999",
+                "an undefined enum value has no member to reflect, so NameForHumans "
+                    + "must reach its ToString() fallback rather than First()-throwing"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for `EnumExtensions.NameForHumans` discovered a real bug: an undefined enum value throws `InvalidOperationException` instead of reaching the method's own `?? ToString()` fallback.
- Root cause behind GH-716, but a distinct, broadly-used Core subject (called from 6+ sites — Cftc/Congress/Cboe MCP tools, Market/Cftc/EconomicData controllers). Tracked in GH-720.
- Test is committed `[Skip]` — un-skip it as part of the fix for GH-720. No production code changed.

## Code changes

- `tests/Equibles.UnitTests/Core/EnumExtensionsUndefinedValueTests.cs` — new unit test asserting `((FredSeriesCategory)999).NameForHumans()` returns `"999"` (its designed fallback). Skipped (`GH-720`) because it currently fails by exposing the bug — see GH-720.