### PR TITLE
test(sec): add skipped repro for GH-745 — ListConversionStep drops anchor-only item content

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepTests.cs
@@ -194,4 +194,26 @@ public class ListConversionStepTests
 
         result.Should().NotBeNull();
     }
+
+    // Contract: converting an item-list wrapper must preserve the item's
+    // content. The fallback branch's own comment says "use all content except
+    // bullet spans", so an item whose content is a hyperlink (no inline
+    // content div, no spans) must not produce an empty <li> — that silently
+    // discards an exhibit reference, exactly the kind of anchor-only list
+    // entry SEC exhibit indexes use.
+    [Fact(Skip = "GH-745 — ListConversionStep drops anchor-only item content")]
+    public void WrapperWithAnchorContentNoSpan_PreservesAnchorContentInLi()
+    {
+        var input = """
+            <div class="item-list-element-wrapper">
+              <span>•</span>
+              <a href="#ex101">Exhibit 10.1</a>
+            </div>
+            """;
+
+        var result = Execute(input);
+
+        result.Should().Contain("<li>");
+        result.Should().Contain("Exhibit 10.1");
+    }
 }


### PR DESCRIPTION
## Summary

- Adversarial test (`/add-test`, Lane A) found a real bug: `ListConversionStep` silently discards an item-list wrapper's content when it's a hyperlink with no `display:inline` content div and no spans — exactly the shape SEC exhibit indexes use — producing an empty `<li>`.
- Repro test committed `[Skip]` pending the fix; tracked in GH-745.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepTests.cs` — adds `WrapperWithAnchorContentNoSpan_PreservesAnchorContentInLi`, skipped — see GH-745. Asserts anchor-only list content survives conversion; currently fails (`<ul><li></li></ul>`), so it is shipped skipped and should be un-skipped as part of the GH-745 fix.