### PR TITLE
fix(sec): guard DocumentType.FromValue/FromDisplayName against null (GH-782)

### DIFF
--- a/src/Equibles.Sec.Data/Models/DocumentType.cs
+++ b/src/Equibles.Sec.Data/Models/DocumentType.cs
@@ -68,11 +68,25 @@ public sealed class DocumentType
 
     public static DocumentType FromValue(string value)
     {
+        // The OrdinalIgnoreCase comparer's GetHashCode throws on null, so a
+        // null lookup key must short-circuit. FromValue is a lookup that
+        // returns null on no match — the EF value converter relies on this
+        // for NULL columns (DocumentType.FromValue(v) ?? new DocumentType(v)).
+        if (value == null)
+        {
+            return null;
+        }
+
         return AllByValue.GetValueOrDefault(value);
     }
 
     public static DocumentType FromDisplayName(string displayName)
     {
+        if (displayName == null)
+        {
+            return null;
+        }
+
         return AllByDisplayName.GetValueOrDefault(displayName);
     }
 

--- a/tests/Equibles.UnitTests/Sec/DocumentTypeFromValueNullTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeFromValueNullTests.cs
@@ -8,7 +8,7 @@ public class DocumentTypeFromValueNullTests
     // (cf. FromValue_UnknownValue_ReturnsNull). Its sole caller is the EF value
     // converter `DocumentType.FromValue(v) ?? new DocumentType(v)`, which gets
     // v == null for a NULL column — so null input must return null, not throw.
-    [Fact(Skip = "GH-782 — DocumentType.FromValue throws on null instead of returning null")]
+    [Fact]
     public void FromValue_NullValue_ReturnsNullInsteadOfThrowing()
     {
         DocumentType.FromValue(null).Should().BeNull();


### PR DESCRIPTION
## Summary

`DocumentType.FromValue` (and the symmetrical `FromDisplayName`) delegated straight to a `ConcurrentDictionary` built with `StringComparer.OrdinalIgnoreCase`. That comparer's `GetHashCode` throws `ArgumentNullException` on a null key, so a null lookup threw instead of returning null. The sole caller is the EF value converter `DocumentType.FromValue(v) ?? new DocumentType(v)`, which receives `v == null` for a NULL column — making the crash reachable from data, not just tests. Fixes GH-782.

## Code changes

- `src/Equibles.Sec.Data/Models/DocumentType.cs` — null-guard `FromValue` and `FromDisplayName` to return null on a null key, matching the documented no-match contract.
- `tests/Equibles.UnitTests/Sec/DocumentTypeFromValueNullTests.cs` — un-skipped the GH-782 repro test (now passing).