### PR TITLE
feat(web): instant as-you-type search results

### DIFF
--- a/src/Equibles.Web/Controllers/SearchController.cs
+++ b/src/Equibles.Web/Controllers/SearchController.cs
@@ -36,4 +36,22 @@ public class SearchController : BaseController
             }
         );
     }
+
+    // Results-only fragment for instant (as-you-type) search. instant-search.js fetches this
+    // and swaps it into the page; the markup is identical to Index's results region.
+    [HttpGet]
+    public async Task<IActionResult> Results(string q, string category)
+    {
+        var groups = await _searchAggregator.Search(q, MaxPerProvider, HttpContext.RequestAborted);
+
+        return PartialView(
+            "_Results",
+            new GlobalSearchViewModel
+            {
+                Query = q,
+                Groups = groups,
+                ActiveCategory = category,
+            }
+        );
+    }
 }

--- a/src/Equibles.Web/Views/Search/Index.cshtml
+++ b/src/Equibles.Web/Views/Search/Index.cshtml
@@ -1,14 +1,9 @@
-@using Equibles.Web.Extensions
 @using Equibles.Web.Search
 @model Equibles.Web.ViewModels.Search.GlobalSearchViewModel
 
 @{
     ViewData["Title"] = "Search";
     ViewData["Description"] = "Search stocks, SEC filings, institutions, insiders, congress members, economic indicators and futures markets.";
-
-    var visibleGroups = string.IsNullOrWhiteSpace(Model.ActiveCategory)
-        ? Model.Groups
-        : Model.Groups.Where(g => string.Equals(g.Category, Model.ActiveCategory, StringComparison.OrdinalIgnoreCase)).ToList();
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
@@ -17,9 +12,10 @@
         <p class="text-base-content/60">Stocks, filings, institutions, insiders, congress, economic indicators and futures</p>
     </div>
 
-    <!-- Search: scope selector + query. The scope sets the `category` param the controller and
-         result view already understand, so a user can narrow the search before submitting. -->
-    <form method="get" class="mb-6">
+    <!-- Search: scope selector + query. instant-search.js progressively enhances this into
+         debounced as-you-type results; without JS the form still submits a normal GET. -->
+    <form id="global-search-form" method="get" asp-controller="Search" asp-action="Index"
+          data-results-url="@Url.Action("Results")" class="mb-6">
         <div class="join w-full max-w-2xl">
             <select name="category" class="select select-bordered join-item w-auto"
                     aria-label="Limit search to a category">
@@ -41,89 +37,7 @@
         </div>
     </form>
 
-    @if (string.IsNullOrWhiteSpace(Model.Query)) {
-        <div class="flex flex-col items-center text-center py-16 gap-5">
-            <icon name="magnifying-glass" size="10" class="text-base-content/30" />
-            <p class="text-base-content/70 max-w-md">
-                Search stocks, SEC filings, institutions, insiders, congress members,
-                economic indicators and futures markets — all at once.
-            </p>
-            <div class="flex flex-col items-center gap-2">
-                <span class="text-sm text-base-content/50">Browse a category</span>
-                <div class="flex flex-wrap justify-center gap-2 max-w-xl">
-                    @foreach (var category in SearchCategories.All) {
-                        <a asp-action="Index" asp-route-category="@category"
-                           class="badge badge-ghost badge-lg transition-colors hover:badge-primary">@category</a>
-                    }
-                </div>
-            </div>
-            <div class="flex flex-wrap justify-center items-center gap-2">
-                <span class="text-sm text-base-content/50">Try:</span>
-                <a asp-action="Index" asp-route-q="AAPL" class="badge badge-ghost badge-lg transition-colors hover:badge-primary">AAPL</a>
-                <a asp-action="Index" asp-route-q="Apple" class="badge badge-ghost badge-lg transition-colors hover:badge-primary">Apple</a>
-                <a asp-action="Index" asp-route-q="10-K" class="badge badge-ghost badge-lg transition-colors hover:badge-primary">10-K</a>
-            </div>
-        </div>
-    } else if (!Model.HasResults) {
-        <div class="flex flex-col items-center text-center py-16 gap-3">
-            <icon name="magnifying-glass" size="10" class="text-base-content/30" />
-            <p class="text-base-content/70">
-                No results for <span class="font-semibold text-base-content">@Model.Query</span>.
-            </p>
-            <p class="text-sm text-base-content/50">Try a ticker symbol, company name, or filing type.</p>
-        </div>
-    } else {
-        <!-- Category filter chips -->
-        <div class="flex flex-wrap gap-2 mb-6">
-            <a asp-action="Index" asp-route-q="@Model.Query"
-               class="badge badge-lg transition-colors hover:badge-primary @(string.IsNullOrWhiteSpace(Model.ActiveCategory) ? "badge-primary" : "badge-ghost")">
-                All
-            </a>
-            @foreach (var group in Model.Groups) {
-                <a asp-action="Index" asp-route-q="@Model.Query" asp-route-category="@group.Category"
-                   class="badge badge-lg transition-colors hover:badge-primary @(string.Equals(group.Category, Model.ActiveCategory, StringComparison.OrdinalIgnoreCase) ? "badge-primary" : "badge-ghost")">
-                    @group.Category (@group.Hits.Count)
-                </a>
-            }
-        </div>
-
-        <!-- Result groups -->
-        <div class="grid gap-6 md:grid-cols-2 items-start">
-            @foreach (var group in visibleGroups) {
-                var seeAll = Url.CategoryUrl(group.Category, Model.Query);
-                <div class="card bg-base-100 shadow-sm">
-                    <div class="card-body p-4 lg:p-6">
-                        <div class="flex items-center justify-between mb-2">
-                            <h2 class="card-title text-lg">@group.Category</h2>
-                            @if (seeAll != null) {
-                                <a href="@seeAll" class="link link-primary text-sm">See all</a>
-                            }
-                        </div>
-                        <ul class="divide-y divide-base-200">
-                            @foreach (var hit in group.Hits) {
-                                var hitUrl = Url.HitUrl(hit);
-                                <li class="py-2">
-                                    @if (hitUrl != null) {
-                                        <a href="@hitUrl" class="block hover:bg-base-200 rounded px-2 -mx-2 py-1">
-                                            <div class="font-medium">@hit.Title</div>
-                                            @if (!string.IsNullOrWhiteSpace(hit.Subtitle)) {
-                                                <div class="text-sm text-base-content/60">@hit.Subtitle</div>
-                                            }
-                                        </a>
-                                    } else {
-                                        <div class="px-2 -mx-2 py-1">
-                                            <div class="font-medium">@hit.Title</div>
-                                            @if (!string.IsNullOrWhiteSpace(hit.Subtitle)) {
-                                                <div class="text-sm text-base-content/60">@hit.Subtitle</div>
-                                            }
-                                        </div>
-                                    }
-                                </li>
-                            }
-                        </ul>
-                    </div>
-                </div>
-            }
-        </div>
-    }
+    <div id="search-results" aria-live="polite" aria-busy="false">
+        <partial name="_Results" model="Model" />
+    </div>
 </div>

--- a/src/Equibles.Web/Views/Search/_Results.cshtml
+++ b/src/Equibles.Web/Views/Search/_Results.cshtml
@@ -1,0 +1,94 @@
+@using Equibles.Web.Extensions
+@model Equibles.Web.ViewModels.Search.GlobalSearchViewModel
+
+@{
+    var visibleGroups = string.IsNullOrWhiteSpace(Model.ActiveCategory)
+        ? Model.Groups
+        : Model.Groups.Where(g => string.Equals(g.Category, Model.ActiveCategory, StringComparison.OrdinalIgnoreCase)).ToList();
+}
+
+@if (string.IsNullOrWhiteSpace(Model.Query)) {
+    <div class="flex flex-col items-center text-center py-16 gap-5">
+        <icon name="magnifying-glass" size="10" class="text-base-content/30" />
+        <p class="text-base-content/70 max-w-md">
+            Search stocks, SEC filings, institutions, insiders, congress members,
+            economic indicators and futures markets — all at once.
+        </p>
+        <div class="flex flex-col items-center gap-2">
+            <span class="text-sm text-base-content/50">Browse a category</span>
+            <div class="flex flex-wrap justify-center gap-2 max-w-xl">
+                @foreach (var category in Equibles.Web.Search.SearchCategories.All) {
+                    <a asp-action="Index" asp-route-category="@category"
+                       class="badge badge-ghost badge-lg transition-colors hover:badge-primary">@category</a>
+                }
+            </div>
+        </div>
+        <div class="flex flex-wrap justify-center items-center gap-2">
+            <span class="text-sm text-base-content/50">Try:</span>
+            <a asp-action="Index" asp-route-q="AAPL" class="badge badge-ghost badge-lg transition-colors hover:badge-primary">AAPL</a>
+            <a asp-action="Index" asp-route-q="Apple" class="badge badge-ghost badge-lg transition-colors hover:badge-primary">Apple</a>
+            <a asp-action="Index" asp-route-q="10-K" class="badge badge-ghost badge-lg transition-colors hover:badge-primary">10-K</a>
+        </div>
+    </div>
+} else if (!Model.HasResults) {
+    <div class="flex flex-col items-center text-center py-16 gap-3">
+        <icon name="magnifying-glass" size="10" class="text-base-content/30" />
+        <p class="text-base-content/70">
+            No results for <span class="font-semibold text-base-content">@Model.Query</span>.
+        </p>
+        <p class="text-sm text-base-content/50">Try a ticker symbol, company name, or filing type.</p>
+    </div>
+} else {
+    <!-- Category filter chips -->
+    <div class="flex flex-wrap gap-2 mb-6">
+        <a asp-action="Index" asp-route-q="@Model.Query"
+           class="badge badge-lg transition-colors hover:badge-primary @(string.IsNullOrWhiteSpace(Model.ActiveCategory) ? "badge-primary" : "badge-ghost")">
+            All
+        </a>
+        @foreach (var group in Model.Groups) {
+            <a asp-action="Index" asp-route-q="@Model.Query" asp-route-category="@group.Category"
+               class="badge badge-lg transition-colors hover:badge-primary @(string.Equals(group.Category, Model.ActiveCategory, StringComparison.OrdinalIgnoreCase) ? "badge-primary" : "badge-ghost")">
+                @group.Category (@group.Hits.Count)
+            </a>
+        }
+    </div>
+
+    <!-- Result groups -->
+    <div class="grid gap-6 md:grid-cols-2 items-start">
+        @foreach (var group in visibleGroups) {
+            var seeAll = Url.CategoryUrl(group.Category, Model.Query);
+            <div class="card bg-base-100 shadow-sm">
+                <div class="card-body p-4 lg:p-6">
+                    <div class="flex items-center justify-between mb-2">
+                        <h2 class="card-title text-lg">@group.Category</h2>
+                        @if (seeAll != null) {
+                            <a href="@seeAll" class="link link-primary text-sm">See all</a>
+                        }
+                    </div>
+                    <ul class="divide-y divide-base-200">
+                        @foreach (var hit in group.Hits) {
+                            var hitUrl = Url.HitUrl(hit);
+                            <li class="py-2">
+                                @if (hitUrl != null) {
+                                    <a href="@hitUrl" class="block hover:bg-base-200 rounded px-2 -mx-2 py-1">
+                                        <div class="font-medium">@hit.Title</div>
+                                        @if (!string.IsNullOrWhiteSpace(hit.Subtitle)) {
+                                            <div class="text-sm text-base-content/60">@hit.Subtitle</div>
+                                        }
+                                    </a>
+                                } else {
+                                    <div class="px-2 -mx-2 py-1">
+                                        <div class="font-medium">@hit.Title</div>
+                                        @if (!string.IsNullOrWhiteSpace(hit.Subtitle)) {
+                                            <div class="text-sm text-base-content/60">@hit.Subtitle</div>
+                                        }
+                                    </div>
+                                }
+                            </li>
+                        }
+                    </ul>
+                </div>
+            </div>
+        }
+    </div>
+}

--- a/src/Equibles.Web/src/index.js
+++ b/src/Equibles.Web/src/index.js
@@ -23,3 +23,4 @@ import './js/messages';
 import './js/modals';
 import './js/homepage-demos';
 import './js/docs-nav';
+import './js/instant-search';

--- a/src/Equibles.Web/src/js/instant-search.js
+++ b/src/Equibles.Web/src/js/instant-search.js
@@ -1,0 +1,69 @@
+// Instant search — debounced as-you-type results on /Search, no full page reload.
+// Progressive enhancement: if this doesn't run, the form still submits a normal GET.
+
+(() => {
+    const form = document.getElementById('global-search-form');
+    const results = document.getElementById('search-results');
+    if (!form || !results || !window.fetch || !window.AbortController) return;
+
+    const input = form.querySelector('input[name="q"]');
+    const scope = form.querySelector('select[name="category"]');
+    if (!input) return;
+
+    const resultsUrl = form.dataset.resultsUrl || '/Search/Results';
+    const action = form.getAttribute('action') || window.location.pathname;
+    let timer;
+    let controller;
+
+    // Fetch the results partial for the current query + scope and swap it in.
+    // push=true adds a history entry (explicit submit); otherwise the URL is replaced
+    // so typing doesn't flood the back stack.
+    async function run(push) {
+        const params = new URLSearchParams();
+        const q = input.value.trim();
+        const category = scope ? scope.value : '';
+        if (q) params.set('q', q);
+        if (category) params.set('category', category);
+
+        if (controller) controller.abort();
+        controller = new AbortController();
+        results.setAttribute('aria-busy', 'true');
+        results.classList.add('opacity-50', 'transition-opacity');
+
+        try {
+            const response = await fetch(`${resultsUrl}?${params}`, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                signal: controller.signal,
+            });
+            if (!response.ok) return;
+            results.innerHTML = await response.text();
+            const url = params.toString() ? `${action}?${params}` : action;
+            window.history[push ? 'pushState' : 'replaceState'](null, '', url);
+        } catch (error) {
+            if (error.name !== 'AbortError') console.error('[instant-search]', error);
+        } finally {
+            results.setAttribute('aria-busy', 'false');
+            results.classList.remove('opacity-50');
+        }
+    }
+
+    // Debounce typing; react immediately to a scope change or explicit submit.
+    input.addEventListener('input', () => {
+        clearTimeout(timer);
+        timer = setTimeout(() => run(false), 250);
+    });
+    scope?.addEventListener('change', () => run(false));
+    form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        clearTimeout(timer);
+        run(true);
+    });
+
+    // Back/forward: re-sync the inputs from the URL and refresh the results.
+    window.addEventListener('popstate', () => {
+        const params = new URLSearchParams(window.location.search);
+        input.value = params.get('q') || '';
+        if (scope) scope.value = params.get('category') || '';
+        run(false);
+    });
+})();


