### PR TITLE
test(integrations): add skipped repro for GH-726 — CftcClient.SplitCsvLine escaped quote

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineEscapedQuoteTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineEscapedQuoteTests.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using Equibles.Integrations.Cftc;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CftcClientSplitCsvLineEscapedQuoteTests
+{
+    private static readonly MethodInfo SplitCsvLineMethod = typeof(CftcClient).GetMethod(
+        "SplitCsvLine",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    [Fact(Skip = "GH-726 — SplitCsvLine does not unescape RFC-4180 doubled quotes")]
+    public void SplitCsvLine_QuotedFieldWithEscapedQuote_UnescapesToSingleQuote()
+    {
+        // Contract: a quote-aware CSV splitter follows the universal convention —
+        // a doubled "" inside a quoted field is one literal ". The existing pin
+        // already requires the split to "honour double quotes".
+        var line = "\"a\"\"b\"";
+
+        var fields = (string[])SplitCsvLineMethod.Invoke(null, [line]);
+
+        fields.Should().Equal("a\"b");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for `CftcClient.SplitCsvLine` found a CSV-spec conformance gap: a doubled `""` inside a quoted field is not unescaped to a single `"` (RFC 4180).
- Latent rather than active — current CFTC COT files are not known to embed literal quotes — but the splitter's own contract (an existing pin requires it to "honour double quotes") is violated. Tracked in GH-726.
- Test is committed `[Skip]` — un-skip it as part of the fix for GH-726. No production code changed.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineEscapedQuoteTests.cs` — new unit test asserting `SplitCsvLine("\"a\"\"b\"")` yields `["a\"b"]`. Skipped (`GH-726`) because it currently fails by exposing the gap — see GH-726.