### PR TITLE
refactor(search): extract QueryableSearchProvider base

### DIFF
--- a/src/Equibles.Cftc.Repositories/Search/CftcContractSearchProvider.cs
+++ b/src/Equibles.Cftc.Repositories/Search/CftcContractSearchProvider.cs
@@ -1,10 +1,11 @@
+using Equibles.Cftc.Data.Models;
 using Equibles.Search.Abstractions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Cftc.Repositories.Search;
 
 /// <summary>Futures group of the global search. Wraps the existing market code/name search.</summary>
-public class CftcContractSearchProvider : ISearchProvider
+public class CftcContractSearchProvider : QueryableSearchProvider<CftcContract>
 {
     private readonly CftcContractRepository _cftcContractRepository;
 
@@ -13,35 +14,24 @@ public class CftcContractSearchProvider : ISearchProvider
         _cftcContractRepository = cftcContractRepository;
     }
 
-    public string Category => "Futures";
+    public override string Category => "Futures";
 
-    public int Order => 60;
+    public override int Order => 60;
 
-    public async Task<SearchResultGroup> Search(
-        SearchRequest request,
+    protected override IQueryable<CftcContract> Filter(SearchRequest request) =>
+        _cftcContractRepository.Search(request.Query).OrderBy(contract => contract.MarketName);
+
+    protected override Task<List<CftcContract>> Materialize(
+        IQueryable<CftcContract> query,
         CancellationToken cancellationToken
-    )
-    {
-        var contracts = await _cftcContractRepository
-            .Search(request.Query)
-            .OrderBy(contract => contract.MarketName)
-            .Take(request.MaxPerProvider)
-            .Select(contract => new { contract.MarketCode, contract.MarketName })
-            .ToListAsync(cancellationToken);
+    ) => query.ToListAsync(cancellationToken);
 
-        return new SearchResultGroup
+    protected override SearchHit Project(CftcContract contract) =>
+        new()
         {
-            Category = Category,
-            Order = Order,
-            Hits = contracts
-                .Select(contract => new SearchHit
-                {
-                    Title = contract.MarketName,
-                    Subtitle = contract.MarketCode,
-                    Kind = "FuturesMarket",
-                    RouteValues = { ["marketCode"] = contract.MarketCode },
-                })
-                .ToList(),
+            Title = contract.MarketName,
+            Subtitle = contract.MarketCode,
+            Kind = "FuturesMarket",
+            RouteValues = { ["marketCode"] = contract.MarketCode },
         };
-    }
 }

--- a/src/Equibles.CommonStocks.Repositories/Search/CommonStockSearchProvider.cs
+++ b/src/Equibles.CommonStocks.Repositories/Search/CommonStockSearchProvider.cs
@@ -1,10 +1,11 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Search.Abstractions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.CommonStocks.Repositories.Search;
 
 /// <summary>Stocks group of the global search. Wraps the existing ticker/name search.</summary>
-public class CommonStockSearchProvider : ISearchProvider
+public class CommonStockSearchProvider : QueryableSearchProvider<CommonStock>
 {
     private readonly CommonStockRepository _commonStockRepository;
 
@@ -13,34 +14,24 @@ public class CommonStockSearchProvider : ISearchProvider
         _commonStockRepository = commonStockRepository;
     }
 
-    public string Category => "Stocks";
+    public override string Category => "Stocks";
 
-    public int Order => 0;
+    public override int Order => 0;
 
-    public async Task<SearchResultGroup> Search(
-        SearchRequest request,
+    protected override IQueryable<CommonStock> Filter(SearchRequest request) =>
+        _commonStockRepository.Search(request.Query);
+
+    protected override Task<List<CommonStock>> Materialize(
+        IQueryable<CommonStock> query,
         CancellationToken cancellationToken
-    )
-    {
-        var stocks = await _commonStockRepository
-            .Search(request.Query)
-            .Take(request.MaxPerProvider)
-            .Select(stock => new { stock.Ticker, stock.Name })
-            .ToListAsync(cancellationToken);
+    ) => query.ToListAsync(cancellationToken);
 
-        return new SearchResultGroup
+    protected override SearchHit Project(CommonStock stock) =>
+        new()
         {
-            Category = Category,
-            Order = Order,
-            Hits = stocks
-                .Select(stock => new SearchHit
-                {
-                    Title = stock.Ticker,
-                    Subtitle = stock.Name,
-                    Kind = "Stock",
-                    RouteValues = { ["ticker"] = stock.Ticker },
-                })
-                .ToList(),
+            Title = stock.Ticker,
+            Subtitle = stock.Name,
+            Kind = "Stock",
+            RouteValues = { ["ticker"] = stock.Ticker },
         };
-    }
 }

