### PR TITLE
test(sec): add skipped repro for GH-782 — DocumentType.FromValue null throws

### DIFF
--- a/tests/Equibles.UnitTests/Sec/DocumentTypeFromValueNullTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeFromValueNullTests.cs
@@ -1,0 +1,16 @@
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.UnitTests.Sec;
+
+public class DocumentTypeFromValueNullTests
+{
+    // Contract: FromValue is a lookup that returns null when there is no match
+    // (cf. FromValue_UnknownValue_ReturnsNull). Its sole caller is the EF value
+    // converter `DocumentType.FromValue(v) ?? new DocumentType(v)`, which gets
+    // v == null for a NULL column — so null input must return null, not throw.
+    [Fact(Skip = "GH-782 — DocumentType.FromValue throws on null instead of returning null")]
+    public void FromValue_NullValue_ReturnsNullInsteadOfThrowing()
+    {
+        DocumentType.FromValue(null).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test (`/add-test`, Lane A) found a real bug: `DocumentType.FromValue` is `AllByValue.GetValueOrDefault(value)`; `ConcurrentDictionary.TryGetValue(null)` throws `ArgumentNullException`. Its sole caller is the EF converter `FromValue(v) ?? new DocumentType(v)` (SecModuleConfiguration), so a NULL DocumentType column makes entity materialisation throw instead of falling back.
- Repro test committed `[Skip]` pending the fix; tracked in GH-782.

## Code changes

- `tests/Equibles.UnitTests/Sec/DocumentTypeFromValueNullTests.cs` — adds `FromValue_NullValue_ReturnsNullInsteadOfThrowing`, skipped — see GH-782. Asserts `FromValue(null)` returns null (consistent with the existing unknown-value→null pin); currently throws `ArgumentNullException`, so it ships skipped and should be un-skipped as part of the GH-782 fix (null guard before the dictionary lookup).