### PR TITLE
feat(web): notify operators when a new release is available (GH-806)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ MCP_API_KEY=my-secret-key
 # Options: Verbose, Debug, Information, Warning, Error, Fatal
 MINIMUM_LOG_LEVEL=Warning
 
+# --- Update notifications (optional — defaults to true when unset) ---
+# When true, the Web portal periodically checks GitHub Releases and shows a
+# banner if a newer version is available. Set to false to disable the check.
+# CHECK_FOR_UPDATES=true
+
 # --- FINRA Short Data (free API key from developer.finra.org) ---
 # Finra__ClientId=my-finra-client-id
 # Finra__ClientSecret=my-finra-client-secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Web portal now checks GitHub Releases and shows a banner when a newer version
+  is available, displaying the new and current versions with links to the
+  "Updating" guide and an in-app rendered changelog. The check is cached, runs
+  off the request path, fails silently, and can be disabled with the
+  `CHECK_FOR_UPDATES` environment variable (default `true`).
+
 ### Fixed
 
 - Embedding service healthcheck used `curl`, which is not present in the

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Worker__MinSyncDate=2024-01-01
 | `Embedding__ModelName` | — | Model name (e.g., `bge-m3`) |
 | `Embedding__BatchSize` | `10` | Texts per embedding batch |
 
+**Update notifications (optional):**
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `CHECK_FOR_UPDATES` | `true` | When `true`, the web portal checks GitHub Releases and shows a banner when a newer version is available. Set to `false` to disable. |
+
 **Authentication (optional):**
 
 | Setting | Default | Description |
@@ -119,6 +125,26 @@ Worker__MinSyncDate=2024-01-01
 | `MCP_API_KEY` | — | MCP server API key (auth disabled if empty) |
 
 When set, the web portal requires login and the MCP server requires `Authorization: Bearer <key>` header. When unset, everything is open access (default).
+
+## Updating
+
+The web portal checks GitHub Releases on a schedule and shows a banner when a newer version is available (disable with `CHECK_FOR_UPDATES=false`). To update to the latest release:
+
+**Docker Compose:**
+
+```bash
+git pull
+docker compose up -d --build
+```
+
+**From source:**
+
+```bash
+git pull
+dotnet build Equibles.sln
+```
+
+Database migrations are applied automatically on startup. Review the [changelog](CHANGELOG.md) for notable changes before upgrading.
 
 ## Web Portal
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       Finra__ClientId: ${Finra__ClientId:-}
       Fred__ApiKey: ${Fred__ApiKey:-}
       MinimumLogLevel: ${MINIMUM_LOG_LEVEL:-Warning}
+      CheckForUpdates: ${CHECK_FOR_UPDATES:-true}
     volumes:
       - web-keys:/app/keys
     depends_on:

--- a/src/Equibles.Web/Controllers/ChangelogController.cs
+++ b/src/Equibles.Web/Controllers/ChangelogController.cs
@@ -1,0 +1,38 @@
+using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Services;
+using Equibles.Web.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Equibles.Web.Controllers;
+
+public class ChangelogController : BaseController
+{
+    private const string GitHubChangelogUrl =
+        "https://github.com/daniel3303/Equibles/blob/main/CHANGELOG.md";
+
+    private readonly ChangelogService _changelogService;
+
+    public ChangelogController(
+        ILogger<ChangelogController> logger,
+        ChangelogService changelogService
+    )
+        : base(logger)
+    {
+        _changelogService = changelogService;
+    }
+
+    [HttpGet]
+    public IActionResult Index()
+    {
+        var html = _changelogService.RenderHtml();
+        if (html == null)
+        {
+            // Graceful fallback when the file was not shipped with the build.
+            Logger.LogWarning("CHANGELOG.md not found; redirecting to GitHub");
+            return Redirect(GitHubChangelogUrl);
+        }
+
+        ViewData["Title"] = "Changelog";
+        return View(new ChangelogViewModel { Html = html });
+    }
+}

--- a/src/Equibles.Web/Dockerfile
+++ b/src/Equibles.Web/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y curl && \
     apt-get install -y nodejs
 
 COPY Directory.Build.props Directory.Packages.props ./
+COPY CHANGELOG.md ./
 COPY src/ src/
 
 WORKDIR /src/src/Equibles.Web

