### PR TITLE
fix(embeddings): isolate per-chunk failures + back off on systemic outage (supersedes #744)

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingClient.cs
+++ b/src/Equibles.Sec.BusinessLogic/Embeddings/EmbeddingClient.cs
@@ -50,24 +50,16 @@ public class EmbeddingClient : IEmbeddingClient
             return [];
         }
 
-        try
-        {
-            var batches = texts.Chunk(_config.BatchSize).ToList();
-            var allEmbeddings = new List<float[]>();
+        var batches = texts.Chunk(_config.BatchSize).ToList();
+        var allEmbeddings = new List<float[]>(texts.Count);
 
-            foreach (var batch in batches)
-            {
-                var batchEmbeddings = await ProcessBatch(batch.ToList());
-                allEmbeddings.AddRange(batchEmbeddings);
-            }
-
-            return allEmbeddings;
-        }
-        catch (Exception ex)
+        foreach (var batch in batches)
         {
-            _logger.LogError(ex, "Error generating embeddings for {Count} texts", texts.Count);
-            throw;
+            allEmbeddings.AddRange(await ProcessBatch(batch.ToList()));
         }
+
+        // Positionally aligned to `texts`; entries are null where embedding failed.
+        return allEmbeddings;
     }
 
     public async Task<int> GetEmbeddingDimension()
@@ -86,51 +78,45 @@ public class EmbeddingClient : IEmbeddingClient
 
     private async Task<List<float[]>> ProcessBatch(List<string> batch)
     {
-        // For single text, we can call the new /api/embed endpoint
-        if (batch.Count == 1)
-        {
-            var singlePayload = new { model = _config.ModelName, input = batch[0] };
-
-            var singleJson = JsonSerializer.Serialize(singlePayload);
-            using var singleContent = new StringContent(
-                singleJson,
-                System.Text.Encoding.UTF8,
-                "application/json"
-            );
-
-            // Use the new /api/embed endpoint
-            var response = await _httpClient.PostAsync("/api/embed", singleContent);
-            response.EnsureSuccessStatusCode();
-
-            var responseJson = await response.Content.ReadAsStringAsync();
-            var result = JsonSerializer.Deserialize<OllamaEmbedResponse>(responseJson);
-
-            return result.Embeddings;
-        }
-
-        // For multiple texts, we need to call the endpoint multiple times
-        // as Ollama's /api/embed doesn't support batch processing like OpenAI
-        var embeddings = new List<float[]>();
+        // Ollama's /api/embed handles one input per call. Embed each text
+        // independently and return a list positionally aligned to `batch`,
+        // using null for any text that fails (e.g. Ollama returns 500 because
+        // the model emitted a NaN vector for that specific input). One bad
+        // chunk must never abort the batch or crash the document processor —
+        // the caller skips null entries so the backlog keeps draining.
+        var embeddings = new List<float[]>(batch.Count);
         foreach (var text in batch)
         {
-            var payload = new { model = _config.ModelName, input = text };
-
-            var json = JsonSerializer.Serialize(payload);
-            using var content = new StringContent(
-                json,
-                System.Text.Encoding.UTF8,
-                "application/json"
-            );
-
-            var response = await _httpClient.PostAsync("/api/embed", content);
-            response.EnsureSuccessStatusCode();
-
-            var responseJson = await response.Content.ReadAsStringAsync();
-            var result = JsonSerializer.Deserialize<OllamaEmbedResponse>(responseJson);
-
-            if (result.Embeddings != null && result.Embeddings.Count > 0)
+            try
             {
-                embeddings.Add(result.Embeddings[0]);
+                var payload = new { model = _config.ModelName, input = text };
+
+                var json = JsonSerializer.Serialize(payload);
+                using var content = new StringContent(
+                    json,
+                    System.Text.Encoding.UTF8,
+                    "application/json"
+                );
+
+                var response = await _httpClient.PostAsync("/api/embed", content);
+                response.EnsureSuccessStatusCode();
+
+                var responseJson = await response.Content.ReadAsStringAsync();
+                var result = JsonSerializer.Deserialize<OllamaEmbedResponse>(responseJson);
+
+                embeddings.Add(
+                    result?.Embeddings != null && result.Embeddings.Count > 0
+                        ? result.Embeddings[0]
+                        : null
+                );
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Skipping a chunk that failed to embed (continuing with the rest)"
+                );
+                embeddings.Add(null);
             }
         }
 

