### PR TITLE
feat(web): add category scope filter to global search

### DIFF
--- a/src/Equibles.Web/Search/SearchCategories.cs
+++ b/src/Equibles.Web/Search/SearchCategories.cs
@@ -1,0 +1,22 @@
+namespace Equibles.Web.Search;
+
+/// <summary>
+/// Canonical, display-ordered list of the categories the global search can return. These strings
+/// must match each module's <c>ISearchProvider.Category</c> verbatim — the search view compares
+/// them with <c>OrdinalIgnoreCase</c> to drive the scope selector and the post-results chips.
+/// Kept in the Web layer (a presentation concern, like <see cref="Extensions.SearchCategoryRouteExtensions"/>)
+/// so providers stay MVC-free; ordering mirrors each provider's <c>Order</c>.
+/// </summary>
+public static class SearchCategories
+{
+    public static readonly IReadOnlyList<string> All =
+    [
+        "Stocks",
+        "SEC Filings",
+        "Economic Indicators",
+        "Institutions",
+        "Insiders",
+        "Congress",
+        "Futures",
+    ];
+}

--- a/src/Equibles.Web/Views/Search/Index.cshtml
+++ b/src/Equibles.Web/Views/Search/Index.cshtml
@@ -1,4 +1,5 @@
 @using Equibles.Web.Extensions
+@using Equibles.Web.Search
 @model Equibles.Web.ViewModels.Search.GlobalSearchViewModel
 
 @{
@@ -16,9 +17,20 @@
         <p class="text-base-content/60">Stocks, filings, institutions, insiders, congress, economic indicators and futures</p>
     </div>
 
-    <!-- Search -->
+    <!-- Search: scope selector + query. The scope sets the `category` param the controller and
+         result view already understand, so a user can narrow the search before submitting. -->
     <form method="get" class="mb-6">
-        <div class="join w-full max-w-xl">
+        <div class="join w-full max-w-2xl">
+            <select name="category" class="select select-bordered join-item w-auto"
+                    aria-label="Limit search to a category">
+                <option value="">All categories</option>
+                @foreach (var category in SearchCategories.All) {
+                    <option value="@category"
+                            selected="@(string.Equals(category, Model.ActiveCategory, StringComparison.OrdinalIgnoreCase))">
+                        @category
+                    </option>
+                }
+            </select>
             <input type="search" name="q" value="@Model.Query"
                    class="input input-bordered join-item grow"
                    aria-label="Search everything"
@@ -30,13 +42,22 @@
     </form>
 
     @if (string.IsNullOrWhiteSpace(Model.Query)) {
-        <div class="flex flex-col items-center text-center py-16 gap-4">
+        <div class="flex flex-col items-center text-center py-16 gap-5">
             <icon name="magnifying-glass" size="10" class="text-base-content/30" />
             <p class="text-base-content/70 max-w-md">
                 Search stocks, SEC filings, institutions, insiders, congress members,
                 economic indicators and futures markets — all at once.
             </p>
-            <div class="flex flex-wrap justify-center gap-2">
+            <div class="flex flex-col items-center gap-2">
+                <span class="text-sm text-base-content/50">Browse a category</span>
+                <div class="flex flex-wrap justify-center gap-2 max-w-xl">
+                    @foreach (var category in SearchCategories.All) {
+                        <a asp-action="Index" asp-route-category="@category"
+                           class="badge badge-ghost badge-lg transition-colors hover:badge-primary">@category</a>
+                    }
+                </div>
+            </div>
+            <div class="flex flex-wrap justify-center items-center gap-2">
                 <span class="text-sm text-base-content/50">Try:</span>
                 <a asp-action="Index" asp-route-q="AAPL" class="badge badge-ghost badge-lg transition-colors hover:badge-primary">AAPL</a>
                 <a asp-action="Index" asp-route-q="Apple" class="badge badge-ghost badge-lg transition-colors hover:badge-primary">Apple</a>


### PR DESCRIPTION
## Summary

- The `/Search` page offered only a free-text box; the `category` param was reachable solely via chips that appear *after* results exist, so users could not narrow a search before submitting and the empty landing state hid what was searchable.
- Adds an always-visible category scope selector and surfaces every searchable category on the landing state — directly addressing "not enough filters / make search easy to use".

## Code changes

- `src/Equibles.Web/Search/SearchCategories.cs` — new single canonical, display-ordered category list (Web presentation concern, mirrors each `ISearchProvider.Category`).
- `src/Equibles.Web/Views/Search/Index.cshtml` — add a category `<select>` joined to the search input (All categories + the 7 categories), preselected from the active category via the existing `category` query param; replace the 3 ad-hoc example badges in the empty state with the full ordered category list (recognition over recall), keeping the example queries.