--- a/src/Equibles.Web/Equibles.Web.csproj
+++ b/src/Equibles.Web/Equibles.Web.csproj
@@ -1,4 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <!-- Running version surfaced by the update-notification banner. Bump on each release to match the git tag. -->
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Repo-root CHANGELOG.md, copied so the in-app /changelog page can render it. -->
+    <Content Include="..\..\CHANGELOG.md" Link="CHANGELOG.md" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Equibles.Core.AutoWiring" />
     <PackageReference Include="Markdig" />

--- a/src/Equibles.Web/Equibles.Web.csproj
+++ b/src/Equibles.Web/Equibles.Web.csproj
@@ -6,7 +6,11 @@
 
   <ItemGroup>
     <!-- Repo-root CHANGELOG.md, copied so the in-app /changelog page can render it. -->
-    <Content Include="..\..\CHANGELOG.md" Link="CHANGELOG.md" CopyToOutputDirectory="PreserveNewest" />
+    <Content
+      Include="..\..\CHANGELOG.md"
+      Link="CHANGELOG.md"
+      CopyToOutputDirectory="PreserveNewest"
+    />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Equibles.Web/Filters/VersionCheckFilter.cs
+++ b/src/Equibles.Web/Filters/VersionCheckFilter.cs
@@ -1,0 +1,38 @@
+using Equibles.Web.Models;
+using Equibles.Web.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Equibles.Web.Filters;
+
+/// <summary>
+/// Exposes the cached update-check result to every view via
+/// <c>ViewData["VersionUpdate"]</c> so the layout can render the banner.
+/// Mirrors <see cref="StatusBadgeFilter"/>.
+/// </summary>
+public class VersionCheckFilter : IAsyncActionFilter
+{
+    private readonly VersionCheckService _versionCheckService;
+
+    public VersionCheckFilter(VersionCheckService versionCheckService)
+    {
+        _versionCheckService = versionCheckService;
+    }
+
+    public async Task OnActionExecutionAsync(
+        ActionExecutingContext context,
+        ActionExecutionDelegate next
+    )
+    {
+        if (context.Controller is Controller controller)
+        {
+            var result = _versionCheckService.Get();
+            if (result.UpdateAvailable)
+            {
+                controller.ViewData["VersionUpdate"] = result;
+            }
+        }
+
+        await next();
+    }
+}

--- a/src/Equibles.Web/Models/GitHubRelease.cs
+++ b/src/Equibles.Web/Models/GitHubRelease.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Equibles.Web.Models;
+
+/// <summary>
+/// Minimal projection of the GitHub "latest release" API response
+/// (<c>/repos/{owner}/{repo}/releases/latest</c>).
+/// </summary>
+public class GitHubRelease
+{
+    [JsonProperty("tag_name")]
+    public string TagName { get; set; }
+
+    [JsonProperty("html_url")]
+    public string HtmlUrl { get; set; }
+}

--- a/src/Equibles.Web/Models/VersionCheckResult.cs
+++ b/src/Equibles.Web/Models/VersionCheckResult.cs
@@ -1,0 +1,13 @@
+namespace Equibles.Web.Models;
+
+/// <summary>
+/// Outcome of comparing the running Web portal version against the latest
+/// published GitHub Release. Surfaced to every page via <c>ViewData</c>.
+/// </summary>
+public class VersionCheckResult
+{
+    public string CurrentVersion { get; set; }
+    public string LatestVersion { get; set; }
+    public bool UpdateAvailable { get; set; }
+    public string ReleaseUrl { get; set; }
+}

--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -82,11 +82,15 @@ public partial class Program
             options.LowercaseUrls = true;
         });
 
+        builder.Services.AddHttpClient();
+
         builder.Services.AddScoped<Equibles.Web.Filters.StatusBadgeFilter>();
+        builder.Services.AddScoped<Equibles.Web.Filters.VersionCheckFilter>();
         builder
             .Services.AddControllersWithViews(options =>
             {
                 options.Filters.AddService<Equibles.Web.Filters.StatusBadgeFilter>();
+                options.Filters.AddService<Equibles.Web.Filters.VersionCheckFilter>();
             })
             .AddRazorRuntimeCompilation();
 