--- a/src/Equibles.Sec.BusinessLogic/Embeddings/IEmbeddingClient.cs
+++ b/src/Equibles.Sec.BusinessLogic/Embeddings/IEmbeddingClient.cs
@@ -3,7 +3,22 @@ namespace Equibles.Sec.BusinessLogic.Embeddings;
 public interface IEmbeddingClient
 {
     bool IsEnabled { get; }
+
+    /// <summary>
+    /// Embeds a single text. Returns <c>null</c> when the text could not be
+    /// embedded (e.g. the model emitted a degenerate vector) — callers must
+    /// null-check the result.
+    /// </summary>
     Task<float[]> GenerateEmbedding(string text);
+
+    /// <summary>
+    /// Embeds each text. The result is positionally aligned to
+    /// <paramref name="texts"/> (same length, same order); an entry is
+    /// <c>null</c> where that text could not be embedded. Callers must keep the
+    /// alignment and null-check each entry. A single failed text never aborts
+    /// the batch.
+    /// </summary>
     Task<List<float[]>> GenerateEmbeddings(List<string> texts);
+
     Task<int> GetEmbeddingDimension();
 }

--- a/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
+++ b/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
@@ -87,13 +87,15 @@ public class DocumentProcessor : IDocumentProcessor
             }
             catch (Exception ex)
             {
-                _logger.LogError(
+                // Do not rethrow: an unexpected failure on one document must not
+                // tear down the whole document-processor worker. Log and move on;
+                // the chunk stays unembedded and is retried on a later pass.
+                _logger.LogWarning(
                     ex,
-                    "Error generating embeddings for document {DocumentId}. "
-                        + "Stopping batch — embedding server is likely down",
+                    "Skipping embeddings for document {DocumentId} after an unexpected "
+                        + "error; continuing with the rest",
                     group.Key
                 );
-                throw;
             }
         }
     }
@@ -183,27 +185,35 @@ public class DocumentProcessor : IDocumentProcessor
 
         var embeddings = await _embeddingClient.GenerateEmbeddings(chunkContents);
 
-        if (embeddings.Count != chunks.Count)
+        // embeddings is positionally aligned to chunks; an entry is null when
+        // that chunk could not be embedded (e.g. the model returned a NaN
+        // vector and Ollama 500'd). Skip those chunks instead of failing the
+        // whole batch — they simply stay unembedded and can be retried later.
+        var count = Math.Min(chunks.Count, embeddings.Count);
+        var added = 0;
+        for (int i = 0; i < count; i++)
         {
-            throw new InvalidOperationException(
-                $"Embedding count mismatch: expected {chunks.Count}, got {embeddings.Count}"
-            );
-        }
-
-        for (int i = 0; i < chunks.Count; i++)
-        {
-            var embedding = new Embedding
+            if (embeddings[i] == null)
             {
-                Chunk = chunks[i],
-                Model = _embeddingConfig.ModelName,
-                Vector = new Vector(embeddings[i]),
-                VectorDimension = embeddings[i].Length,
-                CreationTime = DateTime.UtcNow,
-            };
+                continue;
+            }
 
-            _embeddingRepository.Add(embedding);
+            _embeddingRepository.Add(
+                new Embedding
+                {
+                    Chunk = chunks[i],
+                    Model = _embeddingConfig.ModelName,
+                    Vector = new Vector(embeddings[i]),
+                    VectorDimension = embeddings[i].Length,
+                    CreationTime = DateTime.UtcNow,
+                }
+            );
+            added++;
         }
 
-        await _embeddingRepository.SaveChanges();
+        if (added > 0)
+        {
+            await _embeddingRepository.SaveChanges();
+        }
     }
 }

--- a/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
+++ b/src/Equibles.Sec.BusinessLogic/Processing/DocumentProcessor.cs
@@ -67,6 +67,9 @@ public class DocumentProcessor : IDocumentProcessor
         // Group by document for logging
         var chunksByDocument = chunks.GroupBy(c => c.DocumentId);
 
+        var totalChunks = 0;
+        var totalEmbedded = 0;
+
         foreach (var group in chunksByDocument)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -76,20 +79,23 @@ public class DocumentProcessor : IDocumentProcessor
             }
 
             var documentChunks = group.ToList();
+            totalChunks += documentChunks.Count;
             try
             {
-                await GenerateEmbeddingsForChunks(documentChunks);
+                var embedded = await GenerateEmbeddingsForChunks(documentChunks);
+                totalEmbedded += embedded;
                 _logger.LogInformation(
-                    "Generated embeddings for {Count} chunks of document {DocumentId}",
+                    "Generated embeddings for {Embedded}/{Count} chunks of document {DocumentId}",
+                    embedded,
                     documentChunks.Count,
                     group.Key
                 );
             }
             catch (Exception ex)
             {
-                // Do not rethrow: an unexpected failure on one document must not
-                // tear down the whole document-processor worker. Log and move on;
-                // the chunk stays unembedded and is retried on a later pass.
+                // Do not rethrow here: an unexpected failure on one document must
+                // not abort embedding for the remaining documents. Log and move
+                // on; the chunks stay unembedded and are retried on a later pass.
                 _logger.LogWarning(
                     ex,
                     "Skipping embeddings for document {DocumentId} after an unexpected "
@@ -97,6 +103,19 @@ public class DocumentProcessor : IDocumentProcessor
                     group.Key
                 );
             }
