### PR TITLE
feat(messaging): publish StockCusipChanged from CommonStockManager.SetCusip [step 2/3]

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -2,6 +2,8 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Exceptions;
+using Equibles.Messaging.Contracts.CommonStocks;
+using MassTransit;
 
 namespace Equibles.CommonStocks.BusinessLogic;
 
@@ -9,10 +11,44 @@ namespace Equibles.CommonStocks.BusinessLogic;
 public class CommonStockManager
 {
     private readonly CommonStockRepository _commonStockRepository;
+    private readonly IPublishEndpoint _publishEndpoint;
 
-    public CommonStockManager(CommonStockRepository commonStockRepository)
+    public CommonStockManager(
+        CommonStockRepository commonStockRepository,
+        IPublishEndpoint publishEndpoint
+    )
     {
         _commonStockRepository = commonStockRepository;
+        _publishEndpoint = publishEndpoint;
+    }
+
+    /// <summary>
+    /// Sets a stock's CUSIP. When the value actually changes, publishes
+    /// <see cref="StockCusipChanged"/> (before SaveChanges, so the EF outbox
+    /// captures it in the same transaction) so the Holdings module can
+    /// backfill quarterly 13F data sets that were processed while this stock
+    /// was still unresolvable. A no-op change publishes nothing.
+    /// </summary>
+    public async Task SetCusip(CommonStock commonStock, string cusip)
+    {
+        if (commonStock == null)
+        {
+            throw new ArgumentNullException(nameof(commonStock));
+        }
+
+        if (string.Equals(commonStock.Cusip, cusip, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var previousCusip = commonStock.Cusip;
+        commonStock.Cusip = cusip;
+
+        // Publish before SaveChanges (outbox pattern).
+        await _publishEndpoint.Publish(
+            new StockCusipChanged(commonStock.Id, commonStock.Ticker, previousCusip, cusip)
+        );
+        await _commonStockRepository.SaveChanges();
     }
 
     public async Task<CommonStock> Create(CommonStock commonStock)

--- a/src/Equibles.CommonStocks.BusinessLogic/Equibles.CommonStocks.BusinessLogic.csproj
+++ b/src/Equibles.CommonStocks.BusinessLogic/Equibles.CommonStocks.BusinessLogic.csproj
@@ -6,5 +6,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Messaging/Contracts/CommonStocks/StockCusipChanged.cs
+++ b/src/Equibles.Messaging/Contracts/CommonStocks/StockCusipChanged.cs
@@ -1,0 +1,12 @@
+namespace Equibles.Messaging.Contracts.CommonStocks;
+
+// Raised when a CommonStock's CUSIP is set or changed (typically the FTD
+// scraper seeding a previously-null CUSIP). Lets the Holdings module
+// invalidate any quarterly 13F data sets that were marked processed before
+// this stock was resolvable, so they get re-imported and backfilled.
+public record StockCusipChanged(
+    Guid CommonStockId,
+    string Ticker,
+    string PreviousCusip,
+    string Cusip
+);

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.IO.Compression;
+using Equibles.CommonStocks.BusinessLogic;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
@@ -156,6 +157,7 @@ public class FtdImportService
 
         using var scope = _scopeFactory.CreateScope();
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var stockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
 
         // Load stocks that don't have CUSIPs yet
         var tickers = tickerToCusip.Keys.ToList();
@@ -169,14 +171,12 @@ public class FtdImportService
         {
             if (tickerToCusip.TryGetValue(stock.Ticker, out var cusip))
             {
-                stock.Cusip = cusip;
+                // Route through the manager so a StockCusipChanged event is
+                // published (outbox) — lets Holdings backfill any 13F data
+                // sets processed before this stock had a CUSIP.
+                await stockManager.SetCusip(stock, cusip);
                 seeded++;
             }
-        }
-
-        if (seeded > 0)
-        {
-            await stockRepo.SaveChanges();
         }
 
         return seeded;

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerCreateWhitespaceTickerTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerCreateWhitespaceTickerTests.cs
@@ -4,6 +4,8 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Exceptions;
 using Equibles.IntegrationTests.Helpers;
+using MassTransit;
+using NSubstitute;
 
 namespace Equibles.IntegrationTests.CommonStocks;
 
@@ -14,7 +16,10 @@ public class CommonStockManagerCreateWhitespaceTickerTests
     public CommonStockManagerCreateWhitespaceTickerTests()
     {
         var context = TestDbContextFactory.Create(new CommonStocksModuleConfiguration());
-        _sut = new CommonStockManager(new CommonStockRepository(context));
+        _sut = new CommonStockManager(
+            new CommonStockRepository(context),
+            Substitute.For<IPublishEndpoint>()
+        );
     }
 
     // Contract: "Ticker is required". Ticker is also the globally-unique key

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerSetCusipTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerSetCusipTests.cs
@@ -1,0 +1,75 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging.Contracts.CommonStocks;
+using MassTransit;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.CommonStocks;
+
+public class CommonStockManagerSetCusipTests
+{
+    private readonly CommonStockManager _sut;
+    private readonly IPublishEndpoint _publishEndpoint = Substitute.For<IPublishEndpoint>();
+    private readonly CommonStockRepository _repository;
+
+    public CommonStockManagerSetCusipTests()
+    {
+        var context = TestDbContextFactory.Create(new CommonStocksModuleConfiguration());
+        _repository = new CommonStockRepository(context);
+        _sut = new CommonStockManager(_repository, _publishEndpoint);
+    }
+
+    private async Task<CommonStock> SeedStock(string cusip)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+            Cusip = cusip,
+        };
+        _repository.Add(stock);
+        await _repository.SaveChanges();
+        return stock;
+    }
+
+    // Contract: a real CUSIP change publishes StockCusipChanged (so Holdings
+    // can backfill 13F data sets processed while the stock was unresolvable)
+    // and persists the new value.
+    [Fact]
+    public async Task SetCusip_CusipChanged_PublishesEventAndPersists()
+    {
+        var stock = await SeedStock(null);
+
+        await _sut.SetCusip(stock, "037833100");
+
+        stock.Cusip.Should().Be("037833100");
+        await _publishEndpoint
+            .Received(1)
+            .Publish(
+                Arg.Is<StockCusipChanged>(e =>
+                    e.CommonStockId == stock.Id
+                    && e.Ticker == "AAPL"
+                    && e.PreviousCusip == null
+                    && e.Cusip == "037833100"
+                ),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    // No-op change must not publish (avoids spurious backfills / event noise).
+    [Fact]
+    public async Task SetCusip_SameCusip_DoesNotPublish()
+    {
+        var stock = await SeedStock("037833100");
+
+        await _sut.SetCusip(stock, "037833100");
+
+        await _publishEndpoint
+            .DidNotReceive()
+            .Publish(Arg.Any<StockCusipChanged>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerTests.cs
@@ -4,6 +4,8 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Exceptions;
 using Equibles.IntegrationTests.Helpers;
+using MassTransit;
+using NSubstitute;
 
 namespace Equibles.IntegrationTests.CommonStocks;
 
@@ -16,7 +18,7 @@ public class CommonStockManagerTests
     {
         var context = TestDbContextFactory.Create(new CommonStocksModuleConfiguration());
         _repository = new CommonStockRepository(context);
-        _sut = new CommonStockManager(_repository);
+        _sut = new CommonStockManager(_repository, Substitute.For<IPublishEndpoint>());
     }
 
     private static CommonStock MakeStock(

--- a/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
+++ b/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
@@ -87,5 +87,6 @@
     <ProjectReference Include="..\..\src\Equibles.Cboe.HostedService\Equibles.Cboe.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Migrations\Equibles.Migrations.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Mcp.Server\Equibles.Mcp.Server.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Equibles.IntegrationTests/Helpers/ParadeDbFixture.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/ParadeDbFixture.cs
@@ -9,6 +9,7 @@ using Equibles.Fred.Data;
 using Equibles.Holdings.Data;
 using Equibles.InsiderTrading.Data;
 using Equibles.Media.Data;
+using Equibles.Messaging;
 using Equibles.ParadeDB.EntityFrameworkCore;
 using Equibles.Sec.Data;
 using Equibles.Yahoo.Data;
@@ -116,6 +117,7 @@ public class ParadeDbFixture : IAsyncLifetime
             new SecModuleConfiguration(),
             new MediaModuleConfiguration(),
             new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration(),
         ];
 
         return new EquiblesDbContext(optionsBuilder.Options, modules);

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceActiveTickerCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceActiveTickerCollisionTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -80,7 +81,10 @@ public class CompanySyncServiceActiveTickerCollisionTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceCreateNewStockCatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceCreateNewStockCatchTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -54,7 +55,10 @@ public class CompanySyncServiceCreateNewStockCatchTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceDispatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceDispatchTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -37,7 +38,10 @@ public class CompanySyncServiceDispatchTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceOrchestrationSkipTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceOrchestrationSkipTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -82,7 +83,10 @@ public class CompanySyncServiceOrchestrationSkipTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCatchTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -67,7 +68,10 @@ public class CompanySyncServiceReplaceObsoleteCatchTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteHolderNullTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteHolderNullTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -71,7 +72,10 @@ public class CompanySyncServiceReplaceObsoleteHolderNullTests : ParadeDbMcpTestB
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -71,7 +72,10 @@ public class CompanySyncServiceReplaceObsoleteTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceResolveCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceResolveCollisionTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -103,7 +104,10 @@ public class CompanySyncServiceResolveCollisionTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -62,7 +63,10 @@ public class CompanySyncServiceTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTickerFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTickerFilterTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -61,7 +62,10 @@ public class CompanySyncServiceTickerFilterTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -44,7 +45,10 @@ public class CompanySyncServiceUpdateExistingCollisionTests : ParadeDbMcpTestBas
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingRollbackTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingRollbackTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -69,7 +70,10 @@ public class CompanySyncServiceUpdateExistingRollbackTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingTests.cs
@@ -8,6 +8,7 @@ using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -67,7 +68,10 @@ public class CompanySyncServiceUpdateExistingTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(new CommonStockRepository(DbContext))
+                new CommonStockManager(
+                    new CommonStockRepository(DbContext),
+                    Substitute.For<IPublishEndpoint>()
+                )
             ),
             (typeof(EquiblesDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceFullPipelineTests.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Text;
+using Equibles.CommonStocks.BusinessLogic;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Configuration;
@@ -11,6 +12,7 @@ using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Sec.Repositories;
 using Equibles.Worker;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -80,6 +82,13 @@ public class FtdImportServiceFullPipelineTests : IAsyncLifetime
                 sp.GetService(typeof(EquiblesDbContext)).Returns(ctx);
                 sp.GetService(typeof(CommonStockRepository))
                     .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(CommonStockManager))
+                    .Returns(
+                        new CommonStockManager(
+                            new CommonStockRepository(ctx),
+                            Substitute.For<IPublishEndpoint>()
+                        )
+                    );
                 sp.GetService(typeof(FailToDeliverRepository))
                     .Returns(new FailToDeliverRepository(ctx));
                 sp.GetService(typeof(TickerMapService)).Returns(new TickerMapService(scopeFactory));

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
+using MassTransit;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -73,7 +74,7 @@ public class CompanySyncServiceUpdateExistingBranchATests
         );
         Set("SecondaryCikToParent", new Dictionary<string, CommonStock>());
         Set("CommonStockRepository", new CommonStockRepository(db));
-        Set("CommonStockManager", new CommonStockManager(new CommonStockRepository(db)));
+        Set("CommonStockManager", new CommonStockManager(new CommonStockRepository(db), Substitute.For<IPublishEndpoint>()));
         Set("DbContext", db);
         return s;
     }


### PR DESCRIPTION
Step 2 of 3 (after #837). Adds the **publisher** side; the Holdings consumer that acts on it is step 3.

## Summary

- **`StockCusipChanged` contract** (`Equibles.Messaging/Contracts/CommonStocks`).
- **`CommonStockManager.SetCusip(stock, cusip)`** — mirrors the commercial `ProblemReportManager` pattern: injects `IPublishEndpoint`, publishes `StockCusipChanged` **before** `SaveChanges` (EF outbox captures it in the same transaction). A no-op change publishes nothing.
- **`FtdImportService.SeedCusips`** now routes CUSIP writes through `CommonStockManager.SetCusip` (was a direct `stock.Cusip = …` + bulk save) so seeding a previously-null CUSIP emits the event.
- **Tests**: `CommonStockManagerSetCusipTests` (publishes on real change w/ correct payload; silent on no-op). All ~16 existing `new CommonStockManager(...)` sites updated for the new `IPublishEndpoint` ctor arg (substitute).

## Also fixes a main breakage from #837

#837 added the outbox entities to the migration **snapshot** but `ParadeDbFixture` didn't compose `MessagingModuleConfiguration`, so its runtime model diverged → EF 10 `MigrateAsync` throws `PendingModelChangesWarning` → **integration suite currently red on main**. This PR adds `MessagingModuleConfiguration` to `ParadeDbFixture` (+ test project reference), restoring it.

No consumer yet, so no behavior change beyond event emission. Verified: full solution builds; impacted integration tests (SetCusip, manager ctor sites, FtdImportService SeedCusips, CompanySyncService) + the modified unit test all green (28 + 2).