--- a/src/Equibles.Web/Services/ChangelogService.cs
+++ b/src/Equibles.Web/Services/ChangelogService.cs
@@ -1,0 +1,35 @@
+using Equibles.Core.AutoWiring;
+using Markdig;
+
+namespace Equibles.Web.Services;
+
+/// <summary>
+/// Reads the bundled CHANGELOG.md and renders it to HTML for the in-app
+/// changelog page. Keeps file I/O and Markdown rendering out of the controller.
+/// </summary>
+[Service]
+public class ChangelogService
+{
+    // Raw HTML is disabled: the CHANGELOG is a trusted repo file, but rendering
+    // it with HTML enabled would be a latent stored-XSS sink.
+    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .DisableHtml()
+        .Build();
+
+    /// <summary>
+    /// Returns the changelog rendered as HTML, or <c>null</c> when the file
+    /// was not shipped with the build (caller falls back to the GitHub copy).
+    /// </summary>
+    public string RenderHtml()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "CHANGELOG.md");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        var markdown = File.ReadAllText(path);
+        return Markdown.ToHtml(markdown, Pipeline);
+    }
+}

--- a/src/Equibles.Web/Services/VersionCheckService.cs
+++ b/src/Equibles.Web/Services/VersionCheckService.cs
@@ -1,0 +1,210 @@
+using System.Reflection;
+using Equibles.Core.AutoWiring;
+using Equibles.Web.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+
+namespace Equibles.Web.Services;
+
+/// <summary>
+/// Checks the running Web portal version against the latest published GitHub
+/// Release. The result is cached in memory and refreshed off the request path
+/// (a request is never blocked on the network) and the check fails silently —
+/// no telemetry is sent and errors are never surfaced to the operator.
+/// </summary>
+[Service(ServiceLifetime.Singleton)]
+public class VersionCheckService
+{
+    private const string ReleaseApiUrl =
+        "https://api.github.com/repos/daniel3303/Equibles/releases/latest";
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(6);
+
+    // After a failed check, retry sooner than the full TTL so a transient
+    // GitHub outage doesn't blind the banner for hours.
+    private static readonly TimeSpan FailureBackoff = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(3);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<VersionCheckService> _logger;
+
+    private volatile VersionCheckResult _cached;
+    private long _cachedAtTicks;
+    private int _refreshing;
+
+    public VersionCheckService(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<VersionCheckService> logger
+    )
+    {
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the last known check result immediately. When the cache is empty
+    /// or stale a background refresh is kicked off and a "no update" result is
+    /// returned meanwhile, so callers never wait on the network.
+    /// </summary>
+    public VersionCheckResult Get()
+    {
+        var current = GetCurrentVersion();
+
+        if (!_configuration.GetValue("CheckForUpdates", true))
+        {
+            return new VersionCheckResult { CurrentVersion = current, UpdateAvailable = false };
+        }
+
+        // Read the timestamp first, then the payload. Writers publish in the
+        // opposite order (payload, then timestamp via Interlocked), so a fresh
+        // timestamp guarantees an at-least-as-fresh payload.
+        var cachedAtTicks = Interlocked.Read(ref _cachedAtTicks);
+        var cached = _cached;
+        if (cached != null && DateTime.UtcNow.Ticks - cachedAtTicks < CacheTtl.Ticks)
+        {
+            return cached;
+        }
+
+        TriggerRefresh();
+        return cached
+            ?? new VersionCheckResult { CurrentVersion = current, UpdateAvailable = false };
+    }
+
+    // Ensures only one outbound GitHub request runs at a time.
+    private void TriggerRefresh()
+    {
+        if (Interlocked.CompareExchange(ref _refreshing, 1, 0) != 0)
+        {
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Refresh();
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _refreshing, 0);
+            }
+        });
+    }
+
+    private async Task Refresh()
+    {
+        var current = GetCurrentVersion();
+        try
+        {
+            var client = _httpClientFactory.CreateClient();
+            client.Timeout = HttpTimeout;
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, ReleaseApiUrl);
+            request.Headers.UserAgent.ParseAdd("Equibles");
+            request.Headers.Accept.ParseAdd("application/vnd.github+json");
+
+            var token = _configuration["GitHubToken"];
+            if (!string.IsNullOrEmpty(token))
+            {
+                request.Headers.Authorization =
+                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+            }
+
+            using var response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync();
+            var release = JsonConvert.DeserializeObject<GitHubRelease>(json);
+            var latest = NormalizeVersion(release?.TagName);
+
+            StoreResult(
+                new VersionCheckResult
+                {
+                    CurrentVersion = current,
+                    LatestVersion = latest,
+                    UpdateAvailable = IsNewer(current, latest),
+                    ReleaseUrl = release?.HtmlUrl,
+                },
+                CacheTtl
+            );
+        }
+        catch (Exception ex)
+        {
+            // Fail silent: never surface update-check failures to the operator.
+            // Keep the last good result if we have one (a transient outage must
+            // not hide a real update) and retry sooner than the full TTL.
+            _logger.LogDebug(ex, "Update check against GitHub Releases failed");
+            var fallback =
+                _cached
+                ?? new VersionCheckResult { CurrentVersion = current, UpdateAvailable = false };
+            StoreResult(fallback, FailureBackoff);
+        }
+    }
+
+    // Publishes the payload first, then the timestamp via Interlocked, so a
+    // reader that observes a fresh timestamp also sees the matching payload.
+    // <paramref name="freshFor"/> controls how long the entry counts as fresh.
+    private void StoreResult(VersionCheckResult result, TimeSpan freshFor)
+    {
+        _cached = result;
+        var effectiveTicks = DateTime.UtcNow.Ticks - (CacheTtl - freshFor).Ticks;
+        Interlocked.Exchange(ref _cachedAtTicks, effectiveTicks);
+    }
+
+    // Compares Major.Minor.Build only so tag formatting variance
+    // (e.g. "v1.0.0" vs an assembly "1.0.0.0") can't trigger a spurious banner.
+    private static bool IsNewer(string current, string latest)
+    {
+        if (
+            !Version.TryParse(NormalizeVersion(current), out var currentVersion)
+            || !Version.TryParse(latest, out var latestVersion)
+        )
+        {
+            return false;
+        }
+
+        static Version ToCore(Version v) => new(v.Major, v.Minor, v.Build < 0 ? 0 : v.Build);
+
+        return ToCore(latestVersion) > ToCore(currentVersion);
+    }
+
+    private static string GetCurrentVersion()
+    {
+        var assembly = typeof(VersionCheckService).Assembly;
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+        if (!string.IsNullOrEmpty(informational))
+        {
+            return NormalizeVersion(informational);
+        }
+
+        return assembly.GetName().Version?.ToString();
+    }
+
+    // Strips a leading "v" and any pre-release/build metadata so the value
+    // parses with System.Version (tags look like "v1.0.0").
+    private static string NormalizeVersion(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var normalized = value.Trim();
+        if (normalized.StartsWith('v') || normalized.StartsWith('V'))
+        {
+            normalized = normalized[1..];
+        }
+
+        var cut = normalized.IndexOfAny(['-', '+']);
+        if (cut >= 0)
+        {
+            normalized = normalized[..cut];
+        }
+
+        return normalized;
+    }
+}

