### PR TITLE
feat(web): show result count summary on search

### DIFF
--- a/src/Equibles.Web/Views/Search/_Results.cshtml
+++ b/src/Equibles.Web/Views/Search/_Results.cshtml
@@ -39,6 +39,17 @@
         <p class="text-sm text-base-content/50">Try a ticker symbol, company name, or filing type.</p>
     </div>
 } else {
+    <!-- Result count: visibility of system status — tells the user how broad the
+         match is before they scan the groups. -->
+    <p class="text-sm text-base-content/60 mb-3">
+        <span class="font-semibold text-base-content">@visibleGroups.Sum(g => g.Hits.Count)</span>
+        @(visibleGroups.Sum(g => g.Hits.Count) == 1 ? "result" : "results") for
+        <span class="font-semibold text-base-content">@Model.Query</span>
+        in @(string.IsNullOrWhiteSpace(Model.ActiveCategory)
+            ? (visibleGroups.Count == 1 ? "1 category" : $"{visibleGroups.Count} categories")
+            : Model.ActiveCategory)
+    </p>
+
     <!-- Category filter chips -->
     <div class="flex flex-wrap gap-2 mb-6">
         <a asp-action="Index" asp-route-q="@Model.Query"


### PR DESCRIPTION
## Summary

- The results page jumped straight to the category chips with no at-a-glance sense of how broad a match was (Nielsen #1, visibility of system status). Adds a concise "**N** results for **<query>** in <scope>" line above the chips.
- `<scope>` is the active category when one is selected, otherwise the matched-category count ("1 category" / "N categories"). Counts reflect the hits shown — same `MaxPerProvider` cap the existing per-group chip counts use — so the two stay consistent.
- Continues the #935 slice (richer, easier search): after `/` shortcut (#934), sort (#936) and clear button (#937), this is the result-count indicator.

## Code changes

- `src/Equibles.Web/Views/Search/_Results.cshtml` — inline summary `<p>` rendered in the shared partial, so it appears for both the full page and the instant-search fragment; uses Razor expressions (no code block) for the count and scope label.

Verified live: "6 results for **a** in 1 category" (all) and "6 results for **a** in Stocks" (filtered); no console errors; web build green.