### PR TITLE
test: nightly live contract/smoke test tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,12 @@ jobs:
 
       - name: Test
         # Functional tests need Playwright + a ParadeDB container and live in functional.yml.
+        # Live (contract/smoke) tests hit real upstream APIs and run nightly in smoke.yml.
         # Do not pin LogFileName: with multiple test projects in the sln, a fixed
         # filename makes each project overwrite the previous TRX so only the last
         # project's results survive. Letting dotnet test auto-name produces one
         # TRX per project for dorny/test-reporter's coverage/**/*.trx glob.
-        run: dotnet test Equibles.sln --no-build -c Release --filter "Category!=Functional" --logger trx --collect:"XPlat Code Coverage" --settings coverage.runsettings --results-directory ./coverage
+        run: dotnet test Equibles.sln --no-build -c Release --filter "Category!=Functional&Category!=Live" --logger trx --collect:"XPlat Code Coverage" --settings coverage.runsettings --results-directory ./coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,46 @@
+name: Smoke Tests (Live)
+
+on:
+  schedule:
+    # Nightly at 06:00 UTC. These hit real upstream APIs (Yahoo, etc.) and detect
+    # contract drift before a release — they are NOT a per-PR gate.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Restore
+        run: dotnet restore Equibles.sln
+
+      - name: Build smoke test project
+        run: dotnet build tests/Equibles.SmokeTests/Equibles.SmokeTests.csproj --no-restore -c Release
+
+      - name: Run smoke tests
+        # Category=Live is excluded from ci.yml; this is the only place it runs.
+        run: dotnet test tests/Equibles.SmokeTests/Equibles.SmokeTests.csproj --no-build -c Release --filter "Category=Live" --logger "trx;LogFileName=results.trx" --results-directory ./smoke-results
+
+      - name: Test Report
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3
+        if: success() || failure()
+        with:
+          name: Smoke Test Results
+          path: smoke-results/**/*.trx
+          reporter: dotnet-trx

--- a/Equibles.sln
+++ b/Equibles.sln
@@ -139,6 +139,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.IntegrationTests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Messaging", "src\Equibles.Messaging\Equibles.Messaging.csproj", "{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.SmokeTests", "tests\Equibles.SmokeTests\Equibles.SmokeTests.csproj", "{A15FB700-5BF7-4284-B695-FE04E80D258F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -941,6 +943,18 @@ Global
 		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Release|x64.Build.0 = Release|Any CPU
 		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Release|x86.ActiveCfg = Release|Any CPU
 		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5}.Release|x86.Build.0 = Release|Any CPU
+		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Debug|x64.Build.0 = Debug|Any CPU
+		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Debug|x86.Build.0 = Debug|Any CPU
+		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Release|x64.ActiveCfg = Release|Any CPU
+		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Release|x64.Build.0 = Release|Any CPU
+		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Release|x86.ActiveCfg = Release|Any CPU
+		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1012,6 +1026,7 @@ Global
 		{DF75E095-623E-4BC4-AD6C-7C6406AB7E0B} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{174B4C75-C06A-412D-AA54-F5EA658C9200} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{4EF8D5D7-52E2-4D15-85B1-BF59F6CAAAB5} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{A15FB700-5BF7-4284-B695-FE04E80D258F} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/tests/Equibles.SmokeTests/Equibles.SmokeTests.csproj
+++ b/tests/Equibles.SmokeTests/Equibles.SmokeTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Equibles.SmokeTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Equibles.Integrations.Yahoo\Equibles.Integrations.Yahoo.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Equibles.SmokeTests/YahooHistoricalPricesSmokeTests.cs
+++ b/tests/Equibles.SmokeTests/YahooHistoricalPricesSmokeTests.cs
@@ -1,0 +1,40 @@
+using Equibles.Integrations.Yahoo;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Equibles.SmokeTests;
+
+// Live contract / drift-detection test. Hits the real Yahoo Finance API and asserts the
+// SHAPE and INVARIANTS of the response — never exact values — for an immutable past window.
+// Its only job is to fail loudly when Yahoo changes its payload so the parser can be fixed
+// before a release. Excluded from per-PR CI via the "Live" category; runs nightly (smoke.yml).
+[Trait("Category", "Live")]
+public class YahooHistoricalPricesSmokeTests
+{
+    [Fact]
+    public async Task GetHistoricalPrices_KnownPastWindow_ReturnsWellFormedDailyBars()
+    {
+        var client = new YahooFinanceClient(
+            new HttpClient(),
+            NullLogger<YahooFinanceClient>.Instance
+        );
+        // January 2024 is closed and immutable: ~21 NYSE trading days. We assert a lower
+        // bound (>= 15) rather than an exact count so a single missing/holiday bar upstream
+        // doesn't make this flaky — drift in the response shape is what we want to catch.
+        var start = new DateOnly(2024, 1, 2);
+        var end = new DateOnly(2024, 1, 31);
+
+        var prices = await client.GetHistoricalPrices("AAPL", start, end);
+
+        prices.Should().NotBeNullOrEmpty("Yahoo must still return daily bars for AAPL");
+        prices.Count.Should().BeGreaterThanOrEqualTo(15, "January 2024 had ~21 trading days");
+
+        prices.Should().OnlyContain(p => p.Date >= start && p.Date <= end);
+        prices.Should().OnlyContain(p => p.High >= p.Low);
+        prices.Should().OnlyContain(p => p.High >= p.Open && p.High >= p.Close);
+        prices.Should().OnlyContain(p => p.Low <= p.Open && p.Low <= p.Close);
+        prices.Should().OnlyContain(p => p.Close > 0 && p.AdjustedClose > 0);
+        prices.Should().OnlyContain(p => p.Volume > 0);
+    }
+}


### PR DESCRIPTION
## Summary
Adds a scheduled live contract/smoke test tier. Detects upstream API (Yahoo) payload drift before a release, without making external-API flakiness a per-PR gate.

## Code changes
- `tests/Equibles.SmokeTests/` — new xUnit project (matches repo stack: xUnit v2 + FluentAssertions). `YahooHistoricalPricesSmokeTests` hits real Yahoo Finance for an immutable past window (Jan 2024) and asserts **shape + invariants only**, never exact values. Tagged `[Trait("Category","Live")]`.
- `.github/workflows/smoke.yml` — nightly cron (06:00 UTC) + `workflow_dispatch`, runs `--filter "Category=Live"` only.
- `.github/workflows/ci.yml` — per-PR test filter now `Category!=Functional&Category!=Live` so the live tier never runs on PRs.
- `Equibles.sln` — registers the new project.

Verified locally: build clean, csharpier clean, live test passes against real Yahoo.