### PR TITLE
test(search): pin SearchAggregator.Search drops provider returning null group

### DIFF
--- a/tests/Equibles.UnitTests/Search/SearchAggregatorNullGroupTests.cs
+++ b/tests/Equibles.UnitTests/Search/SearchAggregatorNullGroupTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Equibles.Search;
+using Equibles.Search.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.UnitTests.Search;
+
+public class SearchAggregatorNullGroupTests
+{
+    private static SearchAggregator Build(params ISearchProvider[] providers)
+    {
+        var services = new ServiceCollection();
+        foreach (var provider in providers)
+        {
+            services.AddScoped(typeof(ISearchProvider), _ => provider);
+        }
+        var serviceProvider = services.BuildServiceProvider();
+
+        return new SearchAggregator(
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<SearchAggregator>.Instance
+        );
+    }
+
+    [Fact]
+    public async Task Search_ProviderReturnsNullGroup_IsDroppedAndHealthyGroupStillReturned()
+    {
+        // Contract (XML doc + the "RunProvider never returns null" / Empty-sentinel
+        // comment): a degraded provider must not NRE the ordering step and must be
+        // dropped uniformly, while healthy providers still return. A provider whose
+        // Search completes with a null SearchResultGroup is exactly such a provider.
+        var aggregator = Build(
+            new NullGroupProvider("Broken", 0),
+            new HealthyProvider("Healthy", 1)
+        );
+
+        var result = await aggregator.Search("query", 5, CancellationToken.None);
+
+        result.Should().ContainSingle();
+        result[0].Category.Should().Be("Healthy");
+    }
+
+    private sealed class NullGroupProvider : ISearchProvider
+    {
+        public NullGroupProvider(string category, int order)
+        {
+            Category = category;
+            Order = order;
+        }
+
+        public string Category { get; }
+
+        public int Order { get; }
+
+        public Task<SearchResultGroup> Search(
+            SearchRequest request,
+            CancellationToken cancellationToken
+        ) => Task.FromResult<SearchResultGroup>(null);
+    }
+
+    private sealed class HealthyProvider : ISearchProvider
+    {
+        public HealthyProvider(string category, int order)
+        {
+            Category = category;
+            Order = order;
+        }
+
+        public string Category { get; }
+
+        public int Order { get; }
+
+        public Task<SearchResultGroup> Search(
+            SearchRequest request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new SearchResultGroup
+                {
+                    Category = Category,
+                    Order = Order,
+                    Hits = [new SearchHit { Title = "hit" }],
+                }
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test pinning the `SearchAggregator.Search` fault-isolation contract for the new in-process global search feature (#885).
- Covers a previously untested branch: a provider whose `Search` completes with a **null** `SearchResultGroup`. The class promises "RunProvider never returns null … the ordering step cannot NRE and degraded providers are dropped uniformly."
- Test passes — confirms and pins the guarantee (the `?? Empty` guard at `SearchAggregator.cs:101`, not exercised by existing tests).

## Code changes

- `tests/Equibles.UnitTests/Search/SearchAggregatorNullGroupTests.cs` — new unit test. Registers a provider returning `Task.FromResult<SearchResultGroup>(null)` alongside a healthy provider; asserts the aggregator does not throw and returns only the healthy group. Self-contained stubs, no shared infrastructure.