### PR TITLE
chore(lint): fix csharpier formatting on main (messaging migration + unit test)

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260517233058_AddMassTransitOutbox.cs
+++ b/src/Equibles.Migrations/Migrations/20260517233058_AddMassTransitOutbox.cs
@@ -16,24 +16,48 @@ namespace Equibles.Migrations.Migrations
                 name: "InboxState",
                 columns: table => new
                 {
-                    Id = table.Column<long>(type: "bigint", nullable: false)
-                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Id = table
+                        .Column<long>(type: "bigint", nullable: false)
+                        .Annotation(
+                            "Npgsql:ValueGenerationStrategy",
+                            NpgsqlValueGenerationStrategy.IdentityByDefaultColumn
+                        ),
                     MessageId = table.Column<Guid>(type: "uuid", nullable: false),
                     ConsumerId = table.Column<Guid>(type: "uuid", nullable: false),
                     LockId = table.Column<Guid>(type: "uuid", nullable: false),
-                    RowVersion = table.Column<byte[]>(type: "bytea", rowVersion: true, nullable: true),
-                    Received = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    RowVersion = table.Column<byte[]>(
+                        type: "bytea",
+                        rowVersion: true,
+                        nullable: true
+                    ),
+                    Received = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
                     ReceiveCount = table.Column<int>(type: "integer", nullable: false),
-                    ExpirationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    Consumed = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    Delivered = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: true)
+                    ExpirationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: true
+                    ),
+                    Consumed = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: true
+                    ),
+                    Delivered = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: true
+                    ),
+                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: true),
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_InboxState", x => x.Id);
-                    table.UniqueConstraint("AK_InboxState_MessageId_ConsumerId", x => new { x.MessageId, x.ConsumerId });
-                });
+                    table.UniqueConstraint(
+                        "AK_InboxState_MessageId_ConsumerId",
+                        x => new { x.MessageId, x.ConsumerId }
+                    );
+                }
+            );
 
             migrationBuilder.CreateTable(
                 name: "OutboxState",
@@ -41,42 +65,86 @@ namespace Equibles.Migrations.Migrations
                 {
                     OutboxId = table.Column<Guid>(type: "uuid", nullable: false),
                     LockId = table.Column<Guid>(type: "uuid", nullable: false),
-                    RowVersion = table.Column<byte[]>(type: "bytea", rowVersion: true, nullable: true),
-                    Created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
-                    Delivered = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: true)
+                    RowVersion = table.Column<byte[]>(
+                        type: "bytea",
+                        rowVersion: true,
+                        nullable: true
+                    ),
+                    Created = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                    Delivered = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: true
+                    ),
+                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: true),
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_OutboxState", x => x.OutboxId);
-                });
+                }
+            );
 
             migrationBuilder.CreateTable(
                 name: "OutboxMessage",
                 columns: table => new
                 {
-                    SequenceNumber = table.Column<long>(type: "bigint", nullable: false)
-                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
-                    EnqueueTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    SentTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    SequenceNumber = table
+                        .Column<long>(type: "bigint", nullable: false)
+                        .Annotation(
+                            "Npgsql:ValueGenerationStrategy",
+                            NpgsqlValueGenerationStrategy.IdentityByDefaultColumn
+                        ),
+                    EnqueueTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: true
+                    ),
+                    SentTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
                     Headers = table.Column<string>(type: "text", nullable: true),
                     Properties = table.Column<string>(type: "text", nullable: true),
                     InboxMessageId = table.Column<Guid>(type: "uuid", nullable: true),
                     InboxConsumerId = table.Column<Guid>(type: "uuid", nullable: true),
                     OutboxId = table.Column<Guid>(type: "uuid", nullable: true),
                     MessageId = table.Column<Guid>(type: "uuid", nullable: false),
-                    ContentType = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    ContentType = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: false
+                    ),
                     MessageType = table.Column<string>(type: "text", nullable: false),
                     Body = table.Column<string>(type: "text", nullable: false),
                     ConversationId = table.Column<Guid>(type: "uuid", nullable: true),
                     CorrelationId = table.Column<Guid>(type: "uuid", nullable: true),
                     InitiatorId = table.Column<Guid>(type: "uuid", nullable: true),
                     RequestId = table.Column<Guid>(type: "uuid", nullable: true),
