### PR TITLE
test(search): pin InsiderOwnerSearchProvider.DescribeRole officer title precedence

### DIFF
--- a/tests/Equibles.UnitTests/Search/InsiderOwnerSearchProviderDescribeRoleTests.cs
+++ b/tests/Equibles.UnitTests/Search/InsiderOwnerSearchProviderDescribeRoleTests.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using Equibles.InsiderTrading.Repositories.Search;
+
+namespace Equibles.UnitTests.Search;
+
+/// <summary>
+/// Pins the role-precedence contract of InsiderOwnerSearchProvider.DescribeRole
+/// (new global search #885, 0% covered). An owner is routinely both an officer
+/// and a director; the descriptor must show the specific officer title, not the
+/// generic "Director". A regression reordering the checks would mislabel every
+/// officer-director. DescribeRole is private static → reflection (repo pattern).
+/// </summary>
+public class InsiderOwnerSearchProviderDescribeRoleTests
+{
+    [Fact]
+    public void DescribeRole_OfficerTitlePresentAndAlsoDirectorAndTenPercent_OfficerTitleWins()
+    {
+        var describeRole = typeof(InsiderOwnerSearchProvider).GetMethod(
+            "DescribeRole",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+        var result = (string)describeRole.Invoke(null, ["Chief Financial Officer", true, true])!;
+
+        result.Should().Be("Chief Financial Officer");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial/pin unit test for `InsiderOwnerSearchProvider.DescribeRole` (new global-search feature #885); the file was 0% covered.
- Pins the role-precedence contract: an owner who is simultaneously an officer, a director, and a 10% owner must be labelled with the specific officer title — not the generic "Director". A reordering regression would mislabel every officer-director.
- Test passes — confirms and pins the precedence.

## Code changes

- `tests/Equibles.UnitTests/Search/InsiderOwnerSearchProviderDescribeRoleTests.cs` — new unit test invoking the `private static` `DescribeRole` via reflection (repo's established non-public pattern) with officer title + both flags set; asserts the officer title wins.