### PR TITLE
feat(holdings): near-real-time 13F-HR ingestion alongside quarterly bulk (GH-749)

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -22,5 +22,6 @@ public class HoldingsModuleConfiguration : Equibles.Data.IModuleConfiguration
             .AreNullsDistinct(false);
 
         builder.Entity<ProcessedDataSet>();
+        builder.Entity<ProcessedFiling>();
     }
 }

--- a/src/Equibles.Holdings.Data/Models/ProcessedFiling.cs
+++ b/src/Equibles.Holdings.Data/Models/ProcessedFiling.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.Data.Models;
+
+/// <summary>
+/// Records every individual 13F-HR submission the real-time ingestion path has
+/// already handed to the import pipeline, keyed by accession number.
+///
+/// This is the dedup ledger that makes re-sweeping the daily index safe: an
+/// amendment carries a <em>new</em> accession, so it is still processed, but a
+/// previously-handled original is never re-processed — without this, a later
+/// sweep of an original (whose holdings rows were deleted by its own
+/// amendment's delete-by-period) would upsert stale holdings back over the
+/// amendment. Filings that produced no tracked holdings are recorded too, so
+/// they are not re-downloaded every cycle.
+/// </summary>
+[Index(nameof(AccessionNumber), IsUnique = true)]
+public class ProcessedFiling
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [MaxLength(32)]
+    public string AccessionNumber { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Holdings.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Holdings.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ public static class ServiceCollectionExtensions
         services.AutoWireServicesFrom<HoldingsImportService>();
 
         services.AddHostedService<HoldingsScraperWorker>();
+        services.AddHostedService<Holdings13FRealtimeWorker>();
 
         return services;
     }

--- a/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
+++ b/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
@@ -1,0 +1,81 @@
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Worker;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Holdings.HostedService;
+
+/// <summary>
+/// Near-real-time 13F-HR ingestion worker. Runs in parallel with the quarterly
+/// <see cref="HoldingsScraperWorker"/>: this surfaces freshly filed 13F-HRs
+/// within hours, while the bulk data set remains the authoritative source that
+/// reconciles everything at quarter end. Both paths write through the same
+/// import pipeline and upsert key, so the later bulk import updates rather than
+/// duplicates anything this worker inserted.
+/// </summary>
+public class Holdings13FRealtimeWorker : BaseScraperWorker
+{
+    // EDGAR daily indexes aren't published on weekends/holidays, and filings
+    // can be accepted late; a short rolling look-back makes the sweep robust
+    // to gaps. Re-seeing a filing is harmless — the import upsert is idempotent.
+    // Exposed as a seam so tests can pin it without changing production.
+    protected virtual int LookbackDays => 4;
+
+    private readonly WorkerOptions _workerOptions;
+    private readonly IConfiguration _configuration;
+
+    protected override string WorkerName => "13F real-time ingestion";
+    protected override TimeSpan SleepInterval => TimeSpan.FromHours(6);
+    protected override ErrorSource ErrorSource => ErrorSource.HoldingsScraper;
+
+    public Holdings13FRealtimeWorker(
+        ILogger<Holdings13FRealtimeWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<WorkerOptions> workerOptions,
+        IConfiguration configuration
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        _workerOptions = workerOptions.Value;
+        _configuration = configuration;
+    }
+
+    protected override bool ValidateConfiguration()
+    {
+        if (string.IsNullOrEmpty(_configuration["Sec:ContactEmail"]))
+        {
+            Logger.LogWarning(
+                "13F real-time ingestion stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."
+            );
+            return false;
+        }
+        return true;
+    }
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        var startDate = _workerOptions.MinSyncDate ?? new DateTime(2020, 1, 1);
+        var minReportDate = DateOnly.FromDateTime(startDate);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var ingestionService =
+            scope.ServiceProvider.GetRequiredService<Realtime13FIngestionService>();
+
+        var count = await ingestionService.IngestRecentFilings(
+            today,
+            LookbackDays,
+            minReportDate,
+            stoppingToken
+        );
+
+        Logger.LogInformation(
+            "13F real-time ingestion cycle complete: {Count} filings processed",
+            count
+        );
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Models/Parsed13FFiling.cs
+++ b/src/Equibles.Holdings.HostedService/Models/Parsed13FFiling.cs
@@ -1,0 +1,28 @@
+namespace Equibles.Holdings.HostedService.Models;
+
+/// <summary>
+/// A single 13F-HR (or 13F-HR/A) submission parsed from its raw EDGAR XML
+/// (<c>primary_doc.xml</c> cover page + information-table XML). This is the
+/// real-time path's equivalent of one filing's worth of rows from the
+/// quarterly structured data set, and is projected back into the same TSV
+/// shape so it flows through the identical, already-tested import pipeline.
+/// </summary>
+public class Parsed13FFiling
+{
+    public string Cik { get; set; }
+    public string AccessionNumber { get; set; }
+    public DateOnly FilingDate { get; set; }
+    public DateOnly PeriodOfReport { get; set; }
+    public bool IsAmendment { get; set; }
+
+    public string FilingManagerName { get; set; }
+    public string City { get; set; }
+    public string StateOrCountry { get; set; }
+    public string Form13FFileNumber { get; set; }
+    public string CrdNumber { get; set; }
+
+    /// <summary>Other-manager table: sequence number → manager name.</summary>
+    public Dictionary<int, string> OtherManagers { get; set; } = [];
+
+    public List<Parsed13FHolding> Holdings { get; set; } = [];
+}

--- a/src/Equibles.Holdings.HostedService/Models/Parsed13FHolding.cs
+++ b/src/Equibles.Holdings.HostedService/Models/Parsed13FHolding.cs
@@ -1,0 +1,33 @@
+namespace Equibles.Holdings.HostedService.Models;
+
+/// <summary>
+/// One <c>&lt;infoTable&gt;</c> row parsed from a 13F-HR information-table XML.
+/// Codes (<see cref="ShareType"/>, <see cref="InvestmentDiscretion"/>,
+/// <see cref="PutCall"/>) are kept as the raw SEC strings so the real-time path
+/// reuses the exact same parsing helpers as the bulk-dataset path.
+/// </summary>
+public class Parsed13FHolding
+{
+    public string Cusip { get; set; }
+    public string TitleOfClass { get; set; }
+
+    /// <summary>SEC <c>sshPrnamtType</c> code: <c>SH</c> or <c>PRN</c>.</summary>
+    public string ShareType { get; set; }
+    public long Shares { get; set; }
+
+    /// <summary>SEC <c>putCall</c>: <c>Put</c>, <c>Call</c>, or null/empty.</summary>
+    public string PutCall { get; set; }
+
+    /// <summary>SEC <c>investmentDiscretion</c> code: <c>SOLE</c>, <c>DFND</c>, <c>OTR</c>.</summary>
+    public string InvestmentDiscretion { get; set; }
+
+    public long VotingAuthSole { get; set; }
+    public long VotingAuthShared { get; set; }
+    public long VotingAuthNone { get; set; }
+
+    /// <summary>
+    /// Reference into the filing's other-manager table (sequence number), or
+    /// null when the holding is reported solely by the filing manager.
+    /// </summary>
+    public int? OtherManagerNumber { get; set; }
+}

--- a/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
@@ -30,36 +30,46 @@ public class Filing13FXmlParser
         if (root == null)
             throw new FormatException("primary_doc.xml has no root element");
 
+        // Scope every lookup to its structural parent. Several local names
+        // (cik, form13FFileNumber, name) legitimately recur elsewhere in the
+        // document — under headerData vs an otherManager block — so an
+        // unscoped first-match would silently grab the wrong element.
+        var headerData = Descendant(root, "headerData");
         var coverPage = Descendant(root, "coverPage");
         var filingManager = coverPage == null ? null : Descendant(coverPage, "filingManager");
         var address = filingManager == null ? null : Descendant(filingManager, "address");
 
-        var xmlCik = Value(Descendant(root, "cik"));
+        var xmlCik = headerData == null ? null : Value(Descendant(headerData, "cik"));
 
         var filing = new Parsed13FFiling
         {
             AccessionNumber = accessionNumber,
             Cik = string.IsNullOrEmpty(xmlCik) ? cik?.TrimStart('0') : xmlCik.TrimStart('0'),
             FilingDate = filingDate,
-            PeriodOfReport = ParseSecDate(Value(Descendant(root, "reportCalendarOrQuarter"))),
-            IsAmendment = IsAmendmentValue(Value(Descendant(root, "isAmendment"))),
-            FilingManagerName = Value(filingManager == null ? null : Child(filingManager, "name")),
-            City = Value(address == null ? null : Descendant(address, "city")),
-            StateOrCountry = Value(
-                address == null ? null : Descendant(address, "stateOrCountry")
+            PeriodOfReport = ParseSecDate(
+                Value(coverPage == null ? null : Descendant(coverPage, "reportCalendarOrQuarter"))
             ),
-            Form13FFileNumber = Value(Descendant(root, "form13FFileNumber")),
-            CrdNumber = Value(Descendant(root, "crdNumber")),
+            IsAmendment = IsAmendmentValue(
+                Value(coverPage == null ? null : Descendant(coverPage, "isAmendment"))
+            ),
+            FilingManagerName = Value(filingManager == null ? null : Child(filingManager, "name")),
+            City = Value(address == null ? null : Child(address, "city")),
+            StateOrCountry = Value(address == null ? null : Child(address, "stateOrCountry")),
+            Form13FFileNumber = Value(
+                coverPage == null ? null : Descendant(coverPage, "form13FFileNumber")
+            ),
+            CrdNumber = Value(coverPage == null ? null : Descendant(coverPage, "crdNumber")),
         };
 
-        foreach (var otherManager2 in Descendants(root, "otherManager2"))
+        var otherManagersScope = coverPage ?? root;
+        foreach (var otherManager2 in Descendants(otherManagersScope, "otherManager2"))
         {
-            var seqText = Value(Descendant(otherManager2, "sequenceNumber"));
+            var seqText = Value(Child(otherManager2, "sequenceNumber"));
             if (!int.TryParse(seqText, out var seq))
                 continue;
 
-            var inner = Descendant(otherManager2, "otherManager");
-            var name = Value(inner == null ? null : Descendant(inner, "name"));
+            var inner = Child(otherManager2, "otherManager");
+            var name = Value(inner == null ? null : Child(inner, "name"));
             if (!string.IsNullOrEmpty(name))
                 filing.OtherManagers[seq] = name;
         }
@@ -82,40 +92,51 @@ public class Filing13FXmlParser
         if (root == null)
             return holdings;
 
-        foreach (var info in Descendants(root, "infoTable"))
+        // infoTable rows are flat direct children of the table root. Use
+        // direct-child traversal so a field is never read from a sibling row
+        // (recursive Descendants would cross row boundaries if the schema ever
+        // nested). Fall back to a recursive scan only if the root is wrapped.
+        var rows = Children(root, "infoTable").ToList();
+        if (rows.Count == 0)
+            rows = Descendants(root, "infoTable").ToList();
+
+        foreach (var info in rows)
         {
-            var amount = Descendant(info, "shrsOrPrnAmt");
-            var voting = Descendant(info, "votingAuthority");
+            var amount = Child(info, "shrsOrPrnAmt");
+            var voting = Child(info, "votingAuthority");
 
             holdings.Add(
                 new Parsed13FHolding
                 {
-                    Cusip = Value(Descendant(info, "cusip")),
-                    TitleOfClass = Value(Descendant(info, "titleOfClass")),
-                    ShareType = Value(
-                        amount == null ? null : Descendant(amount, "sshPrnamtType")
-                    ),
-                    Shares = ParseLong(
-                        Value(amount == null ? null : Descendant(amount, "sshPrnamt"))
-                    ),
-                    PutCall = Value(Descendant(info, "putCall")),
-                    InvestmentDiscretion = Value(Descendant(info, "investmentDiscretion")),
+                    Cusip = Value(Child(info, "cusip")),
+                    TitleOfClass = Value(Child(info, "titleOfClass")),
+                    ShareType = Value(amount == null ? null : Child(amount, "sshPrnamtType")),
+                    Shares = ParseLong(Value(amount == null ? null : Child(amount, "sshPrnamt"))),
+                    PutCall = Value(Child(info, "putCall")),
+                    InvestmentDiscretion = Value(Child(info, "investmentDiscretion")),
                     VotingAuthSole = ParseLong(
-                        Value(voting == null ? null : Descendant(voting, "Sole"))
+                        Value(voting == null ? null : Child(voting, "Sole"))
                     ),
                     VotingAuthShared = ParseLong(
-                        Value(voting == null ? null : Descendant(voting, "Shared"))
+                        Value(voting == null ? null : Child(voting, "Shared"))
                     ),
                     VotingAuthNone = ParseLong(
-                        Value(voting == null ? null : Descendant(voting, "None"))
+                        Value(voting == null ? null : Child(voting, "None"))
                     ),
-                    OtherManagerNumber = ParseFirstInt(Value(Descendant(info, "otherManager"))),
+                    OtherManagerNumber = ParseFirstInt(Value(Child(info, "otherManager"))),
                 }
             );
         }
 
         return holdings;
     }
+
+    private static IEnumerable<XElement> Children(XElement parent, string localName) =>
+        parent
+            .Elements()
+            .Where(e =>
+                string.Equals(e.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)
+            );
 
     private static XElement Descendant(XElement parent, string localName) =>
         parent

--- a/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
@@ -146,7 +146,8 @@ public class Filing13FXmlParser
             );
 
     private static IEnumerable<XElement> Descendants(XElement parent, string localName) =>
