### PR TITLE
test(sec): add skipped repro for GH-911 — FinancialFactsImportService.Import

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceIdempotencyTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceIdempotencyTests.cs
@@ -1,0 +1,161 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models.Responses;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Adversarial test of the idempotency contract on the class XML doc:
+/// "Idempotent: facts are upserted on their natural key so re-running a
+/// company is a no-op when nothing new was filed." A second Import of the
+/// exact same Company Facts must not duplicate rows and must not surface an
+/// error — the `GetLastFiledSeen` short-circuit (lastSeen >= maxFiled) is the
+/// mechanism. Input deliberately carries a single non-duplicate value so this
+/// exercises the no-op path, not the within-batch dedup path (GH-883).
+/// Skipped — see GH-911: even a single non-duplicate value persists zero rows,
+/// proving the dedup GroupBy is not the root cause.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FinancialFactsImportServiceIdempotencyTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesDbContext> _contexts = [];
+
+    public FinancialFactsImportServiceIdempotencyTests(ParadeDbFixture fixture) =>
+        _fixture = fixture;
+
+    public Task InitializeAsync() => _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private EquiblesDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesDbContext)).Returns(ctx);
+                sp.GetService(typeof(FinancialConceptRepository))
+                    .Returns(new FinancialConceptRepository(ctx));
+                sp.GetService(typeof(FinancialFactsSyncStatusRepository))
+                    .Returns(new FinancialFactsSyncStatusRepository(ctx));
+                sp.GetService(typeof(DocumentRepository)).Returns(new DocumentRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    [Fact(Skip = "GH-911 — single non-duplicate Company Facts value persists zero rows")]
+    public async Task Import_RunTwiceWithIdenticalFacts_SecondRunIsNoOpNoDuplicateRows()
+    {
+        var apple = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(apple);
+            await seed.SaveChangesAsync(CancellationToken.None);
+        }
+
+        // A single, non-duplicate value: one ParsedFact, one row. This avoids
+        // the within-batch ON CONFLICT collision (GH-883) so the first import
+        // genuinely persists and sets the sync checkpoint.
+        var value = new CompanyFactValue
+        {
+            Start = new DateOnly(2023, 1, 1),
+            End = new DateOnly(2023, 12, 31),
+            Val = 100m,
+            Accn = "0000320193-24-000001",
+            Fy = 2023,
+            Fp = "FY",
+            Form = "10-K",
+            Filed = new DateOnly(2024, 1, 15),
+            Frame = "CY2023",
+        };
+        var response = new CompanyFactsResponse
+        {
+            Cik = 320193,
+            EntityName = "Apple Inc.",
+            Facts = new()
+            {
+                ["us-gaap"] = new()
+                {
+                    ["Revenues"] = new CompanyFactConcept
+                    {
+                        Label = "Revenues",
+                        Units = new() { ["USD"] = [value] },
+                    },
+                },
+            },
+        };
+
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient.GetCompanyFacts("0000320193").Returns(response);
+
+        var errorReporter = Substitute.For<ErrorReporter>(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+
+        var sut = new FinancialFactsImportService(
+            CreateScopeFactory(),
+            secEdgarClient,
+            Substitute.For<ILogger<FinancialFactsImportService>>(),
+            errorReporter
+        );
+
+        await sut.Import(apple, CancellationToken.None);
+        await sut.Import(apple, CancellationToken.None);
+
+        await using var verify = _fixture.CreateDbContext();
+        var facts = await verify
+            .Set<FinancialFact>()
+            .Where(f => f.CommonStockId == apple.Id)
+            .ToListAsync(CancellationToken.None);
+
+        facts.Should().ContainSingle("re-running a company with nothing new filed must be a no-op");
+        facts[0].Value.Should().Be(100m);
+        await errorReporter
+            .DidNotReceive()
+            .Report(
+                Arg.Any<Equibles.Errors.Data.Models.ErrorSource>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>()
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial regression test for the `FinancialFactsImportService.Import` idempotency contract (SEC Company Facts ingestion, new feature #690 / #879).
- The test reveals a real defect: a **single, non-duplicate** Company Facts value persists **zero** `FinancialFact` rows. Filed as #911.
- This narrows #883 — the dedup `GroupBy` is **not** the root cause, since the empty-result reproduces with no within-batch duplicate at all. Committed `[Skip]`; un-skip when #911 is fixed.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceIdempotencyTests.cs` — new `[Collection(ParadeDbCollection.Name)]` integration test. Seeds one `CommonStock`, substitutes `ISecEdgarClient.GetCompanyFacts` with a single `us-gaap:Revenues/USD` value, calls `Import` twice, and asserts exactly one persisted row with no error reported (idempotent no-op on the second run). Skipped pending GH-911.