### PR TITLE
test(web): add skipped repro for GH-955 — ComputeRsi zero-loss RSI should be 100

### DIFF
--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceComputeRsiZeroLossTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceComputeRsiZeroLossTests.cs
@@ -1,0 +1,21 @@
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+public class TechnicalIndicatorServiceComputeRsiZeroLossTests
+{
+    // Oracle = the well-known RSI domain rule (Wilder 1978; StockCharts; Investopedia):
+    // RSI = 100 - 100/(1+RS), RS = avgGain/avgLoss. Over a window with NO losses,
+    // avgLoss = 0 so RS is infinite and RSI is 100 by definition (the overbought
+    // extreme). A strictly increasing series has zero losses, so its first
+    // computable RSI must be exactly 100. Asserting the contract, not the code.
+    [Fact(Skip = "GH-955 — ComputeRsi returns 99.01 not 100 for a zero-loss series")]
+    public void ComputeRsi_StrictlyIncreasingSeries_FirstValueIs100()
+    {
+        var prices = new List<decimal> { 1m, 2m, 3m, 4m, 5m };
+
+        var result = TechnicalIndicatorService.ComputeRsi(prices, 3);
+
+        result[3].Should().Be(100m, "a window with zero losses has infinite RS, so RSI is 100");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test derived from the well-known RSI domain rule found a real bug: `TechnicalIndicatorService.ComputeRsi` returns **99.01** (not **100**) for a zero-loss/strictly-increasing window, because the `rs = avgLoss == 0 ? 100m` sentinel caps RS at 100 instead of treating it as infinite.
- Filed as **#955**. The regression test is committed **skipped — see GH-955**; un-skip it as part of the fix. No production code changed.
- Note: the pre-existing `ComputeRsi_AllGains_ReturnsRsi100` test is misnamed and pins `99.01m` (its own comment flags the discrepancy) — it enshrined the defect; the issue calls for correcting it in the fix PR.

## Code changes

- `tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceComputeRsiZeroLossTests.cs` — one `[Fact(Skip = "GH-955 …")]`: `ComputeRsi([1,2,3,4,5], 3)[3]` must be `100m` per the standard RSI definition (zero average loss ⇒ infinite RS ⇒ RSI 100). Currently observes `99.01m`.