### PR TITLE
fix(messaging): include outbox module in every DbContext composition (fix red CI + Web/Mcp startup)

### DIFF
--- a/src/Equibles.Mcp.Server/Equibles.Mcp.Server.csproj
+++ b/src/Equibles.Mcp.Server/Equibles.Mcp.Server.csproj
@@ -23,5 +23,6 @@
     <ProjectReference Include="..\Equibles.Finra.Mcp\Equibles.Finra.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Yahoo.Mcp\Equibles.Yahoo.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Plugins\Equibles.Plugins.csproj" />
+    <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -21,6 +21,7 @@ using Equibles.Mcp.Contracts;
 using Equibles.Mcp.Extensions;
 using Equibles.Mcp.Middleware;
 using Equibles.Media.Data.Extensions;
+using Equibles.Messaging.Extensions;
 using Equibles.Sec.Data.Extensions;
 using Equibles.Sec.Mcp.Extensions;
 using Equibles.Yahoo.Data.Extensions;
@@ -60,7 +61,13 @@ public partial class Program
         Equibles.Plugins.PluginLoader.LoadAll();
 
         var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
-        builder.Services.AddEquiblesDbContext(connectionString, modules => modules.AddAllModules());
+        // .AddMessaging() explicitly so the MassTransit outbox entities (in the
+        // shared migration snapshot) are always in this host's model too —
+        // AddAllModules' reflection only sees already-loaded assemblies.
+        builder.Services.AddEquiblesDbContext(
+            connectionString,
+            modules => modules.AddAllModules().AddMessaging()
+        );
         builder.Services.AddAllRepositories();
 
         builder.Services.AutoWireServicesFrom<Equibles.Errors.BusinessLogic.ErrorManager>();

--- a/src/Equibles.Web/Equibles.Web.csproj
+++ b/src/Equibles.Web/Equibles.Web.csproj
@@ -6,11 +6,7 @@
 
   <ItemGroup>
     <!-- Repo-root CHANGELOG.md, copied so the in-app /changelog page can render it. -->
-    <Content
-      Include="..\..\CHANGELOG.md"
-      Link="CHANGELOG.md"
-      CopyToOutputDirectory="PreserveNewest"
-    />
+    <Content Include="..\..\CHANGELOG.md" Link="CHANGELOG.md" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,5 +39,6 @@
     <ProjectReference Include="..\Equibles.Yahoo.Repositories\Equibles.Yahoo.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Cftc.Repositories\Equibles.Cftc.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Cboe.Repositories\Equibles.Cboe.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -1,6 +1,7 @@
 using Equibles.Core.AutoWiring;
 using Equibles.Data;
 using Equibles.Data.Extensions;
+using Equibles.Messaging.Extensions;
 using Equibles.Web.Authentication;
 using Equibles.Web.FlashMessage;
 using Microsoft.AspNetCore.Authentication;
@@ -44,7 +45,12 @@ public partial class Program
         var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
         builder.Services.AddEquiblesDbContext(
             connectionString,
-            modules => modules.AddAllModules(),
+            // .AddMessaging() explicitly: the MassTransit outbox entities are in
+            // the shared migration snapshot, so every host that runs/validates
+            // migrations must include them or EF throws PendingModelChanges.
+            // AddAllModules' reflection only sees already-loaded assemblies, so
+            // the explicit call guarantees it deterministically.
+            modules => modules.AddAllModules().AddMessaging(),
             migrationsAssembly: typeof(Equibles.Migrations.DesignTimeDbContextFactory).Assembly
         );
         builder.Services.AddAllRepositories();

--- a/tests/Equibles.FunctionalTests/Fixtures/McpServerAppFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/McpServerAppFixture.cs
@@ -11,6 +11,7 @@ using Equibles.Holdings.Data;
 using Equibles.InsiderTrading.Data;
 using Equibles.Mcp.Server;
 using Equibles.Media.Data;
+using Equibles.Messaging;
 using Equibles.ParadeDB.EntityFrameworkCore;
 using Equibles.Sec.Data;
 using Equibles.Yahoo.Data;
@@ -205,6 +206,7 @@ public class McpServerAppFixture : IAsyncLifetime
             new SecModuleConfiguration(),
             new MediaModuleConfiguration(),
             new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration(),
         ];
 
         return new EquiblesDbContext(optionsBuilder.Options, modules);

