### PR TITLE
test(web): pin VersionCheckService.IsNewer missing-Build clamp contract

### DIFF
--- a/tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerTests.cs
+++ b/tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+/// <summary>
+/// IsNewer's documented contract: "Compares Major.Minor.Build only so tag
+/// formatting variance (e.g. 'v1.0.0' vs an assembly '1.0.0.0') can't trigger a
+/// spurious banner." A two-segment version ("1.2") parses with Build == -1; the
+/// contract requires that to be treated as Build 0, so "1.2" vs "1.2.0" is the
+/// same release and must NOT report an update. The existing integration test
+/// only covers four-segment latest tags (Build >= 0); the missing-Build clamp is
+/// unpinned. A refactor dropping `Build &lt; 0 ? 0 : Build` would make the
+/// System.Version ctor throw on a negative build — surfacing as either an
+/// exception or a spurious banner, the exact failure the contract forbids.
+/// </summary>
+public class VersionCheckServiceIsNewerTests
+{
+    [Fact]
+    public void IsNewer_TwoSegmentCurrentVsThreeSegmentLatest_TreatsMissingBuildAsNoUpdate()
+    {
+        var method = typeof(VersionCheckService).GetMethod(
+            "IsNewer",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (bool)method.Invoke(null, ["1.2", "1.2.0"]);
+
+        result.Should().BeFalse("'1.2' and '1.2.0' are the same Major.Minor.Build release");
+    }
+}


### PR DESCRIPTION
## Summary

- `VersionCheckService.IsNewer` documents "compares Major.Minor.Build only so tag formatting variance can't trigger a spurious banner", relying on a `Build < 0 ? 0 : Build` clamp. The existing integration test only covers four-segment latest tags (Build >= 0); the two-segment / missing-Build clamp arm was unpinned at the unit level.
- Adds one unit test pinning that contract.

## Code changes

- `tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerTests.cs` — new test. Invokes the private static `IsNewer` via reflection with `("1.2", "1.2.0")` and asserts `false` (same Major.Minor.Build release → no update banner). A refactor dropping the `Build < 0 ? 0 : Build` clamp would throw in the `System.Version` ctor or report a spurious update — the exact failure the contract forbids.