### PR TITLE
test(congress): add skipped repro for GH-724 — IsValidDisclosureUrl null url

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlNullTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlNullTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperIsValidUrlNullTests
+{
+    [Fact(Skip = "GH-724 — IsValidDisclosureUrl NREs on null url instead of returning false")]
+    public void IsValidDisclosureUrl_NullUrl_ReturnsFalseInsteadOfThrowing()
+    {
+        // Contract: this is a security allowlist predicate — it must be total and
+        // return false for anything not under the expected base, including null.
+        // A null href is reachable from the scraper's HTML parsing pipeline.
+        var result = DisclosureParsingHelper.IsValidDisclosureUrl(
+            null,
+            "https://disclosures.house.gov"
+        );
+
+        result
+            .Should()
+            .BeFalse(
+                "a URL-allowlist guard must reject null as invalid, not throw a "
+                    + "NullReferenceException that crashes (or is swallowed by) the caller"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for the security allowlist predicate `DisclosureParsingHelper.IsValidDisclosureUrl` discovered a real bug: a null `url` throws `NullReferenceException` instead of returning `false`.
- A validation predicate must be total; a null href is reachable from the disclosure HTML parsing pipeline. Tracked in GH-724.
- Test is committed `[Skip]` — un-skip it as part of the fix for GH-724. No production code changed.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlNullTests.cs` — new unit test asserting `IsValidDisclosureUrl(null, base)` returns `false`. Skipped (`GH-724`) because it currently fails by exposing the bug — see GH-724.