### PR TITLE
fix(compose): use `ollama list` for embedding healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- Embedding service healthcheck used `curl`, which is not present in the
+  `ollama/ollama` image, leaving the container permanently `unhealthy` and
+  preventing `embedding-pull` / `worker-embedding` (and thus the entire vector
+  embedding profile) from starting. Switched the probe to `ollama list`.
+
 ## [1.0.0] — 2026-05-15
 
 First tagged release.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     volumes:
       - ollama-data:/root/.ollama
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:11434/api/tags || exit 1"]
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary

The `embedding` service healthcheck calls `curl`, which the `ollama/ollama`
image does not ship. The probe fails on every attempt (`curl: not found`), so
the container is permanently `unhealthy` and the dependent `embedding-pull` /
`worker-embedding` services (gated on `condition: service_healthy`) never
start — vector embeddings cannot be enabled at all via
`docker compose --profile embedding up`.

## Code changes

- `docker-compose.yml`: `embedding` healthcheck test changed from
  `curl -f http://localhost:11434/api/tags || exit 1` to
  `ollama list >/dev/null 2>&1 || exit 1`. The `ollama` binary ships in the
  image, and `ollama list` only exits 0 when the Ollama server is reachable, so
  it is an accurate readiness probe with no extra image tooling.
- `CHANGELOG.md`: added a `### Fixed` entry under `## [Unreleased]`.

## Verification

- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] `dotnet build` / `dotnet test` / `dotnet csharpier` — **N/A**, compose-only change, no application code touched

Manual verification:

- Reproduced on upstream `main`: `docker compose --profile embedding up -d`
  leaves `embedding` `unhealthy`; `docker inspect` health log shows
  `/bin/sh: 1: curl: not found` (failing streak); `embedding-pull` and
  `worker-embedding` remain in `Created` and never start.
- Confirmed `ollama/ollama:latest` has no `curl` but does provide
  `/usr/bin/ollama`.
- After the fix: `embedding` becomes `healthy`, `embedding-pull` runs and pulls
  `bge-m3` (exits 0), and `worker-embedding` starts.

## Notes for reviewers

- `ollama list` queries the local API and exits non-zero unless it is
  reachable, so it doubles as a server-readiness check without needing `curl`
  or `wget` in the image.
- Optional follow-up (intentionally left out to keep this focused): adding a
  `start_period:` would avoid counting early-boot failures, though the existing
  `retries: 10` × `interval: 10s` already tolerates startup.
- Tested on Docker with CPU-only Ollama on Windows.
