### PR TITLE
fix(yahoo): fall back AdjustedClose to Close on adjclose null hole (#898)

### DIFF
--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -100,10 +100,14 @@ public class YahooFinanceClient : IYahooFinanceClient
                     High = Math.Round(high.Value, 4),
                     Low = Math.Round(low.Value, 4),
                     Close = Math.Round(close.Value, 4),
-                    AdjustedClose =
-                        adjCloseList != null && i < adjCloseList.Count
-                            ? Math.Round(adjCloseList[i] ?? 0, 4)
-                            : Math.Round(close.Value, 4),
+                    // adjclose may be absent (no array / short) OR a null hole
+                    // on a holiday-edge row. Both mean "unavailable" → fall
+                    // back to the day's Close, never 0.
+                    AdjustedClose = Math.Round(
+                        (adjCloseList != null && i < adjCloseList.Count ? adjCloseList[i] : null)
+                            ?? close.Value,
+                        4
+                    ),
                     Volume = (i < quote.Volume.Count ? quote.Volume[i] : null) ?? 0,
                 }
             );

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalAdjCloseNullHoleTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalAdjCloseNullHoleTests.cs
@@ -54,7 +54,7 @@ public class YahooFinanceClientHistoricalAdjCloseNullHoleTests
         }
     }
 
-    [Fact(Skip = "GH-898 — adjclose null hole yields AdjustedClose=0 instead of Close fallback")]
+    [Fact]
     public async Task GetHistoricalPrices_AdjCloseArrayPresentWithNullHole_FallsBackToClose()
     {
         await WithSeededSession(async () =>


### PR DESCRIPTION
## Summary

- Fixes #898. `GetHistoricalPrices` only fell back AdjustedClose → Close when the `adjclose` array was null or short. When the array was present and full-length but carried a `null` element on a holiday-edge row, `adjCloseList[i] ?? 0` produced `AdjustedClose = 0` while `Close > 0`, violating the live smoke test's `AdjustedClose > 0` invariant.
- Now any unavailable adjclose (absent array, short array, or null element) falls back to the day's Close. Distinct from #889 (OHLC columns), fixed separately.
- Un-skips the regression test committed for #898.

## Code changes

- `src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs` — `AdjustedClose` now coalesces a null/absent adjclose value to `close.Value` instead of `0`.
- `tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalAdjCloseNullHoleTests.cs` — removed `Skip` (GH-898 resolved); test now asserts the fix.