### PR TITLE
style(web): richer search result groups

### DIFF
--- a/src/Equibles.Web/Views/Search/_Results.cshtml
+++ b/src/Equibles.Web/Views/Search/_Results.cshtml
@@ -5,6 +5,21 @@
     var visibleGroups = string.IsNullOrWhiteSpace(Model.ActiveCategory)
         ? Model.Groups
         : Model.Groups.Where(g => string.Equals(g.Category, Model.ActiveCategory, StringComparison.OrdinalIgnoreCase)).ToList();
+
+    // Maps each search category to its module's Heroicon so result groups are
+    // scannable at a glance instead of being seven near-identical text cards.
+    // Unknown categories fall back to the generic search glyph.
+    string CategoryIcon(string category) => category switch
+    {
+        "Stocks" => "chart-bar",
+        "SEC Filings" => "document-text",
+        "Economic Indicators" => "presentation-chart-line",
+        "Institutions" => "building-library",
+        "Insiders" => "user-group",
+        "Congress" => "building-office",
+        "Futures" => "cube",
+        _ => "magnifying-glass",
+    };
 }
 
 @if (string.IsNullOrWhiteSpace(Model.Query)) {
@@ -68,30 +83,40 @@
     <div class="grid gap-6 md:grid-cols-2 items-start">
         @foreach (var group in visibleGroups) {
             var seeAll = Url.CategoryUrl(group.Category, Model.Query);
-            <div class="card bg-base-100 shadow-sm">
+            <div class="card bg-base-100 shadow-sm transition-shadow hover:shadow-md">
                 <div class="card-body p-4 lg:p-6">
-                    <div class="flex items-center justify-between mb-2">
-                        <h2 class="card-title text-lg">@group.Category</h2>
+                    <div class="flex items-center justify-between mb-3">
+                        <div class="flex items-center gap-3 min-w-0">
+                            <span class="flex items-center justify-center size-9 rounded-lg bg-primary/10 text-primary shrink-0">
+                                <icon name="@CategoryIcon(group.Category)" size="5" />
+                            </span>
+                            <h2 class="card-title text-lg truncate">@group.Category</h2>
+                            <span class="badge badge-ghost badge-sm shrink-0">@group.Hits.Count</span>
+                        </div>
                         @if (seeAll != null) {
-                            <a href="@seeAll" class="link link-primary text-sm">See all</a>
+                            <a href="@seeAll" class="link link-primary text-sm shrink-0">See all</a>
                         }
                     </div>
                     <ul class="divide-y divide-base-200">
                         @foreach (var hit in group.Hits) {
                             var hitUrl = Url.HitUrl(hit);
-                            <li class="py-2">
+                            <li>
                                 @if (hitUrl != null) {
-                                    <a href="@hitUrl" class="block hover:bg-base-200 rounded px-2 -mx-2 py-1">
-                                        <div class="font-medium">@hit.Title</div>
-                                        @if (!string.IsNullOrWhiteSpace(hit.Subtitle)) {
-                                            <div class="text-sm text-base-content/60">@hit.Subtitle</div>
-                                        }
+                                    <a href="@hitUrl" class="group flex items-center gap-3 hover:bg-base-200 rounded-lg px-3 -mx-3 py-2.5 transition-colors">
+                                        <span class="min-w-0 grow">
+                                            <span class="block font-medium truncate">@hit.Title</span>
+                                            @if (!string.IsNullOrWhiteSpace(hit.Subtitle)) {
+                                                <span class="block text-sm text-base-content/60 truncate">@hit.Subtitle</span>
+                                            }
+                                        </span>
+                                        <icon name="chevron-right" size="4"
+                                              class="text-base-content/30 shrink-0 opacity-0 -translate-x-1 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
                                     </a>
                                 } else {
-                                    <div class="px-2 -mx-2 py-1">
-                                        <div class="font-medium">@hit.Title</div>
+                                    <div class="px-3 -mx-3 py-2.5">
+                                        <span class="block font-medium truncate">@hit.Title</span>
                                         @if (!string.IsNullOrWhiteSpace(hit.Subtitle)) {
-                                            <div class="text-sm text-base-content/60">@hit.Subtitle</div>
+                                            <span class="block text-sm text-base-content/60 truncate">@hit.Subtitle</span>
                                         }
                                     </div>
                                 }


### PR DESCRIPTION
## Summary

- After searching, the `/Search` result groups were seven near-identical text-only cards. This makes the results page scannable and modern, addressing the "after searching the page should be rich" goal.

## Code changes

- `src/Equibles.Web/Views/Search/_Results.cshtml`:
  - Added a `CategoryIcon` map (category → existing module Heroicon, generic fallback).
  - Group headers now show the category icon in a primary-tinted rounded badge plus a hit-count badge; cards lift on hover.
  - Hit rows are taller, truncate cleanly, and reveal a chevron affordance on hover so their clickability is obvious.
- No new dependencies or design-token values — existing DaisyUI/Tailwind utilities only.