### PR TITLE
test(cftc): pin SplitCsvLine quoted-comma is value not delimiter

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineEmbeddedCommaTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineEmbeddedCommaTests.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+using Equibles.Integrations.Cftc;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CftcClientSplitCsvLineEmbeddedCommaTests
+{
+    private static readonly MethodInfo SplitCsvLineMethod = typeof(CftcClient).GetMethod(
+        "SplitCsvLine",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    [Fact]
+    public void SplitCsvLine_CommaInsideQuotedField_IsTreatedAsValueNotDelimiter()
+    {
+        // Contract (doc-comment: comma-separated values with quoted fields,
+        // RFC 4180): a comma inside a quoted field is part of the value, not a
+        // field separator. The existing pins cover escaped quotes and leading
+        // padding but never a quoted comma — the defining property of CSV.
+        var line = "123, \"Hello, World\" ,456";
+
+        var fields = (string[])SplitCsvLineMethod.Invoke(null, [line]);
+
+        fields.Should().Equal("123", "Hello, World", "456");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `CftcClient.SplitCsvLine`. Existing pins cover escaped quotes and leading padding but never the defining CSV property: a comma inside a quoted field is part of the value, not a separator.
- Oracle from the doc-comment (comma-separated values with quoted fields, RFC 4180): `123, "Hello, World" ,456` must split into exactly `["123", "Hello, World", "456"]`. Test passes; behavior locked.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineEmbeddedCommaTests.cs` — new test; invokes the private static `SplitCsvLine` via reflection (mirroring the sibling pins) with a quoted field containing a comma + CFTC-style padding.