--- a/src/Equibles.Congress.Repositories/Search/CongressMemberSearchProvider.cs
+++ b/src/Equibles.Congress.Repositories/Search/CongressMemberSearchProvider.cs
@@ -1,10 +1,11 @@
+using Equibles.Congress.Data.Models;
 using Equibles.Search.Abstractions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Congress.Repositories.Search;
 
 /// <summary>Congress group of the global search. Wraps the existing member name search.</summary>
-public class CongressMemberSearchProvider : ISearchProvider
+public class CongressMemberSearchProvider : QueryableSearchProvider<CongressMember>
 {
     private readonly CongressMemberRepository _congressMemberRepository;
 
@@ -13,34 +14,23 @@ public class CongressMemberSearchProvider : ISearchProvider
         _congressMemberRepository = congressMemberRepository;
     }
 
-    public string Category => "Congress";
+    public override string Category => "Congress";
 
-    public int Order => 50;
+    public override int Order => 50;
 
-    public async Task<SearchResultGroup> Search(
-        SearchRequest request,
+    protected override IQueryable<CongressMember> Filter(SearchRequest request) =>
+        _congressMemberRepository.Search(request.Query).OrderBy(member => member.Name);
+
+    protected override Task<List<CongressMember>> Materialize(
+        IQueryable<CongressMember> query,
         CancellationToken cancellationToken
-    )
-    {
-        var members = await _congressMemberRepository
-            .Search(request.Query)
-            .OrderBy(member => member.Name)
-            .Take(request.MaxPerProvider)
-            .Select(member => new { member.Name })
-            .ToListAsync(cancellationToken);
+    ) => query.ToListAsync(cancellationToken);
 
-        return new SearchResultGroup
+    protected override SearchHit Project(CongressMember member) =>
+        new()
         {
-            Category = Category,
-            Order = Order,
-            Hits = members
-                .Select(member => new SearchHit
-                {
-                    Title = member.Name,
-                    Kind = "CongressMember",
-                    RouteValues = { ["name"] = member.Name },
-                })
-                .ToList(),
+            Title = member.Name,
+            Kind = "CongressMember",
+            RouteValues = { ["name"] = member.Name },
         };
-    }
 }

--- a/src/Equibles.Fred.Repositories/Search/FredSeriesSearchProvider.cs
+++ b/src/Equibles.Fred.Repositories/Search/FredSeriesSearchProvider.cs
@@ -1,10 +1,11 @@
+using Equibles.Fred.Data.Models;
 using Equibles.Search.Abstractions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Fred.Repositories.Search;
 
 /// <summary>Economic-indicator group. Wraps the existing FRED series id/title search.</summary>
-public class FredSeriesSearchProvider : ISearchProvider
+public class FredSeriesSearchProvider : QueryableSearchProvider<FredSeries>
 {
     private readonly FredSeriesRepository _fredSeriesRepository;
 
@@ -13,42 +14,26 @@ public class FredSeriesSearchProvider : ISearchProvider
         _fredSeriesRepository = fredSeriesRepository;
     }
 
-    public string Category => "Economic Indicators";
+    public override string Category => "Economic Indicators";
 
-    public int Order => 20;
+    public override int Order => 20;
 
-    public async Task<SearchResultGroup> Search(
-        SearchRequest request,
+    protected override IQueryable<FredSeries> Filter(SearchRequest request) =>
+        _fredSeriesRepository.Search(request.Query).OrderBy(series => series.Title);
+
+    protected override Task<List<FredSeries>> Materialize(
+        IQueryable<FredSeries> query,
         CancellationToken cancellationToken
-    )
-    {
-        var series = await _fredSeriesRepository
-            .Search(request.Query)
-            .OrderBy(s => s.Title)
-            .Take(request.MaxPerProvider)
-            .Select(s => new
-            {
-                s.SeriesId,
-                s.Title,
-                s.Units,
-            })
-            .ToListAsync(cancellationToken);
+    ) => query.ToListAsync(cancellationToken);
 
-        return new SearchResultGroup
+    protected override SearchHit Project(FredSeries series) =>
+        new()
         {
-            Category = Category,
-            Order = Order,
-            Hits = series
-                .Select(s => new SearchHit
-                {
-                    Title = s.Title,
-                    Subtitle = string.IsNullOrWhiteSpace(s.Units)
-                        ? s.SeriesId
-                        : $"{s.SeriesId} · {s.Units}",
-                    Kind = "EconomicSeries",
-                    RouteValues = { ["seriesId"] = s.SeriesId },
-                })
-                .ToList(),
+            Title = series.Title,
+            Subtitle = string.IsNullOrWhiteSpace(series.Units)
+                ? series.SeriesId
+                : $"{series.SeriesId} · {series.Units}",
+            Kind = "EconomicSeries",
+            RouteValues = { ["seriesId"] = series.SeriesId },
         };
-    }
 }