-                    SourceAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
-                    DestinationAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
-                    ResponseAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
-                    FaultAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
-                    ExpirationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                    SourceAddress = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: true
+                    ),
+                    DestinationAddress = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: true
+                    ),
+                    ResponseAddress = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: true
+                    ),
+                    FaultAddress = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: true
+                    ),
+                    ExpirationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: true
+                    ),
                 },
                 constraints: table =>
                 {
@@ -85,58 +153,64 @@ namespace Equibles.Migrations.Migrations
                         name: "FK_OutboxMessage_InboxState_InboxMessageId_InboxConsumerId",
                         columns: x => new { x.InboxMessageId, x.InboxConsumerId },
                         principalTable: "InboxState",
-                        principalColumns: new[] { "MessageId", "ConsumerId" });
+                        principalColumns: new[] { "MessageId", "ConsumerId" }
+                    );
                     table.ForeignKey(
                         name: "FK_OutboxMessage_OutboxState_OutboxId",
                         column: x => x.OutboxId,
                         principalTable: "OutboxState",
-                        principalColumn: "OutboxId");
-                });
+                        principalColumn: "OutboxId"
+                    );
+                }
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_InboxState_Delivered",
                 table: "InboxState",
-                column: "Delivered");
+                column: "Delivered"
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_OutboxMessage_EnqueueTime",
                 table: "OutboxMessage",
-                column: "EnqueueTime");
+                column: "EnqueueTime"
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_OutboxMessage_ExpirationTime",
                 table: "OutboxMessage",
-                column: "ExpirationTime");
+                column: "ExpirationTime"
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_OutboxMessage_InboxMessageId_InboxConsumerId_SequenceNumber",
                 table: "OutboxMessage",
                 columns: new[] { "InboxMessageId", "InboxConsumerId", "SequenceNumber" },
-                unique: true);
+                unique: true
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_OutboxMessage_OutboxId_SequenceNumber",
                 table: "OutboxMessage",
                 columns: new[] { "OutboxId", "SequenceNumber" },
-                unique: true);
+                unique: true
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_OutboxState_Created",
                 table: "OutboxState",
-                column: "Created");
+                column: "Created"
+            );
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(
-                name: "OutboxMessage");
+            migrationBuilder.DropTable(name: "OutboxMessage");
 
-            migrationBuilder.DropTable(
-                name: "InboxState");
+            migrationBuilder.DropTable(name: "InboxState");
 
-            migrationBuilder.DropTable(
-                name: "OutboxState");
+            migrationBuilder.DropTable(name: "OutboxState");
         }
     }
 }

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs
@@ -9,13 +9,13 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
-using MassTransit;
 
 namespace Equibles.UnitTests.Sec;
 
@@ -74,7 +74,13 @@ public class CompanySyncServiceUpdateExistingBranchATests
         );
         Set("SecondaryCikToParent", new Dictionary<string, CommonStock>());
         Set("CommonStockRepository", new CommonStockRepository(db));
-        Set("CommonStockManager", new CommonStockManager(new CommonStockRepository(db), Substitute.For<IPublishEndpoint>()));
+        Set(
+            "CommonStockManager",
+            new CommonStockManager(
+                new CommonStockRepository(db),
+                Substitute.For<IPublishEndpoint>()
+            )
+        );
         Set("DbContext", db);
         return s;
     }


### PR DESCRIPTION
## Summary

`main`'s **lint (csharpier)** CI is red: two files merged unformatted via the messaging steps —

- `src/Equibles.Migrations/Migrations/20260517233058_AddMassTransitOutbox.cs` — EF-generated migration (#837); never run through csharpier (Step 1 formatted only the new `Equibles.Messaging` files).
- `tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs` — the Step-2 `using` insertion left imports out of csharpier's sort order (Step 2 formatted `tests/Equibles.IntegrationTests` but not `tests/Equibles.UnitTests`).

## Code changes

- Ran the repo-pinned `csharpier format` on exactly those two files. Formatting-only, no semantic change. `csharpier check .` is now clean for tracked sources (the only remaining hits are gitignored `coverage/*.xml` artifacts, absent in CI's clean checkout).