### PR TITLE
feat(messaging): MassTransit Postgres-transport + EF outbox infrastructure [step 1/3]

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -137,6 +137,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.UnitTests", "tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.IntegrationTests", "tests\Equibles.IntegrationTests\Equibles.IntegrationTests.csproj", "{174B4C75-C06A-412D-AA54-F5EA658C9200}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Messaging", "src\Equibles.Messaging\Equibles.Messaging.csproj", "{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -927,6 +929,18 @@ Global
 		{174B4C75-C06A-412D-AA54-F5EA658C9200}.Release|x64.Build.0 = Release|Any CPU
 		{174B4C75-C06A-412D-AA54-F5EA658C9200}.Release|x86.ActiveCfg = Release|Any CPU
 		{174B4C75-C06A-412D-AA54-F5EA658C9200}.Release|x86.Build.0 = Release|Any CPU
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Debug|x64.Build.0 = Debug|Any CPU
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Debug|x86.Build.0 = Debug|Any CPU
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Release|x64.ActiveCfg = Release|Any CPU
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Release|x64.Build.0 = Release|Any CPU
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Release|x86.ActiveCfg = Release|Any CPU
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -997,6 +1011,7 @@ Global
 		{BC16DBEB-49CA-44B3-9B3F-E6CBBFA4B238} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{DF75E095-623E-4BC4-AD6C-7C6406AB7E0B} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{174B4C75-C06A-412D-AA54-F5EA658C9200} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
         required: false
     environment:
       ConnectionStrings__DefaultConnection: "Host=db;Database=equibles;Username=postgres;Password=postgres"
+      ConnectionStrings__TransportConnection: "Host=db;Database=equibles;Username=postgres;Password=postgres"
+      MassTransit__RunMigration: "true"
       Sec__ContactEmail: ${SEC_CONTACT_EMAIL}
       Embedding__Enabled: "false"
       MinimumLogLevel: ${MINIMUM_LOG_LEVEL:-Warning}

--- a/src/Equibles.Messaging/Attributes/ConsumerAttribute.cs
+++ b/src/Equibles.Messaging/Attributes/ConsumerAttribute.cs
@@ -1,0 +1,16 @@
+namespace Equibles.Messaging.Attributes;
+
+// Marks an IConsumer<T> for auto-registration by AddMessaging's assembly scan.
+// allowMultiple: when the same consumer type is registered from multiple
+// assemblies, true => every instance gets the message (distinct endpoints);
+// false => a single shared endpoint (round-robin, one handles it).
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public class ConsumerAttribute : Attribute
+{
+    public bool AllowMultiple { get; }
+
+    public ConsumerAttribute(bool allowMultiple = false)
+    {
+        AllowMultiple = allowMultiple;
+    }
+}

--- a/src/Equibles.Messaging/Equibles.Messaging.csproj
+++ b/src/Equibles.Messaging/Equibles.Messaging.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="MassTransit" />
+    <PackageReference Include="MassTransit.EntityFrameworkCore" />
+    <PackageReference Include="MassTransit.SqlTransport.PostgreSQL" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Data\Equibles.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.Messaging/Extensions/MessagingServiceCollectionExtensions.cs
+++ b/src/Equibles.Messaging/Extensions/MessagingServiceCollectionExtensions.cs
@@ -1,0 +1,124 @@
+using System.Reflection;
+using Equibles.Data;
+using Equibles.Messaging.Attributes;
+using MassTransit;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.Messaging.Extensions;
+
+public static class MessagingServiceCollectionExtensions
+{
+    public static void AddMessaging(this IServiceCollection services, IConfiguration configuration)
+    {
+        // Only the host that owns the DB should create the transport schema /
+        // infrastructure (idempotent, but gated to avoid every host racing it).
+        if (configuration.GetValue("MassTransit:RunMigration", false))
+        {
+            services.AddPostgresMigrationHostedService(x =>
+            {
+                x.CreateDatabase = false;
+                x.CreateInfrastructure = true;
+                x.CreateSchema = true;
+            });
+        }
+
+        services.AddMassTransit(x =>
+        {
+            // Transactional outbox in the shared EquiblesDbContext: events are
+            // captured in the same transaction as the domain write and only
+            // delivered after SaveChanges commits.
+            x.AddEntityFrameworkOutbox<EquiblesDbContext>(o =>
+            {
+                o.UsePostgres();
+                o.UseBusOutbox();
+                o.DuplicateDetectionWindow = TimeSpan.FromMinutes(1);
+                o.QueryDelay = TimeSpan.FromSeconds(1);
+            });
+
+            var mainAssemblyName =
+                Assembly.GetEntryAssembly()?.GetName().Name?.ToLowerInvariant()
+                ?? throw new InvalidOperationException("Could not determine main assembly name.");
+            x.SetEndpointNameFormatter(new KebabCaseEndpointNameFormatter(mainAssemblyName, true));
+
+            // Auto-register every [Consumer] IConsumer<T> across loaded assemblies.
+            var consumerTypes = AppDomain
+                .CurrentDomain.GetAssemblies()
+                .Where(a => !IsSystemAssembly(a))
+                .SelectMany(a =>
+                {
+                    try
+                    {
+                        return a.GetTypes();
+                    }
+                    catch
+                    {
+                        return [];
+                    }
+                })
+                .Where(t =>
+                    t.GetCustomAttribute<ConsumerAttribute>() != null
+                    && t.GetInterfaces()
+                        .Any(i =>
+                            i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IConsumer<>)
+                        )
+                )
+                .ToList();
+
+            foreach (var consumerType in consumerTypes)
+            {
+                var attribute = consumerType.GetCustomAttribute<ConsumerAttribute>();
+                if (attribute == null)
+                    continue;
+
+                x.AddConsumer(consumerType)
+                    .Endpoint(e =>
+                    {
+                        e.Name = attribute.AllowMultiple
+                            ? $"{mainAssemblyName}-{consumerType.Namespace}-{consumerType.Name}".ToLowerInvariant()
+                            : $"{consumerType.Namespace}-{consumerType.Name}".ToLowerInvariant();
+                    });
+            }
+
+            x.AddSqlMessageScheduler();
+            x.UsingPostgres(
+                (context, cfg) =>
+                {
+                    cfg.UseSqlMessageScheduler();
+                    cfg.UseJobSagaPartitionKeyFormatters();
+                    cfg.AutoStart = true;
+                    cfg.UseMessageRetry(r =>
+                    {
+                        r.Exponential(
+                            5,
+                            TimeSpan.FromSeconds(5),
+                            TimeSpan.FromMinutes(5),
+                            TimeSpan.FromSeconds(10)
+                        );
+                    });
+
+                    cfg.ConfigureEndpoints(context);
+                }
+            );
+        });
+
+        services
+            .AddOptions<SqlTransportOptions>()
+            .Configure(options =>
+            {
+                options.ConnectionString = configuration.GetConnectionString("TransportConnection");
+            });
+    }
+
+    private static bool IsSystemAssembly(Assembly assembly)
+    {
+        var name = assembly.GetName().Name;
+        if (name == null)
+            return true;
+
+        return name.StartsWith("System", StringComparison.Ordinal)
+            || name.StartsWith("Microsoft", StringComparison.Ordinal)
+            || name.StartsWith("netstandard", StringComparison.Ordinal)
+            || name.StartsWith("mscorlib", StringComparison.Ordinal);
+    }
+}

