### PR TITLE
fix(sec): guard empty keyword in HighlightKeyword to stop DoS loop (GH-700)

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -185,6 +185,12 @@ public class DocumentTextTools
 
     private static string HighlightKeyword(string line, string keyword)
     {
+        // An empty keyword makes IndexOf return the start position every
+        // iteration, so index never advances and the loop runs unbounded
+        // (DoS — keyword reaches here unvalidated from the MCP tool).
+        if (string.IsNullOrEmpty(keyword))
+            return line;
+
         var result = new StringBuilder();
         var index = 0;
 

--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsEmptyKeywordTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsEmptyKeywordTests.cs
@@ -18,7 +18,7 @@ public class DocumentTextToolsEmptyKeywordTests
     // (Ambiguity: empty keyword could be argued a caller error — but it must
     // never produce an unbounded loop / DoS.) Timeout-bounded so the harness
     // can't hang; exceeding it is the failure signal.
-    [Fact(Timeout = 2000, Skip = "GH-700 — HighlightKeyword infinite-loops on empty keyword")]
+    [Fact(Timeout = 2000)]
     public async Task HighlightKeyword_EmptyKeyword_ReturnsLineUnchangedWithoutHanging()
     {
         var result = await Task.Run(() => (string)HighlightKeywordMethod.Invoke(null, ["abc", ""]));


### PR DESCRIPTION
## Summary

`DocumentTextTools.HighlightKeyword` enters an unbounded loop when `keyword` is empty: `line.IndexOf("", index)` returns `index` every iteration, so `index` never advances and the `StringBuilder` grows until the process OOMs/hangs. It is reachable from untrusted input — the `SearchDocumentKeyword` MCP tool passes its `keyword` through unvalidated, and `line.Contains("")` makes every line "match".

Fixes #700.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs` — return the line unchanged when `keyword` is null/empty (root guard stopping the DoS loop).
- `tests/Equibles.UnitTests/Sec/DocumentTextToolsEmptyKeywordTests.cs` — un-skipped the GH-700 regression test (now passing).