### PR TITLE
test(congress): add skipped repro for GH-780 — ParseAmountRange open-top bracket

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseAmountRangeOpenTopTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseAmountRangeOpenTopTests.cs
@@ -1,0 +1,19 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperParseAmountRangeOpenTopTests
+{
+    // Contract: ParseAmountRange maps a disclosed amount bracket to (from, to).
+    // The House top bracket "$50,000,000 +" is a lower-bounded open range
+    // (>= $50M) — semantically identical to "Over $50,000,000", which the
+    // existing pin maps to (val, val). So `from` must be 50,000,000, not 0;
+    // returning (0, 50M) inverts the position (claims it is AT MOST $50M).
+    [Fact(Skip = "GH-780 — ParseAmountRange mishandles '$X +' open-top bracket")]
+    public void ParseAmountRange_PlusSuffixOpenTopBracket_LowerBoundIsTheValue()
+    {
+        var (from, _) = DisclosureParsingHelper.ParseAmountRange("$50,000,000 +");
+
+        from.Should().Be(50_000_000);
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test (`/add-test`, Lane A) found a real bug: `DisclosureParsingHelper.ParseAmountRange` only treats the literal word "Over" as a lower-bounded open range. The House disclosure top bracket `"$50,000,000 +"` (a `+` suffix) falls to the `(0, val)` arm, so a position that is **≥ $50M** is recorded as **≤ $50M** with lower bound $0 — the magnitude is inverted, understating large positions in aggregates.
- Repro test committed `[Skip]` pending the fix; tracked in GH-780.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseAmountRangeOpenTopTests.cs` — adds `ParseAmountRange_PlusSuffixOpenTopBracket_LowerBoundIsTheValue`, skipped — see GH-780. Asserts `ParseAmountRange("$50,000,000 +").from == 50_000_000` (consistent with the existing "Over $X" → (val,val) pin); currently fails (`from == 0`), so it ships skipped and should be un-skipped as part of the GH-780 fix (treat trailing `+`/"and over" like "Over").