### PR TITLE
feat(web): sort and market-cap filter on the stock browser

### DIFF
--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -34,7 +34,12 @@ public class StocksController : BaseController
     }
 
     [HttpGet]
-    public async Task<IActionResult> Index(string search, int page = 1)
+    public async Task<IActionResult> Index(
+        string search,
+        StockSort sort = StockSort.Ticker,
+        double? minMarketCap = null,
+        int page = 1
+    )
     {
         ViewData["Title"] = "Stocks";
 
@@ -46,6 +51,24 @@ public class StocksController : BaseController
 
         const int pageSize = 50;
         var query = _commonStockRepository.Search(search);
+
+        if (minMarketCap.HasValue)
+            query = query.Where(s => s.MarketCapitalization >= minMarketCap.Value);
+
+        // The later OrderBy replaces the repository's default Ticker ordering;
+        // Ticker is the tie-breaker so paging stays stable on equal market caps.
+        query = sort switch
+        {
+            StockSort.Name => query.OrderBy(s => s.Name).ThenBy(s => s.Ticker),
+            StockSort.MarketCapDescending => query
+                .OrderByDescending(s => s.MarketCapitalization)
+                .ThenBy(s => s.Ticker),
+            StockSort.MarketCapAscending => query
+                .OrderBy(s => s.MarketCapitalization)
+                .ThenBy(s => s.Ticker),
+            _ => query.OrderBy(s => s.Ticker),
+        };
+
         var totalCount = await query.CountAsync();
 
         var stocks = await query
@@ -66,6 +89,8 @@ public class StocksController : BaseController
         {
             Stocks = stocks,
             Search = search,
+            Sort = sort,
+            MinMarketCap = minMarketCap,
             Page = page,
             PageSize = pageSize,
             TotalCount = totalCount,

--- a/src/Equibles.Web/ViewModels/Stocks/StockBrowserViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/StockBrowserViewModel.cs
@@ -4,6 +4,8 @@ public class StockBrowserViewModel
 {
     public List<StockListItemViewModel> Stocks { get; set; } = [];
     public string Search { get; set; }
+    public StockSort Sort { get; set; }
+    public double? MinMarketCap { get; set; }
     public int Page { get; set; } = 1;
     public int PageSize { get; set; } = 50;
     public int TotalCount { get; set; }

--- a/src/Equibles.Web/ViewModels/Stocks/StockSort.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/StockSort.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Web.ViewModels.Stocks;
+
+/// <summary>Sort options for the stock browser. Display names drive the sort dropdown.</summary>
+public enum StockSort
+{
+    [Display(Name = "Ticker (A–Z)")]
+    Ticker,
+
+    [Display(Name = "Name (A–Z)")]
+    Name,
+
+    [Display(Name = "Market cap (high → low)")]
+    MarketCapDescending,
+
+    [Display(Name = "Market cap (low → high)")]
+    MarketCapAscending,
+}

--- a/src/Equibles.Web/Views/Stocks/Index.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Index.cshtml
@@ -1,8 +1,22 @@
+@using Equibles.Web.ViewModels.Stocks
 @model Equibles.Web.ViewModels.Stocks.StockBrowserViewModel
 
 @{
     ViewData["Title"] = "Stocks";
     ViewData["Description"] = "Browse and search US common stocks with institutional holdings, short volume, short interest, and fails-to-deliver data.";
+
+    // Active filters carried across pagination links so paging never drops them.
+    var filterRoute = new Dictionary<string, string>();
+    if (!string.IsNullOrEmpty(Model.Search)) {
+        filterRoute["search"] = Model.Search;
+    }
+    if (Model.Sort != StockSort.Ticker) {
+        filterRoute["sort"] = Model.Sort.ToString();
+    }
+    if (Model.MinMarketCap.HasValue) {
+        filterRoute["minMarketCap"] = Model.MinMarketCap.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+    var hasFilters = filterRoute.Count > 0;
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
@@ -11,15 +25,36 @@
         <p class="text-base-content/60">Browse @Model.TotalCount.ToString("N0") US common stocks</p>
     </div>
 
-    <!-- Search -->
+    <!-- Search + filters (plain query-param names, bound to StocksController.Index) -->
     <form method="get" class="mb-6">
-        <div class="flex gap-3">
-            <input type="text" name="search" value="@Model.Search"
-                   class="input input-bordered flex-1 max-w-md"
-                   aria-label="Search stocks by ticker or name"
-                   placeholder="Search by ticker or name..." />
-            <button type="submit" class="btn btn-primary">Search</button>
-            @if (!string.IsNullOrEmpty(Model.Search)) {
+        <div class="flex flex-wrap gap-3 items-end">
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">Search</span>
+                <input type="text" name="search" value="@Model.Search"
+                       class="input input-bordered w-64"
+                       aria-label="Search stocks by ticker or name"
+                       placeholder="Ticker or name..." />
+            </label>
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">Sort by</span>
+                <select name="sort" class="select select-bordered" aria-label="Sort stocks">
+                    @foreach (var option in Html.GetEnumSelectList<StockSort>()) {
+                        <option value="@option.Value"
+                                selected="@(option.Value == ((int)Model.Sort).ToString())">
+                            @option.Text
+                        </option>
+                    }
+                </select>
+            </label>
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">Min market cap ($)</span>
+                <input type="number" name="minMarketCap" value="@Model.MinMarketCap"
+                       min="0" step="any" class="input input-bordered w-48"
+                       aria-label="Minimum market capitalization"
+                       placeholder="e.g. 1000000000" />
+            </label>
+            <button type="submit" class="btn btn-primary">Apply</button>
+            @if (hasFilters) {
                 <a asp-action="Index" class="btn btn-ghost">Clear</a>
             }
         </div>
@@ -52,6 +87,13 @@
                             </td>
                         </tr>
                     }
+                    @if (Model.Stocks.Count == 0) {
+                        <tr>
+                            <td colspan="4" class="text-center py-10 text-base-content/60">
+                                No stocks match these filters.
+                            </td>
+                        </tr>
+                    }
                 </tbody>
             </table>
         </div>
@@ -62,7 +104,7 @@
         <div class="flex justify-center mt-6">
             <div class="join">
                 @if (Model.Page > 1) {
-                    <a asp-action="Index" asp-route-search="@Model.Search" asp-route-page="@(Model.Page - 1)" class="join-item btn btn-sm">Previous</a>
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page - 1)" class="join-item btn btn-sm">Previous</a>
                 }
 
                 @{
@@ -71,14 +113,14 @@
                 }
 
                 @if (startPage > 1) {
-                    <a asp-action="Index" asp-route-search="@Model.Search" asp-route-page="1" class="join-item btn btn-sm">1</a>
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="1" class="join-item btn btn-sm">1</a>
                     @if (startPage > 2) {
                         <span class="join-item btn btn-sm btn-disabled">...</span>
                     }
                 }
 
                 @for (var i = startPage; i <= endPage; i++) {
-                    <a asp-action="Index" asp-route-search="@Model.Search" asp-route-page="@i"
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@i"
                        class="join-item btn btn-sm @(i == Model.Page ? "btn-active" : "")">@i</a>
                 }
 
@@ -86,11 +128,11 @@
                     @if (endPage < Model.TotalPages - 1) {
                         <span class="join-item btn btn-sm btn-disabled">...</span>
                     }
-                    <a asp-action="Index" asp-route-search="@Model.Search" asp-route-page="@Model.TotalPages" class="join-item btn btn-sm">@Model.TotalPages</a>
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@Model.TotalPages" class="join-item btn btn-sm">@Model.TotalPages</a>
                 }
 
                 @if (Model.Page < Model.TotalPages) {
-                    <a asp-action="Index" asp-route-search="@Model.Search" asp-route-page="@(Model.Page + 1)" class="join-item btn btn-sm">Next</a>
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page + 1)" class="join-item btn btn-sm">Next</a>
                 }
             </div>
         </div>

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerIndexSortAndFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerIndexSortAndFilterTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Covers the stock browser's sort + minimum-market-cap filters: ordering must
+/// follow the requested <c>sort</c>, <c>minMarketCap</c> must exclude smaller
+/// companies, and unparseable filter values must degrade to defaults rather
+/// than 500 (model binding maps a bad enum or double to the default / null).
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class StocksControllerIndexSortAndFilterTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public StocksControllerIndexSortAndFilterTests(WebHostFixture fixture) => _fixture = fixture;
+
+    private async Task SeedThreeStocks()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "ZED",
+                    Name = "Zeta Small Co.",
+                    MarketCapitalization = 100d,
+                }
+            );
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "MID",
+                    Name = "Mid Cap Co.",
+                    MarketCapitalization = 5_000_000_000d,
+                }
+            );
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "TOP",
+                    Name = "Apex Large Co.",
+                    MarketCapitalization = 9_000_000_000d,
+                }
+            );
+            await Task.CompletedTask;
+        });
+    }
+
+    [Fact]
+    public async Task Index_SortMarketCapDescending_OrdersLargestFirst()
+    {
+        await SeedThreeStocks();
+
+        var response = await _fixture.Client.GetAsync("/Stocks?sort=MarketCapDescending");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.IndexOf("TOP", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(html.IndexOf("MID", StringComparison.Ordinal));
+        html.IndexOf("MID", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(html.IndexOf("ZED", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Index_SortMarketCapAscending_OrdersSmallestFirst()
+    {
+        await SeedThreeStocks();
+
+        var response = await _fixture.Client.GetAsync("/Stocks?sort=MarketCapAscending");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.IndexOf("ZED", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(html.IndexOf("TOP", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Index_MinMarketCap_ExcludesCompaniesBelowThreshold()
+    {
+        await SeedThreeStocks();
+
+        var response = await _fixture.Client.GetAsync("/Stocks?minMarketCap=1000000000");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("TOP");
+        html.Should().Contain("MID");
+        html.Should().NotContain(">ZED<");
+    }
+
+    [Fact]
+    public async Task Index_UnparseableFilterValues_DegradeToDefaultsNot500()
+    {
+        await SeedThreeStocks();
+
+        var response = await _fixture.Client.GetAsync(
+            "/Stocks?sort=not-a-sort&minMarketCap=not-a-number"
+        );
+
+        response
+            .StatusCode.Should()
+            .Be(
+                HttpStatusCode.OK,
+                "an invalid sort/minMarketCap must bind to the default / null, "
+                    + "not surface a model-binding failure as HTTP 500"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- The stock browser (the search "See all" destination) had only a free-text box + pagination — the recurring "not enough filters" gap. Adds the filters a stock screener needs: sort + minimum market cap, with state preserved across paging.

## Code changes

- `src/Equibles.Web/ViewModels/Stocks/StockSort.cs` — new enum (Ticker / Name / Market cap high→low / low→high) with `[Display]` labels.
- `src/Equibles.Web/ViewModels/Stocks/StockBrowserViewModel.cs` — carry `Sort` + `MinMarketCap` for echo and pagination links.
- `src/Equibles.Web/Controllers/StocksController.cs` — `Index` accepts `sort`/`minMarketCap`; applies the market-cap `Where` before count and an order switch (Ticker tie-breaker for stable paging). Reads via repository (standard MVC read path); invalid values bind to defaults (no 500).
- `src/Equibles.Web/Views/Stocks/Index.cshtml` — sort `<select>` + min-market-cap input (plain query-param names), controls echo state, Clear when active, empty-result row, and pagination links now thread search+sort+minMarketCap via `asp-all-route-data` (fixes a latent bug where paging dropped the active search filter).

Verified with seeded data: market-cap-desc order exact (AAPL→MSFT→NVDA→GOOGL→AMZN→META), `minMarketCap=1e12` excludes sub-$1T (6 rows), controls echo state, invalid input returns 200.