### PR TITLE
test(sec): pin SanitizeXml preserves hex numeric character references

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSanitizeXmlNumericEntityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSanitizeXmlNumericEntityTests.cs
@@ -1,0 +1,23 @@
+using System.Xml.Linq;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InsiderTradingFilingProcessorSanitizeXmlNumericEntityTests
+{
+    // Contract: SanitizeXml escapes bare ampersands so the result is well-formed
+    // XML, but must NOT double-escape already-valid references. SEC filings carry
+    // accented insider names as hex numeric character references (e.g. é = &#xE9;).
+    // Double-escaping to &amp;#xE9; would corrupt every such name. Pin that a valid
+    // hex char-ref survives intact and the output still parses.
+    [Fact]
+    public void SanitizeXml_HexNumericCharacterReference_IsPreservedNotDoubleEscaped()
+    {
+        var input = "<XML><ownershipDocument><name>Jos&#xE9;</name></ownershipDocument></XML>";
+
+        var result = InsiderTradingFilingProcessor.SanitizeXml(input);
+
+        result.Should().Contain("&#xE9;").And.NotContain("&amp;#xE9;");
+        XDocument.Parse(result).Root!.Value.Should().Be("José");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `InsiderTradingFilingProcessor.SanitizeXml` (untested contract): a valid hex numeric character reference (e.g. `&#xE9;`, used by SEC filings to carry accented insider names) must be **preserved, not double-escaped** to `&amp;#xE9;`, which would corrupt every such name.
- Behavior confirmed correct (the entity-name regex whitelists `#x[\da-fA-F]+;`); the test locks it against a regression in that negative-lookahead.

## Code changes

- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSanitizeXmlNumericEntityTests.cs` — new single-`[Fact]` test: sanitizes `Jos&#xE9;` inside an SGML envelope, asserts `&#xE9;` survives intact (not `&amp;#xE9;`) and the result parses to `José`. No production code touched.