### PR TITLE
test(plugins): pin HasPluginAttribute returns false on a non-PE file without throwing

### DIFF
--- a/tests/Equibles.UnitTests/Plugins/PluginLoaderHasPluginAttributeCorruptFileTests.cs
+++ b/tests/Equibles.UnitTests/Plugins/PluginLoaderHasPluginAttributeCorruptFileTests.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using Equibles.Plugins;
+
+namespace Equibles.UnitTests.Plugins;
+
+public class PluginLoaderHasPluginAttributeCorruptFileTests
+{
+    private static readonly MethodInfo HasPluginAttributeMethod = typeof(PluginLoader).GetMethod(
+        "HasPluginAttribute",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    // Contract (PluginLoader XML-doc): third-party DLLs are opt-in and LoadAll
+    // runs at startup over every *.dll in the app directory. A file that exists
+    // but is NOT a valid PE/.NET image (PEReader throws BadImageFormatException)
+    // must be safely treated as "not a plugin" — false, no throw — or one stray
+    // junk .dll crashes startup. Existing pins cover missing-file and
+    // valid-DLL-without-attr; the corrupt-but-present file is a distinct catch.
+    [Fact]
+    public void HasPluginAttribute_FileExistsButIsNotAValidAssembly_ReturnsFalseWithoutThrowing()
+    {
+        var junkDll = Path.Combine(Path.GetTempPath(), $"equibles-junk-{Guid.NewGuid():N}.dll");
+        File.WriteAllText(junkDll, "this is plain text, not a PE image at all");
+        try
+        {
+            var act = () => (bool)HasPluginAttributeMethod.Invoke(null, [junkDll]);
+
+            act.Should().NotThrow().Which.Should().BeFalse();
+        }
+        finally
+        {
+            File.Delete(junkDll);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `PluginLoader.LoadAll` runs at startup over every `*.dll` in the app directory; `HasPluginAttribute`'s broad `catch` is pinned for *missing file* and *valid-DLL-without-attr*, but not for a file that exists yet is not a valid PE/.NET image (`PEReader` throws `BadImageFormatException`) — a distinct catch trigger.
- Adds one adversarial unit test deriving its oracle from the doc contract (third-party DLLs are opt-in; a stray junk `.dll` must be skipped, not crash startup). It passes, so the behavior is now a pinned guarantee.

## Code changes

- `tests/Equibles.UnitTests/Plugins/PluginLoaderHasPluginAttributeCorruptFileTests.cs` — one `[Fact]`: a temp `.dll` containing plain text (not a PE image) → `HasPluginAttribute` returns `false` and does not throw. Temp file cleaned up in `finally`. Mirrors the existing reflection-based test style.