### PR TITLE
feat(common-stocks): detect fiscal year-end from SEC EDGAR (#691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Fiscal year-end detection for companies. The SEC document scraper now reads
+  EDGAR's submissions `fiscalYearEnd` field and persists `FiscalYearEndMonth` /
+  `FiscalYearEndDay` on `CommonStock` (sourced entirely from public SEC data,
+  no extra request on the common path — the metadata fetch primes the
+  submissions cache reused by the filings fetch). A new `FiscalCalendar` helper
+  maps any date to a company's fiscal quarter/year, so off-calendar filers
+  (e.g. Apple ≈ September, Microsoft = June) are no longer misrepresented by
+  calendar-quarter math.
 - Web portal now checks GitHub Releases and shows a banner when a newer version
   is available, displaying the new and current versions with links to the
   "Updating" guide and an in-app rendered changelog. The check is cached, runs

--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -51,6 +51,44 @@ public class CommonStockManager
         await _commonStockRepository.SaveChanges();
     }
 
+    /// <summary>
+    /// Sets the company's fiscal year-end (month 1-12, optional day 1-31),
+    /// sourced from SEC EDGAR's submissions <c>fiscalYearEnd</c> field. A
+    /// no-op change persists nothing. Saves directly via the repository — like
+    /// <see cref="SetCusip"/>, this mutates a single non-key field and must not
+    /// re-run the full ticker/CIK uniqueness validation.
+    /// </summary>
+    public async Task SetFiscalYearEnd(CommonStock commonStock, int month, int? day)
+    {
+        if (commonStock == null)
+        {
+            throw new ArgumentNullException(nameof(commonStock));
+        }
+
+        if (month is < 1 or > 12)
+        {
+            throw new DomainValidationException(
+                $"Fiscal year-end month must be between 1 and 12, got {month}"
+            );
+        }
+
+        if (day is < 1 or > 31)
+        {
+            throw new DomainValidationException(
+                $"Fiscal year-end day must be between 1 and 31, got {day}"
+            );
+        }
+
+        if (commonStock.FiscalYearEndMonth == month && commonStock.FiscalYearEndDay == day)
+        {
+            return;
+        }
+
+        commonStock.FiscalYearEndMonth = month;
+        commonStock.FiscalYearEndDay = day;
+        await _commonStockRepository.SaveChanges();
+    }
+
     public async Task<CommonStock> Create(CommonStock commonStock)
     {
         await ValidateCommonStock(commonStock, true);

--- a/src/Equibles.CommonStocks.BusinessLogic/FiscalCalendar.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/FiscalCalendar.cs
@@ -1,0 +1,65 @@
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.CommonStocks.BusinessLogic;
+
+/// <summary>
+/// Maps an arbitrary date to a company's fiscal quarter/year given the month
+/// its fiscal year ends in. Replaces ad-hoc calendar-quarter math for
+/// off-calendar filers (e.g. Apple ≈ September, Microsoft = June).
+/// </summary>
+/// <remarks>
+/// Quarters are derived purely from the fiscal-year-end <em>month</em>: the
+/// fiscal year starts the first day of the following month and each quarter is
+/// three calendar months. The fiscal-year-end <em>day</em> is deliberately
+/// ignored — many filers use a moving "last Saturday of the month" 52/53-week
+/// calendar whose day shifts year to year, so a day-precise period range would
+/// be wrong as often as it is right. Month-granularity matches how SEC 10-K /
+/// 10-Q reporting periods line up.
+/// </remarks>
+public static class FiscalCalendar
+{
+    private const int MonthsPerQuarter = 3;
+
+    /// <summary>
+    /// Returns the fiscal period for <paramref name="date"/> given a fiscal
+    /// year that ends in <paramref name="fiscalYearEndMonth"/> (1-12, where 12
+    /// is a plain calendar-year filer).
+    /// </summary>
+    public static FiscalPeriod GetPeriod(DateOnly date, int fiscalYearEndMonth)
+    {
+        if (fiscalYearEndMonth is < 1 or > 12)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(fiscalYearEndMonth),
+                fiscalYearEndMonth,
+                "Fiscal year-end month must be between 1 and 12."
+            );
+        }
+
+        // The fiscal year is labelled by the calendar year it ends in. A date
+        // in or before the end month belongs to a fiscal year ending this
+        // calendar year; a date after it belongs to the one ending next year.
+        var fiscalYear = date.Month <= fiscalYearEndMonth ? date.Year : date.Year + 1;
+
+        var fiscalStartMonth = fiscalYearEndMonth % 12 + 1;
+        var monthsIntoYear = (date.Month - fiscalStartMonth + 12) % 12;
+        var quarter = monthsIntoYear / MonthsPerQuarter + 1;
+
+        return new FiscalPeriod(fiscalYear, quarter);
+    }
+
+    /// <summary>
+    /// Returns the fiscal period for <paramref name="date"/> using the stock's
+    /// detected <see cref="CommonStock.FiscalYearEndMonth"/>, or null when the
+    /// fiscal year-end has not been detected yet.
+    /// </summary>
+    public static FiscalPeriod? GetPeriod(DateOnly date, CommonStock commonStock)
+    {
+        if (commonStock == null)
+        {
+            throw new ArgumentNullException(nameof(commonStock));
+        }
+
+        return commonStock.FiscalYearEndMonth is { } month ? GetPeriod(date, month) : null;
+    }
+}

