### PR TITLE
feat(web): visible clear button for the search box

### DIFF
--- a/src/Equibles.Web/Views/Search/Index.cshtml
+++ b/src/Equibles.Web/Views/Search/Index.cshtml
@@ -32,6 +32,11 @@
                    class="input input-bordered join-item grow"
                    aria-label="Search everything"
                    placeholder="Search for a ticker, company, filing, indicator..." autofocus />
+            <button type="button" id="search-clear"
+                    class="btn btn-ghost border border-base-300 join-item @(string.IsNullOrEmpty(Model.Query) ? "hidden" : "")"
+                    aria-label="Clear search" title="Clear search">
+                <icon name="x-mark" size="5" />
+            </button>
             <button type="submit" class="btn btn-primary join-item" aria-label="Search" title="Search">
                 <icon name="magnifying-glass" size="5" />
             </button>

--- a/src/Equibles.Web/src/index.js
+++ b/src/Equibles.Web/src/index.js
@@ -26,3 +26,4 @@ import './js/docs-nav';
 import './js/instant-search';
 import './js/search-keyboard';
 import './js/global-search-shortcut';
+import './js/search-clear';

--- a/src/Equibles.Web/src/js/search-clear.js
+++ b/src/Equibles.Web/src/js/search-clear.js
@@ -1,0 +1,28 @@
+// Visible clear (✕) button for the /Search query box. Escape already clears the
+// field (search-keyboard.js), but that is keyboard-only and undiscoverable — this
+// gives a mouse affordance and keeps it in sync with what the user has typed.
+//
+// Clearing dispatches a bubbling `input` event so instant-search.js re-queries and
+// swaps back to the empty state; no separate reset path to keep in sync.
+
+(() => {
+    const form = document.getElementById('global-search-form');
+    const button = document.getElementById('search-clear');
+    if (!form || !button) return;
+
+    const input = form.querySelector('input[name="q"]');
+    if (!input) return;
+
+    const sync = () => button.classList.toggle('hidden', input.value.length === 0);
+
+    input.addEventListener('input', sync);
+
+    button.addEventListener('click', () => {
+        input.value = '';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.focus();
+    });
+
+    // Reflect the field's initial state (e.g. on a server-rendered query).
+    sync();
+})();


### PR DESCRIPTION
## Summary

- `Escape` already clears the `/Search` query (search-keyboard.js) but that is keyboard-only and undiscoverable. This adds a visible ✕ button so the search is easy to reset by mouse — Nielsen #3 (user control & freedom), continuing the discoverability theme of the `/` shortcut and sort controls.
- The button shows only when the box has text; clicking it empties the field, refocuses it, and dispatches `input` so instant-search.js swaps back to the empty state — no separate reset path to keep in sync.

## Code changes

- `src/Equibles.Web/Views/Search/Index.cshtml` — ✕ `join-item` between the input and submit button; server-rendered `hidden` when the query is empty so it is correct before JS runs.
- `src/Equibles.Web/src/js/search-clear.js` (new) — toggles the button's visibility on `input`, wires the click (clear + refocus + dispatch `input`).
- `src/Equibles.Web/src/index.js` — register the new module in the bundle.

Verified live: ✕ appears only with text, clears + refocuses + resets to the empty state, URL returns to `/search`, reappears on typing; no console errors; web build + Vite bundle green.