### PR TITLE
fix(sec): enforce bare-name allowlist in IsSafeFilename (GH-693)

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
@@ -72,17 +72,15 @@ public static class SecDocumentEnvelopeParser
         // not a bare name and the remote server decodes it back to a traversal.
         foreach (var ch in value)
         {
-            var isAllowed =
-                (ch >= 'A' && ch <= 'Z')
-                || (ch >= 'a' && ch <= 'z')
-                || (ch >= '0' && ch <= '9')
-                || ch == '.'
-                || ch == '_'
-                || ch == '-';
-            if (!isAllowed)
+            if (!IsBareNameChar(ch))
                 return false;
         }
         return true;
+    }
+
+    private static bool IsBareNameChar(char ch)
+    {
+        return char.IsAsciiLetterOrDigit(ch) || ch == '.' || ch == '_' || ch == '-';
     }
 
     private static bool TryExtractSgmlTagValue(string block, string tagName, out string value)

--- a/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
@@ -67,9 +67,19 @@ public static class SecDocumentEnvelopeParser
             return false;
         if (value[0] == '.')
             return false;
+        // Enforce the bare-name allowlist rather than blocklisting only literal
+        // separators: a name containing '%' (URL-encoded '../' = %2e%2e%2f) is
+        // not a bare name and the remote server decodes it back to a traversal.
         foreach (var ch in value)
         {
-            if (ch == '/' || ch == '\\')
+            var isAllowed =
+                (ch >= 'A' && ch <= 'Z')
+                || (ch >= 'a' && ch <= 'z')
+                || (ch >= '0' && ch <= '9')
+                || ch == '.'
+                || ch == '_'
+                || ch == '-';
+            if (!isAllowed)
                 return false;
         }
         return true;

--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserEncodedTraversalTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserEncodedTraversalTests.cs
@@ -13,7 +13,7 @@ public class SecDocumentEnvelopeParserEncodedTraversalTests
     // traversal. Literal `../` and `\` are already pinned — the encoded form
     // (the classic allowlist-bypass) is not. Per the stated contract this must
     // be rejected: TryExtractPaperPdfFilename returns false, filename empty.
-    [Fact(Skip = "GH-693 — IsSafeFilename accepts URL-encoded path traversal (%2e%2e%2f)")]
+    [Fact]
     public void TryExtractPaperPdfFilename_UrlEncodedPathTraversal_RejectsAndReturnsFalse()
     {
         var envelope = """


### PR DESCRIPTION
## Summary

`SecDocumentEnvelopeParser.IsSafeFilename` only blocklisted a leading `.` and literal `/`/`\`, so a `<FILENAME>` of `report%2e%2e%2f%2e%2e%2fadmin.pdf` passed — and the remote server decodes `%2e%2e%2f` back to `../`, escaping the per-filing directory the comment claims to defend. The filename flows into `/Archives/edgar/data/{cik}/{accession}/{filename}`.

Fixes #693.

## Code changes

- `src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs` — enforce the documented `[A-Za-z0-9._-]` allowlist (rejects `%` and any non-bare char) instead of blocklisting only literal separators.
- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserEncodedTraversalTests.cs` — un-skipped the GH-693 regression test (now passing; all existing parser tests still green).