### PR TITLE
test(sec): pin FinancialFactsScraperWorker rejects missing SEC contact email

### DIFF
--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="..\..\src\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Errors.Repositories\Equibles.Errors.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Sec.HostedService\Equibles.Sec.HostedService.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Sec.FinancialFacts.HostedService\Equibles.Sec.FinancialFacts.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Media.Data\Equibles.Media.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Media.BusinessLogic\Equibles.Media.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Congress.HostedService\Equibles.Congress.HostedService.csproj" />

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsScraperWorkerTests.cs
@@ -1,0 +1,53 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Sec.FinancialFacts.HostedService;
+using Equibles.Sec.FinancialFacts.HostedService.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactsScraperWorkerTests
+{
+    [Fact]
+    public void ValidateConfiguration_SecContactEmailMissing_ReturnsFalse()
+    {
+        // Every SEC request the financial-facts scraper makes needs a contact
+        // email in the User-Agent or SEC 403-bans the source IP. The contract
+        // of ValidateConfiguration is the startup gate that stops the worker
+        // from looping uselessly (and risking a ban) when Sec:ContactEmail is
+        // unset. Pin empty-config → false so a renamed key or stray default
+        // can't ship a worker that hammers SEC without identifying itself.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>())
+            .Build();
+        var sut = new TestableFinancialFactsScraperWorker(
+            Substitute.For<ILogger<FinancialFactsScraperWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new FinancialFactsScraperOptions()),
+            config
+        );
+
+        sut.InvokeValidateConfiguration().Should().BeFalse();
+    }
+
+    private sealed class TestableFinancialFactsScraperWorker : FinancialFactsScraperWorker
+    {
+        public TestableFinancialFactsScraperWorker(
+            ILogger<FinancialFactsScraperWorker> logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            IOptions<FinancialFactsScraperOptions> options,
+            IConfiguration configuration
+        )
+            : base(logger, scopeFactory, errorReporter, options, configuration) { }
+
+        public bool InvokeValidateConfiguration() => ValidateConfiguration();
+    }
+}


### PR DESCRIPTION
## Summary

Adversarial unit test for the new `FinancialFactsScraperWorker.ValidateConfiguration` (#690 / #879). Bases on the feature branch since the code is not yet on `main`.

## Code changes

- Adds `tests/Equibles.UnitTests/Sec/FinancialFactsScraperWorkerTests.cs`: asserts the worker's startup gate returns `false` when `Sec:ContactEmail` is unset — SEC 403-bans requests whose User-Agent lacks a contact email, so a renamed key or stray default must not ship a worker that loops hammering SEC. Test passes (contract confirmed, pinned).
- `tests/Equibles.UnitTests/Equibles.UnitTests.csproj`: adds the required `ProjectReference` to `Equibles.Sec.FinancialFacts.HostedService` (the new module was not yet referenced by the unit-test project, so it was untestable without this). Test-project plumbing only; no production code modified.

Stacks on #879.