### PR TITLE
test(messaging): cover AddMessaging bus wiring, transport options, consumer scan

### DIFF
--- a/tests/Equibles.IntegrationTests/Messaging/MessagingServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.IntegrationTests/Messaging/MessagingServiceCollectionExtensionsTests.cs
@@ -1,0 +1,51 @@
+using Equibles.Holdings.HostedService.Consumers;
+using Equibles.Messaging.Extensions;
+using MassTransit;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.IntegrationTests.Messaging;
+
+public class MessagingServiceCollectionExtensionsTests
+{
+    private const string TransportConnection =
+        "Host=localhost;Database=equibles;Username=postgres;Password=postgres";
+
+    // AddMessaging is the Worker/Web/Mcp messaging composition root: it must wire
+    // MassTransit, bind SqlTransportOptions from ConnectionStrings:TransportConnection,
+    // and auto-register every [Consumer] IConsumer<T> via the loaded-assembly scan.
+    // Touching StockCusipChangedConsumer forces its assembly to load so the scan
+    // (and IsSystemAssembly filtering) actually runs, as in a real host.
+    [Fact]
+    public void AddMessaging_WithRunMigration_WiresBusBindsTransportOptionsAndAutoRegistersConsumers()
+    {
+        _ = typeof(StockCusipChangedConsumer);
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string>
+                {
+                    ["MassTransit:RunMigration"] = "true",
+                    ["ConnectionStrings:TransportConnection"] = TransportConnection,
+                }
+            )
+            .Build();
+
+        services.AddMessaging(configuration);
+
+        using var provider = services.BuildServiceProvider();
+
+        provider
+            .GetRequiredService<IOptions<SqlTransportOptions>>()
+            .Value.ConnectionString.Should()
+            .Be(TransportConnection, "AddMessaging binds the transport connection string");
+        services
+            .Should()
+            .Contain(d => d.ServiceType == typeof(IBus), "AddMassTransit registered the bus")
+            .And.Contain(
+                d => d.ImplementationType == typeof(StockCusipChangedConsumer),
+                "the [Consumer] assembly scan auto-registered the real consumer"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- `MessagingServiceCollectionExtensions` was 0% covered (99 uncovered lines) — the Worker/Web/Mcp messaging composition root had no test. Phase 1 of the integration-coverage plan toward 95%.
- No new test infrastructure; uses a plain `ServiceCollection` + in-memory config. Fast (no Testcontainers).

## Code changes

- `tests/Equibles.IntegrationTests/Messaging/MessagingServiceCollectionExtensionsTests.cs` — one `[Fact]`: with `MassTransit:RunMigration=true` + `ConnectionStrings:TransportConnection`, `AddMessaging` binds `SqlTransportOptions.ConnectionString`, registers the MassTransit `IBus`, and the `[Consumer]` assembly scan auto-registers the real `StockCusipChangedConsumer` (touching the type forces its assembly to load so the scan + `IsSystemAssembly` filter execute as in a real host). Exercises the migration-gated branch, the outbox/bus config lambda, the consumer-scan loop, and the options binding.