### PR TITLE
feat(search): navigable institution/insider/congress profiles

### DIFF
--- a/src/Equibles.Congress.Repositories/Search/CongressMemberSearchProvider.cs
+++ b/src/Equibles.Congress.Repositories/Search/CongressMemberSearchProvider.cs
@@ -31,6 +31,6 @@ public class CongressMemberSearchProvider : QueryableSearchProvider<CongressMemb
         {
             Title = member.Name,
             Kind = "CongressMember",
-            RouteValues = { ["name"] = member.Name },
+            RouteValues = { ["id"] = member.Id.ToString() },
         };
 }

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -1,0 +1,140 @@
+using Equibles.Congress.Repositories;
+using Equibles.Holdings.Repositories;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Extensions;
+using Equibles.Web.ViewModels.Profiles;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Web.Controllers;
+
+// Standalone read-only profiles so global-search hits for institutions, insiders and
+// congress members are navigable (issue #888) — they previously had no destination.
+public class ProfilesController : BaseController
+{
+    private const int RecentRowLimit = 25;
+
+    private readonly InstitutionalHolderRepository _institutionalHolderRepository;
+    private readonly InstitutionalHoldingRepository _institutionalHoldingRepository;
+    private readonly InsiderOwnerRepository _insiderOwnerRepository;
+    private readonly InsiderTransactionRepository _insiderTransactionRepository;
+    private readonly CongressMemberRepository _congressMemberRepository;
+    private readonly CongressionalTradeRepository _congressionalTradeRepository;
+
+    public ProfilesController(
+        InstitutionalHolderRepository institutionalHolderRepository,
+        InstitutionalHoldingRepository institutionalHoldingRepository,
+        InsiderOwnerRepository insiderOwnerRepository,
+        InsiderTransactionRepository insiderTransactionRepository,
+        CongressMemberRepository congressMemberRepository,
+        CongressionalTradeRepository congressionalTradeRepository,
+        ILogger<ProfilesController> logger
+    )
+        : base(logger)
+    {
+        _institutionalHolderRepository = institutionalHolderRepository;
+        _institutionalHoldingRepository = institutionalHoldingRepository;
+        _insiderOwnerRepository = insiderOwnerRepository;
+        _insiderTransactionRepository = insiderTransactionRepository;
+        _congressMemberRepository = congressMemberRepository;
+        _congressionalTradeRepository = congressionalTradeRepository;
+    }
+
+    [HttpGet("~/Institutions/{cik}")]
+    public async Task<IActionResult> Institution(string cik)
+    {
+        var holder = await _institutionalHolderRepository.GetByCik(cik);
+        if (holder == null)
+            return NotFound();
+
+        var holdings = await _institutionalHoldingRepository
+            .GetHistoryByHolder(holder)
+            .OrderByDescending(holding => holding.ReportDate)
+            .Take(RecentRowLimit)
+            .Select(holding => new HoldingRowViewModel
+            {
+                Ticker = holding.CommonStock.Ticker,
+                Company = holding.CommonStock.Name,
+                ReportDate = holding.ReportDate,
+                Shares = holding.Shares,
+                Value = holding.Value,
+            })
+            .ToListAsync();
+
+        ViewData["Title"] = holder.Name;
+        return View(
+            new InstitutionProfileViewModel
+            {
+                Name = holder.Name,
+                Cik = holder.Cik,
+                Location = ProfileFormatting.JoinLocation(holder.City, holder.StateOrCountry),
+                Holdings = holdings,
+            }
+        );
+    }
+
+    [HttpGet("~/Insiders/{ownerCik}")]
+    public async Task<IActionResult> Insider(string ownerCik)
+    {
+        var owner = await _insiderOwnerRepository.GetByOwnerCik(ownerCik);
+        if (owner == null)
+            return NotFound();
+
+        var transactions = await _insiderTransactionRepository
+            .GetByOwner(owner)
+            .OrderByDescending(transaction => transaction.TransactionDate)
+            .Take(RecentRowLimit)
+            .Select(transaction => new InsiderTradeRowViewModel
+            {
+                Ticker = transaction.CommonStock.Ticker,
+                TransactionDate = transaction.TransactionDate,
+                SecurityTitle = transaction.SecurityTitle,
+                Shares = transaction.Shares,
+                PricePerShare = transaction.PricePerShare,
+            })
+            .ToListAsync();
+
+        ViewData["Title"] = owner.Name;
+        return View(
+            new InsiderProfileViewModel
+            {
+                Name = owner.Name,
+                OwnerCik = owner.OwnerCik,
+                Location = ProfileFormatting.JoinLocation(owner.City, owner.StateOrCountry),
+                Role = ProfileFormatting.DescribeRole(
+                    owner.OfficerTitle,
+                    owner.IsDirector,
+                    owner.IsTenPercentOwner
+                ),
+                Transactions = transactions,
+            }
+        );
+    }
+
+    [HttpGet("~/Congress/{id:guid}")]
+    public async Task<IActionResult> Member(Guid id)
+    {
+        var member = await _congressMemberRepository.Get(id);
+        if (member == null)
+            return NotFound();
+
+        var trades = await _congressionalTradeRepository
+            .GetByMember(member)
+            .OrderByDescending(trade => trade.TransactionDate)
+            .Take(RecentRowLimit)
+            .Select(trade => new CongressTradeRowViewModel
+            {
+                Ticker = trade.CommonStock.Ticker,
+                TransactionDate = trade.TransactionDate,
+                AssetName = trade.AssetName,
+                OwnerType = trade.OwnerType,
+                AmountFrom = trade.AmountFrom,
+                AmountTo = trade.AmountTo,
+            })
+            .ToListAsync();
+
+        ViewData["Title"] = member.Name;
+        return View(new CongressProfileViewModel { Name = member.Name, Trades = trades });
+    }
+}

