### PR TITLE
fix(congress): handle "S (partial)" abbreviation in ParseTransactionType (GH-695)

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -208,16 +208,24 @@ public static partial class DisclosureParsingHelper
     {
         if (string.IsNullOrEmpty(type))
             return null;
+        // The House abbreviation may carry a qualifier suffix ("S (partial)"),
+        // so accept the bare letter or the letter followed by a space/'(' in
+        // addition to the Senate full words.
+        var trimmed = type.Trim();
         if (
-            type.Contains("Sale", StringComparison.OrdinalIgnoreCase)
-            || type.Contains("Sold", StringComparison.OrdinalIgnoreCase)
-            || type.Equals("S", StringComparison.OrdinalIgnoreCase)
+            trimmed.Contains("Sale", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Contains("Sold", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("S", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("S ", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("S(", StringComparison.OrdinalIgnoreCase)
         )
             return CongressTransactionType.Sale;
         if (
-            type.Contains("Purchase", StringComparison.OrdinalIgnoreCase)
-            || type.Contains("Buy", StringComparison.OrdinalIgnoreCase)
-            || type.Equals("P", StringComparison.OrdinalIgnoreCase)
+            trimmed.Contains("Purchase", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Contains("Buy", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("P", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("P ", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("P(", StringComparison.OrdinalIgnoreCase)
         )
             return CongressTransactionType.Purchase;
         return null;

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperPartialSaleTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperPartialSaleTests.cs
@@ -11,9 +11,7 @@ public class DisclosureParsingHelperPartialSaleTests
     // explicitly listed House abbreviation, so per the contract it must resolve
     // to Sale. Existing tests pin "Sale (Partial)" and bare "S" but not this
     // exact documented token.
-    [Fact(
-        Skip = "GH-695 — ParseTransactionType returns null for documented House abbreviation \"S (partial)\""
-    )]
+    [Fact]
     public void ParseTransactionType_HouseAbbreviationSPartial_ReturnsSale()
     {
         var result = DisclosureParsingHelper.ParseTransactionType("S (partial)");


### PR DESCRIPTION
## Summary

`DisclosureParsingHelper.ParseTransactionType` returned `null` for `"S (partial)"` — an explicitly documented House abbreviation — because the Sale branch only did `Equals("S")`. The caller treats null as "skip the row", so House disclosure rows using this token were silently dropped.

Fixes #695.

## Code changes

- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — accept the trimmed abbreviation followed by a space or `(` (e.g. `"S (partial)"`), mirrored for `P`.
- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperPartialSaleTests.cs` — un-skipped the GH-695 regression test (now passing; all existing tests still green).