### PR TITLE
fix(embeddings): isolate per-chunk failures instead of killing the worker

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingClient.cs
+++ b/src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingClient.cs
@@ -50,24 +50,16 @@ public class EmbeddingClient : IEmbeddingClient
             return [];
         }
 
-        try
-        {
-            var batches = texts.Chunk(_config.BatchSize).ToList();
-            var allEmbeddings = new List<float[]>();
+        var batches = texts.Chunk(_config.BatchSize).ToList();
+        var allEmbeddings = new List<float[]>(texts.Count);
 
-            foreach (var batch in batches)
-            {
-                var batchEmbeddings = await ProcessBatch(batch.ToList());
-                allEmbeddings.AddRange(batchEmbeddings);
-            }
-
-            return allEmbeddings;
-        }
-        catch (Exception ex)
+        foreach (var batch in batches)
         {
-            _logger.LogError(ex, "Error generating embeddings for {Count} texts", texts.Count);
-            throw;
+            allEmbeddings.AddRange(await ProcessBatch(batch.ToList()));
         }
+
+        // Positionally aligned to `texts`; entries are null where embedding failed.
+        return allEmbeddings;
     }
 
     public async Task<int> GetEmbeddingDimension()
@@ -86,51 +78,45 @@ public class EmbeddingClient : IEmbeddingClient
 
     private async Task<List<float[]>> ProcessBatch(List<string> batch)
     {
-        // For single text, we can call the new /api/embed endpoint
-        if (batch.Count == 1)
-        {
-            var singlePayload = new { model = _config.ModelName, input = batch[0] };
-
-            var singleJson = JsonSerializer.Serialize(singlePayload);
-            using var singleContent = new StringContent(
-                singleJson,
-                System.Text.Encoding.UTF8,
-                "application/json"
-            );
-
-            // Use the new /api/embed endpoint
-            var response = await _httpClient.PostAsync("/api/embed", singleContent);
-            response.EnsureSuccessStatusCode();
-
-            var responseJson = await response.Content.ReadAsStringAsync();
-            var result = JsonSerializer.Deserialize<OllamaEmbedResponse>(responseJson);
-
-            return result.Embeddings;
-        }
-
-        // For multiple texts, we need to call the endpoint multiple times
-        // as Ollama's /api/embed doesn't support batch processing like OpenAI
-        var embeddings = new List<float[]>();
+        // Ollama's /api/embed handles one input per call. Embed each text
+        // independently and return a list positionally aligned to `batch`,
+        // using null for any text that fails (e.g. Ollama returns 500 because
+        // the model emitted a NaN vector for that specific input). One bad
+        // chunk must never abort the batch or crash the document processor —
+        // the caller skips null entries so the backlog keeps draining.
+        var embeddings = new List<float[]>(batch.Count);
         foreach (var text in batch)
         {
-            var payload = new { model = _config.ModelName, input = text };
-
-            var json = JsonSerializer.Serialize(payload);
-            using var content = new StringContent(
-                json,
-                System.Text.Encoding.UTF8,
-                "application/json"
-            );
-
-            var response = await _httpClient.PostAsync("/api/embed", content);
-            response.EnsureSuccessStatusCode();
-
-            var responseJson = await response.Content.ReadAsStringAsync();
-            var result = JsonSerializer.Deserialize<OllamaEmbedResponse>(responseJson);
-
-            if (result.Embeddings != null && result.Embeddings.Count > 0)
+            try
             {
-                embeddings.Add(result.Embeddings[0]);
+                var payload = new { model = _config.ModelName, input = text };
+
+                var json = JsonSerializer.Serialize(payload);
+                using var content = new StringContent(
+                    json,
+                    System.Text.Encoding.UTF8,
+                    "application/json"
+                );
+
+                var response = await _httpClient.PostAsync("/api/embed", content);
+                response.EnsureSuccessStatusCode();
+
+                var responseJson = await response.Content.ReadAsStringAsync();
+                var result = JsonSerializer.Deserialize<OllamaEmbedResponse>(responseJson);
+
+                embeddings.Add(
+                    result?.Embeddings != null && result.Embeddings.Count > 0
+                        ? result.Embeddings[0]
+                        : null
+                );
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Skipping a chunk that failed to embed (continuing with the rest)"
+                );
+                embeddings.Add(null);
             }
         }
 