--- a/src/Equibles.Web/ViewModels/ChangelogViewModel.cs
+++ b/src/Equibles.Web/ViewModels/ChangelogViewModel.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Web.ViewModels;
+
+/// <summary>
+/// Backing model for the in-app changelog page: the repo CHANGELOG.md rendered
+/// to HTML.
+/// </summary>
+public class ChangelogViewModel
+{
+    public string Html { get; set; }
+}

--- a/src/Equibles.Web/Views/Changelog/Index.cshtml
+++ b/src/Equibles.Web/Views/Changelog/Index.cshtml
@@ -1,0 +1,32 @@
+@model Equibles.Web.ViewModels.ChangelogViewModel
+@{
+    ViewData["Title"] = "Changelog";
+}
+
+@section Styles {
+    <style>
+        /* Plain CSS (not Tailwind utilities) so the Markdig-rendered CHANGELOG
+           reads well without depending on the typography plugin. */
+        .changelog-content h1 { font-size: 1.875rem; font-weight: 700; margin: 1.5rem 0 1rem; }
+        .changelog-content h2 { font-size: 1.375rem; font-weight: 700; margin: 2rem 0 .75rem; padding-bottom: .3rem; border-bottom: 1px solid var(--color-base-300); }
+        .changelog-content h3 { font-size: 1.05rem; font-weight: 600; margin: 1.25rem 0 .5rem; opacity: .85; }
+        .changelog-content p { margin: .5rem 0; }
+        .changelog-content ul { list-style: disc; padding-left: 1.5rem; margin: .5rem 0; }
+        .changelog-content li { margin: .3rem 0; }
+        .changelog-content a { color: var(--color-info); text-decoration: underline; }
+        .changelog-content code { background: var(--color-base-200); padding: .1rem .35rem; border-radius: .25rem; font-size: .85em; }
+    </style>
+}
+
+<div class="max-w-6xl mx-auto px-6 py-8">
+    <h1 class="text-3xl font-bold mb-2">Changelog</h1>
+    <p class="text-base-content/70 mb-8">
+        All notable changes to Equibles, newest first.
+    </p>
+
+    <div class="card bg-base-100 shadow-sm">
+        <div class="card-body p-6 changelog-content">
+            @Html.Raw(Model.Html)
+        </div>
+    </div>
+</div>