### PR DESCRIPTION
## Summary

- Global search required typing, pressing the button, and a full page reload for every query and every scope change — slow and not the modern search experience users expect ("should be very easy to use").
- Search results now update live as you type and on scope change, with no page reload, while remaining fully functional without JavaScript.

## Code changes

- `src/Equibles.Web/Views/Search/_Results.cshtml` — new partial holding the results region (landing / no-results / chips + grouped hits), markup identical to the previous inline block.
- `src/Equibles.Web/Views/Search/Index.cshtml` — keeps header + form (now `id`/`asp-action`/`data-results-url`), renders the partial inside an `aria-live` `#search-results` container; results logic removed (moved to partial).
- `src/Equibles.Web/Controllers/SearchController.cs` — add `Results(q, category)` returning the `_Results` partial for AJAX.
- `src/Equibles.Web/src/js/instant-search.js` — new: debounced (250 ms) as-you-type fetch, immediate on scope change, `AbortController` to drop stale requests, `aria-busy`/opacity loading state, `replaceState`/`pushState` so reload/share/back work.
- `src/Equibles.Web/src/index.js` — import the new module.

Progressive enhancement: the form keeps `method=get`/`asp-action`, so it still submits normally without JS. Verified in-browser: typing and scope change swap results via AJAX with no full navigation; URL stays in sync; no-JS fallback intact.