### PR TITLE
chore(lint): csharpier-format GH-852 files (fix red main lint)

### DIFF
--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -63,9 +63,7 @@ public class HoldingsScraperWorker : BaseScraperWorker
         var completed = await Task.WhenAny(wake, delay);
         if (completed == wake && !stoppingToken.IsCancellationRequested)
         {
-            Logger.LogInformation(
-                "Holdings scraper woken early by a CUSIP-change rescan request"
-            );
+            Logger.LogInformation("Holdings scraper woken early by a CUSIP-change rescan request");
         }
         else
         {

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerBackfillTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerBackfillTests.cs
@@ -59,7 +59,8 @@ public class HoldingsScraperWorkerBackfillTests : ParadeDbMcpTestBase
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Options.Create(new WorkerOptions()),
-            configuration, new HoldingsRescanSignal()
+            configuration,
+            new HoldingsRescanSignal()
         );
 
         var method = typeof(HoldingsScraperWorker).GetMethod(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkCycleTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkCycleTests.cs
@@ -41,7 +41,14 @@ public class HoldingsScraperWorkerDoWorkCycleTests : ParadeDbMcpTestBase
             IOptions<WorkerOptions> workerOptions,
             IConfiguration configuration
         )
-            : base(logger, scopeFactory, errorReporter, workerOptions, configuration, new HoldingsRescanSignal()) { }
+            : base(
+                logger,
+                scopeFactory,
+                errorReporter,
+                workerOptions,
+                configuration,
+                new HoldingsRescanSignal()
+            ) { }
 
         protected override TimeSpan[] RetryDelays =>
             [

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkTests.cs
@@ -55,7 +55,8 @@ public class HoldingsScraperWorkerDoWorkTests : ParadeDbMcpTestBase
             scopeFactory,
             BuildErrorReporter(),
             Options.Create(new WorkerOptions { MinSyncDate = new DateTime(2099, 1, 1) }),
-            ConfigWithContactEmail(), new HoldingsRescanSignal()
+            ConfigWithContactEmail(),
+            new HoldingsRescanSignal()
         );
 
         var doWork = typeof(HoldingsScraperWorker).GetMethod(
@@ -87,7 +88,8 @@ public class HoldingsScraperWorkerDoWorkTests : ParadeDbMcpTestBase
             scopeFactory,
             BuildErrorReporter(),
             Options.Create(new WorkerOptions()),
-            ConfigWithContactEmail(), new HoldingsRescanSignal()
+            ConfigWithContactEmail(),
+            new HoldingsRescanSignal()
         );
 
         var tryProcess = typeof(HoldingsScraperWorker).GetMethod(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerIsAlreadyProcessedTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerIsAlreadyProcessedTests.cs
@@ -56,7 +56,8 @@ public class HoldingsScraperWorkerIsAlreadyProcessedTests : ParadeDbMcpTestBase
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Options.Create(new WorkerOptions()),
-            configuration, new HoldingsRescanSignal()
+            configuration,
+            new HoldingsRescanSignal()
         );
         var method = typeof(HoldingsScraperWorker).GetMethod(
             "IsAlreadyProcessed",

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerMarkAsProcessedTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerMarkAsProcessedTests.cs
@@ -46,7 +46,8 @@ public class HoldingsScraperWorkerMarkAsProcessedTests : ParadeDbMcpTestBase
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Options.Create(new WorkerOptions()),
-            configuration, new HoldingsRescanSignal()
+            configuration,
+            new HoldingsRescanSignal()
         );
 
         var method = typeof(HoldingsScraperWorker).GetMethod(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerMarkProcessedFailTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerMarkProcessedFailTests.cs
@@ -111,7 +111,8 @@ public class HoldingsScraperWorkerMarkProcessedFailTests : ParadeDbMcpTestBase
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Options.Create(new WorkerOptions()),
-            config, new HoldingsRescanSignal()
+            config,
+            new HoldingsRescanSignal()
         );
 
         var method = typeof(HoldingsScraperWorker).GetMethod(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRecalculateTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRecalculateTests.cs
@@ -38,7 +38,8 @@ public class HoldingsScraperWorkerRecalculateTests
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
             Options.Create(new WorkerOptions()),
-            configuration, new HoldingsRescanSignal()
+            configuration,
+            new HoldingsRescanSignal()
         );
 
         var method = typeof(HoldingsScraperWorker).GetMethod(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRetryArmsTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRetryArmsTests.cs
@@ -42,7 +42,14 @@ public class HoldingsScraperWorkerRetryArmsTests : ParadeDbMcpTestBase
             IOptions<WorkerOptions> workerOptions,
             IConfiguration configuration
         )
