### PR TITLE
test(holdings): add skipped repro for GH-810 — Holdings13FRealtimeWorker.ValidateConfiguration

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerTests.cs
@@ -1,0 +1,52 @@
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Holdings.HostedService;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Holdings13FRealtimeWorkerTests
+{
+    [Fact(Skip = "GH-810 — whitespace-only Sec:ContactEmail wrongly passes ValidateConfiguration")]
+    public void ValidateConfiguration_SecContactEmailWhitespaceOnly_ReturnsFalse()
+    {
+        // Contract (from the worker's own warning + the SEC EDGAR User-Agent rule it
+        // guards): the worker must stop when the contact email is "not configured".
+        // A whitespace-only value (e.g. `SEC_CONTACT_EMAIL= ` in .env) is not a usable
+        // contact — SEC silently 403s a blank contact — so it must be treated as
+        // unconfigured and return false, exactly like an empty value.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { ["Sec:ContactEmail"] = "   " })
+            .Build();
+        var sut = new TestableHoldings13FRealtimeWorker(
+            Substitute.For<ILogger<Holdings13FRealtimeWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions()),
+            config
+        );
+
+        sut.InvokeValidateConfiguration().Should().BeFalse();
+    }
+
+    private sealed class TestableHoldings13FRealtimeWorker : Holdings13FRealtimeWorker
+    {
+        public TestableHoldings13FRealtimeWorker(
+            ILogger<Holdings13FRealtimeWorker> logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            IOptions<WorkerOptions> workerOptions,
+            IConfiguration configuration
+        )
+            : base(logger, scopeFactory, errorReporter, workerOptions, configuration) { }
+
+        public bool InvokeValidateConfiguration() => ValidateConfiguration();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for the zero-coverage `Holdings13FRealtimeWorker.ValidateConfiguration` startup guard. It **discovered a real bug** (GH-810): a whitespace-only `Sec:ContactEmail` passes the guard because the check is `string.IsNullOrEmpty` rather than `IsNullOrWhiteSpace`, so the worker runs with an effectively-blank SEC User-Agent contact and is silently 403'd every cycle.
- Per the add-test workflow, the test is committed **skipped** — un-skip it as part of the GH-810 fix. No production code is changed here.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerTests.cs` — new test, `[Fact(Skip = "GH-810 ...")]` (skipped — see GH-810). Feeds `Sec:ContactEmail = "   "` and asserts `ValidateConfiguration()` returns `false` (currently returns `true` → the bug).