### PR TITLE
fix(sec): parse SEC submissions ISO dates with InvariantCulture in MapToFilingData (GH-776)

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -493,10 +493,24 @@ public class SecEdgarClient : ISecEdgarClient
                 {
                     Cik = cik,
                     AccessionNumber = accessionNumber,
-                    FilingDate = DateOnly.TryParse(recent.FilingDate[i], out var fd)
+                    // SEC submissions feed dates are ISO yyyy-MM-dd. Parse them
+                    // culture-independently — under a non-Gregorian host culture
+                    // (e.g. ar-SA Umm al-Qura) culture-sensitive TryParse fails
+                    // and every filing would be stamped DateOnly.MinValue.
+                    FilingDate = DateOnly.TryParse(
+                        recent.FilingDate[i],
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        System.Globalization.DateTimeStyles.None,
+                        out var fd
+                    )
                         ? fd
                         : DateOnly.MinValue,
-                    ReportDate = DateOnly.TryParse(recent.ReportDate[i], out var rd)
+                    ReportDate = DateOnly.TryParse(
+                        recent.ReportDate[i],
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        System.Globalization.DateTimeStyles.None,
+                        out var rd
+                    )
                         ? rd
                         : DateOnly.MinValue,
                     Form = recent.Form[i],

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientMapToFilingDataCultureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientMapToFilingDataCultureTests.cs
@@ -12,7 +12,7 @@ public class SecEdgarClientMapToFilingDataCultureTests
     // culture-independent: ar-SA defaults to the Umm al-Qura (Hijri) calendar,
     // where culture-sensitive DateOnly.TryParse fails on an ISO string — a
     // Worker there would stamp every SEC filing with DateOnly.MinValue.
-    [Fact(Skip = "GH-776 — MapToFilingData ISO date parse fails under Hijri culture")]
+    [Fact]
     public void MapToFilingData_IsoDatesUnderHijriCulture_MapsToGregorianDates()
     {
         var original = CultureInfo.CurrentCulture;


### PR DESCRIPTION
## Summary

`SecEdgarClient.MapToFilingData` parsed the SEC submissions feed's ISO `filingDate`/`reportDate` with culture-sensitive `DateOnly.TryParse`. Under a non-Gregorian host culture (`ar-SA` Umm al-Qura) the parse fails and every filing is stamped `DateOnly.MinValue`. SEC feed dates are ISO yyyy-MM-dd and must be culture-independent. Fixes GH-776.

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — `MapToFilingData` now parses `FilingDate`/`ReportDate` with `CultureInfo.InvariantCulture`.
- `tests/Equibles.UnitTests/Sec/SecEdgarClientMapToFilingDataCultureTests.cs` — un-skipped the GH-776 repro test (now passing).