### PR TITLE
fix(web): clamp HomeController.Error status to valid HTTP range (GH-714)

### DIFF
--- a/src/Equibles.Web/Controllers/HomeController.cs
+++ b/src/Equibles.Web/Controllers/HomeController.cs
@@ -17,6 +17,11 @@ public class HomeController : BaseController
     public IActionResult Error(int? statusCode = null)
     {
         var code = statusCode ?? 500;
+        // The route value is echoed onto Response.StatusCode; an out-of-range
+        // value (e.g. 0) makes Kestrel emit a malformed status line. HTTP status
+        // codes are constrained to 100-599 (RFC 9110) — fall back to 500.
+        if (code < 100 || code > 599)
+            code = 500;
         Response.StatusCode = code;
         ViewData["Title"] = code switch
         {

--- a/tests/Equibles.IntegrationTests/Web/HomeControllerErrorOutOfRangeStatusTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HomeControllerErrorOutOfRangeStatusTests.cs
@@ -19,7 +19,7 @@ public class HomeControllerErrorOutOfRangeStatusTests
 
     public HomeControllerErrorOutOfRangeStatusTests(WebHostFixture fixture) => _fixture = fixture;
 
-    [Fact(Skip = "GH-714 — Home/Error/0 emits malformed status line 'HTTP/1.1 0 '")]
+    [Fact]
     public async Task Error_RouteStatusCodeIsZero_RespondsWithValidHttpStatus()
     {
         var response = await _fixture.Client.GetAsync("/Home/Error/0");


### PR DESCRIPTION
## Summary

`HomeController.Error` wrote the route value straight onto `Response.StatusCode`. `GET /Home/Error/0` (a valid int, out-of-range HTTP status) made Kestrel emit the malformed status line `HTTP/1.1 0 `, which HTTP clients reject. `/Home/Error` is also the configured exception handler.

Fixes #714.

## Code changes

- `src/Equibles.Web/Controllers/HomeController.cs` — clamp `code` outside 100-599 (RFC 9110) to 500 before assigning `Response.StatusCode`.
- `tests/Equibles.IntegrationTests/Web/HomeControllerErrorOutOfRangeStatusTests.cs` — un-skipped the GH-714 regression test (now passing).