### PR TITLE
fix(worker): FTD/Yahoo skip-and-retry-soon on empty universe instead of 24h no-op (GH-851)

### DIFF
--- a/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
@@ -1,3 +1,4 @@
+using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Sec.HostedService.Configuration;
@@ -11,6 +12,7 @@ namespace Equibles.Sec.HostedService;
 public class FtdScraperWorker : BaseScraperWorker
 {
     private readonly IConfiguration _configuration;
+    private readonly WorkerOptions _workerOptions;
 
     protected override string WorkerName => "FTD scraper";
     protected override TimeSpan SleepInterval { get; }
@@ -21,11 +23,13 @@ public class FtdScraperWorker : BaseScraperWorker
         IServiceScopeFactory scopeFactory,
         ErrorReporter errorReporter,
         IOptions<FtdScraperOptions> options,
+        IOptions<WorkerOptions> workerOptions,
         IConfiguration configuration
     )
         : base(logger, scopeFactory, errorReporter)
     {
         SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
+        _workerOptions = workerOptions.Value;
         _configuration = configuration;
     }
 
@@ -44,6 +48,22 @@ public class FtdScraperWorker : BaseScraperWorker
     protected override async Task DoWork(CancellationToken stoppingToken)
     {
         await using var scope = ScopeFactory.CreateAsyncScope();
+
+        // Cold-start guard (GH-851): the SEC CompanySync may not have populated
+        // CommonStock yet. If the tracked universe is empty the FTD import would
+        // match nothing and seed no CUSIPs, starving the Holdings pipeline for a
+        // whole 24h cycle. Skip and retry soon instead.
+        var tickerMapService = scope.ServiceProvider.GetRequiredService<TickerMapService>();
+        var tickerMap = await tickerMapService.Build(_workerOptions.TickersToSync, stoppingToken);
+        if (tickerMap.Count == 0)
+        {
+            Logger.LogInformation(
+                "FTD scraper: tracked stock universe is empty (company sync pending) — skipping; will retry soon"
+            );
+            RequestRetrySoon();
+            return;
+        }
+
         var ftdService = scope.ServiceProvider.GetRequiredService<FtdImportService>();
         await ftdService.Import(stoppingToken);
     }

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -12,9 +12,26 @@ public abstract class BaseScraperWorker : BackgroundService
     protected readonly IServiceScopeFactory ScopeFactory;
     protected readonly ErrorReporter ErrorReporter;
 
+    private bool _retrySoonRequested;
+
     protected abstract string WorkerName { get; }
     protected abstract TimeSpan SleepInterval { get; }
     protected abstract ErrorSource ErrorSource { get; }
+
+    /// <summary>
+    /// Wait used after a cycle that called <see cref="RequestRetrySoon"/> —
+    /// e.g. a cold start where a dependency (the tracked-stock universe) isn't
+    /// populated yet. Short by design so the scraper recovers in minutes
+    /// instead of sleeping the full <see cref="SleepInterval"/>.
+    /// </summary>
+    protected virtual TimeSpan NotReadyRetryInterval => TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Marks the just-finished cycle as a no-op caused by a not-yet-ready
+    /// dependency, so the loop waits <see cref="NotReadyRetryInterval"/>
+    /// instead of <see cref="SleepInterval"/>. Reset at the start of each cycle.
+    /// </summary>
+    protected void RequestRetrySoon() => _retrySoonRequested = true;
 
     protected BaseScraperWorker(
         ILogger logger,
@@ -35,6 +52,7 @@ public abstract class BaseScraperWorker : BackgroundService
         while (!stoppingToken.IsCancellationRequested)
         {
             Logger.LogInformation("{Worker} running at: {Time}", WorkerName, DateTimeOffset.Now);
+            _retrySoonRequested = false;
 
             try
             {
@@ -56,12 +74,15 @@ public abstract class BaseScraperWorker : BackgroundService
                 );
             }
 
+            var interval = _retrySoonRequested ? NotReadyRetryInterval : SleepInterval;
             Logger.LogInformation(
-                "{Worker} cycle complete. Sleeping for {Interval}",
+                _retrySoonRequested
+                    ? "{Worker} not ready (dependency pending); retrying in {Interval}"
+                    : "{Worker} cycle complete. Sleeping for {Interval}",
                 WorkerName,
-                SleepInterval
+                interval
             );
-            await Task.Delay(SleepInterval, stoppingToken);
+            await Task.Delay(interval, stoppingToken);
         }
     }
 

