### PR TITLE
test(sec): add skipped repro for GH-820 — EmbeddingClient drops empty embeddings

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/EmbeddingClientEmptyEmbeddingAlignmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/EmbeddingClientEmptyEmbeddingAlignmentTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using System.Text;
+using Equibles.Sec.BusinessLogic.Embeddings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Adversarial sibling to <see cref="EmbeddingClientMultiTextBatchTests"/>.
+/// Contract (from the only caller, DocumentProcessor.GenerateEmbeddingsForChunks):
+/// it guards with <c>if (embeddings.Count != chunks.Count) throw</c> and then
+/// indexes <c>embeddings[i]</c> against <c>chunks[i]</c> — so GenerateEmbeddings
+/// must return one entry per input text, positionally aligned. A text whose
+/// vector cannot be produced must keep its slot; silently dropping it shifts
+/// every later vector onto the wrong chunk and trips the count guard, killing
+/// embedding generation for the whole document.
+/// </summary>
+public class EmbeddingClientEmptyEmbeddingAlignmentTests
+{
+    [Fact(
+        Skip = "GH-820 — EmbeddingClient.GenerateEmbeddings silently drops empty embeddings, "
+            + "breaking positional alignment with chunks"
+    )]
+    public async Task GenerateEmbeddings_OneTextReturnsEmptyEmbedding_StaysPositionallyAlignedToInputs()
+    {
+        // Ollama answers 200 but with no vector for the 2nd input (degenerate
+        // model output). Per the caller's contract the result must still have
+        // one entry per input, in order — never silently shrink/misalign.
+        var handler = new SequencedHandler(
+            "{\"model\":\"nomic-embed-text\",\"embeddings\":[[0.1,0.2]]}",
+            "{\"model\":\"nomic-embed-text\",\"embeddings\":[]}"
+        );
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(handler));
+
+        var sut = new EmbeddingClient(
+            factory,
+            Options.Create(
+                new EmbeddingConfig
+                {
+                    Enabled = true,
+                    BaseUrl = "http://ollama.test",
+                    ModelName = "nomic-embed-text",
+                    BatchSize = 10,
+                }
+            ),
+            Substitute.For<ILogger<EmbeddingClient>>()
+        );
+
+        var vectors = await sut.GenerateEmbeddings(["first chunk", "second chunk"]);
+
+        vectors.Should().HaveCount(2);
+        vectors[0].Should().Equal(0.1f, 0.2f);
+    }
+
+    private sealed class SequencedHandler : HttpMessageHandler
+    {
+        private readonly Queue<string> _bodies;
+
+        public SequencedHandler(params string[] bodies) => _bodies = new Queue<string>(bodies);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var body = _bodies.Dequeue();
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/json"),
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for the embedding service: it asserts `EmbeddingClient.GenerateEmbeddings` stays positionally aligned to its inputs when one text's embedding comes back empty.
- The test **fails against current `main`** — it discovered a real bug (filed as GH-820), so it ships `[Skip]`-ped until production is fixed.
- The bug is the exact failure mode the pending PR #744 targets: one empty/degenerate embedding silently shrinks the result, trips `DocumentProcessor`'s count guard, and kills embedding generation for the whole document.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/EmbeddingClientEmptyEmbeddingAlignmentTests.cs` — new single-`[Fact]` test, skipped — see GH-820. Stubs the Ollama HTTP client so the 2nd of two texts returns `200 {"embeddings":[]}`, then asserts the returned list has one entry per input (Count == 2) with `[0]` aligned to the first text. Contract derived from the only caller, `DocumentProcessor.GenerateEmbeddingsForChunks`, which guards on `embeddings.Count != chunks.Count` and indexes `embeddings[i]` against `chunks[i]`.

Resolution: un-skip this test as part of the GH-820 / PR #744 fix. No production code modified.