### PR TITLE
test(web): pin MarkdownToHtml neutralizes entity-encoded javascript scheme

### DIFF
--- a/tests/Equibles.UnitTests/Web/MarkdownExtensionsEntityEncodedSchemeTests.cs
+++ b/tests/Equibles.UnitTests/Web/MarkdownExtensionsEntityEncodedSchemeTests.cs
@@ -1,0 +1,30 @@
+using Equibles.Web.Extensions;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Web;
+
+public class MarkdownExtensionsEntityEncodedSchemeTests
+{
+    // Contract (stated anti-XSS intent): MarkdownToHtml renders untrusted
+    // ingested content via Raw() and must neutralize dangerous link schemes.
+    // The scheme allowlist regex requires a literal `scheme:`; an entity-encoded
+    // colon (`javascript&#58;…`) defeats the regex so IsSafeUrl returns true and
+    // the URL is left intact, but a browser HTML-decodes the href attribute back
+    // to `javascript:` — so the output must not carry that scheme in any form.
+    [Fact]
+    public void MarkdownToHtml_EntityEncodedColonInJavascriptScheme_DoesNotEmitJavascriptHref()
+    {
+        string captured = null;
+        var htmlHelper = Substitute.For<IHtmlHelper>();
+        htmlHelper
+            .Raw(Arg.Do<string>(s => captured = s))
+            .Returns(callInfo => new HtmlString(callInfo.Arg<string>()));
+
+        htmlHelper.MarkdownToHtml("[x](javascript&#58;alert(1))");
+
+        captured.Should().NotBeNull();
+        captured.Should().NotContain("javascript");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test (`/add-test`, Lane A) — **no bug found**: probed the markdown XSS sanitizer with an entity-encoded-colon scheme obfuscation (`[x](javascript&#58;alert(1))`) that defeats the `UriSchemeRegex` allowlist check. Markdig's link rendering + the existing sanitizer together neutralize it (the `javascript` scheme does not survive to an active href), so the test passes and is kept as a security regression pin.
- This locks in defense against a known sanitizer-bypass class so a future Markdig upgrade or sanitizer refactor can't silently regress it.

## Code changes

- `tests/Equibles.UnitTests/Web/MarkdownExtensionsEntityEncodedSchemeTests.cs` — adds `MarkdownToHtml_EntityEncodedColonInJavascriptScheme_DoesNotEmitJavascriptHref` (active, passing). Asserts the rendered output carries no `javascript` scheme when the markdown link uses an HTML-entity-encoded colon. Sibling to the existing `[x](javascript:…)` and raw-`<script>` pins.