### PR TITLE
fix(congress): extract dotted class-share tickers in ExtractTickerFromAssetName (GH-785)

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -275,8 +275,9 @@ public static partial class DisclosureParsingHelper
             && parsed.Port == baseUri.Port;
     }
 
-    // Matches tickers in parentheses/brackets: (AAPL), [MSFT], case-insensitive
-    [GeneratedRegex(@"[\(\[]\s*([A-Za-z]{1,5})\s*[\)\]]")]
+    // Matches tickers in parentheses/brackets: (AAPL), [MSFT], case-insensitive,
+    // including a dotted class-share suffix: (BRK.B), [BF.B]
+    [GeneratedRegex(@"[\(\[]\s*([A-Za-z]{1,5}(?:\.[A-Za-z]{1,2})?)\s*[\)\]]")]
     public static partial Regex TickerRegex();
 
     // Matches dollar amounts: $1,001 — requires $ prefix to avoid false positives

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperExtractTickerClassShareTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperExtractTickerClassShareTests.cs
@@ -10,7 +10,7 @@ public class DisclosureParsingHelperExtractTickerClassShareTests
     // disclosures; they must be extracted, not dropped. (Ambiguity: the regex
     // is deliberately [A-Za-z]{1,5}; but a caller relies on dotted class
     // tickers mapping, since otherwise those trades silently lose their stock.)
-    [Fact(Skip = "GH-785 — ExtractTickerFromAssetName drops dotted class-share tickers")]
+    [Fact]
     public void ExtractTickerFromAssetName_DottedClassShareTicker_ExtractsFullTicker()
     {
         var result = DisclosureParsingHelper.ExtractTickerFromAssetName(


### PR DESCRIPTION
## Summary

`ExtractTickerFromAssetName`'s regex `[A-Za-z]{1,5}` dropped dotted class-share tickers (`BRK.B`, `BF.B`) common in real congressional disclosures, so those trades silently lost their stock link. Owner-approved fix for GH-785.

## Code changes

- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — `TickerRegex` now allows an optional dotted class suffix `(?:\.[A-Za-z]{1,2})?`. Non-dotted tickers `(AAPL)`/`[MSFT]` and the lowercase/no-ticker cases are unchanged.
- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperExtractTickerClassShareTests.cs` — un-skipped the GH-785 repro (now passing); all 8 existing ExtractTicker cases still pass.