### PR TITLE
feat(mcp): financial statement query tool

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -151,6 +151,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Search", "src\Equi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.SmokeTests", "tests\Equibles.SmokeTests\Equibles.SmokeTests.csproj", "{A15FB700-5BF7-4284-B695-FE04E80D258F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Sec.FinancialFacts.Mcp", "src\Equibles.Sec.FinancialFacts.Mcp\Equibles.Sec.FinancialFacts.Mcp.csproj", "{2E08AC17-1840-4BBE-A914-6133F83BB43B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1025,6 +1027,18 @@ Global
 		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Release|x64.Build.0 = Release|Any CPU
 		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Release|x86.ActiveCfg = Release|Any CPU
 		{A15FB700-5BF7-4284-B695-FE04E80D258F}.Release|x86.Build.0 = Release|Any CPU
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Debug|x64.Build.0 = Debug|Any CPU
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Debug|x86.Build.0 = Debug|Any CPU
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Release|x64.ActiveCfg = Release|Any CPU
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Release|x64.Build.0 = Release|Any CPU
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Release|x86.ActiveCfg = Release|Any CPU
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1102,6 +1116,7 @@ Global
 		{C0411D78-096D-41B4-ADE0-A9ABC76F703B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{CC59BCF3-6989-44DD-999A-95EEDF297F47} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{A15FB700-5BF7-4284-B695-FE04E80D258F} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{2E08AC17-1840-4BBE-A914-6133F83BB43B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.Mcp.Server/Equibles.Mcp.Server.csproj
+++ b/src/Equibles.Mcp.Server/Equibles.Mcp.Server.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\Equibles.Holdings.Mcp\Equibles.Holdings.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.InsiderTrading.Mcp\Equibles.InsiderTrading.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Sec.Mcp\Equibles.Sec.Mcp.csproj" />
+    <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Mcp\Equibles.Sec.FinancialFacts.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Fred.Mcp\Equibles.Fred.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Congress.Repositories\Equibles.Congress.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Finra.Repositories\Equibles.Finra.Repositories.csproj" />

--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -23,6 +23,7 @@ using Equibles.Mcp.Middleware;
 using Equibles.Media.Data.Extensions;
 using Equibles.Messaging.Extensions;
 using Equibles.Sec.Data.Extensions;
+using Equibles.Sec.FinancialFacts.Mcp.Extensions;
 using Equibles.Sec.Mcp.Extensions;
 using Equibles.Yahoo.Data.Extensions;
 using Equibles.Yahoo.Mcp.Extensions;
@@ -85,6 +86,7 @@ public partial class Program
             mcp.AddInsiderTrading();
             mcp.AddFred();
             mcp.AddSec();
+            mcp.AddFinancialFacts();
             mcp.AddCftc();
             mcp.AddCboe();
             mcp.AddCongress();

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Equibles.Sec.FinancialFacts.Mcp.csproj
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Equibles.Sec.FinancialFacts.Mcp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
+    <ProjectReference Include="..\Equibles.Mcp\Equibles.Mcp.csproj" />
+    <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Repositories\Equibles.Sec.FinancialFacts.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Extensions/McpBuilderExtensions.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Extensions/McpBuilderExtensions.cs
@@ -1,0 +1,12 @@
+using Equibles.Mcp;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.Sec.FinancialFacts.Mcp.Extensions;
+
+public static class McpBuilderExtensions
+{
+    public static EquiblesMcpBuilder AddFinancialFacts(this EquiblesMcpBuilder builder)
+    {
+        return builder.AddModule<AssemblyMcpModule<FinancialStatementTools>>();
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -1,0 +1,298 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Extensions;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Mcp;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+[McpServerToolType]
+public class FinancialStatementTools
+{
+    private readonly FinancialFactRepository _financialFactRepository;
+    private readonly FinancialConceptRepository _financialConceptRepository;
+    private readonly CommonStockRepository _commonStockRepository;
+    private readonly ErrorManager _errorManager;
+    private readonly ILogger<FinancialStatementTools> _logger;
+
+    public FinancialStatementTools(
+        FinancialFactRepository financialFactRepository,
+        FinancialConceptRepository financialConceptRepository,
+        CommonStockRepository commonStockRepository,
+        ErrorManager errorManager,
+        ILogger<FinancialStatementTools> logger
+    )
+    {
+        _financialFactRepository = financialFactRepository;
+        _financialConceptRepository = financialConceptRepository;
+        _commonStockRepository = commonStockRepository;
+        _errorManager = errorManager;
+        _logger = logger;
+    }
+
+    [McpServerTool(Name = "GetFinancialStatement")]
+    [Description(
+        "Get a company's income statement, balance sheet, or cash-flow statement for a "
+            + "given fiscal year and period, sourced from SEC Company Facts (structured XBRL). "
+            + "Returns the standard line items (e.g. revenue, net income, total assets, "
+            + "operating cash flow) with the latest-restated value for the period. "
+            + "Company-specific dimensional facts (e.g. product-segment revenue) are not included."
+    )]
+    public Task<string> GetFinancialStatement(
+        [Description("Stock ticker symbol (e.g., AAPL, MSFT, GME)")] string ticker,
+        [Description(
+            "Statement: 'income' (income statement), 'balance' (balance sheet), or "
+                + "'cashflow' (cash-flow statement). Defaults to income."
+        )]
+            string statement = "income",
+        [Description("Fiscal year, e.g. 2023. Defaults to the latest reported year.")]
+            int? year = null,
+        [Description(
+            "Fiscal period: 'FY' (annual) or 'Q1'..'Q4'. Defaults to the latest reported period."
+        )]
+            string period = null
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                if (string.IsNullOrWhiteSpace(ticker))
+                    return "A ticker symbol is required.";
+
+                var stock = await _commonStockRepository.GetByTicker(
+                    ticker.Trim().ToUpperInvariant()
+                );
+                if (stock == null)
+                    return $"Stock '{ticker}' not found.";
+
+                if (!TryParseStatement(statement, out var statementType))
+                    return $"Unknown statement '{statement}'. Use 'income', 'balance', or 'cashflow'.";
+
+                // Parse the period once into a nullable; null means "no explicit
+                // period requested" (default to latest), a value means the caller
+                // asked for that exact period.
+                SecFiscalPeriod? requestedPeriod = null;
+                if (period != null)
+                {
+                    if (!TryParsePeriod(period, out var parsedPeriod))
+                        return $"Unknown period '{period}'. Use 'FY' or 'Q1'..'Q4'.";
+                    requestedPeriod = parsedPeriod;
+                }
+
+                var availablePeriods = await _financialFactRepository
+                    .GetByStock(stock)
+                    .Select(f => new { f.FiscalYear, f.FiscalPeriod })
+                    .Distinct()
+                    .ToListAsync();
+
+                if (availablePeriods.Count == 0)
+                    return $"No structured financial facts have been ingested for {stock.Ticker}.";
+
+                var ordered = availablePeriods
+                    .OrderByDescending(p => p.FiscalYear)
+                    .ThenByDescending(p => ChronologicalRank(p.FiscalPeriod))
+                    .ToList();
+
+                // An explicit year/period must match exactly — never silently
+                // substitute a different period's figures for financial data.
+                // When neither is given, the first (chronologically latest) wins.
+                var selected = ordered.FirstOrDefault(p =>
+                    (year == null || p.FiscalYear == year)
+                    && (requestedPeriod == null || p.FiscalPeriod == requestedPeriod.Value)
+                );
+
+                if (selected == null)
+                {
+                    var latest = ordered[0];
+                    var wanted =
+                        $"{(year?.ToString() ?? "the latest year")} "
+                        + $"{(requestedPeriod?.NameForHumans() ?? "period")}";
+                    return $"{stock.Ticker} has no data for {wanted}. Latest available: "
+                        + $"FY{latest.FiscalYear} {latest.FiscalPeriod.NameForHumans()}.";
+                }
+
+                var statementLines = FinancialStatementConcepts.For(statementType);
+                var taxonomies = statementLines.Select(l => l.Taxonomy).Distinct().ToList();
+                var tags = statementLines.Select(l => l.Tag).Distinct().ToList();
+
+                var concepts = await _financialConceptRepository
+                    .GetMatching(taxonomies, tags)
+                    .Select(c => new
+                    {
+                        c.Id,
+                        c.Taxonomy,
+                        c.Tag,
+                    })
+                    .ToListAsync();
+                var conceptIdByKey = concepts.ToDictionary(c => (c.Taxonomy, c.Tag), c => c.Id);
+                var conceptIds = concepts.Select(c => c.Id).ToHashSet();
+
+                var facts = await _financialFactRepository
+                    .GetByStock(stock)
+                    .Where(f =>
+                        f.FiscalYear == selected.FiscalYear
+                        && f.FiscalPeriod == selected.FiscalPeriod
+                        && conceptIds.Contains(f.FinancialConceptId)
+                    )
+                    .ToListAsync();
+
+                // Restatements re-emit the same concept; the latest-filed value
+                // is the currently-reported one.
+                var latestByConcept = facts
+                    .GroupBy(f => f.FinancialConceptId)
+                    .ToDictionary(g => g.Key, g => g.OrderByDescending(f => f.FiledDate).First());
+
+                var result = new StringBuilder();
+                result.AppendLine(
+                    $"{statementType.NameForHumans()} for {stock.Ticker} ({Md(stock.Name)}) — "
+                        + $"FY{selected.FiscalYear} {selected.FiscalPeriod.NameForHumans()}:"
+                );
+                result.AppendLine();
+                result.AppendLine("| Line Item | Value | Unit | Period End | Form | Filed |");
+                result.AppendLine("|-----------|------:|------|-----------|------|-------|");
+
+                var rendered = 0;
+                foreach (var line in statementLines)
+                {
+                    if (
+                        !conceptIdByKey.TryGetValue((line.Taxonomy, line.Tag), out var conceptId)
+                        || !latestByConcept.TryGetValue(conceptId, out var fact)
+                    )
+                    {
+                        result.AppendLine($"| {Md(line.Label)} | — | | | | |");
+                        continue;
+                    }
+
+                    var isPerShare =
+                        fact.Unit != null
+                        && fact.Unit.EndsWith("/shares", StringComparison.OrdinalIgnoreCase);
+                    // Format culture-invariantly so the LLM-facing output is
+                    // identical regardless of the server's locale.
+                    var number = fact.Value.ToString(
+                        isPerShare ? "N2" : "N0",
+                        CultureInfo.InvariantCulture
+                    );
+                    // Only USD gets a "$"; other currencies (EUR/GBP for 20-F /
+                    // 40-F filers) are conveyed by the Unit column rather than
+                    // mislabelled with a dollar sign.
+                    var isUsd =
+                        fact.Unit != null
+                        && fact.Unit.StartsWith("USD", StringComparison.OrdinalIgnoreCase);
+                    var value = isUsd ? "$" + number : number;
+
+                    result.AppendLine(
+                        $"| {Md(line.Label)} | {value} | {Md(fact.Unit)} | "
+                            + $"{fact.PeriodEnd:yyyy-MM-dd} | {Md(fact.Form?.DisplayName)} | "
+                            + $"{fact.FiledDate:yyyy-MM-dd} |"
+                    );
+                    rendered++;
+                }
+
+                if (rendered == 0)
+                    result.AppendLine(
+                        $"\n_No line items of this statement were reported for the period._"
+                    );
+
+                return result.ToString();
+            },
+            _logger,
+            "GetFinancialStatement",
+            $"ticker: {Clean(ticker)}, statement: {Clean(statement)}, "
+                + $"year: {year}, period: {Clean(period)}",
+            ReportError
+        );
+    }
+
+    // Escapes the Markdown table delimiters so a value containing '|' or a
+    // newline (e.g. some ADR/fund names) can't break the table the LLM consumes.
+    private static string Md(string value) =>
+        value == null ? "" : value.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ");
+
+    // Strips control chars from untrusted args before they reach logs / the
+    // error store, matching the repo's existing log-hygiene precedent (e91e72a).
+    private static string Clean(string value) =>
+        value == null ? "" : new string(value.Where(c => !char.IsControl(c)).ToArray());
+
+    private static bool TryParseStatement(string value, out FinancialStatementType type)
+    {
+        switch (value?.Trim().ToLowerInvariant())
+        {
+            case "income":
+            case "income-statement":
+            case "incomestatement":
+            case "is":
+            case "p&l":
+            case "pnl":
+                type = FinancialStatementType.IncomeStatement;
+                return true;
+            case "balance":
+            case "balance-sheet":
+            case "balancesheet":
+            case "bs":
+                type = FinancialStatementType.BalanceSheet;
+                return true;
+            case "cashflow":
+            case "cash-flow":
+            case "cash flow":
+            case "cf":
+                type = FinancialStatementType.CashFlow;
+                return true;
+            default:
+                type = default;
+                return false;
+        }
+    }
+
+    private static bool TryParsePeriod(string value, out SecFiscalPeriod period)
+    {
+        switch (value?.Trim().ToUpperInvariant())
+        {
+            case "FY":
+            case "FULLYEAR":
+            case "ANNUAL":
+                period = SecFiscalPeriod.FullYear;
+                return true;
+            case "Q1":
+                period = SecFiscalPeriod.Q1;
+                return true;
+            case "Q2":
+                period = SecFiscalPeriod.Q2;
+                return true;
+            case "Q3":
+                period = SecFiscalPeriod.Q3;
+                return true;
+            case "Q4":
+                period = SecFiscalPeriod.Q4;
+                return true;
+            default:
+                period = default;
+                return false;
+        }
+    }
+
+    // Chronological order within a fiscal year: Q1 < Q2 < Q3 < Q4 < FullYear.
+    private static int ChronologicalRank(SecFiscalPeriod period) =>
+        period switch
+        {
+            SecFiscalPeriod.Q1 => 1,
+            SecFiscalPeriod.Q2 => 2,
+            SecFiscalPeriod.Q3 => 3,
+            SecFiscalPeriod.Q4 => 4,
+            SecFiscalPeriod.FullYear => 5,
+            _ => 0,
+        };
+
+    private Task ReportError(string toolName, string message, string stackTrace, string context)
+    {
+        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
+++ b/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
@@ -73,6 +73,7 @@
     <ProjectReference Include="..\..\src\Equibles.Fred.Mcp\Equibles.Fred.Mcp.csproj" />
     <ProjectReference Include="..\..\src\Equibles.InsiderTrading.Mcp\Equibles.InsiderTrading.Mcp.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Sec.Mcp\Equibles.Sec.Mcp.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Sec.FinancialFacts.Mcp\Equibles.Sec.FinancialFacts.Mcp.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Congress.Mcp\Equibles.Congress.Mcp.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Finra.Mcp\Equibles.Finra.Mcp.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Yahoo.Mcp\Equibles.Yahoo.Mcp.csproj" />

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsTests.cs
@@ -1,0 +1,257 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class FinancialStatementToolsTests : ParadeDbMcpTestBase
+{
+    public FinancialStatementToolsTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private FinancialStatementTools Sut() =>
+        new(
+            new FinancialFactRepository(DbContext),
+            new FinancialConceptRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<FinancialStatementTools>()
+        );
+
+    private static CommonStock Apple() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+
+    [Fact]
+    public async Task GetFinancialStatement_UnknownTicker_ReturnsNotFound()
+    {
+        var result = await Sut().GetFinancialStatement("ZZZZ");
+
+        result.Should().Be("Stock 'ZZZZ' not found.");
+    }
+
+    [Fact]
+    public async Task GetFinancialStatement_UnknownStatement_ReturnsGuidance()
+    {
+        DbContext.Set<CommonStock>().Add(Apple());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialStatement("AAPL", statement: "wat");
+
+        result.Should().Contain("Unknown statement 'wat'");
+    }
+
+    [Fact]
+    public async Task GetFinancialStatement_NoFacts_ReturnsNotIngestedMessage()
+    {
+        DbContext.Set<CommonStock>().Add(Apple());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialStatement("AAPL", statement: "income");
+
+        result.Should().Contain("No structured financial facts have been ingested for AAPL");
+    }
+
+    [Fact]
+    public async Task GetFinancialStatement_SeededIncomeStatement_RendersLatestFiledTableAndDefaultsToLatest()
+    {
+        var stock = Apple();
+        var revenue = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "Revenues",
+            Label = "Revenues",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<FinancialConcept>().Add(revenue);
+        DbContext
+            .Set<FinancialFact>()
+            .AddRange(
+                new FinancialFact
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = stock.Id,
+                    FinancialConceptId = revenue.Id,
+                    Unit = "USD",
+                    PeriodType = FactPeriodType.Duration,
+                    PeriodStart = new DateOnly(2023, 1, 1),
+                    PeriodEnd = new DateOnly(2023, 12, 31),
+                    Value = 383_000_000_000m,
+                    FiscalYear = 2023,
+                    FiscalPeriod = SecFiscalPeriod.FullYear,
+                    Form = DocumentType.TenK,
+                    FiledDate = new DateOnly(2024, 1, 15),
+                    AccessionNumber = "0000320193-24-000001",
+                },
+                new FinancialFact
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = stock.Id,
+                    FinancialConceptId = revenue.Id,
+                    Unit = "USD",
+                    PeriodType = FactPeriodType.Duration,
+                    PeriodStart = new DateOnly(2023, 1, 1),
+                    PeriodEnd = new DateOnly(2023, 12, 31),
+                    Value = 400_000_000_000m,
+                    FiscalYear = 2023,
+                    FiscalPeriod = SecFiscalPeriod.FullYear,
+                    Form = DocumentType.TenK,
+                    FiledDate = new DateOnly(2024, 6, 1),
+                    AccessionNumber = "0000320193-24-000099",
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        // No year/period given — must default to the latest reported period.
+        var result = await Sut().GetFinancialStatement("AAPL", statement: "income");
+
+        result.Should().Contain("Income Statement for AAPL (Apple Inc.) — FY2023 FY:");
+        result.Should().Contain("| Revenue | $400,000,000,000 | USD |");
+        result.Should().NotContain("$383,000,000,000", "the latest-filed restatement wins");
+        // A curated concept the company never reported still renders as a
+        // placeholder row so the statement keeps its shape.
+        result.Should().Contain("| Net Income | — |");
+    }
+
+    private async Task SeedRevenue(
+        CommonStock stock,
+        FinancialConcept concept,
+        int fiscalYear,
+        SecFiscalPeriod period,
+        decimal value,
+        string unit,
+        string accession
+    )
+    {
+        DbContext
+            .Set<FinancialFact>()
+            .Add(
+                new FinancialFact
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = stock.Id,
+                    FinancialConceptId = concept.Id,
+                    Unit = unit,
+                    PeriodType = FactPeriodType.Duration,
+                    PeriodStart = new DateOnly(fiscalYear, 1, 1),
+                    PeriodEnd = new DateOnly(fiscalYear, 12, 31),
+                    Value = value,
+                    FiscalYear = fiscalYear,
+                    FiscalPeriod = period,
+                    Form = DocumentType.TenK,
+                    FiledDate = new DateOnly(fiscalYear + 1, 2, 1),
+                    AccessionNumber = accession,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetFinancialStatement_ExplicitPeriodNeverReported_DoesNotSilentlyFallBack()
+    {
+        var stock = Apple();
+        var revenue = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "Revenues",
+            Label = "Revenues",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<FinancialConcept>().Add(revenue);
+        // Only an annual figure exists.
+        await SeedRevenue(
+            stock,
+            revenue,
+            2023,
+            SecFiscalPeriod.FullYear,
+            400_000_000_000m,
+            "USD",
+            "a-fy"
+        );
+
+        var result = await Sut()
+            .GetFinancialStatement("AAPL", statement: "income", year: 2023, period: "Q2");
+
+        result.Should().Contain("has no data for 2023 Q2");
+        result.Should().Contain("Latest available: FY2023 FY");
+        result
+            .Should()
+            .NotContain(
+                "$400,000,000,000",
+                "Q2 was requested but never reported — the annual figure must not be substituted"
+            );
+    }
+
+    [Fact]
+    public async Task GetFinancialStatement_MultipleYears_DefaultsToLatestAnnual()
+    {
+        var stock = Apple();
+        var revenue = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "Revenues",
+            Label = "Revenues",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<FinancialConcept>().Add(revenue);
+        await SeedRevenue(
+            stock,
+            revenue,
+            2022,
+            SecFiscalPeriod.FullYear,
+            300_000_000_000m,
+            "USD",
+            "a-2022"
+        );
+        await SeedRevenue(
+            stock,
+            revenue,
+            2023,
+            SecFiscalPeriod.FullYear,
+            400_000_000_000m,
+            "USD",
+            "a-2023"
+        );
+
+        var result = await Sut().GetFinancialStatement("AAPL", statement: "income");
+
+        result.Should().Contain("FY2023 FY:");
+        result.Should().Contain("$400,000,000,000");
+        result.Should().NotContain("$300,000,000,000", "the latest year is the default");
+    }
+
+    [Fact]
+    public async Task GetFinancialStatement_PerShareUnit_FormatsWithCents()
+    {
+        var stock = Apple();
+        var eps = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "EarningsPerShareDiluted",
+            Label = "EarningsPerShareDiluted",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<FinancialConcept>().Add(eps);
+        await SeedRevenue(stock, eps, 2023, SecFiscalPeriod.FullYear, 6.13m, "USD/shares", "a-eps");
+
+        var result = await Sut().GetFinancialStatement("AAPL", statement: "income");
+
+        result.Should().Contain("| EPS (Diluted) | $6.13 | USD/shares |");
+    }
+}


### PR DESCRIPTION
## Summary

- New `Equibles.Sec.FinancialFacts.Mcp` module exposing a `GetFinancialStatement` MCP tool: ticker + statement (income / balance sheet / cash flow) + optional fiscal year & period, sourced from the ingested SEC Company Facts. Reuses the shared `FinancialStatementConcepts` catalog; restatements collapse to the latest-filed value.
- Per post-implementation review: an explicit year/period must match exactly — financial figures from a *different* period are never silently substituted (defaults to latest only when unspecified). Plus ticker guard, single typed period parse, invariant-culture formatting, Markdown-delimiter escaping, and control-char-stripped error context.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Mcp/` — new project: `.csproj`, `Extensions/McpBuilderExtensions.cs` (`AddFinancialFacts`), `Tools/FinancialStatementTools.cs` (the tool, following the `FailToDeliverTools` pattern: `McpToolExecutor.Execute`, `ErrorManager` reporting, ticker→`CommonStock`).
- `src/Equibles.Mcp.Server/` — `Program.cs` (`mcp.AddFinancialFacts()`) + `.csproj` project reference; `Equibles.sln` updated.
- `tests/Equibles.IntegrationTests/Mcp/FinancialStatementToolsTests.cs` — 7 tests: not-found, bad statement, no-facts, latest-filed restatement wins + curated shape, explicit-unmatched-period no-fallback, multi-year default-to-latest, per-share formatting.

Closes #875