### PR TITLE
fix(web): add aria-label to stocks search input

### DIFF
--- a/src/Equibles.Web/Views/Stocks/Index.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Index.cshtml
@@ -16,6 +16,7 @@
         <div class="flex gap-3">
             <input type="text" name="search" value="@Model.Search"
                    class="input input-bordered flex-1 max-w-md"
+                   aria-label="Search stocks by ticker or name"
                    placeholder="Search by ticker or name..." />
             <button type="submit" class="btn btn-primary">Search</button>
             @if (!string.IsNullOrEmpty(Model.Search)) {


### PR DESCRIPTION
## Summary

- The ticker/name search input on `/stocks` had no associated `<label>`, `aria-label`, or `aria-labelledby`, leaving it unlabelled for screen-reader users (WCAG 2.1 — form labels).
- Found during a frontend accessibility audit (severity: High, route `/stocks`, selector `input[name=search]`).

## Code changes

- `src/Equibles.Web/Views/Stocks/Index.cshtml` — added `aria-label="Search stocks by ticker or name"` to the search `<input>`. No visual change; placeholder retained.