### PR TITLE
style(web): move search clear button inside the input field

### DIFF
--- a/src/Equibles.Web/Views/Search/Index.cshtml
+++ b/src/Equibles.Web/Views/Search/Index.cshtml
@@ -28,15 +28,16 @@
                     </option>
                 }
             </select>
-            <input type="search" name="q" value="@Model.Query"
-                   class="input input-bordered join-item grow"
-                   aria-label="Search everything"
-                   placeholder="Search for a ticker, company, filing, indicator..." autofocus />
-            <button type="button" id="search-clear"
-                    class="btn btn-ghost border border-base-300 join-item @(string.IsNullOrEmpty(Model.Query) ? "hidden" : "")"
-                    aria-label="Clear search" title="Clear search">
-                <icon name="x-mark" size="5" />
-            </button>
+            <label class="input input-bordered join-item grow flex items-center gap-2">
+                <input type="search" name="q" value="@Model.Query" class="grow"
+                       aria-label="Search everything"
+                       placeholder="Search for a ticker, company, filing, indicator..." autofocus />
+                <button type="button" id="search-clear"
+                        class="btn btn-ghost btn-xs btn-circle @(string.IsNullOrEmpty(Model.Query) ? "hidden" : "")"
+                        aria-label="Clear search" title="Clear search">
+                    <icon name="x-mark" size="4" />
+                </button>
+            </label>
             <button type="submit" class="btn btn-primary join-item" aria-label="Search" title="Search">
                 <icon name="magnifying-glass" size="5" />
             </button>


### PR DESCRIPTION
## Summary

- The `/Search` clear (✕) control was a separate bordered `btn-ghost` wedged between the query input and the submit button, reading as a heavy third button rather than part of the search box.
- Restructure to the DaisyUI `label.input` pattern so the field is one clean box with the clear affordance inside it (canonical modern search-box layout); the primary submit stays as the only trailing join element. Continues the "rich, modern, easy to use" search-bar work.

## Code changes

- `src/Equibles.Web/Views/Search/Index.cshtml` — wrapped the query `<input>` in a `<label class="input input-bordered join-item grow">`; moved `#search-clear` inside it as a small `btn-ghost btn-xs btn-circle`. No JS changes: `id="search-clear"` and `name="q"` are preserved, so `search-clear.js` and `instant-search.js` work unchanged.