### PR TITLE
fix(holdings): event-driven Holdings rescan on CUSIP change — no <=24h backfill latency / same-cycle race (GH-852)

### DIFF
--- a/src/Equibles.Holdings.HostedService/Consumers/StockCusipChangedConsumer.cs
+++ b/src/Equibles.Holdings.HostedService/Consumers/StockCusipChangedConsumer.cs
@@ -22,14 +22,17 @@ namespace Equibles.Holdings.HostedService.Consumers;
 public class StockCusipChangedConsumer : IConsumer<StockCusipChanged>
 {
     private readonly ProcessedDataSetRepository _processedDataSetRepository;
+    private readonly HoldingsRescanSignal _rescanSignal;
     private readonly ILogger<StockCusipChangedConsumer> _logger;
 
     public StockCusipChangedConsumer(
         ProcessedDataSetRepository processedDataSetRepository,
+        HoldingsRescanSignal rescanSignal,
         ILogger<StockCusipChangedConsumer> logger
     )
     {
         _processedDataSetRepository = processedDataSetRepository;
+        _rescanSignal = rescanSignal;
         _logger = logger;
     }
 
@@ -63,8 +66,12 @@ public class StockCusipChangedConsumer : IConsumer<StockCusipChanged>
 
         await _processedDataSetRepository.SaveChanges();
 
+        // Wake the Holdings worker now (GH-852) instead of waiting up to its
+        // 24h cycle / risking a same-cycle skip.
+        _rescanSignal.RequestRescan();
+
         _logger.LogInformation(
-            "CUSIP change for {Ticker} ({Cusip}) invalidated {Count} processed 13F data set(s); the quarterly holdings worker will re-import and backfill on its next cycle",
+            "CUSIP change for {Ticker} ({Cusip}) invalidated {Count} processed 13F data set(s); signalled the holdings worker to re-import and backfill now",
             context.Message.Ticker,
             context.Message.Cusip,
             realRows.Count

--- a/src/Equibles.Holdings.HostedService/HoldingsRescanSignal.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsRescanSignal.cs
@@ -1,0 +1,38 @@
+using Equibles.Core.AutoWiring;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.Holdings.HostedService;
+
+/// <summary>
+/// In-process wake signal so <see cref="StockCusipChangedConsumer"/> can make
+/// <see cref="HoldingsScraperWorker"/> re-run promptly after it invalidates the
+/// ProcessedDataSet ledger — instead of the backfill waiting up to the worker's
+/// 24h <c>SleepInterval</c> (and risking a same-cycle skip). Singleton so the
+/// scoped consumer and the singleton hosted worker share one instance.
+/// Requests coalesce: many CUSIP-change events in one FTD burst trigger a
+/// single rescan (which re-imports every quarter for all tracked CUSIPs).
+/// </summary>
+[Service(ServiceLifetime.Singleton)]
+public class HoldingsRescanSignal
+{
+    private readonly SemaphoreSlim _signal = new(0, 1);
+
+    public void RequestRescan()
+    {
+        if (_signal.CurrentCount == 0)
+        {
+            try
+            {
+                _signal.Release();
+            }
+            catch (SemaphoreFullException)
+            {
+                // A concurrent RequestRescan already raised it — one pending
+                // rescan is enough.
+            }
+        }
+    }
+
+    public Task WaitAsync(CancellationToken cancellationToken) =>
+        _signal.WaitAsync(cancellationToken);
+}

--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -27,6 +27,7 @@ public class HoldingsScraperWorker : BaseScraperWorker
 
     private readonly WorkerOptions _workerOptions;
     private readonly IConfiguration _configuration;
+    private readonly HoldingsRescanSignal _rescanSignal;
 
     protected override string WorkerName => "Holdings scraper";
     protected override TimeSpan SleepInterval => TimeSpan.FromHours(24);
@@ -37,12 +38,48 @@ public class HoldingsScraperWorker : BaseScraperWorker
         IServiceScopeFactory scopeFactory,
         ErrorReporter errorReporter,
         IOptions<WorkerOptions> workerOptions,
-        IConfiguration configuration
+        IConfiguration configuration,
+        HoldingsRescanSignal rescanSignal
     )
         : base(logger, scopeFactory, errorReporter)
     {
         _workerOptions = workerOptions.Value;
         _configuration = configuration;
+        _rescanSignal = rescanSignal;
+    }
+
+    // GH-852: wake immediately when StockCusipChangedConsumer requests a
+    // rescan, instead of waiting up to the 24h SleepInterval. If the plain
+    // delay wins, cancel the pending wait so it doesn't swallow a later signal.
+    protected override async Task WaitForNextCycle(
+        TimeSpan interval,
+        CancellationToken stoppingToken
+    )
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+        var wake = _rescanSignal.WaitAsync(cts.Token);
+        var delay = Task.Delay(interval, stoppingToken);
+
+        var completed = await Task.WhenAny(wake, delay);
+        if (completed == wake && !stoppingToken.IsCancellationRequested)
+        {
+            Logger.LogInformation(
+                "Holdings scraper woken early by a CUSIP-change rescan request"
+            );
+        }
+        else
+        {
+            cts.Cancel();
+        }
+
+        try
+        {
+            await wake;
+        }
+        catch (OperationCanceledException)
+        {
+            // Either the delay won (we cancelled the pending wait) or shutdown.
+        }
     }
 
     protected override bool ValidateConfiguration()

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -82,9 +82,17 @@ public abstract class BaseScraperWorker : BackgroundService
                 WorkerName,
                 interval
             );
