### PR TITLE
test(search): pin InstitutionalHolderSearchProvider.Project drops blank location parts

### DIFF
--- a/tests/Equibles.UnitTests/Search/InstitutionalHolderSearchProviderProjectTests.cs
+++ b/tests/Equibles.UnitTests/Search/InstitutionalHolderSearchProviderProjectTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories.Search;
+using Equibles.Search.Abstractions;
+
+namespace Equibles.UnitTests.Search;
+
+/// <summary>
+/// Pins InstitutionalHolderSearchProvider.Project (new global search #885, 0%
+/// covered). The Subtitle joins city/state but must drop null/whitespace parts —
+/// a naive "$"{City}, {State}"" would emit ", " for a holder with no location.
+/// Also pins the cross-component wiring HitUrl's "Institution" arm relies on
+/// (Kind + RouteValues["cik"]). Project is protected → reflection (repo pattern).
+/// </summary>
+public class InstitutionalHolderSearchProviderProjectTests
+{
+    [Fact]
+    public void Project_NullAndWhitespaceLocationParts_SubtitleEmptyAndWiresInstitutionRoute()
+    {
+        var provider = new InstitutionalHolderSearchProvider(null);
+        var holder = new InstitutionalHolder
+        {
+            Cik = "0001067983",
+            Name = "Berkshire Hathaway Inc",
+            City = null,
+            StateOrCountry = "   ",
+        };
+
+        var project = typeof(InstitutionalHolderSearchProvider).GetMethod(
+            "Project",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+
+        var hit = (SearchHit)project.Invoke(provider, [holder])!;
+
+        hit.Subtitle.Should().BeEmpty();
+        hit.Kind.Should().Be("Institution");
+        hit.RouteValues.Should().ContainKey("cik").WhoseValue.Should().Be("0001067983");
+        hit.Title.Should().Be("Berkshire Hathaway Inc");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial/pin unit test for `InstitutionalHolderSearchProvider.Project` (new global-search feature #885); file was 0% covered.
- Pins the location-join branch: a holder with null/whitespace city and state must yield an empty Subtitle (no dangling `", "` a naive interpolation would produce), plus the cross-component `Kind`/`RouteValues["cik"]` wiring `SearchCategoryRouteExtensions.HitUrl`'s "Institution" arm consumes.
- Test passes — confirms and pins.

## Code changes

- `tests/Equibles.UnitTests/Search/InstitutionalHolderSearchProviderProjectTests.cs` — new unit test invoking the `protected` `Project` via reflection (repo's non-public pattern) with `City=null`, `StateOrCountry="   "`; asserts empty Subtitle, Kind, cik route value, Title.