### PR TITLE
style(web): simplify navbar search to a single query box

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -33,32 +33,22 @@
                 </nav>
             </div>
             <div class="flex items-center gap-2">
-                <!-- Global search: scope + query posted to SearchController.Index as ?category=&q=.
-                     Echoes the active category and query so the navbar reflects the current
-                     search and the chosen scope survives refining from any page. -->
+                <!-- Global search: a single query box that GETs SearchController.Index.
+                     Kept deliberately minimal — the /Search page owns category and sort
+                     refinement. Echoes the active query so the box reflects the current search. -->
                 @{
-                    var activeSearchCategory = Context.Request.Query["category"].ToString();
                     var activeSearchQuery = Context.Request.Query["q"].ToString();
                 }
                 <form asp-controller="Search" asp-action="Index" method="get" class="hidden lg:block">
                     <div class="join">
-                        <select name="category" class="select select-sm select-bordered join-item"
-                                aria-label="Limit search to a category">
-                            <option value="">All</option>
-                            @foreach (var category in Equibles.Web.Search.SearchCategories.All) {
-                                <option value="@category"
-                                        selected="@(string.Equals(category, activeSearchCategory, StringComparison.OrdinalIgnoreCase))">
-                                    @category
-                                </option>
-                            }
-                        </select>
-                        <label class="input input-sm input-bordered join-item flex items-center gap-2 w-44 xl:w-56">
+                        <input id="navbar-search-input" type="search" name="q" value="@activeSearchQuery"
+                               class="input input-sm input-bordered join-item w-48 xl:w-64"
+                               placeholder="Search..." aria-label="Search everything"
+                               aria-keyshortcuts="/" />
+                        <button type="submit" class="btn btn-sm btn-primary join-item"
+                                aria-label="Search" title="Search">
                             <icon name="magnifying-glass" size="4" />
-                            <input id="navbar-search-input" type="search" name="q" value="@activeSearchQuery" class="grow"
-                                   placeholder="Search everything..." aria-label="Search everything"
-                                   aria-keyshortcuts="/" />
-                            <kbd class="kbd kbd-sm text-base-content/50" aria-hidden="true">/</kbd>
-                        </label>
+                        </button>
                     </div>
                 </form>
                 <a href="https://github.com/daniel3303/Equibles" target="_blank" class="btn btn-ghost btn-sm" title="GitHub">


### PR DESCRIPTION
## Summary

- The navbar's top-bar search joined a category `<select>` to the input — visual noise in a global header. The `/Search` page already owns category and sort refinement.
- Replace it with a single query input plus a primary submit button carrying the magnifying-glass icon on the right: simple, modern, one obvious action.

## Code changes

- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — removed the category `<select>`, the `activeSearchCategory` echo, the decorative leading icon and the `/` `<kbd>` hint from the navbar search. Kept `id="navbar-search-input"` (used by `global-search-shortcut.js`), `name="q"`, `type="search"`, the active-query echo, and `aria-keyshortcuts="/"`. Added a `btn-primary` submit button with the search icon.