--- a/src/Equibles.Messaging/Extensions/ModuleBuilderExtensions.cs
+++ b/src/Equibles.Messaging/Extensions/ModuleBuilderExtensions.cs
@@ -1,0 +1,11 @@
+using Equibles.Data;
+
+namespace Equibles.Messaging.Extensions;
+
+public static class ModuleBuilderExtensions
+{
+    public static EquiblesModuleBuilder AddMessaging(this EquiblesModuleBuilder builder)
+    {
+        return builder.AddModule<MessagingModuleConfiguration>();
+    }
+}

--- a/src/Equibles.Messaging/MessagingModuleConfiguration.cs
+++ b/src/Equibles.Messaging/MessagingModuleConfiguration.cs
@@ -1,0 +1,18 @@
+using Equibles.Data;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Messaging;
+
+// Registers the MassTransit EF Core outbox/inbox entities into the shared
+// EquiblesDbContext via the module system, so the transactional outbox is
+// captured in the same DB as domain writes (no separate context).
+public class MessagingModuleConfiguration : IModuleConfiguration
+{
+    public void ConfigureEntities(ModelBuilder builder)
+    {
+        builder.AddInboxStateEntity();
+        builder.AddOutboxStateEntity();
+        builder.AddOutboxMessageEntity();
+    }
+}

