### PR TITLE
fix(yahoo): skip incomplete OHLC rows instead of emitting impossible bars (#889)

### DIFF
--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -79,20 +79,26 @@ public class YahooFinanceClient : IYahooFinanceClient
         for (var i = 0; i < result.Timestamp.Count; i++)
         {
             // Yahoo occasionally returns a ragged payload — a timestamp array
-            // longer than the OHLC/volume columns. Bound every column access
-            // (as adjclose already is) so a missing tail is treated like a
-            // holiday gap instead of throwing and aborting the whole import.
+            // longer than the OHLC/volume columns, or a column with a null
+            // hole on a holiday / early-close row. Bound every column access
+            // and require the full OHLC quartet: an incomplete row is treated
+            // like a holiday gap (skipped) rather than emitted as an
+            // OHLC-impossible bar (e.g. High=0 while Close>0) or aborting the
+            // whole import.
+            var open = i < quote.Open.Count ? quote.Open[i] : null;
+            var high = i < quote.High.Count ? quote.High[i] : null;
+            var low = i < quote.Low.Count ? quote.Low[i] : null;
             var close = i < quote.Close.Count ? quote.Close[i] : null;
-            if (close == null)
+            if (open == null || high == null || low == null || close == null)
                 continue;
 
             prices.Add(
                 new HistoricalPrice
                 {
                     Date = FromUnixTimestamp(result.Timestamp[i]),
-                    Open = Math.Round((i < quote.Open.Count ? quote.Open[i] : null) ?? 0, 4),
-                    High = Math.Round((i < quote.High.Count ? quote.High[i] : null) ?? 0, 4),
-                    Low = Math.Round((i < quote.Low.Count ? quote.Low[i] : null) ?? 0, 4),
+                    Open = Math.Round(open.Value, 4),
+                    High = Math.Round(high.Value, 4),
+                    Low = Math.Round(low.Value, 4),
                     Close = Math.Round(close.Value, 4),
                     AdjustedClose =
                         adjCloseList != null && i < adjCloseList.Count

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalPartialRaggedOhlcTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalPartialRaggedOhlcTests.cs
@@ -18,7 +18,7 @@ public class YahooFinanceClientHistoricalPartialRaggedOhlcTests
     // row is skipped (as the null-Close path does); it must not be emitted as an
     // OHLC-impossible bar (High=0 while Close>0), which would silently import
     // garbage and break the smoke test's own invariants.
-    [Fact(Skip = "GH-889 — partial-ragged OHLC emits High=0 bar with Close>0")]
+    [Fact]
     public async Task GetHistoricalPrices_CloseLongerThanHighColumn_DoesNotEmitOhlcImpossibleBar()
     {
         var unixDec23 = new DateTimeOffset(


### PR DESCRIPTION
## Summary

- Fixes #889. `GetHistoricalPrices` only skipped a row when its `Close` was null. A partially-ragged Yahoo payload (Close present, but `open`/`high`/`low` column short or null on a holiday / early-close row) was emitted as an OHLC-impossible bar (`High=0` while `Close>0`), violating the live smoke test invariants and corrupting imported prices.
- Now the full OHLC quartet is required: an incomplete row is treated like the existing null-Close holiday gap (skipped). Volume/AdjustedClose behaviour unchanged.
- Un-skips the regression test committed for #889.

## Code changes

- `src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs` — read `open/high/low/close` into bounds-checked locals; `continue` if any is null; build the bar from the non-null values (no `?? 0` fallback for OHLC).
- `tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalPartialRaggedOhlcTests.cs` — removed `Skip` (GH-889 resolved); test now asserts the fix.