### PR TITLE
fix(holdings): treat whitespace-only Sec:ContactEmail as unconfigured (GH-810)

### DIFF
--- a/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
+++ b/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
@@ -46,7 +46,7 @@ public class Holdings13FRealtimeWorker : BaseScraperWorker
 
     protected override bool ValidateConfiguration()
     {
-        if (string.IsNullOrEmpty(_configuration["Sec:ContactEmail"]))
+        if (string.IsNullOrWhiteSpace(_configuration["Sec:ContactEmail"]))
         {
             Logger.LogWarning(
                 "13F real-time ingestion stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."

--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -82,7 +82,7 @@ public class HoldingsScraperWorker : BaseScraperWorker
 
     protected override bool ValidateConfiguration()
     {
-        if (string.IsNullOrEmpty(_configuration["Sec:ContactEmail"]))
+        if (string.IsNullOrWhiteSpace(_configuration["Sec:ContactEmail"]))
         {
             Logger.LogWarning(
                 "Holdings Scraper stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."

--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerTests.cs
@@ -11,7 +11,7 @@ namespace Equibles.UnitTests.Holdings;
 
 public class Holdings13FRealtimeWorkerTests
 {
-    [Fact(Skip = "GH-810 — whitespace-only Sec:ContactEmail wrongly passes ValidateConfiguration")]
+    [Fact]
     public void ValidateConfiguration_SecContactEmailWhitespaceOnly_ReturnsFalse()
     {
         // Contract (from the worker's own warning + the SEC EDGAR User-Agent rule it


### PR DESCRIPTION
## Summary

Closes #810.

`Holdings13FRealtimeWorker.ValidateConfiguration` (and its sibling `HoldingsScraperWorker.ValidateConfiguration`) used `string.IsNullOrEmpty` to guard against a missing SEC contact email. A whitespace-only value (e.g. `SEC_CONTACT_EMAIL= ` in `.env`) passed the guard, so the worker ran with an effectively-blank User-Agent contact that SEC EDGAR silently 403s — looping every 6h importing nothing with no error surfaced.

## Code changes

- `Holdings13FRealtimeWorker.cs` — guard now uses `string.IsNullOrWhiteSpace`.
- `HoldingsScraperWorker.cs` — same latent bug fixed (per the issue's note to check the sibling).
- `Holdings13FRealtimeWorkerTests.cs` — removed `Skip` from the regression test; it now passes.

## Note

Bugs #828, #825, #820 (embedding pipeline) were left untouched — they are already addressed by open PR #744 and the issues explicitly say to reconcile there rather than fix twice.