### PR TITLE
fix(media): don't upscale images already within max bounds in SaveImage (GH-768)

### DIFF
--- a/src/Equibles.Media.BusinessLogic/ImageManager.cs
+++ b/src/Equibles.Media.BusinessLogic/ImageManager.cs
@@ -56,7 +56,13 @@ public class ImageManager : IImageManager
 
         using var contentStream = new MemoryStream(content);
         using var imageProcessor = await SixLabors.ImageSharp.Image.LoadAsync(contentStream);
-        if (maxWidth != null || maxHeight != null)
+        // maxWidth/maxHeight are a *maximum* — only resize when the source
+        // actually exceeds them. A source already within bounds must not be
+        // enlarged (wastes storage and blurs the image).
+        var exceedsMaxBounds =
+            (maxWidth != null && imageProcessor.Width > maxWidth)
+            || (maxHeight != null && imageProcessor.Height > maxHeight);
+        if (exceedsMaxBounds)
         {
             imageProcessor.Mutate(i =>
                 i.Resize(maxWidth ?? 0, maxHeight ?? 0, new BicubicResampler())

--- a/tests/Equibles.IntegrationTests/Media/ImageManagerSaveImageMaxBoundsTests.cs
+++ b/tests/Equibles.IntegrationTests/Media/ImageManagerSaveImageMaxBoundsTests.cs
@@ -29,7 +29,7 @@ public class ImageManagerSaveImageMaxBoundsTests
     // A source already within those bounds must not be enlarged — a 10x10
     // image saved with a 4000x4000 cap should stay 10x10, not be upscaled
     // (which wastes storage and blurs the image).
-    [Fact(Skip = "GH-768 — SaveImage upscales beyond documented max bounds")]
+    [Fact]
     public async Task SaveImage_SourceSmallerThanMax_IsNotUpscaled()
     {
         var content = CreateMinimalPng(10, 10);


### PR DESCRIPTION
## Summary

`ImageManager.SaveImage` called `Resize(maxWidth, maxHeight)` whenever a bound was supplied, which enlarges a source smaller than the box. `maxWidth`/`maxHeight` are documented as the *maximum*, so a 10x10 image saved with a 4000x4000 cap was upscaled to 4000x4000 — wasting storage and blurring the image. Fixes GH-768.

## Code changes

- `src/Equibles.Media.BusinessLogic/ImageManager.cs` — resize only when the source actually exceeds `maxWidth`/`maxHeight`; downscale behaviour (including the `0`/aspect-ratio path) is unchanged.
- `tests/Equibles.IntegrationTests/Media/ImageManagerSaveImageMaxBoundsTests.cs` — un-skipped the GH-768 repro test (now passing); existing downscale tests still pass.