### PR TITLE
chore(search): order-independent provider discovery

### DIFF
--- a/src/Equibles.Search/Equibles.Search.csproj
+++ b/src/Equibles.Search/Equibles.Search.csproj
@@ -6,5 +6,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Search.Abstractions\Equibles.Search.Abstractions.csproj" />
+    <ProjectReference Include="..\Equibles.Plugins\Equibles.Plugins.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Search/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Search/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
+using Equibles.Plugins;
 using Equibles.Search.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,6 +16,10 @@ public static class ServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddEquiblesSearch(this IServiceCollection services)
     {
+        // Self-load every Equibles.* plugin assembly so discovery never depends on another
+        // registrar (e.g. AddAllRepositories) having run first. LoadAll is cached/idempotent.
+        PluginLoader.LoadAll();
+
         var providerTypes = AppDomain
             .CurrentDomain.GetAssemblies()
             .Where(assembly =>

--- a/tests/Equibles.UnitTests/Search/SearchServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Search/SearchServiceCollectionExtensionsTests.cs
@@ -2,6 +2,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Equibles.Search;
 using Equibles.Search.Abstractions;
+using Equibles.CommonStocks.Repositories.Search;
 using Equibles.Search.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -26,6 +27,24 @@ public class SearchServiceCollectionExtensionsTests
                 && descriptor.ImplementationType == typeof(DiscoverableTestProvider)
             );
         services.Should().Contain(descriptor => descriptor.ServiceType == typeof(SearchAggregator));
+    }
+
+    [Fact]
+    public void AddEquiblesSearch_WithoutAddAllRepositories_StillDiscoversRealModuleProvider()
+    {
+        // Ordering-independence (issue #887): AddEquiblesSearch self-loads plugin assemblies via
+        // PluginLoader, so a real module provider is discovered even though AddAllRepositories
+        // (the registrar it used to implicitly depend on) was never called.
+        var services = new ServiceCollection();
+
+        services.AddEquiblesSearch();
+
+        services
+            .Should()
+            .Contain(descriptor =>
+                descriptor.ServiceType == typeof(ISearchProvider)
+                && descriptor.ImplementationType == typeof(CommonStockSearchProvider)
+            );
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Fixes #887: `AddEquiblesSearch()` scanned only already-loaded assemblies and worked only because `AddAllRepositories()` ran just before it. It now self-loads every `Equibles.*` plugin via the cached `PluginLoader.LoadAll()`.

## Code changes

- `Equibles.Search.csproj` — project reference to `Equibles.Plugins`.
- `Extensions/ServiceCollectionExtensions.cs` — call `PluginLoader.LoadAll()` before scanning.
- `SearchServiceCollectionExtensionsTests.cs` — test pinning discovery of a real module provider without `AddAllRepositories`.