-        parent.Descendants()
+        parent
+            .Descendants()
             .Where(e =>
                 string.Equals(e.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)
             );
@@ -215,7 +216,10 @@ public class Filing13FXmlParser
         if (string.IsNullOrWhiteSpace(raw))
             return null;
 
-        var first = raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        var first = raw.Split(
+                ',',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+            )
             .FirstOrDefault();
         return int.TryParse(first, out var value) ? value : null;
     }

--- a/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
@@ -1,0 +1,201 @@
+using System.Globalization;
+using System.Xml.Linq;
+using Equibles.Core.AutoWiring;
+using Equibles.Holdings.HostedService.Models;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Parses the raw XML of a single 13F-HR filing. SEC ships several namespace
+/// variants of these schemas over time, so every lookup is by element
+/// <see cref="XName.LocalName"/> and ignores namespaces entirely — the only
+/// approach that survives historical and current filings alike.
+/// </summary>
+[Service]
+public class Filing13FXmlParser
+{
+    /// <summary>
+    /// Parses the cover page (<c>primary_doc.xml</c>) into filing metadata.
+    /// <paramref name="accessionNumber"/> and <paramref name="cik"/> come from
+    /// the daily index and are used as fallbacks when the XML omits them.
+    /// </summary>
+    public Parsed13FFiling ParseCoverPage(
+        string primaryDocXml,
+        string accessionNumber,
+        string cik,
+        DateOnly filingDate
+    )
+    {
+        var root = XDocument.Parse(primaryDocXml).Root;
+        if (root == null)
+            throw new FormatException("primary_doc.xml has no root element");
+
+        var coverPage = Descendant(root, "coverPage");
+        var filingManager = coverPage == null ? null : Descendant(coverPage, "filingManager");
+        var address = filingManager == null ? null : Descendant(filingManager, "address");
+
+        var xmlCik = Value(Descendant(root, "cik"));
+
+        var filing = new Parsed13FFiling
+        {
+            AccessionNumber = accessionNumber,
+            Cik = string.IsNullOrEmpty(xmlCik) ? cik?.TrimStart('0') : xmlCik.TrimStart('0'),
+            FilingDate = filingDate,
+            PeriodOfReport = ParseSecDate(Value(Descendant(root, "reportCalendarOrQuarter"))),
+            IsAmendment = IsAmendmentValue(Value(Descendant(root, "isAmendment"))),
+            FilingManagerName = Value(filingManager == null ? null : Child(filingManager, "name")),
+            City = Value(address == null ? null : Descendant(address, "city")),
+            StateOrCountry = Value(
+                address == null ? null : Descendant(address, "stateOrCountry")
+            ),
+            Form13FFileNumber = Value(Descendant(root, "form13FFileNumber")),
+            CrdNumber = Value(Descendant(root, "crdNumber")),
+        };
+
+        foreach (var otherManager2 in Descendants(root, "otherManager2"))
+        {
+            var seqText = Value(Descendant(otherManager2, "sequenceNumber"));
+            if (!int.TryParse(seqText, out var seq))
+                continue;
+
+            var inner = Descendant(otherManager2, "otherManager");
+            var name = Value(inner == null ? null : Descendant(inner, "name"));
+            if (!string.IsNullOrEmpty(name))
+                filing.OtherManagers[seq] = name;
+        }
+
+        return filing;
+    }
+
+    /// <summary>
+    /// Parses the information-table XML into holding rows. Tolerates a missing
+    /// or empty table (an amendment that removes every position) by returning
+    /// an empty list.
+    /// </summary>
+    public List<Parsed13FHolding> ParseInformationTable(string infoTableXml)
+    {
+        var holdings = new List<Parsed13FHolding>();
+        if (string.IsNullOrWhiteSpace(infoTableXml))
+            return holdings;
+
+        var root = XDocument.Parse(infoTableXml).Root;
+        if (root == null)
+            return holdings;
+
+        foreach (var info in Descendants(root, "infoTable"))
+        {
+            var amount = Descendant(info, "shrsOrPrnAmt");
+            var voting = Descendant(info, "votingAuthority");
+
+            holdings.Add(
+                new Parsed13FHolding
+                {
+                    Cusip = Value(Descendant(info, "cusip")),
+                    TitleOfClass = Value(Descendant(info, "titleOfClass")),
+                    ShareType = Value(
+                        amount == null ? null : Descendant(amount, "sshPrnamtType")
+                    ),
+                    Shares = ParseLong(
+                        Value(amount == null ? null : Descendant(amount, "sshPrnamt"))
+                    ),
+                    PutCall = Value(Descendant(info, "putCall")),
+                    InvestmentDiscretion = Value(Descendant(info, "investmentDiscretion")),
+                    VotingAuthSole = ParseLong(
+                        Value(voting == null ? null : Descendant(voting, "Sole"))
+                    ),
+                    VotingAuthShared = ParseLong(
+                        Value(voting == null ? null : Descendant(voting, "Shared"))
+                    ),
+                    VotingAuthNone = ParseLong(
+                        Value(voting == null ? null : Descendant(voting, "None"))
+                    ),
+                    OtherManagerNumber = ParseFirstInt(Value(Descendant(info, "otherManager"))),
+                }
+            );
+        }
+
+        return holdings;
+    }
+
+    private static XElement Descendant(XElement parent, string localName) =>
+        parent
+            .Descendants()
+            .FirstOrDefault(e =>
+                string.Equals(e.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)
+            );
+
+    private static IEnumerable<XElement> Descendants(XElement parent, string localName) =>
+        parent.Descendants()
+            .Where(e =>
+                string.Equals(e.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)
+            );
+
+    private static XElement Child(XElement parent, string localName) =>
+        parent
+            .Elements()
+            .FirstOrDefault(e =>
+                string.Equals(e.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)
+            );
+
+    private static string Value(XElement element) => element?.Value.Trim();
+
+    private static bool IsAmendmentValue(string raw) =>
+        !string.IsNullOrEmpty(raw)
+        && (
+            raw.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || raw.Equals("y", StringComparison.OrdinalIgnoreCase)
+            || raw.Equals("yes", StringComparison.OrdinalIgnoreCase)
+            || raw == "1"
+        );
+
+    /// <summary>
+    /// Cover-page dates are <c>MM-DD-YYYY</c>; a few historical filings use
+    /// ISO. Returns <see cref="DateOnly.MinValue"/> when unparseable so the
+    /// downstream pipeline filters the filing out rather than crashing.
+    /// </summary>
+    private static DateOnly ParseSecDate(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return DateOnly.MinValue;
+
+        if (
+            DateOnly.TryParseExact(
+                raw.Trim(),
+                "MM-dd-yyyy",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var exact
+            )
+        )
+            return exact;
+
+        return DateOnly.TryParse(
+            raw.Trim(),
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var general
+        )
+            ? general
+            : DateOnly.MinValue;
+    }
+
+    private static long ParseLong(string raw) =>
+        long.TryParse(
+            raw?.Replace(",", string.Empty),
+            NumberStyles.Integer,
+            CultureInfo.InvariantCulture,
+            out var value
+        )
+            ? value
+            : 0;
+
+    private static int? ParseFirstInt(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return null;
+
+        var first = raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault();
+        return int.TryParse(first, out var value) ? value : null;
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -142,7 +142,16 @@ public class HoldingsImportService
 
         foreach (var group in byCikAndPeriod)
         {
-            var latest = group.OrderByDescending(s => s.FilingDate).First();
+            // FilingDate is day-granular (and, on the real-time path, derived
+            // from the daily-index date), so an original and its same-day
+            // amendment can tie. Break ties by accession number — SEC assigns
+            // these monotonically per filer agent, so the lexicographically
+            // greatest accession is the later submission. Without this the
+            // winner is nondeterministic and an amendment can be dropped.
+            var latest = group
+                .OrderByDescending(s => s.FilingDate, StringComparer.Ordinal)
+                .ThenByDescending(s => s.AccessionNumber, StringComparer.Ordinal)
+                .First();
 
             foreach (var s in group.Where(s => s.AccessionNumber != latest.AccessionNumber))
             {

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
@@ -103,17 +103,25 @@ public class Realtime13FArchiveBuilder
             }
         }
 
-        var buffer = new MemoryStream();
-        using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        // Build into a throwaway buffer, then hand the read archive an
+        // independently-owned stream. Ownership is then unambiguous: disposing
+        // the returned archive disposes its stream, and a failure while writing
+        // disposes the build buffer here instead of leaking it.
+        byte[] zipBytes;
+        using (var buffer = new MemoryStream())
         {
-            WriteEntry(writer, "SUBMISSION.tsv", submission);
-            WriteEntry(writer, "COVERPAGE.tsv", coverPage);
-            WriteEntry(writer, "INFOTABLE.tsv", infoTable);
-            WriteEntry(writer, "OTHERMANAGER2.tsv", otherManager);
+            using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                WriteEntry(writer, "SUBMISSION.tsv", submission);
+                WriteEntry(writer, "COVERPAGE.tsv", coverPage);
+                WriteEntry(writer, "INFOTABLE.tsv", infoTable);
+                WriteEntry(writer, "OTHERMANAGER2.tsv", otherManager);
+            }
+            zipBytes = buffer.ToArray();
         }
 
-        buffer.Position = 0;
-        return new ZipArchive(buffer, ZipArchiveMode.Read);
+        // Disposing the returned archive transitively disposes this stream.
+        return new ZipArchive(new MemoryStream(zipBytes), ZipArchiveMode.Read);
     }
 
     private static void WriteEntry(ZipArchive archive, string name, StringBuilder content)

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
@@ -1,0 +1,138 @@
+using System.IO.Compression;
+using System.Text;
+using Equibles.Core.AutoWiring;
+using Equibles.Holdings.HostedService.Models;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Projects real-time-parsed 13F filings back into the exact TSV layout of
+/// SEC's quarterly structured data set (SUBMISSION / COVERPAGE / INFOTABLE /
+/// OTHERMANAGER2). Feeding this synthetic archive through the existing
+/// <see cref="HoldingsImportService"/> guarantees the real-time path
+/// reconciles byte-for-byte with the bulk path: identical dedup, amendment
+/// delete-by-period, CUSIP/price resolution and upsert key. No persistence
+/// logic is duplicated.
+/// </summary>
+[Service]
+public class Realtime13FArchiveBuilder
+{
+    public ZipArchive Build(IReadOnlyCollection<Parsed13FFiling> filings)
+    {
+        var submission = new StringBuilder(
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+        );
+        var coverPage = new StringBuilder(
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\t"
+                + "FILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+        );
+        var infoTable = new StringBuilder(
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMTTYPE\tPUTCALL\tSSHPRNAMT\tVOTING_AUTH_SOLE\t"
+                + "VOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\tINVESTMENTDISCRETION\n"
+        );
+        var otherManager = new StringBuilder("ACCESSION_NUMBER\tSEQUENCENUMBER\tNAME\n");
+
+        foreach (var filing in filings)
+        {
+            var formType = filing.IsAmendment ? "13F-HR/A" : "13F-HR";
+
+            submission
+                .Append(formType)
+                .Append('\t')
+                .Append(Clean(filing.AccessionNumber))
+                .Append('\t')
+                .Append(filing.FilingDate.ToString("yyyy-MM-dd"))
+                .Append('\t')
+                .Append(filing.PeriodOfReport.ToString("yyyy-MM-dd"))
+                .Append('\t')
+                .Append(Clean(filing.Cik))
+                .Append('\n');
+
+            coverPage
+                .Append(Clean(filing.AccessionNumber))
+                .Append('\t')
+                .Append(filing.IsAmendment ? "Y" : "N")
+                .Append('\t')
+                .Append(Clean(filing.FilingManagerName))
+                .Append('\t')
+                .Append(Clean(filing.City))
+                .Append('\t')
+                .Append(Clean(filing.StateOrCountry))
+                .Append('\t')
+                .Append(Clean(filing.Form13FFileNumber))
+                .Append('\t')
+                .Append(Clean(filing.CrdNumber))
+                .Append('\n');
+
+            foreach (var (seq, name) in filing.OtherManagers)
+            {
+                otherManager
+                    .Append(Clean(filing.AccessionNumber))
+                    .Append('\t')
+                    .Append(seq)
+                    .Append('\t')
+                    .Append(Clean(name))
+                    .Append('\n');
+            }
+
+            foreach (var holding in filing.Holdings)
+            {
+                infoTable
+                    .Append(Clean(filing.AccessionNumber))
+                    .Append('\t')
+                    .Append(Clean(holding.Cusip))
+                    .Append('\t')
+                    .Append(Clean(holding.ShareType))
+                    .Append('\t')
+                    .Append(Clean(holding.PutCall))
+                    .Append('\t')
+                    .Append(holding.Shares)
+                    .Append('\t')
+                    .Append(holding.VotingAuthSole)
+                    .Append('\t')
+                    .Append(holding.VotingAuthShared)
+                    .Append('\t')
+                    .Append(holding.VotingAuthNone)
+                    .Append('\t')
+                    .Append(Clean(holding.TitleOfClass))
+                    .Append('\t')
+                    .Append(holding.OtherManagerNumber?.ToString() ?? string.Empty)
+                    .Append('\t')
+                    .Append(Clean(holding.InvestmentDiscretion))
+                    .Append('\n');
+            }
+        }
+
+        var buffer = new MemoryStream();
+        using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            WriteEntry(writer, "SUBMISSION.tsv", submission);
+            WriteEntry(writer, "COVERPAGE.tsv", coverPage);
+            WriteEntry(writer, "INFOTABLE.tsv", infoTable);
+            WriteEntry(writer, "OTHERMANAGER2.tsv", otherManager);
+        }
+
+        buffer.Position = 0;
+        return new ZipArchive(buffer, ZipArchiveMode.Read);
+    }
+
+    private static void WriteEntry(ZipArchive archive, string name, StringBuilder content)
+    {
+        var entry = archive.CreateEntry(name);
+        using var stream = entry.Open();
+        var bytes = Encoding.UTF8.GetBytes(content.ToString());
+        stream.Write(bytes, 0, bytes.Length);
+    }
+
+    /// <summary>
+    /// The TSV reader splits on tabs and newlines; any of those embedded in a
+    /// free-text field (manager names, titles) would corrupt the whole row.
+    /// Replace them with spaces — the import pipeline trims values anyway.
+    /// </summary>
+    private static string Clean(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+        return value.Replace('\t', ' ').Replace('\r', ' ').Replace('\n', ' ');
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
@@ -1,8 +1,10 @@
 using System.Text;
 using Equibles.Core.AutoWiring;
+using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.HostedService.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Holdings.HostedService.Services;
@@ -61,22 +63,28 @@ public class Realtime13FIngestionService
             return 0;
         }
 
+        var alreadyProcessed = await LoadProcessedAccessions(
+            entries.Select(e => e.AccessionNumber),
+            cancellationToken
+        );
+
         var filings = new List<Parsed13FFiling>();
+        var handedOffAccessions = new List<string>();
         foreach (var entry in entries)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (alreadyProcessed.Contains(entry.AccessionNumber))
+            {
+                _logger.LogDebug(
+                    "Skipping already-processed filing {Accession}",
+                    entry.AccessionNumber
+                );
+                continue;
+            }
+
             try
             {
-                if (await AlreadyImported(entry.AccessionNumber, cancellationToken))
-                {
-                    _logger.LogDebug(
-                        "Skipping already-imported filing {Accession}",
-                        entry.AccessionNumber
-                    );
-                    continue;
-                }
-
                 var filing = await ParseFiling(entry, cancellationToken);
                 if (filing == null)
                     continue;
@@ -94,6 +102,7 @@ public class Realtime13FIngestionService
                     continue;
 
                 filings.Add(filing);
+                handedOffAccessions.Add(entry.AccessionNumber);
             }
             catch (OperationCanceledException)
             {
@@ -123,13 +132,19 @@ public class Realtime13FIngestionService
             filings.Count
         );
 
-        using var archive = _archiveBuilder.Build(filings);
-        await _importService.ImportDataSet(archive, minReportDate, cancellationToken);
+        using (var archive = _archiveBuilder.Build(filings))
+        {
+            await _importService.ImportDataSet(archive, minReportDate, cancellationToken);
+        }
+
+        // Record the ledger only after the import succeeded: a crash mid-import
+        // must not permanently skip these accessions on the next sweep.
+        await RecordProcessed(handedOffAccessions, cancellationToken);
 
         return filings.Count;
     }
 