--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -94,6 +94,8 @@
         </div>
     </div>
 
+    <partial name="_VersionBanner" />
+
     <!-- Main Content -->
     <main class="flex-1 relative">
         @body

--- a/src/Equibles.Web/Views/Shared/_VersionBanner.cshtml
+++ b/src/Equibles.Web/Views/Shared/_VersionBanner.cshtml
@@ -1,0 +1,52 @@
+@using Equibles.Web.Models
+@{
+    if (ViewData["VersionUpdate"] is not VersionCheckResult update || !update.UpdateAvailable)
+    {
+        return;
+    }
+}
+
+<div id="version-banner" data-version="@update.LatestVersion" class="hidden bg-info/10 border-b border-info/30">
+    <div class="max-w-6xl mx-auto w-full px-6 py-2.5 flex items-center gap-3 text-sm">
+        <icon name="arrow-up-circle" size="5" class="text-info shrink-0" />
+        <span class="flex-1 text-base-content/80">
+            A new version <b class="text-base-content">@update.LatestVersion</b> is available — you are running
+            <b class="text-base-content">@update.CurrentVersion</b>.
+        </span>
+        <a href="https://github.com/daniel3303/Equibles#updating" target="_blank" rel="noopener"
+           class="btn btn-ghost btn-sm border border-base-300">
+            How to update
+        </a>
+        <a asp-controller="Changelog" asp-action="Index" class="btn btn-ghost btn-sm border border-base-300">
+            View changelog
+        </a>
+        <button type="button" id="version-banner-dismiss" class="btn btn-ghost btn-sm btn-square"
+                title="Dismiss">
+            <icon name="x-mark" size="4" />
+        </button>
+    </div>
+</div>
+
+<script>
+    // Update banner: shown once per browser session unless a newer version
+    // appears. The dismissed version is kept in sessionStorage so it reappears
+    // for a newer release but not on every page navigation.
+    (function () {
+        var banner = document.getElementById('version-banner');
+        if (!banner) return;
+
+        var key = 'equibles-version-dismissed';
+        var version = banner.getAttribute('data-version');
+
+        // Reveal the banner only if this version hasn't been dismissed this session.
+        if (sessionStorage.getItem(key) !== version) {
+            banner.classList.remove('hidden');
+        }
+
+        // Hide and remember the dismissed version for the rest of the session.
+        document.getElementById('version-banner-dismiss').addEventListener('click', function () {
+            banner.classList.add('hidden');
+            sessionStorage.setItem(key, version);
+        });
+    })();
+</script>

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionZeroHoldingsSkipTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionZeroHoldingsSkipTests.cs
@@ -1,0 +1,181 @@
+using System.Globalization;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// GH-749 guard: a NON-amendment 13F-HR whose information table parses to zero
+/// holdings (wrong artifact picked, or a parse failure) must be skipped with
+/// NO side effects — no phantom holding rows AND no ProcessedFiling ledger
+/// entry. Recording it would permanently suppress a filing we never actually
+/// ingested, so the authoritative quarterly bulk import could never backfill
+/// it. Empty-is-legitimate is reserved for amendments only.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsRealtimeIngestionZeroHoldingsSkipTests : IAsyncLifetime
+{
+    private const string Cik = "1067983";
+
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesDbContext> _contexts = [];
+    private readonly CultureInfo _previousCulture;
+
+    public HoldingsRealtimeIngestionZeroHoldingsSkipTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+        _previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        CultureInfo.CurrentCulture = _previousCulture;
+        return Task.CompletedTask;
+    }
+
+    private EquiblesDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesDbContext)).Returns(ctx);
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(InstitutionalHolderRepository))
+                    .Returns(new InstitutionalHolderRepository(ctx));
+                sp.GetService(typeof(InstitutionalHoldingRepository))
+                    .Returns(new InstitutionalHoldingRepository(ctx));
+                sp.GetService(typeof(ProcessedFilingRepository))
+                    .Returns(new ProcessedFilingRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    [Fact]
+    public async Task IngestRecentFilings_NonAmendmentWithNoParseableHoldings_SkippedWithNoSideEffects()
+    {
+        var edgar = Substitute.For<ISecEdgarClient>();
+        edgar
+            .GetDailyIndex(Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+                [
+                    new EdgarDailyIndexEntry
+                    {
+                        FormType = "13F-HR",
+                        CompanyName = "EMPTY FILER",
+                        Cik = Cik,
+                        DateFiled = new DateOnly(2024, 11, 20),
+                        AccessionNumber = "ACC-EMPTY",
+                    },
+                ]
+            );
+        edgar
+            .GetFilingArtifactNames(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(["primary_doc.xml", "infotable.xml"]);
+        edgar
+            .GetDocumentFileBytes(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(ci =>
+            {
+                var file = ci.ArgAt<string>(2);
+                var xml = file.Equals("primary_doc.xml", StringComparison.OrdinalIgnoreCase)
+                    ? """
+                    <edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler">
+                      <headerData><filerInfo><filer><credentials><cik>0001067983</cik></credentials></filer></filerInfo></headerData>
+                      <formData><coverPage>
+                        <reportCalendarOrQuarter>09-30-2024</reportCalendarOrQuarter>
+                        <isAmendment>false</isAmendment>
+                        <filingManager><name>EMPTY FILER</name></filingManager>
+                      </coverPage></formData>
+                    </edgarSubmission>
+                    """
+                    // Well-formed information table with NO infoTable rows.
+                    : """<informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable" />""";
+                return Encoding.UTF8.GetBytes(xml);
+            });
+
+        var scopeFactory = CreateScopeFactory();
+        var prices = Substitute.For<IStockPriceProvider>();
+        prices
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(new Dictionary<(Guid, DateOnly), decimal>()));
+
+        var importService = new HoldingsImportService(
+            scopeFactory,
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            prices
+        );
+        var ingestion = new Realtime13FIngestionService(
+            edgar,
+            new Filing13FXmlParser(),
+            new Realtime13FArchiveBuilder(),
+            importService,
+            scopeFactory,
+            Substitute.For<ILogger<Realtime13FIngestionService>>()
+        );
+
+        var count = await ingestion.IngestRecentFilings(
+            new DateOnly(2024, 11, 25),
+            1,
+            new DateOnly(2024, 1, 1),
+            CancellationToken.None
+        );
+
+        count.Should().Be(0);
+
+        using var verify = FreshContext();
+        (await verify.Set<InstitutionalHolding>().AnyAsync()).Should().BeFalse();
+        // Not recorded: a skipped filing must remain eligible for the
+        // authoritative quarterly bulk import to backfill later.
+        (await verify.Set<ProcessedFiling>().AnyAsync(p => p.AccessionNumber == "ACC-EMPTY"))
+            .Should()
+            .BeFalse();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Web/VersionCheckFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/VersionCheckFilterTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Text;
+using Equibles.Web.Filters;
+using Equibles.Web.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Web;
+
+public class VersionCheckFilterTests
+{
+    private class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _json;
+
+        public StubHttpMessageHandler(string json) => _json = json;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_json, Encoding.UTF8, "application/json"),
+                }
+            );
+    }
+
+    private static VersionCheckService CreateService(string json, bool checkForUpdates)
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory
+            .CreateClient(Arg.Any<string>())
+            .Returns(_ => new HttpClient(new StubHttpMessageHandler(json), disposeHandler: false));
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string>
+                {
+                    ["CheckForUpdates"] = checkForUpdates ? "true" : "false",
+                }
+            )
+            .Build();
+
+        return new VersionCheckService(
+            factory,
+            configuration,
+            Substitute.For<ILogger<VersionCheckService>>()
+        );
+    }
+
+    private static (ActionExecutingContext context, bool[] nextCalled) CreateActionContext()
+    {
+        var actionContext = new ActionContext(
+            new DefaultHttpContext(),
+            new RouteData(),
+            new ActionDescriptor(),
+            new ModelStateDictionary()
+        );
+        var executingContext = new ActionExecutingContext(
+            actionContext,
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object>(),
+            new FakeController()
+        );
+        return (executingContext, new[] { false });
+    }
+
+    private static ActionExecutionDelegate Next(bool[] called, ActionExecutingContext ctx) =>
+        () =>
+        {
+            called[0] = true;
+            return Task.FromResult(
+                new ActionExecutedContext(ctx, new List<IFilterMetadata>(), ctx.Controller)
+            );
+        };
+
+    [Fact]
+    public async Task OnActionExecution_NoUpdate_DoesNotSetViewDataButCallsNext()
+    {
+        var sut = new VersionCheckFilter(CreateService("{}", checkForUpdates: false));
+        var (context, nextCalled) = CreateActionContext();
+
+        await sut.OnActionExecutionAsync(context, Next(nextCalled, context));
+
+        var controller = Assert.IsType<FakeController>(context.Controller);
+        Assert.False(controller.ViewData.ContainsKey("VersionUpdate"));
+        Assert.True(nextCalled[0]);
+    }
+
+    [Fact]
+    public async Task OnActionExecution_UpdateAvailable_SetsViewData()
+    {
+        var service = CreateService("{\"tag_name\":\"v99.0.0\"}", checkForUpdates: true);
+
+        // Prime the cache via the service's background refresh.
+        for (var i = 0; i < 100 && service.Get().LatestVersion == null; i++)
+        {
+            await Task.Delay(20);
+        }
+
+        var sut = new VersionCheckFilter(service);
+        var (context, nextCalled) = CreateActionContext();
+
+        await sut.OnActionExecutionAsync(context, Next(nextCalled, context));
+
+        var controller = Assert.IsType<FakeController>(context.Controller);
+        Assert.True(controller.ViewData.ContainsKey("VersionUpdate"));
+        Assert.True(nextCalled[0]);
+    }
+
+    private class FakeController : Controller { }
+}

