### PR TITLE
fix(cftc): unescape RFC-4180 doubled quotes in SplitCsvLine (GH-726)

### DIFF
--- a/src/Equibles.Integrations.Cftc/CftcClient.cs
+++ b/src/Equibles.Integrations.Cftc/CftcClient.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.IO.Compression;
 using System.Net;
+using System.Text;
 using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Cftc.Contracts;
 using Equibles.Integrations.Cftc.Models;
@@ -198,25 +199,54 @@ public class CftcClient : ICftcClient
 
     private static string[] SplitCsvLine(string line)
     {
-        // CFTC files use comma-separated values with quoted fields
+        // CFTC files use comma-separated values with quoted fields. Follows
+        // RFC 4180: inside a quoted field a doubled "" is one literal ".
+        // Quoted content is taken verbatim; unquoted fields are whitespace-trimmed.
         var fields = new List<string>();
+        var field = new StringBuilder();
         var inQuotes = false;
-        var start = 0;
+        var wasQuoted = false;
 
         for (var i = 0; i < line.Length; i++)
         {
-            if (line[i] == '"')
+            var c = line[i];
+            if (inQuotes)
             {
-                inQuotes = !inQuotes;
+                if (c == '"')
+                {
+                    if (i + 1 < line.Length && line[i + 1] == '"')
+                    {
+                        field.Append('"');
+                        i++;
+                    }
+                    else
+                    {
+                        inQuotes = false;
+                    }
+                }
+                else
+                {
+                    field.Append(c);
+                }
             }
-            else if (line[i] == ',' && !inQuotes)
+            else if (c == '"')
             {
-                fields.Add(line[start..i].Trim().Trim('"'));
-                start = i + 1;
+                inQuotes = true;
+                wasQuoted = true;
+            }
+            else if (c == ',')
+            {
+                fields.Add(wasQuoted ? field.ToString() : field.ToString().Trim());
+                field.Clear();
+                wasQuoted = false;
+            }
+            else
+            {
+                field.Append(c);
             }
         }
 
-        fields.Add(line[start..].Trim().Trim('"'));
+        fields.Add(wasQuoted ? field.ToString() : field.ToString().Trim());
         return fields.ToArray();
     }
 

--- a/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineEscapedQuoteTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineEscapedQuoteTests.cs
@@ -10,7 +10,7 @@ public class CftcClientSplitCsvLineEscapedQuoteTests
         BindingFlags.NonPublic | BindingFlags.Static
     );
 
-    [Fact(Skip = "GH-726 — SplitCsvLine does not unescape RFC-4180 doubled quotes")]
+    [Fact]
     public void SplitCsvLine_QuotedFieldWithEscapedQuote_UnescapesToSingleQuote()
     {
         // Contract: a quote-aware CSV splitter follows the universal convention —


### PR DESCRIPTION
## Summary

`CftcClient.SplitCsvLine` is a quote-aware CSV splitter but did not implement the RFC 4180 convention that a doubled `""` inside a quoted field is one literal `"`. Its toggle state machine + `Trim('"')` left the escaped quote verbatim (`a""b` instead of `a"b`).

Fixes #726.

## Code changes

- `src/Equibles.Integrations.Cftc/CftcClient.cs` — replace the toggle/trim splitter with an RFC 4180 state machine (doubled `""` → `"`; quoted content verbatim; unquoted fields whitespace-trimmed). Existing embedded-comma quoting behaviour preserved.
- `tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineEscapedQuoteTests.cs` — un-skipped the GH-726 regression test (now passing; all existing CftcClient tests still green).