### PR TITLE
fix(sec): reject whitespace-only Sec:ContactEmail in SEC-ban gate

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -42,7 +42,7 @@ public class SecEdgarClient : ISecEdgarClient
         _logger = logger;
 
         var contactEmail = configuration["Sec:ContactEmail"];
-        if (!string.IsNullOrEmpty(contactEmail))
+        if (!string.IsNullOrWhiteSpace(contactEmail))
         {
             _httpClient.DefaultRequestHeaders.Add(
                 "User-Agent",

--- a/src/Equibles.Sec.FinancialFacts.HostedService/FinancialFactsScraperWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/FinancialFactsScraperWorker.cs
@@ -38,7 +38,7 @@ public class FinancialFactsScraperWorker : BaseScraperWorker
 
     protected override bool ValidateConfiguration()
     {
-        if (string.IsNullOrEmpty(_configuration["Sec:ContactEmail"]))
+        if (string.IsNullOrWhiteSpace(_configuration["Sec:ContactEmail"]))
         {
             Logger.LogWarning(
                 "Financial facts scraper stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsScraperWorkerWhitespaceEmailTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsScraperWorkerWhitespaceEmailTests.cs
@@ -11,7 +11,7 @@ namespace Equibles.UnitTests.Sec;
 
 public class FinancialFactsScraperWorkerWhitespaceEmailTests
 {
-    [Fact(Skip = "GH-916 — whitespace-only Sec:ContactEmail passes the SEC-ban gate")]
+    [Fact]
     public void ValidateConfiguration_SecContactEmailWhitespaceOnly_ReturnsFalse()
     {
         // Contract: the gate exists so the scraper never hits SEC without a usable


### PR DESCRIPTION
## Summary

- A whitespace-only `Sec:ContactEmail` (e.g. `"   "` from a stray `.env` line) passed the SEC-ban gate because both checks used `string.IsNullOrEmpty`. The scraper then issued SEC requests with `User-Agent: Equibles Open Source/1.0 (   )` — no real contact — triggering the exact 403 ban the gate exists to prevent.
- Fixes #916 by treating a whitespace-only contact email as unset at both call sites.

## Code changes

- `src/Equibles.Sec.FinancialFacts.HostedService/FinancialFactsScraperWorker.cs` — `ValidateConfiguration` now uses `string.IsNullOrWhiteSpace`, so the worker stops (and logs the "not configured" warning) on a whitespace-only contact email.
- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — same `IsNullOrEmpty` → `IsNullOrWhiteSpace` change in User-Agent construction, keeping the gate and the actual request consistent.
- `tests/Equibles.UnitTests/Sec/FinancialFactsScraperWorkerWhitespaceEmailTests.cs` — un-skipped the committed regression test (`ValidateConfiguration_SecContactEmailWhitespaceOnly_ReturnsFalse`); it fails on pre-fix code, passes after.

closes #916