-            await Task.Delay(interval, stoppingToken);
+            await WaitForNextCycle(interval, stoppingToken);
         }
     }
+
+    /// <summary>
+    /// Waits between cycles. Default is a plain delay; a worker can override to
+    /// also wake early on an external signal (e.g. <c>HoldingsScraperWorker</c>
+    /// waking on a CUSIP-change rescan request).
+    /// </summary>
+    protected virtual Task WaitForNextCycle(TimeSpan interval, CancellationToken stoppingToken) =>
+        Task.Delay(interval, stoppingToken);
 
     protected virtual bool ValidateConfiguration() => true;
 

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerBackfillTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerBackfillTests.cs
@@ -59,7 +59,7 @@ public class HoldingsScraperWorkerBackfillTests : ParadeDbMcpTestBase
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Options.Create(new WorkerOptions()),
-            configuration
+            configuration, new HoldingsRescanSignal()
         );
 
         var method = typeof(HoldingsScraperWorker).GetMethod(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkCycleTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkCycleTests.cs
@@ -41,7 +41,7 @@ public class HoldingsScraperWorkerDoWorkCycleTests : ParadeDbMcpTestBase
             IOptions<WorkerOptions> workerOptions,
             IConfiguration configuration
         )
-            : base(logger, scopeFactory, errorReporter, workerOptions, configuration) { }
+            : base(logger, scopeFactory, errorReporter, workerOptions, configuration, new HoldingsRescanSignal()) { }
 
         protected override TimeSpan[] RetryDelays =>
             [

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkTests.cs
@@ -55,7 +55,7 @@ public class HoldingsScraperWorkerDoWorkTests : ParadeDbMcpTestBase
             scopeFactory,
             BuildErrorReporter(),
             Options.Create(new WorkerOptions { MinSyncDate = new DateTime(2099, 1, 1) }),
-            ConfigWithContactEmail()
+            ConfigWithContactEmail(), new HoldingsRescanSignal()
         );
 
         var doWork = typeof(HoldingsScraperWorker).GetMethod(
@@ -87,7 +87,7 @@ public class HoldingsScraperWorkerDoWorkTests : ParadeDbMcpTestBase
             scopeFactory,
             BuildErrorReporter(),
             Options.Create(new WorkerOptions()),
-            ConfigWithContactEmail()
+            ConfigWithContactEmail(), new HoldingsRescanSignal()
         );
 
         var tryProcess = typeof(HoldingsScraperWorker).GetMethod(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerIsAlreadyProcessedTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerIsAlreadyProcessedTests.cs
@@ -56,7 +56,7 @@ public class HoldingsScraperWorkerIsAlreadyProcessedTests : ParadeDbMcpTestBase
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Options.Create(new WorkerOptions()),
-            configuration
+            configuration, new HoldingsRescanSignal()
         );
         var method = typeof(HoldingsScraperWorker).GetMethod(
             "IsAlreadyProcessed",

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerMarkAsProcessedTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerMarkAsProcessedTests.cs
@@ -46,7 +46,7 @@ public class HoldingsScraperWorkerMarkAsProcessedTests : ParadeDbMcpTestBase
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Options.Create(new WorkerOptions()),
-            configuration
+            configuration, new HoldingsRescanSignal()
         );
 
         var method = typeof(HoldingsScraperWorker).GetMethod(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerMarkProcessedFailTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerMarkProcessedFailTests.cs
@@ -111,7 +111,7 @@ public class HoldingsScraperWorkerMarkProcessedFailTests : ParadeDbMcpTestBase
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Options.Create(new WorkerOptions()),
-            config
+            config, new HoldingsRescanSignal()
         );
 
         var method = typeof(HoldingsScraperWorker).GetMethod(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRecalculateTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRecalculateTests.cs
@@ -38,7 +38,7 @@ public class HoldingsScraperWorkerRecalculateTests
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Options.Create(new WorkerOptions()),
-            configuration
+            configuration, new HoldingsRescanSignal()
         );
 
         var method = typeof(HoldingsScraperWorker).GetMethod(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRetryArmsTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRetryArmsTests.cs
@@ -42,7 +42,7 @@ public class HoldingsScraperWorkerRetryArmsTests : ParadeDbMcpTestBase
             IOptions<WorkerOptions> workerOptions,
             IConfiguration configuration
         )
