### PR TITLE
feat(mcp): financial-concept time-series tool

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -1,0 +1,114 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+
+namespace Equibles.Sec.FinancialFacts.Data.Statements;
+
+/// <summary>
+/// Maps a friendly concept name (e.g. <c>"revenue"</c>, <c>"net-income"</c>) to
+/// the ordered set of XBRL (taxonomy, tag) pairs that express it. Shared by the
+/// FinancialFacts MCP tools so callers need not know SEC tag names. A single
+/// alias can map to several tags because companies switch concepts over time
+/// (e.g. <c>Revenues</c> → <c>RevenueFromContractWithCustomerExcludingAssessedTax</c>
+/// after ASC 606); callers query the union and pick per period.
+/// </summary>
+public static class FinancialConceptAliases
+{
+    public sealed class ConceptRef
+    {
+        public ConceptRef(FactTaxonomy taxonomy, string tag)
+        {
+            Taxonomy = taxonomy;
+            Tag = tag;
+        }
+
+        public FactTaxonomy Taxonomy { get; }
+
+        public string Tag { get; }
+    }
+
+    private static readonly Dictionary<string, IReadOnlyList<ConceptRef>> Map = new()
+    {
+        ["revenue"] =
+        [
+            new(FactTaxonomy.UsGaap, "Revenues"),
+            new(FactTaxonomy.UsGaap, "RevenueFromContractWithCustomerExcludingAssessedTax"),
+        ],
+        ["cost-of-revenue"] = [new(FactTaxonomy.UsGaap, "CostOfRevenue")],
+        ["gross-profit"] = [new(FactTaxonomy.UsGaap, "GrossProfit")],
+        ["operating-expenses"] = [new(FactTaxonomy.UsGaap, "OperatingExpenses")],
+        ["research-and-development"] = [new(FactTaxonomy.UsGaap, "ResearchAndDevelopmentExpense")],
+        ["operating-income"] = [new(FactTaxonomy.UsGaap, "OperatingIncomeLoss")],
+        ["net-income"] = [new(FactTaxonomy.UsGaap, "NetIncomeLoss")],
+        ["eps-basic"] = [new(FactTaxonomy.UsGaap, "EarningsPerShareBasic")],
+        ["eps-diluted"] = [new(FactTaxonomy.UsGaap, "EarningsPerShareDiluted")],
+        ["total-assets"] = [new(FactTaxonomy.UsGaap, "Assets")],
+        ["current-assets"] = [new(FactTaxonomy.UsGaap, "AssetsCurrent")],
+        ["total-liabilities"] = [new(FactTaxonomy.UsGaap, "Liabilities")],
+        ["current-liabilities"] = [new(FactTaxonomy.UsGaap, "LiabilitiesCurrent")],
+        ["stockholders-equity"] = [new(FactTaxonomy.UsGaap, "StockholdersEquity")],
+        ["retained-earnings"] = [new(FactTaxonomy.UsGaap, "RetainedEarningsAccumulatedDeficit")],
+        ["cash"] = [new(FactTaxonomy.UsGaap, "CashAndCashEquivalentsAtCarryingValue")],
+        ["operating-cash-flow"] =
+        [
+            new(FactTaxonomy.UsGaap, "NetCashProvidedByUsedInOperatingActivities"),
+        ],
+        ["investing-cash-flow"] =
+        [
+            new(FactTaxonomy.UsGaap, "NetCashProvidedByUsedInInvestingActivities"),
+        ],
+        ["financing-cash-flow"] =
+        [
+            new(FactTaxonomy.UsGaap, "NetCashProvidedByUsedInFinancingActivities"),
+        ],
+    };
+
+    // Spelt-out synonyms normalise onto a canonical key so callers can use
+    // natural phrasing ("net income", "r&d", "diluted eps").
+    private static readonly Dictionary<string, string> Synonyms = new()
+    {
+        ["sales"] = "revenue",
+        ["net-revenue"] = "revenue",
+        ["total-revenue"] = "revenue",
+        ["cogs"] = "cost-of-revenue",
+        ["rnd"] = "research-and-development",
+        ["r-and-d"] = "research-and-development",
+        ["r&d"] = "research-and-development",
+        ["operating-profit"] = "operating-income",
+        ["net-profit"] = "net-income",
+        ["earnings"] = "net-income",
+        ["diluted-eps"] = "eps-diluted",
+        ["basic-eps"] = "eps-basic",
+        ["assets"] = "total-assets",
+        ["liabilities"] = "total-liabilities",
+        ["equity"] = "stockholders-equity",
+        ["ocf"] = "operating-cash-flow",
+    };
+
+    public static IReadOnlyCollection<string> SupportedAliases => Map.Keys;
+
+    public static bool TryResolve(string alias, out IReadOnlyList<ConceptRef> concepts)
+    {
+        var key = Normalize(alias);
+        if (Synonyms.TryGetValue(key, out var canonical))
+            key = canonical;
+        if (Map.TryGetValue(key, out var refs))
+        {
+            concepts = refs;
+            return true;
+        }
+
+        concepts = [];
+        return false;
+    }
+
+    private static string Normalize(string alias)
+    {
+        if (string.IsNullOrWhiteSpace(alias))
+            return string.Empty;
+        return alias
+            .Trim()
+            .ToLowerInvariant()
+            .Replace(' ', '-')
+            .Replace('_', '-')
+            .Replace("/", "-");
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FactMarkdown.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FactMarkdown.cs
@@ -1,0 +1,60 @@
+using System.Globalization;
+
+namespace Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+/// <summary>
+/// Shared rendering helpers for the FinancialFacts MCP tools so the
+/// Markdown-table output (escaping, culture-invariant value formatting,
+/// log-context hygiene) is defined once rather than per tool.
+/// </summary>
+public static class FactMarkdown
+{
+    /// <summary>
+    /// Escapes the Markdown table delimiters so a value containing '|' or a
+    /// newline (e.g. some ADR/fund names) can't break the table the LLM reads.
+    /// </summary>
+    public static string Cell(string value) =>
+        value == null ? "" : value.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ");
+
+    /// <summary>
+    /// Strips control chars from untrusted args before they reach logs / the
+    /// error store, matching the repo's log-hygiene precedent (e91e72a).
+    /// </summary>
+    public static string Clean(string value) =>
+        value == null ? "" : new string(value.Where(c => !char.IsControl(c)).ToArray());
+
+    /// <summary>
+    /// Formats a reported value culture-invariantly. Per-share units get cents
+    /// precision; large monetary / share-count units get grouped whole numbers;
+    /// dimensionless or ratio units (e.g. <c>pure</c>) keep their fractional
+    /// precision rather than being rounded to an integer. Only USD is prefixed
+    /// with '$'; other currencies (EUR/GBP for 20-F / 40-F filers) are conveyed
+    /// by the unit column rather than mislabelled with a dollar sign.
+    /// </summary>
+    public static string Value(decimal value, string unit)
+    {
+        var u = unit?.Trim();
+        var isPerShare = u != null && u.EndsWith("/shares", StringComparison.OrdinalIgnoreCase);
+        var isUsd = u != null && u.StartsWith("USD", StringComparison.OrdinalIgnoreCase);
+        // "shares" is a large integer count; other plain-currency units are
+        // large monetary values — both read best as grouped whole numbers.
+        var isWholeMagnitude =
+            isUsd
+            || string.Equals(u, "shares", StringComparison.OrdinalIgnoreCase)
+            || (u != null && IsBareCurrency(u));
+
+        string number;
+        if (isPerShare)
+            number = value.ToString("N2", CultureInfo.InvariantCulture);
+        else if (isWholeMagnitude)
+            number = value.ToString("N0", CultureInfo.InvariantCulture);
+        else
+            // pure / dimensionless / ratios — don't destroy the fraction.
+            number = value.ToString("0.############", CultureInfo.InvariantCulture);
+
+        return isUsd ? "$" + number : number;
+    }
+
+    // A bare 3-letter currency code (USD already handled above): EUR, GBP, JPY…
+    private static bool IsBareCurrency(string unit) => unit.Length == 3 && unit.All(char.IsLetter);
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -1,0 +1,247 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Extensions;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Mcp;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+[McpServerToolType]
+public class FinancialFactsTools
+{
+    private const int MaxResultsCap = 200;
+
+    private readonly FinancialFactRepository _financialFactRepository;
+    private readonly FinancialConceptRepository _financialConceptRepository;
+    private readonly CommonStockRepository _commonStockRepository;
+    private readonly ErrorManager _errorManager;
+    private readonly ILogger<FinancialFactsTools> _logger;
+
+    public FinancialFactsTools(
+        FinancialFactRepository financialFactRepository,
+        FinancialConceptRepository financialConceptRepository,
+        CommonStockRepository commonStockRepository,
+        ErrorManager errorManager,
+        ILogger<FinancialFactsTools> logger
+    )
+    {
+        _financialFactRepository = financialFactRepository;
+        _financialConceptRepository = financialConceptRepository;
+        _commonStockRepository = commonStockRepository;
+        _errorManager = errorManager;
+        _logger = logger;
+    }
+
+    [McpServerTool(Name = "GetFinancialFact")]
+    [Description(
+        "Get a single financial concept (e.g. revenue, net income, diluted EPS, total "
+            + "assets, operating cash flow) over time for a company, sourced from SEC "
+            + "Company Facts (structured XBRL). Returns a time series, one row per fiscal "
+            + "period, using the latest restated value unless asOriginallyReported is set."
+    )]
+    public Task<string> GetFinancialFact(
+        [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description(
+            "Concept alias, e.g. 'revenue', 'net-income', 'eps-diluted', 'total-assets', "
+                + "'operating-cash-flow'. Call with an unknown value to list supported aliases."
+        )]
+            string concept,
+        [Description("Optional SEC form filter, e.g. '10-K' or '10-Q'")] string form = null,
+        [Description("Optional earliest period-end date, YYYY-MM-DD")] string fromDate = null,
+        [Description("Optional latest period-end date, YYYY-MM-DD")] string toDate = null,
+        [Description("Maximum periods to return, newest first (default 40, max 200)")]
+            int maxResults = 40,
+        [Description(
+            "When true, show the value as originally filed (earliest filing) instead of "
+                + "the latest restatement. Default false."
+        )]
+            bool asOriginallyReported = false
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                if (string.IsNullOrWhiteSpace(ticker))
+                    return "A ticker symbol is required.";
+
+                if (string.IsNullOrWhiteSpace(concept))
+                    return "A concept is required. Supported: "
+                        + $"{string.Join(", ", FinancialConceptAliases.SupportedAliases)} "
+                        + "(common synonyms like 'sales', 'r&d', 'ocf' also work).";
+
+                var stock = await _commonStockRepository.GetByTicker(
+                    ticker.Trim().ToUpperInvariant()
+                );
+                if (stock == null)
+                    return $"Stock '{ticker}' not found.";
+
+                if (!FinancialConceptAliases.TryResolve(concept, out var conceptRefs))
+                    return $"Unknown concept '{concept}'. Supported: "
+                        + $"{string.Join(", ", FinancialConceptAliases.SupportedAliases)} "
+                        + "(common synonyms like 'sales', 'r&d', 'ocf' also work).";
+
+                DocumentType formFilter = null;
+                if (!string.IsNullOrWhiteSpace(form))
+                {
+                    formFilter = DocumentType.FromDisplayName(form.Trim());
+                    if (formFilter == null)
+                        return $"Unknown form '{form}'. Use e.g. '10-K' or '10-Q'.";
+                }
+
+                if (!TryParseBound(fromDate, out var fromBound))
+                    return $"Unknown date '{fromDate}'. Use YYYY-MM-DD.";
+                if (!TryParseBound(toDate, out var toBound))
+                    return $"Unknown date '{toDate}'. Use YYYY-MM-DD.";
+
+                // conceptId → alias priority (0 = the alias's primary tag). Used
+                // to break ties deterministically when one period carries facts
+                // under several of the alias's tags (the ASC 606 transition).
+                var conceptPriority = await ResolveConceptPriority(conceptRefs);
+                if (conceptPriority.Count == 0)
+                    return $"No '{concept}' data has been ingested for {stock.Ticker}.";
+
+                var facts = await _financialFactRepository
+                    .GetByStock(stock)
+                    .Where(f => conceptPriority.Keys.Contains(f.FinancialConceptId))
+                    .ToListAsync();
+
+                // Form / period-end filtering in memory: a single concept's
+                // history is small, and DocumentType is a value-converted type
+                // so equality is kept off the SQL side for provider safety.
+                var filtered = facts.Where(f =>
+                    (formFilter == null || f.Form == formFilter)
+                    && (fromBound == null || f.PeriodEnd >= fromBound.Value)
+                    && (toBound == null || f.PeriodEnd <= toBound.Value)
+                );
+
+                // One row per fiscal period. The alias may span several tags and
+                // a single period can carry facts under more than one of them
+                // (the ASC 606 transition year tags both Revenues and the new
+                // concept). Pick deterministically: the alias's primary tag
+                // wins, then the latest filing — or the earliest, when the
+                // caller wants the figure as originally reported.
+                var perPeriod = filtered
+                    .GroupBy(f => (f.FiscalYear, f.FiscalPeriod))
+                    .Select(g =>
+                    {
+                        var byPriority = g.OrderBy(f => conceptPriority[f.FinancialConceptId]);
+                        var ordered = asOriginallyReported
+                            ? byPriority.ThenBy(f => f.FiledDate)
+                            : byPriority.ThenByDescending(f => f.FiledDate);
+                        return ordered.First();
+                    })
+                    .OrderByDescending(f => f.PeriodEnd)
+                    .Take(Math.Clamp(maxResults, 1, MaxResultsCap))
+                    .ToList();
+
+                if (perPeriod.Count == 0)
+                    return $"No '{concept}' data found for {stock.Ticker} with the given filters.";
+
+                var basis = asOriginallyReported ? "as originally reported" : "latest restated";
+                var result = new StringBuilder();
+                result.AppendLine(
+                    $"{concept} for {stock.Ticker} ({FactMarkdown.Cell(stock.Name)}) — {basis}:"
+                );
+                result.AppendLine();
+                result.AppendLine(
+                    "| Period End | FY | Period | Value | Unit | Form | Filed | Accession |"
+                );
+                result.AppendLine(
+                    "|-----------|---:|--------|------:|------|------|-------|-----------|"
+                );
+                foreach (var f in perPeriod)
+                {
+                    result.AppendLine(
+                        $"| {f.PeriodEnd:yyyy-MM-dd} | {f.FiscalYear} | "
+                            + $"{f.FiscalPeriod.NameForHumans()} | "
+                            + $"{FactMarkdown.Value(f.Value, f.Unit)} | "
+                            + $"{FactMarkdown.Cell(f.Unit)} | "
+                            + $"{FactMarkdown.Cell(f.Form?.DisplayName)} | "
+                            + $"{f.FiledDate:yyyy-MM-dd} | "
+                            + $"{FactMarkdown.Cell(f.AccessionNumber)} |"
+                    );
+                }
+
+                return result.ToString();
+            },
+            _logger,
+            "GetFinancialFact",
+            $"ticker: {FactMarkdown.Clean(ticker)}, concept: {FactMarkdown.Clean(concept)}, "
+                + $"form: {FactMarkdown.Clean(form)}",
+            ReportError
+        );
+    }
+
+    private async Task<Dictionary<Guid, int>> ResolveConceptPriority(
+        IReadOnlyList<FinancialConceptAliases.ConceptRef> conceptRefs
+    )
+    {
+        var taxonomies = conceptRefs.Select(c => c.Taxonomy).Distinct().ToList();
+        var tags = conceptRefs.Select(c => c.Tag).Distinct().ToList();
+        // (taxonomy, tag) → position in the alias's ordered tag list; lower
+        // index is the alias's preferred/primary concept.
+        var priorityByPair = new Dictionary<(FactTaxonomy, string), int>();
+        for (var i = 0; i < conceptRefs.Count; i++)
+            priorityByPair.TryAdd((conceptRefs[i].Taxonomy, conceptRefs[i].Tag), i);
+
+        var rows = await _financialConceptRepository
+            .GetMatching(taxonomies, tags)
+            .Select(c => new
+            {
+                c.Id,
+                c.Taxonomy,
+                c.Tag,
+            })
+            .ToListAsync();
+
+        // GetMatching is a taxonomy×tag cross product over a tiny alias tag set
+        // (over-fetch is negligible here); narrow to the alias's exact pairs.
+        return rows.Where(r => priorityByPair.ContainsKey((r.Taxonomy, r.Tag)))
+            .ToDictionary(r => r.Id, r => priorityByPair[(r.Taxonomy, r.Tag)]);
+    }
+
+    // Accepts an absent bound (null/blank → no bound) but rejects a non-empty
+    // value that is not an ISO yyyy-MM-dd date, so a typo can't silently widen
+    // the result set.
+    private static bool TryParseBound(string value, out DateOnly? bound)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            bound = null;
+            return true;
+        }
+
+        if (
+            DateOnly.TryParseExact(
+                value.Trim(),
+                "yyyy-MM-dd",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var parsed
+            )
+        )
+        {
+            bound = parsed;
+            return true;
+        }
+
+        bound = null;
+        return false;
+    }
+
+    private Task ReportError(string toolName, string message, string stackTrace, string context)
+    {
+        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Globalization;
 using System.Text;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Extensions;
@@ -8,6 +7,7 @@ using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Statements;
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -153,7 +153,8 @@ public class FinancialStatementTools
 
                 var result = new StringBuilder();
                 result.AppendLine(
-                    $"{statementType.NameForHumans()} for {stock.Ticker} ({Md(stock.Name)}) — "
+                    $"{statementType.NameForHumans()} for {stock.Ticker} "
+                        + $"({FactMarkdown.Cell(stock.Name)}) — "
                         + $"FY{selected.FiscalYear} {selected.FiscalPeriod.NameForHumans()}:"
                 );
                 result.AppendLine();
@@ -168,30 +169,16 @@ public class FinancialStatementTools
                         || !latestByConcept.TryGetValue(conceptId, out var fact)
                     )
                     {
-                        result.AppendLine($"| {Md(line.Label)} | — | | | | |");
+                        result.AppendLine($"| {FactMarkdown.Cell(line.Label)} | — | | | | |");
                         continue;
                     }
 
