### PR TITLE
fix(errors): surrogate-safe truncation in ErrorManager.Create (GH-774)

### DIFF
--- a/src/Equibles.Errors.BusinessLogic/ErrorManager.cs
+++ b/src/Equibles.Errors.BusinessLogic/ErrorManager.cs
@@ -29,14 +29,27 @@ public class ErrorManager
         var error = new Error
         {
             Source = source,
-            Context = context.Length > 128 ? context[..128] : context,
-            Message = message.Length > 512 ? message[..512] : message,
+            Context = Truncate(context, 128),
+            Message = Truncate(message, 512),
             StackTrace = stackTrace,
-            RequestSummary = requestSummary?.Length > 512 ? requestSummary[..512] : requestSummary,
+            RequestSummary = Truncate(requestSummary, 512),
         };
 
         _errorRepository.Add(error);
         await _errorRepository.SaveChanges();
+    }
+
+    // Caps a value to maxLength UTF-16 units without splitting a surrogate
+    // pair. Exception text routinely contains non-BMP chars (emoji); a raw
+    // [..maxLength] slice could leave a dangling lone surrogate, which then
+    // corrupts the text column and any JSON serialization for the dashboard.
+    private static string Truncate(string value, int maxLength)
+    {
+        if (value == null || value.Length <= maxLength)
+            return value;
+
+        var end = char.IsHighSurrogate(value[maxLength - 1]) ? maxLength - 1 : maxLength;
+        return value[..end];
     }
 
     public async Task MarkAsSeen(Error error)

--- a/tests/Equibles.IntegrationTests/Errors/ErrorManagerCreateSurrogateTruncationTests.cs
+++ b/tests/Equibles.IntegrationTests/Errors/ErrorManagerCreateSurrogateTruncationTests.cs
@@ -23,7 +23,7 @@ public class ErrorManagerCreateSurrogateTruncationTests
     // must yield a valid string. Index-slicing at 512 must not split a
     // surrogate pair (emoji/non-BMP chars are common in exception text) into a
     // dangling lone surrogate.
-    [Fact(Skip = "GH-774 — ErrorManager.Create truncation splits surrogate pairs")]
+    [Fact]
     public async Task Create_MessageTruncationAtSurrogatePair_DoesNotLeaveLoneSurrogate()
     {
         // 511 'a' + "😀" (U+1F600, 2 UTF-16 units) => length 513; a raw [..512]


### PR DESCRIPTION
## Summary

`ErrorManager.Create` capped `Context`/`Message`/`RequestSummary` with a raw `value[..maxLength]` slice. When index `maxLength-1` lands on a high surrogate (non-BMP chars like emoji are common in exception text), the slice keeps a dangling lone surrogate — corrupting the stored text column and any JSON serialization for the dashboard. Fixes GH-774.

## Code changes

- `src/Equibles.Errors.BusinessLogic/ErrorManager.cs` — extracted a `Truncate` helper that backs off one unit when the cut would split a surrogate pair; applied to all three capped fields (null-safe for the optional `requestSummary`).
- `tests/Equibles.IntegrationTests/Errors/ErrorManagerCreateSurrogateTruncationTests.cs` — un-skipped the GH-774 repro test (now passing).