### PR TITLE
test(congress): add skipped repro for GH-785 — ExtractTicker dotted class tickers

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperExtractTickerClassShareTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperExtractTickerClassShareTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperExtractTickerClassShareTests
+{
+    // Contract: ExtractTickerFromAssetName pulls the stock ticker out of a
+    // disclosed asset name so the trade can be linked to a company. Class-share
+    // tickers with a dot ("BRK.B", "BF.B") are common in real congressional
+    // disclosures; they must be extracted, not dropped. (Ambiguity: the regex
+    // is deliberately [A-Za-z]{1,5}; but a caller relies on dotted class
+    // tickers mapping, since otherwise those trades silently lose their stock.)
+    [Fact(Skip = "GH-785 — ExtractTickerFromAssetName drops dotted class-share tickers")]
+    public void ExtractTickerFromAssetName_DottedClassShareTicker_ExtractsFullTicker()
+    {
+        var result = DisclosureParsingHelper.ExtractTickerFromAssetName(
+            "Berkshire Hathaway Inc. Class B (BRK.B)"
+        );
+
+        result.Should().Be("BRK.B");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test (`/add-test`, Lane A) found a real bug: `DisclosureParsingHelper.ExtractTickerFromAssetName`'s `TickerRegex` capture group is alpha-only (`[A-Za-z]{1,5}`), so dotted class-share tickers (`BRK.B`, `BF.B`, `RDS.A`) inside `(...)` never match — the method returns null and the trade loses its stock mapping. These tickers appear routinely in real House/Senate disclosures.
- Repro test committed `[Skip]` pending the fix; tracked in GH-785.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperExtractTickerClassShareTests.cs` — adds `ExtractTickerFromAssetName_DottedClassShareTicker_ExtractsFullTicker`, skipped — see GH-785. Asserts `"…Class B (BRK.B)"` extracts `"BRK.B"`; currently fails (`null`), so it ships skipped and should be un-skipped as part of the GH-785 fix (allow `.`/`-` in the ticker capture).