### PR TITLE
test(errors): add skipped repro for GH-774 — Create splits surrogate pairs

### DIFF
--- a/tests/Equibles.IntegrationTests/Errors/ErrorManagerCreateSurrogateTruncationTests.cs
+++ b/tests/Equibles.IntegrationTests/Errors/ErrorManagerCreateSurrogateTruncationTests.cs
@@ -1,0 +1,38 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Data.Models;
+using Equibles.Errors.Repositories;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Errors;
+
+public class ErrorManagerCreateSurrogateTruncationTests
+{
+    private readonly ErrorManager _sut;
+    private readonly ErrorRepository _repository;
+
+    public ErrorManagerCreateSurrogateTruncationTests()
+    {
+        var context = TestDbContextFactory.Create(new ErrorsModuleConfiguration());
+        _repository = new ErrorRepository(context);
+        _sut = new ErrorManager(_repository);
+    }
+
+    // Contract: Create caps Message to fit storage; the stored value is later
+    // persisted to text and JSON-serialized for the dashboard, so truncation
+    // must yield a valid string. Index-slicing at 512 must not split a
+    // surrogate pair (emoji/non-BMP chars are common in exception text) into a
+    // dangling lone surrogate.
+    [Fact(Skip = "GH-774 — ErrorManager.Create truncation splits surrogate pairs")]
+    public async Task Create_MessageTruncationAtSurrogatePair_DoesNotLeaveLoneSurrogate()
+    {
+        // 511 'a' + "😀" (U+1F600, 2 UTF-16 units) => length 513; a raw [..512]
+        // slice keeps the high surrogate at index 511 and drops its low pair.
+        var message = new string('a', 511) + "\U0001F600";
+
+        await _sut.Create(ErrorSource.McpTool, "ctx", message, "stack");
+
+        var stored = _repository.GetAll().Single().Message;
+        char.IsHighSurrogate(stored[^1]).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test (`/add-test`, Lane A) found a real bug: `ErrorManager.Create` truncates `Message`/`Context`/`RequestSummary` with a raw `[..N]` UTF-16 slice. When the cut index lands inside a surrogate pair (any non-BMP char — emoji/CJK, common in exception text), it leaves a dangling lone surrogate. That value is invalid Unicode and is serialized as U+FFFD (or throws) when the errors dashboard renders it, corrupting the message irrecoverably.
- Repro test committed `[Skip]` pending the fix; tracked in GH-774.

## Code changes

- `tests/Equibles.IntegrationTests/Errors/ErrorManagerCreateSurrogateTruncationTests.cs` — adds `Create_MessageTruncationAtSurrogatePair_DoesNotLeaveLoneSurrogate`, skipped — see GH-774. Asserts a 513-unit message ending in `😀` is not truncated into a lone high surrogate; currently fails (`char.IsHighSurrogate(stored[^1]) == true`), so it ships skipped and should be un-skipped as part of the GH-774 fix (truncate on a rune/text-element boundary).