### PR TITLE
chore(ci): make main green — format repro tests + culture-invariant CFTC asserts

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/CftcIndexViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/CftcIndexViewRenderingTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Encodings.Web;
 using Equibles.Cftc.Data.Models;
 using Equibles.IntegrationTests.Helpers;
 using Xunit;
@@ -57,11 +58,15 @@ public class CftcIndexViewRenderingTests
                 "/futures/067651",
                 "asp-action=\"Show\" must resolve to the (lowercased) Show route, not an empty href"
             );
-        // N0 uses the host culture's group separator (a non-breaking space here),
-        // HTML-encoded by Razor as &#xA0; — pins the CommercialNet.HasValue branch.
+        // N0 uses the host culture's group separator, HTML-encoded by Razor.
+        // The separator char is ICU/culture-dependent (U+00A0 vs U+202F across
+        // runtimes), so compute the expected token with the same encoder Razor
+        // uses instead of hardcoding one separator — pins the
+        // CommercialNet.HasValue branch.
+        var expectedCommercialNet = HtmlEncoder.Default.Encode(200_000.ToString("N0"));
         html.Should()
             .Contain(
-                "200&#xA0;000",
+                expectedCommercialNet,
                 "CommercialNet (CommLong - CommShort = 200000) must render formatted N0"
             );
     }

--- a/tests/Equibles.IntegrationTests/Web/CftcShowViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/CftcShowViewRenderingTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Encodings.Web;
 using Equibles.Cftc.Data.Models;
 using Equibles.IntegrationTests.Helpers;
 using Xunit;
@@ -51,8 +52,16 @@ public class CftcShowViewRenderingTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync();
         html.Should().Contain("CRUDE OIL, LIGHT SWEET-WTI", "the market name must render");
+        // Razor formats with the host culture's N0 separator and HTML-encodes it.
+        // The separator char is ICU/culture-dependent (U+00A0 vs U+202F across
+        // runtimes), so compute the expected token with the same encoder Razor
+        // uses instead of hardcoding one separator.
+        var expectedOpenInterest = HtmlEncoder.Default.Encode(250_000.ToString("N0"));
         html.Should()
-            .Contain("250&#xA0;000", "the latest OpenInterest stat must render formatted N0");
+            .Contain(
+                expectedOpenInterest,
+                "the latest OpenInterest stat must render formatted N0"
+            );
         html.Should().Contain("2026-01-06", "the seeded report row date must render in the table");
         html.Should()
             .Contain(

--- a/tests/Equibles.IntegrationTests/Web/CftcShowViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/CftcShowViewRenderingTests.cs
@@ -58,10 +58,7 @@ public class CftcShowViewRenderingTests
         // uses instead of hardcoding one separator.
         var expectedOpenInterest = HtmlEncoder.Default.Encode(250_000.ToString("N0"));
         html.Should()
-            .Contain(
-                expectedOpenInterest,
-                "the latest OpenInterest stat must render formatted N0"
-            );
+            .Contain(expectedOpenInterest, "the latest OpenInterest stat must render formatted N0");
         html.Should().Contain("2026-01-06", "the seeded report row date must render in the table");
         html.Should()
             .Contain(

--- a/tests/Equibles.IntegrationTests/Web/EconomicDataControllerShowSingleObservationTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/EconomicDataControllerShowSingleObservationTests.cs
@@ -11,7 +11,9 @@ namespace Equibles.IntegrationTests.Web;
 
 public class EconomicDataControllerShowSingleObservationTests
 {
-    [Fact(Skip = "GH-718 — EconomicData.Show OverflowExceptions on single-observation series (NaN StdDev cast)")]
+    [Fact(
+        Skip = "GH-718 — EconomicData.Show OverflowExceptions on single-observation series (NaN StdDev cast)"
+    )]
     public async Task Show_SeriesWithExactlyOneObservation_RendersViewInsteadOfThrowing()
     {
         // Contract: a valid series detail page must render. Show casts

--- a/tests/Equibles.UnitTests/Core/EnumExtensionsUndefinedValueTests.cs
+++ b/tests/Equibles.UnitTests/Core/EnumExtensionsUndefinedValueTests.cs
@@ -5,7 +5,9 @@ namespace Equibles.UnitTests.Core;
 
 public class EnumExtensionsUndefinedValueTests
 {
-    [Fact(Skip = "GH-720 — NameForHumans throws on undefined enum value instead of ToString() fallback")]
+    [Fact(
+        Skip = "GH-720 — NameForHumans throws on undefined enum value instead of ToString() fallback"
+    )]
     public void NameForHumans_UndefinedEnumValue_FallsBackToToStringInsteadOfThrowing()
     {
         // Contract: NameForHumans is a total Enum helper — its own `?? enumValue.ToString()`


### PR DESCRIPTION
## Summary

`main`'s required checks are red independent of feature work, blocking every open PR (strict branch protection):

1. **lint** — two merged skipped repro test files (`EnumExtensionsUndefinedValueTests.cs`, `EconomicDataControllerShowSingleObservationTests.cs`) have over-long `[Fact(Skip=...)]` lines that fail `dotnet csharpier check .`.
2. **build-and-test** — `CftcIndexViewRenderingTests` / `CftcShowViewRenderingTests` hardcode U+00A0 as the `N0` group separator; the CI runner's ICU emits a different separator (U+202F), so the `Contain` asserts fail.

This makes main green so the queued bug-fix PRs can land. Test/format-only — no production behavior change.

## Code changes

- `tests/Equibles.UnitTests/Core/EnumExtensionsUndefinedValueTests.cs`, `tests/Equibles.IntegrationTests/Web/EconomicDataControllerShowSingleObservationTests.cs` — csharpier line-wrap of long attribute argument.
- `tests/Equibles.IntegrationTests/Web/CftcShowViewRenderingTests.cs`, `tests/Equibles.IntegrationTests/Web/CftcIndexViewRenderingTests.cs` — compute the expected N0 token via `HtmlEncoder.Default.Encode(value.ToString("N0"))` (the same encoder + current culture the Razor view uses) instead of hardcoding one separator char.