-    private async Task<List<Equibles.Integrations.Sec.Models.EdgarDailyIndexEntry>> DiscoverEntries(
+    private async Task<List<EdgarDailyIndexEntry>> DiscoverEntries(
         DateOnly today,
         int lookbackDays,
         CancellationToken cancellationToken
@@ -138,7 +153,7 @@ public class Realtime13FIngestionService
         // Deduplicate by accession across the window: an amendment carries a
         // distinct accession number, so this only collapses the same filing
         // re-listed across overlapping sweeps, never an original vs amendment.
-        var byAccession = new Dictionary<string, Equibles.Integrations.Sec.Models.EdgarDailyIndexEntry>(
+        var byAccession = new Dictionary<string, EdgarDailyIndexEntry>(
             StringComparer.OrdinalIgnoreCase
         );
 
@@ -149,33 +164,62 @@ public class Realtime13FIngestionService
             var date = today.AddDays(-offset);
             var indexEntries = await _edgarClient.GetDailyIndex(date, cancellationToken);
 
+            // The client already filters to 13F-HR / 13F-HR/A; only guard
+            // against a malformed row with no accession number here.
             foreach (var entry in indexEntries)
             {
-                if (
-                    !string.IsNullOrEmpty(entry.AccessionNumber)
-                    && entry.FormType.StartsWith("13F-HR", StringComparison.OrdinalIgnoreCase)
-                )
-                {
+                if (!string.IsNullOrEmpty(entry.AccessionNumber))
                     byAccession[entry.AccessionNumber] = entry;
-                }
             }
         }
 
         return byAccession.Values.ToList();
     }
 
-    private async Task<bool> AlreadyImported(
-        string accessionNumber,
+    private async Task<HashSet<string>> LoadProcessedAccessions(
+        IEnumerable<string> accessionNumbers,
         CancellationToken cancellationToken
     )
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
-        var repo = scope.ServiceProvider.GetRequiredService<InstitutionalHoldingRepository>();
-        return await repo.GetByAccessionNumber(accessionNumber).AnyAsync(cancellationToken);
+        var repo = scope.ServiceProvider.GetRequiredService<ProcessedFilingRepository>();
+
+        var processed = await repo.GetByAccessionNumbers(accessionNumbers.ToList())
+            .Select(p => p.AccessionNumber)
+            .ToListAsync(cancellationToken);
+
+        return new HashSet<string>(processed, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private async Task RecordProcessed(
+        IReadOnlyCollection<string> accessionNumbers,
+        CancellationToken cancellationToken
+    )
+    {
+        if (accessionNumbers.Count == 0)
+            return;
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ProcessedFilingRepository>();
+
+        // Re-check inside the write scope: a parallel sweep (or the quarterly
+        // worker) may have recorded some of these between discovery and now.
+        var existing = await repo.GetByAccessionNumbers(accessionNumbers.ToList())
+            .Select(p => p.AccessionNumber)
+            .ToListAsync(cancellationToken);
+        var existingSet = new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var accession in accessionNumbers)
+        {
+            if (existingSet.Add(accession))
+                repo.Add(new ProcessedFiling { AccessionNumber = accession });
+        }
+
+        await repo.SaveChanges();
     }
 
     private async Task<Parsed13FFiling> ParseFiling(
-        Equibles.Integrations.Sec.Models.EdgarDailyIndexEntry entry,
+        EdgarDailyIndexEntry entry,
         CancellationToken cancellationToken
     )
     {
@@ -211,28 +255,53 @@ public class Realtime13FIngestionService
             entry.DateFiled
         );
 
-        var infoTableName = SelectInfoTable(artifacts);
-        if (infoTableName != null)
+        filing.Holdings = await ResolveHoldings(entry, artifacts, cancellationToken);
+
+        // A non-amendment with no parseable holdings means we picked the wrong
+        // artifact or the table failed to parse — never feed an empty original
+        // through (it would be a no-op at best, masking a real gap). Skip it and
+        // let the authoritative quarterly bulk import reconcile it later.
+        if (filing.Holdings.Count == 0 && !filing.IsAmendment)
         {
-            var infoTableXml = await DownloadText(
-                entry.Cik,
-                entry.AccessionNumber,
-                infoTableName,
-                cancellationToken
-            );
-            filing.Holdings = _parser.ParseInformationTable(infoTableXml);
-        }
-        else
-        {
-            // No information table is legitimate for an amendment that removes
-            // every position; the pipeline's amendment delete-by-period still runs.
-            _logger.LogInformation(
-                "Filing {Accession} has no information table (likely a holdings-removing amendment)",
+            _logger.LogWarning(
+                "Filing {Accession} yielded no holdings and is not an amendment — skipping",
                 entry.AccessionNumber
             );
+            return null;
         }
 
         return filing;
+    }
+
+    /// <summary>
+    /// Downloads candidate information-table XML artifacts and returns the
+    /// first that actually parses to one or more <c>&lt;infoTable&gt;</c> rows.
+    /// An empty result is only legitimate for a holdings-removing amendment —
+    /// the caller enforces that.
+    /// </summary>
+    private async Task<List<Parsed13FHolding>> ResolveHoldings(
+        EdgarDailyIndexEntry entry,
+        List<string> artifacts,
+        CancellationToken cancellationToken
+    )
+    {
+        foreach (var name in OrderedInfoTableCandidates(artifacts))
+        {
+            var xml = await DownloadText(
+                entry.Cik,
+                entry.AccessionNumber,
+                name,
+                cancellationToken
+            );
+            if (string.IsNullOrWhiteSpace(xml))
+                continue;
+
+            var holdings = _parser.ParseInformationTable(xml);
+            if (holdings.Count > 0)
+                return holdings;
+        }
+
+        return [];
     }
 
     private async Task<string> DownloadText(
@@ -257,12 +326,14 @@ public class Realtime13FIngestionService
         );
 
     /// <summary>
-    /// The information table is the filing's other <c>.xml</c> artifact. SEC
-    /// names it inconsistently (<c>infotable.xml</c>, <c>form13fInfoTable.xml</c>,
-    /// <c>&lt;accession&gt;.xml</c>), so prefer a name that looks like an info
-    /// table and fall back to any non-cover, non-schema XML.
+    /// The information table is one of the filing's non-cover <c>.xml</c>
+    /// artifacts; SEC names it inconsistently (<c>infotable.xml</c>,
+    /// <c>form13fInfoTable.xml</c>, <c>&lt;accession&gt;.xml</c>) and filings
+    /// can also ship rendering/schema XML. Yield the table-looking names first,
+    /// then the rest, so the caller can validate by content rather than trust
+    /// a single name guess.
     /// </summary>
-    private static string SelectInfoTable(List<string> artifacts)
+    private static IEnumerable<string> OrderedInfoTableCandidates(List<string> artifacts)
     {
         var candidates = artifacts
             .Where(a =>
@@ -271,10 +342,12 @@ public class Realtime13FIngestionService
             )
             .ToList();
 
-        return candidates.FirstOrDefault(a =>
+        return candidates
+            .OrderByDescending(a =>
                 a.Contains("info", StringComparison.OrdinalIgnoreCase)
                 || a.Contains("table", StringComparison.OrdinalIgnoreCase)
                 || a.Contains("13f", StringComparison.OrdinalIgnoreCase)
-            ) ?? candidates.FirstOrDefault();
+            )
+            .ToList();
     }
 }

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
@@ -287,12 +287,7 @@ public class Realtime13FIngestionService
     {
         foreach (var name in OrderedInfoTableCandidates(artifacts))
         {
-            var xml = await DownloadText(
-                entry.Cik,
-                entry.AccessionNumber,
-                name,
-                cancellationToken
-            );
+            var xml = await DownloadText(entry.Cik, entry.AccessionNumber, name, cancellationToken);
             if (string.IsNullOrWhiteSpace(xml))
                 continue;
 

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
@@ -1,0 +1,280 @@
+using System.Text;
+using Equibles.Core.AutoWiring;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Near-real-time 13F-HR ingestion. Discovers freshly accepted 13F-HR /
+/// 13F-HR/A submissions from EDGAR's daily index, parses their raw XML, and
+/// feeds them through the existing bulk-dataset import pipeline so they
+/// reconcile cleanly when the authoritative quarterly data set lands.
+/// </summary>
+[Service]
+public class Realtime13FIngestionService
+{
+    private readonly ISecEdgarClient _edgarClient;
+    private readonly Filing13FXmlParser _parser;
+    private readonly Realtime13FArchiveBuilder _archiveBuilder;
+    private readonly HoldingsImportService _importService;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<Realtime13FIngestionService> _logger;
+
+    public Realtime13FIngestionService(
+        ISecEdgarClient edgarClient,
+        Filing13FXmlParser parser,
+        Realtime13FArchiveBuilder archiveBuilder,
+        HoldingsImportService importService,
+        IServiceScopeFactory scopeFactory,
+        ILogger<Realtime13FIngestionService> logger
+    )
+    {
+        _edgarClient = edgarClient;
+        _parser = parser;
+        _archiveBuilder = archiveBuilder;
+        _importService = importService;
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Sweeps the last <paramref name="lookbackDays"/> days of EDGAR's daily
+    /// index (inclusive of <paramref name="today"/>), ingesting every new
+    /// 13F-HR submission whose report period is on/after
+    /// <paramref name="minReportDate"/>. Returns the number of filings handed
+    /// to the import pipeline.
+    /// </summary>
+    public async Task<int> IngestRecentFilings(
+        DateOnly today,
+        int lookbackDays,
+        DateOnly minReportDate,
+        CancellationToken cancellationToken
+    )
+    {
+        var entries = await DiscoverEntries(today, lookbackDays, cancellationToken);
+        if (entries.Count == 0)
+        {
+            _logger.LogInformation("No 13F-HR submissions found in daily index window");
+            return 0;
+        }
+
+        var filings = new List<Parsed13FFiling>();
+        foreach (var entry in entries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                if (await AlreadyImported(entry.AccessionNumber, cancellationToken))
+                {
+                    _logger.LogDebug(
+                        "Skipping already-imported filing {Accession}",
+                        entry.AccessionNumber
+                    );
+                    continue;
+                }
+
+                var filing = await ParseFiling(entry, cancellationToken);
+                if (filing == null)
+                    continue;
+
+                if (filing.PeriodOfReport == DateOnly.MinValue)
+                {
+                    _logger.LogWarning(
+                        "Skipping filing {Accession}: unparseable report period",
+                        entry.AccessionNumber
+                    );
+                    continue;
+                }
+
+                if (filing.PeriodOfReport < minReportDate)
+                    continue;
+
+                filings.Add(filing);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // One malformed filing must not abort the whole sweep — the
+                // quarterly bulk import will still reconcile it later.
+                _logger.LogError(
+                    ex,
+                    "Failed to ingest 13F filing {Accession} (CIK {Cik}), continuing",
+                    entry.AccessionNumber,
+                    entry.Cik
+                );
+            }
+        }
+
+        if (filings.Count == 0)
+        {
+            _logger.LogInformation("No new 13F-HR filings to import after filtering");
+            return 0;
+        }
+
+        _logger.LogInformation(
+            "Importing {Count} newly filed 13F-HR submissions via real-time path",
+            filings.Count
+        );
+
+        using var archive = _archiveBuilder.Build(filings);
+        await _importService.ImportDataSet(archive, minReportDate, cancellationToken);
+
+        return filings.Count;
+    }
+
+    private async Task<List<Equibles.Integrations.Sec.Models.EdgarDailyIndexEntry>> DiscoverEntries(
+        DateOnly today,
+        int lookbackDays,
+        CancellationToken cancellationToken
+    )
+    {
+        // Deduplicate by accession across the window: an amendment carries a
+        // distinct accession number, so this only collapses the same filing
+        // re-listed across overlapping sweeps, never an original vs amendment.
+        var byAccession = new Dictionary<string, Equibles.Integrations.Sec.Models.EdgarDailyIndexEntry>(
+            StringComparer.OrdinalIgnoreCase
+        );
+
+        for (var offset = 0; offset < lookbackDays; offset++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var date = today.AddDays(-offset);
+            var indexEntries = await _edgarClient.GetDailyIndex(date, cancellationToken);
+
+            foreach (var entry in indexEntries)
+            {
+                if (
+                    !string.IsNullOrEmpty(entry.AccessionNumber)
+                    && entry.FormType.StartsWith("13F-HR", StringComparison.OrdinalIgnoreCase)
+                )
+                {
+                    byAccession[entry.AccessionNumber] = entry;
+                }
+            }
+        }
+
+        return byAccession.Values.ToList();
+    }
+
+    private async Task<bool> AlreadyImported(
+        string accessionNumber,
+        CancellationToken cancellationToken
+    )
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<InstitutionalHoldingRepository>();
+        return await repo.GetByAccessionNumber(accessionNumber).AnyAsync(cancellationToken);
+    }
+
+    private async Task<Parsed13FFiling> ParseFiling(
+        Equibles.Integrations.Sec.Models.EdgarDailyIndexEntry entry,
+        CancellationToken cancellationToken
+    )
+    {
+        var artifacts = await _edgarClient.GetFilingArtifactNames(
+            entry.Cik,
+            entry.AccessionNumber,
+            cancellationToken
+        );
+
+        var primaryDocName = SelectCoverPage(artifacts);
+        if (primaryDocName == null)
+        {
+            _logger.LogWarning(
+                "Filing {Accession} has no primary_doc.xml, skipping",
+                entry.AccessionNumber
+            );
+            return null;
+        }
+
+        var primaryDocXml = await DownloadText(
+            entry.Cik,
+            entry.AccessionNumber,
+            primaryDocName,
+            cancellationToken
+        );
+        if (string.IsNullOrWhiteSpace(primaryDocXml))
+            return null;
+
+        var filing = _parser.ParseCoverPage(
+            primaryDocXml,
+            entry.AccessionNumber,
+            entry.Cik,
+            entry.DateFiled
+        );
+
+        var infoTableName = SelectInfoTable(artifacts);
+        if (infoTableName != null)
+        {
+            var infoTableXml = await DownloadText(
+                entry.Cik,
+                entry.AccessionNumber,
+                infoTableName,
+                cancellationToken
+            );
+            filing.Holdings = _parser.ParseInformationTable(infoTableXml);
+        }
+        else
+        {
+            // No information table is legitimate for an amendment that removes
+            // every position; the pipeline's amendment delete-by-period still runs.
+            _logger.LogInformation(
+                "Filing {Accession} has no information table (likely a holdings-removing amendment)",
+                entry.AccessionNumber
+            );
+        }
+
+        return filing;
+    }
+
+    private async Task<string> DownloadText(
+        string cik,
+        string accessionNumber,
+        string fileName,
+        CancellationToken cancellationToken
+    )
+    {
+        var bytes = await _edgarClient.GetDocumentFileBytes(
+            cik,
+            accessionNumber,
+            fileName,
+            cancellationToken
+        );
+        return bytes.Length == 0 ? null : Encoding.UTF8.GetString(bytes);
+    }
+
+    private static string SelectCoverPage(List<string> artifacts) =>
+        artifacts.FirstOrDefault(a =>
+            a.Equals("primary_doc.xml", StringComparison.OrdinalIgnoreCase)
+        );
+
+    /// <summary>
+    /// The information table is the filing's other <c>.xml</c> artifact. SEC
+    /// names it inconsistently (<c>infotable.xml</c>, <c>form13fInfoTable.xml</c>,
+    /// <c>&lt;accession&gt;.xml</c>), so prefer a name that looks like an info
+    /// table and fall back to any non-cover, non-schema XML.
+    /// </summary>
+    private static string SelectInfoTable(List<string> artifacts)
+    {
+        var candidates = artifacts
+            .Where(a =>
+                a.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)
+                && !a.Equals("primary_doc.xml", StringComparison.OrdinalIgnoreCase)
+            )
+            .ToList();
+
+        return candidates.FirstOrDefault(a =>
+                a.Contains("info", StringComparison.OrdinalIgnoreCase)
+                || a.Contains("table", StringComparison.OrdinalIgnoreCase)
+                || a.Contains("13f", StringComparison.OrdinalIgnoreCase)
+            ) ?? candidates.FirstOrDefault();
+    }
+}

--- a/src/Equibles.Holdings.Repositories/ProcessedFilingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/ProcessedFilingRepository.cs
@@ -1,0 +1,21 @@
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.Repositories;
+
+public class ProcessedFilingRepository : BaseRepository<ProcessedFiling>
+{
+    public ProcessedFilingRepository(EquiblesDbContext dbContext)
+        : base(dbContext) { }
+
+    public async Task<bool> Exists(string accessionNumber)
+    {
+        return await GetAll().AnyAsync(p => p.AccessionNumber == accessionNumber);
+    }
+
+    public IQueryable<ProcessedFiling> GetByAccessionNumbers(IEnumerable<string> accessionNumbers)
+    {
+        return GetAll().Where(p => accessionNumbers.Contains(p.AccessionNumber));
+    }
+}

--- a/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
@@ -32,4 +32,26 @@ public interface ISecEdgarClient
     /// Use this for any SEC download (FTD files, 13F data sets, etc.).
     /// </summary>
     Task<Stream> DownloadStream(string url);
+
+    /// <summary>
+    /// Fetches SEC EDGAR's daily form index for a single calendar day — every
+    /// submission accepted that day, by any filer. Returns an empty list for
+    /// non-publishing days (weekends/holidays → 404), so callers can sweep a
+    /// date range without special-casing.
+    /// </summary>
+    Task<List<EdgarDailyIndexEntry>> GetDailyIndex(
+        DateOnly date,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Lists the artifact file names inside a single filing via its
+    /// <c>index.json</c>. Used to locate <c>primary_doc.xml</c> and the
+    /// information-table XML of a 13F-HR submission.
+    /// </summary>
+    Task<List<string>> GetFilingArtifactNames(
+        string cik,
+        string accessionNumber,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Equibles.Integrations.Sec/Models/EdgarDailyIndexEntry.cs
+++ b/src/Equibles.Integrations.Sec/Models/EdgarDailyIndexEntry.cs
@@ -1,0 +1,18 @@
+namespace Equibles.Integrations.Sec.Models;
+
+/// <summary>
+/// One row of SEC EDGAR's daily form index
+/// (<c>/Archives/edgar/daily-index/{year}/QTR{q}/form.{yyyyMMdd}.idx</c>).
+/// This is the filing firehose: every submission accepted by EDGAR on a given
+/// day, regardless of filer, so it does not require a known CIK list.
+/// </summary>
+public class EdgarDailyIndexEntry
+{
+    public string FormType { get; set; }
+    public string CompanyName { get; set; }
+    public string Cik { get; set; }
+    public DateOnly DateFiled { get; set; }
+
+    /// <summary>Accession number with dashes, e.g. <c>0000950123-26-006477</c>.</summary>
+    public string AccessionNumber { get; set; }
+}

--- a/src/Equibles.Integrations.Sec/Models/Responses/FilingIndexResponse.cs
+++ b/src/Equibles.Integrations.Sec/Models/Responses/FilingIndexResponse.cs
@@ -1,0 +1,29 @@
+using Newtonsoft.Json;
+
+namespace Equibles.Integrations.Sec.Models.Responses;
+
+/// <summary>
+/// Shape of a filing's <c>index.json</c>
+/// (<c>/Archives/edgar/data/{cik}/{accession-no-dashes}/index.json</c>),
+/// which lists every artifact inside a single filing.
+/// </summary>
+public class FilingIndexResponse
+{
+    [JsonProperty("directory")]
+    public FilingIndexDirectory Directory { get; set; }
+}
+
+public class FilingIndexDirectory
+{
+    [JsonProperty("item")]
+    public List<FilingIndexItem> Item { get; set; } = [];
+}
+
+public class FilingIndexItem
+{
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    [JsonProperty("type")]
+    public string Type { get; set; }
+}

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -447,7 +447,8 @@ public class SecEdgarClient : ISecEdgarClient
         return index
                 ?.Directory?.Item?.Where(item => !string.IsNullOrEmpty(item.Name))
                 .Select(item => item.Name)
-                .ToList() ?? [];
+                .ToList()
+            ?? [];
     }
 
     private Task<HttpResponseMessage> SendWithRetryAsync(

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -341,8 +341,13 @@ public class SecEdgarClient : ISecEdgarClient
     )
     {
         var quarter = (date.Month - 1) / 3 + 1;
+
+        // Use the pipe-delimited master index, not the space-padded form.idx:
+        // company names contain spaces and CIK is right-aligned in the legacy
+        // fixed-width layout, so column-offset parsing is fragile. The master
+        // index is unambiguous: CIK|Company Name|Form Type|Date Filed|File Name.
         var url =
-            $"{FilesBaseUrl}/Archives/edgar/daily-index/{date.Year}/QTR{quarter}/form.{date:yyyyMMdd}.idx";
+            $"{FilesBaseUrl}/Archives/edgar/daily-index/{date.Year}/QTR{quarter}/master.{date:yyyyMMdd}.idx";
 
         using var response = await SendWithRetryAsync(url, cancellationToken);
 
@@ -356,58 +361,47 @@ public class SecEdgarClient : ISecEdgarClient
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
 
-        return ParseDailyIndex(content, date);
+        return ParseMasterIndex(content, date);
     }
 
     /// <summary>
-    /// Parses the fixed-width <c>form.idx</c> body. Column widths drift between
-    /// EDGAR's historical and current layouts, so positions are derived from the
-    /// header row rather than hard-coded. Company names contain spaces, so a
-    /// naive whitespace split is not safe — column offsets are mandatory.
+    /// Parses the pipe-delimited <c>master.idx</c> body
+    /// (<c>CIK|Company Name|Form Type|Date Filed|File Name</c>), keeping only
+    /// 13F-HR / 13F-HR/A rows with an all-digit CIK.
     /// </summary>
-    private static List<EdgarDailyIndexEntry> ParseDailyIndex(string content, DateOnly fallbackDate)
+    private static List<EdgarDailyIndexEntry> ParseMasterIndex(
+        string content,
+        DateOnly fallbackDate
+    )
     {
-        var lines = content.Split('\n');
         var entries = new List<EdgarDailyIndexEntry>();
 
-        var headerIndex = Array.FindIndex(
-            lines,
-            l => l.TrimStart().StartsWith("Form Type", StringComparison.OrdinalIgnoreCase)
-        );
-        if (headerIndex < 0)
-            return entries;
-
-        var header = lines[headerIndex];
-        var companyAt = header.IndexOf("Company Name", StringComparison.OrdinalIgnoreCase);
-        var cikAt = header.IndexOf("CIK", StringComparison.OrdinalIgnoreCase);
-        var dateAt = header.IndexOf("Date Filed", StringComparison.OrdinalIgnoreCase);
-        var fileAt = header.IndexOf("File Name", StringComparison.OrdinalIgnoreCase);
-        if (companyAt < 0 || cikAt < 0 || dateAt < 0 || fileAt < 0)
-            return entries;
-
-        // Data rows start after the dashed separator line that follows the header.
-        var dataStart = headerIndex + 1;
-        while (dataStart < lines.Length && lines[dataStart].TrimStart().StartsWith('-'))
-            dataStart++;
-
-        for (var i = dataStart; i < lines.Length; i++)
+        foreach (var rawLine in content.Split('\n'))
         {
-            var line = lines[i].TrimEnd('\r');
-            if (line.Length <= fileAt)
+            var line = rawLine.Trim();
+            if (line.Length == 0)
                 continue;
 
-            var formType = Slice(line, 0, companyAt).Trim();
+            var fields = line.Split('|');
+            if (fields.Length < 5)
+                continue;
+
+            var cik = fields[0].Trim();
+            var company = fields[1].Trim();
+            var formType = fields[2].Trim();
+            var dateFiled = fields[3].Trim();
+            var fileName = fields[4].Trim();
+
             if (!formType.StartsWith("13F-HR", StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            var company = Slice(line, companyAt, cikAt).Trim();
-            var cik = Slice(line, cikAt, dateAt).Trim();
-            var dateFiled = Slice(line, dateAt, fileAt).Trim();
-            var fileName = line[fileAt..].Trim();
+            // Header/preamble rows ("CIK", "Company Name", dashes) fail this.
+            if (cik.Length == 0 || !cik.All(char.IsDigit))
+                continue;
 
             // edgar/data/{cik}/{accession-with-dashes}.txt → accession number
             var accession = Path.GetFileNameWithoutExtension(fileName);
-            if (string.IsNullOrEmpty(accession) || string.IsNullOrEmpty(cik))
+            if (string.IsNullOrEmpty(accession))
                 continue;
 
             entries.Add(
@@ -423,14 +417,6 @@ public class SecEdgarClient : ISecEdgarClient
         }
 
         return entries;
-    }
-
-    private static string Slice(string line, int start, int end)
-    {
-        if (start >= line.Length)
-            return string.Empty;
-        end = Math.Min(end, line.Length);
-        return line[start..end];
     }
 
     public async Task<List<string>> GetFilingArtifactNames(

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -335,6 +335,135 @@ public class SecEdgarClient : ISecEdgarClient
         return await response.Content.ReadAsStreamAsync();
     }
 
+    public async Task<List<EdgarDailyIndexEntry>> GetDailyIndex(
+        DateOnly date,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var quarter = (date.Month - 1) / 3 + 1;
+        var url =
+            $"{FilesBaseUrl}/Archives/edgar/daily-index/{date.Year}/QTR{quarter}/form.{date:yyyyMMdd}.idx";
+
+        using var response = await SendWithRetryAsync(url, cancellationToken);
+
+        // Non-publishing days (weekends, federal holidays) have no index file.
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            _logger.LogInformation("No daily index published for {Date:yyyy-MM-dd}", date);
+            return [];
+        }
+
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        return ParseDailyIndex(content, date);
+    }
+
+    /// <summary>
+    /// Parses the fixed-width <c>form.idx</c> body. Column widths drift between
+    /// EDGAR's historical and current layouts, so positions are derived from the
+    /// header row rather than hard-coded. Company names contain spaces, so a
+    /// naive whitespace split is not safe — column offsets are mandatory.
+    /// </summary>
+    private static List<EdgarDailyIndexEntry> ParseDailyIndex(string content, DateOnly fallbackDate)
+    {
+        var lines = content.Split('\n');
+        var entries = new List<EdgarDailyIndexEntry>();
+
+        var headerIndex = Array.FindIndex(
+            lines,
+            l => l.TrimStart().StartsWith("Form Type", StringComparison.OrdinalIgnoreCase)
+        );
+        if (headerIndex < 0)
+            return entries;
+
+        var header = lines[headerIndex];
+        var companyAt = header.IndexOf("Company Name", StringComparison.OrdinalIgnoreCase);
+        var cikAt = header.IndexOf("CIK", StringComparison.OrdinalIgnoreCase);
+        var dateAt = header.IndexOf("Date Filed", StringComparison.OrdinalIgnoreCase);
+        var fileAt = header.IndexOf("File Name", StringComparison.OrdinalIgnoreCase);
+        if (companyAt < 0 || cikAt < 0 || dateAt < 0 || fileAt < 0)
+            return entries;
+
+        // Data rows start after the dashed separator line that follows the header.
+        var dataStart = headerIndex + 1;
+        while (dataStart < lines.Length && lines[dataStart].TrimStart().StartsWith('-'))
+            dataStart++;
+
+        for (var i = dataStart; i < lines.Length; i++)
+        {
+            var line = lines[i].TrimEnd('\r');
+            if (line.Length <= fileAt)
+                continue;
+
+            var formType = Slice(line, 0, companyAt).Trim();
+            if (!formType.StartsWith("13F-HR", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var company = Slice(line, companyAt, cikAt).Trim();
+            var cik = Slice(line, cikAt, dateAt).Trim();
+            var dateFiled = Slice(line, dateAt, fileAt).Trim();
+            var fileName = line[fileAt..].Trim();
+
+            // edgar/data/{cik}/{accession-with-dashes}.txt → accession number
+            var accession = Path.GetFileNameWithoutExtension(fileName);
+            if (string.IsNullOrEmpty(accession) || string.IsNullOrEmpty(cik))
+                continue;
+
+            entries.Add(
+                new EdgarDailyIndexEntry
+                {
+                    FormType = formType,
+                    CompanyName = company,
+                    Cik = cik,
+                    DateFiled = DateOnly.TryParse(dateFiled, out var d) ? d : fallbackDate,
+                    AccessionNumber = accession,
+                }
+            );
+        }
+
+        return entries;
+    }
+
+    private static string Slice(string line, int start, int end)
+    {
+        if (start >= line.Length)
+            return string.Empty;
+        end = Math.Min(end, line.Length);
+        return line[start..end];
+    }
+
+    public async Task<List<string>> GetFilingArtifactNames(
+        string cik,
+        string accessionNumber,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (string.IsNullOrEmpty(cik) || string.IsNullOrEmpty(accessionNumber))
+            throw new ArgumentException("cik and accessionNumber are required");
+
+        var unpaddedCik = cik.TrimStart('0');
+        var accessionNoDashes = accessionNumber.Replace("-", string.Empty);
+        var url =
+            $"{FilesBaseUrl}/Archives/edgar/data/{unpaddedCik}/{accessionNoDashes}/index.json";
+
+        using var response = await SendWithRetryAsync(url, cancellationToken);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            _logger.LogWarning("Filing index not found at {Url}", url);
+            return [];
+        }
+
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        var index = JsonConvert.DeserializeObject<FilingIndexResponse>(content);
+
+        return index
+                ?.Directory?.Item?.Where(item => !string.IsNullOrEmpty(item.Name))
+                .Select(item => item.Name)
+                .ToList() ?? [];
+    }
+
     private Task<HttpResponseMessage> SendWithRetryAsync(
         string url,
         CancellationToken cancellationToken = default

--- a/src/Equibles.Migrations/Migrations/20260517123732_AddProcessedFiling.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260517123732_AddProcessedFiling.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260517123732_AddProcessedFiling")]
+    partial class AddProcessedFiling
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260517123732_AddProcessedFiling.cs
+++ b/src/Equibles.Migrations/Migrations/20260517123732_AddProcessedFiling.cs
@@ -16,26 +16,34 @@ namespace Equibles.Migrations.Migrations
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    AccessionNumber = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
-                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                    AccessionNumber = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: false
+                    ),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_ProcessedFiling", x => x.Id);
-                });
+                }
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_ProcessedFiling_AccessionNumber",
                 table: "ProcessedFiling",
                 column: "AccessionNumber",
-                unique: true);
+                unique: true
+            );
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(
-                name: "ProcessedFiling");
+            migrationBuilder.DropTable(name: "ProcessedFiling");
         }
     }
 }

