### PR TITLE
test(commonstocks): add skipped repro for GH-772 — whitespace required fields

### DIFF
--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerCreateWhitespaceTickerTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerCreateWhitespaceTickerTests.cs
@@ -1,0 +1,38 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Exceptions;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.CommonStocks;
+
+public class CommonStockManagerCreateWhitespaceTickerTests
+{
+    private readonly CommonStockManager _sut;
+
+    public CommonStockManagerCreateWhitespaceTickerTests()
+    {
+        var context = TestDbContextFactory.Create(new CommonStocksModuleConfiguration());
+        _sut = new CommonStockManager(new CommonStockRepository(context));
+    }
+
+    // Contract: "Ticker is required". Ticker is also the globally-unique key
+    // and the lookup key (GetByPrimaryTicker), so a whitespace-only value is
+    // not a provided ticker and must be rejected — persisting one corrupts the
+    // uniqueness invariant and ticker lookups.
+    [Fact(Skip = "GH-772 — required-field validation uses IsNullOrEmpty, allows whitespace ticker")]
+    public async Task Create_WhitespaceOnlyTicker_IsRejected()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "   ",
+            Name = "Whitespace Ticker Co",
+            Cik = "0001234567",
+        };
+
+        var act = async () => await _sut.Create(stock);
+
+        await act.Should().ThrowAsync<DomainValidationException>();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test (`/add-test`, Lane A) found a real bug: `CommonStockManager.ValidateCommonStock` enforces "Ticker/Name/Cik is required" with `string.IsNullOrEmpty`, so a whitespace-only Ticker (`"   "`) passes validation and is persisted. Ticker is the global-uniqueness key and the `GetByPrimaryTicker` lookup key, so a blank ticker corrupts the uniqueness invariant and ticker resolution.
- Repro test committed `[Skip]` pending the fix; tracked in GH-772.

## Code changes

- `tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerCreateWhitespaceTickerTests.cs` — adds `Create_WhitespaceOnlyTicker_IsRejected`, skipped — see GH-772. Asserts `Create` with `Ticker = "   "` throws `DomainValidationException`; currently fails (no exception, stock persisted), so it ships skipped and should be un-skipped as part of the GH-772 fix (use `IsNullOrWhiteSpace`).