### PR TITLE
test(yahoo): pin GetHistoricalPrices single-day boundary trim — exact-date bar

### DIFF
--- a/tests/Equibles.SmokeTests/YahooHistoricalPricesBoundarySmokeTests.cs
+++ b/tests/Equibles.SmokeTests/YahooHistoricalPricesBoundarySmokeTests.cs
@@ -1,0 +1,41 @@
+using Equibles.Integrations.Yahoo;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Equibles.SmokeTests;
+
+// Live contract / drift-detection test for the BOUNDARY case of GetHistoricalPrices.
+// The existing mid-month smoke test never exercises the timezone over-fetch/trim path:
+// the client deliberately over-fetches [start-1d, end+2d] in UTC then trims to the exact
+// exchange-local [start, end] window. A single-trading-day request is the tightest probe
+// of that arithmetic — it must return exactly one bar stamped on that exact date, never
+// drop the boundary day, never leak an adjacent day. Fails loudly if Yahoo's timestamp
+// stamping or the trim logic drifts. Excluded from per-PR CI ("Live"); nightly (smoke.yml).
+[Trait("Category", "Live")]
+public class YahooHistoricalPricesBoundarySmokeTests
+{
+    [Fact]
+    public async Task GetHistoricalPrices_SingleKnownTradingDay_ReturnsExactlyThatDaysBar()
+    {
+        var client = new YahooFinanceClient(
+            new HttpClient(),
+            NullLogger<YahooFinanceClient>.Instance
+        );
+
+        // 2024-01-03 is an immutable, ordinary NYSE trading day (Wed; Jan 1 was the
+        // holiday, Jan 2 & 3 traded). Requesting exactly [03,03] must yield one bar
+        // dated 2024-01-03 — the over-fetch must be trimmed back to the exact day.
+        var day = new DateOnly(2024, 1, 3);
+
+        var prices = await client.GetHistoricalPrices("AAPL", day, day);
+
+        prices.Should().ContainSingle("a single trading-day window must trim to exactly one bar");
+        prices[0]
+            .Date.Should()
+            .Be(day, "the boundary day must be stamped on the exchange-local date");
+        prices[0].High.Should().BeGreaterThanOrEqualTo(prices[0].Low);
+        prices[0].Close.Should().BeGreaterThan(0);
+        prices[0].Volume.Should().BeGreaterThan(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a nightly **live** drift-detection smoke test for the boundary case of `YahooFinanceClient.GetHistoricalPrices`. The existing mid-month smoke test never exercises the timezone over-fetch/trim path.
- The client deliberately over-fetches `[start-1d, end+2d]` in UTC then trims to the exact exchange-local `[start, end]` window. A single-trading-day request is the tightest probe of that arithmetic — it must return exactly one bar stamped on that exact date, never drop the boundary day, never leak an adjacent day.
- Uses an immutable past trading day (2024-01-03, ordinary NYSE Wed) and asserts only invariants, so it stays stable while still failing loudly if Yahoo's timestamp stamping or the trim logic drifts.

## Code changes

- `tests/Equibles.SmokeTests/YahooHistoricalPricesBoundarySmokeTests.cs` — new `[Trait("Category", "Live")]` test `GetHistoricalPrices_SingleKnownTradingDay_ReturnsExactlyThatDaysBar`; requests AAPL for `[2024-01-03, 2024-01-03]` and asserts exactly one bar dated 2024-01-03 with sane OHLC/volume. Runs nightly via `smoke.yml` (`Category=Live`), excluded from per-PR CI. Verified green against live Yahoo locally.