### PR TITLE
fix(messaging): MassTransitV9Outbox migration — repair red main after the MassTransit 9 bump (#849)

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260518111950_MassTransitV9Outbox.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260518111950_MassTransitV9Outbox.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518111950_MassTransitV9Outbox")]
+    partial class MassTransitV9Outbox
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260518111950_MassTransitV9Outbox.cs
+++ b/src/Equibles.Migrations/Migrations/20260518111950_MassTransitV9Outbox.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class MassTransitV9Outbox : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BusName",
+                table: "OutboxState",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxState_BusName_Created",
+                table: "OutboxState",
+                columns: new[] { "BusName", "Created" }
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OutboxState_BusName_Created",
+                table: "OutboxState"
+            );
+
+            migrationBuilder.DropColumn(name: "BusName", table: "OutboxState");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

#849 bumped MassTransit 8.5.7 → **9.1.1** (major). MT9's EF outbox entity model differs from the 8.5.7-era `AddMassTransitOutbox` snapshot, so `EquiblesDbContext` had **pending model changes** → `MigrateAsync` threw `PendingModelChangesWarning` → **every fixture-backed Integration + Functional test failed** (main red on both `CI` build-and-test and `Functional Tests`).

## Code changes

- New EF migration **`MassTransitV9Outbox`** (generated via `dotnet ef migrations add`): MT9's only schema delta — adds `OutboxState.BusName` (varchar(256), nullable) + index `IX_OutboxState_BusName_Created`. Additive, non-destructive; resolves the snapshot/model mismatch. csharpier-formatted (the EF generator output isn't, which has reddened lint before).

Verified locally on MT 9.1.1: solution builds; previously-failing Integration (Cboe full pipeline, StockCusipChangedConsumer, HoldingsScraperWorker) 9/9 and Functional (McpServerToolCorrectness) 5/5 now green. MT9 SQL-transport/outbox runtime works (consumer + worker tests pass).