### PR TITLE
fix(sec): preserve anchor/non-span item content in ListConversionStep fallback (GH-745)

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/ListConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/ListConversionStep.cs
@@ -105,15 +105,11 @@ internal class ListConversionStep : IHtmlNormalizationStep
         }
         else
         {
-            // Fallback: use all content except bullet spans
-            var allSpans = itemElement
-                .QuerySelectorAll("span")
-                .Where(s => s.TextContent.Trim() is not ("•" or "·" or "-"))
-                .ToList();
-            foreach (var span in allSpans)
-            {
-                liElement.AppendChild(span.Clone(true));
-            }
+            // Fallback: use the entire remaining content (the bullet span is
+            // already removed). Cloning only <span> children silently dropped
+            // anchor-only items (e.g. SEC exhibit-index entries), producing an
+            // empty <li> and discarding the reference.
+            liElement.InnerHtml = itemElement.InnerHtml;
         }
 
         return liElement;

--- a/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepTests.cs
@@ -201,7 +201,7 @@ public class ListConversionStepTests
     // content div, no spans) must not produce an empty <li> — that silently
     // discards an exhibit reference, exactly the kind of anchor-only list
     // entry SEC exhibit indexes use.
-    [Fact(Skip = "GH-745 — ListConversionStep drops anchor-only item content")]
+    [Fact]
     public void WrapperWithAnchorContentNoSpan_PreservesAnchorContentInLi()
     {
         var input = """


### PR DESCRIPTION
## Summary

When a list item had no `display:inline` content div, `ConvertItemToListItem` fell back to cloning only non-bullet `<span>` children. An anchor-only item (`<a href=...>Exhibit 10.1</a>`, exactly the shape SEC exhibit indexes use) has no spans, so it produced an empty `<li>` — silently discarding the exhibit reference. Fixes GH-745.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/ListConversionStep.cs` — the fallback now uses the item's entire remaining inner HTML (the bullet span is already removed), matching the method's "or use the entire content" intent.
- `tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepTests.cs` — un-skipped the GH-745 repro test (now passing); the existing span-fallback pin still passes.