### PR TITLE
fix(yahoo): date bars on exchange-local calendar via meta.gmtoffset (#904)

### DIFF
--- a/src/Equibles.Integrations.Yahoo/Models/Responses/YahooChartResponse.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/Responses/YahooChartResponse.cs
@@ -20,11 +20,26 @@ public class ChartContainer
 
 public class ChartResult
 {
+    [JsonProperty("meta")]
+    public ChartMeta Meta { get; set; }
+
     [JsonProperty("timestamp")]
     public List<long> Timestamp { get; set; } = [];
 
     [JsonProperty("indicators")]
     public ChartIndicators Indicators { get; set; }
+}
+
+public class ChartMeta
+{
+    // Exchange UTC offset in seconds. Yahoo stamps daily-bar timestamps in the
+    // exchange's local time; this is how a UTC epoch maps back to the trading
+    // day. Defaults to 0 when absent (UTC).
+    [JsonProperty("gmtoffset")]
+    public long GmtOffset { get; set; }
+
+    [JsonProperty("exchangeTimezoneName")]
+    public string ExchangeTimezoneName { get; set; }
 }
 
 public class ChartIndicators

--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -55,8 +55,14 @@ public class YahooFinanceClient : IYahooFinanceClient
     )
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ticker);
-        var period1 = ToUnixTimestamp(startDate);
-        var period2 = ToUnixTimestamp(endDate.AddDays(1)); // inclusive end
+        // Yahoo stamps daily bars in the exchange's local time, but the
+        // period1/period2 query bounds are UTC epoch seconds. An exchange east
+        // of UTC has its startDate bar stamped before startDate-UTC-midnight,
+        // so a naive window silently drops boundary days. Over-fetch by a full
+        // day on each side (max real offset is ±14h) and trim to the exact
+        // exchange-local [startDate, endDate] window after parsing.
+        var period1 = ToUnixTimestamp(startDate.AddDays(-1));
+        var period2 = ToUnixTimestamp(endDate.AddDays(2));
 
         var url =
             $"{ChartBaseUrl}/{Uri.EscapeDataString(ticker)}"
@@ -74,10 +80,26 @@ public class YahooFinanceClient : IYahooFinanceClient
             return [];
 
         var adjCloseList = result.Indicators?.AdjClose?.FirstOrDefault()?.AdjustedClose;
+        // Exchange-local offset (seconds). Adding it to a UTC epoch shifts the
+        // instant into exchange-local time, so the existing UTC-based
+        // FromUnixTimestamp then yields the correct trading-day calendar date.
+        var offsetSeconds = result.Meta?.GmtOffset ?? 0;
         var prices = new List<HistoricalPrice>();
