### PR TITLE
test(sec): pin IsPartHeading discriminates PART headings from PART-prefixed words

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+/// <summary>
+/// IsPartHeading classifies SEC 10-K "PART" section headings. The Execute-level
+/// test only covers the positive "PART I" path and is confounded by the
+/// all-uppercase rule. This isolates the discriminator: a canonical part
+/// heading is recognised, but a word merely prefixed "Part" (Participants,
+/// Partnership…) must NOT be — the trailing space in StartsWith("PART ") is the
+/// only thing preventing every such word from being mis-tagged as a heading.
+/// </summary>
+public class HeadingConversionStepIsPartHeadingTests
+{
+    [Fact]
+    public void IsPartHeading_AcceptsCanonicalPartButRejectsPartPrefixedWord()
+    {
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "IsPartHeading",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var step = new HeadingConversionStep();
+
+        var canonical = (bool)method.Invoke(step, ["Part IV"]);
+        var prefixedWord = (bool)method.Invoke(step, ["Participants"]);
+
+        canonical.Should().BeTrue("'Part IV' is a canonical SEC 10-K section heading");
+        prefixedWord
+            .Should()
+            .BeFalse("'Participants' merely starts with 'Part' and is not a section heading");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `HeadingConversionStep.IsPartHeading`. The existing Execute-level test only covers the positive `PART I` path and is confounded by the all-uppercase rule; the discriminator's false-positive defense was uncovered.
- Oracle from the contract: a canonical SEC heading (`Part IV`) is recognised, but a word merely prefixed `Part` (`Participants`) must not be — the trailing space in `StartsWith("PART ")` is the only guard against mis-tagging every such word as a heading. Test passes; behavior locked.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingTests.cs` — new test; invokes the private `IsPartHeading` via reflection (isolating it from the confounded Execute path) and asserts `Part IV` → true, `Participants` → false.