--- a/src/Equibles.Migrations/DesignTimeDbContextFactory.cs
+++ b/src/Equibles.Migrations/DesignTimeDbContextFactory.cs
@@ -9,6 +9,7 @@ using Equibles.Fred.Data;
 using Equibles.Holdings.Data;
 using Equibles.InsiderTrading.Data;
 using Equibles.Media.Data;
+using Equibles.Messaging;
 using Equibles.ParadeDB.EntityFrameworkCore;
 using Equibles.Sec.Data;
 using Equibles.Yahoo.Data;
@@ -59,6 +60,7 @@ public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<EquiblesDb
             new SecModuleConfiguration(),
             new MediaModuleConfiguration(),
             new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration(),
         ];
 
         return new EquiblesDbContext(optionsBuilder.Options, modules);

--- a/src/Equibles.Migrations/Equibles.Migrations.csproj
+++ b/src/Equibles.Migrations/Equibles.Migrations.csproj
@@ -19,5 +19,6 @@
     <ProjectReference Include="..\Equibles.Yahoo.Data\Equibles.Yahoo.Data.csproj" />
     <ProjectReference Include="..\Equibles.Cftc.Data\Equibles.Cftc.Data.csproj" />
     <ProjectReference Include="..\Equibles.Cboe.Data\Equibles.Cboe.Data.csproj" />
+    <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Migrations/Migrations/20260517233058_AddMassTransitOutbox.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260517233058_AddMassTransitOutbox.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260517233058_AddMassTransitOutbox")]
+    partial class AddMassTransitOutbox
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260517233058_AddMassTransitOutbox.cs
+++ b/src/Equibles.Migrations/Migrations/20260517233058_AddMassTransitOutbox.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMassTransitOutbox : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InboxState",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    MessageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ConsumerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RowVersion = table.Column<byte[]>(type: "bytea", rowVersion: true, nullable: true),
+                    Received = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ReceiveCount = table.Column<int>(type: "integer", nullable: false),
+                    ExpirationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Consumed = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Delivered = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InboxState", x => x.Id);
+                    table.UniqueConstraint("AK_InboxState_MessageId_ConsumerId", x => new { x.MessageId, x.ConsumerId });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OutboxState",
+                columns: table => new
+                {
+                    OutboxId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RowVersion = table.Column<byte[]>(type: "bytea", rowVersion: true, nullable: true),
+                    Created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Delivered = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxState", x => x.OutboxId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OutboxMessage",
+                columns: table => new
+                {
+                    SequenceNumber = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    EnqueueTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    SentTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Headers = table.Column<string>(type: "text", nullable: true),
+                    Properties = table.Column<string>(type: "text", nullable: true),
+                    InboxMessageId = table.Column<Guid>(type: "uuid", nullable: true),
+                    InboxConsumerId = table.Column<Guid>(type: "uuid", nullable: true),
+                    OutboxId = table.Column<Guid>(type: "uuid", nullable: true),
+                    MessageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContentType = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    MessageType = table.Column<string>(type: "text", nullable: false),
+                    Body = table.Column<string>(type: "text", nullable: false),
+                    ConversationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CorrelationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    InitiatorId = table.Column<Guid>(type: "uuid", nullable: true),
+                    RequestId = table.Column<Guid>(type: "uuid", nullable: true),
+                    SourceAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    DestinationAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ResponseAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    FaultAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ExpirationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxMessage", x => x.SequenceNumber);
+                    table.ForeignKey(
+                        name: "FK_OutboxMessage_InboxState_InboxMessageId_InboxConsumerId",
+                        columns: x => new { x.InboxMessageId, x.InboxConsumerId },
+                        principalTable: "InboxState",
+                        principalColumns: new[] { "MessageId", "ConsumerId" });
+                    table.ForeignKey(
+                        name: "FK_OutboxMessage_OutboxState_OutboxId",
+                        column: x => x.OutboxId,
+                        principalTable: "OutboxState",
+                        principalColumn: "OutboxId");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InboxState_Delivered",
+                table: "InboxState",
+                column: "Delivered");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_EnqueueTime",
+                table: "OutboxMessage",
+                column: "EnqueueTime");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_ExpirationTime",
+                table: "OutboxMessage",
+                column: "ExpirationTime");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_InboxMessageId_InboxConsumerId_SequenceNumber",
+                table: "OutboxMessage",
+                columns: new[] { "InboxMessageId", "InboxConsumerId", "SequenceNumber" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_OutboxId_SequenceNumber",
+                table: "OutboxMessage",
+                columns: new[] { "OutboxId", "SequenceNumber" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxState_Created",
+                table: "OutboxState",
+                column: "Created");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OutboxMessage");
+
+            migrationBuilder.DropTable(
+                name: "InboxState");
+
+            migrationBuilder.DropTable(
+                name: "OutboxState");
+        }
+    }
+}

