### PR TITLE
test(search): pin CongressMemberSearchProvider.Project CongressMember kind + id route

### DIFF
--- a/tests/Equibles.UnitTests/Search/CongressMemberSearchProviderProjectTests.cs
+++ b/tests/Equibles.UnitTests/Search/CongressMemberSearchProviderProjectTests.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.Repositories.Search;
+using Equibles.Search.Abstractions;
+
+namespace Equibles.UnitTests.Search;
+
+/// <summary>
+/// Pins CongressMemberSearchProvider.Project (new global search #885, 0%
+/// covered). For the hit to become a working profile link, Project must emit
+/// Kind "CongressMember" and the member's Guid id under RouteValues key "id" —
+/// the exact key SearchCategoryRouteExtensions.HitUrl's "CongressMember" arm
+/// reads. Project is protected → reflection (the repo's non-public pattern).
+/// </summary>
+public class CongressMemberSearchProviderProjectTests
+{
+    [Fact]
+    public void Project_Member_EmitsCongressMemberKindAndGuidIdRouteValue()
+    {
+        var id = Guid.Parse("11112222-3333-4444-5555-666677778888");
+        var provider = new CongressMemberSearchProvider(null);
+        var member = new CongressMember { Id = id, Name = "Jane Representative" };
+
+        var project = typeof(CongressMemberSearchProvider).GetMethod(
+            "Project",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+
+        var hit = (SearchHit)project.Invoke(provider, [member])!;
+
+        hit.Kind.Should().Be("CongressMember");
+        hit.RouteValues.Should().ContainKey("id").WhoseValue.Should().Be(id.ToString());
+        hit.Title.Should().Be("Jane Representative");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial/pin unit test for `CongressMemberSearchProvider.Project` (new global-search feature #885); file was 0% covered.
- Pins the cross-component contract: the hit must carry `Kind="CongressMember"` and the member's Guid id under `RouteValues["id"]` — the exact key `SearchCategoryRouteExtensions.HitUrl`'s "CongressMember" arm reads to build the profile link. No compile-time check guards this.
- Test passes — confirms and pins.

## Code changes

- `tests/Equibles.UnitTests/Search/CongressMemberSearchProviderProjectTests.cs` — new unit test invoking the `protected` `Project` via reflection (repo's non-public pattern) with a fixed Guid id; asserts `Kind`, `RouteValues["id"]` round-trips the Guid, `Title`.