### PR TITLE
chore: fix csharpier formatting to unblock lint gate

### DIFF
--- a/src/Equibles.Web/Extensions/ProfileFormatting.cs
+++ b/src/Equibles.Web/Extensions/ProfileFormatting.cs
@@ -11,11 +11,7 @@ public static class ProfileFormatting
         );
     }
 
-    public static string DescribeRole(
-        string officerTitle,
-        bool isDirector,
-        bool isTenPercentOwner
-    )
+    public static string DescribeRole(string officerTitle, bool isDirector, bool isTenPercentOwner)
     {
         if (!string.IsNullOrWhiteSpace(officerTitle))
             return officerTitle;

--- a/tests/Equibles.UnitTests/Search/SearchServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Search/SearchServiceCollectionExtensionsTests.cs
@@ -1,8 +1,8 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Equibles.CommonStocks.Repositories.Search;
 using Equibles.Search;
 using Equibles.Search.Abstractions;
-using Equibles.CommonStocks.Repositories.Search;
 using Equibles.Search.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 


### PR DESCRIPTION
## Summary

- `origin/main` is red on the `lint` CI gate (`dotnet csharpier check .`), which — under strict required status checks — blocks every open PR from merging.
- Two files drifted out of csharpier formatting on main; this re-runs the formatter so the gate goes green again. Formatting only, no behavior change.

## Code changes

- `tests/Equibles.UnitTests/Search/SearchServiceCollectionExtensionsTests.cs` — reorder `using` directives to csharpier's alphabetical order.
- `src/Equibles.Web/Extensions/ProfileFormatting.cs` — collapse a method signature onto one line per csharpier width rules.