### PR TITLE
fix(web): return null from SafeRound for out-of-decimal-range doubles (GH-698)

### DIFF
--- a/src/Equibles.Web/Extensions/StatisticsExtensions.cs
+++ b/src/Equibles.Web/Extensions/StatisticsExtensions.cs
@@ -4,12 +4,19 @@ namespace Equibles.Web.Extensions;
 
 public static class StatisticsExtensions
 {
-    // Returns null when the value is NaN or infinity — protects view-model casts from
-    // OverflowException, since (decimal)NaN throws. DescriptiveStatistics.StandardDeviation
-    // returns NaN for a single-value sample, which is the realistic trigger.
+    // Returns null when the (decimal) cast would throw OverflowException — i.e. NaN,
+    // infinity, or a finite value outside decimal's representable range (~7.9e28).
+    // Protects view-model casts: DescriptiveStatistics.StandardDeviation returns NaN
+    // for a single-value sample, and variance/ratio math can produce huge finites.
     public static decimal? SafeRound(this double value, int digits)
     {
-        return double.IsFinite(value) ? (decimal?)Math.Round(value, digits) : null;
+        if (
+            !double.IsFinite(value)
+            || value > (double)decimal.MaxValue
+            || value < (double)decimal.MinValue
+        )
+            return null;
+        return (decimal?)Math.Round(value, digits);
     }
 
     // Simple moving average aligned to the input: positions before the first full window

--- a/tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundOverflowTests.cs
@@ -11,9 +11,7 @@ public class StatisticsExtensionsSafeRoundOverflowTests
     // it through. (Ambiguity: the literal comment only names NaN/infinity; the
     // method name + stated purpose imply no OverflowException for any double.)
     // A caller relying on "Safe" must get null, not a crashed view render.
-    [Fact(
-        Skip = "GH-698 — SafeRound throws OverflowException for finite double exceeding decimal range"
-    )]
+    [Fact]
     public void SafeRound_FiniteValueExceedingDecimalRange_ReturnsNullInsteadOfThrowing()
     {
         var result = 1e29.SafeRound(2);


### PR DESCRIPTION
## Summary

`StatisticsExtensions.SafeRound` is named "Safe" and documented to *protect view-model casts from OverflowException*, but it guarded only `NaN`/infinity. A **finite** double larger than `decimal.MaxValue` (~7.9e28) — realistic from sums-of-squares/variance or near-zero-denominator ratio math — still threw `OverflowException` on the `(decimal)` cast, crashing the view render.

Fixes #698.

## Code changes

- `src/Equibles.Web/Extensions/StatisticsExtensions.cs` — return `null` when the value is non-finite **or** outside decimal's representable range, before the cast.
- `tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundOverflowTests.cs` — un-skipped the GH-698 regression test (now passing; all existing SafeRound tests still green).