### PR TITLE
fix(web): reject undefined numeric enum type in PutCallRatio (GH-716)

### DIFF
--- a/src/Equibles.Web/Controllers/MarketController.cs
+++ b/src/Equibles.Web/Controllers/MarketController.cs
@@ -77,7 +77,13 @@ public class MarketController : BaseController
     [HttpGet("~/Market/PutCallRatio/{type}")]
     public async Task<IActionResult> PutCallRatio(string type)
     {
-        if (!Enum.TryParse<CboePutCallRatioType>(type, true, out var ratioType))
+        // Enum.TryParse accepts any numeric string in range (e.g. "999" -> an
+        // undefined enum), so pair it with Enum.IsDefined to reject values that
+        // map to no named member.
+        if (
+            !Enum.TryParse<CboePutCallRatioType>(type, true, out var ratioType)
+            || !Enum.IsDefined(ratioType)
+        )
             return NotFound();
 
         var records = await _putCallRepository

--- a/tests/Equibles.IntegrationTests/Web/MarketControllerPutCallRatioNumericTypeTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/MarketControllerPutCallRatioNumericTypeTests.cs
@@ -10,7 +10,7 @@ namespace Equibles.IntegrationTests.Web;
 
 public class MarketControllerPutCallRatioNumericTypeTests
 {
-    [Fact(Skip = "GH-716 — PutCallRatio numeric type string slips past Enum.TryParse and 500s")]
+    [Fact]
     public async Task PutCallRatio_NumericTypeStringNotADefinedEnum_ReturnsNotFound()
     {
         // Contract: an unknown ratio type must yield 404 (pinned for alphabetic input


### PR DESCRIPTION
## Summary

`MarketController.PutCallRatio` must 404 for an unknown ratio type. `Enum.TryParse<CboePutCallRatioType>` returns `true` for any numeric string in range, so `/Market/PutCallRatio/999` parsed to an undefined enum, slipped past the `NotFound` guard, and 500'd at `NameForHumans()`.

Fixes #716.

## Code changes

- `src/Equibles.Web/Controllers/MarketController.cs` — pair `Enum.TryParse` with `Enum.IsDefined` so an undefined value returns 404.
- `tests/Equibles.IntegrationTests/Web/MarketControllerPutCallRatioNumericTypeTests.cs` — un-skipped the GH-716 regression test (now passing).