### PR TITLE
fix(media): enforce AcceptedExtensions allowlist in FileManager.SaveFile (GH-766)

### DIFF
--- a/src/Equibles.Media.BusinessLogic/FileManager.cs
+++ b/src/Equibles.Media.BusinessLogic/FileManager.cs
@@ -58,6 +58,16 @@ public class FileManager : IFileManager
             throw new ArgumentException("The file extension cannot be null or empty.");
         }
 
+        // Enforce the curated allowlist (whitelist, case-insensitive). Without
+        // this, an unenforced allowlist gives false assurance — an .exe/.svg/
+        // .html payload would be persisted and later served.
+        if (!AcceptedExtensions.Contains(fileExtension, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                $"The file extension '.{fileExtension}' is not allowed. Accepted extensions: {AcceptedExtensionsString()}."
+            );
+        }
+
         // Get the content type from the file extension
         var contentType = MimeTypeMap.GetMimeType(fileExtension);
         if (string.IsNullOrEmpty(contentType))

--- a/tests/Equibles.IntegrationTests/Media/FileManagerSaveFileExtensionAllowlistTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/FileManagerSaveFileExtensionAllowlistTests.cs
@@ -20,7 +20,7 @@ public class FileManagerSaveFileExtensionAllowlistTests
     // — otherwise an executable/HTML/SVG payload is persisted and later served,
     // and the allowlist is decorative. SaveFile already throws ArgumentException
     // for a missing extension; a disallowed one must be rejected the same way.
-    [Fact(Skip = "GH-766 — FileManager.SaveFile does not enforce AcceptedExtensions")]
+    [Fact]
     public async Task SaveFile_ExtensionNotInAcceptedAllowlist_IsRejected()
     {
         var act = async () => await _sut.SaveFile([0x4d, 0x5a], "malware.exe");

--- a/tests/Equibles.IntegrationTests/Media/FileManagerSaveFileExtensionAllowlistTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/FileManagerSaveFileExtensionAllowlistTests.cs
@@ -1,0 +1,30 @@
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.Data;
+using Equibles.Media.Repositories;
+
+namespace Equibles.IntegrationTests.Media;
+
+public class FileManagerSaveFileExtensionAllowlistTests
+{
+    private readonly FileManager _sut;
+
+    public FileManagerSaveFileExtensionAllowlistTests()
+    {
+        var context = TestDbContextFactory.Create(new MediaModuleConfiguration());
+        _sut = new FileManager(new FileRepository(context));
+    }
+
+    // Contract: FileManager publishes a curated AcceptedExtensions allowlist
+    // (+ AcceptedExtensionsString()). A caller relies on SaveFile enforcing it
+    // — otherwise an executable/HTML/SVG payload is persisted and later served,
+    // and the allowlist is decorative. SaveFile already throws ArgumentException
+    // for a missing extension; a disallowed one must be rejected the same way.
+    [Fact(Skip = "GH-766 — FileManager.SaveFile does not enforce AcceptedExtensions")]
+    public async Task SaveFile_ExtensionNotInAcceptedAllowlist_IsRejected()
+    {
+        var act = async () => await _sut.SaveFile([0x4d, 0x5a], "malware.exe");
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Media/FileManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/FileManagerTests.cs
@@ -55,27 +55,21 @@ public class FileManagerTests
     }
 
     [Fact]
-    public async Task SaveFile_UnknownExtension_FallsBackToApplicationOctetStream()
+    public async Task SaveFile_AllowlistedExtensionWithNoSpecificMime_UsesOctetStream()
     {
         // SaveFile derives Content-Type from MimeTypeMap.GetMimeType(extension).
-        // Every existing test (.pdf, .jpg, .png, .txt) hits a mapped entry, so
-        // the fallback path — `if (string.IsNullOrEmpty(contentType))
-        // contentType = "application/octet-stream";` — is unexercised. That
-        // fallback is the only thing that prevents an unknown extension
-        // (e.g. SEC paper-filing artifacts with bespoke suffixes like
-        // `.xbrl.zip.gz`, partner uploads with obsolete suffixes, anything
-        // outside the curated AcceptedExtensions list) from persisting a
-        // null or empty `ContentType` column — which downstream blows up
-        // when the file is served back to the browser (the response either
-        // 500s on null header, or sniffs into something dangerous like
-        // text/html). A refactor that drops the fallback (e.g. assuming
-        // MimeTypeMap always returns non-empty, which it doesn't for
-        // unknown suffixes) would compile cleanly and pass every existing
-        // test, then silently corrupt the file metadata on the next bespoke
-        // upload. Pin the fallback so the regression surfaces here.
-        var file = await _sut.SaveFile([0x01, 0x02, 0x03], "weird.zzz");
+        // Most allowlisted types (.pdf, .jpg, .png, .txt, .doc…) map to a
+        // specific MIME, but `.psd` has no specific mapping and resolves to
+        // application/octet-stream. This pins the safe-content-type behaviour
+        // for an allowlisted-but-unmapped extension so the column is never
+        // null/empty (which would 500 or content-sniff when served back).
+        // Note: SaveFile now enforces the AcceptedExtensions allowlist
+        // (GH-766), so a genuinely unknown extension is rejected outright —
+        // this exercises the octet-stream path within that contract using a
+        // permitted extension.
+        var file = await _sut.SaveFile([0x38, 0x42, 0x50, 0x53], "layers.psd");
 
-        file.Extension.Should().Be("zzz");
+        file.Extension.Should().Be("psd");
         file.ContentType.Should().Be("application/octet-stream");
     }
 


### PR DESCRIPTION
## Summary

Fixes #766 (security: unenforced upload allowlist). `FileManager.SaveFile` published an `AcceptedExtensions` allowlist (+ `AcceptedExtensionsString()`) but never enforced it — any extension (`.exe`, `.svg`, `.html`, …) was persisted with a derived content type, giving false assurance to callers.

This PR (started as the GH-766 skipped repro) now contains the fix:

- `SaveFile` rejects any extension not in `AcceptedExtensions` (case-insensitive whitelist), throwing `ArgumentException` consistently with the existing empty-extension guard.
- Un-skips the GH-766 regression test.
- Repoints the pre-existing `SaveFile_UnknownExtension_FallsBackToApplicationOctetStream` test (which asserted the *opposite*, now-insecure contract) to an **allowlisted-but-unmapped** extension (`.psd`) and renames it `SaveFile_AllowlistedExtensionWithNoSpecificMime_UsesOctetStream`, so octet-stream content-type coverage is preserved under the strict contract.

Verified the only production caller (`DocumentScraper` → `DocumentPersistenceService`) uses `.txt` (allowlisted) — no functional regression. All 12 FileManager tests pass.

## Code changes

- `src/Equibles.Media.BusinessLogic/FileManager.cs` — enforce the allowlist in `SaveFile`.
- `tests/.../Media/FileManagerSaveFileExtensionAllowlistTests.cs` — un-skip the GH-766 repro.
- `tests/.../Media/FileManagerTests.cs` — repoint/rename the obsolete unknown-extension test to keep octet-stream coverage within the strict contract.