### PR TITLE
feat(web): date-range filter on global search

### DIFF
--- a/src/Equibles.Search.Abstractions/SearchRequest.cs
+++ b/src/Equibles.Search.Abstractions/SearchRequest.cs
@@ -10,4 +10,10 @@ public class SearchRequest
 
     /// <summary>How hits are ordered within each group; applied by the aggregator, not providers.</summary>
     public SearchSort SortBy { get; set; } = SearchSort.Relevance;
+
+    /// <summary>Inclusive lower bound on a hit's date; only providers with a date dimension honor it.</summary>
+    public DateOnly? DateFrom { get; set; }
+
+    /// <summary>Inclusive upper bound on a hit's date; only providers with a date dimension honor it.</summary>
+    public DateOnly? DateTo { get; set; }
 }

--- a/src/Equibles.Search/SearchAggregator.cs
+++ b/src/Equibles.Search/SearchAggregator.cs
@@ -28,7 +28,9 @@ public class SearchAggregator
         string query,
         int maxPerProvider,
         CancellationToken cancellationToken,
-        SearchSort sortBy = SearchSort.Relevance
+        SearchSort sortBy = SearchSort.Relevance,
+        DateOnly? dateFrom = null,
+        DateOnly? dateTo = null
     )
     {
         if (string.IsNullOrWhiteSpace(query))
@@ -54,6 +56,8 @@ public class SearchAggregator
             Query = query.Trim(),
             MaxPerProvider = maxPerProvider,
             SortBy = sortBy,
+            DateFrom = dateFrom,
+            DateTo = dateTo,
         };
 
         var groups = await Task.WhenAll(

--- a/src/Equibles.Sec.Repositories/Search/SecDocumentSearchProvider.cs
+++ b/src/Equibles.Sec.Repositories/Search/SecDocumentSearchProvider.cs
@@ -31,6 +31,8 @@ public class SecDocumentSearchProvider : ISearchProvider
         var chunks = await _chunkRepository.HybridSearch(
             request.Query,
             request.MaxPerProvider * ChunkOverFetchFactor,
+            startDate: request.DateFrom,
+            endDate: request.DateTo,
             cancellationToken: cancellationToken
         );
 

--- a/src/Equibles.Web/Controllers/SearchController.cs
+++ b/src/Equibles.Web/Controllers/SearchController.cs
@@ -20,7 +20,13 @@ public class SearchController : BaseController
     }
 
     [HttpGet]
-    public async Task<IActionResult> Index(string q, string category, SearchSort sort)
+    public async Task<IActionResult> Index(
+        string q,
+        string category,
+        SearchSort sort,
+        DateOnly? dateFrom,
+        DateOnly? dateTo
+    )
     {
         ViewData["Title"] = "Search";
 
@@ -30,7 +36,9 @@ public class SearchController : BaseController
             q,
             MaxPerProvider,
             HttpContext.RequestAborted,
-            sort
+            sort,
+            dateFrom,
+            dateTo
         );
 
         return View(
@@ -40,6 +48,8 @@ public class SearchController : BaseController
                 Groups = groups,
                 ActiveCategory = category,
                 SortBy = sort,
+                DateFrom = dateFrom,
+                DateTo = dateTo,
             }
         );
     }
@@ -47,13 +57,21 @@ public class SearchController : BaseController
     // Results-only fragment for instant (as-you-type) search. instant-search.js fetches this
     // and swaps it into the page; the markup is identical to Index's results region.
     [HttpGet]
-    public async Task<IActionResult> Results(string q, string category, SearchSort sort)
+    public async Task<IActionResult> Results(
+        string q,
+        string category,
+        SearchSort sort,
+        DateOnly? dateFrom,
+        DateOnly? dateTo
+    )
     {
         var groups = await _searchAggregator.Search(
             q,
             MaxPerProvider,
             HttpContext.RequestAborted,
-            sort
+            sort,
+            dateFrom,
+            dateTo
         );
 
         return PartialView(
@@ -64,6 +82,8 @@ public class SearchController : BaseController
                 Groups = groups,
                 ActiveCategory = category,
                 SortBy = sort,
+                DateFrom = dateFrom,
+                DateTo = dateTo,
             }
         );
     }

--- a/src/Equibles.Web/ViewModels/Search/GlobalSearchViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Search/GlobalSearchViewModel.cs
@@ -15,5 +15,10 @@ public class GlobalSearchViewModel
     /// <summary>Selected hit ordering.</summary>
     public SearchSort SortBy { get; set; } = SearchSort.Relevance;
 
+    /// <summary>Inclusive date-range filter (honored by date-aware providers, e.g. SEC Filings).</summary>
+    public DateOnly? DateFrom { get; set; }
+
+    public DateOnly? DateTo { get; set; }
+
     public bool HasResults => Groups.Count > 0;
 }

