### PR TITLE
test(holdings): pin ParseCoverPage unparseable-date sentinel (GH-749)

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserMalformedDateTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserMalformedDateTests.cs
@@ -1,0 +1,41 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class Filing13FXmlParserMalformedDateTests
+{
+    [Fact]
+    public void ParseCoverPage_UnparseableReportPeriod_ReturnsMinValueNotThrowOrBogusDate()
+    {
+        // Contract: an unparseable <reportCalendarOrQuarter> must yield
+        // PeriodOfReport == DateOnly.MinValue — NOT an exception and NOT a
+        // coerced/today date. The ingestion sweep relies on MinValue as the
+        // "skip this filing" sentinel; a throw aborts the filing's catch path
+        // and a bogus date silently mis-keys every holding in the upsert.
+        const string xml = """
+            <edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler">
+              <headerData><filerInfo><filer><credentials><cik>0001067983</cik></credentials></filer></filerInfo></headerData>
+              <formData><coverPage>
+                <reportCalendarOrQuarter>Q3-2024</reportCalendarOrQuarter>
+                <filingManager><name>BIG FUND</name></filingManager>
+                <form13FFileNumber>028-1</form13FFileNumber>
+              </coverPage></formData>
+            </edgarSubmission>
+            """;
+
+        var parser = new Filing13FXmlParser();
+
+        var filing = parser.ParseCoverPage(
+            xml,
+            accessionNumber: "0001067983-24-000900",
+            cik: "0001067983",
+            filingDate: new DateOnly(2024, 11, 20)
+        );
+
+        filing.PeriodOfReport.Should().Be(DateOnly.MinValue);
+        // No <isAmendment> element present → must default to a plain original.
+        filing.IsAmendment.Should().BeFalse();
+        // Parsing still succeeds for the rest of the cover page.
+        filing.FilingManagerName.Should().Be("BIG FUND");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial Lane A regression test for GH-749 (stacks on PR #754, base `feature/13f-realtime-ingestion`).
- A `primary_doc.xml` whose `<reportCalendarOrQuarter>` is non-date junk (`Q3-2024`) with no `<isAmendment>` element.
- Asserts `PeriodOfReport == DateOnly.MinValue` — the ingestion sweep's "skip this filing" sentinel — rather than a thrown exception (which would abort the per-filing catch path) or a coerced/today date (which would silently mis-key every holding in the upsert). Also: `IsAmendment` defaults false, and the rest of the cover page still parses.
- Test passes.

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserMalformedDateTests.cs` — one `[Fact]`, no production code touched.