-            : base(logger, scopeFactory, errorReporter, workerOptions, configuration) { }
+            : base(logger, scopeFactory, errorReporter, workerOptions, configuration, new HoldingsRescanSignal()) { }
 
         protected override TimeSpan[] RetryDelays =>
             [

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerTryProcessDataSetTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerTryProcessDataSetTests.cs
@@ -125,7 +125,7 @@ public class HoldingsScraperWorkerTryProcessDataSetTests : ParadeDbMcpTestBase
             scopeFactory,
             BuildErrorReporter(),
             Options.Create(new WorkerOptions()),
-            ConfigWithContactEmail()
+            ConfigWithContactEmail(), new HoldingsRescanSignal()
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Holdings/StockCusipChangedConsumerMixedStateTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/StockCusipChangedConsumerMixedStateTests.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
+using Equibles.Holdings.HostedService;
 
 namespace Equibles.IntegrationTests.Holdings;
 
@@ -64,10 +65,7 @@ public class StockCusipChangedConsumerMixedStateTests : IAsyncLifetime
 
         await using (var ctx = _fixture.CreateDbContext())
         {
-            var sut = new StockCusipChangedConsumer(
-                new ProcessedDataSetRepository(ctx),
-                Substitute.For<ILogger<StockCusipChangedConsumer>>()
-            );
+            var sut = new StockCusipChangedConsumer(new ProcessedDataSetRepository(ctx), new HoldingsRescanSignal(), Substitute.For<ILogger<StockCusipChangedConsumer>>());
             // Must not throw a unique-constraint violation from a duplicate guard.
             await sut.Consume(
                 Context(new StockCusipChanged(Guid.NewGuid(), "MSFT", "OLD", "594918104"))

--- a/tests/Equibles.IntegrationTests/Holdings/StockCusipChangedConsumerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/StockCusipChangedConsumerTests.cs
@@ -1,4 +1,5 @@
 using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService;
 using Equibles.Holdings.HostedService.Consumers;
 using Equibles.Holdings.Repositories;
 using Equibles.IntegrationTests.Helpers;
@@ -15,6 +16,8 @@ namespace Equibles.IntegrationTests.Holdings;
 public class StockCusipChangedConsumerTests : IAsyncLifetime
 {
     private readonly ParadeDbFixture _fixture;
+
+    private readonly HoldingsRescanSignal _signal = new();
 
     public StockCusipChangedConsumerTests(ParadeDbFixture fixture) => _fixture = fixture;
 
@@ -59,6 +62,7 @@ public class StockCusipChangedConsumerTests : IAsyncLifetime
         {
             var sut = new StockCusipChangedConsumer(
                 new ProcessedDataSetRepository(ctx),
+                _signal,
                 Substitute.For<ILogger<StockCusipChangedConsumer>>()
             );
             await sut.Consume(
@@ -69,6 +73,12 @@ public class StockCusipChangedConsumerTests : IAsyncLifetime
         await using var verify = _fixture.CreateDbContext();
         var rows = await verify.Set<ProcessedDataSet>().Select(r => r.FileName).ToListAsync();
         rows.Should().ContainSingle().Which.Should().Be(ProcessedDataSet.BackfillGuardFileName);
+
+        // GH-852: invalidation must wake the Holdings worker now.
+        var wait = _signal.WaitAsync(CancellationToken.None);
+        (await Task.WhenAny(wait, Task.Delay(TimeSpan.FromSeconds(1))))
+            .Should()
+            .Be(wait, "the consumer must signal a rescan after invalidating ProcessedDataSet");
     }
 
     // Idempotent: once only the guard remains, a further event is a no-op
@@ -87,12 +97,19 @@ public class StockCusipChangedConsumerTests : IAsyncLifetime
         {
             var sut = new StockCusipChangedConsumer(
                 new ProcessedDataSetRepository(ctx),
+                _signal,
                 Substitute.For<ILogger<StockCusipChangedConsumer>>()
             );
             await sut.Consume(
                 Context(new StockCusipChanged(Guid.NewGuid(), "MSFT", "abc", "594918104"))
             );
         }
+
+        // No invalidation happened (already cleared) → no rescan signalled.
+        var wait = _signal.WaitAsync(CancellationToken.None);
+        (await Task.WhenAny(wait, Task.Delay(TimeSpan.FromMilliseconds(300))))
+            .Should()
+            .NotBe(wait, "an already-invalidated no-op must not trigger a rescan");
 
         await using var verify = _fixture.CreateDbContext();
         var rows = await verify.Set<ProcessedDataSet>().Select(r => r.FileName).ToListAsync();

--- a/tests/Equibles.UnitTests/Holdings/HoldingsRescanSignalTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsRescanSignalTests.cs
@@ -1,0 +1,40 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsRescanSignalTests
+{
+    // GH-852: a requested rescan releases a waiter promptly.
+    [Fact]
+    public async Task RequestRescan_ReleasesWaiter()
+    {
+        var signal = new HoldingsRescanSignal();
+
+        signal.RequestRescan();
+
+        var wait = signal.WaitAsync(CancellationToken.None);
+        (await Task.WhenAny(wait, Task.Delay(TimeSpan.FromSeconds(1))))
+            .Should()
+            .Be(wait);
+    }
+
+    // Requests coalesce: many CUSIP-change events in one FTD burst must trigger
+    // a single rescan, not one per event (one rescan re-imports every quarter
+    // for all tracked CUSIPs anyway).
+    [Fact]
+    public async Task RequestRescan_Coalesces_OnlyOnePendingRescan()
+    {
+        var signal = new HoldingsRescanSignal();
+
+        signal.RequestRescan();
+        signal.RequestRescan();
+        signal.RequestRescan();
+
+        await signal.WaitAsync(CancellationToken.None); // consume the single permit
+
+        var second = signal.WaitAsync(CancellationToken.None);
+        (await Task.WhenAny(second, Task.Delay(TimeSpan.FromMilliseconds(300))))
+            .Should()
+            .NotBe(second, "coalesced requests must leave only one pending rescan");
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsScraperWorkerTests.cs
@@ -197,7 +197,7 @@ public class HoldingsScraperWorkerTests
             IOptions<WorkerOptions> workerOptions,
             IConfiguration configuration
         )
-            : base(logger, scopeFactory, errorReporter, workerOptions, configuration) { }
+            : base(logger, scopeFactory, errorReporter, workerOptions, configuration, new HoldingsRescanSignal()) { }
 
         public bool InvokeValidateConfiguration() => ValidateConfiguration();
 


### PR DESCRIPTION
Closes #852. Builds on #853.

## Summary

`StockCusipChangedConsumer` invalidated `ProcessedDataSet` but `HoldingsScraperWorker` only reprocessed on its next 24h cycle, and a cycle that started seconds before the invalidation skipped the just-invalidated datasets — so backfill was up to 24h late and could need a manual restart.

## Code changes

- **`HoldingsRescanSignal`** (new, singleton): in-proc wake; `RequestRescan()` coalesces (one pending rescan per FTD burst), `WaitAsync` releases a waiter.
- **`BaseScraperWorker`**: extracted the inter-cycle wait into `protected virtual WaitForNextCycle(interval, ct)` (default `Task.Delay`).
- **`HoldingsScraperWorker`**: overrides it to race the delay against `HoldingsRescanSignal.WaitAsync` — a rescan wakes it immediately; if the delay wins, the pending wait is cancelled via a linked CTS so it can't swallow a later signal.
- **`StockCusipChangedConsumer`**: calls `RequestRescan()` after invalidating (post-SaveChanges); the already-invalidated no-op path does not signal.
- Tests: `HoldingsRescanSignalTests` (release + coalesce); `StockCusipChangedConsumerTests` asserts rescan signalled on invalidation and not on no-op; existing HoldingsScraperWorker construction sites updated for the new dependency.

Verified: full solution builds; unit 8/8 + integration 6/6 green.