--- a/src/Equibles.Web/Views/Search/Index.cshtml
+++ b/src/Equibles.Web/Views/Search/Index.cshtml
@@ -41,18 +41,31 @@
                 <icon name="magnifying-glass" size="5" />
             </button>
         </div>
-        <!-- Sort order. instant-search.js submits it alongside q + category and re-renders. -->
-        <div class="mt-3 flex items-center gap-2 text-sm text-base-content/60">
-            <label for="search-sort">Sort by</label>
-            <select id="search-sort" name="sort" class="select select-bordered select-sm w-auto"
-                    aria-label="Sort results">
-                @foreach (var option in Html.GetEnumSelectList<SearchSort>()) {
-                    <option value="@option.Value"
-                            selected="@(option.Value == ((int)Model.SortBy).ToString())">
-                        @option.Text
-                    </option>
-                }
-            </select>
+        <!-- Sort + date range. instant-search.js submits these alongside q + category
+             and re-renders. The date range only narrows date-aware results (SEC filings). -->
+        <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-base-content/60">
+            <div class="flex items-center gap-2">
+                <label for="search-sort">Sort by</label>
+                <select id="search-sort" name="sort" class="select select-bordered select-sm w-auto"
+                        aria-label="Sort results">
+                    @foreach (var option in Html.GetEnumSelectList<SearchSort>()) {
+                        <option value="@option.Value"
+                                selected="@(option.Value == ((int)Model.SortBy).ToString())">
+                            @option.Text
+                        </option>
+                    }
+                </select>
+            </div>
+            <div class="flex items-center gap-2">
+                <label for="search-date-from">Filed between</label>
+                <input id="search-date-from" type="date" name="dateFrom"
+                       value="@(Model.DateFrom?.ToString("yyyy-MM-dd"))"
+                       class="input input-bordered input-sm w-auto" aria-label="Filed on or after" />
+                <span aria-hidden="true">–</span>
+                <input id="search-date-to" type="date" name="dateTo"
+                       value="@(Model.DateTo?.ToString("yyyy-MM-dd"))"
+                       class="input input-bordered input-sm w-auto" aria-label="Filed on or before" />
+            </div>
         </div>
     </form>
 

--- a/src/Equibles.Web/src/js/instant-search.js
+++ b/src/Equibles.Web/src/js/instant-search.js
@@ -9,6 +9,8 @@
     const input = form.querySelector('input[name="q"]');
     const scope = form.querySelector('select[name="category"]');
     const sort = form.querySelector('select[name="sort"]');
+    const dateFrom = form.querySelector('input[name="dateFrom"]');
+    const dateTo = form.querySelector('input[name="dateTo"]');
     if (!input) return;
 
     const resultsUrl = form.dataset.resultsUrl || '/Search/Results';
@@ -27,6 +29,8 @@
         if (q) params.set('q', q);
         if (category) params.set('category', category);
         if (sortBy && sortBy !== '0') params.set('sort', sortBy);
+        if (dateFrom?.value) params.set('dateFrom', dateFrom.value);
+        if (dateTo?.value) params.set('dateTo', dateTo.value);
 
         if (controller) controller.abort();
         controller = new AbortController();
@@ -57,6 +61,8 @@
     });
     scope?.addEventListener('change', () => run(false));
     sort?.addEventListener('change', () => run(false));
+    dateFrom?.addEventListener('change', () => run(false));
+    dateTo?.addEventListener('change', () => run(false));
     form.addEventListener('submit', (event) => {
         event.preventDefault();
         clearTimeout(timer);
@@ -69,6 +75,8 @@
         input.value = params.get('q') || '';
         if (scope) scope.value = params.get('category') || '';
         if (sort) sort.value = params.get('sort') || '0';
+        if (dateFrom) dateFrom.value = params.get('dateFrom') || '';
+        if (dateTo) dateTo.value = params.get('dateTo') || '';
         run(false);
     });
 })();

