### PR TITLE
fix(sec): persist financial facts — Guid keys must be client-generated

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialConcept.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialConcept.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +13,10 @@ namespace Equibles.Sec.FinancialFacts.Data.Models;
 [Index(nameof(Taxonomy), nameof(Tag), IsUnique = true)]
 public class FinancialConcept
 {
+    // Client-generated Guid key. Without DatabaseGeneratedOption.None EF marks
+    // it store-generated, so FlexLabs UpsertRange omits it from the INSERT and
+    // Postgres (no column default) rejects the row with a NOT NULL violation.
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public Guid Id { get; set; } = Guid.NewGuid();
 
     public FactTaxonomy Taxonomy { get; set; }

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFact.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFact.cs
@@ -28,6 +28,10 @@ namespace Equibles.Sec.FinancialFacts.Data.Models;
 )]
 public class FinancialFact
 {
+    // Client-generated Guid key. Without DatabaseGeneratedOption.None EF marks
+    // it store-generated, so FlexLabs UpsertRange omits it from the INSERT and
+    // Postgres (no column default) rejects the row with a NOT NULL violation.
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public Guid Id { get; set; } = Guid.NewGuid();
 
     public Guid CommonStockId { get; set; }

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFactsSyncStatus.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFactsSyncStatus.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations.Schema;
 using Equibles.CommonStocks.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,6 +11,10 @@ namespace Equibles.Sec.FinancialFacts.Data.Models;
 [Index(nameof(CommonStockId), IsUnique = true)]
 public class FinancialFactsSyncStatus
 {
+    // Client-generated Guid key. Without DatabaseGeneratedOption.None EF marks
+    // it store-generated, so FlexLabs UpsertRange omits it from the INSERT and
+    // Postgres (no column default) rejects the row with a NOT NULL violation.
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public Guid Id { get; set; } = Guid.NewGuid();
 
     public Guid CommonStockId { get; set; }

--- a/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceDedupTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceDedupTests.cs
@@ -74,7 +74,7 @@ public class FinancialFactsImportServiceDedupTests : IAsyncLifetime
         return scopeFactory;
     }
 
-    [Fact(Skip = "GH-883 — duplicate-tuple Company Facts import persists zero rows")]
+    [Fact]
     public async Task Import_DuplicateConceptPeriodAccessionTuples_CollapsesToLatestFiledOneRow()
     {
         var apple = new CommonStock

--- a/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceIdempotencyTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceIdempotencyTests.cs
@@ -74,7 +74,7 @@ public class FinancialFactsImportServiceIdempotencyTests : IAsyncLifetime
         return scopeFactory;
     }
 
-    [Fact(Skip = "GH-911 — single non-duplicate Company Facts value persists zero rows")]
+    [Fact]
     public async Task Import_RunTwiceWithIdenticalFacts_SecondRunIsNoOpNoDuplicateRows()
     {
         var apple = new CommonStock


### PR DESCRIPTION
## Summary

- `FinancialFactsImportService.Import` persisted **zero** `FinancialFact` rows: EF marked the Guid PKs of `FinancialConcept` / `FinancialFact` / `FinancialFactsSyncStatus` as store-generated, so FlexLabs `UpsertRange` omitted `Id` from the INSERT; Postgres (no column default) rejected every row with `23502 NOT NULL`, swallowed by the per-company catch.
- Root cause confirmed by un-skipping and running the two committed regression tests against ParadeDB; both now pass.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Data/Models/FinancialConcept.cs`, `FinancialFact.cs`, `FinancialFactsSyncStatus.cs` — add `[DatabaseGenerated(DatabaseGeneratedOption.None)]` to the Guid `Id`, matching the working `FailToDeliver` pattern. Metadata-only — no DDL change, no migration.
- `tests/Equibles.IntegrationTests/Sec/FinancialFactsImportServiceDedupTests.cs`, `FinancialFactsImportServiceIdempotencyTests.cs` — un-skip the regression tests (GH-883 / GH-911).

Closes #883
Closes #911