### PR TITLE
test(sec): pin ParseCompaniesFromResponse multi-ticker CIK grouping

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientParseCompaniesMultiTickerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientParseCompaniesMultiTickerTests.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Reflection;
+using Equibles.Integrations.Sec;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Adversarial sibling to <see cref="SecEdgarClientParseCompaniesFromResponseTests"/>,
+/// which only covers the skip guards. The documented grouping contract — "the
+/// SEC file has one row per ticker … companies with multiple tickers appear as
+/// multiple rows. The first ticker per CIK is the primary" — is unexercised.
+/// A regression that emitted one CompanyInfo per row would create duplicate
+/// stocks for every dual-class issuer (GOOGL/GOOG, BRK.A/BRK.B) downstream.
+/// </summary>
+public class SecEdgarClientParseCompaniesMultiTickerTests
+{
+    private static readonly MethodInfo ParseCompaniesFromResponseMethod =
+        typeof(SecEdgarClient).GetMethod(
+            "ParseCompaniesFromResponse",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    [Fact]
+    public void ParseCompaniesFromResponse_SameCikMultipleTickerRows_CollapsedToOneCompanyFirstTickerPrimary()
+    {
+        var responseType = typeof(SecEdgarClient).Assembly.GetType(
+            "Equibles.Integrations.Sec.Models.Responses.CompanyTickersResponse"
+        );
+        var response = Activator.CreateInstance(responseType);
+        responseType
+            .GetProperty("Fields")!
+            .SetValue(response, new List<string> { "cik", "name", "ticker", "exchange" });
+        responseType
+            .GetProperty("Data")!
+            .SetValue(
+                response,
+                new List<List<object>>
+                {
+                    new() { "0001652044", "Alphabet Inc.", "GOOGL", "Nasdaq" },
+                    new() { "0001652044", "Alphabet Inc.", "GOOG", "Nasdaq" },
+                    new() { "0000789019", "Microsoft Corp", "MSFT", "Nasdaq" },
+                }
+            );
+
+        var result = (IEnumerable)ParseCompaniesFromResponseMethod.Invoke(null, [response]);
+        var companies = result.Cast<CompanyInfo>().ToList();
+
+        companies.Should().HaveCount(2, "the two GOOGL/GOOG rows are one company");
+        var alphabet = companies.Single(c => c.Cik == "0001652044");
+        // Order preserved: the first row's ticker is the primary.
+        alphabet.Tickers.Should().Equal("GOOGL", "GOOG");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `SecEdgarClient.ParseCompaniesFromResponse`. The existing sibling only covers the skip guards; the documented grouping contract ("one row per ticker … companies with multiple tickers appear as multiple rows. The first ticker per CIK is the primary") was uncovered.
- Oracle from the in-code contract: two rows with the same CIK (GOOGL then GOOG) must collapse into one `CompanyInfo` with `Tickers == [GOOGL, GOOG]`. A regression emitting one company per row would create duplicate stocks for every dual-class issuer. Test passes; behavior locked.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecEdgarClientParseCompaniesMultiTickerTests.cs` — new test; reflection-invokes the private static `ParseCompaniesFromResponse` (mirroring the sibling pin) with two same-CIK rows + one unrelated company, asserts 2 companies and order-preserved ticker grouping.