### PR TITLE
test(cboe): pin ParseVixCsv culture-independent OHLC mapping

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CboeClientParseVixCsvCultureTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientParseVixCsvCultureTests.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.Integrations.Cboe;
+using Equibles.Integrations.Cboe.Models;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CboeClientParseVixCsvCultureTests
+{
+    private static readonly MethodInfo ParseVixCsvMethod = typeof(CboeClient).GetMethod(
+        "ParseVixCsv",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    [Fact]
+    public void ParseVixCsv_FullyPopulatedRowUnderCommaDecimalCulture_MapsOhlcCultureIndependently()
+    {
+        // VIX history is US-formatted: MM/dd/yyyy dates, dot-decimal OHLC. The
+        // parser pins this with InvariantCulture; the existing VIX pins only
+        // cover skip paths, never the mapping nor that the InvariantCulture
+        // guarantee actually holds. Under de-DE (comma decimal, dd.MM dates) a
+        // regression dropping InvariantCulture would misparse 17.96 -> 1796 or
+        // reject the date — invisible on a US dev box, broken in production.
+        var previous = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+        try
+        {
+            var csv = "DATE,OPEN,HIGH,LOW,CLOSE\n" + "01/02/2004,17.96,18.68,17.54,18.22\n";
+
+            var records = (List<CboeVixRecord>)ParseVixCsvMethod.Invoke(null, [csv]);
+
+            var record = records.Should().ContainSingle().Subject;
+            record.Date.Should().Be(new DateOnly(2004, 1, 2));
+            record.Open.Should().Be(17.96m);
+            record.High.Should().Be(18.68m);
+            record.Low.Should().Be(17.54m);
+            record.Close.Should().Be(18.22m);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `CboeClient.ParseVixCsv`. Existing VIX pins only cover skip paths (short row, bad decimal) — never the OHLC mapping nor that the `InvariantCulture` guarantee actually holds. CBOE VIX history is US-formatted (MM/dd/yyyy, dot-decimal).
- Oracle from the code's explicit contract: under `de-DE` (comma decimal, dd.MM dates) a valid row `01/02/2004,17.96,…` must still map to Date 2004-01-02 and the exact OHLC decimals. A regression dropping `CultureInfo.InvariantCulture` is invisible on a US dev box but breaks production elsewhere — this pins it. Test passes; behavior locked.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CboeClientParseVixCsvCultureTests.cs` — new test; sets `CurrentCulture = de-DE`, reflection-invokes the private static `ParseVixCsv` with a header + one full data row, asserts the single record's Date/Open/High/Low/Close.