-                    var isPerShare =
-                        fact.Unit != null
-                        && fact.Unit.EndsWith("/shares", StringComparison.OrdinalIgnoreCase);
-                    // Format culture-invariantly so the LLM-facing output is
-                    // identical regardless of the server's locale.
-                    var number = fact.Value.ToString(
-                        isPerShare ? "N2" : "N0",
-                        CultureInfo.InvariantCulture
-                    );
-                    // Only USD gets a "$"; other currencies (EUR/GBP for 20-F /
-                    // 40-F filers) are conveyed by the Unit column rather than
-                    // mislabelled with a dollar sign.
-                    var isUsd =
-                        fact.Unit != null
-                        && fact.Unit.StartsWith("USD", StringComparison.OrdinalIgnoreCase);
-                    var value = isUsd ? "$" + number : number;
-
                     result.AppendLine(
-                        $"| {Md(line.Label)} | {value} | {Md(fact.Unit)} | "
-                            + $"{fact.PeriodEnd:yyyy-MM-dd} | {Md(fact.Form?.DisplayName)} | "
+                        $"| {FactMarkdown.Cell(line.Label)} | "
+                            + $"{FactMarkdown.Value(fact.Value, fact.Unit)} | "
+                            + $"{FactMarkdown.Cell(fact.Unit)} | "
+                            + $"{fact.PeriodEnd:yyyy-MM-dd} | "
+                            + $"{FactMarkdown.Cell(fact.Form?.DisplayName)} | "
                             + $"{fact.FiledDate:yyyy-MM-dd} |"
                     );
                     rendered++;
