### PR TITLE
feat(messaging): StockCusipChanged consumer → 13F quarterly backfill [step 3/3]

### DIFF
--- a/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
+++ b/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
@@ -6,6 +6,13 @@ namespace Equibles.Holdings.Data.Models;
 [Index(nameof(FileName), IsUnique = true)]
 public class ProcessedDataSet
 {
+    // Sentinel row name. Never matches a real quarterly data-set file, so it
+    // is never downloaded/processed, but its presence keeps the table
+    // non-empty so HoldingsScraperWorker.BackfillProcessedDataSets does NOT
+    // re-seed history as "processed" after StockCusipChangedConsumer clears
+    // the real rows for a backfill.
+    public const string BackfillGuardFileName = "__backfill-guard__";
+
     public Guid Id { get; set; } = Guid.NewGuid();
 
     [Required]

--- a/src/Equibles.Holdings.HostedService/Consumers/StockCusipChangedConsumer.cs
+++ b/src/Equibles.Holdings.HostedService/Consumers/StockCusipChangedConsumer.cs
@@ -1,0 +1,73 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Messaging.Attributes;
+using Equibles.Messaging.Contracts.CommonStocks;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.HostedService.Consumers;
+
+/// <summary>
+/// When a CommonStock's CUSIP is set/changed (typically FTD seeding a
+/// previously-null CUSIP), the quarterly 13F data sets that were already
+/// marked processed while the stock was unresolvable hold no holdings for it.
+/// This consumer clears the <see cref="ProcessedDataSet"/> ledger (keeping a
+/// guard sentinel so the worker's first-boot backfill seeding doesn't re-skip
+/// history) so <c>HoldingsScraperWorker</c> re-imports every data set on its
+/// next cycle and backfills the now-resolvable stock. Reprocessing is
+/// idempotent (upsert), so over-invalidation is safe; the FTD cold-start
+/// burst of events collapses to a no-op once already cleared.
+/// </summary>
+[Consumer]
+public class StockCusipChangedConsumer : IConsumer<StockCusipChanged>
+{
+    private readonly ProcessedDataSetRepository _processedDataSetRepository;
+    private readonly ILogger<StockCusipChangedConsumer> _logger;
+
+    public StockCusipChangedConsumer(
+        ProcessedDataSetRepository processedDataSetRepository,
+        ILogger<StockCusipChangedConsumer> logger
+    )
+    {
+        _processedDataSetRepository = processedDataSetRepository;
+        _logger = logger;
+    }
+
+    public async Task Consume(ConsumeContext<StockCusipChanged> context)
+    {
+        var rows = await _processedDataSetRepository
+            .GetAll()
+            .ToListAsync(context.CancellationToken);
+
+        var realRows = rows.Where(r => r.FileName != ProcessedDataSet.BackfillGuardFileName)
+            .ToList();
+        var hasGuard = rows.Any(r => r.FileName == ProcessedDataSet.BackfillGuardFileName);
+
+        if (realRows.Count == 0 && hasGuard)
+        {
+            // Already invalidated (e.g. a prior event in the FTD seeding burst).
+            return;
+        }
+
+        if (realRows.Count > 0)
+        {
+            _processedDataSetRepository.Delete(realRows);
+        }
+
+        if (!hasGuard)
+        {
+            _processedDataSetRepository.Add(
+                new ProcessedDataSet { FileName = ProcessedDataSet.BackfillGuardFileName }
+            );
+        }
+
+        await _processedDataSetRepository.SaveChanges();
+
+        _logger.LogInformation(
+            "CUSIP change for {Ticker} ({Cusip}) invalidated {Count} processed 13F data set(s); the quarterly holdings worker will re-import and backfill on its next cycle",
+            context.Message.Ticker,
+            context.Message.Cusip,
+            realRows.Count
+        );
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Equibles.Holdings.HostedService.csproj
+++ b/src/Equibles.Holdings.HostedService/Equibles.Holdings.HostedService.csproj
@@ -18,5 +18,6 @@
     <ProjectReference Include="..\Equibles.CommonStocks.BusinessLogic\Equibles.CommonStocks.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Worker\Equibles.Worker.csproj" />
+    <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Equibles.IntegrationTests/Holdings/StockCusipChangedConsumerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/StockCusipChangedConsumerTests.cs
@@ -1,0 +1,101 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Consumers;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging.Contracts.CommonStocks;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+[Collection(ParadeDbCollection.Name)]
+public class StockCusipChangedConsumerTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+
+    public StockCusipChangedConsumerTests(ParadeDbFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static ConsumeContext<StockCusipChanged> Context(StockCusipChanged message)
+    {
+        var ctx = Substitute.For<ConsumeContext<StockCusipChanged>>();
+        ctx.Message.Returns(message);
+        ctx.CancellationToken.Returns(CancellationToken.None);
+        return ctx;
+    }
+
+    // Contract: a CUSIP change clears the real quarterly ProcessedDataSet rows
+    // (so HoldingsScraperWorker re-imports/backfills) while leaving a guard
+    // sentinel (so the worker's empty-table backfill seeding doesn't re-skip
+    // history).
+    [Fact]
+    public async Task Consume_InvalidatesRealDataSets_AndLeavesGuardSentinel()
+    {
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<ProcessedDataSet>()
+                .AddRange(
+                    new ProcessedDataSet
+                    {
+                        FileName = "01mar2025-31may2025_form13f.zip",
+                        SubmissionCount = 7987,
+                    },
+                    new ProcessedDataSet
+                    {
+                        FileName = "01dec2025-28feb2026_form13f.zip",
+                        SubmissionCount = 8943,
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var ctx = _fixture.CreateDbContext())
+        {
+            var sut = new StockCusipChangedConsumer(
+                new ProcessedDataSetRepository(ctx),
+                Substitute.For<ILogger<StockCusipChangedConsumer>>()
+            );
+            await sut.Consume(
+                Context(new StockCusipChanged(Guid.NewGuid(), "AAPL", null, "037833100"))
+            );
+        }
+
+        await using var verify = _fixture.CreateDbContext();
+        var rows = await verify.Set<ProcessedDataSet>().Select(r => r.FileName).ToListAsync();
+        rows.Should().ContainSingle().Which.Should().Be(ProcessedDataSet.BackfillGuardFileName);
+    }
+
+    // Idempotent: once only the guard remains, a further event is a no-op
+    // (the FTD cold-start seeding burst publishes one event per stock).
+    [Fact]
+    public async Task Consume_AlreadyInvalidated_IsNoOp()
+    {
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<ProcessedDataSet>()
+                .Add(new ProcessedDataSet { FileName = ProcessedDataSet.BackfillGuardFileName });
+            await seed.SaveChangesAsync();
+        }
+
+        await using (var ctx = _fixture.CreateDbContext())
+        {
+            var sut = new StockCusipChangedConsumer(
+                new ProcessedDataSetRepository(ctx),
+                Substitute.For<ILogger<StockCusipChangedConsumer>>()
+            );
+            await sut.Consume(
+                Context(new StockCusipChanged(Guid.NewGuid(), "MSFT", "abc", "594918104"))
+            );
+        }
+
+        await using var verify = _fixture.CreateDbContext();
+        var rows = await verify.Set<ProcessedDataSet>().Select(r => r.FileName).ToListAsync();
+        rows.Should().ContainSingle().Which.Should().Be(ProcessedDataSet.BackfillGuardFileName);
+    }
+}


### PR DESCRIPTION
Final step (after #837, #839). Closes the event-driven loop: a CUSIP change now auto-triggers a quarterly-13F backfill — no polling retry-cap, nothing tracked in the DB (your design). #819 remains the cold-start safety net.

## Summary

- **`StockCusipChangedConsumer`** (`[Consumer]`, auto-registered by `AddMessaging`'s scan) in Holdings.HostedService: on `StockCusipChanged`, deletes the real `ProcessedDataSet` rows so `HoldingsScraperWorker` re-imports every quarterly data set next cycle and backfills the now-resolvable stock. Reprocessing is idempotent (upsert), so over-invalidation is safe; the FTD cold-start burst collapses to a no-op once cleared.
- **`ProcessedDataSet.BackfillGuardFileName` sentinel**: the consumer leaves one guard row so `BackfillProcessedDataSets` (which seeds all-but-latest as processed only when the table is *empty*) doesn't re-skip history after invalidation. The sentinel never matches a real data-set filename, so it's never downloaded/processed.

## End-to-end behaviour

FTD seeds a previously-null CUSIP → `CommonStockManager.SetCusip` publishes `StockCusipChanged` (outbox, #839) → this consumer clears `ProcessedDataSet` (+guard) → next `HoldingsScraperWorker` cycle reprocesses all quarters with the CUSIP now mapped → holdings backfilled. Self-healing, event-driven, no retry loop.

Verified: full solution builds; `StockCusipChangedConsumerTests` (invalidates real rows + keeps guard; idempotent no-op when already cleared) green.