--- a/tests/Equibles.IntegrationTests/Web/VersionCheckServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/VersionCheckServiceTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Text;
+using Equibles.Web.Models;
+using Equibles.Web.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Web;
+
+public class VersionCheckServiceTests
+{
+    // Replays a canned GitHub "latest release" response without touching the network.
+    private class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _json;
+        private readonly HttpStatusCode _status;
+        public int Calls { get; private set; }
+
+        public StubHttpMessageHandler(string json, HttpStatusCode status = HttpStatusCode.OK)
+        {
+            _json = json;
+            _status = status;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            Calls++;
+            return Task.FromResult(
+                new HttpResponseMessage(_status)
+                {
+                    Content = new StringContent(_json, Encoding.UTF8, "application/json"),
+                }
+            );
+        }
+    }
+
+    private static VersionCheckService CreateService(
+        StubHttpMessageHandler handler,
+        bool checkForUpdates = true
+    )
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory
+            .CreateClient(Arg.Any<string>())
+            .Returns(_ => new HttpClient(handler, disposeHandler: false));
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string>
+                {
+                    ["CheckForUpdates"] = checkForUpdates ? "true" : "false",
+                }
+            )
+            .Build();
+
+        return new VersionCheckService(
+            factory,
+            configuration,
+            Substitute.For<ILogger<VersionCheckService>>()
+        );
+    }
+
+    // Polls Get() until the background refresh has populated the cache.
+    private static async Task<VersionCheckResult> WaitForRefresh(VersionCheckService sut)
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var result = sut.Get();
+            if (result.LatestVersion != null)
+            {
+                return result;
+            }
+
+            await Task.Delay(20);
+        }
+
+        return sut.Get();
+    }
+
+    [Fact]
+    public void Get_CheckForUpdatesDisabled_ReturnsNoUpdateWithoutHttpCall()
+    {
+        var handler = new StubHttpMessageHandler("{}");
+        var sut = CreateService(handler, checkForUpdates: false);
+
+        var result = sut.Get();
+
+        Assert.False(result.UpdateAvailable);
+        Assert.False(string.IsNullOrEmpty(result.CurrentVersion));
+        Assert.Equal(0, handler.Calls);
+    }
+
+    [Fact]
+    public void Get_ColdCache_ReturnsImmediatelyWithoutBlocking()
+    {
+        var handler = new StubHttpMessageHandler("{\"tag_name\":\"v99.0.0\"}");
+        var sut = CreateService(handler);
+
+        var result = sut.Get();
+
+        // First call must not wait on the background refresh.
+        Assert.False(result.UpdateAvailable);
+        Assert.Null(result.LatestVersion);
+    }
+
+    [Fact]
+    public async Task Get_NewerReleaseAvailable_ReportsUpdate()
+    {
+        var handler = new StubHttpMessageHandler(
+            "{\"tag_name\":\"v99.0.0\",\"html_url\":\"https://github.com/daniel3303/Equibles/releases/tag/v99.0.0\"}"
+        );
+        var sut = CreateService(handler);
+
+        var result = await WaitForRefresh(sut);
+
+        Assert.True(result.UpdateAvailable);
+        Assert.Equal("99.0.0", result.LatestVersion);
+        Assert.Equal("1.0.0", result.CurrentVersion);
+        Assert.Equal(
+            "https://github.com/daniel3303/Equibles/releases/tag/v99.0.0",
+            result.ReleaseUrl
+        );
+    }
+
+    [Fact]
+    public async Task Get_SameVersion_DoesNotReportUpdate()
+    {
+        var handler = new StubHttpMessageHandler("{\"tag_name\":\"v1.0.0\"}");
+        var sut = CreateService(handler);
+
+        var result = await WaitForRefresh(sut);
+
+        Assert.False(result.UpdateAvailable);
+        Assert.Equal("1.0.0", result.LatestVersion);
+    }
+
+    [Fact]
+    public async Task Get_FourSegmentSameVersionTag_DoesNotReportSpuriousUpdate()
+    {
+        // Regression: "v1.0.0.0" must not compare as newer than assembly "1.0.0".
+        var handler = new StubHttpMessageHandler("{\"tag_name\":\"v1.0.0.0\"}");
+        var sut = CreateService(handler);
+
+        var result = await WaitForRefresh(sut);
+
+        Assert.False(result.UpdateAvailable);
+    }
+
+    [Fact]
+    public void Get_GitHubUnreachable_FailsSilentWithNoUpdate()
+    {
+        var handler = new StubHttpMessageHandler("nope", HttpStatusCode.InternalServerError);
+        var sut = CreateService(handler);
+
+        // Cold call returns immediately; the failed background refresh must not throw.
+        var result = sut.Get();
+
+        Assert.False(result.UpdateAvailable);
+    }
+}


