### PR TITLE
test(congress): add skipped repro for GH-747 — ParseDate culture bug

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseDateCultureTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseDateCultureTests.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperParseDateCultureTests
+{
+    // Contract: ParseDate parses US congressional disclosure dates, which use
+    // the US MM/dd/yyyy convention. "03/04/2025" is March 4, 2025 regardless
+    // of the host machine's culture — a Worker deployed under en-GB/de-DE must
+    // not silently read it as April 3.
+    [Fact(Skip = "GH-747 — ParseDate uses CurrentCulture, misreads US dates")]
+    public void ParseDate_UsFormatUnderNonUsCulture_InterpretsAsMonthDayYear()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("en-GB");
+
+            var result = DisclosureParsingHelper.ParseDate("03/04/2025");
+
+            result.Should().Be(new DateOnly(2025, 3, 4));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test (`/add-test`, Lane A) found a real bug: `DisclosureParsingHelper.ParseDate` calls `DateOnly.TryParse` without an invariant culture, so under a non-US host culture (`en-GB`, `de-DE`, …) it reads the US `MM/dd/yyyy` filing date as `dd/MM/yyyy` and silently records the wrong transaction date.
- Repro test committed `[Skip]` pending the fix; tracked in GH-747.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseDateCultureTests.cs` — adds `ParseDate_UsFormatUnderNonUsCulture_InterpretsAsMonthDayYear`, skipped — see GH-747. Pins `ParseDate("03/04/2025")` to March 4, 2025 under `en-GB`; currently fails (returns April 3), so it ships skipped and should be un-skipped as part of the GH-747 fix.