### PR TITLE
fix(congress): origin-based check in IsValidDisclosureUrl to close SSRF bypass (GH-750)

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -260,7 +260,19 @@ public static partial class DisclosureParsingHelper
     {
         if (string.IsNullOrEmpty(url) || string.IsNullOrEmpty(expectedBaseUrl))
             return false;
-        return url.StartsWith(expectedBaseUrl, StringComparison.OrdinalIgnoreCase);
+
+        // A StartsWith check is an SSRF bypass: an attacker domain that merely
+        // prefixes the base ("house.gov.evil.example") would pass. Compare the
+        // actual origin — scheme, host and port must match exactly.
+        if (
+            !Uri.TryCreate(url, UriKind.Absolute, out var parsed)
+            || !Uri.TryCreate(expectedBaseUrl, UriKind.Absolute, out var baseUri)
+        )
+            return false;
+
+        return string.Equals(parsed.Scheme, baseUri.Scheme, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(parsed.Host, baseUri.Host, StringComparison.OrdinalIgnoreCase)
+            && parsed.Port == baseUri.Port;
     }
 
     // Matches tickers in parentheses/brackets: (AAPL), [MSFT], case-insensitive

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlBoundaryTests.cs
@@ -9,7 +9,7 @@ public class DisclosureParsingHelperIsValidUrlBoundaryTests
     // host. An attacker-registered domain that merely *prefixes* the expected
     // base ("...house.gov.evil.example") is NOT on the house.gov origin and
     // must be rejected, or the guard is an SSRF bypass.
-    [Fact(Skip = "GH-750 — IsValidDisclosureUrl StartsWith allows prefix-domain bypass")]
+    [Fact]
     public void IsValidDisclosureUrl_AttackerDomainWithBaseAsPrefix_ReturnsFalse()
     {
         var result = DisclosureParsingHelper.IsValidDisclosureUrl(


### PR DESCRIPTION
## Summary

`IsValidDisclosureUrl` gated which URLs the scraper fetches using `url.StartsWith(expectedBaseUrl)`. An attacker-registered domain that merely *prefixes* the expected base (`https://disclosures-clerk.house.gov.evil.example/malware.pdf`) passed the check — an SSRF bypass. Fixes GH-750.

## Code changes

- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — parse both URLs and require an exact origin match (scheme + host + port) instead of a string prefix. Null/relative/unparseable inputs still return false.
- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlBoundaryTests.cs` — un-skipped the GH-750 repro test (now passing); existing IsValidDisclosureUrl matching/different/case-insensitive/null tests and the Senate client tests still pass.