--- a/tests/Equibles.IntegrationTests/Web/SearchControllerDateFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/SearchControllerDateFilterTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Covers the global search date-range binding: SearchController binds
+/// <c>?dateFrom=</c>/<c>?dateTo=</c> (DateOnly) for both the full page
+/// (<c>Index</c>) and the instant fragment (<c>Results</c>) and threads them
+/// through the aggregator. Date-unaware providers (e.g. Stocks) ignore the
+/// bounds, so a stock query still returns with a range applied; an
+/// unparseable date model-binds to null rather than 500.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class SearchControllerDateFilterTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public SearchControllerDateFilterTests(WebHostFixture fixture) => _fixture = fixture;
+
+    private async Task SeedStock()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "GXA",
+                    Name = "Globex Alpha Corp",
+                    MarketCapitalization = 1_000_000_000d,
+                }
+            );
+            await Task.CompletedTask;
+        });
+    }
+
+    [Fact]
+    public async Task Index_WithDateRange_BindsAndStillReturnsDateUnawareGroups()
+    {
+        await SeedStock();
+
+        var response = await _fixture.Client.GetAsync(
+            "/Search?q=Globex&dateFrom=2024-01-01&dateTo=2024-12-31"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Globex Alpha Corp");
+    }
+
+    [Fact]
+    public async Task Results_WithDateFromOnly_ReturnsFragmentWithoutError()
+    {
+        await SeedStock();
+
+        var response = await _fixture.Client.GetAsync(
+            "/Search/Results?q=Globex&dateFrom=2023-06-15"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Index_UnparseableDate_DegradesToNullNot500()
+    {
+        await SeedStock();
+
+        var response = await _fixture.Client.GetAsync("/Search?q=Globex&dateFrom=not-a-date");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/Equibles.UnitTests/Search/SearchAggregatorTests.cs
+++ b/tests/Equibles.UnitTests/Search/SearchAggregatorTests.cs
@@ -124,6 +124,53 @@ public class SearchAggregatorTests
     }
 
     [Fact]
+    public async Task Search_DateRange_IsThreadedIntoTheProviderRequest()
+    {
+        SearchRequest captured = null;
+        var from = new DateOnly(2024, 1, 1);
+        var to = new DateOnly(2024, 6, 30);
+        var aggregator = Build(
+            new StubA(
+                "Stocks",
+                0,
+                request =>
+                {
+                    captured = request;
+                    return GroupWithTitles("Stocks", "AAPL");
+                }
+            )
+        );
+
+        await aggregator.Search("are", 5, CancellationToken.None, SearchSort.Relevance, from, to);
+
+        captured.Should().NotBeNull();
+        captured.DateFrom.Should().Be(from);
+        captured.DateTo.Should().Be(to);
+    }
+
+    [Fact]
+    public async Task Search_NoDateRange_LeavesProviderRequestBoundsNull()
+    {
+        SearchRequest captured = null;
+        var aggregator = Build(
+            new StubA(
+                "Stocks",
+                0,
+                request =>
+                {
+                    captured = request;
+                    return GroupWithTitles("Stocks", "AAPL");
+                }
+            )
+        );
+
+        await aggregator.Search("are", 5, CancellationToken.None);
+
+        captured.DateFrom.Should().BeNull();
+        captured.DateTo.Should().BeNull();
+    }
+
+    [Fact]
     public async Task Search_OneProviderThrows_OtherGroupsStillReturned()
     {
         var aggregator = Build(


### PR DESCRIPTION
## Summary

- Adds the most-requested missing search filter — a "Filed between" date range next to the sort control. `SearchRequest` now carries `DateFrom`/`DateTo`; date-aware providers honor them (SEC Filings passes them straight into `ChunkRepository.HybridSearch`'s existing `startDate`/`endDate`, filtering on `ReportingDate` at the DB level), date-unaware providers ignore them.
- Threaded exactly like the `sort` filter: optional aggregator params, controller binds `?dateFrom=`/`?dateTo=` (DateOnly) for Index + Results, the view model echoes them back, and instant-search.js submits + re-syncs on popstate. Closes the last shippable slice of #935.

## Code changes

- `Equibles.Search.Abstractions/SearchRequest.cs` — `DateFrom`/`DateTo` (`DateOnly?`).
- `Equibles.Search/SearchAggregator.cs` — optional `dateFrom`/`dateTo` params set on the request.
- `Equibles.Sec.Repositories/Search/SecDocumentSearchProvider.cs` — passes the bounds into `HybridSearch`.
- `Equibles.Web/Controllers/SearchController.cs` — binds `dateFrom`/`dateTo` on Index + Results, threads through, echoes to the view model.
- `Equibles.Web/ViewModels/Search/GlobalSearchViewModel.cs` — carries the selected range.
- `Equibles.Web/Views/Search/Index.cshtml` — "Filed between" `<input type="date">` pair in the filter row.
- `Equibles.Web/src/js/instant-search.js` — submits `dateFrom`/`dateTo`, reacts to change, re-syncs on popstate.
- `tests/Equibles.UnitTests/Search/SearchAggregatorTests.cs` — aggregator threads the range into the provider request / leaves it null when unset.
- `tests/Equibles.IntegrationTests/Web/SearchControllerDateFilterTests.cs` (new) — controller binds the range for Index + Results; unparseable date degrades to null, not 500.

Verified live: the date pair renders in the filter row, setting a date fires instant-search and updates the URL (`?…&dateFrom=2024-03-01`), value persists across the partial swap, no console errors. Solution build, Vite bundle, 11 unit + 3 integration tests all green.