### PR TITLE
fix(core): fall back to ToString for undefined enum values (GH-720)

### DIFF
--- a/src/Equibles.Core/Extensions/EnumExtensions.cs
+++ b/src/Equibles.Core/Extensions/EnumExtensions.cs
@@ -10,8 +10,8 @@ public static class EnumExtensions
         return enumValue
                 .GetType()
                 .GetMember(enumValue.ToString())
-                .First()
-                .GetCustomAttribute<DisplayAttribute>()
+                .FirstOrDefault()
+                ?.GetCustomAttribute<DisplayAttribute>()
                 ?.GetName()
             ?? enumValue.ToString();
     }

--- a/tests/Equibles.UnitTests/Core/EnumExtensionsUndefinedValueTests.cs
+++ b/tests/Equibles.UnitTests/Core/EnumExtensionsUndefinedValueTests.cs
@@ -5,9 +5,7 @@ namespace Equibles.UnitTests.Core;
 
 public class EnumExtensionsUndefinedValueTests
 {
-    [Fact(
-        Skip = "GH-720 — NameForHumans throws on undefined enum value instead of ToString() fallback"
-    )]
+    [Fact]
     public void NameForHumans_UndefinedEnumValue_FallsBackToToStringInsteadOfThrowing()
     {
         // Contract: NameForHumans is a total Enum helper — its own `?? enumValue.ToString()`


### PR DESCRIPTION
## Summary

`EnumExtensions.NameForHumans` is a total helper (its own `?? enumValue.ToString()` clause proves the intent). But `.GetMember(enumValue.ToString()).First()` threw `InvalidOperationException` for an **undefined** enum value (any cast int) because `GetMember("999")` returns an empty array and `.First()` never reached the fallback. It is called from CftcTools, CongressTools, CboeTools and the Market/Cftc/EconomicData controllers — any undefined enum 500s.

Fixes #720. Also hardens the #716 call path at its root.

## Code changes

- `src/Equibles.Core/Extensions/EnumExtensions.cs` — `.First()` → `.FirstOrDefault()?.` so an undefined value reaches the existing `?? enumValue.ToString()` fallback.
- `tests/Equibles.UnitTests/Core/EnumExtensionsUndefinedValueTests.cs` — un-skipped the GH-720 regression test (now passing).