--- a/src/Equibles.CommonStocks.BusinessLogic/FiscalPeriod.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/FiscalPeriod.cs
@@ -1,0 +1,12 @@
+namespace Equibles.CommonStocks.BusinessLogic;
+
+/// <summary>
+/// A company's fiscal year and quarter for a given date. <see cref="Year"/> is
+/// labelled by the calendar year in which the fiscal year <em>ends</em> — the
+/// US filer convention (Apple's October-2023 quarter is FY2024 Q1; a
+/// calendar-year filer's 2024 is simply FY2024).
+/// </summary>
+public readonly record struct FiscalPeriod(int Year, int Quarter)
+{
+    public override string ToString() => $"FY{Year} Q{Quarter}";
+}

--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -45,6 +45,22 @@ public class CommonStock
     [MaxLength(9)]
     public string Cusip { get; set; }
 
+    /// <summary>
+    /// Calendar month (1-12) the company's fiscal year ends in, sourced from
+    /// SEC EDGAR's submissions <c>fiscalYearEnd</c> field. Null until detected.
+    /// Off-calendar filers (e.g. Apple ≈ September, Microsoft = June) need this
+    /// so quarter math reflects their real reporting periods rather than
+    /// calendar quarters.
+    /// </summary>
+    public int? FiscalYearEndMonth { get; set; }
+
+    /// <summary>
+    /// Day of month (1-31) the company's fiscal year ends on, sourced from the
+    /// same SEC field. Informational — quarter math keys off the month, since
+    /// many filers use a moving "last Saturday" day that varies year to year.
+    /// </summary>
+    public int? FiscalYearEndDay { get; set; }
+
     public Guid? IndustryId { get; set; }
     public virtual Industry Industry { get; set; }
 }

--- a/src/Equibles.Integrations.Sec/Models/CompanyMetadata.cs
+++ b/src/Equibles.Integrations.Sec/Models/CompanyMetadata.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Equibles.Integrations.Sec.Models;
 
 public class CompanyMetadata
@@ -5,6 +7,80 @@ public class CompanyMetadata
     public string Cik { get; set; }
     public string EntityType { get; set; }
     public List<string> Exchanges { get; set; } = [];
+
+    /// <summary>
+    /// SEC's raw current fiscal year-end as a 4-character "MMDD" string
+    /// (e.g. "0928" for Apple). Null/blank when the filer never reported one.
+    /// </summary>
+    public string FiscalYearEnd { get; set; }
+
+    /// <summary>
+    /// Month (1-12) parsed from <see cref="FiscalYearEnd"/>, or null when the
+    /// value is missing or not a valid calendar MMDD date.
+    /// </summary>
+    public int? FiscalYearEndMonth => ParseFiscalYearEnd().Month;
+
+    /// <summary>
+    /// Day of month parsed from <see cref="FiscalYearEnd"/>, or null when the
+    /// value is missing or not a valid calendar MMDD date.
+    /// </summary>
+    public int? FiscalYearEndDay => ParseFiscalYearEnd().Day;
+
+    // Memoised against the trimmed source so the common
+    // "read Month then read Day" access pattern parses once, and a re-set of
+    // FiscalYearEnd re-parses (this is a deserialisation DTO).
+    private string _parsedSource;
+    private (int? Month, int? Day) _parsed;
+
+    /// <summary>
+    /// Parses the SEC "MMDD" fiscal year-end string. Returns (null, null) for
+    /// anything that is not exactly four digits forming a real calendar date
+    /// (1-12 month and a day that exists in that month, Feb 29 allowed) — SEC
+    /// occasionally emits blanks or malformed values, and a silently wrong
+    /// month would corrupt every downstream fiscal-quarter calculation while a
+    /// bogus day (e.g. "0931") would persist a date that does not exist.
+    /// </summary>
+    private (int? Month, int? Day) ParseFiscalYearEnd()
+    {
+        var value = FiscalYearEnd?.Trim();
+        if (_parsedSource == value)
+        {
+            return _parsed;
+        }
+
+        _parsedSource = value;
+        _parsed = Compute(value);
+        return _parsed;
+
+        static (int? Month, int? Day) Compute(string value)
+        {
+            if (
+                value is not { Length: 4 }
+                || !int.TryParse(
+                    value.AsSpan(0, 2),
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out var month
+                )
+                || !int.TryParse(
+                    value.AsSpan(2, 2),
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out var day
+                )
+                || month is < 1 or > 12
+                // Leap year (2000) so a legitimate Feb-29 fiscal year-end is
+                // accepted; Feb-30, Sep-31, Apr-31, etc. are rejected.
+                || day < 1
+                || day > DateTime.DaysInMonth(2000, month)
+            )
+            {
+                return (null, null);
+            }
+
+            return (month, day);
+        }
+    }
 
     public bool IsOperatingCompany =>
         string.Equals(EntityType, "operating", StringComparison.OrdinalIgnoreCase);