--- a/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
+++ b/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
@@ -87,13 +87,15 @@ public class DocumentProcessor : IDocumentProcessor
             }
             catch (Exception ex)
             {
-                _logger.LogError(
+                // Do not rethrow: an unexpected failure on one document must not
+                // tear down the whole document-processor worker. Log and move on;
+                // the chunk stays unembedded and is retried on a later pass.
+                _logger.LogWarning(
                     ex,
-                    "Error generating embeddings for document {DocumentId}. "
-                        + "Stopping batch — embedding server is likely down",
+                    "Skipping embeddings for document {DocumentId} after an unexpected "
+                        + "error; continuing with the rest",
                     group.Key
                 );
-                throw;
             }
         }
     }
@@ -183,27 +185,35 @@ public class DocumentProcessor : IDocumentProcessor
 
         var embeddings = await _embeddingClient.GenerateEmbeddings(chunkContents);
 
-        if (embeddings.Count != chunks.Count)
+        // embeddings is positionally aligned to chunks; an entry is null when
+        // that chunk could not be embedded (e.g. the model returned a NaN
+        // vector and Ollama 500'd). Skip those chunks instead of failing the
+        // whole batch — they simply stay unembedded and can be retried later.
+        var count = Math.Min(chunks.Count, embeddings.Count);
+        var added = 0;
+        for (int i = 0; i < count; i++)
         {
-            throw new InvalidOperationException(
-                $"Embedding count mismatch: expected {chunks.Count}, got {embeddings.Count}"
-            );
-        }
-
-        for (int i = 0; i < chunks.Count; i++)
-        {
-            var embedding = new Embedding
+            if (embeddings[i] == null)
             {
-                Chunk = chunks[i],
-                Model = _embeddingConfig.ModelName,
-                Vector = new Vector(embeddings[i]),
-                VectorDimension = embeddings[i].Length,
-                CreationTime = DateTime.UtcNow,
-            };
+                continue;
+            }
 
-            _embeddingRepository.Add(embedding);
+            _embeddingRepository.Add(
+                new Embedding
+                {
+                    Chunk = chunks[i],
+                    Model = _embeddingConfig.ModelName,
+                    Vector = new Vector(embeddings[i]),
+                    VectorDimension = embeddings[i].Length,
+                    CreationTime = DateTime.UtcNow,
+                }
+            );
+            added++;
         }
 
-        await _embeddingRepository.SaveChanges();
+        if (added > 0)
+        {
+            await _embeddingRepository.SaveChanges();
+        }
     }
 }


### PR DESCRIPTION
## Summary

A single embedding failure takes down the entire document processor. When
Ollama returns 500 for one chunk (e.g. the model emits a `NaN` vector for that
input), `EmbeddingClient.GenerateEmbeddings` logs and rethrows, `DocumentProcessor`
rethrows per document, and `DocumentProcessorWorker` takes a fatal error — so
**all** embedding generation halts until the worker is manually restarted.

## Code changes

- `EmbeddingClient.cs`: embed each text independently and return a list that is
  **positionally aligned** to the input, using `null` for any text that failed
  (per-text try/catch, no rethrow). Removes the previous all-or-nothing batch
  behaviour and the single-vs-multi code split.
- `DocumentProcessor.cs`: `GenerateEmbeddingsForChunks` skips `null` embeddings
  (preserving the `chunks[i]` to `embeddings[i]` alignment the caller relies on)
  instead of throwing on a count mismatch; `GenerateEmbeddings` no longer
  rethrows per-document.

## Verification

- Reproduced: one NaN chunk produced `[FTL] Critical error in Document
  processor` and the `Embedding` count stayed flat for 10+ minutes.
- After the fix: `Embedding` count climbs (+336 in one observation window),
  `worker-embedding` stays `running`, **0** `[FTL]` errors, and exactly the
  poison chunk is skipped (`skipped_chunks=1`) while the backlog keeps draining.

## Notes for reviewers

- The alignment constraint is load-bearing: the caller maps `embeddings[i]` to
  `chunks[i]`, so failed entries must be `null` placeholders, never omitted.
  Verified that input/output counts stay aligned.
- Net effect: a small number of NaN-prone chunks remain unembedded (acceptable
  minor RAG gap) instead of the entire pipeline dying.
- Independent of the other two embedding-related PRs; CHANGELOG intentionally
  untouched to avoid cross-PR conflicts.
