### PR TITLE
fix(web): return RSI 100 for a zero-loss window

### DIFF
--- a/src/Equibles.Web/Services/TechnicalIndicatorService.cs
+++ b/src/Equibles.Web/Services/TechnicalIndicatorService.cs
@@ -95,9 +95,9 @@ public static class TechnicalIndicatorService
         for (var i = 1; i < period; i++)
             result.Add(null);
 
-        // First RSI value
-        var rs = avgLoss == 0 ? 100m : avgGain / avgLoss;
-        result.Add(Math.Round(100m - 100m / (1m + rs), 2));
+        // First RSI value. avgLoss == 0 ⇒ RS is infinite ⇒ RSI is 100 by
+        // definition (a window with no losses is the overbought extreme).
+        result.Add(avgLoss == 0 ? 100m : Math.Round(100m - 100m / (1m + avgGain / avgLoss), 2));
 
         // Smoothed RSI for remaining values
         for (var i = period + 1; i < prices.Count; i++)
@@ -105,8 +105,7 @@ public static class TechnicalIndicatorService
             avgGain = (avgGain * (period - 1) + gains[i]) / period;
             avgLoss = (avgLoss * (period - 1) + losses[i]) / period;
 
-            rs = avgLoss == 0 ? 100m : avgGain / avgLoss;
-            result.Add(Math.Round(100m - 100m / (1m + rs), 2));
+            result.Add(avgLoss == 0 ? 100m : Math.Round(100m - 100m / (1m + avgGain / avgLoss), 2));
         }
 
         return result;

--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceComputeRsiZeroLossTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceComputeRsiZeroLossTests.cs
@@ -9,7 +9,7 @@ public class TechnicalIndicatorServiceComputeRsiZeroLossTests
     // avgLoss = 0 so RS is infinite and RSI is 100 by definition (the overbought
     // extreme). A strictly increasing series has zero losses, so its first
     // computable RSI must be exactly 100. Asserting the contract, not the code.
-    [Fact(Skip = "GH-955 — ComputeRsi returns 99.01 not 100 for a zero-loss series")]
+    [Fact]
     public void ComputeRsi_StrictlyIncreasingSeries_FirstValueIs100()
     {
         var prices = new List<decimal> { 1m, 2m, 3m, 4m, 5m };

--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceTests.cs
@@ -365,10 +365,8 @@ public class TechnicalIndicatorServiceTests
     [Fact]
     public void ComputeRsi_AllGains_ReturnsRsi100()
     {
-        // Prices that only go up => avgLoss=0 => rs=100 => RSI = 100 - 100/101 = 99.01
-        // Wait, let's re-read: rs = avgLoss == 0 ? 100m : avgGain / avgLoss
-        // RSI = 100 - 100/(1+100) = 100 - 100/101 = 100 - 0.990099.. = 99.0099.. => rounded to 99.01
-        // Hmm, that's not exactly 100. Let's verify with period=3 for simplicity.
+        // Prices that only go up => avgLoss=0 => RS infinite => RSI = 100
+        // (a window with no losses is the overbought extreme, by definition).
         var prices = new List<decimal> { 10m, 11m, 12m, 13m, 14m };
         var result = TechnicalIndicatorService.ComputeRsi(prices, 3);
 
@@ -376,14 +374,11 @@ public class TechnicalIndicatorServiceTests
         // changes: [_, +1, +1, +1, +1]
         // gains:   [0, 1, 1, 1, 1]
         // losses:  [0, 0, 0, 0, 0]
-        // avgGain = (1+1+1)/3 = 1; avgLoss = 0/3 = 0
-        // rs = 100 (avgLoss==0 branch)
-        // RSI[3] = 100 - 100/(1+100) = 100 - 0.990099... = 99.0099... => 99.01
-        result[3].Should().Be(99.01m);
+        // avgGain = (1+1+1)/3 = 1; avgLoss = 0/3 = 0 => RSI = 100
+        result[3].Should().Be(100m);
 
-        // Index 4: avgGain = (1*2 + 1)/3 = 1; avgLoss = (0*2 + 0)/3 = 0
-        // rs = 100 => RSI = 99.01
-        result[4].Should().Be(99.01m);
+        // Index 4: avgGain = (1*2 + 1)/3 = 1; avgLoss = (0*2 + 0)/3 = 0 => RSI = 100
+        result[4].Should().Be(100m);
     }
 
     [Fact]
@@ -460,13 +455,12 @@ public class TechnicalIndicatorServiceTests
     [Fact]
     public void ComputeRsi_ConstantPrices_AllZeroChanges()
     {
-        // All changes are 0 => avgGain=0, avgLoss=0
-        // rs = 100 (avgLoss==0 branch) => RSI = 99.01
+        // All changes are 0 => avgGain=0, avgLoss=0. avgLoss==0 ⇒ RS infinite
+        // ⇒ RSI = 100 by the same no-losses rule (Wilder); not 99.01.
         var prices = new List<decimal> { 50m, 50m, 50m, 50m, 50m };
         var result = TechnicalIndicatorService.ComputeRsi(prices, 3);
 
-        // avgGain=0, avgLoss=0 => avgLoss==0 => rs=100 => RSI = 99.01
-        result[3].Should().Be(99.01m);
+        result[3].Should().Be(100m);
     }
 
     [Fact]
@@ -484,8 +478,8 @@ public class TechnicalIndicatorServiceTests
             result[i].Should().BeNull($"index {i} should be null during lookback");
         }
 
-        // Index 14 should be the first RSI value (all gains => 99.01)
-        result[14].Should().Be(99.01m);
+        // Index 14 should be the first RSI value (all gains, zero losses => 100)
+        result[14].Should().Be(100m);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `TechnicalIndicatorService.ComputeRsi` fed a finite sentinel (`rs = avgLoss == 0 ? 100m : avgGain/avgLoss`) into `100 - 100/(1+rs)`, returning **99.01** for a window with no losses instead of the definitional RSI **100** (RS is infinite when `avgLoss = 0`; Wilder 1978 / StockCharts / Investopedia). A pure uptrend never reported the overbought extreme, so any caller keying on `RSI == 100` silently never triggered.
- Fixes #955 by computing `100` directly on the `avgLoss == 0` branch at both the initial and smoothed sites — the only behavior change is the documented bug, per the same no-losses rule.

## Code changes

- `src/Equibles.Web/Services/TechnicalIndicatorService.cs` — both RSI sites: `avgLoss == 0 ? 100m : Math.Round(100 - 100/(1 + avgGain/avgLoss), 2)`. The `avgLoss != 0` path is byte-identical; the now-unused `rs` local is removed.
- `tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceComputeRsiZeroLossTests.cs` — un-skipped the committed regression test (fails pre-fix at 99.01, passes after).
- `tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceTests.cs` — corrected three existing tests that pinned the buggy 99.01 for zero-loss inputs (`ComputeRsi_AllGains_ReturnsRsi100`, `ComputeRsi_ConstantPrices_AllZeroChanges`, `ComputeRsi_DefaultPeriodIs14`) and their stale comments.

closes #955