### PR TITLE
test(holdings): align NoTrackedStocks test with GH-817 retry contract

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceTests.cs
@@ -298,17 +298,18 @@ public class HoldingsImportServiceTests
     }
 
     [Fact]
-    public async Task ImportDataSet_NoCusipsInInfoTableMatchTrackedStocks_ReturnsParsedCountComplete()
+    public async Task ImportDataSet_NoCusipsInInfoTableMatchTrackedStocks_ReturnsParsedCountNotComplete()
     {
-        // BuildCusipMapping returns false when none of the CUSIPs in
-        // INFOTABLE.tsv match a tracked CommonStock. ImportDataSet maps
-        // this to (count, IsComplete:true) — the file was structurally
-        // sound and we just don't track any of its issuers, so retrying
-        // would produce the same empty mapping. This is the inverse of
-        // the COVERPAGE.tsv-missing pin above (true vs false IsComplete
-        // for the same SubmissionCount), and a swap regression between
-        // them would corrupt ProcessedDataSet bookkeeping in opposite
-        // directions for opposite root causes.
+        // BuildCusipMapping returns NoTrackedStocks when none of the CUSIPs
+        // in INFOTABLE.tsv match a tracked CommonStock. Per GH-817 this is
+        // NOT terminal — typically a cold start where the FTD scraper has
+        // not seeded CUSIPs yet — so ImportDataSet maps it to
+        // (count, IsComplete:false) and leaves the data set unprocessed so
+        // a later cycle backfills it once CUSIPs exist. Marking it complete
+        // here (the old behavior) permanently locked the data set out of
+        // retry. The structural NoInfoTable case still returns true (it
+        // won't change on re-download); a swap regression between the two
+        // would corrupt ProcessedDataSet bookkeeping in opposite directions.
         var submissionTsv =
             "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
             + "13F-HR\tACC-001\t2024-10-15\t2024-09-30\t0001234567\n";
@@ -343,6 +344,6 @@ public class HoldingsImportServiceTests
         );
 
         result.SubmissionCount.Should().Be(1);
-        result.IsComplete.Should().BeTrue();
+        result.IsComplete.Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Summary

- Fixes the single failing test that has kept `build-and-test` red on `main` since PR #819 merged — blocking CI for every subsequent PR (e.g. #830) once it falls behind base.
- The production behavior is **correct**: PR #819 (commit 4bbb287, closes GH-817) intentionally changed `HoldingsImportService.ImportDataSet` so that a 13F data set whose CUSIPs match no tracked stock (cold start) returns `IsComplete: false` and is **retried on a later cycle**, instead of being marked processed and permanently locked out. PR #819 added new pipeline tests but left this pre-existing test asserting the old `IsComplete: true`, so it has failed on `main` ever since (`Expected result.IsComplete to be True, but found False`).
- Test-only change; no production code modified.

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceTests.cs` — in the `NoCusipsInInfoTableMatchTrackedStocks` test: flip `result.IsComplete.Should().BeTrue()` → `.BeFalse()` to match GH-817's retry contract; rename the method `..._ReturnsParsedCountComplete` → `..._ReturnsParsedCountNotComplete`; rewrite the comment to describe the not-terminal/retry semantics (and the contrast with the still-terminal `NoInfoTable` case). Verified: the test now passes locally.