### PR TITLE
test(cftc): add skipped repro for GH-764 — SplitCsvLine pre-quote whitespace

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineLeadingSpaceTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineLeadingSpaceTests.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+using Equibles.Integrations.Cftc;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CftcClientSplitCsvLineLeadingSpaceTests
+{
+    private static readonly MethodInfo SplitCsvLineMethod = typeof(CftcClient).GetMethod(
+        "SplitCsvLine",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    // Contract: "quoted content is taken verbatim" — a field's value is what is
+    // *inside* the quotes. A space between the delimiter and the opening quote
+    // (`, "b"`, ubiquitous in CFTC CSVs) is not part of the quoted content, so
+    // the parsed value must be "b", not " b".
+    [Fact(Skip = "GH-764 — SplitCsvLine leaks pre-quote whitespace into quoted value")]
+    public void SplitCsvLine_SpaceBeforeOpeningQuote_DoesNotLeakSpaceIntoQuotedValue()
+    {
+        var line = "a, \"b\"";
+
+        var fields = (string[])SplitCsvLineMethod.Invoke(null, [line]);
+
+        fields.Should().Equal("a", "b");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test (`/add-test`, Lane A) found a real bug: `CftcClient.SplitCsvLine` documents RFC-4180 "quoted content taken verbatim", but a character between the delimiter and the opening quote (`, "b"` — ubiquitous in CFTC CSV exports) is appended to the buffer and `wasQuoted` then suppresses the trim, so the value becomes `" b"` instead of `"b"`.
- Repro test committed `[Skip]` pending the fix; tracked in GH-764.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineLeadingSpaceTests.cs` — adds `SplitCsvLine_SpaceBeforeOpeningQuote_DoesNotLeakSpaceIntoQuotedValue`, skipped — see GH-764. Asserts `a, "b"` parses to `["a","b"]`; currently fails (`["a"," b"]`), so it ships skipped and should be un-skipped as part of the GH-764 fix.