### PR TITLE
fix(commonstocks): reject whitespace-only required fields (GH-772)

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -37,18 +37,20 @@ public class CommonStockManager
             throw new ArgumentNullException(nameof(commonStock));
         }
 
-        // Checks for the required fields
-        if (string.IsNullOrEmpty(commonStock.Ticker))
+        // Required fields: a whitespace-only value is not a provided value.
+        // Ticker is the globally-unique key and the lookup key, so accepting
+        // whitespace would corrupt the uniqueness invariant and ticker lookups.
+        if (string.IsNullOrWhiteSpace(commonStock.Ticker))
         {
             throw new DomainValidationException("Ticker is required");
         }
 
-        if (string.IsNullOrEmpty(commonStock.Name))
+        if (string.IsNullOrWhiteSpace(commonStock.Name))
         {
             throw new DomainValidationException("Name is required");
         }
 
-        if (string.IsNullOrEmpty(commonStock.Cik))
+        if (string.IsNullOrWhiteSpace(commonStock.Cik))
         {
             throw new DomainValidationException("Cik is required");
         }

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerCreateWhitespaceTickerTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerCreateWhitespaceTickerTests.cs
@@ -21,7 +21,7 @@ public class CommonStockManagerCreateWhitespaceTickerTests
     // and the lookup key (GetByPrimaryTicker), so a whitespace-only value is
     // not a provided ticker and must be rejected — persisting one corrupts the
     // uniqueness invariant and ticker lookups.
-    [Fact(Skip = "GH-772 — required-field validation uses IsNullOrEmpty, allows whitespace ticker")]
+    [Fact]
     public async Task Create_WhitespaceOnlyTicker_IsRejected()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

`CommonStockManager.ValidateCommonStock` enforced required fields with `string.IsNullOrEmpty`, so a whitespace-only Ticker/Name/Cik passed validation. Ticker is the globally-unique key and the `GetByPrimaryTicker` lookup key, so persisting a blank value corrupts the uniqueness invariant and ticker lookups. Fixes GH-772.

## Code changes

- `src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs` — Ticker/Name/Cik required-field checks now use `string.IsNullOrWhiteSpace`.
- `tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerCreateWhitespaceTickerTests.cs` — un-skipped the GH-772 repro test (now passing).