--- a/tests/Equibles.IntegrationTests/Data/DataLayerTests.cs
+++ b/tests/Equibles.IntegrationTests/Data/DataLayerTests.cs
@@ -31,6 +31,7 @@ using Equibles.InsiderTrading.Data.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
 using Equibles.Media.Data.Extensions;
+using Equibles.Messaging;
 using Equibles.Sec.Data.Extensions;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Data.Extensions;
@@ -572,6 +573,7 @@ public class ModuleConfigurationTests : IDisposable
                 new SecTestModuleConfiguration(),
                 new MediaModuleConfiguration(),
                 new ErrorsModuleConfiguration(),
+                new MessagingModuleConfiguration(),
                 new FredModuleConfiguration(),
                 new FinraModuleConfiguration(),
                 new YahooModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Errors/ErrorManagerCreateSurrogateTruncationTests.cs
+++ b/tests/Equibles.IntegrationTests/Errors/ErrorManagerCreateSurrogateTruncationTests.cs
@@ -3,6 +3,7 @@ using Equibles.Errors.Data;
 using Equibles.Errors.Data.Models;
 using Equibles.Errors.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging;
 
 namespace Equibles.IntegrationTests.Errors;
 
@@ -13,7 +14,10 @@ public class ErrorManagerCreateSurrogateTruncationTests
 
     public ErrorManagerCreateSurrogateTruncationTests()
     {
-        var context = TestDbContextFactory.Create(new ErrorsModuleConfiguration());
+        var context = TestDbContextFactory.Create(
+            new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration()
+        );
         _repository = new ErrorRepository(context);
         _sut = new ErrorManager(_repository);
     }

--- a/tests/Equibles.IntegrationTests/Errors/ErrorManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Errors/ErrorManagerTests.cs
@@ -3,6 +3,7 @@ using Equibles.Errors.Data;
 using Equibles.Errors.Data.Models;
 using Equibles.Errors.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging;
 
 namespace Equibles.IntegrationTests.Errors;
 
@@ -13,7 +14,10 @@ public class ErrorManagerTests
 
     public ErrorManagerTests()
     {
-        var context = TestDbContextFactory.Create(new ErrorsModuleConfiguration());
+        var context = TestDbContextFactory.Create(
+            new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration()
+        );
         _repository = new ErrorRepository(context);
         _sut = new ErrorManager(_repository);
     }

--- a/tests/Equibles.IntegrationTests/Errors/ErrorReporterTests.cs
+++ b/tests/Equibles.IntegrationTests/Errors/ErrorReporterTests.cs
@@ -3,6 +3,7 @@ using Equibles.Errors.Data;
 using Equibles.Errors.Data.Models;
 using Equibles.Errors.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -15,7 +16,10 @@ public class ErrorReporterTests
     [Fact]
     public async Task Report_DelegatesToErrorManager_ErrorPersisted()
     {
-        var context = TestDbContextFactory.Create(new ErrorsModuleConfiguration());
+        var context = TestDbContextFactory.Create(
+            new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration()
+        );
         var repository = new ErrorRepository(context);
         var errorManager = new ErrorManager(repository);
         var scopeFactory = ServiceScopeSubstitute.Create((typeof(ErrorManager), errorManager));

--- a/tests/Equibles.IntegrationTests/Errors/ErrorRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Errors/ErrorRepositoryTests.cs
@@ -3,6 +3,7 @@ using Equibles.Errors.Data;
 using Equibles.Errors.Data.Models;
 using Equibles.Errors.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.IntegrationTests.Errors;
@@ -14,7 +15,10 @@ public class ErrorRepositoryTests : IDisposable
 
     public ErrorRepositoryTests()
     {
-        _dbContext = TestDbContextFactory.Create(new ErrorsModuleConfiguration());
+        _dbContext = TestDbContextFactory.Create(
+            new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration()
+        );
         _repository = new ErrorRepository(_dbContext);
     }
 

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorMalformedOwnershipXmlTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorMalformedOwnershipXmlTests.cs
@@ -8,6 +8,7 @@ using Equibles.InsiderTrading.Repositories;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
 using Microsoft.Extensions.Logging;
@@ -34,7 +35,8 @@ public class InsiderTradingFilingProcessorMalformedOwnershipXmlTests
         var dbContext = TestDbContextFactory.Create(
             new InsiderTradingModuleConfiguration(),
             new CommonStocksModuleConfiguration(),
-            new ErrorsModuleConfiguration()
+            new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration()
         );
 
         var errorRepo = new ErrorRepository(dbContext);

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -9,6 +9,7 @@ using Equibles.InsiderTrading.Repositories;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -300,7 +301,8 @@ public class InsiderTradingFilingProcessorTests
         var dbContext = TestDbContextFactory.Create(
             new InsiderTradingModuleConfiguration(),
             new CommonStocksModuleConfiguration(),
-            new ErrorsModuleConfiguration()
+            new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration()
         );
 
         var ownerRepo = new InsiderOwnerRepository(dbContext);

--- a/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
@@ -23,6 +23,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -880,6 +881,7 @@ public class StatusControllerTests : IDisposable
             new FredModuleConfiguration(),
             new YahooModuleConfiguration(),
             new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration(),
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration()
         );

