### PR TITLE
test(sec): add skipped repro for GH-828 — DocumentProcessor aborts batch on one doc failure

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorPerDocumentIsolationTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorPerDocumentIsolationTests.cs
@@ -1,0 +1,67 @@
+using Equibles.Sec.BusinessLogic.Embeddings;
+using Equibles.Sec.BusinessLogic.Processing;
+using Equibles.Sec.BusinessLogic.Tokenization;
+using Equibles.Sec.Data.Models.Chunks;
+using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Adversarial sibling to <see cref="DocumentProcessorGenerateEmbeddingsTests"/>.
+/// Contract (PR #744 intent + the per-document try/catch in GenerateEmbeddings):
+/// chunks are grouped per document and a failure embedding one document must be
+/// isolated — the remaining documents must still be embedded, never aborted by
+/// the first failure. One bad document must not kill the whole batch/worker.
+/// </summary>
+public class DocumentProcessorPerDocumentIsolationTests
+{
+    [Fact(
+        Skip = "GH-828 — DocumentProcessor.GenerateEmbeddings rethrows on one document's "
+            + "failure, aborting embeddings for all remaining documents"
+    )]
+    public async Task GenerateEmbeddings_FirstDocumentFails_StillEmbedsTheSecondDocument()
+    {
+        var docA = Guid.NewGuid();
+        var docB = Guid.NewGuid();
+        var chunks = new List<Chunk>
+        {
+            new() { DocumentId = docA, Content = "doc-a-content" },
+            new() { DocumentId = docB, Content = "doc-b-content" },
+        };
+
+        var embeddingClient = Substitute.For<IEmbeddingClient>();
+        embeddingClient
+            .GenerateEmbeddings(Arg.Is<List<string>>(l => l.Contains("doc-a-content")))
+            .Returns(Task.FromException<List<float[]>>(new HttpRequestException("server down")));
+        embeddingClient
+            .GenerateEmbeddings(Arg.Is<List<string>>(l => l.Contains("doc-b-content")))
+            .Returns(new List<float[]> { new float[] { 0.1f, 0.2f } });
+
+        var embeddingRepository = Substitute.For<EmbeddingRepository>(
+            (Equibles.Data.EquiblesDbContext)null
+        );
+        var sut = new DocumentProcessor(
+            Substitute.For<ChunkRepository>((Equibles.Data.EquiblesDbContext)null),
+            embeddingRepository,
+            embeddingClient,
+            new ChunkingStrategy(new TokenCounter()),
+            Options.Create(new EmbeddingConfig { ModelName = "nomic-embed-text" }),
+            Substitute.For<ILogger<DocumentProcessor>>()
+        );
+
+        // doc A's failure must be isolated; the call must complete and doc B
+        // must still be embedded — not aborted by the first document's error.
+        var act = async () => await sut.GenerateEmbeddings(chunks, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+
+        var added = embeddingRepository
+            .ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(EmbeddingRepository.Add))
+            .Select(c => (Embedding)c.GetArguments()[0])
+            .ToList();
+        added.Should().ContainSingle(e => e.Chunk.Content == "doc-b-content");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for `DocumentProcessor.GenerateEmbeddings`: asserts a per-document embedding failure is isolated so the remaining documents are still embedded.
- The test **fails against current `main`** — it discovered a real bug (filed as GH-828), so it ships `[Skip]`-ped until production is fixed.
- Distinct member from GH-820 / GH-825 (those are `EmbeddingClient`-level facets). Here the outer per-document loop's `catch { LogError; throw; }` rethrows the first document's failure, aborting embeddings for every remaining document — the exact "one failure kills the batch" mode the pending PR #744 targets.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/DocumentProcessorPerDocumentIsolationTests.cs` — new single-`[Fact]` test, skipped — see GH-828. Two documents (A, B); embedding A throws `HttpRequestException`, B would succeed. Asserts the call does not rethrow and B's embedding is still persisted. Contract derived from PR #744's stated intent and the per-document try/catch structure. No production code modified.

Resolution: un-skip this test as part of the GH-828 / PR #744 fix.