### PR TITLE
test(media): add skipped repro for GH-768 — SaveImage upscales beyond max

### DIFF
--- a/tests/Equibles.IntegrationTests/Media/ImageManagerSaveImageMaxBoundsTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/ImageManagerSaveImageMaxBoundsTests.cs
@@ -1,0 +1,42 @@
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.Data;
+using Equibles.Media.Repositories;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace Equibles.IntegrationTests.Media;
+
+public class ImageManagerSaveImageMaxBoundsTests
+{
+    private readonly ImageManager _sut;
+
+    public ImageManagerSaveImageMaxBoundsTests()
+    {
+        var context = TestDbContextFactory.Create(new MediaModuleConfiguration());
+        _sut = new ImageManager(new ImageRepository(context));
+    }
+
+    private static byte[] CreateMinimalPng(int width, int height)
+    {
+        using var image = new Image<Rgba32>(width, height);
+        using var stream = new MemoryStream();
+        image.SaveAsPng(stream);
+        return stream.ToArray();
+    }
+
+    // Contract: maxWidth/maxHeight are documented as the *maximum* width/height.
+    // A source already within those bounds must not be enlarged — a 10x10
+    // image saved with a 4000x4000 cap should stay 10x10, not be upscaled
+    // (which wastes storage and blurs the image).
+    [Fact(Skip = "GH-768 — SaveImage upscales beyond documented max bounds")]
+    public async Task SaveImage_SourceSmallerThanMax_IsNotUpscaled()
+    {
+        var content = CreateMinimalPng(10, 10);
+
+        var image = await _sut.SaveImage(content, "small.png", 4000, 4000);
+
+        image.Width.Should().Be(10);
+        image.Height.Should().Be(10);
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test (`/add-test`, Lane A) found a real bug: `ImageManager.SaveImage` documents `maxWidth`/`maxHeight` as the *maximum* dimensions, but `imageProcessor.Resize(maxWidth, maxHeight, ...)` resizes to exactly those dimensions — ImageSharp upscales a smaller source, so a 10x10 image with a 4000x4000 "max" becomes 4000x4000 (and aspect ratio is ignored when both are set).
- Repro test committed `[Skip]` pending the fix; tracked in GH-768.

## Code changes

- `tests/Equibles.IntegrationTests/Media/ImageManagerSaveImageMaxBoundsTests.cs` — adds `SaveImage_SourceSmallerThanMax_IsNotUpscaled`, skipped — see GH-768. Asserts a 10x10 PNG saved with a 4000x4000 cap stays 10x10; currently fails (becomes 4000x4000), so it ships skipped and should be un-skipped as part of the GH-768 fix (use `ResizeMode.Max` / only downscale).