### PR TITLE
build(deps): block dependabot Microsoft.Bcl.Memory major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
       # .SqlTransport.PostgreSQL.
       - dependency-name: "MassTransit*"
         update-types: ["version-update:semver-major"]
+      # Microsoft.Bcl.Memory is a deliberate direct pin at 9.0.16 that
+      # overrides the transitive high-severity advisory NU1903
+      # (GHSA-73j8-2gch-69rq). Block major bumps so the 10.x PR can't reopen;
+      # 9.0.x patches are still allowed.
+      - dependency-name: "Microsoft.Bcl.Memory"
+        update-types: ["version-update:semver-major"]
     groups:
       microsoft-extensions:
         patterns:


### PR DESCRIPTION
## Summary

Closed dependabot PR #850 (Microsoft.Bcl.Memory 9.0.16 → 10.0.8). 9.0.16 is a deliberate direct pin overriding the transitive high-severity advisory **NU1903 (GHSA-73j8-2gch-69rq)**; the 10.x bump is a major, fails required CI, and isn't wanted. This stops dependabot from reopening it.

## Code changes

- `.github/dependabot.yml` — add `Microsoft.Bcl.Memory` to the `ignore` list for `version-update:semver-major` (same mechanism already used for the licensed SixLabors.ImageSharp 4.x and MassTransit 9.x). 9.0.x patch updates remain allowed.