### PR TITLE
test(yahoo): pin GetKeyStatistics live drift — large-cap shares outstanding > 0

### DIFF
--- a/tests/Equibles.SmokeTests/YahooKeyStatisticsSmokeTests.cs
+++ b/tests/Equibles.SmokeTests/YahooKeyStatisticsSmokeTests.cs
@@ -1,0 +1,36 @@
+using Equibles.Integrations.Yahoo;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Equibles.SmokeTests;
+
+// Live contract / drift-detection test. Hits the real Yahoo Finance quoteSummary API and
+// asserts the INVARIANT (never an exact value) that a real large-cap reports positive shares
+// outstanding. GetKeyStatistics maps via `stats.SharesOutstanding?.Raw ?? 0`, so if Yahoo
+// renames the defaultKeyStatistics module or the sharesOutstanding.raw field the parser
+// silently returns 0 with no error — this test fails loudly so it's caught before a release.
+// Excluded from per-PR CI via the "Live" category; runs nightly (smoke.yml).
+[Trait("Category", "Live")]
+public class YahooKeyStatisticsSmokeTests
+{
+    [Fact]
+    public async Task GetKeyStatistics_KnownLargeCap_ReturnsPositiveSharesOutstanding()
+    {
+        var client = new YahooFinanceClient(
+            new HttpClient(),
+            NullLogger<YahooFinanceClient>.Instance
+        );
+
+        // Apple has had billions of shares outstanding for decades — the exact figure
+        // drifts with buybacks/splits, but it can never be <= 0 for a live large-cap.
+        // Asserting only the sign keeps this immune to legitimate value changes while
+        // still catching the silent `?? 0` fallback when the payload shape drifts.
+        var stats = await client.GetKeyStatistics("AAPL");
+
+        stats.Should().NotBeNull("Yahoo must still return a defaultKeyStatistics module for AAPL");
+        stats
+            .SharesOutstanding.Should()
+            .BeGreaterThan(0, "a live large-cap always reports positive shares outstanding");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a nightly **live** drift-detection smoke test for `YahooFinanceClient.GetKeyStatistics`, a public client method that previously had zero live coverage (only `GetHistoricalPrices` was covered).
- `GetKeyStatistics` maps shares outstanding via `stats.SharesOutstanding?.Raw ?? 0` and returns `null` when the `defaultKeyStatistics` module is absent — so if Yahoo renames the module or the `sharesOutstanding.raw` field, the parser silently yields `0`/`null` with no error. This test fails loudly when that shape drifts, before a release.
- Asserts only the invariant (a live large-cap reports positive shares outstanding), never an exact value, so legitimate buyback/split changes don't make it flaky.

## Code changes

- `tests/Equibles.SmokeTests/YahooKeyStatisticsSmokeTests.cs` — new `[Trait("Category", "Live")]` test `GetKeyStatistics_KnownLargeCap_ReturnsPositiveSharesOutstanding`; hits real Yahoo quoteSummary for AAPL and asserts non-null result with `SharesOutstanding > 0`. Runs nightly via `smoke.yml` (`Category=Live`), excluded from per-PR CI. Verified green against live Yahoo locally.