--- a/src/Equibles.Integrations.Sec/Models/Responses/SecApiResponse.cs
+++ b/src/Equibles.Integrations.Sec/Models/Responses/SecApiResponse.cs
@@ -16,6 +16,14 @@ internal class SecApiResponse
     [JsonProperty("exchanges")]
     public List<string> Exchanges { get; set; } = [];
 
+    /// <summary>
+    /// SEC's reported current fiscal year-end as a 4-character "MMDD" string
+    /// (e.g. "0928" for Apple, "0630" for Microsoft, "1231" for calendar-year
+    /// filers). May be null/blank for filers that never reported one.
+    /// </summary>
+    [JsonProperty("fiscalYearEnd")]
+    public string FiscalYearEnd { get; set; }
+
     [JsonProperty("filings")]
     public FilingsContainer Filings { get; set; } = new();
 }

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -107,11 +107,19 @@ public class SecEdgarClient : ISecEdgarClient
             if (apiResponse == null)
                 return null;
 
+            // Cache the submissions payload keyed by URL so an immediately
+            // following GetCompanyFilings(cik) — which hits the same
+            // /submissions/CIK*.json URL — reuses it instead of re-fetching.
+            // This keeps fiscal-year detection in the scraper net-zero extra
+            // SEC requests on the common path.
+            _cachedContent = new CachedResponse(url, content);
+
             return new CompanyMetadata
             {
                 Cik = cik,
                 EntityType = apiResponse.EntityType,
                 Exchanges = apiResponse.Exchanges ?? [],
+                FiscalYearEnd = apiResponse.FiscalYearEnd,
             };
         }
         catch (HttpRequestException ex)

--- a/src/Equibles.Migrations/Migrations/20260518131043_AddFiscalYearEndToCommonStock.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260518131043_AddFiscalYearEndToCommonStock.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518131043_AddFiscalYearEndToCommonStock")]
+    partial class AddFiscalYearEndToCommonStock
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260518131043_AddFiscalYearEndToCommonStock.cs
+++ b/src/Equibles.Migrations/Migrations/20260518131043_AddFiscalYearEndToCommonStock.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFiscalYearEndToCommonStock : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "FiscalYearEndDay",
+                table: "CommonStock",
+                type: "integer",
+                nullable: true
+            );
+
+            migrationBuilder.AddColumn<int>(
+                name: "FiscalYearEndMonth",
+                table: "CommonStock",
+                type: "integer",
+                nullable: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "FiscalYearEndDay", table: "CommonStock");
+
+            migrationBuilder.DropColumn(name: "FiscalYearEndMonth", table: "CommonStock");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Equibles.CommonStocks.BusinessLogic;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Configuration;
@@ -178,6 +179,8 @@ public class DocumentScraper : IDocumentScraper
         var persistenceService =
             scope.ServiceProvider.GetRequiredService<IDocumentPersistenceService>();
 
+        var commonStockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
+
         var company = await companyRepository.Get(companyUntracked.Id);
 
         try
@@ -187,6 +190,11 @@ public class DocumentScraper : IDocumentScraper
                 company.Ticker,
                 company.Name
             );
