### PR TITLE
feat(common-stocks): add FiscalCalendar.GetQuarterEndDate inverse helper

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/FiscalCalendar.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/FiscalCalendar.cs
@@ -49,6 +49,54 @@ public static class FiscalCalendar
     }
 
     /// <summary>
+    /// Inverse of <see cref="GetPeriod(DateOnly,int)"/>: the last calendar day
+    /// of <paramref name="fiscalQuarter"/> (1-4) of fiscal year
+    /// <paramref name="fiscalYear"/>, for a company whose fiscal year ends in
+    /// <paramref name="fiscalYearEndMonth"/> (1-12, 12 = calendar-year filer).
+    /// </summary>
+    /// <remarks>
+    /// Month-granular by design — the day is the last of the quarter's end
+    /// month, matching how <see cref="GetPeriod(DateOnly,int)"/> buckets dates
+    /// and how SEC 10-Q/10-K reporting periods line up. 52/53-week filers whose
+    /// period end drifts a few days are intentionally normalised to month-end
+    /// (see the type remarks). Round-trips with <see cref="GetPeriod(DateOnly,int)"/>:
+    /// <c>GetPeriod(GetQuarterEndDate(y, q, m), m) == new FiscalPeriod(y, q)</c>.
+    /// </remarks>
+    public static DateOnly GetQuarterEndDate(
+        int fiscalYear,
+        int fiscalQuarter,
+        int fiscalYearEndMonth
+    )
+    {
+        if (fiscalYearEndMonth is < 1 or > 12)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(fiscalYearEndMonth),
+                fiscalYearEndMonth,
+                "Fiscal year-end month must be between 1 and 12."
+            );
+        }
+
+        if (fiscalQuarter is < 1 or > 4)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(fiscalQuarter),
+                fiscalQuarter,
+                "Fiscal quarter must be between 1 and 4."
+            );
+        }
+
+        // Q4 ends in the fiscal-year-end month of the fiscal year's labelling
+        // calendar year; each earlier quarter ends three months before. When
+        // that walk crosses January it lands in the previous calendar year.
+        var endMonthRaw = fiscalYearEndMonth - 3 * (4 - fiscalQuarter);
+        var endMonth = endMonthRaw <= 0 ? endMonthRaw + 12 : endMonthRaw;
+        var endYear = endMonthRaw <= 0 ? fiscalYear - 1 : fiscalYear;
+
+        return new DateOnly(endYear, endMonth, DateTime.DaysInMonth(endYear, endMonth));
+    }
+
+    /// <summary>
     /// Returns the fiscal period for <paramref name="date"/> using the stock's
     /// detected <see cref="CommonStock.FiscalYearEndMonth"/>, or null when the
     /// fiscal year-end has not been detected yet.
@@ -61,5 +109,27 @@ public static class FiscalCalendar
         }
 
         return commonStock.FiscalYearEndMonth is { } month ? GetPeriod(date, month) : null;
+    }
+
+    /// <summary>
+    /// The quarter-end date for <paramref name="fiscalQuarter"/>/
+    /// <paramref name="fiscalYear"/> using the stock's detected
+    /// <see cref="CommonStock.FiscalYearEndMonth"/>, or null when the fiscal
+    /// year-end has not been detected yet.
+    /// </summary>
+    public static DateOnly? GetQuarterEndDate(
+        int fiscalYear,
+        int fiscalQuarter,
+        CommonStock commonStock
+    )
+    {
+        if (commonStock == null)
+        {
+            throw new ArgumentNullException(nameof(commonStock));
+        }
+
+        return commonStock.FiscalYearEndMonth is { } month
+            ? GetQuarterEndDate(fiscalYear, fiscalQuarter, month)
+            : null;
     }
 }