--- a/src/Equibles.Worker.Host/Equibles.Worker.Host.csproj
+++ b/src/Equibles.Worker.Host/Equibles.Worker.Host.csproj
@@ -23,5 +23,6 @@
     <ProjectReference Include="..\Equibles.Integrations.Cftc\Equibles.Integrations.Cftc.csproj" />
     <ProjectReference Include="..\Equibles.Integrations.Cboe\Equibles.Integrations.Cboe.csproj" />
     <ProjectReference Include="..\Equibles.Plugins\Equibles.Plugins.csproj" />
+    <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -17,6 +17,7 @@ using Equibles.Holdings.Data.Extensions;
 using Equibles.Holdings.HostedService.Extensions;
 using Equibles.InsiderTrading.Data.Extensions;
 using Equibles.Media.Data.Extensions;
+using Equibles.Messaging.Extensions;
 using Equibles.Sec.Data.Extensions;
 using Equibles.Sec.HostedService.Configuration;
 using Equibles.Sec.HostedService.Extensions;
@@ -46,6 +47,11 @@ Equibles.Plugins.PluginLoader.LoadAll();
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
 builder.Services.AddEquiblesDbContext(connectionString, modules => modules.AddAllModules());
 builder.Services.AddAllRepositories();
+
+// MassTransit (Postgres SQL transport + EF outbox in EquiblesDbContext).
+// AddAllModules() auto-discovers MessagingModuleConfiguration via reflection
+// since this host references Equibles.Messaging.
+builder.Services.AddMessaging(builder.Configuration);
 
 // Worker-specific configuration
 builder.Services.Configure<WorkerOptions>(builder.Configuration.GetSection("Worker"));

--- a/src/Equibles.Worker.Host/appsettings.json
+++ b/src/Equibles.Worker.Host/appsettings.json
@@ -1,6 +1,10 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=equibles;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=localhost;Database=equibles;Username=postgres;Password=postgres",
+    "TransportConnection": "Host=localhost;Database=equibles;Username=postgres;Password=postgres"
+  },
+  "MassTransit": {
+    "RunMigration": true
   },
   "Embedding": {
     "Enabled": false,


### PR DESCRIPTION
Step 1 of 3 toward event-driven CUSIP-change → quarterly-13F backfill (replaces the polling retry-cap idea; #819 stays as the cold-start safety net).

## Summary

Introduces the message-bus foundation, mirroring the commercial Equibles `Equibles.Messaging` module and its modular-DbContext integration. **No behaviour change yet** — no events are published or consumed; this only stands up the bus + outbox tables. Steps 2 (publish `StockCusipChanged` from `CommonStockManager`) and 3 (Holdings consumer invalidates `ProcessedDataSet`) follow as separate PRs.

## Changes

- **New `Equibles.Messaging` project**: `MessagingModuleConfiguration : IModuleConfiguration` (adds MassTransit Inbox/Outbox entities to the shared `EquiblesDbContext` via the existing module system — no change to `Equibles.Data`); `AddMessaging` service-collection extension (Postgres SQL transport, EF `UseBusOutbox`, SQL scheduler, exponential retry, kebab endpoints, `[Consumer]` assembly auto-scan); `ConsumerAttribute`; `AddMessaging` module-builder extension. MassTransit packages were already centrally pinned (8.5.7) — no `Directory.Packages.props` change.
- **Worker.Host** (only host that will publish/consume): references `Equibles.Messaging`, calls `AddMessaging(configuration)`. `AddAllModules()` auto-discovers the messaging module via reflection. `appsettings.json` + `docker-compose` worker env gain `ConnectionStrings:TransportConnection` (same equibles DB; SQL transport isolates in its own schema) and `MassTransit:RunMigration=true`.
- **Migration `AddMassTransitOutbox`**: adds exactly `InboxState`/`OutboxState`/`OutboxMessage` (+ indexes); `DesignTimeDbContextFactory` now includes `MessagingModuleConfiguration`. Web/Mcp don't reference messaging — they still apply the migration (extra tables, unmapped, harmless).

Full solution builds clean (0 errors). Not auto-merging — per-step review as agreed.