### PR TITLE
fix(insider): stop reporting expected legacy/malformed ownership XML as errors

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -72,11 +72,41 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             return false;
         }
 
+        var sanitized = SanitizeXml(xmlContent);
+
+        // Pre-XML-era ownership filings (Forms 3/4/5 before SEC mandated XML around
+        // mid-2003) are PEM/SGML text with no <ownershipDocument> root, so XML parsing
+        // always fails with "Data at the root level is invalid". They are unsupported
+        // by design — skip them quietly instead of reporting a guaranteed error per file.
+        if (!sanitized.Contains("<ownershipDocument", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug(
+                "Skipping legacy non-XML ownership filing for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return false;
+        }
+
         // Parse XML
         XDocument doc;
         try
         {
-            doc = XDocument.Parse(SanitizeXml(xmlContent));
+            doc = XDocument.Parse(sanitized);
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            // Many legacy ownership filings are technically <ownershipDocument> XML
+            // but malformed (broken <footnote>, unescaped entities, mismatched tags).
+            // These are expected, non-actionable, and historically numerous — skip
+            // quietly instead of flooding the Errors table with one row per filing.
+            _logger.LogDebug(
+                ex,
+                "Skipping malformed ownership XML for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return false;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

`InsiderTradingFilingProcessor` runs `XDocument.Parse` on every Form 3/4/5.
Pre-XML-era filings (before the SEC mandated ownership XML around mid-2003) are
PEM/SGML text with no `<ownershipDocument>` root, and a significant number of
later filings are malformed XML. Each one throws and is written to the `Errors`
table — hundreds to thousands of rows on a full historical backfill — even
though skipping the filing is the correct behaviour. This buries genuine,
actionable errors on the Status page.

## Code changes

- `InsiderTradingFilingProcessor.cs`:
  - Skip submissions whose sanitized content has no `<ownershipDocument>` root
    (legacy / non-XML) — `LogDebug`, no error report.
  - Treat `XmlException` from `XDocument.Parse` as an expected, non-actionable
    skip (`LogDebug`, no error report) rather than reporting every one.
  - Genuinely unexpected exceptions are still logged at Warning and reported.

## Verification

- Reproduced on a backfill: `InsiderTrading.ParseXml` error rows grew to 2,366
  (262+ "Data at the root level is invalid" — all 2002 SGML filings; the rest
  malformed 2003+ XML).
- After the fix: **0** new `InsiderTrading.ParseXml` errors over a window in
  which `InsiderTransaction` grew from 358k to 390k — i.e. valid filings still
  parse and import normally; only the unparseable ones are now skipped quietly.

## Notes for reviewers

- Two confirmed sub-classes, both expected and non-actionable: pre-XML SGML
  (no root element) and 2003+ malformed ownership XML (broken `<footnote>`,
  unescaped entities, mismatched tags).
- CHANGELOG intentionally left untouched to avoid conflicts with the related
  embedding PRs.