+        }
+
+        // Distinguish a few poison chunks (isolated above, so the backlog keeps
+        // draining) from a systemic outage. If we attempted chunks but embedded
+        // none, the embedding server is down: throw so the worker's base loop
+        // logs it loudly, reports it, and backs off for a cycle — instead of
+        // hot-looping on the same batch with zero progress and no error.
+        if (totalChunks > 0 && totalEmbedded == 0)
+        {
+            throw new InvalidOperationException(
+                $"No embeddings were produced for any of {totalChunks} chunks — "
+                    + "the embedding server is likely down. Backing off this cycle."
+            );
         }
     }
 
@@ -179,7 +198,13 @@ public class DocumentProcessor : IDocumentProcessor
         return allChunks;
     }
 
-    private async Task GenerateEmbeddingsForChunks(List<Chunk> chunks)
+    /// <summary>
+    /// Embeds the given chunks and persists the successful ones. Returns the
+    /// number of embeddings actually written — entries the embedding client
+    /// could not produce (null, positionally aligned to the input) are skipped,
+    /// so a return of 0 means nothing in this document could be embedded.
+    /// </summary>
+    private async Task<int> GenerateEmbeddingsForChunks(List<Chunk> chunks)
     {
         var chunkContents = chunks.Select(c => c.Content).ToList();
 
@@ -215,5 +240,7 @@ public class DocumentProcessor : IDocumentProcessor
         {
             await _embeddingRepository.SaveChanges();
         }
+
+        return added;
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorPerDocumentIsolationTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorPerDocumentIsolationTests.cs
@@ -18,10 +18,7 @@ namespace Equibles.IntegrationTests.Sec;
 /// </summary>
 public class DocumentProcessorPerDocumentIsolationTests
 {
-    [Fact(
-        Skip = "GH-828 — DocumentProcessor.GenerateEmbeddings rethrows on one document's "
-            + "failure, aborting embeddings for all remaining documents"
-    )]
+    [Fact]
     public async Task GenerateEmbeddings_FirstDocumentFails_StillEmbedsTheSecondDocument()
     {
         var docA = Guid.NewGuid();

--- a/tests/Equibles.IntegrationTests/Sec/DocumentProcessorSystemicFailureBackoffTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentProcessorSystemicFailureBackoffTests.cs
@@ -1,0 +1,66 @@
+using Equibles.Sec.BusinessLogic.Embeddings;
+using Equibles.Sec.BusinessLogic.Processing;
+using Equibles.Sec.BusinessLogic.Tokenization;
+using Equibles.Sec.Data.Models.Chunks;
+using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Guards the systemic-failure path raised in the PR #744 review: per-chunk
+/// isolation must not regress total outage into a silent, backoff-free hot
+/// loop. Contract: when the embedding server is fully down — every chunk comes
+/// back unembedded (null) — GenerateEmbeddings must throw, so the worker's
+/// base loop logs it loudly, reports it, and backs off for a cycle instead of
+/// re-pulling the same batch every iteration with zero progress and no error.
+/// A few poison chunks among otherwise-successful ones must NOT throw (that is
+/// covered by <see cref="DocumentProcessorPerDocumentIsolationTests"/>).
+/// </summary>
+public class DocumentProcessorSystemicFailureBackoffTests
+{
+    [Fact]
+    public async Task GenerateEmbeddings_EveryChunkFailsToEmbed_ThrowsSoTheWorkerBacksOff()
+    {
+        var docA = Guid.NewGuid();
+        var docB = Guid.NewGuid();
+        var chunks = new List<Chunk>
+        {
+            new() { DocumentId = docA, Content = "doc-a-content" },
+            new() { DocumentId = docB, Content = "doc-b-content" },
+        };
+
+        // Embedding server is down: the client stays aligned to its input but
+        // every entry is null (no vector could be produced for any chunk).
+        var embeddingClient = Substitute.For<IEmbeddingClient>();
+        embeddingClient
+            .GenerateEmbeddings(Arg.Any<List<string>>())
+            .Returns(ci => new List<float[]>(new float[][] { null }));
+
+        var embeddingRepository = Substitute.For<EmbeddingRepository>(
+            (Equibles.Data.EquiblesDbContext)null
+        );
+        var sut = new DocumentProcessor(
+            Substitute.For<ChunkRepository>((Equibles.Data.EquiblesDbContext)null),
+            embeddingRepository,
+            embeddingClient,
+            new ChunkingStrategy(new TokenCounter()),
+            Options.Create(new EmbeddingConfig { ModelName = "nomic-embed-text" }),
+            Substitute.For<ILogger<DocumentProcessor>>()
+        );
+
+        // Nothing embedded across the whole batch ⇒ systemic outage ⇒ throw,
+        // so BaseScraperWorker logs/reports it and waits a cycle.
+        var act = async () => await sut.GenerateEmbeddings(chunks, CancellationToken.None);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        // And it must not have persisted anything.
+        embeddingRepository
+            .ReceivedCalls()
+            .Count(c => c.GetMethodInfo().Name == nameof(EmbeddingRepository.Add))
+            .Should()
+            .Be(0);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/EmbeddingClientEmptyEmbeddingAlignmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/EmbeddingClientEmptyEmbeddingAlignmentTests.cs
@@ -19,10 +19,7 @@ namespace Equibles.IntegrationTests.Sec;
 /// </summary>
 public class EmbeddingClientEmptyEmbeddingAlignmentTests
 {
-    [Fact(
-        Skip = "GH-820 — EmbeddingClient.GenerateEmbeddings silently drops empty embeddings, "
-            + "breaking positional alignment with chunks"
-    )]
+    [Fact]
     public async Task GenerateEmbeddings_OneTextReturnsEmptyEmbedding_StaysPositionallyAlignedToInputs()
     {
         // Ollama answers 200 but with no vector for the 2nd input (degenerate

--- a/tests/Equibles.IntegrationTests/Sec/EmbeddingClientSingleTextNullEmbeddingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/EmbeddingClientSingleTextNullEmbeddingsTests.cs
@@ -17,10 +17,7 @@ namespace Equibles.IntegrationTests.Sec;
 /// </summary>
 public class EmbeddingClientSingleTextNullEmbeddingsTests
 {
-    [Fact(
-        Skip = "GH-825 — EmbeddingClient.GenerateEmbeddings single-text branch throws "
-            + "ArgumentNullException when Ollama 200 has no embeddings field"
-    )]
+    [Fact]
     public async Task GenerateEmbeddings_SingleTextOllamaReturnsNoEmbeddingsField_DoesNotThrowAndStaysAligned()
     {
         // Ollama answers 200 but omits the "embeddings" field for this input


### PR DESCRIPTION
## Summary

Supersedes #744 (its branch was 154 commits behind `main` and on a fork that can't be rebased without a force-push). The original fix commit by @LBJohnnyD is preserved here (`fix(embeddings): isolate per-chunk failures instead of killing the worker`), cherry-picked clean onto current `main`, with the blocking review feedback addressed on top.

Closes #828. Closes #825. Closes #820.

## Problem

The embedding pipeline killed the document-processor worker on a single bad chunk/document (GH-828/825/820). #744 isolated per-chunk failures but, per the review, **regressed systemic failure**: when Ollama is fully down every chunk → `null` → nothing saved, no rethrow → `GenerateEmbeddingBatch` still returns `true` → `DocumentProcessorWorker` hot-loops on the same batch forever with zero progress and no ERR/FTL.

## Code changes

- **`DocumentProcessor.GenerateEmbeddings`** — tracks attempted vs embedded across the whole batch. A few poison chunks stay isolated (backlog keeps draining); but if **nothing** embedded for a non-empty batch it throws `InvalidOperationException`, so `BaseScraperWorker` logs it (`LogCritical`), reports it via `ErrorReporter`, and backs off a cycle instead of hot-looping. This distinguishes per-chunk poison from a total outage.
- **`GenerateEmbeddingsForChunks`** — now returns the count actually persisted.
- **`IEmbeddingClient`** — documented the null-entry / positional-alignment contract. Kept `List<float[]>` rather than the reviewer-suggested `List<float[]?>`: the repo is `<Nullable>disable</Nullable>` project-wide with zero `#nullable enable`, so the annotation emits CS8632 and breaks house convention (coding-standards). The intent — callers must handle null — is satisfied: the only consumers (`DocumentProcessor`, single-text `GenerateEmbedding`) are null-safe and now contract-documented. Flagging for the reviewer to confirm this tradeoff.
- **Tests** — un-skipped the GH-820 / GH-825 / GH-828 regression tests (all green against this code). Added `DocumentProcessorSystemicFailureBackoffTests` guarding the new backoff path.

## Verification

- Full unit suite: **1163/1163** passed.
- Embedding/document regression + new backoff test: **4/4** passed.
- **Live AI model**: ran the real `EmbeddingClient` against Ollama `bge-m3` (`docker compose --profile embedding`) — two inputs returned positionally-aligned, non-null vectors of equal dimension matching `GetEmbeddingDimension()`. Embeddings confirmed working end-to-end through production code.

## Note

Recommend closing #744 in favour of this PR (stale fork branch, credit preserved in commit authorship).