--- a/src/Equibles.Holdings.Repositories/Search/InstitutionalHolderSearchProvider.cs
+++ b/src/Equibles.Holdings.Repositories/Search/InstitutionalHolderSearchProvider.cs
@@ -1,10 +1,11 @@
+using Equibles.Holdings.Data.Models;
 using Equibles.Search.Abstractions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Holdings.Repositories.Search;
 
 /// <summary>Institutions group of the global search. Wraps the existing holder name search.</summary>
-public class InstitutionalHolderSearchProvider : ISearchProvider
+public class InstitutionalHolderSearchProvider : QueryableSearchProvider<InstitutionalHolder>
 {
     private readonly InstitutionalHolderRepository _institutionalHolderRepository;
 
@@ -15,46 +16,29 @@ public class InstitutionalHolderSearchProvider : ISearchProvider
         _institutionalHolderRepository = institutionalHolderRepository;
     }
 
-    public string Category => "Institutions";
+    public override string Category => "Institutions";
 
-    public int Order => 30;
+    public override int Order => 30;
 
-    public async Task<SearchResultGroup> Search(
-        SearchRequest request,
+    protected override IQueryable<InstitutionalHolder> Filter(SearchRequest request) =>
+        _institutionalHolderRepository.Search(request.Query).OrderBy(holder => holder.Name);
+
+    protected override Task<List<InstitutionalHolder>> Materialize(
+        IQueryable<InstitutionalHolder> query,
         CancellationToken cancellationToken
-    )
-    {
-        var holders = await _institutionalHolderRepository
-            .Search(request.Query)
-            .OrderBy(holder => holder.Name)
-            .Take(request.MaxPerProvider)
-            .Select(holder => new
-            {
-                holder.Name,
-                holder.Cik,
-                holder.City,
-                holder.StateOrCountry,
-            })
-            .ToListAsync(cancellationToken);
+    ) => query.ToListAsync(cancellationToken);
 
-        return new SearchResultGroup
+    protected override SearchHit Project(InstitutionalHolder holder) =>
+        new()
         {
-            Category = Category,
-            Order = Order,
-            Hits = holders
-                .Select(holder => new SearchHit
-                {
-                    Title = holder.Name,
-                    Subtitle = string.Join(
-                        ", ",
-                        new[] { holder.City, holder.StateOrCountry }.Where(part =>
-                            !string.IsNullOrWhiteSpace(part)
-                        )
-                    ),
-                    Kind = "Institution",
-                    RouteValues = { ["cik"] = holder.Cik },
-                })
-                .ToList(),
+            Title = holder.Name,
+            Subtitle = string.Join(
+                ", ",
+                new[] { holder.City, holder.StateOrCountry }.Where(part =>
+                    !string.IsNullOrWhiteSpace(part)
+                )
+            ),
+            Kind = "Institution",
+            RouteValues = { ["cik"] = holder.Cik },
         };
-    }
 }

--- a/src/Equibles.InsiderTrading.Repositories/Search/InsiderOwnerSearchProvider.cs
+++ b/src/Equibles.InsiderTrading.Repositories/Search/InsiderOwnerSearchProvider.cs
@@ -1,10 +1,11 @@
+using Equibles.InsiderTrading.Data.Models;
 using Equibles.Search.Abstractions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.InsiderTrading.Repositories.Search;
 
 /// <summary>Insiders group of the global search. Wraps the existing owner name search.</summary>
-public class InsiderOwnerSearchProvider : ISearchProvider
+public class InsiderOwnerSearchProvider : QueryableSearchProvider<InsiderOwner>
 {
     private readonly InsiderOwnerRepository _insiderOwnerRepository;
 
@@ -13,48 +14,26 @@ public class InsiderOwnerSearchProvider : ISearchProvider
         _insiderOwnerRepository = insiderOwnerRepository;
     }
 
-    public string Category => "Insiders";
+    public override string Category => "Insiders";
 
-    public int Order => 40;
+    public override int Order => 40;
 