--- a/src/Equibles.Yahoo.HostedService/YahooPriceScraperWorker.cs
+++ b/src/Equibles.Yahoo.HostedService/YahooPriceScraperWorker.cs
@@ -1,3 +1,4 @@
+using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Worker;
@@ -11,6 +12,8 @@ namespace Equibles.Yahoo.HostedService;
 
 public class YahooPriceScraperWorker : BaseScraperWorker
 {
+    private readonly WorkerOptions _workerOptions;
+
     protected override string WorkerName => "Yahoo price scraper";
     protected override TimeSpan SleepInterval { get; }
     protected override ErrorSource ErrorSource => ErrorSource.YahooPriceScraper;
@@ -19,16 +22,32 @@ public class YahooPriceScraperWorker : BaseScraperWorker
         ILogger<YahooPriceScraperWorker> logger,
         IServiceScopeFactory scopeFactory,
         ErrorReporter errorReporter,
-        IOptions<YahooPriceScraperOptions> options
+        IOptions<YahooPriceScraperOptions> options,
+        IOptions<WorkerOptions> workerOptions
     )
         : base(logger, scopeFactory, errorReporter)
     {
         SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
+        _workerOptions = workerOptions.Value;
     }
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {
         await using var scope = ScopeFactory.CreateAsyncScope();
+
+        // Cold-start guard (GH-851): skip + retry soon if CompanySync hasn't
+        // populated CommonStock yet, instead of a 0-stock no-op then 24h sleep.
+        var tickerMapService = scope.ServiceProvider.GetRequiredService<TickerMapService>();
+        var tickerMap = await tickerMapService.Build(_workerOptions.TickersToSync, stoppingToken);
+        if (tickerMap.Count == 0)
+        {
+            Logger.LogInformation(
+                "Yahoo price scraper: tracked stock universe is empty (company sync pending) — skipping; will retry soon"
+            );
+            RequestRetrySoon();
+            return;
+        }
+
         var importService = scope.ServiceProvider.GetRequiredService<YahooPriceImportService>();
         await importService.Import(stoppingToken);
     }

--- a/tests/Equibles.UnitTests/Sec/FtdScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdScraperWorkerTests.cs
@@ -189,7 +189,14 @@ public class FtdScraperWorkerTests
             IOptions<FtdScraperOptions> options,
             IConfiguration configuration
         )
