### PR TITLE
fix(holdings): don't permanently skip a 13F data set when no tracked CUSIPs map yet (GH-817)

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -62,8 +62,16 @@ public class HoldingsImportService
         var submissionCount = context.Submissions.Count;
         if (!await ParseCoverPages(context, cancellationToken))
             return new ImportResult(submissionCount, IsComplete: false);
-        if (!await BuildCusipMapping(context, cancellationToken))
+        var cusipResult = await BuildCusipMapping(context, cancellationToken);
+        if (cusipResult == CusipMappingOutcome.NoInfoTable)
+            // Structural: a missing INFOTABLE.tsv won't appear on re-download —
+            // terminal, mark processed so we don't loop on a broken archive.
             return new ImportResult(submissionCount, IsComplete: true);
+        if (cusipResult == CusipMappingOutcome.NoTrackedStocks)
+            // No tracked stock mapped — typically a cold start where the FTD
+            // scraper hasn't seeded CUSIPs yet. NOT terminal: leave the data
+            // set unprocessed so a later cycle backfills it once CUSIPs exist.
+            return new ImportResult(submissionCount, IsComplete: false);
         await BuildPriceMap(context, cancellationToken);
         await ParseOtherManagers(context, cancellationToken);
         await UpsertInstitutionalHolders(context, cancellationToken);
@@ -201,7 +209,17 @@ public class HoldingsImportService
         return true;
     }
 
-    private async Task<bool> BuildCusipMapping(
+    // Distinguishes a terminal structural failure (missing INFOTABLE) from a
+    // recoverable "no tracked CUSIPs yet" so the caller can decide whether the
+    // data set is permanently done or should be retried on a later cycle.
+    private enum CusipMappingOutcome
+    {
+        Mapped,
+        NoInfoTable,
+        NoTrackedStocks,
+    }
+
+    private async Task<CusipMappingOutcome> BuildCusipMapping(
         ImportContext context,
         CancellationToken cancellationToken
     )
@@ -210,7 +228,7 @@ public class HoldingsImportService
         if (infoTableEntry == null)
         {
             _logger.LogWarning("INFOTABLE.tsv not found in archive");
-            return false;
+            return CusipMappingOutcome.NoInfoTable;
         }
 
         var uniqueCusips = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -257,12 +275,14 @@ public class HoldingsImportService
 
         if (cusipMapping.Count == 0)
         {
-            _logger.LogInformation("No tracked stocks found for this data set, skipping");
-            return false;
+            _logger.LogInformation(
+                "No tracked stocks mapped for this data set (CUSIPs may not be seeded yet) — will retry on a later cycle"
+            );
+            return CusipMappingOutcome.NoTrackedStocks;
         }
 
         context.CusipMapping = cusipMapping;
-        return true;
+        return CusipMappingOutcome.Mapped;
     }
 
     /// <summary>

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
@@ -214,6 +214,51 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
         holder.City.Should().Be("Omaha");
     }
 
+    // ── Cold-start CUSIP race (GH-817) ─────────────────────────────────
+
+    [Fact]
+    public async Task ImportDataSet_NoTrackedStockHasMatchingCusip_IsNotComplete_SoDataSetIsRetriedNotMarkedProcessed()
+    {
+        // GH-817: on a cold start the FTD scraper hasn't seeded CUSIPs yet, so
+        // no tracked CommonStock has a Cusip and BuildCusipMapping maps nothing.
+        // That must NOT be reported as a completed import — otherwise the
+        // worker marks the data set processed and never backfills it once
+        // CUSIPs are seeded. Contract: submissions still parse (SubmissionCount
+        // > 0) but IsComplete is false, and nothing is persisted.
+        // No CommonStock is seeded here (mirrors the cold-start DB state).
+        var submission =
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+            + "13F-HR\tACC-777\t2026-05-15\t2026-03-31\t0001067983\n";
+        var coverPage =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+            + "ACC-777\tN\tBerkshire Hathaway\tOmaha\tNE\t028-12345\t12345\n";
+        var infoTable =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n"
+            + "ACC-777\t037833100\t1000\tSH\t\tSOLE\t1000\t0\t0\tCOM\t\n";
+
+        using var archive = BuildArchive(
+            ("SUBMISSION.tsv", submission),
+            ("COVERPAGE.tsv", coverPage),
+            ("INFOTABLE.tsv", infoTable)
+        );
+
+        var sut = CreateImporter(
+            PriceProviderReturning(new Dictionary<(Guid, DateOnly), decimal>())
+        );
+
+        var result = await sut.ImportDataSet(
+            archive,
+            new DateOnly(2025, 1, 1),
+            CancellationToken.None
+        );
+
+        result.SubmissionCount.Should().Be(1);
+        result.IsComplete.Should().BeFalse();
+
+        using var verify = FreshContext();
+        (await verify.Set<InstitutionalHolding>().CountAsync()).Should().Be(0);
+    }
+
     // ── Price missing ──────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
Closes #817.

## Summary

Found while running the pipeline end-to-end for AAPL: the quarterly 13F bulk import processed `01dec2025-28feb2026_form13f.zip` (8943 submissions) but stored **0** `InstitutionalHolding` and locked itself out of ever retrying.

`HoldingsImportService.BuildCusipMapping` returned `false` for two unrelated reasons — missing `INFOTABLE.tsv` (structural) **and** zero tracked-CUSIP matches (cold start: the FTD scraper hadn't seeded `CommonStock.Cusip` yet). `ImportDataSet` collapsed both into `IsComplete: true`, so `HoldingsScraperWorker` called `MarkAsProcessed` and every later cycle skipped the data set via `IsAlreadyProcessed` — no backfill even after CUSIPs were seeded.

## Code changes

- `HoldingsImportService` — `BuildCusipMapping` now returns a `CusipMappingOutcome` (`Mapped` / `NoInfoTable` / `NoTrackedStocks`). `ImportDataSet` keeps `IsComplete: true` only for the terminal structural case (`NoInfoTable` — re-download won't help); `NoTrackedStocks` now returns `IsComplete: false` so the data set is left unprocessed and retried on a later cycle once CUSIPs exist.
- `HoldingsImportServiceFullPipelineTests` — added a ParadeDB-backed test: submissions parse but no tracked stock has the CUSIP ⇒ `SubmissionCount=1`, `IsComplete=false`, nothing persisted. Happy-path test still asserts `IsComplete=true` (Mapped path unchanged).

Verified locally: all 9 FullPipeline tests pass.