### PR TITLE
fix(sec): strip script/style/comment nodes in ChunkingStrategy.CleanText (GH-752)

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Processing/ChunkingStrategy.cs
+++ b/src/Equibles.Sec.BusinessLogic/Processing/ChunkingStrategy.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using AngleSharp.Dom;
 using AngleSharp.Html.Parser;
 using Equibles.Core.AutoWiring;
 using Equibles.Sec.BusinessLogic.Tokenization;
@@ -84,6 +85,20 @@ public class ChunkingStrategy
         // Strip any residual HTML tags using AngleSharp
         var parser = new HtmlParser();
         using var document = parser.ParseDocument($"<body>{text}</body>");
+
+        // TextContent concatenates the text of ALL descendants — including
+        // raw-text elements (<script>/<style>) and comments. SEC EDGAR HTML
+        // routinely carries boilerplate inline JS/CSS; left in, its source
+        // pollutes embeddings and document search. Remove those nodes first.
+        foreach (var node in document.QuerySelectorAll("script, style").ToList())
+        {
+            node.Remove();
+        }
+        foreach (var comment in document.Body.Descendants<IComment>().ToList())
+        {
+            comment.Remove();
+        }
+
         text = document.Body.TextContent;
 
         text = Regex.Replace(text, @"\s+", " ");

--- a/tests/Equibles.UnitTests/Sec/ChunkingStrategyCleanTextScriptTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ChunkingStrategyCleanTextScriptTests.cs
@@ -11,7 +11,7 @@ public class ChunkingStrategyCleanTextScriptTests
     // document text that gets embedded into RAG / public search. A caller
     // relies on script source NOT leaking through — minified JS in a filing's
     // boilerplate must not become searchable "content".
-    [Fact(Skip = "GH-752 — CleanText leaks <script>/<style> source via TextContent")]
+    [Fact]
     public void CleanText_ScriptElement_DoesNotLeakScriptSourceIntoOutput()
     {
         var result = _strategy.CleanText(

--- a/tests/Equibles.UnitTests/Sec/ChunkingStrategyCleanTextScriptTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ChunkingStrategyCleanTextScriptTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Sec.BusinessLogic.Processing;
+using Equibles.Sec.BusinessLogic.Tokenization;
+
+namespace Equibles.UnitTests.Sec;
+
+public class ChunkingStrategyCleanTextScriptTests
+{
+    private readonly ChunkingStrategy _strategy = new(new TokenCounter());
+
+    // Contract: CleanText strips residual HTML so the result is the readable
+    // document text that gets embedded into RAG / public search. A caller
+    // relies on script source NOT leaking through — minified JS in a filing's
+    // boilerplate must not become searchable "content".
+    [Fact(Skip = "GH-752 — CleanText leaks <script>/<style> source via TextContent")]
+    public void CleanText_ScriptElement_DoesNotLeakScriptSourceIntoOutput()
+    {
+        var result = _strategy.CleanText(
+            "<script>alert('xss-leak')</script><p>Real annual report content.</p>"
+        );
+
+        result.Should().Be("Real annual report content.");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #752. `ChunkingStrategy.CleanText` stripped tags via `document.Body.TextContent`, which per the DOM spec concatenates the text of **all** descendants — including `<script>`/`<style>` raw-text elements and comment nodes. SEC EDGAR HTML routinely carries boilerplate inline JS/CSS, so its minified source was being ingested as document "content", polluting RAG embeddings, `SearchDocumentKeyword`, and the document viewer.

Started as the GH-752 skipped repro; now contains the fix:

- Remove `script`/`style` elements and comment nodes from the parsed document **before** reading `TextContent`.
- Un-skips the GH-752 regression test.
- Branch brought up to date with `main` (merge, no force-push).

All 12 ChunkingStrategy tests pass; no regression to normal HTML-stripping behaviour.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Processing/ChunkingStrategy.cs` — strip `<script>`/`<style>`/comment nodes before extracting text.
- `tests/Equibles.UnitTests/Sec/ChunkingStrategyCleanTextScriptTests.cs` — un-skip the GH-752 repro.