### PR TITLE
test(holdings): pin Filing13FXmlParser.ParseSecDate MM-DD-YYYY ordering

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseSecDateTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseSecDateTests.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Filing13FXmlParserParseSecDateTests
+{
+    // Adversarial: the XML-doc contract states cover-page dates are MM-DD-YYYY.
+    // "02-03-2024" is the ambiguous case — under the documented US ordering it is
+    // February 3 2024, NOT March 2. A caller relies on this ordering; a regression
+    // to dd-MM-yyyy (or a culture-dependent fallback) would silently swap every
+    // such date. Pin the month/day ordering against that.
+    [Fact]
+    public void ParseSecDate_AmbiguousMonthDay_UsesDocumentedUsOrdering()
+    {
+        var parse = typeof(Filing13FXmlParser).GetMethod(
+            "ParseSecDate",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+        var result = (DateOnly)parse.Invoke(null, ["02-03-2024"])!;
+
+        result.Should().Be(new DateOnly(2024, 2, 3));
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `Filing13FXmlParser.ParseSecDate` (previously untested): pins the documented `MM-DD-YYYY` cover-page date contract for the ambiguous `"02-03-2024"` case — it must resolve to **February 3 2024** (US ordering), not March 2.
- Behavior confirmed correct; the test locks the month/day ordering against a regression to `dd-MM-yyyy` or a culture-dependent fallback that would silently swap every ambiguous date.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseSecDateTests.cs` — new single-`[Fact]` test invoking the private static `ParseSecDate` via reflection (the repo's established pattern for these parsers). No production code touched.