### PR TITLE
test(congress): pin ParseTransactionLines 'S (full)' classifies as Sale

### DIFF
--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientParseTransactionLinesFullSaleTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientParseTransactionLinesFullSaleTests.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Congress.HostedService.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Adversarial sibling to <see cref="HouseDisclosureClientParseTransactionLinesTests"/>,
+/// which exercises only the <c>S (partial)</c> sale variant. The House PTR
+/// contract documented on ExtractTransactionType enumerates four codes —
+/// P, S, S (partial), and <b>S (full)</b>. A full-sale line must classify as
+/// Sale, not be dropped: silently losing every "S (full)" disclosure would
+/// under-report members liquidating entire positions.
+/// </summary>
+public class HouseDisclosureClientParseTransactionLinesFullSaleTests
+{
+    [Fact]
+    public void ParseTransactionLines_FullSaleTypeCode_ClassifiesAsSale()
+    {
+        var client = new HouseDisclosureClient(
+            new HttpClient(),
+            Substitute.For<ILogger<HouseDisclosureClient>>()
+        );
+
+        var filingType = typeof(HouseDisclosureClient).GetNestedType(
+            "HouseFiling",
+            BindingFlags.NonPublic
+        );
+        var filing = Activator.CreateInstance(
+            filingType,
+            "Jane Smith",
+            "20012345",
+            new DateOnly(2025, 2, 14),
+            "CA01"
+        );
+
+        var lines = new[]
+        {
+            "JT Nvidia Corp (NVDA) S (full) 02/10/2025 02/14/2025 $15,001 - $50,000",
+        };
+
+        var method = typeof(HouseDisclosureClient).GetMethod(
+            "ParseTransactionLines",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var result = (List<DisclosureTransaction>)method.Invoke(client, [lines, filing]);
+
+        result.Should().ContainSingle("the S (full) line is well-formed and must not be dropped");
+        var sale = result.Single();
+        sale.TransactionType.Should().Be(CongressTransactionType.Sale);
+        sale.Ticker.Should().Be("NVDA");
+        sale.OwnerType.Should().Be("JT");
+        sale.TransactionDate.Should().Be(new DateOnly(2025, 2, 10));
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `HouseDisclosureClient.ParseTransactionLines`. The existing sibling test only covers the `S (partial)` sale variant; ExtractTransactionType's documented contract enumerates four House PTR codes — P, S, S (partial), **S (full)** — and the `(full)` regex alternation was uncovered.
- Oracle from the contract: a well-formed `S (full)` line must classify as a Sale (not be dropped) — silently losing full-sale rows would under-report members liquidating entire positions. Test passes; behavior locked.

## Code changes

- `tests/Equibles.UnitTests/Congress/HouseDisclosureClientParseTransactionLinesFullSaleTests.cs` — new test; invokes the private `ParseTransactionLines` via reflection (mirroring the established sibling pattern) with an `S (full)` House-PTR line and asserts a single `CongressTransactionType.Sale` with the right ticker/owner/date.