### PR TITLE
test(search): pin SearchCategoryRouteExtensions.CategoryUrl null for no-browse group

### DIFF
--- a/tests/Equibles.UnitTests/Search/SearchCategoryUrlTests.cs
+++ b/tests/Equibles.UnitTests/Search/SearchCategoryUrlTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Web.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Search;
+
+public class SearchCategoryUrlTests
+{
+    [Fact]
+    public void CategoryUrl_ShippedGroupWithNoBrowsePage_ReturnsNull()
+    {
+        // Contract (XML doc): CategoryUrl is the "See all" destination for a group,
+        // "or null when no browse page exists". "Insiders" is a real shipped search
+        // group (InsiderOwnerSearchProvider.Category) with no browse page, so it must
+        // return null even though the URL helper can resolve any action.
+        var url = Substitute.For<IUrlHelper>();
+        url.Action(Arg.Any<UrlActionContext>()).Returns("/resolved/path");
+
+        var result = url.CategoryUrl("Insiders", "berkshire");
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test pinning the `SearchCategoryRouteExtensions.CategoryUrl` contract for the new global-search feature (#885).
- `CategoryUrl` was wholly untested. Its XML doc promises the "See all" URL "or null when no browse page exists" — this exercises the previously uncovered `_ => null` arm for a real shipped group.
- Test passes — confirms and pins the guarantee.

## Code changes

- `tests/Equibles.UnitTests/Search/SearchCategoryUrlTests.cs` — new unit test. Stubs `IUrlHelper.Action` to always resolve a path, then asserts `CategoryUrl("Insiders", …)` (a shipped `InsiderOwnerSearchProvider` group with no browse page) returns null rather than a fabricated URL.