### PR TITLE
fix(web): clamp non-positive page in StocksController.Index (GH-712)

### DIFF
--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -38,6 +38,12 @@ public class StocksController : BaseController
     {
         ViewData["Title"] = "Stocks";
 
+        // page is a client-supplied query value; a non-positive page would emit
+        // Skip((page-1)*pageSize) = a negative OFFSET, which PostgreSQL rejects
+        // (22023) and surfaces as HTTP 500. Clamp to the first page.
+        if (page < 1)
+            page = 1;
+
         const int pageSize = 50;
         var query = _commonStockRepository.Search(search);
         var totalCount = await query.CountAsync();

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerIndexNonPositivePageTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerIndexNonPositivePageTests.cs
@@ -21,7 +21,7 @@ public class StocksControllerIndexNonPositivePageTests
 
     public StocksControllerIndexNonPositivePageTests(WebHostFixture fixture) => _fixture = fixture;
 
-    [Fact(Skip = "GH-712 — Stocks/Index returns HTTP 500 for non-positive page (OFFSET -50)")]
+    [Fact]
     public async Task Index_PageQueryIsZero_ServesPageInsteadOfServerError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

`StocksController.Index` answered a non-positive `page` query with HTTP 500. `Skip((page - 1) * pageSize)` with `page=0` evaluates to `OFFSET -50`, which PostgreSQL rejects (22023). Any client-supplied `page <= 0` triggered it on the anonymous, user-facing browser.

Fixes #712.

## Code changes

- `src/Equibles.Web/Controllers/StocksController.cs` — clamp `page` to a minimum of 1 before computing the offset.
- `tests/Equibles.IntegrationTests/Web/StocksControllerIndexNonPositivePageTests.cs` — un-skipped the GH-712 regression test (now passing).