### PR TITLE
fix(sec): skip ragged rows in MapToFilingData instead of throwing

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -683,6 +683,18 @@ public class SecEdgarClient : ISecEdgarClient
 
         for (var i = 0; i < recent.AccessionNumber.Count; i++)
         {
+            // SEC can emit a ragged payload where a secondary array is shorter
+            // than AccessionNumber. Skip rows that cannot be fully mapped rather
+            // than throw, mirroring ParseCompaniesFromResponse's short-row guard.
+            if (
+                recent.FilingDate.Count <= i
+                || recent.ReportDate.Count <= i
+                || recent.Form.Count <= i
+                || recent.PrimaryDocument.Count <= i
+                || recent.PrimaryDocDescription.Count <= i
+            )
+                continue;
+
             var accessionNumber = recent.AccessionNumber[i];
             filings.Add(
                 new FilingData

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientMapToFilingDataRaggedArraysTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientMapToFilingDataRaggedArraysTests.cs
@@ -14,7 +14,7 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class SecEdgarClientMapToFilingDataRaggedArraysTests
 {
-    [Fact(Skip = "GH-918 — ragged SEC submissions arrays throw, aborting the filing ingest")]
+    [Fact]
     public void MapToFilingData_SecondaryArrayShorterThanAccessionNumbers_DoesNotThrowAndKeepsMappableRow()
     {
         var asm = typeof(SecEdgarClient).Assembly;


### PR DESCRIPTION
## Summary

- `SecEdgarClient.MapToFilingData` drove its loop off `AccessionNumber.Count` and positionally indexed five secondary parallel arrays. A ragged SEC submissions payload (a shorter secondary array, which SEC can emit) threw `ArgumentOutOfRangeException`; `GetCompanyFilings` logs-and-rethrows, so one malformed company response aborted that company's entire filing ingest.
- Fixes #918 by skipping rows that cannot be fully mapped, mirroring the short-row resilience already in the same class's `ParseCompaniesFromResponse`.

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — guard at the top of the `MapToFilingData` loop: `continue` when any of the five secondary arrays (`FilingDate`, `ReportDate`, `Form`, `PrimaryDocument`, `PrimaryDocDescription`) has `Count <= i`. Equal-length payloads map identically as before; only previously-crashing ragged tail rows are skipped.
- `tests/Equibles.UnitTests/Sec/SecEdgarClientMapToFilingDataRaggedArraysTests.cs` — un-skipped the committed regression test (fails pre-fix with `ArgumentOutOfRangeException`, passes after; sibling well-formed/culture pins still green).

closes #918