### PR DESCRIPTION
## Summary

- Self-hosted operators had no way to learn a newer release exists. The Web portal now checks the latest GitHub Release and shows a dismissible top banner (new vs current version) when behind. Closes #806.
- A new `CHECK_FOR_UPDATES` env var (default `true` when unset) gates the whole feature; the check is cached (6h, 15m failure backoff), runs off the request path, and fails silently — no telemetry.
- Includes a README "Updating" guide, an in-app Markdig-rendered changelog page, and 8 unit tests.

## Code changes

- `Services/VersionCheckService.cs` — singleton; polls `releases/latest`, atomic cache publication, single-flight refresh, Major.Minor.Build comparison, fail-silent with short backoff.
- `Filters/VersionCheckFilter.cs` — exposes the result to every view via `ViewData` (mirrors `StatusBadgeFilter`); registered in `Program.cs` alongside `AddHttpClient()`.
- `Services/ChangelogService.cs` + `Controllers/ChangelogController.cs` + `Views/Changelog/Index.cshtml` — in-app changelog rendered from bundled `CHANGELOG.md` with raw HTML disabled; GitHub fallback if absent.
- `Views/Shared/_VersionBanner.cshtml` + `_Layout.cshtml` — DaisyUI banner under the navbar, session-scoped dismissal.
- `Models/{VersionCheckResult,GitHubRelease}.cs`, `ViewModels/ChangelogViewModel.cs` — DTOs/view model.
- `Equibles.Web.csproj` — `<Version>1.0.0</Version>` (bump per release) + `CHANGELOG.md` content; `Dockerfile` copies `CHANGELOG.md` into the build.
- `docker-compose.yml`, `.env.example`, `README.md`, `CHANGELOG.md` — `CHECK_FOR_UPDATES` wiring + docs.
- `tests/.../VersionCheckServiceTests.cs`, `VersionCheckFilterTests.cs` — 8 hermetic tests (disabled-gate, cold-cache non-blocking, newer/equal/4-segment-tag comparison, fail-silent, filter ViewData).