### PR TITLE
test(congress): pin IsValidDisclosureUrl rejects https→http scheme downgrade

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlSchemeTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlSchemeTests.cs
@@ -1,0 +1,31 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperIsValidUrlSchemeTests
+{
+    // Contract: "scheme, host and port must match exactly." Existing tests pin
+    // the host-prefix SSRF bypass and the null case, but NOT the scheme half.
+    // A URL on the exact correct host with the scheme downgraded https→http is
+    // a classic SSRF/MITM vector the guard must reject — while the legitimate
+    // https origin must still be accepted (proves the predicate isn't vacuous).
+    [Fact]
+    public void IsValidDisclosureUrl_SchemeDowngradedToHttpOnExactHost_ReturnsFalse()
+    {
+        const string baseUrl = "https://disclosures-clerk.house.gov";
+
+        var downgraded = DisclosureParsingHelper.IsValidDisclosureUrl(
+            "http://disclosures-clerk.house.gov/public_disc/financial-pdfs/2025FD.zip",
+            baseUrl
+        );
+        var legitimate = DisclosureParsingHelper.IsValidDisclosureUrl(
+            "https://disclosures-clerk.house.gov/public_disc/financial-pdfs/2025FD.zip",
+            baseUrl
+        );
+
+        downgraded
+            .Should()
+            .BeFalse("an http:// downgrade is not the https origin and must be rejected");
+        legitimate.Should().BeTrue("the exact https origin is the only allowed source");
+    }
+}


### PR DESCRIPTION
## Summary

- `IsValidDisclosureUrl`'s contract requires "scheme, host and port must match exactly". The host-prefix SSRF bypass and the null case are already pinned, but the **scheme** half was not — an `https→http` downgrade on the exact correct host is a classic SSRF/MITM vector.
- Adds one adversarial unit test deriving its oracle from that contract; it passes, so the guard is now a pinned security guarantee.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlSchemeTests.cs` — one `[Fact]`: an `http://` URL on the exact `disclosures-clerk.house.gov` host is rejected, while the legitimate `https://` origin is accepted (control proves the predicate is not vacuously false). Covers the scheme-comparison branch of the security predicate.