### PR TITLE
feat(web): sort global search results by relevance or name

### DIFF
--- a/src/Equibles.Search.Abstractions/SearchRequest.cs
+++ b/src/Equibles.Search.Abstractions/SearchRequest.cs
@@ -7,4 +7,7 @@ public class SearchRequest
 
     /// <summary>Upper bound on hits a single provider returns for the grouped view.</summary>
     public int MaxPerProvider { get; set; } = 5;
+
+    /// <summary>How hits are ordered within each group; applied by the aggregator, not providers.</summary>
+    public SearchSort SortBy { get; set; } = SearchSort.Relevance;
 }

--- a/src/Equibles.Search.Abstractions/SearchSort.cs
+++ b/src/Equibles.Search.Abstractions/SearchSort.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Search.Abstractions;
+
+/// <summary>
+/// How the consumer wants hits ordered within each result group. Applied centrally by the
+/// aggregator on the hits providers return, so no provider needs to know about it.
+/// </summary>
+public enum SearchSort
+{
+    /// <summary>Keep each provider's own ranking (provider-local <see cref="SearchHit.Score"/>).</summary>
+    [Display(Name = "Relevance")]
+    Relevance = 0,
+
+    /// <summary>Alphabetical by <see cref="SearchHit.Title"/>, case-insensitive.</summary>
+    [Display(Name = "Name (A–Z)")]
+    Name = 1,
+}

--- a/src/Equibles.Search/SearchAggregator.cs
+++ b/src/Equibles.Search/SearchAggregator.cs
@@ -27,7 +27,8 @@ public class SearchAggregator
     public async Task<List<SearchResultGroup>> Search(
         string query,
         int maxPerProvider,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        SearchSort sortBy = SearchSort.Relevance
     )
     {
         if (string.IsNullOrWhiteSpace(query))
@@ -48,7 +49,12 @@ public class SearchAggregator
                 .ToList();
         }
 
-        var request = new SearchRequest { Query = query.Trim(), MaxPerProvider = maxPerProvider };
+        var request = new SearchRequest
+        {
+            Query = query.Trim(),
+            MaxPerProvider = maxPerProvider,
+            SortBy = sortBy,
+        };
 
         var groups = await Task.WhenAll(
             providerTypes.Select(providerType =>
@@ -58,9 +64,24 @@ public class SearchAggregator
 
         return groups
             .Where(group => group.Hits.Count > 0)
+            .Select(group => SortHits(group, sortBy))
             .OrderBy(group => group.Order)
             .ThenBy(group => group.Category ?? string.Empty, StringComparer.Ordinal)
             .ToList();
+    }
+
+    // Reorders a group's hits per the requested sort. Relevance keeps the provider's own ranking
+    // (providers return hits already scored); Name is a stable, case-insensitive title sort.
+    private static SearchResultGroup SortHits(SearchResultGroup group, SearchSort sortBy)
+    {
+        if (sortBy == SearchSort.Name)
+        {
+            group.Hits = group
+                .Hits.OrderBy(hit => hit.Title ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        return group;
     }
 
     private async Task<SearchResultGroup> RunProvider(

--- a/src/Equibles.Web/Controllers/SearchController.cs
+++ b/src/Equibles.Web/Controllers/SearchController.cs
@@ -1,4 +1,5 @@
 using Equibles.Search;
+using Equibles.Search.Abstractions;
 using Equibles.Web.Controllers.Abstract;
 using Equibles.Web.ViewModels.Search;
 using Microsoft.AspNetCore.Mvc;
@@ -19,13 +20,18 @@ public class SearchController : BaseController
     }
 
     [HttpGet]
-    public async Task<IActionResult> Index(string q, string category)
+    public async Task<IActionResult> Index(string q, string category, SearchSort sort)
     {
         ViewData["Title"] = "Search";
 
         // Aggregator returns every non-empty group; the view filters for display so the category
         // chips can still list all matched categories even when one is selected.
-        var groups = await _searchAggregator.Search(q, MaxPerProvider, HttpContext.RequestAborted);
+        var groups = await _searchAggregator.Search(
+            q,
+            MaxPerProvider,
+            HttpContext.RequestAborted,
+            sort
+        );
 
         return View(
             new GlobalSearchViewModel
@@ -33,6 +39,7 @@ public class SearchController : BaseController
                 Query = q,
                 Groups = groups,
                 ActiveCategory = category,
+                SortBy = sort,
             }
         );
     }
@@ -40,9 +47,14 @@ public class SearchController : BaseController
     // Results-only fragment for instant (as-you-type) search. instant-search.js fetches this
     // and swaps it into the page; the markup is identical to Index's results region.
     [HttpGet]
-    public async Task<IActionResult> Results(string q, string category)
+    public async Task<IActionResult> Results(string q, string category, SearchSort sort)
     {
-        var groups = await _searchAggregator.Search(q, MaxPerProvider, HttpContext.RequestAborted);
+        var groups = await _searchAggregator.Search(
+            q,
+            MaxPerProvider,
+            HttpContext.RequestAborted,
+            sort
+        );
 
         return PartialView(
             "_Results",
@@ -51,6 +63,7 @@ public class SearchController : BaseController
                 Query = q,
                 Groups = groups,
                 ActiveCategory = category,
+                SortBy = sort,
             }
         );
     }

--- a/src/Equibles.Web/ViewModels/Search/GlobalSearchViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Search/GlobalSearchViewModel.cs
@@ -12,5 +12,8 @@ public class GlobalSearchViewModel
     /// <summary>Selected category filter; null means "all".</summary>
     public string ActiveCategory { get; set; }
 
+    /// <summary>Selected hit ordering.</summary>
+    public SearchSort SortBy { get; set; } = SearchSort.Relevance;
+
     public bool HasResults => Groups.Count > 0;
 }

