### PR TITLE
feat(web): add category scope filter to the global navbar search

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -33,12 +33,22 @@
                 </nav>
             </div>
             <div class="flex items-center gap-2">
-                <!-- Global search: posts the query to SearchController.Index as ?q= -->
+                <!-- Global search: scope + query posted to SearchController.Index as ?category=&q=.
+                     Scope mirrors the /Search page so the filter is reachable from every page. -->
                 <form asp-controller="Search" asp-action="Index" method="get" class="hidden lg:block">
-                    <label class="input input-sm input-bordered flex items-center gap-2 w-48 xl:w-64">
-                        <icon name="magnifying-glass" size="4" />
-                        <input type="text" name="q" class="grow" placeholder="Search everything..." aria-label="Search everything" />
-                    </label>
+                    <div class="join">
+                        <select name="category" class="select select-sm select-bordered join-item"
+                                aria-label="Limit search to a category">
+                            <option value="">All</option>
+                            @foreach (var category in Equibles.Web.Search.SearchCategories.All) {
+                                <option value="@category">@category</option>
+                            }
+                        </select>
+                        <label class="input input-sm input-bordered join-item flex items-center gap-2 w-44 xl:w-56">
+                            <icon name="magnifying-glass" size="4" />
+                            <input type="search" name="q" class="grow" placeholder="Search everything..." aria-label="Search everything" />
+                        </label>
+                    </div>
                 </form>
                 <a href="https://github.com/daniel3303/Equibles" target="_blank" class="btn btn-ghost btn-sm" title="GitHub">
                     <svg class="size-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>


### PR DESCRIPTION
## Summary

- The `/Search` page gained a category scope filter (#926), but the always-visible navbar search — the most-used entry point on every page — stayed a bare text box. That is both a consistency gap and the "not enough filters" issue reported for the global search.
- The navbar search now carries the same scope filter, reachable from any page, and exposes a native clear affordance.

## Code changes

- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — wrap the navbar global-search form in a DaisyUI `join`, add a category `<select>` (All + the 7 `SearchCategories`) posting the existing `category`+`q` GET params already handled by `SearchController.Index` and the result view; switch the query input to `type=search` for a browser-native clear, matching the `/Search` page form.

Verified end-to-end: navbar scoped submit → `/search?category=Stocks&q=AAPL`, results page preselects scope=Stocks.