-            : base(logger, scopeFactory, errorReporter, options, configuration) { }
+            : base(
+                logger,
+                scopeFactory,
+                errorReporter,
+                options,
+                Options.Create(new Equibles.Core.Configuration.WorkerOptions()),
+                configuration
+            ) { }
 
         public bool InvokeValidateConfiguration() => ValidateConfiguration();
 

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerRetrySoonTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerRetrySoonTests.cs
@@ -1,0 +1,85 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Worker;
+
+public class BaseScraperWorkerRetrySoonTests
+{
+    // GH-851: a cycle that calls RequestRetrySoon (e.g. cold start, tracked
+    // universe not populated yet) must wait the short NotReadyRetryInterval,
+    // NOT the full SleepInterval — so a second cycle happens within a moment.
+    // SleepInterval is set to 1h here: if the retry-soon path didn't apply, the
+    // second cycle would never arrive and the test would time out.
+    [Fact]
+    public async Task RequestRetrySoon_UsesShortInterval_SoNextCycleRunsPromptly()
+    {
+        var secondCycle = new TaskCompletionSource();
+        var cycles = 0;
+        var sut = new TestWorker(
+            sleepInterval: TimeSpan.FromHours(1),
+            retryInterval: TimeSpan.FromMilliseconds(20),
+            doWork: (worker, _) =>
+            {
+                cycles++;
+                if (cycles == 1)
+                {
+                    worker.CallRequestRetrySoon();
+                }
+                else
+                {
+                    secondCycle.TrySetResult();
+                }
+                return Task.CompletedTask;
+            }
+        );
+
+        await sut.StartAsync(CancellationToken.None);
+        var reached = await Task.WhenAny(secondCycle.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        await sut.StopAsync(CancellationToken.None);
+
+        reached
+            .Should()
+            .Be(secondCycle.Task, "the retry-soon interval should trigger a prompt second cycle");
+        cycles.Should().BeGreaterThanOrEqualTo(2);
+    }
+
+    private sealed class TestWorker : BaseScraperWorker
+    {
+        private readonly TimeSpan _sleep;
+        private readonly TimeSpan _retry;
+        private readonly Func<TestWorker, CancellationToken, Task> _doWork;
+
+        public TestWorker(
+            TimeSpan sleepInterval,
+            TimeSpan retryInterval,
+            Func<TestWorker, CancellationToken, Task> doWork
+        )
+            : base(
+                NullLogger.Instance,
+                Substitute.For<IServiceScopeFactory>(),
+                new ErrorReporter(
+                    Substitute.For<IServiceScopeFactory>(),
+                    NullLogger<ErrorReporter>.Instance
+                )
+            )
+        {
+            _sleep = sleepInterval;
+            _retry = retryInterval;
+            _doWork = doWork;
+        }
+
+        protected override string WorkerName => "Test";
+        protected override TimeSpan SleepInterval => _sleep;
+        protected override TimeSpan NotReadyRetryInterval => _retry;
+        protected override ErrorSource ErrorSource => ErrorSource.FtdScraper;
+
+        public void CallRequestRetrySoon() => RequestRetrySoon();
+
+        protected override Task DoWork(CancellationToken stoppingToken) =>
+            _doWork(this, stoppingToken);
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceScraperWorkerTests.cs
@@ -109,7 +109,13 @@ public class YahooPriceScraperWorkerTests
             ErrorReporter errorReporter,
             IOptions<YahooPriceScraperOptions> options
         )
-            : base(logger, scopeFactory, errorReporter, options) { }
+            : base(
+                logger,
+                scopeFactory,
+                errorReporter,
+                options,
+                Options.Create(new Equibles.Core.Configuration.WorkerOptions())
+            ) { }
 
         public TimeSpan InvokeSleepInterval() => SleepInterval;
 


### PR DESCRIPTION
Closes #851.

## Summary

On a cold start the FTD/Yahoo scrapers built their ticker map before SEC CompanySync populated `CommonStock`, captured an empty universe, imported/seeded nothing, then slept the full 24h `SleepInterval` — starving the whole Holdings pipeline (no FTD → no CUSIPs → no 13F backfill) until a manual restart.

## Code changes

- `BaseScraperWorker` — adds `RequestRetrySoon()` + `NotReadyRetryInterval` (default 2 min). When a cycle marks itself not-ready, the loop waits the short interval instead of `SleepInterval` (flag resets each cycle; logged distinctly, not an error).
- `FtdScraperWorker` / `YahooPriceScraperWorker` — before importing, probe `TickerMapService.Build(TickersToSync)`; if the tracked universe is empty (company sync pending), log + `RequestRetrySoon()` + return. Once `CommonStock` is populated they proceed normally on the next short retry.
- Test: `BaseScraperWorkerRetrySoonTests` pins that a retry-soon cycle runs the next cycle promptly (short interval), with `SleepInterval`=1h proving the fix. Existing FTD/Yahoo worker tests updated for the new `IOptions<WorkerOptions>` ctor param (default supplied in the Testable wrappers — no call-site churn).

Verified: full solution builds; affected worker tests 9/9 green.