--- a/src/Equibles.Web/Views/Search/Index.cshtml
+++ b/src/Equibles.Web/Views/Search/Index.cshtml
@@ -1,3 +1,4 @@
+@using Equibles.Search.Abstractions
 @using Equibles.Web.Search
 @model Equibles.Web.ViewModels.Search.GlobalSearchViewModel
 
@@ -34,6 +35,19 @@
             <button type="submit" class="btn btn-primary join-item" aria-label="Search" title="Search">
                 <icon name="magnifying-glass" size="5" />
             </button>
+        </div>
+        <!-- Sort order. instant-search.js submits it alongside q + category and re-renders. -->
+        <div class="mt-3 flex items-center gap-2 text-sm text-base-content/60">
+            <label for="search-sort">Sort by</label>
+            <select id="search-sort" name="sort" class="select select-bordered select-sm w-auto"
+                    aria-label="Sort results">
+                @foreach (var option in Html.GetEnumSelectList<SearchSort>()) {
+                    <option value="@option.Value"
+                            selected="@(option.Value == ((int)Model.SortBy).ToString())">
+                        @option.Text
+                    </option>
+                }
+            </select>
         </div>
     </form>
 

--- a/src/Equibles.Web/src/js/instant-search.js
+++ b/src/Equibles.Web/src/js/instant-search.js
@@ -8,6 +8,7 @@
 
     const input = form.querySelector('input[name="q"]');
     const scope = form.querySelector('select[name="category"]');
+    const sort = form.querySelector('select[name="sort"]');
     if (!input) return;
 
     const resultsUrl = form.dataset.resultsUrl || '/Search/Results';
@@ -22,8 +23,10 @@
         const params = new URLSearchParams();
         const q = input.value.trim();
         const category = scope ? scope.value : '';
+        const sortBy = sort ? sort.value : '';
         if (q) params.set('q', q);
         if (category) params.set('category', category);
+        if (sortBy && sortBy !== '0') params.set('sort', sortBy);
 
         if (controller) controller.abort();
         controller = new AbortController();
@@ -53,6 +56,7 @@
         timer = setTimeout(() => run(false), 250);
     });
     scope?.addEventListener('change', () => run(false));
+    sort?.addEventListener('change', () => run(false));
     form.addEventListener('submit', (event) => {
         event.preventDefault();
         clearTimeout(timer);
@@ -64,6 +68,7 @@
         const params = new URLSearchParams(window.location.search);
         input.value = params.get('q') || '';
         if (scope) scope.value = params.get('category') || '';
+        if (sort) sort.value = params.get('sort') || '0';
         run(false);
     });
 })();

