### PR TITLE
feat(web): global "/" shortcut to focus the navbar search

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -54,8 +54,10 @@
                         </select>
                         <label class="input input-sm input-bordered join-item flex items-center gap-2 w-44 xl:w-56">
                             <icon name="magnifying-glass" size="4" />
-                            <input type="search" name="q" value="@activeSearchQuery" class="grow"
-                                   placeholder="Search everything..." aria-label="Search everything" />
+                            <input id="navbar-search-input" type="search" name="q" value="@activeSearchQuery" class="grow"
+                                   placeholder="Search everything..." aria-label="Search everything"
+                                   aria-keyshortcuts="/" />
+                            <kbd class="kbd kbd-sm text-base-content/50" aria-hidden="true">/</kbd>
                         </label>
                     </div>
                 </form>

--- a/src/Equibles.Web/src/index.js
+++ b/src/Equibles.Web/src/index.js
@@ -25,3 +25,4 @@ import './js/homepage-demos';
 import './js/docs-nav';
 import './js/instant-search';
 import './js/search-keyboard';
+import './js/global-search-shortcut';

--- a/src/Equibles.Web/src/js/global-search-shortcut.js
+++ b/src/Equibles.Web/src/js/global-search-shortcut.js
@@ -1,0 +1,22 @@
+// Global "/" search shortcut — focus the navbar search box from anywhere on the site,
+// so the user can start a search without reaching for the mouse on any page.
+//
+// The /Search page has its own richer keyboard handling (search-keyboard.js, which also
+// owns "/" there and adds result navigation). To avoid two "/" handlers fighting, this
+// module stays out of the way whenever that page's form is present.
+
+(() => {
+    const input = document.getElementById('navbar-search-input');
+    if (!input || document.getElementById('global-search-form')) return;
+
+    // "/" focuses search — unless the user is already typing in a field.
+    document.addEventListener('keydown', (e) => {
+        if (e.key !== '/') return;
+        const tag = document.activeElement?.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
+            || document.activeElement?.isContentEditable) return;
+        e.preventDefault();
+        input.focus();
+        input.select();
+    });
+})();


### PR DESCRIPTION
## Summary

- The `/` search shortcut (search-keyboard.js) only bound on the `/Search` page, where the input already autofocuses — so from every other page it did nothing and there was no hint it existed. A hidden, undiscoverable feature (Nielsen #6, recognition over recall).
- This makes `/` focus the navbar search from any page and surfaces a visible `<kbd>/</kbd>` affordance, making site-wide search keyboard-reachable and discoverable.

## Code changes

- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — add `id="navbar-search-input"`, `aria-keyshortcuts="/"`, and a visible `<kbd>/</kbd>` badge to the navbar search input.
- `src/Equibles.Web/src/js/global-search-shortcut.js` (new) — focuses + selects the navbar search on `/` from anywhere; bails when typing in a field, and stays out of the way on `/Search` where search-keyboard.js owns `/` plus result navigation.
- `src/Equibles.Web/src/index.js` — register the new module in the bundle.