### PR TITLE
test(sec): pin CompanyMetadata.FiscalYearEnd re-parse on re-set

### DIFF
--- a/tests/Equibles.UnitTests/Sec/CompanyMetadataFiscalYearEndReparseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanyMetadataFiscalYearEndReparseTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Adversarial sibling to <see cref="CompanyMetadataFiscalYearEndTests"/>,
+/// which only parses a single fixed value. The parse is memoised, but the
+/// contract is explicit: "this is a deserialisation DTO" and "a re-set of
+/// FiscalYearEnd re-parses". A stale memo would make a re-bound DTO report the
+/// previous filer's fiscal year-end — corrupting every downstream quarter calc.
+/// </summary>
+public class CompanyMetadataFiscalYearEndReparseTests
+{
+    [Fact]
+    public void FiscalYearEnd_ReSetAfterRead_ReparsesToNewValue()
+    {
+        var metadata = new CompanyMetadata { FiscalYearEnd = "0928" };
+
+        // Read first so the parse is memoised against "0928" (month 9, day 28).
+        _ = metadata.FiscalYearEndMonth;
+
+        metadata.FiscalYearEnd = "0630";
+
+        metadata.FiscalYearEndMonth.Should().Be(6);
+        metadata.FiscalYearEndDay.Should().Be(30);
+    }
+}


### PR DESCRIPTION
## Summary

One adversarial regression test for PR #867 (fiscal year-end detection). Targets `feature/691-fiscal-year-end` (code under test isn't on `main`).

## Code changes

- `tests/Equibles.UnitTests/Sec/CompanyMetadataFiscalYearEndReparseTests.cs` — new. `CompanyMetadataFiscalYearEndTests` only parses a single fixed value; the parse is **memoised** and the docstring explicitly promises a re-set re-parses ("this is a deserialisation DTO"). Asserts that after reading `FiscalYearEndMonth` (caching `0928`) then re-setting `FiscalYearEnd = 0630`, the DTO reports the new `(6, 30)` — guarding against a stale memo reporting the previous filer's year-end. Expected derived from the contract.

## Result

Passes — re-parse works; now pinned. No production code modified.