### PR TITLE
test(holdings): add skipped repro for GH-770 — TryParseDateOnly Hijri-culture ISO failure

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTryParseDateOnlyCultureTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTryParseDateOnlyCultureTests.cs
@@ -1,0 +1,32 @@
+using System.Globalization;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsParsingHelperTryParseDateOnlyCultureTests
+{
+    // Contract (XML-doc): "Parses date strings in both ISO (yyyy-MM-dd) and
+    // SEC (dd-MMM-yyyy) formats." This is unconditional, so an ISO 13F date
+    // must parse to the same Gregorian date on any host. ar-SA defaults to the
+    // Umm al-Qura (Hijri) calendar — the first branch uses culture-sensitive
+    // DateOnly.TryParse, so a Worker there must still read "2024-03-15" as
+    // 15 March 2024, not a Hijri reinterpretation.
+    [Fact(Skip = "GH-770 — TryParseDateOnly fails ISO dates under Hijri-calendar culture")]
+    public void TryParseDateOnly_IsoDateUnderHijriCalendarCulture_ReturnsGregorianDate()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+
+            var success = HoldingsParsingHelper.TryParseDateOnly("2024-03-15", out var result);
+
+            success.Should().BeTrue();
+            result.Should().Be(new DateOnly(2024, 3, 15));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test (`/add-test`, Lane A) found a real bug: `HoldingsParsingHelper.TryParseDateOnly`'s XML-doc unconditionally promises ISO `yyyy-MM-dd` support, but the first branch uses culture-sensitive `DateOnly.TryParse`. Under `ar-SA` (Hijri default calendar) `"2024-03-15"` fails to parse and the only fallback (`dd-MMM-yyyy` invariant exact) can't match an ISO string — so the method returns `false` and the 13F date is dropped. Sibling of GH-747; here the doc makes it an explicit contract violation.
- Repro test committed `[Skip]` pending the fix; tracked in GH-770.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTryParseDateOnlyCultureTests.cs` — adds `TryParseDateOnly_IsoDateUnderHijriCalendarCulture_ReturnsGregorianDate`, skipped — see GH-770. Asserts `"2024-03-15"` parses to 2024-03-15 under `ar-SA`; currently fails (`success == false`), so it ships skipped and should be un-skipped as part of the GH-770 fix (parse the ISO branch with InvariantCulture).