### PR TITLE
test(common-stocks): pin FiscalCalendar.GetPeriod January fiscal-year-end mapping

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarJanuaryFiscalYearEndTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarJanuaryFiscalYearEndTests.cs
@@ -1,0 +1,24 @@
+using Equibles.CommonStocks.BusinessLogic;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Adversarial sibling to <see cref="FiscalCalendarTests"/>, which only pins
+/// September/June/December filers. Contract (FiscalCalendar + FiscalPeriod
+/// docs): the period is derived from the fiscal-year-end month, and the year
+/// is labelled by the calendar year the fiscal year *ends* in. The entire
+/// retail sector (Walmart, Target, Home Depot) ends its fiscal year in
+/// January, so FY2024 runs Feb 2023–Jan 2024 with Q4 = Nov 2023–Jan 2024.
+/// A December-2023 date must therefore map to FY2024 Q4 — exercising both the
+/// year-label flip and the early-end-month quarter wrap, untested until now.
+/// </summary>
+public class FiscalCalendarJanuaryFiscalYearEndTests
+{
+    [Fact]
+    public void GetPeriod_JanuaryFiscalYearEnd_DecemberDate_IsNextYearQ4()
+    {
+        var period = FiscalCalendar.GetPeriod(new DateOnly(2023, 12, 31), fiscalYearEndMonth: 1);
+
+        period.Should().Be(new FiscalPeriod(2024, 4));
+    }
+}


### PR DESCRIPTION
## Summary

Adds one adversarial regression test for PR #867 (fiscal year-end detection). Targets `feature/691-fiscal-year-end` (not `main`) because the code under test only exists on that PR branch — this stacks coverage onto #867 before it merges.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/FiscalCalendarJanuaryFiscalYearEndTests.cs` — new. `FiscalCalendarTests` only pins September/June/December filers; the entire **retail sector** (Walmart, Target, Home Depot) ends its fiscal year in **January**, which was untested. Asserts that `GetPeriod(2023-12-31, fiscalYearEndMonth: 1)` → `FY2024 Q4`, exercising both the year-label flip and the early-end-month quarter wrap. Expected value derived from the FiscalCalendar/FiscalPeriod contract, not the implementation.

## Result

Passes — behavior is correct and now pinned against regression. No production code modified.