-    public async Task<SearchResultGroup> Search(
-        SearchRequest request,
+    protected override IQueryable<InsiderOwner> Filter(SearchRequest request) =>
+        _insiderOwnerRepository.Search(request.Query).OrderBy(owner => owner.Name);
+
+    protected override Task<List<InsiderOwner>> Materialize(
+        IQueryable<InsiderOwner> query,
         CancellationToken cancellationToken
-    )
-    {
-        var owners = await _insiderOwnerRepository
-            .Search(request.Query)
-            .OrderBy(owner => owner.Name)
-            .Take(request.MaxPerProvider)
-            .Select(owner => new
-            {
-                owner.Name,
-                owner.OwnerCik,
-                owner.OfficerTitle,
-                owner.IsDirector,
-                owner.IsTenPercentOwner,
-            })
-            .ToListAsync(cancellationToken);
+    ) => query.ToListAsync(cancellationToken);
 
-        return new SearchResultGroup
+    protected override SearchHit Project(InsiderOwner owner) =>
+        new()
         {
-            Category = Category,
-            Order = Order,
-            Hits = owners
-                .Select(owner => new SearchHit
-                {
-                    Title = owner.Name,
-                    Subtitle = DescribeRole(
-                        owner.OfficerTitle,
-                        owner.IsDirector,
-                        owner.IsTenPercentOwner
-                    ),
-                    Kind = "Insider",
-                    RouteValues = { ["ownerCik"] = owner.OwnerCik },
-                })
-                .ToList(),
+            Title = owner.Name,
+            Subtitle = DescribeRole(owner.OfficerTitle, owner.IsDirector, owner.IsTenPercentOwner),
+            Kind = "Insider",
+            RouteValues = { ["ownerCik"] = owner.OwnerCik },
         };
-    }
 
     private static string DescribeRole(string officerTitle, bool isDirector, bool isTenPercentOwner)
     {

--- a/src/Equibles.Search.Abstractions/QueryableSearchProvider.cs
+++ b/src/Equibles.Search.Abstractions/QueryableSearchProvider.cs
@@ -1,0 +1,47 @@
+namespace Equibles.Search.Abstractions;
+
+/// <summary>
+/// Base for providers backed by an <see cref="IQueryable{T}"/> repository search. Owns the common
+/// pipeline — cap to <see cref="SearchRequest.MaxPerProvider"/>, materialise, project, build the
+/// group — so a concrete provider only declares its category, query and per-row projection.
+/// <para>
+/// This package stays EF-free: materialisation is deferred to <see cref="Materialize"/>, which the
+/// module implements as a one-line <c>ToListAsync</c> where EF Core is already referenced.
+/// </para>
+/// </summary>
+public abstract class QueryableSearchProvider<TEntity> : ISearchProvider
+{
+    public abstract string Category { get; }
+
+    public abstract int Order { get; }
+
+    /// <summary>The (ideally ordered) query for this request, before the result cap is applied.</summary>
+    protected abstract IQueryable<TEntity> Filter(SearchRequest request);
+
+    /// <summary>Maps one matched entity to a <see cref="SearchHit"/>.</summary>
+    protected abstract SearchHit Project(TEntity entity);
+
+    /// <summary>Runs the capped query. Implemented per module as <c>query.ToListAsync(token)</c>.</summary>
+    protected abstract Task<List<TEntity>> Materialize(
+        IQueryable<TEntity> query,
+        CancellationToken cancellationToken
+    );
+
+    public async Task<SearchResultGroup> Search(
+        SearchRequest request,
+        CancellationToken cancellationToken
+    )
+    {
+        var entities = await Materialize(
+            Filter(request).Take(request.MaxPerProvider),
+            cancellationToken
+        );
+
+        return new SearchResultGroup
+        {
+            Category = Category,
+            Order = Order,
+            Hits = entities.Select(Project).ToList(),
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #886. The six IQueryable-backed providers were ~25 near-identical lines each; they now extend a shared `QueryableSearchProvider<TEntity>` and declare only Category, Order, Filter, Project and a one-line Materialize.
- `Equibles.Search.Abstractions` stays EF-free — materialisation (`ToListAsync`) is overridden per module where EF Core is already referenced.

## Code changes

- `Equibles.Search.Abstractions/QueryableSearchProvider.cs` — new shared base owning the pipeline.
- 6 `*SearchProvider.cs` — reduced to declarations; behaviour unchanged.

Verified in Chrome: AAPL and Vanguard queries return identical groups/subtitles. 15 Search unit tests green.