--- a/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarQuarterEndDateTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarQuarterEndDateTests.cs
@@ -1,0 +1,116 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Pins the inverse fiscal mapping (period → quarter-end date). Earnings-call
+/// ingestion gets a fiscal (year, quarter) from the data provider and must
+/// store the *real* period-end — storing a calendar quarter-end for an
+/// off-calendar filer (Apple's FQ1 ends in December, not March) is exactly the
+/// historical-data bug this helper exists to prevent.
+/// </summary>
+public class FiscalCalendarQuarterEndDateTests
+{
+    [Theory]
+    // Apple — fiscal year ends in September.
+    [InlineData(2024, 1, 9, "2023-12-31")]
+    [InlineData(2024, 2, 9, "2024-03-31")]
+    [InlineData(2024, 3, 9, "2024-06-30")]
+    [InlineData(2024, 4, 9, "2024-09-30")]
+    // Microsoft — fiscal year ends in June.
+    [InlineData(2024, 1, 6, "2023-09-30")]
+    [InlineData(2024, 2, 6, "2023-12-31")]
+    [InlineData(2024, 3, 6, "2024-03-31")]
+    [InlineData(2024, 4, 6, "2024-06-30")]
+    // Plain calendar-year filer.
+    [InlineData(2024, 1, 12, "2024-03-31")]
+    [InlineData(2024, 4, 12, "2024-12-31")]
+    // Fiscal year ending February — Q4 end lands on a leap day.
+    [InlineData(2024, 4, 2, "2024-02-29")]
+    [InlineData(2023, 4, 2, "2023-02-28")]
+    public void GetQuarterEndDate_ReturnsLastDayOfTheFiscalQuarter(
+        int fiscalYear,
+        int fiscalQuarter,
+        int fiscalYearEndMonth,
+        string expected
+    )
+    {
+        var result = FiscalCalendar.GetQuarterEndDate(
+            fiscalYear,
+            fiscalQuarter,
+            fiscalYearEndMonth
+        );
+
+        result.Should().Be(DateOnly.Parse(expected));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(6)]
+    [InlineData(9)]
+    [InlineData(12)]
+    public void GetQuarterEndDate_RoundTripsWithGetPeriod(int fiscalYearEndMonth)
+    {
+        for (var year = 2020; year <= 2026; year++)
+        {
+            for (var quarter = 1; quarter <= 4; quarter++)
+            {
+                var end = FiscalCalendar.GetQuarterEndDate(year, quarter, fiscalYearEndMonth);
+
+                FiscalCalendar
+                    .GetPeriod(end, fiscalYearEndMonth)
+                    .Should()
+                    .Be(
+                        new FiscalPeriod(year, quarter),
+                        "the quarter-end date must map back to the same fiscal period"
+                    );
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(5)]
+    [InlineData(-1)]
+    public void GetQuarterEndDate_InvalidQuarter_Throws(int fiscalQuarter)
+    {
+        var act = () => FiscalCalendar.GetQuarterEndDate(2024, fiscalQuarter, 9);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(13)]
+    public void GetQuarterEndDate_InvalidFiscalYearEndMonth_Throws(int fiscalYearEndMonth)
+    {
+        var act = () => FiscalCalendar.GetQuarterEndDate(2024, 1, fiscalYearEndMonth);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void GetQuarterEndDate_StockWithoutDetectedFiscalYearEnd_ReturnsNull()
+    {
+        var stock = new CommonStock { FiscalYearEndMonth = null };
+
+        FiscalCalendar.GetQuarterEndDate(2024, 1, stock).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetQuarterEndDate_StockWithDetectedFiscalYearEnd_ReturnsDate()
+    {
+        var stock = new CommonStock { FiscalYearEndMonth = 9 };
+
+        FiscalCalendar.GetQuarterEndDate(2024, 1, stock).Should().Be(new DateOnly(2023, 12, 31));
+    }
+
+    [Fact]
+    public void GetQuarterEndDate_NullStock_Throws()
+    {
+        var act = () => FiscalCalendar.GetQuarterEndDate(2024, 1, (CommonStock)null);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the inverse of `FiscalCalendar.GetPeriod`: given a fiscal year + quarter + fiscal-year-end month, returns the quarter's period-end date. Round-trips with `GetPeriod`.
- Prerequisite for fixing earnings-call ingestion so transcripts store the real fiscal period end instead of a calendar quarter-end for off-calendar filers (Apple FQ1 ends December, not March). Follow-up to #691 / #867.

## Code changes

- `Equibles.CommonStocks.BusinessLogic/FiscalCalendar.cs` — `GetQuarterEndDate(fiscalYear, fiscalQuarter, fiscalYearEndMonth)` + a `CommonStock` overload returning null when the fiscal year-end is undetected.
- `tests/Equibles.UnitTests/CommonStocks/FiscalCalendarQuarterEndDateTests.cs` — Apple/Microsoft/calendar/leap-Feb cases, a `GetPeriod` round-trip property test, and argument-validation cases.