--- a/tests/Equibles.IntegrationTests/Web/SearchControllerSortTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/SearchControllerSortTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Covers the global search <c>sort</c> flow end to end: the SearchController
+/// binds <c>?sort=</c> for both the full page (<c>Index</c>) and the instant
+/// fragment (<c>Results</c>), and the aggregator applies it. <c>Name</c> must
+/// alphabetise hits within a group; <c>Relevance</c> (and an unparseable value,
+/// which model-binds to the default) must not 500.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class SearchControllerSortTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public SearchControllerSortTests(WebHostFixture fixture) => _fixture = fixture;
+
+    private async Task SeedTwoStocks()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "GXZ",
+                    Name = "Globex Zeta Corp",
+                    MarketCapitalization = 1_000_000_000d,
+                }
+            );
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "GXA",
+                    Name = "Globex Alpha Corp",
+                    MarketCapitalization = 2_000_000_000d,
+                }
+            );
+            await Task.CompletedTask;
+        });
+    }
+
+    [Fact]
+    public async Task Index_SortByName_AlphabetisesHitsWithinGroup()
+    {
+        await SeedTwoStocks();
+
+        var response = await _fixture.Client.GetAsync("/Search?q=Globex&sort=Name");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.IndexOf("Globex Alpha Corp", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(html.IndexOf("Globex Zeta Corp", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Results_SortByRelevance_ReturnsFragmentWithoutError()
+    {
+        await SeedTwoStocks();
+
+        var response = await _fixture.Client.GetAsync("/Search/Results?q=Globex&sort=Relevance");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Globex");
+    }
+
+    [Fact]
+    public async Task Index_UnparseableSort_DegradesToDefaultNot500()
+    {
+        await SeedTwoStocks();
+
+        var response = await _fixture.Client.GetAsync("/Search?q=Globex&sort=not-a-sort");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/Equibles.UnitTests/Search/SearchAggregatorTests.cs
+++ b/tests/Equibles.UnitTests/Search/SearchAggregatorTests.cs
@@ -66,6 +66,63 @@ public class SearchAggregatorTests
         result.Select(g => g.Category).Should().Equal("Alpha", "Beta");
     }
 
+    private static SearchResultGroup GroupWithTitles(string category, params string[] titles)
+    {
+        return new SearchResultGroup
+        {
+            Category = category,
+            Order = 0,
+            Hits = titles.Select(t => new SearchHit { Title = t }).ToList(),
+        };
+    }
+
+    [Fact]
+    public async Task Search_SortByName_OrdersHitsByTitleCaseInsensitive()
+    {
+        var aggregator = Build(
+            new StubA(
+                "Stocks",
+                0,
+                _ => GroupWithTitles("Stocks", "delta", "Alpha", "charlie", "Bravo")
+            )
+        );
+
+        var result = await aggregator.Search("are", 5, CancellationToken.None, SearchSort.Name);
+
+        result.Should().ContainSingle();
+        result[0].Hits.Select(h => h.Title).Should().Equal("Alpha", "Bravo", "charlie", "delta");
+    }
+
+    [Fact]
+    public async Task Search_SortByRelevance_PreservesProviderHitOrder()
+    {
+        var aggregator = Build(
+            new StubA("Stocks", 0, _ => GroupWithTitles("Stocks", "zeta", "alpha", "mid"))
+        );
+
+        var result = await aggregator.Search(
+            "are",
+            5,
+            CancellationToken.None,
+            SearchSort.Relevance
+        );
+
+        result.Should().ContainSingle();
+        result[0].Hits.Select(h => h.Title).Should().Equal("zeta", "alpha", "mid");
+    }
+
+    [Fact]
+    public async Task Search_DefaultSort_PreservesProviderHitOrder()
+    {
+        var aggregator = Build(
+            new StubA("Stocks", 0, _ => GroupWithTitles("Stocks", "zeta", "alpha", "mid"))
+        );
+
+        var result = await aggregator.Search("are", 5, CancellationToken.None);
+
+        result[0].Hits.Select(h => h.Title).Should().Equal("zeta", "alpha", "mid");
+    }
+
     [Fact]
     public async Task Search_OneProviderThrows_OtherGroupsStillReturned()
     {


### PR DESCRIPTION
## Summary

- Global search only exposed the category scope filter — users had no way to reorder hits. This adds a **Sort by** control (Relevance | Name A–Z) next to the search box, wired through the existing instant-search flow (no full reload).
- Sorting is applied centrally in `SearchAggregator` on the hits providers return, so **no provider changes** are needed — providers stay MVC/feature-agnostic and the change stays contained.
- Partial slice of #935 (richer global search filters).

## Code changes

- `src/Equibles.Search.Abstractions/SearchSort.cs` (new) — `SearchSort` enum (`Relevance`, `Name`) with `[Display]` labels.
- `src/Equibles.Search.Abstractions/SearchRequest.cs` — add `SortBy` (default `Relevance`).
- `src/Equibles.Search/SearchAggregator.cs` — `Search` takes an optional `SearchSort`; `Name` applies a stable `OrdinalIgnoreCase` title sort to each group's hits, `Relevance` keeps provider ranking.
- `src/Equibles.Web/Controllers/SearchController.cs` — `Index`/`Results` bind `?sort=` and pass it through.
- `src/Equibles.Web/ViewModels/Search/GlobalSearchViewModel.cs` — carry the selected `SortBy` back to the view.
- `src/Equibles.Web/Views/Search/Index.cshtml` — render the sort `<select>` via `Html.GetEnumSelectList<SearchSort>()`.
- `src/Equibles.Web/src/js/instant-search.js` — submit `sort` alongside `q`/`category`, react to its change, and re-sync on `popstate`.

Verified live: control renders, changing it fires instant-search and updates the URL to `?...&sort=1`; full solution build, Razor publish, and 32 search unit tests all green.