### PR TITLE
fix(cftc): strip whitespace padding around quoted CSV fields in SplitCsvLine (GH-764)

### DIFF
--- a/src/Equibles.Integrations.Cftc/CftcClient.cs
+++ b/src/Equibles.Integrations.Cftc/CftcClient.cs
@@ -233,6 +233,10 @@ public class CftcClient : ICftcClient
             {
                 inQuotes = true;
                 wasQuoted = true;
+                // CFTC pads delimiters as `, "value"`. The space(s) before the
+                // opening quote are not part of the quoted content — discard
+                // them so the value is taken verbatim from inside the quotes.
+                field.Clear();
             }
             else if (c == ',')
             {
@@ -240,10 +244,12 @@ public class CftcClient : ICftcClient
                 field.Clear();
                 wasQuoted = false;
             }
-            else
+            else if (!wasQuoted)
             {
                 field.Append(c);
             }
+            // Characters after a closing quote (CFTC's trailing padding before
+            // the next delimiter) are likewise not part of the verbatim value.
         }
 
         fields.Add(wasQuoted ? field.ToString() : field.ToString().Trim());

--- a/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineLeadingSpaceTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineLeadingSpaceTests.cs
@@ -14,7 +14,7 @@ public class CftcClientSplitCsvLineLeadingSpaceTests
     // *inside* the quotes. A space between the delimiter and the opening quote
     // (`, "b"`, ubiquitous in CFTC CSVs) is not part of the quoted content, so
     // the parsed value must be "b", not " b".
-    [Fact(Skip = "GH-764 — SplitCsvLine leaks pre-quote whitespace into quoted value")]
+    [Fact]
     public void SplitCsvLine_SpaceBeforeOpeningQuote_DoesNotLeakSpaceIntoQuotedValue()
     {
         var line = "a, \"b\"";


### PR DESCRIPTION
## Summary

CFTC CSVs pad delimiters as `, "value"`. `SplitCsvLine` appended the space(s) before the opening quote into the field buffer and, because `wasQuoted` suppresses trimming, leaked them into the parsed value (` b` instead of `b`). Trailing padding after the closing quote leaked symmetrically. This corrupts every quoted CFTC column. Fixes GH-764.

## Code changes

- `src/Equibles.Integrations.Cftc/CftcClient.cs` — on the opening quote, clear any accumulated pre-quote padding; ignore characters after a closing quote until the next delimiter. Quoted content is now taken verbatim as documented; RFC-4180 doubled-quote escaping and unquoted-field trimming are unchanged.
- `tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineLeadingSpaceTests.cs` — un-skipped the GH-764 repro test (now passing); the existing escaped-quote test still passes.