### PR TITLE
fix(sec): parse Form 4 transactionDate with InvariantCulture (GH-778)

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -327,7 +327,18 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             ?.Element("value")
             ?.Value?.Trim();
 
-        if (!DateOnly.TryParse(transactionDateStr, out var transactionDate))
+        // Form 4 transactionDate is ISO yyyy-MM-dd (ownership XSD). Parse it
+        // culture-independently — under a non-Gregorian host culture (e.g.
+        // ar-SA Umm al-Qura) culture-sensitive TryParse fails and every
+        // insider transaction would be silently dropped.
+        if (
+            !DateOnly.TryParse(
+                transactionDateStr,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None,
+                out var transactionDate
+            )
+        )
             return null;
 
         return new InsiderTransaction

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCultureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCultureTests.cs
@@ -15,7 +15,7 @@ public class InsiderTradingFilingProcessorParseTransactionCultureTests
     // DateOnly.TryParse fails on an ISO string, and ParseTransaction returns
     // null on a failed date parse, so a Worker there silently drops EVERY
     // insider transaction.
-    [Fact(Skip = "GH-778 — ParseTransaction drops Form 4 tx on ISO date parse under Hijri culture")]
+    [Fact]
     public void ParseTransaction_IsoTransactionDateUnderHijriCulture_ReturnsTransaction()
     {
         var original = CultureInfo.CurrentCulture;


### PR DESCRIPTION
## Summary

`InsiderTradingFilingProcessor.ParseTransaction` parsed the ISO Form 4 `transactionDate` with culture-sensitive `DateOnly.TryParse`, and returns null on a failed parse. Under a non-Gregorian host culture (`ar-SA` Umm al-Qura) the parse fails, so a Worker there silently dropped **every** insider transaction. Fixes GH-778.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — `ParseTransaction` now parses `transactionDate` with `CultureInfo.InvariantCulture`.
- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCultureTests.cs` — un-skipped the GH-778 repro test (now passing).