--- a/src/Equibles.Web/Extensions/ProfileFormatting.cs
+++ b/src/Equibles.Web/Extensions/ProfileFormatting.cs
@@ -1,0 +1,28 @@
+namespace Equibles.Web.Extensions;
+
+/// <summary>Small presentation helpers shared by the entity profile pages.</summary>
+public static class ProfileFormatting
+{
+    public static string JoinLocation(string city, string stateOrCountry)
+    {
+        return string.Join(
+            ", ",
+            new[] { city, stateOrCountry }.Where(part => !string.IsNullOrWhiteSpace(part))
+        );
+    }
+
+    public static string DescribeRole(
+        string officerTitle,
+        bool isDirector,
+        bool isTenPercentOwner
+    )
+    {
+        if (!string.IsNullOrWhiteSpace(officerTitle))
+            return officerTitle;
+        if (isDirector)
+            return "Director";
+        if (isTenPercentOwner)
+            return "10% owner";
+        return null;
+    }
+}

--- a/src/Equibles.Web/Extensions/SearchCategoryRouteExtensions.cs
+++ b/src/Equibles.Web/Extensions/SearchCategoryRouteExtensions.cs
@@ -38,10 +38,23 @@ public static class SearchCategoryRouteExtensions
                 "Cftc",
                 new { marketCode = hit.RouteValues.GetValueOrDefault("marketCode") }
             ),
-            // Intentionally non-linkable: "Institution", "Insider", "CongressMember" have no
-            // standalone Web detail page, so they render as inert text. Any NEW kind that falls
-            // here is a gap — SearchCategoryRouteMappingTests pins this allowlist so a new
-            // provider can't silently ship dead entries.
+            "Institution" => url.Action(
+                "Institution",
+                "Profiles",
+                new { cik = hit.RouteValues.GetValueOrDefault("cik") }
+            ),
+            "Insider" => url.Action(
+                "Insider",
+                "Profiles",
+                new { ownerCik = hit.RouteValues.GetValueOrDefault("ownerCik") }
+            ),
+            "CongressMember" => url.Action(
+                "Member",
+                "Profiles",
+                new { id = hit.RouteValues.GetValueOrDefault("id") }
+            ),
+            // Every shipped Kind resolves above. A new provider Kind falling here is a gap —
+            // SearchCategoryRouteMappingTests pins the allowlist so it can't ship dead entries.
             _ => null,
         };
     }

--- a/src/Equibles.Web/ViewModels/Profiles/CongressProfileViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/CongressProfileViewModel.cs
@@ -1,0 +1,7 @@
+namespace Equibles.Web.ViewModels.Profiles;
+
+public class CongressProfileViewModel
+{
+    public string Name { get; set; }
+    public List<CongressTradeRowViewModel> Trades { get; set; } = [];
+}

--- a/src/Equibles.Web/ViewModels/Profiles/CongressTradeRowViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/CongressTradeRowViewModel.cs
@@ -1,0 +1,11 @@
+namespace Equibles.Web.ViewModels.Profiles;
+
+public class CongressTradeRowViewModel
+{
+    public string Ticker { get; set; }
+    public DateOnly TransactionDate { get; set; }
+    public string AssetName { get; set; }
+    public string OwnerType { get; set; }
+    public long AmountFrom { get; set; }
+    public long AmountTo { get; set; }
+}

