### PR TITLE
fix(web): route EconomicData.Show stats through SafeRound (GH-718)

### DIFF
--- a/src/Equibles.Web/Controllers/EconomicDataController.cs
+++ b/src/Equibles.Web/Controllers/EconomicDataController.cs
@@ -2,6 +2,7 @@ using Equibles.Core.Extensions;
 using Equibles.Fred.Data.Models;
 using Equibles.Fred.Repositories;
 using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Extensions;
 using Equibles.Web.ViewModels.EconomicData;
 using MathNet.Numerics.Statistics;
 using Microsoft.AspNetCore.Mvc;
@@ -103,11 +104,11 @@ public class EconomicDataController : BaseController
         if (values.Length > 0)
         {
             var stats = new DescriptiveStatistics(values);
-            viewModel.Mean = (decimal)Math.Round(stats.Mean, 4);
-            viewModel.Min = (decimal)stats.Minimum;
-            viewModel.Max = (decimal)stats.Maximum;
-            viewModel.Median = (decimal)Math.Round(values.Median(), 4);
-            viewModel.StdDev = (decimal)Math.Round(stats.StandardDeviation, 4);
+            viewModel.Mean = stats.Mean.SafeRound(4);
+            viewModel.Min = stats.Minimum.SafeRound(4);
+            viewModel.Max = stats.Maximum.SafeRound(4);
+            viewModel.Median = values.Median().SafeRound(4);
+            viewModel.StdDev = stats.StandardDeviation.SafeRound(4);
             viewModel.LatestValue = observations[0].Value; // observations are desc by date
             if (observations.Count > 1)
                 viewModel.PreviousValue = observations[1].Value;

--- a/tests/Equibles.IntegrationTests/Web/EconomicDataControllerShowSingleObservationTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/EconomicDataControllerShowSingleObservationTests.cs
@@ -11,9 +11,7 @@ namespace Equibles.IntegrationTests.Web;
 
 public class EconomicDataControllerShowSingleObservationTests
 {
-    [Fact(
-        Skip = "GH-718 — EconomicData.Show OverflowExceptions on single-observation series (NaN StdDev cast)"
-    )]
+    [Fact]
     public async Task Show_SeriesWithExactlyOneObservation_RendersViewInsteadOfThrowing()
     {
         // Contract: a valid series detail page must render. Show casts


### PR DESCRIPTION
## Summary

`EconomicDataController.Show` cast `DescriptiveStatistics` values straight to `decimal` with no NaN guard (unlike `MarketController`). For a series with exactly one observation `StandardDeviation` is `NaN`, and `(decimal)Math.Round(NaN, 4)` throws `OverflowException` → HTTP 500.

Fixes #718.

## Code changes

- `src/Equibles.Web/Controllers/EconomicDataController.cs` — route Mean/Min/Max/Median/StdDev through the NaN-safe `SafeRound` (mirrors `MarketController`); add `Equibles.Web.Extensions` using.
- `tests/Equibles.IntegrationTests/Web/EconomicDataControllerShowSingleObservationTests.cs` — un-skipped the GH-718 regression test (now passing).