@@ -206,21 +193,11 @@ public class FinancialStatementTools
             },
             _logger,
             "GetFinancialStatement",
-            $"ticker: {Clean(ticker)}, statement: {Clean(statement)}, "
-                + $"year: {year}, period: {Clean(period)}",
+            $"ticker: {FactMarkdown.Clean(ticker)}, statement: {FactMarkdown.Clean(statement)}, "
+                + $"year: {year}, period: {FactMarkdown.Clean(period)}",
             ReportError
         );
     }
-
-    // Escapes the Markdown table delimiters so a value containing '|' or a
-    // newline (e.g. some ADR/fund names) can't break the table the LLM consumes.
-    private static string Md(string value) =>
-        value == null ? "" : value.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ");
-
-    // Strips control chars from untrusted args before they reach logs / the
-    // error store, matching the repo's existing log-hygiene precedent (e91e72a).
-    private static string Clean(string value) =>
-        value == null ? "" : new string(value.Where(c => !char.IsControl(c)).ToArray());
 
     private static bool TryParseStatement(string value, out FinancialStatementType type)
     {

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsTests.cs
@@ -1,0 +1,299 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class FinancialFactsToolsTests : ParadeDbMcpTestBase
+{
+    public FinancialFactsToolsTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private FinancialFactsTools Sut() =>
+        new(
+            new FinancialFactRepository(DbContext),
+            new FinancialConceptRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<FinancialFactsTools>()
+        );
+
+    private static CommonStock Apple() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+
+    private FinancialConcept AddConcept(string tag)
+    {
+        var c = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = tag,
+            Label = tag,
+        };
+        DbContext.Set<FinancialConcept>().Add(c);
+        return c;
+    }
+
+    private void AddFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        int fy,
+        SecFiscalPeriod period,
+        decimal value,
+        DateOnly filed,
+        DocumentType form,
+        string accn
+    )
+    {
+        DbContext
+            .Set<FinancialFact>()
+            .Add(
+                new FinancialFact
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = stock.Id,
+                    FinancialConceptId = concept.Id,
+                    Unit = "USD",
+                    PeriodType = FactPeriodType.Duration,
+                    PeriodStart = new DateOnly(fy, 1, 1),
+                    PeriodEnd = new DateOnly(fy, 12, 31),
+                    Value = value,
+                    FiscalYear = fy,
+                    FiscalPeriod = period,
+                    Form = form,
+                    FiledDate = filed,
+                    AccessionNumber = accn,
+                }
+            );
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_UnknownTicker_ReturnsNotFound()
+    {
+        var result = await Sut().GetFinancialFact("ZZZZ", "revenue");
+
+        result.Should().Be("Stock 'ZZZZ' not found.");
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_UnknownConcept_ListsSupportedAliases()
+    {
+        DbContext.Set<CommonStock>().Add(Apple());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("AAPL", "ebitda");
+
+        result.Should().Contain("Unknown concept 'ebitda'");
+        result.Should().Contain("net-income");
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_NoFacts_ReturnsNotIngestedMessage()
+    {
+        DbContext.Set<CommonStock>().Add(Apple());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("AAPL", "revenue");
+
+        result.Should().Contain("No 'revenue' data has been ingested for AAPL");
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_RestatementAndTagSwitch_LatestRestatedAcrossAliasTags()
+    {
+        var stock = Apple();
+        DbContext.Set<CommonStock>().Add(stock);
+        var revenues = AddConcept("Revenues");
+        var asc606 = AddConcept("RevenueFromContractWithCustomerExcludingAssessedTax");
+        // FY2022 under the old tag, reported then restated.
+        AddFact(
+            stock,
+            revenues,
+            2022,
+            SecFiscalPeriod.FullYear,
+            300_000_000_000m,
+            new DateOnly(2023, 1, 15),
+            DocumentType.TenK,
+            "a-2022-orig"
+        );
+        AddFact(
+            stock,
+            revenues,
+            2022,
+            SecFiscalPeriod.FullYear,
+            320_000_000_000m,
+            new DateOnly(2023, 8, 1),
+            DocumentType.TenK,
+            "a-2022-restate"
+        );
+        // FY2023 under the ASC 606 tag — same alias 'revenue'.
+        AddFact(
+            stock,
+            asc606,
+            2023,
+            SecFiscalPeriod.FullYear,
+            400_000_000_000m,
+            new DateOnly(2024, 1, 15),
+            DocumentType.TenK,
+            "a-2023"
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("AAPL", "revenue");
+
+        // Newest period first; the alias spans both tags.
+        result.Should().Contain("| 2023-12-31 | 2023 | FY | $400,000,000,000 |");
+        result.Should().Contain("| 2022-12-31 | 2022 | FY | $320,000,000,000 |");
+        result.Should().NotContain("$300,000,000,000", "the latest restatement wins by default");
+        var idx2023 = result.IndexOf("2023-12-31", StringComparison.Ordinal);
+        var idx2022 = result.IndexOf("2022-12-31", StringComparison.Ordinal);
+        idx2023.Should().BeLessThan(idx2022, "rows are ordered newest period first");
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_AsOriginallyReported_ShowsEarliestFiling()
+    {
+        var stock = Apple();
+        DbContext.Set<CommonStock>().Add(stock);
+        var revenues = AddConcept("Revenues");
+        AddFact(
+            stock,
+            revenues,
+            2022,
+            SecFiscalPeriod.FullYear,
+            300_000_000_000m,
+            new DateOnly(2023, 1, 15),
+            DocumentType.TenK,
+            "a-orig"
+        );
+        AddFact(
+            stock,
+            revenues,
+            2022,
+            SecFiscalPeriod.FullYear,
+            320_000_000_000m,
+            new DateOnly(2023, 8, 1),
+            DocumentType.TenK,
+            "a-restate"
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("AAPL", "revenue", asOriginallyReported: true);
+
+        result.Should().Contain("as originally reported");
+        result.Should().Contain("$300,000,000,000");
+        result.Should().NotContain("$320,000,000,000");
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_FormFilter_ReturnsOnlyMatchingForm()
+    {
+        var stock = Apple();
+        DbContext.Set<CommonStock>().Add(stock);
+        var revenues = AddConcept("Revenues");
+        AddFact(
+            stock,
+            revenues,
+            2023,
+            SecFiscalPeriod.Q1,
+            90_000_000_000m,
+            new DateOnly(2023, 5, 1),
+            DocumentType.TenQ,
+            "q1"
+        );
+        AddFact(
+            stock,
+            revenues,
+            2023,
+            SecFiscalPeriod.FullYear,
+            383_000_000_000m,
+            new DateOnly(2024, 1, 15),
+            DocumentType.TenK,
+            "fy"
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("AAPL", "revenue", form: "10-K");
+
+        result.Should().Contain("$383,000,000,000");
+        result.Should().NotContain("$90,000,000,000", "the 10-Q row is filtered out");
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_SamePeriodBothAliasTags_PrimaryTagWinsDeterministically()
+    {
+        var stock = Apple();
+        DbContext.Set<CommonStock>().Add(stock);
+        var revenues = AddConcept("Revenues");
+        var asc606 = AddConcept("RevenueFromContractWithCustomerExcludingAssessedTax");
+        // ASC 606 transition: the SAME FY2023 period is tagged under both
+        // concepts in the same filing (identical FiledDate). The alias lists
+        // 'Revenues' first, so it must win deterministically.
+        AddFact(
+            stock,
+            revenues,
+            2023,
+            SecFiscalPeriod.FullYear,
+            383_000_000_000m,
+            new DateOnly(2024, 1, 15),
+            DocumentType.TenK,
+            "a-2023"
+        );
+        AddFact(
+            stock,
+            asc606,
+            2023,
+            SecFiscalPeriod.FullYear,
+            999_000_000_000m,
+            new DateOnly(2024, 1, 15),
+            DocumentType.TenK,
+            "a-2023"
+        );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("AAPL", "revenue");
+
+        result.Should().Contain("$383,000,000,000", "the alias's primary tag (Revenues) wins");
+        result
+            .Should()
+            .NotContain(
+                "$999,000,000,000",
+                "the secondary tag must not win a same-period, same-filed tie"
+            );
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_InvalidDate_ReturnsGuidanceNotSilentlyUnfiltered()
+    {
+        DbContext.Set<CommonStock>().Add(Apple());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("AAPL", "revenue", fromDate: "yesterday");
+
+        result.Should().Contain("Unknown date 'yesterday'");
+    }
+
+    [Fact]
+    public async Task GetFinancialFact_BlankConcept_ReturnsConceptRequired()
+    {
+        DbContext.Set<CommonStock>().Add(Apple());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetFinancialFact("AAPL", "   ");
+
+        result.Should().Contain("A concept is required");
+    }
+}


### PR DESCRIPTION
## Summary

- New `GetFinancialFact` MCP tool: a single financial concept over time for a ticker via a friendly alias (`revenue`, `net-income`, `eps-diluted`, `total-assets`, `operating-cash-flow`, …), with optional form / period-end range / maxResults / `asOriginallyReported`.
- Introduces a shared `FinancialConceptAliases` catalog (alias → ordered XBRL tags, with synonyms; spans the ASC 606 `Revenues`→`RevenueFromContractWithCustomerExcludingAssessedTax` switch) and a shared `FactMarkdown` rendering helper; `FinancialStatementTools` refactored onto the helper with no behavioural drift.
- Per post-implementation review: deterministic per-(year,period) selection (alias primary tag wins, then latest/earliest filing), invariant `YYYY-MM-DD` date bounds that reject invalid input rather than silently widening results, ticker/concept guards, and fractional-precision for non-currency units.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs` — new shared alias→(taxonomy,tag) catalog + synonyms.
- `src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FactMarkdown.cs` — new shared cell-escaping / log-hygiene / invariant value formatting.
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — new `GetFinancialFact` tool (follows the `FailToDeliverTools`/`GetFinancialStatement` pattern).
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs` — refactored to use `FactMarkdown` (dedupe).
- `tests/Equibles.IntegrationTests/Mcp/FinancialFactsToolsTests.cs` — 9 tests incl. restatement + ASC 606 tag-switch, same-period dual-tag tie, asOriginallyReported, form filter, invalid date, blank concept.

Closes #874