### PR TITLE
test(search): pin CommonStockSearchProvider.Project Stock kind + ticker route value

### DIFF
--- a/tests/Equibles.UnitTests/Search/CommonStockSearchProviderProjectTests.cs
+++ b/tests/Equibles.UnitTests/Search/CommonStockSearchProviderProjectTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories.Search;
+using Equibles.Search.Abstractions;
+
+namespace Equibles.UnitTests.Search;
+
+/// <summary>
+/// Pins the cross-component wiring of the Stocks search group (new global search,
+/// #885), 0% covered. For a hit to become a working link, Project must emit
+/// Kind "Stock" and the ticker under RouteValues key "ticker" — the exact key
+/// SearchCategoryRouteExtensions.HitUrl's "Stock" arm reads. A rename on either
+/// side ships a dead link with no compile-time check; this is the only guard.
+/// Project is protected → invoked via reflection (the repo's pattern for
+/// non-public members; the repo dependency is unused by Project).
+/// </summary>
+public class CommonStockSearchProviderProjectTests
+{
+    [Fact]
+    public void Project_Stock_EmitsStockKindAndTickerRouteValueForHitUrl()
+    {
+        var provider = new CommonStockSearchProvider(null);
+        var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
+
+        var project = typeof(CommonStockSearchProvider).GetMethod(
+            "Project",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+
+        var hit = (SearchHit)project.Invoke(provider, [stock])!;
+
+        hit.Kind.Should().Be("Stock");
+        hit.RouteValues.Should().ContainKey("ticker").WhoseValue.Should().Be("AAPL");
+        hit.Title.Should().Be("AAPL");
+        hit.Subtitle.Should().Be("Apple Inc.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial/pin unit test for `CommonStockSearchProvider.Project` (new global-search feature #885); the file was 0% covered.
- Pins the cross-component contract: the Stocks hit must carry `Kind="Stock"` and the ticker under `RouteValues["ticker"]` — the exact key `SearchCategoryRouteExtensions.HitUrl`'s "Stock" arm reads. A rename on either side ships a dead link with no compile-time check.
- Test passes — confirms and pins the wiring.

## Code changes

- `tests/Equibles.UnitTests/Search/CommonStockSearchProviderProjectTests.cs` — new unit test. Invokes the `protected` `Project` via reflection (repo's established non-public pattern; the repo dependency is unused by `Project`) with a sample `CommonStock`; asserts `Kind`, `RouteValues["ticker"]`, `Title`, `Subtitle`.