--- a/src/Equibles.Web/ViewModels/Profiles/HoldingRowViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/HoldingRowViewModel.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Web.ViewModels.Profiles;
+
+public class HoldingRowViewModel
+{
+    public string Ticker { get; set; }
+    public string Company { get; set; }
+    public DateOnly ReportDate { get; set; }
+    public long Shares { get; set; }
+    public long Value { get; set; }
+}

--- a/src/Equibles.Web/ViewModels/Profiles/InsiderProfileViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InsiderProfileViewModel.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Web.ViewModels.Profiles;
+
+public class InsiderProfileViewModel
+{
+    public string Name { get; set; }
+    public string OwnerCik { get; set; }
+    public string Location { get; set; }
+    public string Role { get; set; }
+    public List<InsiderTradeRowViewModel> Transactions { get; set; } = [];
+}

--- a/src/Equibles.Web/ViewModels/Profiles/InsiderTradeRowViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InsiderTradeRowViewModel.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Web.ViewModels.Profiles;
+
+public class InsiderTradeRowViewModel
+{
+    public string Ticker { get; set; }
+    public DateOnly TransactionDate { get; set; }
+    public string SecurityTitle { get; set; }
+    public long Shares { get; set; }
+    public decimal PricePerShare { get; set; }
+}

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
@@ -1,0 +1,9 @@
+namespace Equibles.Web.ViewModels.Profiles;
+
+public class InstitutionProfileViewModel
+{
+    public string Name { get; set; }
+    public string Cik { get; set; }
+    public string Location { get; set; }
+    public List<HoldingRowViewModel> Holdings { get; set; } = [];
+}

