### PR TITLE
fix(sec): treat SEC 403 as no-daily-index in GetDailyIndex (#754 follow-up)

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -351,8 +351,12 @@ public class SecEdgarClient : ISecEdgarClient
 
         using var response = await SendWithRetryAsync(url, cancellationToken);
 
-        // Non-publishing days (weekends, federal holidays) have no index file.
-        if (response.StatusCode == HttpStatusCode.NotFound)
+        // No index file for that day → nothing to ingest, skip it rather than
+        // failing the whole real-time sweep. Weekends/holidays can 404, and SEC
+        // returns 403 (Forbidden) for not-yet-published / future-dated index
+        // files (e.g. "today" before the daily index is posted). Both mean the
+        // same thing here: there is no daily index for this date.
+        if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Forbidden)
         {
             _logger.LogInformation("No daily index published for {Date:yyyy-MM-dd}", date);
             return [];

--- a/tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDailyIndexTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDailyIndexTests.cs
@@ -63,6 +63,33 @@ public class SecEdgarClientGetDailyIndexTests
         entries.Should().NotContain(e => e.Cik == "ABCDEFG");
     }
 
+    // SEC returns 403 (Forbidden), not 404, for not-yet-published / future-dated
+    // daily-index files (e.g. "today" before the index is posted, weekends).
+    // GetDailyIndex must treat that as "no index for this day" and return empty
+    // — a throw here kills the entire near-real-time 13F sweep every cycle.
+    [Theory]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.NotFound)]
+    public async Task GetDailyIndex_NoIndexForDate_ReturnsEmptyInsteadOfThrowing(
+        HttpStatusCode status
+    )
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string> { ["Sec:ContactEmail"] = "test@example.com" }
+            )
+            .Build();
+        var sut = new SecEdgarClient(
+            new HttpClient(new StatusStubHandler(status)),
+            Substitute.For<ILogger<SecEdgarClient>>(),
+            config
+        );
+
+        var entries = await sut.GetDailyIndex(new DateOnly(2026, 5, 17));
+
+        entries.Should().BeEmpty();
+    }
+
     private sealed class StubHandler : HttpMessageHandler
     {
         private readonly string _body;
@@ -76,5 +103,17 @@ public class SecEdgarClientGetDailyIndexTests
             Task.FromResult(
                 new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_body) }
             );
+    }
+
+    private sealed class StatusStubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+
+        public StatusStubHandler(HttpStatusCode status) => _status = status;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) => Task.FromResult(new HttpResponseMessage(_status));
     }
 }


### PR DESCRIPTION
## Summary

Found while running the #754 near-real-time 13F worker end-to-end locally: `Holdings13FRealtimeWorker` threw a **FATAL** every cycle.

`SecEdgarClient.GetDailyIndex` only treated **404** as "no index that day". Verified against live SEC EDGAR: a not-yet-published / future-dated / weekend daily-index file returns **403 Forbidden**, while real published days return 200:

| URL | HTTP |
|---|---|
| `daily-index/2026/QTR2/master.20260517.idx` (future/Sunday) | **403** |
| `daily-index/2026/QTR2/master.20260515.idx` (real trading day) | 200 |
| `daily-index/2025/QTR2/master.20250515.idx` | 200 |
| `daily-index/2099/QTR1/master.20990101.idx` | **403** |

So the worker's look-back sweep always hits the current (not-yet-posted) day first → 403 → `EnsureSuccessStatusCode()` throws → the entire real-time ingestion dies before reaching the days that *do* have data. The quarterly bulk path was unaffected.

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — `GetDailyIndex` now treats **403 and 404** as "no daily index for this date" (log + return empty), matching the method's documented "non-publishing days have no index file" intent. `SendWithRetryAsync` still retries 429 only; auth is unchanged (other SEC endpoints on the same client work).
- `tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDailyIndexTests.cs` — added a theory pinning 403 **and** 404 → empty (no throw).