### PR TITLE
fix(web): sanitize markdown link URI schemes to block javascript: XSS (GH-703)

### DIFF
--- a/src/Equibles.Web/Extensions/MarkdownExtensions.cs
+++ b/src/Equibles.Web/Extensions/MarkdownExtensions.cs
@@ -65,9 +65,7 @@ public static partial class MarkdownExtensions
         // URL whose scheme is not allowlisted before rendering (.DisableHtml()
         // only strips raw HTML tags, not markdown link schemes).
         var document = Markdown.Parse(markdown, pipeline);
-        foreach (
-            var link in document.Descendants<LinkInline>().Where(link => !IsSafeUrl(link.Url))
-        )
+        foreach (var link in document.Descendants<LinkInline>().Where(link => !IsSafeUrl(link.Url)))
         {
             link.Url = string.Empty;
         }

--- a/src/Equibles.Web/Extensions/MarkdownExtensions.cs
+++ b/src/Equibles.Web/Extensions/MarkdownExtensions.cs
@@ -1,5 +1,7 @@
 using System.Text.RegularExpressions;
 using Markdig;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
@@ -10,6 +12,33 @@ public static partial class MarkdownExtensions
     // Matches a pipe table row, a blank line, then another pipe table row
     [GeneratedRegex(@"(\|[^\n]*\|)\n\n(\|)")]
     private static partial Regex BlankLineBetweenPipeRows();
+
+    // Matches a leading URI scheme (RFC 3986 scheme grammar), e.g. "javascript:"
+    [GeneratedRegex(@"^\s*([a-zA-Z][a-zA-Z0-9+.\-]*):")]
+    private static partial Regex UriSchemeRegex();
+
+    private static readonly HashSet<string> AllowedUriSchemes = new(
+        StringComparer.OrdinalIgnoreCase
+    )
+    {
+        "http",
+        "https",
+        "mailto",
+    };
+
+    // Markdig is not an HTML sanitizer and .DisableHtml() does not cover link
+    // destinations, so a markdown link/image with a javascript:/data:/vbscript:
+    // scheme renders an active href on ingested untrusted content (stored XSS).
+    // Relative URLs and fragments (no scheme) are left intact.
+    private static bool IsSafeUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return true;
+        var match = UriSchemeRegex().Match(url);
+        if (!match.Success)
+            return true;
+        return AllowedUriSchemes.Contains(match.Groups[1].Value);
+    }
 
     public static IHtmlContent MarkdownToHtml(this IHtmlHelper htmlHelper, string markdown)
     {
@@ -31,6 +60,17 @@ public static partial class MarkdownExtensions
             .UseGridTables()
             .DisableHtml()
             .Build();
-        return htmlHelper.Raw(Markdown.ToHtml(markdown, pipeline));
+
+        // Sanitize link/image destinations: parse to the AST and neutralize any
+        // URL whose scheme is not allowlisted before rendering (.DisableHtml()
+        // only strips raw HTML tags, not markdown link schemes).
+        var document = Markdown.Parse(markdown, pipeline);
+        foreach (var link in document.Descendants<LinkInline>())
+        {
+            if (!IsSafeUrl(link.Url))
+                link.Url = string.Empty;
+        }
+
+        return htmlHelper.Raw(document.ToHtml(pipeline));
     }
 }

--- a/src/Equibles.Web/Extensions/MarkdownExtensions.cs
+++ b/src/Equibles.Web/Extensions/MarkdownExtensions.cs
@@ -65,10 +65,11 @@ public static partial class MarkdownExtensions
         // URL whose scheme is not allowlisted before rendering (.DisableHtml()
         // only strips raw HTML tags, not markdown link schemes).
         var document = Markdown.Parse(markdown, pipeline);
-        foreach (var link in document.Descendants<LinkInline>())
+        foreach (
+            var link in document.Descendants<LinkInline>().Where(link => !IsSafeUrl(link.Url))
+        )
         {
-            if (!IsSafeUrl(link.Url))
-                link.Url = string.Empty;
+            link.Url = string.Empty;
         }
 
         return htmlHelper.Raw(document.ToHtml(pipeline));

--- a/tests/Equibles.UnitTests/Web/MarkdownExtensionsJavascriptUriTests.cs
+++ b/tests/Equibles.UnitTests/Web/MarkdownExtensionsJavascriptUriTests.cs
@@ -17,7 +17,7 @@ public class MarkdownExtensionsJavascriptUriTests
     // active javascript: href. (Ambiguity: contract is implicit security intent,
     // not an XML-doc — but Raw() + DisableHtml + ingested input make it the
     // behaviour a caller must rely on.)
-    [Fact(Skip = "GH-703 — MarkdownToHtml emits active javascript: link href (stored XSS)")]
+    [Fact]
     public void MarkdownToHtml_JavascriptUriInLink_DoesNotEmitActiveJavascriptHref()
     {
         string captured = null;


### PR DESCRIPTION
## Summary

`MarkdownExtensions.MarkdownToHtml` renders ingested untrusted content (SEC filings, earnings-call transcripts) via `htmlHelper.Raw(...)` — unencoded. `.DisableHtml()` strips raw HTML tags but **not** link destinations, so `[click me](javascript:alert(document.cookie))` produced an active `javascript:` `href` — stored XSS. `data:`/`vbscript:` are equivalent variants.

Fixes #703.

## Code changes

- `src/Equibles.Web/Extensions/MarkdownExtensions.cs` — parse to the Markdig AST and blank any `LinkInline` (link or image) whose URI scheme is not allowlisted (`http`/`https`/`mailto`; relative URLs/fragments untouched), then render the sanitized document with the same pipeline.
- `tests/Equibles.UnitTests/Web/MarkdownExtensionsJavascriptUriTests.cs` — un-skipped the GH-703 regression test (now passing; all existing MarkdownExtensions tests still green).