### PR TITLE
fix(sec): retry transient SEC network failures instead of recording them

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -1,4 +1,7 @@
+using System.IO;
 using System.Net;
+using System.Net.Sockets;
+using System.Security.Authentication;
 using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Common.RateLimiter;
 using Equibles.Integrations.Sec.Contracts;
@@ -512,7 +515,29 @@ public class SecEdgarClient : ISecEdgarClient
             await RateLimiter.WaitAsync();
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
-            var response = await _httpClient.GetAsync(url, completionOption, cancellationToken);
+            HttpResponseMessage response;
+            try
+            {
+                response = await _httpClient.GetAsync(url, completionOption, cancellationToken);
+            }
+            catch (HttpRequestException ex)
+                when (IsTransientNetworkError(ex) && attempt < MaxRetries)
+            {
+                // DNS / socket / TLS failures (e.g. transient connectivity to www.sec.gov) are
+                // retryable just like a 5xx — retry with backoff instead of surfacing them as
+                // dashboard errors. Only a sustained outage exhausts retries and throws once.
+                var delay = TransientBackoff(attempt);
+                _logger.LogWarning(
+                    ex,
+                    "Transient network error reaching SEC EDGAR for {Url}, retrying in {Delay}s (attempt {Attempt}/{Max})",
+                    url,
+                    delay.TotalSeconds,
+                    attempt + 1,
+                    MaxRetries
+                );
+                await Task.Delay(delay, cancellationToken);
+                continue;
+            }
             sw.Stop();
 
             _logger.LogDebug(
@@ -586,10 +611,20 @@ public class SecEdgarClient : ISecEdgarClient
             }
         }
 
-        // Exponential backoff: 2s, 4s, 8s, 16s, 32s — capped at 1 min
+        return TransientBackoff(attempt);
+    }
+
+    // Exponential backoff: 2s, 4s, 8s, 16s, 32s — capped at MaxRetryDelay.
+    private static TimeSpan TransientBackoff(int attempt)
+    {
         var backoff = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
         return backoff > MaxRetryDelay ? MaxRetryDelay : backoff;
     }
+
+    // DNS resolution, socket and TLS handshake failures are transient connectivity problems,
+    // not defects — they are retried, never recorded as dashboard errors.
+    private static bool IsTransientNetworkError(HttpRequestException exception) =>
+        exception.InnerException is SocketException or IOException or AuthenticationException;
 
     private static List<CompanyInfo> ParseCompaniesFromResponse(CompanyTickersResponse response)
     {

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientSendWithRetryTransientNetworkTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientSendWithRetryTransientNetworkTests.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Net.Sockets;
+using Equibles.Integrations.Sec;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the transient-network retry branch of <see cref="SecEdgarClient"/>'s SendWithRetryAsync.
+/// DNS / socket / TLS failures reaching www.sec.gov surface as an
+/// <see cref="HttpRequestException"/> wrapping a <see cref="SocketException"/>; before the fix
+/// these bubbled to DocumentScraper and were recorded as dashboard errors. They must now be
+/// retried like a 5xx, so a blip is transparent rather than a hard failure of the sweep.
+/// </summary>
+public class SecEdgarClientSendWithRetryTransientNetworkTests
+{
+    [Fact]
+    public async Task GetActiveCompanies_FirstCallDnsFailure_RetriesThenSucceeds()
+    {
+        var okBody =
+            "{\"fields\":[\"cik\",\"name\",\"ticker\",\"exchange\"],"
+            + "\"data\":[[789019,\"MICROSOFT CORP\",\"MSFT\",\"Nasdaq\"]]}";
+        var handler = new TransientThenOkHandler(okBody);
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string> { ["Sec:ContactEmail"] = "test@example.com" }
+            )
+            .Build();
+        var sut = new SecEdgarClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<SecEdgarClient>>(),
+            config
+        );
+
+        var result = await sut.GetActiveCompanies();
+
+        // Two calls + a parsed company prove the DNS/socket failure drove a retry that then
+        // succeeded — without the fix the first throw would abort the whole sweep.
+        handler.CallCount.Should().Be(2);
+        result.Should().ContainSingle();
+        result[0].Tickers.Should().ContainSingle().Which.Should().Be("MSFT");
+    }
+
+    private sealed class TransientThenOkHandler : HttpMessageHandler
+    {
+        private readonly string _successBody;
+        public int CallCount { get; private set; }
+
+        public TransientThenOkHandler(string successBody)
+        {
+            _successBody = successBody;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            CallCount++;
+            if (CallCount == 1)
+            {
+                throw new HttpRequestException(
+                    "Name or service not known (www.sec.gov:443)",
+                    new SocketException()
+                );
+            }
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_successBody),
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- The Errors dashboard filled with `DocumentScraper.ScrapeDocuments` rows — all transient connectivity failures to `www.sec.gov:443` ("Name or service not known", "Network is unreachable", "SSL connection could not be established", "Resource temporarily unavailable").
- Root cause: `SecEdgarClient.SendWithRetryAsync` retried on HTTP 429/5xx but **not** on network-level exceptions, so DNS/socket/TLS failures bubbled to `DocumentScraper` and were persisted as dashboard errors.
- Fix: classify `HttpRequestException` whose inner is `SocketException`/`IOException`/`AuthenticationException` as transient and retry with the existing exponential backoff (same treatment as a 5xx). Only a sustained outage exhausts retries and throws once. Mirrors the existing transient-vs-permanent pattern in `HoldingsScraperWorker`.

## Code changes

- `SecEdgarClient.cs` — wrap `GetAsync` with a transient-network retry branch; extract `TransientBackoff`; add `IsTransientNetworkError`.
- `SecEdgarClientSendWithRetryTransientNetworkTests.cs` — pins: a first-call DNS/socket failure retries then succeeds (handler called twice, company parsed).

Build green; SendWithRetry tests (2) green.