--- a/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusBadgeFilterTests.cs
@@ -2,6 +2,7 @@ using Equibles.Errors.Data;
 using Equibles.Errors.Data.Models;
 using Equibles.Errors.Repositories;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging;
 using Equibles.Web.Filters;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -20,7 +21,10 @@ public class StatusBadgeFilterTests
 
     public StatusBadgeFilterTests()
     {
-        var context = TestDbContextFactory.Create(new ErrorsModuleConfiguration());
+        var context = TestDbContextFactory.Create(
+            new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration()
+        );
         _errorRepository = new ErrorRepository(context);
         _configBuilder = new ConfigurationBuilder();
     }

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerDataTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerDataTests.cs
@@ -19,6 +19,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -61,6 +62,7 @@ public class StatusControllerDataTests : IDisposable
             new FredModuleConfiguration(),
             new YahooModuleConfiguration(),
             new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration(),
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration()
         );

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerDeleteHappyTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerDeleteHappyTests.cs
@@ -20,6 +20,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -62,6 +63,7 @@ public class StatusControllerDeleteHappyTests : IDisposable
             new FredModuleConfiguration(),
             new YahooModuleConfiguration(),
             new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration(),
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration()
         );

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerMarkAsSeenHappyTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerMarkAsSeenHappyTests.cs
@@ -20,6 +20,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -63,6 +64,7 @@ public class StatusControllerMarkAsSeenHappyTests : IDisposable
             new FredModuleConfiguration(),
             new YahooModuleConfiguration(),
             new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration(),
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration()
         );

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerShowNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerShowNotFoundTests.cs
@@ -19,6 +19,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -61,6 +62,7 @@ public class StatusControllerShowNotFoundTests : IDisposable
             new FredModuleConfiguration(),
             new YahooModuleConfiguration(),
             new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration(),
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration()
         );


### PR DESCRIPTION
## Summary

After the messaging steps, the MassTransit outbox entities live in the **shared migration snapshot**. EF Core 10 throws `PendingModelChangesWarning` from `MigrateAsync` whenever a constructed `EquiblesDbContext` model omits them. Step 1 scoped `Equibles.Messaging` to Worker.Host only, so:

- **Functional Tests red on main** — `McpServerAppFixture.BuildMigrationContext` hand-rolls a module list without messaging → every functional test failed at `MigrateAsync`.
- **Latent prod break** — `Equibles.Web` migrates on startup via `AddAllModules()` (reflection over *loaded* assemblies); it didn't reference `Equibles.Messaging`, so Web would throw on boot. `Equibles.Mcp.Server` likewise.
- 13 other integration-test fixtures had the same hand-rolled-list gap.

## Code changes

- **Web + Mcp.Server**: reference `Equibles.Messaging`; `modules.AddAllModules().AddMessaging()` (explicit + deterministic — reflection alone can't see an unloaded assembly). They don't start the bus (no `services.AddMessaging`); they only need the entity model to match the migration history.
- **14 test fixtures/files**: added `new MessagingModuleConfiguration()` to their explicit module arrays (mirrors the #837 `DesignTimeDbContextFactory` / #839 `ParadeDbFixture` fixes).

Verified locally: full solution builds; previously-failing `McpServerToolCorrectnessTests` now 5/5; patched integration fixtures (`ErrorManagerTests`, `ControllersTests`) green. (#844 already fixed the separate csharpier lint failure.)