-            : base(logger, scopeFactory, errorReporter, workerOptions, configuration, new HoldingsRescanSignal()) { }
+            : base(
+                logger,
+                scopeFactory,
+                errorReporter,
+                workerOptions,
+                configuration,
+                new HoldingsRescanSignal()
+            ) { }
 
         protected override TimeSpan[] RetryDelays =>
             [

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerTryProcessDataSetTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerTryProcessDataSetTests.cs
@@ -125,7 +125,8 @@ public class HoldingsScraperWorkerTryProcessDataSetTests : ParadeDbMcpTestBase
             scopeFactory,
             BuildErrorReporter(),
             Options.Create(new WorkerOptions()),
-            ConfigWithContactEmail(), new HoldingsRescanSignal()
+            ConfigWithContactEmail(),
+            new HoldingsRescanSignal()
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Holdings/StockCusipChangedConsumerMixedStateTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/StockCusipChangedConsumerMixedStateTests.cs
@@ -1,4 +1,5 @@
 using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService;
 using Equibles.Holdings.HostedService.Consumers;
 using Equibles.Holdings.Repositories;
 using Equibles.IntegrationTests.Helpers;
@@ -8,7 +9,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
-using Equibles.Holdings.HostedService;
 
 namespace Equibles.IntegrationTests.Holdings;
 
@@ -65,7 +65,11 @@ public class StockCusipChangedConsumerMixedStateTests : IAsyncLifetime
 
         await using (var ctx = _fixture.CreateDbContext())
         {
-            var sut = new StockCusipChangedConsumer(new ProcessedDataSetRepository(ctx), new HoldingsRescanSignal(), Substitute.For<ILogger<StockCusipChangedConsumer>>());
+            var sut = new StockCusipChangedConsumer(
+                new ProcessedDataSetRepository(ctx),
+                new HoldingsRescanSignal(),
+                Substitute.For<ILogger<StockCusipChangedConsumer>>()
+            );
             // Must not throw a unique-constraint violation from a duplicate guard.
             await sut.Consume(
                 Context(new StockCusipChanged(Guid.NewGuid(), "MSFT", "OLD", "594918104"))

--- a/tests/Equibles.UnitTests/Holdings/HoldingsRescanSignalTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsRescanSignalTests.cs
@@ -13,9 +13,7 @@ public class HoldingsRescanSignalTests
         signal.RequestRescan();
 
         var wait = signal.WaitAsync(CancellationToken.None);
-        (await Task.WhenAny(wait, Task.Delay(TimeSpan.FromSeconds(1))))
-            .Should()
-            .Be(wait);
+        (await Task.WhenAny(wait, Task.Delay(TimeSpan.FromSeconds(1)))).Should().Be(wait);
     }
 
     // Requests coalesce: many CUSIP-change events in one FTD burst must trigger

--- a/tests/Equibles.UnitTests/Holdings/HoldingsScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsScraperWorkerTests.cs
@@ -197,7 +197,14 @@ public class HoldingsScraperWorkerTests
             IOptions<WorkerOptions> workerOptions,
             IConfiguration configuration
         )
-            : base(logger, scopeFactory, errorReporter, workerOptions, configuration, new HoldingsRescanSignal()) { }
+            : base(
+                logger,
+                scopeFactory,
+                errorReporter,
+                workerOptions,
+                configuration,
+                new HoldingsRescanSignal()
+            ) { }
 
         public bool InvokeValidateConfiguration() => ValidateConfiguration();
 


### PR DESCRIPTION
## Summary

PR #855 (GH-852) was committed via a recovery path that skipped `csharpier format`; the local pre-commit hook doesn't run repo-wide `csharpier check` like CI does, so 13 files (incl. `HoldingsScraperWorker.cs` and the script-patched HoldingsScraperWorker/consumer test files) landed unformatted → CI `lint` red on main.

## Code changes

- `dotnet csharpier format` on the 13 affected files. Formatting-only, no behavior change; `csharpier check .` now clean for tracked sources (only gitignored `coverage/*.xml` remain, absent in CI). Full solution still builds.