+
+            // Detect the fiscal year-end before fetching filings: the metadata
+            // call primes the SEC client's submissions cache so the first
+            // GetCompanyFilings hits the same URL and adds no extra request.
+            await UpdateFiscalYearEnd(company, secEdgarClient, commonStockManager);
 
             foreach (var documentType in _options.DocumentTypesToSync)
             {
@@ -232,6 +240,50 @@ public class DocumentScraper : IDocumentScraper
                 ex.Message,
                 ex.StackTrace,
                 $"ticker: {company.Ticker}"
+            );
+        }
+    }
+
+    /// <summary>
+    /// Reads SEC EDGAR's submissions <c>fiscalYearEnd</c> for the company and
+    /// persists it when it changed. Best-effort: a metadata failure is logged
+    /// and reported but never blocks document scraping, since fiscal-year
+    /// metadata is a nice-to-have enrichment, not a prerequisite for filings.
+    /// Errors are still reported (consistent with the other per-company steps)
+    /// so a systemic SEC-schema change that breaks parsing surfaces on the
+    /// dashboard instead of silently disabling fiscal detection platform-wide.
+    /// </summary>
+    private async Task UpdateFiscalYearEnd(
+        CommonStock company,
+        ISecEdgarClient secEdgarClient,
+        CommonStockManager commonStockManager
+    )
+    {
+        try
+        {
+            var metadata = await secEdgarClient.GetCompanyMetadata(company.Cik);
+            if (metadata?.FiscalYearEndMonth is not { } month)
+            {
+                return;
+            }
+
+            await commonStockManager.SetFiscalYearEnd(company, month, metadata.FiscalYearEndDay);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Could not update fiscal year-end for {Ticker} (CIK: {Cik}): {Message}",
+                company.Ticker,
+                company.Cik,
+                ex.Message
+            );
+            await _errorReporter.Report(
+                ErrorSource.DocumentScraper,
+                "DocumentScraper.UpdateFiscalYearEnd",
+                ex.Message,
+                ex.StackTrace,
+                $"ticker: {company.Ticker}, cik: {company.Cik}"
             );
         }
     }

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetFiscalYearEndTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetFiscalYearEndTests.cs
@@ -1,0 +1,98 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Exceptions;
+using Equibles.Data;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// <see cref="CommonStockManager.SetFiscalYearEnd"/> mirrors the SetCusip
+/// no-op-on-unchanged contract: a same-value call must persist nothing (the
+/// SEC scraper calls this for every company on every run, so a naive
+/// always-save would write the entire stock universe each pass). Invalid
+/// SEC-sourced values must be rejected, not stored.
+/// </summary>
+public class CommonStockManagerSetFiscalYearEndTests
+{
+    private static EquiblesDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new EquiblesDbContext(options, [new CommonStocksModuleConfiguration()]);
+    }
+
+    private static CommonStockManager NewManager(CommonStockRepository repository) =>
+        new(repository, Substitute.For<IPublishEndpoint>());
+
+    [Fact]
+    public async Task SetFiscalYearEnd_PreviouslyUndetected_PersistsMonthAndDay()
+    {
+        var db = NewDb();
+        var repository = Substitute.For<CommonStockRepository>(db);
+        var stock = new CommonStock { FiscalYearEndMonth = null, FiscalYearEndDay = null };
+
+        await NewManager(repository).SetFiscalYearEnd(stock, 9, 28);
+
+        stock.FiscalYearEndMonth.Should().Be(9);
+        stock.FiscalYearEndDay.Should().Be(28);
+        await repository.Received(1).SaveChanges();
+    }
+
+    [Fact]
+    public async Task SetFiscalYearEnd_UnchangedValue_PersistsNothing()
+    {
+        var db = NewDb();
+        var repository = Substitute.For<CommonStockRepository>(db);
+        var stock = new CommonStock { FiscalYearEndMonth = 6, FiscalYearEndDay = 30 };
+
+        await NewManager(repository).SetFiscalYearEnd(stock, 6, 30);
+
+        await repository.DidNotReceive().SaveChanges();
+    }
+
+    [Fact]
+    public async Task SetFiscalYearEnd_NullDayMatchesStoredNullDay_PersistsNothing()
+    {
+        var db = NewDb();
+        var repository = Substitute.For<CommonStockRepository>(db);
+        var stock = new CommonStock { FiscalYearEndMonth = 12, FiscalYearEndDay = null };
+
+        await NewManager(repository).SetFiscalYearEnd(stock, 12, null);
+
+        await repository.DidNotReceive().SaveChanges();
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(13, 1)]
+    [InlineData(9, 0)]
+    [InlineData(9, 32)]
+    public async Task SetFiscalYearEnd_InvalidValue_ThrowsAndPersistsNothing(int month, int day)
+    {
+        var db = NewDb();
+        var repository = Substitute.For<CommonStockRepository>(db);
+        var stock = new CommonStock();
+
+        var act = () => NewManager(repository).SetFiscalYearEnd(stock, month, day);
+
+        await act.Should().ThrowAsync<DomainValidationException>();
+        await repository.DidNotReceive().SaveChanges();
+    }
+
+    [Fact]
+    public async Task SetFiscalYearEnd_NullStock_Throws()
+    {
+        var db = NewDb();
+        var repository = Substitute.For<CommonStockRepository>(db);
+
+        var act = () => NewManager(repository).SetFiscalYearEnd(null, 9, 28);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarJanuaryFiscalYearEndTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarJanuaryFiscalYearEndTests.cs
@@ -1,0 +1,24 @@
+using Equibles.CommonStocks.BusinessLogic;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Adversarial sibling to <see cref="FiscalCalendarTests"/>, which only pins
+/// September/June/December filers. Contract (FiscalCalendar + FiscalPeriod
+/// docs): the period is derived from the fiscal-year-end month, and the year
+/// is labelled by the calendar year the fiscal year *ends* in. The entire
+/// retail sector (Walmart, Target, Home Depot) ends its fiscal year in
+/// January, so FY2024 runs Feb 2023–Jan 2024 with Q4 = Nov 2023–Jan 2024.
+/// A December-2023 date must therefore map to FY2024 Q4 — exercising both the
+/// year-label flip and the early-end-month quarter wrap, untested until now.
+/// </summary>
+public class FiscalCalendarJanuaryFiscalYearEndTests
+{
+    [Fact]
+    public void GetPeriod_JanuaryFiscalYearEnd_DecemberDate_IsNextYearQ4()
+    {
+        var period = FiscalCalendar.GetPeriod(new DateOnly(2023, 12, 31), fiscalYearEndMonth: 1);
+
+        period.Should().Be(new FiscalPeriod(2024, 4));
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarTests.cs
@@ -1,0 +1,81 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Pins the fiscal-quarter contract for off-calendar filers. The fiscal year
+/// is labelled by the calendar year it ends in (US filer convention), so
+/// Apple's October-2023 quarter is FY2024 Q1, not FY2023 Q4 — getting this
+/// wrong would mislabel every quarter for ~40% of S&P 500 filers.
+/// </summary>
+public class FiscalCalendarTests
+{
+    [Theory]
+    // Apple — fiscal year ends in September.
+    [InlineData(9, "2023-10-01", 2024, 1)]
+    [InlineData(9, "2023-12-31", 2024, 1)]
+    [InlineData(9, "2024-01-01", 2024, 2)]
+    [InlineData(9, "2024-06-15", 2024, 3)]
+    [InlineData(9, "2024-09-28", 2024, 4)]
+    [InlineData(9, "2024-10-01", 2025, 1)]
+    // Microsoft — fiscal year ends in June.
+    [InlineData(6, "2023-07-01", 2024, 1)]
+    [InlineData(6, "2024-06-30", 2024, 4)]
+    [InlineData(6, "2024-07-01", 2025, 1)]
+    // Plain calendar-year filer.
+    [InlineData(12, "2024-01-15", 2024, 1)]
+    [InlineData(12, "2024-04-01", 2024, 2)]
+    [InlineData(12, "2024-12-31", 2024, 4)]
+    public void GetPeriod_MapsDateToFiscalQuarterAndYear(
+        int fiscalYearEndMonth,
+        string date,
+        int expectedYear,
+        int expectedQuarter
+    )
+    {
+        var period = FiscalCalendar.GetPeriod(DateOnly.Parse(date), fiscalYearEndMonth);
+
+        period.Year.Should().Be(expectedYear);
+        period.Quarter.Should().Be(expectedQuarter);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(13)]
+    [InlineData(-1)]
+    public void GetPeriod_InvalidFiscalYearEndMonth_Throws(int fiscalYearEndMonth)
+    {
+        var act = () => FiscalCalendar.GetPeriod(new DateOnly(2024, 1, 1), fiscalYearEndMonth);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void GetPeriod_StockWithoutDetectedFiscalYearEnd_ReturnsNull()
+    {
+        var stock = new CommonStock { FiscalYearEndMonth = null };
+
+        var period = FiscalCalendar.GetPeriod(new DateOnly(2024, 1, 1), stock);
+
+        period.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPeriod_StockWithDetectedFiscalYearEnd_ReturnsPeriod()
+    {
+        var stock = new CommonStock { FiscalYearEndMonth = 9 };
+
+        var period = FiscalCalendar.GetPeriod(new DateOnly(2023, 10, 1), stock);
+
+        period.Should().Be(new FiscalPeriod(2024, 1));
+    }
+
+    [Fact]
+    public void GetPeriod_NullStock_Throws()
+    {
+        var act = () => FiscalCalendar.GetPeriod(new DateOnly(2024, 1, 1), (CommonStock)null);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/CompanyMetadataFiscalYearEndReparseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanyMetadataFiscalYearEndReparseTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Adversarial sibling to <see cref="CompanyMetadataFiscalYearEndTests"/>,
+/// which only parses a single fixed value. The parse is memoised, but the
+/// contract is explicit: "this is a deserialisation DTO" and "a re-set of
+/// FiscalYearEnd re-parses". A stale memo would make a re-bound DTO report the
+/// previous filer's fiscal year-end — corrupting every downstream quarter calc.
+/// </summary>
+public class CompanyMetadataFiscalYearEndReparseTests
+{
+    [Fact]
+    public void FiscalYearEnd_ReSetAfterRead_ReparsesToNewValue()
+    {
+        var metadata = new CompanyMetadata { FiscalYearEnd = "0928" };
+
+        // Read first so the parse is memoised against "0928" (month 9, day 28).
+        _ = metadata.FiscalYearEndMonth;
+
+        metadata.FiscalYearEnd = "0630";
+
+        metadata.FiscalYearEndMonth.Should().Be(6);
+        metadata.FiscalYearEndDay.Should().Be(30);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/CompanyMetadataFiscalYearEndTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanyMetadataFiscalYearEndTests.cs
@@ -1,0 +1,57 @@
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// SEC's submissions <c>fiscalYearEnd</c> is a free-form "MMDD" string and is
+/// occasionally blank or malformed. A silently-wrong month would corrupt every
+/// downstream fiscal-quarter calculation, so parsing must be strict: exactly
+/// four digits forming a valid 1-12 month and 1-31 day, or null.
+/// </summary>
+public class CompanyMetadataFiscalYearEndTests
+{
+    [Theory]
+    [InlineData("0928", 9, 28)] // Apple
+    [InlineData("0630", 6, 30)] // Microsoft
+    [InlineData("1231", 12, 31)] // calendar-year filer
+    [InlineData("0101", 1, 1)]
+    [InlineData("0229", 2, 29)] // leap-day fiscal year-end is a real date
+    [InlineData(" 0928 ", 9, 28)] // SEC pads/whitespaces some values
+    public void FiscalYearEnd_ValidMmdd_ParsesMonthAndDay(string raw, int month, int day)
+    {
+        var metadata = new CompanyMetadata { FiscalYearEnd = raw };
+
+        metadata.FiscalYearEndMonth.Should().Be(month);
+        metadata.FiscalYearEndDay.Should().Be(day);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("928")] // not 4 chars
+    [InlineData("12311")] // too long
+    [InlineData("0000")] // month 0, day 0
+    [InlineData("1332")] // month 13, day 32
+    [InlineData("0931")] // Sept has 30 days — impossible calendar date
+    [InlineData("0230")] // Feb never has 30 days
+    [InlineData("0431")] // April has 30 days
+    [InlineData("ab12")] // non-numeric
+    [InlineData("09-8")] // non-numeric separator
+    public void FiscalYearEnd_MissingOrMalformed_YieldsNull(string raw)
+    {
+        var metadata = new CompanyMetadata { FiscalYearEnd = raw };
+
+        metadata.FiscalYearEndMonth.Should().BeNull();
+        metadata.FiscalYearEndDay.Should().BeNull();
+    }
+
+    [Fact]
+    public void FiscalYearEnd_MonthInRangeDayOutOfRange_YieldsNull()
+    {
+        var metadata = new CompanyMetadata { FiscalYearEnd = "0932" };
+
+        metadata.FiscalYearEndMonth.Should().BeNull();
+        metadata.FiscalYearEndDay.Should().BeNull();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperDeferredRetryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperDeferredRetryTests.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.BusinessLogic;
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
@@ -12,6 +13,7 @@ using Equibles.Sec.HostedService;
 using Equibles.Sec.HostedService.Configuration;
 using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -91,6 +93,11 @@ public class DocumentScraperDeferredRetryTests
         var services = new ServiceCollection();
         services.AddSingleton(ctx);
         services.AddScoped<CommonStockRepository>();
+        // DocumentScraper resolves CommonStockManager per scope to persist the
+        // SEC-sourced fiscal year-end; IPublishEndpoint is an unrelated ctor
+        // dep (SetCusip outbox event) the fiscal-year path never uses.
+        services.AddSingleton(Substitute.For<IPublishEndpoint>());
+        services.AddScoped<CommonStockManager>();
         services.AddSingleton(secEdgar);
         services.AddSingleton(persistence);
         services.AddSingleton(Substitute.For<ISecDocumentHtmlNormalizer>());

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperProcessCompanyScopeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperProcessCompanyScopeTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Equibles.CommonStocks.BusinessLogic;
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
@@ -12,6 +13,7 @@ using Equibles.Sec.HostedService.Configuration;
 using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Models;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -52,6 +54,11 @@ public class DocumentScraperProcessCompanyScopeTests
         var services = new ServiceCollection();
         services.AddSingleton(dbContext);
         services.AddScoped<CommonStockRepository>();
+        // DocumentScraper resolves CommonStockManager per scope to persist the
+        // SEC-sourced fiscal year-end; IPublishEndpoint is an unrelated ctor
+        // dep (SetCusip outbox event) the fiscal-year path never uses.
+        services.AddSingleton(Substitute.For<IPublishEndpoint>());
+        services.AddScoped<CommonStockManager>();
         services.AddSingleton(_secEdgarClient);
         services.AddSingleton(_persistence);
         var provider = services.BuildServiceProvider();

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Equibles.CommonStocks.BusinessLogic;
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
@@ -13,6 +14,7 @@ using Equibles.Sec.HostedService;
 using Equibles.Sec.HostedService.Configuration;
 using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Services;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -399,6 +401,42 @@ public class DocumentScraperTests
         result.DocumentsAdded.Should().Be(0);
     }
 
+    [Fact]
+    public async Task ScrapeDocuments_SecReportsFiscalYearEnd_PersistsItOnTheStock()
+    {
+        // Covers the fiscal-year-end wiring: GetCompanyMetadata returns an
+        // off-calendar "MMDD", and ProcessCompanyDocumentsWithScope persists
+        // it via CommonStockManager before the (empty) document-type loop.
+        var harness = new Harness();
+        await using var dbContext = harness.CreateDbContext();
+        var company = SeedCompany(dbContext, ticker: "AAPL", cik: "0000320193");
+        harness
+            .SecEdgarClient.GetCompanyMetadata("0000320193")
+            .Returns(new CompanyMetadata { FiscalYearEnd = "0928" });
+
+        await harness.BuildScraper(dbContext).ScrapeDocuments();
+
+        var persisted = await dbContext.Set<CommonStock>().SingleAsync(c => c.Id == company.Id);
+        persisted.FiscalYearEndMonth.Should().Be(9);
+        persisted.FiscalYearEndDay.Should().Be(28);
+    }
+
+    [Fact]
+    public async Task ScrapeDocuments_SecReportsNoFiscalYearEnd_LeavesStockUnchanged()
+    {
+        // The substitute returns null metadata by default; the stock's
+        // fiscal-year columns must stay null rather than throw or be zeroed.
+        var harness = new Harness();
+        await using var dbContext = harness.CreateDbContext();
+        var company = SeedCompany(dbContext, ticker: "ACME", cik: "0000123456");
+
+        await harness.BuildScraper(dbContext).ScrapeDocuments();
+
+        var persisted = await dbContext.Set<CommonStock>().SingleAsync(c => c.Id == company.Id);
+        persisted.FiscalYearEndMonth.Should().BeNull();
+        persisted.FiscalYearEndDay.Should().BeNull();
+    }
+
     // ── helpers ──
 
     private static FilingData BuildFiling(string cik, string accession, string form) =>
@@ -469,6 +507,12 @@ public class DocumentScraperTests
             // registration would invalidate the context after the first scope.
             services.AddSingleton(dbContext);
             services.AddScoped<CommonStockRepository>();
+            // DocumentScraper now resolves CommonStockManager per scope to
+            // persist the SEC-sourced fiscal year-end. IPublishEndpoint is an
+            // unrelated CommonStockManager ctor dep (SetCusip outbox event);
+            // substituted because fiscal-year detection never publishes.
+            services.AddSingleton(Substitute.For<IPublishEndpoint>());
+            services.AddScoped<CommonStockManager>();
             services.AddSingleton(SecEdgarClient);
             services.AddSingleton(Normalizer);
             services.AddSingleton(Converter);

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientFiscalYearEndCacheTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientFiscalYearEndCacheTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using Equibles.Integrations.Sec;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the cache-priming contract added with fiscal-year detection:
+/// <c>GetCompanyMetadata</c> now stores the submissions payload so an
+/// immediately-following <c>GetCompanyFilings</c> for the SAME CIK is served
+/// from cache (net-zero extra SEC request — the whole point of fetching
+/// metadata in the scraper). Critically, the cache is URL-keyed, so priming
+/// it for one CIK must NEVER serve another CIK's filings — a regression that
+/// dropped the URL guard would silently attribute Apple's 10-Ks to whichever
+/// company's metadata happened to be fetched last.
+/// </summary>
+public class SecEdgarClientFiscalYearEndCacheTests
+{
+    private const string CikA = "0000111111";
+    private const string CikB = "0000222222";
+
+    private static string Submissions(string cik, string fiscalYearEnd, bool withFiling)
+    {
+        var recent = withFiling
+            ? "{\"accessionNumber\":[\"0000111111-25-000001\"],"
+                + "\"filingDate\":[\"2025-01-15\"],\"reportDate\":[\"2024-12-31\"],"
+                + "\"form\":[\"10-K\"],\"primaryDocument\":[\"a.htm\"],"
+                + "\"primaryDocDescription\":[\"10-K\"]}"
+            : "{}";
+        return $"{{\"cik\":\"{cik}\",\"fiscalYearEnd\":\"{fiscalYearEnd}\","
+            + $"\"filings\":{{\"recent\":{recent}}}}}";
+    }
+
+    private static SecEdgarClient BuildClient(PerUrlHandler handler)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string> { ["Sec:ContactEmail"] = "test@example.com" }
+            )
+            .Build();
+        return new SecEdgarClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<SecEdgarClient>>(),
+            config
+        );
+    }
+
+    [Fact]
+    public async Task GetCompanyFilings_SameCikAfterGetCompanyMetadata_ServedFromCacheNoSecondFetch()
+    {
+        var handler = new PerUrlHandler(
+            new() { [$"/submissions/CIK{CikA}.json"] = Submissions(CikA, "0331", withFiling: true) }
+        );
+        var sut = BuildClient(handler);
+
+        var metadata = await sut.GetCompanyMetadata(CikA);
+        var filings = await sut.GetCompanyFilings(CikA);
+
+        metadata.FiscalYearEndMonth.Should().Be(3);
+        filings.Should().ContainSingle();
+        handler
+            .CallCountFor($"/submissions/CIK{CikA}.json")
+            .Should()
+            .Be(1, "the filings call must reuse the payload the metadata call cached");
+    }
+
+    [Fact]
+    public async Task GetCompanyFilings_DifferentCikAfterGetCompanyMetadata_DoesNotServeTheOtherCik()
+    {
+        // Metadata primed for B (no filings); filings then requested for A.
+        var handler = new PerUrlHandler(
+            new()
+            {
+                [$"/submissions/CIK{CikB}.json"] = Submissions(CikB, "0928", withFiling: false),
+                [$"/submissions/CIK{CikA}.json"] = Submissions(CikA, "0331", withFiling: true),
+            }
+        );
+        var sut = BuildClient(handler);
+
+        await sut.GetCompanyMetadata(CikB);
+        var filings = await sut.GetCompanyFilings(CikA);
+
+        // A's single filing proves A's URL was fetched and A's body parsed —
+        // the B-primed cache was correctly bypassed on the URL mismatch.
+        filings.Should().ContainSingle().Which.Cik.Should().Be(CikA);
+        handler.CallCountFor($"/submissions/CIK{CikA}.json").Should().Be(1);
+    }
+
+    private sealed class PerUrlHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, string> _bodyByPath;
+        private readonly Dictionary<string, int> _calls = new();
+
+        public PerUrlHandler(Dictionary<string, string> bodyByPath) => _bodyByPath = bodyByPath;
+
+        public int CallCountFor(string path) => _calls.TryGetValue(path, out var n) ? n : 0;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            _calls[path] = CallCountFor(path) + 1;
+
+            if (!_bodyByPath.TryGetValue(path, out var body))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Detect each company's fiscal year-end from SEC EDGAR's submissions `fiscalYearEnd` field (public/gov source only) and persist it on `CommonStock`, so off-calendar filers (Apple ≈ Sep, Microsoft = Jun) are no longer misrepresented by calendar-quarter math. Closes #691.
- Zero extra SEC requests on the common path: the metadata fetch primes the URL-keyed submissions cache reused by the following filings fetch.
- `HoldingsDataSetClient` calendar-quarter math left untouched on purpose — 13F dataset file naming follows SEC's publishing calendar, not company fiscal years.

## Code changes

- `Equibles.Integrations.Sec/Models/Responses/SecApiResponse.cs` — map SEC `fiscalYearEnd` (MMDD).
- `Equibles.Integrations.Sec/Models/CompanyMetadata.cs` — strict, memoised MMDD parser → `FiscalYearEndMonth`/`Day` (rejects blanks, bad months, calendar-impossible days; allows leap-day).
- `Equibles.Integrations.Sec/SecEdgarClient.cs` — `GetCompanyMetadata` maps the field and primes the submissions cache.
- `Equibles.CommonStocks.Data/Models/CommonStock.cs` — nullable `FiscalYearEndMonth`/`FiscalYearEndDay` (+ EF migration, snapshot consistent).
- `Equibles.CommonStocks.BusinessLogic/` — new `FiscalPeriod` + `FiscalCalendar.GetPeriod` (date → fiscal quarter/year); `CommonStockManager.SetFiscalYearEnd` (no-op-on-unchanged write).
- `Equibles.Sec.HostedService/DocumentScraper.cs` — best-effort per-company detection, failures logged and reported via `ErrorReporter`.
- Tests — `FiscalCalendar`, MMDD parsing, manager no-op/validation, scraper wiring, and a cache-isolation regression test. Full unit suite (1212) green; csharpier clean.