### PR TITLE
chore(lint): csharpier-format Equibles.Web.csproj

### DIFF
--- a/src/Equibles.Web/Equibles.Web.csproj
+++ b/src/Equibles.Web/Equibles.Web.csproj
@@ -6,7 +6,11 @@
 
   <ItemGroup>
     <!-- Repo-root CHANGELOG.md, copied so the in-app /changelog page can render it. -->
-    <Content Include="..\..\CHANGELOG.md" Link="CHANGELOG.md" CopyToOutputDirectory="PreserveNewest" />
+    <Content
+      Include="..\..\CHANGELOG.md"
+      Link="CHANGELOG.md"
+      CopyToOutputDirectory="PreserveNewest"
+    />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

`dotnet add reference` (adding the `Equibles.Messaging` ProjectReference in #845) left `Equibles.Web.csproj` in a layout csharpier rejects; CI `lint` (`csharpier check .`) is red on main.

## Code changes

- `dotnet csharpier format` on `src/Equibles.Web/Equibles.Web.csproj` (formatting-only). `csharpier check .` now clean for tracked sources (only gitignored `coverage/*.xml` remain, absent in CI checkout).