--- a/src/Equibles.Web/Views/Profiles/Insider.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Insider.cshtml
@@ -1,0 +1,50 @@
+@model Equibles.Web.ViewModels.Profiles.InsiderProfileViewModel
+
+@{
+    ViewData["Title"] = Model.Name;
+    var meta = string.Join(" · ", new[] { Model.Role, Model.Location }.Where(p => !string.IsNullOrWhiteSpace(p)));
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold mb-2">@Model.Name</h1>
+        <p class="text-base-content/60">
+            Insider@(string.IsNullOrWhiteSpace(meta) ? "" : " · " + meta) · CIK @Model.OwnerCik
+        </p>
+    </div>
+
+    <h2 class="text-xl font-semibold mb-3">Recent transactions</h2>
+    @if (Model.Transactions.Count == 0) {
+        <div class="text-base-content/60 py-8">No reported transactions.</div>
+    } else {
+        <div class="card bg-base-100 shadow-sm">
+            <div class="overflow-x-auto">
+                <table class="table table-zebra table-sm">
+                    <thead>
+                        <tr>
+                            <th>Ticker</th>
+                            <th class="hidden lg:table-cell">Date</th>
+                            <th class="hidden lg:table-cell">Security</th>
+                            <th class="text-right">Shares</th>
+                            <th class="text-right">Price</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var trade in Model.Transactions) {
+                            <tr>
+                                <td>
+                                    <a asp-action="Show" asp-controller="Stocks" asp-route-ticker="@trade.Ticker"
+                                       class="font-semibold link link-primary">@trade.Ticker</a>
+                                </td>
+                                <td class="hidden lg:table-cell">@trade.TransactionDate.ToString("yyyy-MM-dd")</td>
+                                <td class="hidden lg:table-cell max-w-xs truncate">@trade.SecurityTitle</td>
+                                <td class="text-right">@trade.Shares.ToString("N0")</td>
+                                <td class="text-right">$@trade.PricePerShare.ToString("N2")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+</div>

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -1,0 +1,49 @@
+@model Equibles.Web.ViewModels.Profiles.InstitutionProfileViewModel
+
+@{
+    ViewData["Title"] = Model.Name;
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold mb-2">@Model.Name</h1>
+        <p class="text-base-content/60">
+            Institutional holder@(string.IsNullOrWhiteSpace(Model.Location) ? "" : " · " + Model.Location) · CIK @Model.Cik
+        </p>
+    </div>
+
+    <h2 class="text-xl font-semibold mb-3">Recent holdings</h2>
+    @if (Model.Holdings.Count == 0) {
+        <div class="text-base-content/60 py-8">No reported holdings.</div>
+    } else {
+        <div class="card bg-base-100 shadow-sm">
+            <div class="overflow-x-auto">
+                <table class="table table-zebra table-sm">
+                    <thead>
+                        <tr>
+                            <th>Ticker</th>
+                            <th>Company</th>
+                            <th class="hidden lg:table-cell">Report date</th>
+                            <th class="text-right">Shares</th>
+                            <th class="text-right">Value (USD)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var holding in Model.Holdings) {
+                            <tr>
+                                <td>
+                                    <a asp-action="Show" asp-controller="Stocks" asp-route-ticker="@holding.Ticker"
+                                       class="font-semibold link link-primary">@holding.Ticker</a>
+                                </td>
+                                <td class="max-w-xs truncate">@holding.Company</td>
+                                <td class="hidden lg:table-cell">@holding.ReportDate.ToString("yyyy-MM-dd")</td>
+                                <td class="text-right">@holding.Shares.ToString("N0")</td>
+                                <td class="text-right">@holding.Value.ToString("N0")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+</div>

--- a/src/Equibles.Web/Views/Profiles/Member.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Member.cshtml
@@ -1,0 +1,47 @@
+@model Equibles.Web.ViewModels.Profiles.CongressProfileViewModel
+
+@{
+    ViewData["Title"] = Model.Name;
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold mb-2">@Model.Name</h1>
+        <p class="text-base-content/60">Member of Congress</p>
+    </div>
+
+    <h2 class="text-xl font-semibold mb-3">Recent trades</h2>
+    @if (Model.Trades.Count == 0) {
+        <div class="text-base-content/60 py-8">No reported trades.</div>
+    } else {
+        <div class="card bg-base-100 shadow-sm">
+            <div class="overflow-x-auto">
+                <table class="table table-zebra table-sm">
+                    <thead>
+                        <tr>
+                            <th>Ticker</th>
+                            <th class="hidden lg:table-cell">Date</th>
+                            <th class="hidden lg:table-cell">Asset</th>
+                            <th class="hidden lg:table-cell">Owner</th>
+                            <th class="text-right">Amount (USD)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var trade in Model.Trades) {
+                            <tr>
+                                <td>
+                                    <a asp-action="Show" asp-controller="Stocks" asp-route-ticker="@trade.Ticker"
+                                       class="font-semibold link link-primary">@trade.Ticker</a>
+                                </td>
+                                <td class="hidden lg:table-cell">@trade.TransactionDate.ToString("yyyy-MM-dd")</td>
+                                <td class="hidden lg:table-cell max-w-xs truncate">@trade.AssetName</td>
+                                <td class="hidden lg:table-cell">@trade.OwnerType</td>
+                                <td class="text-right">@trade.AmountFrom.ToString("N0") – @trade.AmountTo.ToString("N0")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+</div>

--- a/tests/Equibles.UnitTests/Search/SearchCategoryRouteMappingTests.cs
+++ b/tests/Equibles.UnitTests/Search/SearchCategoryRouteMappingTests.cs
@@ -8,16 +8,16 @@ namespace Equibles.UnitTests.Search;
 
 public class SearchCategoryRouteMappingTests
 {
-    // Pins the linkable/non-linkable allowlist: a new provider Kind must be a conscious decision
-    // here, not a silently inert search result.
+    // Pins the linkable allowlist: every shipped Kind must resolve to a URL. A new provider Kind
+    // is a conscious decision here, never a silently inert search result.
     [Theory]
     [InlineData("Stock", true)]
     [InlineData("Filing", true)]
     [InlineData("EconomicSeries", true)]
     [InlineData("FuturesMarket", true)]
-    [InlineData("Institution", false)]
-    [InlineData("Insider", false)]
-    [InlineData("CongressMember", false)]
+    [InlineData("Institution", true)]
+    [InlineData("Insider", true)]
+    [InlineData("CongressMember", true)]
     public void HitUrl_ResolvesLinkableKinds_AndReturnsNullForKnownNonLinkable(
         string kind,
         bool expectLink


### PR DESCRIPTION
## Summary

- Closes #888. Institutions, Insiders and Congress search hits were inert text (no detail page). Adds minimal read-only profile pages and wires the `HitUrl` mapper so all seven category kinds resolve to a real URL.
- Congress is now keyed by stable id rather than free-text name (project-analyzer Low #13).

## Code changes

- `ProfilesController.cs` — `/Institutions/{cik}`, `/Insiders/{ownerCik}`, `/Congress/{id:guid}`; entity + capped recent activity via existing child repositories.
- `ViewModels/Profiles/*`, `Views/Profiles/{Institution,Insider,Member}.cshtml` — lean DaisyUI tables with ticker links.
- `Extensions/SearchCategoryRouteExtensions.cs` — Institution/Insider/CongressMember cases; allowlist comment updated.
- `Extensions/ProfileFormatting.cs` — shared location/role formatting (keeps controller thin).
- `CongressMemberSearchProvider.cs` — route value name → stable id.
- `SearchCategoryRouteMappingTests` — allowlist now asserts all kinds link.

Verified in Chrome: Vanguard → institution profile with holdings; COOK TIMOTHY D → insider profile with transactions. Congress shares the identical code path (no congress data ingested in the scoped local worker). 15 Search unit tests green.