### PR TITLE
fix(congress): parse US disclosure dates with en-US culture in ParseDate (GH-747)

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -181,13 +181,17 @@ public static partial class DisclosureParsingHelper
     {
         if (string.IsNullOrWhiteSpace(text))
             return null;
-        if (DateOnly.TryParse(text, out var d))
+        // Congressional disclosure dates are US MM/dd/yyyy. Parsing with the
+        // host culture misreads "03/04/2025" as 3 April under en-GB/de-DE, so
+        // pin US culture (and an invariant exact-format fallback).
+        var us = System.Globalization.CultureInfo.GetCultureInfo("en-US");
+        if (DateOnly.TryParse(text, us, System.Globalization.DateTimeStyles.None, out var d))
             return d;
         if (
             DateOnly.TryParseExact(
                 text,
                 "MM/dd/yyyy",
-                null,
+                System.Globalization.CultureInfo.InvariantCulture,
                 System.Globalization.DateTimeStyles.None,
                 out d
             )

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseDateCultureTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseDateCultureTests.cs
@@ -9,7 +9,7 @@ public class DisclosureParsingHelperParseDateCultureTests
     // the US MM/dd/yyyy convention. "03/04/2025" is March 4, 2025 regardless
     // of the host machine's culture — a Worker deployed under en-GB/de-DE must
     // not silently read it as April 3.
-    [Fact(Skip = "GH-747 — ParseDate uses CurrentCulture, misreads US dates")]
+    [Fact]
     public void ParseDate_UsFormatUnderNonUsCulture_InterpretsAsMonthDayYear()
     {
         var original = CultureInfo.CurrentCulture;


### PR DESCRIPTION
## Summary

`DisclosureParsingHelper.ParseDate` used culture-sensitive `DateOnly.TryParse(text, ...)`. Congressional disclosure dates are US `MM/dd/yyyy`, so a Worker under `en-GB`/`de-DE` silently read `03/04/2025` as 3 April instead of 4 March. Fixes GH-747.

## Code changes

- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — `ParseDate` now parses with `en-US` culture and an `InvariantCulture` `MM/dd/yyyy` exact-format fallback (was `null` = host culture).
- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseDateCultureTests.cs` — un-skipped the GH-747 repro test (now passing).