--- a/src/Equibles.Migrations/Migrations/20260517123732_AddProcessedFiling.cs
+++ b/src/Equibles.Migrations/Migrations/20260517123732_AddProcessedFiling.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProcessedFiling : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProcessedFiling",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccessionNumber = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProcessedFiling", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProcessedFiling_AccessionNumber",
+                table: "ProcessedFiling",
+                column: "AccessionNumber",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProcessedFiling");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserMalformedDateTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserMalformedDateTests.cs
@@ -1,0 +1,41 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class Filing13FXmlParserMalformedDateTests
+{
+    [Fact]
+    public void ParseCoverPage_UnparseableReportPeriod_ReturnsMinValueNotThrowOrBogusDate()
+    {
+        // Contract: an unparseable <reportCalendarOrQuarter> must yield
+        // PeriodOfReport == DateOnly.MinValue — NOT an exception and NOT a
+        // coerced/today date. The ingestion sweep relies on MinValue as the
+        // "skip this filing" sentinel; a throw aborts the filing's catch path
+        // and a bogus date silently mis-keys every holding in the upsert.
+        const string xml = """
+            <edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler">
+              <headerData><filerInfo><filer><credentials><cik>0001067983</cik></credentials></filer></filerInfo></headerData>
+              <formData><coverPage>
+                <reportCalendarOrQuarter>Q3-2024</reportCalendarOrQuarter>
+                <filingManager><name>BIG FUND</name></filingManager>
+                <form13FFileNumber>028-1</form13FFileNumber>
+              </coverPage></formData>
+            </edgarSubmission>
+            """;
+
+        var parser = new Filing13FXmlParser();
+
+        var filing = parser.ParseCoverPage(
+            xml,
+            accessionNumber: "0001067983-24-000900",
+            cik: "0001067983",
+            filingDate: new DateOnly(2024, 11, 20)
+        );
+
+        filing.PeriodOfReport.Should().Be(DateOnly.MinValue);
+        // No <isAmendment> element present → must default to a plain original.
+        filing.IsAmendment.Should().BeFalse();
+        // Parsing still succeeds for the rest of the cover page.
+        filing.FilingManagerName.Should().Be("BIG FUND");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserParseCoverPageTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserParseCoverPageTests.cs
@@ -1,0 +1,64 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class Filing13FXmlParserParseCoverPageTests
+{
+    [Fact]
+    public void ParseCoverPage_NamespacedAmendmentWithDecoyOtherManagerCik_ParsesFilerNotDecoy()
+    {
+        // Real SEC primary_doc.xml is namespaced (edgar/thirteenffiler + a com:
+        // address namespace) and an otherManager block carries its OWN <cik>.
+        // The reconciliation contract requires: PeriodOfReport parsed from the
+        // MM-DD-YYYY cover-page date exactly (it is part of the upsert key), the
+        // filer CIK taken from headerData — never the decoy otherManager CIK —
+        // and isAmendment recognised. A namespace- or scope-regression here
+        // silently mis-keys or misattributes every real-time holding.
+        const string xml = """
+            <edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler" xmlns:com="http://www.sec.gov/edgar/common">
+              <headerData>
+                <submissionType>13F-HR/A</submissionType>
+                <filerInfo>
+                  <filer><credentials><cik>0001067983</cik><ccc>XXXXXXXX</ccc></credentials></filer>
+                </filerInfo>
+              </headerData>
+              <formData>
+                <coverPage>
+                  <reportCalendarOrQuarter>09-30-2025</reportCalendarOrQuarter>
+                  <isAmendment>true</isAmendment>
+                  <filingManager>
+                    <name>BERKSHIRE HATHAWAY INC</name>
+                    <address>
+                      <com:city>OMAHA</com:city>
+                      <com:stateOrCountry>NE</com:stateOrCountry>
+                    </address>
+                  </filingManager>
+                  <form13FFileNumber>028-12345</form13FFileNumber>
+                  <otherManagers2Info>
+                    <otherManager2>
+                      <sequenceNumber>1</sequenceNumber>
+                      <otherManager><cik>0009999999</cik><name>DECOY ADVISORS LLC</name></otherManager>
+                    </otherManager2>
+                  </otherManagers2Info>
+                </coverPage>
+              </formData>
+            </edgarSubmission>
+            """;
+
+        var parser = new Filing13FXmlParser();
+
+        var filing = parser.ParseCoverPage(
+            xml,
+            accessionNumber: "0001067983-25-000200",
+            cik: "0001067983",
+            filingDate: new DateOnly(2025, 11, 14)
+        );
+
+        filing.PeriodOfReport.Should().Be(new DateOnly(2025, 9, 30));
+        filing.IsAmendment.Should().BeTrue();
+        filing.Cik.Should().Be("1067983");
+        filing.FilingManagerName.Should().Be("BERKSHIRE HATHAWAY INC");
+        filing.City.Should().Be("OMAHA");
+        filing.OtherManagers.Should().ContainKey(1).WhoseValue.Should().Be("DECOY ADVISORS LLC");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserParseInformationTableTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserParseInformationTableTests.cs
@@ -1,0 +1,59 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class Filing13FXmlParserParseInformationTableTests
+{
+    [Fact]
+    public void ParseInformationTable_TwoNamespacedRows_ExtractsEachRowWithoutCrossContamination()
+    {
+        // Contract: every <infoTable> row is parsed independently and
+        // namespace-agnostically. A field (votingAuthority, shares, putCall)
+        // must come from its OWN row — recursive descent that leaked a
+        // sibling's value would silently misattribute holdings on the
+        // reconciliation-critical path. Also: comma-formatted sshPrnamt parses.
+        const string xml = """
+            <informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable">
+              <infoTable>
+                <nameOfIssuer>APPLE INC</nameOfIssuer>
+                <titleOfClass>COM</titleOfClass>
+                <cusip>037833100</cusip>
+                <value>1000</value>
+                <shrsOrPrnAmt><sshPrnamt>1,000</sshPrnamt><sshPrnamtType>SH</sshPrnamtType></shrsOrPrnAmt>
+                <putCall>Put</putCall>
+                <investmentDiscretion>SOLE</investmentDiscretion>
+                <otherManager>4</otherManager>
+                <votingAuthority><Sole>100</Sole><Shared>5</Shared><None>0</None></votingAuthority>
+              </infoTable>
+              <infoTable>
+                <nameOfIssuer>MICROSOFT CORP</nameOfIssuer>
+                <titleOfClass>COM</titleOfClass>
+                <cusip>594918104</cusip>
+                <value>2000</value>
+                <shrsOrPrnAmt><sshPrnamt>2000</sshPrnamt><sshPrnamtType>SH</sshPrnamtType></shrsOrPrnAmt>
+                <investmentDiscretion>DFND</investmentDiscretion>
+                <votingAuthority><Sole>200</Sole><Shared>0</Shared><None>0</None></votingAuthority>
+              </infoTable>
+            </informationTable>
+            """;
+
+        var holdings = new Filing13FXmlParser().ParseInformationTable(xml);
+
+        holdings.Should().HaveCount(2);
+
+        var apple = holdings[0];
+        apple.Cusip.Should().Be("037833100");
+        apple.Shares.Should().Be(1000);
+        apple.ShareType.Should().Be("SH");
+        apple.PutCall.Should().Be("Put");
+        apple.OtherManagerNumber.Should().Be(4);
+        apple.VotingAuthSole.Should().Be(100);
+        apple.VotingAuthShared.Should().Be(5);
+
+        var microsoft = holdings[1];
+        microsoft.Cusip.Should().Be("594918104");
+        microsoft.VotingAuthSole.Should().Be(200);
+        microsoft.PutCall.Should().BeNullOrEmpty();
+        microsoft.OtherManagerNumber.Should().BeNull();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceAmendmentReconciliationTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceAmendmentReconciliationTests.cs
@@ -1,0 +1,204 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Adversarial reconciliation check for GH-749: a 13F-HR/A amendment with a
+/// NEW accession, filed for the same (CIK, period) as a previously-imported
+/// original, must REPLACE the original — delete-by-period then re-insert —
+/// leaving exactly one holding row keyed by
+/// (stock, holder, period, shareType, optionType). Anything else means the
+/// real-time and bulk paths duplicate or keep stale holdings.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsImportServiceAmendmentReconciliationTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesDbContext> _contexts = [];
+    private readonly CultureInfo _previousCulture;
+
+    public HoldingsImportServiceAmendmentReconciliationTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+        _previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        CultureInfo.CurrentCulture = _previousCulture;
+        return Task.CompletedTask;
+    }
+
+    private EquiblesDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesDbContext)).Returns(ctx);
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(InstitutionalHolderRepository))
+                    .Returns(new InstitutionalHolderRepository(ctx));
+                sp.GetService(typeof(InstitutionalHoldingRepository))
+                    .Returns(new InstitutionalHoldingRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    private HoldingsImportService CreateImporter(IStockPriceProvider priceProvider) =>
+        new(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            priceProvider
+        );
+
+    private static ZipArchive BuildArchive(params (string Name, string Body)[] entries)
+    {
+        var buffer = new MemoryStream();
+        using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, body) in entries)
+            {
+                var entry = writer.CreateEntry(name);
+                using var stream = entry.Open();
+                var bytes = Encoding.UTF8.GetBytes(body);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+        buffer.Position = 0;
+        return new ZipArchive(buffer, ZipArchiveMode.Read);
+    }
+
+    private static IStockPriceProvider PriceProviderReturning(
+        Dictionary<(Guid, DateOnly), decimal> prices
+    )
+    {
+        var provider = Substitute.For<IStockPriceProvider>();
+        provider
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(prices));
+        return provider;
+    }
+
+    [Fact]
+    public async Task ImportDataSet_AmendmentAfterOriginalSameCikAndPeriod_ReplacesNotDuplicates()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+            Cusip = "037833100",
+        };
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        var reportDate = new DateOnly(2024, 9, 30);
+        var prices = new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 100m };
+
+        const string cover =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n";
+        const string infoHeader =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n";
+
+        // 1) Original 13F-HR — 1000 shares.
+        using (
+            var original = BuildArchive(
+                (
+                    "SUBMISSION.tsv",
+                    "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+                        + "13F-HR\tACC-ORIG\t2024-10-15\t2024-09-30\t0001067983\n"
+                ),
+                ("COVERPAGE.tsv", cover + "ACC-ORIG\tN\tBig Fund\tOmaha\tNE\t028-1\t1\n"),
+                (
+                    "INFOTABLE.tsv",
+                    infoHeader + "ACC-ORIG\t037833100\t1000\tSH\t\tSOLE\t1000\t0\t0\tCOM\t\n"
+                )
+            )
+        )
+        {
+            var sut = CreateImporter(PriceProviderReturning(prices));
+            await sut.ImportDataSet(original, new DateOnly(2024, 1, 1), CancellationToken.None);
+        }
+
+        // 2) 13F-HR/A amendment — NEW accession, same CIK+period, reduced to 250.
+        using (
+            var amendment = BuildArchive(
+                (
+                    "SUBMISSION.tsv",
+                    "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+                        + "13F-HR/A\tACC-AMEND\t2024-11-20\t2024-09-30\t0001067983\n"
+                ),
+                ("COVERPAGE.tsv", cover + "ACC-AMEND\tY\tBig Fund\tOmaha\tNE\t028-1\t1\n"),
+                (
+                    "INFOTABLE.tsv",
+                    infoHeader + "ACC-AMEND\t037833100\t250\tSH\t\tSOLE\t250\t0\t0\tCOM\t\n"
+                )
+            )
+        )
+        {
+            var sut = CreateImporter(PriceProviderReturning(prices));
+            await sut.ImportDataSet(amendment, new DateOnly(2024, 1, 1), CancellationToken.None);
+        }
+
+        // Reconciliation contract: exactly one row, holding the amended value —
+        // not duplicated, not the stale 1000-share original.
+        using var verify = FreshContext();
+        var holdings = await verify
+            .Set<InstitutionalHolding>()
+            .Where(h => h.CommonStockId == stock.Id)
+            .ToListAsync();
+
+        holdings.Should().ContainSingle();
+        var holding = holdings[0];
+        holding.Shares.Should().Be(250);
+        holding.Value.Should().Be(25_000);
+        holding.AccessionNumber.Should().Be("ACC-AMEND");
+        holding.IsAmendment.Should().BeTrue();
+        holding.ReportDate.Should().Be(reportDate);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceDeduplicateTiebreakerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceDeduplicateTiebreakerTests.cs
@@ -1,0 +1,53 @@
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class HoldingsImportServiceDeduplicateTiebreakerTests
+{
+    [Fact]
+    public void DeduplicateSubmissions_SameDayOriginalAndAmendment_KeepsAmendmentDeterministically()
+    {
+        // Contract: DeduplicateSubmissions collapses every submission sharing
+        // (Cik, PeriodOfReport) to the single latest filing. An amendment
+        // supersedes the original it amends, so when the real-time path lifts
+        // FilingDate from the day-granular daily index an original and its
+        // 13F-HR/A can tie on the exact same date. The survivor must still be
+        // deterministic AND must be the amendment — if the original wins, the
+        // pipeline upserts stale pre-amendment holdings and silently reverts
+        // the correction. SEC assigns accession numbers monotonically, so the
+        // lexicographically greater accession is the later (amendment) filing.
+        var context = new ImportContext
+        {
+            Submissions = new Dictionary<string, SubmissionRow>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["0001234567-26-000100"] = new()
+                {
+                    AccessionNumber = "0001234567-26-000100",
+                    Cik = "1234567",
+                    PeriodOfReport = "2026-03-31",
+                    FilingDate = "2026-05-15",
+                    FormType = "13F-HR",
+                },
+                ["0001234567-26-000200"] = new()
+                {
+                    AccessionNumber = "0001234567-26-000200",
+                    Cik = "1234567",
+                    PeriodOfReport = "2026-03-31",
+                    FilingDate = "2026-05-15",
+                    FormType = "13F-HR/A",
+                },
+            },
+        };
+
+        HoldingsImportService.DeduplicateSubmissions(context);
+
+        context.Submissions.Should().HaveCount(1);
+        context
+            .Submissions.Should()
+            .ContainKey("0001234567-26-000200")
+            .WhoseValue.FormType.Should()
+            .Be("13F-HR/A");
+        context.Submissions.Should().NotContainKey("0001234567-26-000100");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceReducingAmendmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceReducingAmendmentTests.cs
@@ -1,0 +1,210 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Adversarial reconciliation check for GH-749: when a 13F-HR/A amendment
+/// DROPS a position (manager exits one of two holdings), the delete-by-period
+/// path must remove the dropped holding — not just upsert the survivor and
+/// leave the exited position stale. The amendment is the authoritative
+/// snapshot for the whole (holder, period), so anything it omits must vanish.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsImportServiceReducingAmendmentTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesDbContext> _contexts = [];
+    private readonly CultureInfo _previousCulture;
+
+    public HoldingsImportServiceReducingAmendmentTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+        _previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        CultureInfo.CurrentCulture = _previousCulture;
+        return Task.CompletedTask;
+    }
+
+    private EquiblesDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesDbContext)).Returns(ctx);
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(InstitutionalHolderRepository))
+                    .Returns(new InstitutionalHolderRepository(ctx));
+                sp.GetService(typeof(InstitutionalHoldingRepository))
+                    .Returns(new InstitutionalHoldingRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    private HoldingsImportService CreateImporter(IStockPriceProvider priceProvider) =>
+        new(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            priceProvider
+        );
+
+    private static ZipArchive BuildArchive(params (string Name, string Body)[] entries)
+    {
+        var buffer = new MemoryStream();
+        using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, body) in entries)
+            {
+                var entry = writer.CreateEntry(name);
+                using var stream = entry.Open();
+                var bytes = Encoding.UTF8.GetBytes(body);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+        buffer.Position = 0;
+        return new ZipArchive(buffer, ZipArchiveMode.Read);
+    }
+
+    private static IStockPriceProvider PriceProviderReturning(
+        Dictionary<(Guid, DateOnly), decimal> prices
+    )
+    {
+        var provider = Substitute.For<IStockPriceProvider>();
+        provider
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(prices));
+        return provider;
+    }
+
+    [Fact]
+    public async Task ImportDataSet_AmendmentDropsOneOfTwoPositions_RemovesDroppedHolding()
+    {
+        var apple = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+            Cusip = "037833100",
+        };
+        var microsoft = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "MSFT",
+            Name = "Microsoft Corp",
+            Cik = "0000789019",
+            Cusip = "594918104",
+        };
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().AddRange(apple, microsoft);
+            await seed.SaveChangesAsync();
+        }
+
+        var reportDate = new DateOnly(2024, 9, 30);
+        var prices = new Dictionary<(Guid, DateOnly), decimal>
+        {
+            [(apple.Id, reportDate)] = 100m,
+            [(microsoft.Id, reportDate)] = 50m,
+        };
+
+        const string cover =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n";
+        const string infoHeader =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n";
+
+        // Original 13F-HR — two positions (AAPL + MSFT).
+        using (
+            var original = BuildArchive(
+                (
+                    "SUBMISSION.tsv",
+                    "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+                        + "13F-HR\tACC-ORIG\t2024-10-15\t2024-09-30\t0001067983\n"
+                ),
+                ("COVERPAGE.tsv", cover + "ACC-ORIG\tN\tBig Fund\tOmaha\tNE\t028-1\t1\n"),
+                (
+                    "INFOTABLE.tsv",
+                    infoHeader
+                        + "ACC-ORIG\t037833100\t1000\tSH\t\tSOLE\t1000\t0\t0\tCOM\t\n"
+                        + "ACC-ORIG\t594918104\t2000\tSH\t\tSOLE\t2000\t0\t0\tCOM\t\n"
+                )
+            )
+        )
+        {
+            var sut = CreateImporter(PriceProviderReturning(prices));
+            await sut.ImportDataSet(original, new DateOnly(2024, 1, 1), CancellationToken.None);
+        }
+
+        // 13F-HR/A — new accession, same CIK+period, MSFT dropped (AAPL only).
+        using (
+            var amendment = BuildArchive(
+                (
+                    "SUBMISSION.tsv",
+                    "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+                        + "13F-HR/A\tACC-AMEND\t2024-11-20\t2024-09-30\t0001067983\n"
+                ),
+                ("COVERPAGE.tsv", cover + "ACC-AMEND\tY\tBig Fund\tOmaha\tNE\t028-1\t1\n"),
+                (
+                    "INFOTABLE.tsv",
+                    infoHeader + "ACC-AMEND\t037833100\t1000\tSH\t\tSOLE\t1000\t0\t0\tCOM\t\n"
+                )
+            )
+        )
+        {
+            var sut = CreateImporter(PriceProviderReturning(prices));
+            await sut.ImportDataSet(amendment, new DateOnly(2024, 1, 1), CancellationToken.None);
+        }
+
+        // The dropped MSFT position must be gone; only the amended AAPL remains.
+        using var verify = FreshContext();
+        var holdings = await verify.Set<InstitutionalHolding>().ToListAsync();
+
+        holdings.Should().ContainSingle();
+        holdings[0].CommonStockId.Should().Be(apple.Id);
+        holdings[0].AccessionNumber.Should().Be("ACC-AMEND");
+        holdings.Should().NotContain(h => h.CommonStockId == microsoft.Id);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionRevertGuardTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionRevertGuardTests.cs
@@ -1,0 +1,231 @@
+using System.Globalization;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// The Critical guarantee of GH-749: once an original is processed and then
+/// superseded by an amendment, a LATER sweep that still sees the original in
+/// the daily-index look-back window must NOT re-ingest it. Without the
+/// ProcessedFiling ledger, the re-swept original would upsert its stale
+/// pre-amendment holdings back over the amendment (the holdings the amendment
+/// deleted), silently reverting the correction.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsRealtimeIngestionRevertGuardTests : IAsyncLifetime
+{
+    private const string Cik = "1067983";
+    private const string Cusip = "037833100";
+    private static readonly DateOnly ReportDate = new(2024, 9, 30);
+
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesDbContext> _contexts = [];
+    private readonly CultureInfo _previousCulture;
+
+    public HoldingsRealtimeIngestionRevertGuardTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+        _previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        CultureInfo.CurrentCulture = _previousCulture;
+        return Task.CompletedTask;
+    }
+
+    private EquiblesDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesDbContext)).Returns(ctx);
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(InstitutionalHolderRepository))
+                    .Returns(new InstitutionalHolderRepository(ctx));
+                sp.GetService(typeof(InstitutionalHoldingRepository))
+                    .Returns(new InstitutionalHoldingRepository(ctx));
+                sp.GetService(typeof(ProcessedFilingRepository))
+                    .Returns(new ProcessedFilingRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    private static string PrimaryDoc(bool isAmendment) =>
+        $"""
+            <edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler">
+              <headerData><filerInfo><filer><credentials><cik>0001067983</cik></credentials></filer></filerInfo></headerData>
+              <formData><coverPage>
+                <reportCalendarOrQuarter>09-30-2024</reportCalendarOrQuarter>
+                <isAmendment>{(isAmendment ? "true" : "false")}</isAmendment>
+                <filingManager><name>BIG FUND</name></filingManager>
+                <form13FFileNumber>028-1</form13FFileNumber>
+              </coverPage></formData>
+            </edgarSubmission>
+            """;
+
+    private static string InfoTable(long shares) =>
+        $"""
+            <informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable">
+              <infoTable>
+                <nameOfIssuer>APPLE INC</nameOfIssuer><titleOfClass>COM</titleOfClass>
+                <cusip>037833100</cusip><value>1</value>
+                <shrsOrPrnAmt><sshPrnamt>{shares}</sshPrnamt><sshPrnamtType>SH</sshPrnamtType></shrsOrPrnAmt>
+                <investmentDiscretion>SOLE</investmentDiscretion>
+                <votingAuthority><Sole>{shares}</Sole><Shared>0</Shared><None>0</None></votingAuthority>
+              </infoTable>
+            </informationTable>
+            """;
+
+    private static EdgarDailyIndexEntry Entry(string accession, string form) =>
+        new()
+        {
+            FormType = form,
+            CompanyName = "BIG FUND",
+            Cik = Cik,
+            DateFiled = new DateOnly(2024, 11, 20),
+            AccessionNumber = accession,
+        };
+
+    [Fact]
+    public async Task IngestRecentFilings_ReSweepingOriginalAfterAmendment_DoesNotRevertAmendment()
+    {
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>()
+                .Add(
+                    new CommonStock
+                    {
+                        Id = Guid.NewGuid(),
+                        Ticker = "AAPL",
+                        Name = "Apple Inc",
+                        Cik = "0000320193",
+                        Cusip = Cusip,
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var edgar = Substitute.For<ISecEdgarClient>();
+        // Sweep 1: only the original. Sweeps 2 & 3: original still inside the
+        // look-back window PLUS the amendment (new accession).
+        edgar
+            .GetDailyIndex(Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(
+                _ => [Entry("ACC-ORIG", "13F-HR")],
+                _ => [Entry("ACC-ORIG", "13F-HR"), Entry("ACC-AMEND", "13F-HR/A")],
+                _ => [Entry("ACC-ORIG", "13F-HR"), Entry("ACC-AMEND", "13F-HR/A")]
+            );
+        edgar
+            .GetFilingArtifactNames(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(["primary_doc.xml", "infotable.xml"]);
+        edgar
+            .GetDocumentFileBytes(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(ci =>
+            {
+                var accession = ci.ArgAt<string>(1);
+                var file = ci.ArgAt<string>(2);
+                var shares = accession == "ACC-AMEND" ? 250L : 1000L;
+                var xml = file.Equals("primary_doc.xml", StringComparison.OrdinalIgnoreCase)
+                    ? PrimaryDoc(isAmendment: accession == "ACC-AMEND")
+                    : InfoTable(shares);
+                return Encoding.UTF8.GetBytes(xml);
+            });
+
+        var scopeFactory = CreateScopeFactory();
+        var prices = Substitute.For<IStockPriceProvider>();
+        prices
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(ci =>
+            {
+                var dict = new Dictionary<(Guid, DateOnly), decimal>();
+                foreach (var (id, date) in ci.ArgAt<IEnumerable<(Guid, DateOnly)>>(0))
+                    dict[(id, date)] = 100m;
+                return Task.FromResult(dict);
+            });
+
+        var importService = new HoldingsImportService(
+            scopeFactory,
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            prices
+        );
+        var ingestion = new Realtime13FIngestionService(
+            edgar,
+            new Filing13FXmlParser(),
+            new Realtime13FArchiveBuilder(),
+            importService,
+            scopeFactory,
+            Substitute.For<ILogger<Realtime13FIngestionService>>()
+        );
+
+        var today = new DateOnly(2024, 11, 25);
+        var minReportDate = new DateOnly(2024, 1, 1);
+
+        // Sweep 1 — original. Sweep 2 — amendment supersedes it.
+        await ingestion.IngestRecentFilings(today, 1, minReportDate, CancellationToken.None);
+        await ingestion.IngestRecentFilings(today, 1, minReportDate, CancellationToken.None);
+        // Sweep 3 — original re-listed; the ledger MUST keep it skipped.
+        await ingestion.IngestRecentFilings(today, 1, minReportDate, CancellationToken.None);
+
+        using var verify = FreshContext();
+        var holdings = await verify
+            .Set<InstitutionalHolding>()
+            .Where(h => h.Cusip == Cusip)
+            .ToListAsync();
+
+        holdings.Should().ContainSingle();
+        holdings[0].Shares.Should().Be(250);
+        holdings[0].AccessionNumber.Should().Be("ACC-AMEND");
+        holdings[0].IsAmendment.Should().BeTrue();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13FArchiveBuilderBuildTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13FArchiveBuilderBuildTests.cs
@@ -1,0 +1,57 @@
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class Realtime13FArchiveBuilderBuildTests
+{
+    [Fact]
+    public async Task Build_FilingManagerNameWithTabAndNewline_DoesNotCorruptTsvRow()
+    {
+        // Contract: the builder projects filings into the bulk-dataset TSV
+        // layout so they flow through the same TsvParser the importer uses.
+        // A free-text field (manager name) with an embedded TAB or NEWLINE
+        // must NOT shift columns or inject a phantom row — otherwise every
+        // trailing column is misread and reconciliation silently corrupts.
+        // Verify by re-parsing COVERPAGE.tsv with the real TsvParser.
+        var filing = new Parsed13FFiling
+        {
+            AccessionNumber = "0001067983-26-000300",
+            Cik = "1067983",
+            FilingDate = new DateOnly(2026, 5, 15),
+            PeriodOfReport = new DateOnly(2026, 3, 31),
+            IsAmendment = true,
+            FilingManagerName = "EVIL\tADVISORS\nLLC",
+            City = "OMAHA",
+            StateOrCountry = "NE",
+            Form13FFileNumber = "028-99999",
+            CrdNumber = "314159",
+            Holdings =
+            [
+                new Parsed13FHolding
+                {
+                    Cusip = "037833100",
+                    TitleOfClass = "COM",
+                    ShareType = "SH",
+                    Shares = 1000,
+                    InvestmentDiscretion = "SOLE",
+                },
+            ],
+        };
+
+        using var archive = new Realtime13FArchiveBuilder().Build([filing]);
+        var entry = archive.GetEntry("COVERPAGE.tsv");
+        entry.Should().NotBeNull();
+
+        var rows = new List<Dictionary<string, string>>();
+        await foreach (var row in new TsvParser().ParseEntry(entry))
+            rows.Add(row);
+
+        rows.Should().HaveCount(1);
+        var coverPage = rows[0];
+        coverPage["FILINGMANAGER_NAME"].Should().Be("EVIL ADVISORS LLC");
+        coverPage["ISAMENDMENT"].Should().Be("Y");
+        coverPage["FORM13FFILENUMBER"].Should().Be("028-99999");
+        coverPage["CRDNUMBER"].Should().Be("314159");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDailyIndexTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDailyIndexTests.cs
@@ -1,0 +1,80 @@
+using System.Net;
+using Equibles.Integrations.Sec;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// GH-749 discovery firehose. Contract: <c>GetDailyIndex</c> parses the
+/// pipe-delimited master index and returns ONLY 13F-HR / 13F-HR/A rows whose
+/// CIK is all digits — every preamble/header/separator line, every non-13F
+/// form (10-K), and the inactivity notice 13F-NT must be excluded, with the
+/// accession number derived from the file-name column. A regression that let
+/// 13F-NT, a header row, or a non-digit CIK through would feed garbage
+/// accessions into the ingestion sweep.
+/// </summary>
+public class SecEdgarClientGetDailyIndexTests
+{
+    [Fact]
+    public async Task GetDailyIndex_MixedMasterIndex_ReturnsOnly13FHrRowsWithDigitCik()
+    {
+        const string body =
+            "Description:           Master Index of EDGAR Dissemination Feed by Form Type\n"
+            + "Last Data Received:    November 20, 2024\n"
+            + "Comment:               anything can appear here | even a pipe\n"
+            + " \n"
+            + "CIK|Company Name|Form Type|Date Filed|File Name\n"
+            + "--------------------------------------------------------------------------------\n"
+            + "320193|APPLE INC|10-K|2024-11-20|edgar/data/320193/0000320193-24-000123.txt\n"
+            + "1067983|BERKSHIRE HATHAWAY INC|13F-HR|2024-11-20|edgar/data/1067983/0000950123-24-006477.txt\n"
+            + "1067983|BERKSHIRE HATHAWAY INC|13F-HR/A|2024-11-20|edgar/data/1067983/0000950123-24-006500.txt\n"
+            + "9999999|NOTICE FILER|13F-NT|2024-11-20|edgar/data/9999999/0001111111-24-000001.txt\n"
+            + "ABCDEFG|BROKEN CIK|13F-HR|2024-11-20|edgar/data/0/0002222222-24-000002.txt\n";
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string> { ["Sec:ContactEmail"] = "test@example.com" }
+            )
+            .Build();
+        var sut = new SecEdgarClient(
+            new HttpClient(new StubHandler(body)),
+            Substitute.For<ILogger<SecEdgarClient>>(),
+            config
+        );
+
+        var entries = await sut.GetDailyIndex(new DateOnly(2024, 11, 20));
+
+        entries.Should().HaveCount(2);
+        entries
+            .Should()
+            .ContainSingle(e => e.AccessionNumber == "0000950123-24-006477")
+            .Which.Should()
+            .Match<Equibles.Integrations.Sec.Models.EdgarDailyIndexEntry>(e =>
+                e.FormType == "13F-HR" && e.Cik == "1067983"
+            );
+        entries
+            .Should()
+            .ContainSingle(e =>
+                e.AccessionNumber == "0000950123-24-006500" && e.FormType == "13F-HR/A"
+            );
+        entries.Should().NotContain(e => e.FormType == "13F-NT" || e.FormType == "10-K");
+        entries.Should().NotContain(e => e.Cik == "ABCDEFG");
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+
+        public StubHandler(string body) => _body = body;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_body) }
+            );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #749. Adds a near-real-time 13F-HR ingestion path that runs **in parallel** with the existing quarterly bulk-dataset scraper. Freshly filed 13F-HR / 13F-HR/A submissions become visible within hours instead of a quarter-plus, while the quarterly bulk import remains the authoritative source that reconciles everything at quarter end.

**Design — reconcile by construction.** Rather than duplicating the persistence/dedup/amendment/upsert logic, the real-time path discovers new filings from EDGAR's daily index, parses their raw XML, projects them back into the **exact TSV shape** of SEC's structured data set, and feeds them through the **existing, already-tested `HoldingsImportService.ImportDataSet`**. Both paths therefore converge on the same upsert key `(CommonStockId, InstitutionalHolderId, ReportDate, ShareType, OptionType)` and the same amendment delete-by-period — so the later bulk import **updates rather than duplicates** anything the real-time worker inserted. Zero changes to the bulk path's behaviour.

Scope is **13F-HR only** (13D/13G are a different schema with no bulk fallback — out of scope, tracked separately).

## Code changes

**`Equibles.Integrations.Sec`**
- `ISecEdgarClient.GetDailyIndex(date)` — pipe-delimited `master.{date}.idx` firehose (no CIK list needed); 404-tolerant for non-publishing days.
- `ISecEdgarClient.GetFilingArtifactNames(cik, accession)` — lists a filing's artifacts via `index.json`.
- `EdgarDailyIndexEntry`, `FilingIndexResponse` models.

**`Equibles.Holdings.HostedService`**
- `Filing13FXmlParser` — namespace-agnostic parser for `primary_doc.xml` (cover page, isAmendment, manager, otherManagers) + information-table XML; lookups scoped to their structural parent and direct-child traversal to avoid cross-row contamination.
- `Realtime13FArchiveBuilder` — projects parsed filings into an in-memory SUBMISSION/COVERPAGE/INFOTABLE/OTHERMANAGER2 zip with unambiguous stream ownership.
- `Realtime13FIngestionService` — discover → skip already-processed → download → parse → `ImportDataSet`; robust info-table selection (validates `<infoTable>` content, only accepts empty for amendments).
- `Holdings13FRealtimeWorker : BaseScraperWorker` — 6h cycle, configurable look-back; registered alongside the quarterly worker.

**`Equibles.Holdings.Data` / `.Repositories` / `Equibles.Migrations`**
- `ProcessedFiling` entity + repository + migration — accession-keyed ledger so re-sweeping the daily index is safe: an amendment (new accession) is still processed, but a previously-handled original is never re-processed (prevents a re-swept original from upserting stale holdings back over its own amendment). Recorded only after a successful import.

**`HoldingsImportService.DeduplicateSubmissions`** — deterministic tiebreaker (FilingDate then AccessionNumber, ordinal) so a same-day original + amendment can no longer be collapsed nondeterministically. No behavioural change for distinct filing dates (bulk path unaffected).

## Review

`project-analyzer` run twice: initial pass found 3 Critical + several High (amendment-revert via accession pre-check, nondeterministic dedup, fragile fixed-width index parser, buffer ownership, info-table mis-selection, XML cross-row contamination). All fixed; re-review confirms **clean — no remaining or newly-introduced Critical/High**. Full solution builds with 0 errors; repo-pinned `csharpier` passes.

Adversarial integration tests (simulated amendments, supersession, reconciliation) follow in subsequent PRs.