### PR TITLE
fix(congress): treat '$X +' as open-top lower bound in ParseAmountRange (GH-780)

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -248,9 +248,13 @@ public static partial class DisclosureParsingHelper
         if (matches.Count == 1)
         {
             long.TryParse(matches[0].Groups[1].Value.Replace(",", ""), out var val);
-            return amount.Contains("Over", StringComparison.OrdinalIgnoreCase)
-                ? (val, val)
-                : (0, val);
+            // A single amount is an open-ended lower bound when phrased as
+            // "Over $X" or the House top bracket "$X +" (>= $X) — both map to
+            // (val, val). Otherwise it is an upper bound, e.g. "Under $X".
+            var isOpenTopBracket =
+                amount.Contains("Over", StringComparison.OrdinalIgnoreCase)
+                || amount.TrimEnd().EndsWith('+');
+            return isOpenTopBracket ? (val, val) : (0, val);
         }
 
         return (0, 0);

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseAmountRangeOpenTopTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseAmountRangeOpenTopTests.cs
@@ -9,7 +9,7 @@ public class DisclosureParsingHelperParseAmountRangeOpenTopTests
     // (>= $50M) — semantically identical to "Over $50,000,000", which the
     // existing pin maps to (val, val). So `from` must be 50,000,000, not 0;
     // returning (0, 50M) inverts the position (claims it is AT MOST $50M).
-    [Fact(Skip = "GH-780 — ParseAmountRange mishandles '$X +' open-top bracket")]
+    [Fact]
     public void ParseAmountRange_PlusSuffixOpenTopBracket_LowerBoundIsTheValue()
     {
         var (from, _) = DisclosureParsingHelper.ParseAmountRange("$50,000,000 +");


### PR DESCRIPTION
## Summary

`ParseAmountRange` mapped a single-amount bracket to `(val, val)` only when the text contained "Over". The House top bracket `$50,000,000 +` (>= $50M) is semantically identical but fell through to `(0, val)` — inverting the position to claim it is *at most* $50M. Fixes GH-780.

## Code changes

- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — a single amount ending in `+` is now treated as an open-top lower bound `(val, val)`, consistent with the existing "Over $X" handling.
- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseAmountRangeOpenTopTests.cs` — un-skipped the GH-780 repro test (now passing); existing amount-range pins still pass.