### PR TITLE
chore: run csharpier on AddSecFinancialFacts migration to unblock lint gate

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260518145124_AddSecFinancialFacts.cs
+++ b/src/Equibles.Migrations/Migrations/20260518145124_AddSecFinancialFacts.cs
@@ -16,7 +16,8 @@ namespace Equibles.Migrations.Migrations
                 table: "Document",
                 type: "character varying(32)",
                 maxLength: 32,
-                nullable: true);
+                nullable: true
+            );
 
             migrationBuilder.CreateTable(
                 name: "FinancialConcept",
@@ -24,14 +25,26 @@ namespace Equibles.Migrations.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     Taxonomy = table.Column<int>(type: "integer", nullable: false),
-                    Tag = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
-                    Label = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
-                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                    Tag = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: false
+                    ),
+                    Label = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_FinancialConcept", x => x.Id);
-                });
+                }
+            );
 
             migrationBuilder.CreateTable(
                 name: "FinancialFactsSyncStatus",
@@ -39,8 +52,11 @@ namespace Equibles.Migrations.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
-                    LastCheckedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
-                    LastFiledDateSeen = table.Column<DateOnly>(type: "date", nullable: true)
+                    LastCheckedAt = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                    LastFiledDateSeen = table.Column<DateOnly>(type: "date", nullable: true),
                 },
                 constraints: table =>
                 {
@@ -50,8 +66,10 @@ namespace Equibles.Migrations.Migrations
                         column: x => x.CommonStockId,
                         principalTable: "CommonStock",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
 
             migrationBuilder.CreateTable(
                 name: "FinancialFact",
@@ -61,7 +79,11 @@ namespace Equibles.Migrations.Migrations
                     CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
                     FinancialConceptId = table.Column<Guid>(type: "uuid", nullable: false),
                     DocumentId = table.Column<Guid>(type: "uuid", nullable: true),
-                    Unit = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Unit = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: false
+                    ),
                     PeriodType = table.Column<int>(type: "integer", nullable: false),
                     PeriodStart = table.Column<DateOnly>(type: "date", nullable: false),
                     PeriodEnd = table.Column<DateOnly>(type: "date", nullable: false),
@@ -70,9 +92,20 @@ namespace Equibles.Migrations.Migrations
                     FiscalPeriod = table.Column<int>(type: "integer", nullable: false),
                     Form = table.Column<string>(type: "text", nullable: false),
                     FiledDate = table.Column<DateOnly>(type: "date", nullable: false),
-                    AccessionNumber = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
-                    Frame = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
-                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                    AccessionNumber = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: false
+                    ),
+                    Frame = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
                 },
                 constraints: table =>
                 {
@@ -82,83 +115,96 @@ namespace Equibles.Migrations.Migrations
                         column: x => x.CommonStockId,
                         principalTable: "CommonStock",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Cascade
+                    );
                     table.ForeignKey(
                         name: "FK_FinancialFact_Document_DocumentId",
                         column: x => x.DocumentId,
                         principalTable: "Document",
-                        principalColumn: "Id");
+                        principalColumn: "Id"
+                    );
                     table.ForeignKey(
                         name: "FK_FinancialFact_FinancialConcept_FinancialConceptId",
                         column: x => x.FinancialConceptId,
                         principalTable: "FinancialConcept",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_Document_AccessionNumber",
                 table: "Document",
-                column: "AccessionNumber");
+                column: "AccessionNumber"
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_FinancialConcept_Taxonomy_Tag",
                 table: "FinancialConcept",
                 columns: new[] { "Taxonomy", "Tag" },
-                unique: true);
+                unique: true
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_FinancialFact_CommonStockId_FinancialConceptId_PeriodEnd",
                 table: "FinancialFact",
-                columns: new[] { "CommonStockId", "FinancialConceptId", "PeriodEnd" });
+                columns: new[] { "CommonStockId", "FinancialConceptId", "PeriodEnd" }
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_FinancialFact_CommonStockId_FinancialConceptId_Unit_PeriodS~",
                 table: "FinancialFact",
-                columns: new[] { "CommonStockId", "FinancialConceptId", "Unit", "PeriodStart", "PeriodEnd", "AccessionNumber" },
-                unique: true);
+                columns: new[]
+                {
+                    "CommonStockId",
+                    "FinancialConceptId",
+                    "Unit",
+                    "PeriodStart",
+                    "PeriodEnd",
+                    "AccessionNumber",
+                },
+                unique: true
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_FinancialFact_CommonStockId_FiscalYear_FiscalPeriod",
                 table: "FinancialFact",
-                columns: new[] { "CommonStockId", "FiscalYear", "FiscalPeriod" });
+                columns: new[] { "CommonStockId", "FiscalYear", "FiscalPeriod" }
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_FinancialFact_DocumentId",
                 table: "FinancialFact",
-                column: "DocumentId");
+                column: "DocumentId"
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_FinancialFact_FinancialConceptId",
                 table: "FinancialFact",
-                column: "FinancialConceptId");
+                column: "FinancialConceptId"
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_FinancialFactsSyncStatus_CommonStockId",
                 table: "FinancialFactsSyncStatus",
                 column: "CommonStockId",
-                unique: true);
+                unique: true
+            );
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(
-                name: "FinancialFact");
+            migrationBuilder.DropTable(name: "FinancialFact");
 
-            migrationBuilder.DropTable(
-                name: "FinancialFactsSyncStatus");
+            migrationBuilder.DropTable(name: "FinancialFactsSyncStatus");
 
-            migrationBuilder.DropTable(
-                name: "FinancialConcept");
+            migrationBuilder.DropTable(name: "FinancialConcept");
 
-            migrationBuilder.DropIndex(
-                name: "IX_Document_AccessionNumber",
-                table: "Document");
+            migrationBuilder.DropIndex(name: "IX_Document_AccessionNumber", table: "Document");
 
-            migrationBuilder.DropColumn(
-                name: "AccessionNumber",
-                table: "Document");
+            migrationBuilder.DropColumn(name: "AccessionNumber", table: "Document");
         }
     }
 }


### PR DESCRIPTION
## Summary

- `origin/main` is red on the `lint` CI gate (`dotnet csharpier check .`) because `20260518145124_AddSecFinancialFacts.cs` was committed unformatted — under strict required status checks this blocks every open PR.
- Runs the repo-pinned csharpier on that one migration file. Whitespace/line-wrapping only — no schema, Designer, or snapshot change; this is the formatter output CI itself enforces.

## Code changes

- `src/Equibles.Migrations/Migrations/20260518145124_AddSecFinancialFacts.cs` — csharpier reformat (argument wrapping); behaviour unchanged.