### PR TITLE
fix(congress): guard null url in IsValidDisclosureUrl (GH-724)

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -248,8 +248,12 @@ public static partial class DisclosureParsingHelper
         return (0, 0);
     }
 
-    public static bool IsValidDisclosureUrl(string url, string expectedBaseUrl) =>
-        url.StartsWith(expectedBaseUrl, StringComparison.OrdinalIgnoreCase);
+    public static bool IsValidDisclosureUrl(string url, string expectedBaseUrl)
+    {
+        if (string.IsNullOrEmpty(url) || string.IsNullOrEmpty(expectedBaseUrl))
+            return false;
+        return url.StartsWith(expectedBaseUrl, StringComparison.OrdinalIgnoreCase);
+    }
 
     // Matches tickers in parentheses/brackets: (AAPL), [MSFT], case-insensitive
     [GeneratedRegex(@"[\(\[]\s*([A-Za-z]{1,5})\s*[\)\]]")]

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlNullTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlNullTests.cs
@@ -4,7 +4,7 @@ namespace Equibles.UnitTests.Congress;
 
 public class DisclosureParsingHelperIsValidUrlNullTests
 {
-    [Fact(Skip = "GH-724 — IsValidDisclosureUrl NREs on null url instead of returning false")]
+    [Fact]
     public void IsValidDisclosureUrl_NullUrl_ReturnsFalseInsteadOfThrowing()
     {
         // Contract: this is a security allowlist predicate — it must be total and


### PR DESCRIPTION
## Summary

`DisclosureParsingHelper.IsValidDisclosureUrl` is a security allowlist predicate gating which scraped URLs are fetched. It must be total — return `false` for anything not under the expected base, including `null`. Previously it called `url.StartsWith(...)` with no null guard and threw `NullReferenceException` on a null href (reachable from the disclosure HTML parsing pipeline).

Fixes #724.

## Code changes

- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — guard `null`/empty `url` and `expectedBaseUrl`, returning `false` before the `StartsWith` check.
- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlNullTests.cs` — un-skipped the GH-724 regression test (now passing).