### PR TITLE
chore(web): rename Connect nav label to MCP

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Footer.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Footer.cshtml
@@ -11,7 +11,7 @@
                 <a asp-controller="EconomicData" asp-action="Index" class="hover:text-base-content">Economic Data</a>
                 <a asp-controller="Cftc" asp-action="Index" class="hover:text-base-content">Futures</a>
                 <a asp-controller="Market" asp-action="Index" class="hover:text-base-content">Market</a>
-                <a asp-controller="Home" asp-action="Connect" class="hover:text-base-content">Connect</a>
+                <a asp-controller="Home" asp-action="Connect" class="hover:text-base-content">MCP</a>
                 <a asp-controller="Status" asp-action="Index" class="hover:text-base-content flex items-center gap-1">
                     Status
                     @if (ViewData["StatusBadgeCount"] is int footerBadge && footerBadge > 0) {

--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -23,7 +23,7 @@
                     <a asp-action="Index" asp-controller="EconomicData" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">Economic Data</a>
                     <a asp-action="Index" asp-controller="Cftc" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">Futures</a>
                     <a asp-action="Index" asp-controller="Market" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">Market</a>
-                    <a asp-action="Connect" asp-controller="Home" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">Connect</a>
+                    <a asp-action="Connect" asp-controller="Home" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">MCP</a>
                     <a asp-action="Index" asp-controller="Status" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors flex items-center gap-1">
                         Status
                         @if (ViewData["StatusBadgeCount"] is int badgeCount && badgeCount > 0) {
@@ -89,7 +89,7 @@
                         </li>
                         <li>
                             <a asp-action="Connect" asp-controller="Home">
-                                <icon name="link" size="4" /> Connect
+                                <icon name="link" size="4" /> MCP
                             </a>
                         </li>
                         <li>


### PR DESCRIPTION
## Summary

- Relabels the navbar (desktop + mobile) and footer `Connect` entries to `MCP` — the linked page is the MCP connection guide. Route is unchanged (`Home/Connect`).

## Code changes

- `_Layout.cshtml` — desktop nav + mobile menu label Connect → MCP.
- `_Footer.cshtml` — footer link label Connect → MCP.

Verified in Chrome: navbar shows MCP → /home/connect.