### PR TITLE
test(congress): add skipped repro for GH-750 — IsValidDisclosureUrl bypass

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlBoundaryTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperIsValidUrlBoundaryTests
+{
+    // Contract: IsValidDisclosureUrl guards which URLs the scraper will fetch —
+    // it must accept only URLs that actually belong to the expected disclosure
+    // host. An attacker-registered domain that merely *prefixes* the expected
+    // base ("...house.gov.evil.example") is NOT on the house.gov origin and
+    // must be rejected, or the guard is an SSRF bypass.
+    [Fact(Skip = "GH-750 — IsValidDisclosureUrl StartsWith allows prefix-domain bypass")]
+    public void IsValidDisclosureUrl_AttackerDomainWithBaseAsPrefix_ReturnsFalse()
+    {
+        var result = DisclosureParsingHelper.IsValidDisclosureUrl(
+            "https://disclosures-clerk.house.gov.evil.example/malware.pdf",
+            "https://disclosures-clerk.house.gov"
+        );
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test (`/add-test`, Lane A) found a **security bug**: `DisclosureParsingHelper.IsValidDisclosureUrl` validates a disclosure URL with a raw `string.StartsWith(expectedBaseUrl)`. It has no host/authority boundary, so an attacker-registered domain that merely prefixes the expected base (`https://disclosures-clerk.house.gov.evil.example/…`) passes — an SSRF / arbitrary-fetch bypass on the scraper's download gate.
- Repro test committed `[Skip]` pending the fix; tracked in GH-750.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlBoundaryTests.cs` — adds `IsValidDisclosureUrl_AttackerDomainWithBaseAsPrefix_ReturnsFalse`, skipped — see GH-750. Asserts a prefix-domain attacker URL is rejected for base `https://disclosures-clerk.house.gov`; currently fails (returns `true`), so it ships skipped and should be un-skipped as part of the GH-750 fix (compare `Uri.Scheme`+`Host`, not a string prefix).