### PR TITLE
test(web): pin NormalizeVersion handles SemVer pre-release tags

### DIFF
--- a/tests/Equibles.UnitTests/Web/VersionCheckServiceNormalizeVersionTests.cs
+++ b/tests/Equibles.UnitTests/Web/VersionCheckServiceNormalizeVersionTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Equibles.Web.Services;
+using Xunit;
+
+namespace Equibles.UnitTests.Web;
+
+/// <summary>
+/// NormalizeVersion's documented contract: "Strips a leading 'v' and any
+/// pre-release/build metadata so the value parses with System.Version."
+/// GitHub release tags are routinely SemVer pre-releases (e.g. "v2.1.0-rc.1");
+/// if the metadata isn't cut, System.Version.TryParse fails and IsNewer
+/// silently returns false — the update banner would never appear for any
+/// release cut from a pre-release tag. Existing tests only feed plain tags.
+/// </summary>
+public class VersionCheckServiceNormalizeVersionTests
+{
+    [Fact]
+    public void NormalizeVersion_SemVerPreReleaseTag_ProducesAVersionParseableCoreVersion()
+    {
+        var method = typeof(VersionCheckService).GetMethod(
+            "NormalizeVersion",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var normalized = (string)method.Invoke(null, ["v2.1.0-rc.1"]);
+
+        // The contract is "so the value parses with System.Version" — assert the
+        // promise, not the literal string.
+        Version.TryParse(normalized, out var parsed).Should().BeTrue();
+        parsed.Should().Be(new Version(2, 1, 0));
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `VersionCheckService.NormalizeVersion` (new code from PR #809, 78% covered). Existing tests only feed plain tags (`v99.0.0`, `v1.0.0.0`); the `IndexOfAny(['-','+'])` pre-release/build-metadata cut was uncovered.
- Oracle from the doc-comment ("so the value parses with System.Version"): a GitHub SemVer pre-release tag like `v2.1.0-rc.1` must normalize to a `System.Version`-parseable core (`2.1.0`). If metadata weren't cut, `Version.TryParse` fails and the update banner would never show for any release cut from a pre-release tag. Test passes; behavior locked.

## Code changes

- `tests/Equibles.UnitTests/Web/VersionCheckServiceNormalizeVersionTests.cs` — new test; invokes the private static `NormalizeVersion` via reflection with `v2.1.0-rc.1` and asserts the result is `Version`-parseable and equals `2.1.0`.