### PR TITLE
fix(holdings): parse ISO dates with InvariantCulture in TryParseDateOnly (GH-770)

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsParsingHelper.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsParsingHelper.cs
@@ -28,7 +28,17 @@ internal static class HoldingsParsingHelper
         if (string.IsNullOrEmpty(value))
             return false;
 
-        if (DateOnly.TryParse(value, out result))
+        // ISO/SEC dates are culture-invariant. Parsing with the host culture
+        // breaks on non-Gregorian calendars (e.g. ar-SA Umm al-Qura), where a
+        // Worker would reinterpret "2024-03-15" as a Hijri date.
+        if (
+            DateOnly.TryParse(
+                value,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None,
+                out result
+            )
+        )
             return true;
 
         if (

--- a/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTryParseDateOnlyCultureTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTryParseDateOnlyCultureTests.cs
@@ -11,7 +11,7 @@ public class HoldingsParsingHelperTryParseDateOnlyCultureTests
     // Umm al-Qura (Hijri) calendar — the first branch uses culture-sensitive
     // DateOnly.TryParse, so a Worker there must still read "2024-03-15" as
     // 15 March 2024, not a Hijri reinterpretation.
-    [Fact(Skip = "GH-770 — TryParseDateOnly fails ISO dates under Hijri-calendar culture")]
+    [Fact]
     public void TryParseDateOnly_IsoDateUnderHijriCalendarCulture_ReturnsGregorianDate()
     {
         var original = CultureInfo.CurrentCulture;


### PR DESCRIPTION
## Summary

`HoldingsParsingHelper.TryParseDateOnly` parsed the ISO branch with culture-sensitive `DateOnly.TryParse(value, out result)`. On a host whose culture uses a non-Gregorian calendar (e.g. `ar-SA` Umm al-Qura), a Worker reinterpreted `2024-03-15` as a Hijri date — corrupting or dropping every 13F date. ISO/SEC dates are culture-invariant. Fixes GH-770.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsParsingHelper.cs` — the ISO `DateOnly.TryParse` now uses `CultureInfo.InvariantCulture` (the SEC `dd-MMM-yyyy` branch was already invariant).
- `tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTryParseDateOnlyCultureTests.cs` — un-skipped the GH-770 repro test (now passing).