### PR TITLE
feat(web): recoverable empty state when a category filter hides all hits

### DIFF
--- a/src/Equibles.Web/Views/Search/_Results.cshtml
+++ b/src/Equibles.Web/Views/Search/_Results.cshtml
@@ -64,6 +64,22 @@
         }
     </div>
 
+    @if (!visibleGroups.Any()) {
+        <!-- The active category matched nothing, but other categories did — make the
+             dead-end recoverable in one click instead of showing a blank panel. -->
+        <div class="flex flex-col items-center text-center py-16 gap-4">
+            <icon name="magnifying-glass" size="10" class="text-base-content/30" />
+            <p class="text-base-content/70">
+                No <span class="font-semibold text-base-content">@Model.ActiveCategory</span>
+                results for <span class="font-semibold text-base-content">@Model.Query</span>,
+                but @Model.Groups.Sum(g => g.Hits.Count) match in other categories.
+            </p>
+            <a asp-action="Index" asp-route-q="@Model.Query" class="btn btn-primary">
+                Show all results
+            </a>
+        </div>
+    }
+
     <!-- Result groups -->
     <div class="grid gap-6 md:grid-cols-2 items-start">
         @foreach (var group in visibleGroups) {


### PR DESCRIPTION
## Summary

- Searching with a category scope that matches nothing — while other categories *do* match — rendered the count line and chips over a blank panel ("0 results for apple in Futures" with an empty body). The user had no obvious way out (Nielsen #9, help users recover from errors).
- Now that dead-end shows a clear empty state and a one-click "Show all results" button that drops the category. Continues the #935 ease-of-use slice (after `/` shortcut, sort, clear, result count).

## Code changes

- `src/Equibles.Web/Views/Search/_Results.cshtml` — when `visibleGroups` is empty but `Model.Groups` has matches, render a magnifying-glass empty state naming the active category + how many matched elsewhere, plus a primary `asp-action="Index"` button with only `q` (no category). Normal-result and no-match-at-all states are unchanged.

Verified live: `?q=apple&category=Futures` now shows "No **Futures** results for **apple**, but 1 match in other categories" + working "Show all results" → `/search?q=apple`; normal `?q=apple` unchanged (1 card, no recovery block); no console errors; web build green.