### PR TITLE
fix(di): bind EmbeddingConfig so vector embeddings actually run

### DIFF
--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -67,6 +67,12 @@ public partial class Program
         builder.Services.AutoWireServicesFrom<Equibles.Errors.BusinessLogic.ErrorManager>();
         builder.Services.AutoWireServicesFrom<Equibles.Sec.BusinessLogic.Search.RagManager>();
 
+        // Required for RAG search to embed the query at request time; without this
+        // bind EmbeddingConfig is default (Enabled=false) and semantic search is inert.
+        builder.Services.Configure<Equibles.Sec.BusinessLogic.Embeddings.EmbeddingConfig>(
+            builder.Configuration.GetSection("Embedding")
+        );
+
         builder.Services.AddEquiblesMcp(mcp =>
         {
             mcp.AddHoldings();

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -76,6 +76,7 @@ builder.Services.Configure<Equibles.Cftc.HostedService.Configuration.CftcScraper
 builder.Services.Configure<Equibles.Cboe.HostedService.Configuration.CboeScraperOptions>(
     builder.Configuration.GetSection("CboeScraper")
 );
+
 // Without this bind, IOptions<EmbeddingConfig> is always default (Enabled=false),
 // so GenerateEmbeddingBatch short-circuits and no embeddings are ever produced —
 // the entire worker-embedding profile is inert.

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -76,6 +76,12 @@ builder.Services.Configure<Equibles.Cftc.HostedService.Configuration.CftcScraper
 builder.Services.Configure<Equibles.Cboe.HostedService.Configuration.CboeScraperOptions>(
     builder.Configuration.GetSection("CboeScraper")
 );
+// Without this bind, IOptions<EmbeddingConfig> is always default (Enabled=false),
+// so GenerateEmbeddingBatch short-circuits and no embeddings are ever produced —
+// the entire worker-embedding profile is inert.
+builder.Services.Configure<Equibles.Sec.BusinessLogic.Embeddings.EmbeddingConfig>(
+    builder.Configuration.GetSection("Embedding")
+);
 
 builder.Services.AddHttpClient();
 


### PR DESCRIPTION
## Summary

`EmbeddingConfig` is consumed via `IOptions<EmbeddingConfig>` (`DocumentManager`,
`EmbeddingClient`, `DocumentProcessor`, RAG search) but is never bound to the
`Embedding` configuration section in any host. `IOptions<EmbeddingConfig>.Value`
is therefore always a default instance (`Enabled=false`, `BaseUrl=null`), so
`IsConfigured` is permanently false: `GenerateEmbeddingBatch` short-circuits and
the `worker-embedding` profile produces **zero** embeddings, and the MCP RAG
tools cannot embed queries. No environment variable or compose setting can fix
this without the bind.

## Code changes

- `Equibles.Worker.Host/Program.cs`: add
  `Configure<EmbeddingConfig>(GetSection("Embedding"))` — enables embedding
  generation in the worker.
- `Equibles.Mcp.Server/Program.cs`: same — enables query-time embedding for the
  RAG search tools.
- Mirrors the existing options-binding pattern already used for `WorkerOptions`,
  `FinraOptions`, `FredOptions`, `FtdScraperOptions`, etc.

## Verification

- [ ] `dotnet build` / `dotnet test` — N/A in my environment (Docker-only); the
  change is a one-line DI registration identical in shape to the existing ones.
- Reproduced on upstream: `worker-embedding` logs `Phase 2: Generating all
  pending embeddings` immediately followed by `Phase 2 complete` in the same
  second, **0** calls to Ollama `/api/embed`, and the `Embedding` table stays at
  0 despite ~740k pending chunks.
- After the fix: `Generating embeddings for N chunks` is logged, Ollama
  `/api/embed` calls flow, and the `Embedding` table climbs (0 to 30k+).

## Notes for reviewers

- Root cause is an omission: every other consumed options class is explicitly
  `Configure`d in `Program.cs`; `EmbeddingConfig` is the only one that was never
  bound.
- CHANGELOG intentionally left untouched to avoid guaranteed merge conflicts
  with the two related embedding PRs; happy to add an `## [Unreleased]` entry on
  request.
