### PR TITLE
test(holdings): pin TryParseDateOnly SEC dd-MMM-yyyy leg invariant under ar-SA

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTryParseDateOnlySecCultureTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTryParseDateOnlySecCultureTests.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsParsingHelperTryParseDateOnlySecCultureTests
+{
+    // Contract (XML-doc): "Parses ... SEC (dd-MMM-yyyy) format" — unconditional,
+    // so it must hold on any host. The existing culture test only pins the ISO
+    // leg under ar-SA (Umm al-Qura); the SEC leg parses an English month
+    // abbreviation ("SEP") and only works because it passes InvariantCulture.
+    // Under ar-SA, a current-culture parse of "SEP" fails (Arabic month names),
+    // so a refactor dropping InvariantCulture from the TryParseExact leg would
+    // break SEC 13F dates on non-English-month hosts while every en/invariant
+    // test stayed green. Pin the SEC leg under the documented hostile culture.
+    [Fact]
+    public void TryParseDateOnly_SecFormatUnderHijriCalendarCulture_ReturnsGregorianDate()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+
+            var success = HoldingsParsingHelper.TryParseDateOnly("30-SEP-2024", out var result);
+
+            success.Should().BeTrue();
+            result.Should().Be(new DateOnly(2024, 9, 30));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `TryParseDateOnly`'s contract ("Parses ... SEC (dd-MMM-yyyy) format") is unconditional, but only the ISO leg is pinned under the documented hostile `ar-SA` Umm al-Qura culture; the SEC leg's English-month-abbreviation parse is only tested under en/invariant.
- Adds one adversarial unit test deriving its oracle from that clause; it passes, so the SEC leg's culture-invariance is now a pinned guarantee.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperTryParseDateOnlySecCultureTests.cs` — one `[Fact]`: under `CultureInfo.CurrentCulture = ar-SA`, `"30-SEP-2024"` must parse to Gregorian `2024-09-30` (forces the ISO leg to reject and the SEC `dd-MMM-yyyy` `TryParseExact` leg to handle it). Guards against a refactor dropping `InvariantCulture` from that leg — which would break SEC 13F dates only on non-English-month hosts while every existing test stayed green. Culture saved/restored in `finally`.