### PR TITLE
test(search): pin FredSeriesSearchProvider.Project whitespace-units subtitle + route

### DIFF
--- a/tests/Equibles.UnitTests/Search/FredSeriesSearchProviderProjectTests.cs
+++ b/tests/Equibles.UnitTests/Search/FredSeriesSearchProviderProjectTests.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using Equibles.Fred.Data.Models;
+using Equibles.Fred.Repositories.Search;
+using Equibles.Search.Abstractions;
+
+namespace Equibles.UnitTests.Search;
+
+/// <summary>
+/// Pins FredSeriesSearchProvider.Project (new global search #885, 0% covered).
+/// Subtitle appends units only when a real unit string exists — a whitespace
+/// Units must NOT emit a dangling "SeriesId · " separator (a naive == null check
+/// would). Also pins the cross-component wiring HitUrl's "EconomicSeries" arm
+/// relies on (Kind + RouteValues["seriesId"]). Project is protected → reflection.
+/// </summary>
+public class FredSeriesSearchProviderProjectTests
+{
+    [Fact]
+    public void Project_WhitespaceUnits_SubtitleIsSeriesIdOnlyAndWiresEconomicSeriesRoute()
+    {
+        var provider = new FredSeriesSearchProvider(null);
+        var series = new FredSeries
+        {
+            SeriesId = "GDP",
+            Title = "Gross Domestic Product",
+            Units = "   ",
+        };
+
+        var project = typeof(FredSeriesSearchProvider).GetMethod(
+            "Project",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+
+        var hit = (SearchHit)project.Invoke(provider, [series])!;
+
+        hit.Subtitle.Should().Be("GDP");
+        hit.Kind.Should().Be("EconomicSeries");
+        hit.RouteValues.Should().ContainKey("seriesId").WhoseValue.Should().Be("GDP");
+        hit.Title.Should().Be("Gross Domestic Product");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial/pin unit test for `FredSeriesSearchProvider.Project` (new global-search feature #885); file was 0% covered.
- Pins two things at once: a whitespace `Units` must yield a Subtitle of just the series id (no dangling " · " separator a naive `== null` check would produce), and the cross-component wiring `SearchCategoryRouteExtensions.HitUrl`'s "EconomicSeries" arm depends on (`Kind` + `RouteValues["seriesId"]`).
- Test passes — confirms and pins.

## Code changes

- `tests/Equibles.UnitTests/Search/FredSeriesSearchProviderProjectTests.cs` — new unit test invoking the `protected` `Project` via reflection (repo's non-public pattern) with `Units="   "`; asserts Subtitle, Kind, route value, Title.