+        var skipped = 0;
+        var outsideWindow = 0;
 
         for (var i = 0; i < result.Timestamp.Count; i++)
         {
+            // Trim the over-fetched window down to the requested range, on the
+            // exchange-local calendar (not UTC) — otherwise boundary days land
+            // on the wrong date or get dropped for non-UTC exchanges.
+            var date = FromUnixTimestamp(result.Timestamp[i] + offsetSeconds);
+            if (date < startDate || date > endDate)
+            {
+                outsideWindow++;
+                continue;
+            }
+
             // Yahoo occasionally returns a ragged payload — a timestamp array
             // longer than the OHLC/volume columns, or a column with a null
             // hole on a holiday / early-close row. Bound every column access
@@ -90,12 +112,15 @@ public class YahooFinanceClient : IYahooFinanceClient
             var low = i < quote.Low.Count ? quote.Low[i] : null;
             var close = i < quote.Close.Count ? quote.Close[i] : null;
             if (open == null || high == null || low == null || close == null)
+            {
+                skipped++;
                 continue;
+            }
 
             prices.Add(
                 new HistoricalPrice
                 {
-                    Date = FromUnixTimestamp(result.Timestamp[i]),
+                    Date = date,
                     Open = Math.Round(open.Value, 4),
                     High = Math.Round(high.Value, 4),
                     Low = Math.Round(low.Value, 4),
@@ -113,7 +138,13 @@ public class YahooFinanceClient : IYahooFinanceClient
             );
         }
 
-        _logger.LogDebug("Fetched {Count} historical prices for {Ticker}", prices.Count, ticker);
+        _logger.LogDebug(
+            "Fetched {Count} historical prices for {Ticker} ({Skipped} incomplete, {OutsideWindow} outside window)",
+            prices.Count,
+            ticker,
+            skipped,
+            outsideWindow
+        );
         return prices;
     }
 

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalExchangeLocalDateTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalExchangeLocalDateTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Reflection;
+using System.Text;
+using Equibles.Integrations.Yahoo;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Yahoo;
+
+/// <summary>
+/// Regression for GH-904. Yahoo stamps daily-bar timestamps in the exchange's
+/// local time; the request window and the returned <c>Date</c> must use that
+/// exchange-local calendar (via <c>meta.gmtoffset</c>), not UTC midnight. A
+/// Tokyo (UTC+9) bar for 2024-01-31 is stamped 2024-01-30T15:00Z — under the
+/// old UTC-naive logic it was mis-dated to 2024-01-30 and fell outside a
+/// 2024-01-31 window. Seeded-session reflection keeps the retry loop
+/// network-free; the cached session fields are restored in a finally.
+/// </summary>
+public class YahooFinanceClientHistoricalExchangeLocalDateTests
+{
+    private static readonly FieldInfo CrumbField = typeof(YahooFinanceClient).GetField(
+        "_cachedCrumb",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+    private static readonly FieldInfo CookieField = typeof(YahooFinanceClient).GetField(
+        "_cachedCookieHeader",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+    private static readonly FieldInfo ExpiryField = typeof(YahooFinanceClient).GetField(
+        "_sessionExpiry",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    private static async Task WithSeededSession(Func<Task> body)
+    {
+        var prevCrumb = CrumbField.GetValue(null);
+        var prevCookie = CookieField.GetValue(null);
+        var prevExpiry = ExpiryField.GetValue(null);
+        try
+        {
+            CrumbField.SetValue(null, "test-crumb");
+            CookieField.SetValue(null, "A=1");
+            ExpiryField.SetValue(null, DateTime.UtcNow.AddMinutes(30));
+            await body();
+        }
+        finally
+        {
+            CrumbField.SetValue(null, prevCrumb);
+            CookieField.SetValue(null, prevCookie);
+            ExpiryField.SetValue(null, prevExpiry);
+        }
+    }
+
+    [Fact]
+    public async Task GetHistoricalPrices_EastOfUtcExchange_DatesBarOnExchangeLocalDay()
+    {
+        await WithSeededSession(async () =>
+        {
+            // 2024-01-31 00:00 in Tokyo (UTC+9) == 2024-01-30 15:00 UTC.
+            var tokyoBarUtc = new DateTimeOffset(
+                2024,
+                1,
+                30,
+                15,
+                0,
+                0,
+                TimeSpan.Zero
+            ).ToUnixTimeSeconds();
+
+            var json =
+                "{\"chart\":{\"result\":[{"
+                + "\"meta\":{\"gmtoffset\":32400,\"exchangeTimezoneName\":\"Asia/Tokyo\"},"
+                + "\"timestamp\":["
+                + tokyoBarUtc
+                + "],\"indicators\":{\"quote\":[{"
+                + "\"open\":[100.10],\"high\":[101.50],\"low\":[99.80],"
+                + "\"close\":[101.00],\"volume\":[1500000]}],"
+                + "\"adjclose\":[{\"adjclose\":[100.90]}]}}]}}";
+
+            var sut = new YahooFinanceClient(
+                new HttpClient(new StubHandler(json)),
+                Substitute.For<ILogger<YahooFinanceClient>>()
+            );
+
+            var prices = await sut.GetHistoricalPrices(
+                "7203.T",
+                new DateOnly(2024, 1, 31),
+                new DateOnly(2024, 1, 31)
+            );
+
+            // The bar belongs to the Tokyo trading day 2024-01-31, not the UTC
+            // date 2024-01-30 — and must be inside the requested window.
+            prices.Should().ContainSingle();
+            prices[0].Date.Should().Be(new DateOnly(2024, 1, 31));
+        });
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+
+        public StubHandler(string body) => _body = body;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes #904. `GetHistoricalPrices` computed the request window and bar dates at UTC midnight, but Yahoo stamps `1d` bars in the exchange's local time. For exchanges east of UTC, the start-boundary trading day was stamped before UTC midnight — silently dropped — and returned bars were mis-dated by a day.
- The window is now over-fetched by a day on each side (max real offset ±14h) and trimmed to the exact exchange-local `[startDate, endDate]` range using `chart.result[].meta.gmtoffset`; each bar's `Date` is the exchange-local trading day. Absent meta ⇒ offset 0 ⇒ prior UTC behaviour (back-compatible).
- Added skipped / outside-window counts to the debug log for data-loss observability (companion Low from the #889/#898 review).

## Code changes

- `src/Equibles.Integrations.Yahoo/Models/Responses/YahooChartResponse.cs` — new `ChartMeta` (`gmtoffset`, `exchangeTimezoneName`); `ChartResult.Meta`.
- `src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs` — widen period1/period2; derive exchange offset from `meta.gmtoffset`; date each bar on the exchange-local calendar (`FromUnixTimestamp(ts + offsetSeconds)`, no new overload — existing UTC helper reused); trim to the requested window; richer debug log.
- `tests/Equibles.IntegrationTests/Yahoo/YahooFinanceClientHistoricalExchangeLocalDateTests.cs` — new regression: a Tokyo (UTC+9) bar stamped `2024-01-30T15:00Z` is returned as `2024-01-31` within a `2024-01-31` window.