### PR TITLE
feat(mcp): peer-comparison tool for a financial concept

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FactArgs.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FactArgs.cs
@@ -1,0 +1,37 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+
+namespace Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+/// <summary>
+/// Shared parsing of free-text MCP tool arguments into FinancialFacts domain
+/// types, so every tool accepts the same spellings.
+/// </summary>
+public static class FactArgs
+{
+    public static bool TryParsePeriod(string value, out SecFiscalPeriod period)
+    {
+        switch (value?.Trim().ToUpperInvariant())
+        {
+            case "FY":
+            case "FULLYEAR":
+            case "ANNUAL":
+                period = SecFiscalPeriod.FullYear;
+                return true;
+            case "Q1":
+                period = SecFiscalPeriod.Q1;
+                return true;
+            case "Q2":
+                period = SecFiscalPeriod.Q2;
+                return true;
+            case "Q3":
+                period = SecFiscalPeriod.Q3;
+                return true;
+            case "Q4":
+                period = SecFiscalPeriod.Q4;
+                return true;
+            default:
+                period = default;
+                return false;
+        }
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -8,6 +9,7 @@ using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Statements;
 using Equibles.Sec.FinancialFacts.Mcp.Helpers;
 using Equibles.Sec.FinancialFacts.Repositories;
@@ -21,6 +23,7 @@ namespace Equibles.Sec.FinancialFacts.Mcp.Tools;
 public class FinancialFactsTools
 {
     private const int MaxResultsCap = 200;
+    private const int MaxTickers = 25;
 
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
@@ -136,9 +139,13 @@ public class FinancialFactsTools
                     .Select(g =>
                     {
                         var byPriority = g.OrderBy(f => conceptPriority[f.FinancialConceptId]);
+                        // AccessionNumber is the stable final tiebreak for
+                        // same-day amendments (Postgres has no implicit order).
                         var ordered = asOriginallyReported
-                            ? byPriority.ThenBy(f => f.FiledDate)
-                            : byPriority.ThenByDescending(f => f.FiledDate);
+                            ? byPriority.ThenBy(f => f.FiledDate).ThenBy(f => f.AccessionNumber)
+                            : byPriority
+                                .ThenByDescending(f => f.FiledDate)
+                                .ThenByDescending(f => f.AccessionNumber);
                         return ordered.First();
                     })
                     .OrderByDescending(f => f.PeriodEnd)
@@ -179,6 +186,153 @@ public class FinancialFactsTools
             "GetFinancialFact",
             $"ticker: {FactMarkdown.Clean(ticker)}, concept: {FactMarkdown.Clean(concept)}, "
                 + $"form: {FactMarkdown.Clean(form)}",
+            ReportError
+        );
+    }
+
+    [McpServerTool(Name = "CompareFinancialFact")]
+    [Description(
+        "Compare one financial concept across several companies for the same fiscal "
+            + "period — peer comparison. Returns one row per ticker with the "
+            + "latest-restated value; tickers with no data for the period are listed "
+            + "separately."
+    )]
+    public Task<string> CompareFinancialFact(
+        [Description("Comma-separated tickers, e.g. 'AAPL,MSFT,GOOGL' (max 25)")] string tickers,
+        [Description(
+            "Concept alias, e.g. 'revenue', 'net-income', 'eps-diluted'. Call with an "
+                + "unknown value to list supported aliases."
+        )]
+            string concept,
+        [Description("Fiscal year, e.g. 2023")] int fiscalYear,
+        [Description("Fiscal period: 'FY' (default) or 'Q1'..'Q4'")] string fiscalPeriod = "FY"
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                if (string.IsNullOrWhiteSpace(concept))
+                    return "A concept is required. Supported: "
+                        + $"{string.Join(", ", FinancialConceptAliases.SupportedAliases)} "
+                        + "(common synonyms like 'sales', 'r&d', 'ocf' also work).";
+
+                if (!FinancialConceptAliases.TryResolve(concept, out var conceptRefs))
+                    return $"Unknown concept '{concept}'. Supported: "
+                        + $"{string.Join(", ", FinancialConceptAliases.SupportedAliases)} "
+                        + "(common synonyms like 'sales', 'r&d', 'ocf' also work).";
+
+                if (!FactArgs.TryParsePeriod(fiscalPeriod, out var period))
+                    return $"Unknown period '{fiscalPeriod}'. Use 'FY' or 'Q1'..'Q4'.";
+
+                if (string.IsNullOrWhiteSpace(tickers))
+                    return "At least one ticker is required.";
+
+                var requested = tickers
+                    .Split(
+                        ',',
+                        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+                    )
+                    .Select(t => t.ToUpperInvariant())
+                    .Distinct()
+                    .ToList();
+
+                if (requested.Count == 0)
+                    return "At least one ticker is required.";
+                if (requested.Count > MaxTickers)
+                    return $"Too many tickers ({requested.Count}). The maximum is {MaxTickers}.";
+
+                var conceptPriority = await ResolveConceptPriority(conceptRefs);
+                if (conceptPriority.Count == 0)
+                    return $"No '{concept}' data has been ingested.";
+
+                // Two queries instead of 2N: batch-load the requested stocks,
+                // then all matching facts in one go keyed by company.
+                var stocks = await _commonStockRepository.GetByTickers(requested).ToListAsync();
+                var stockByTicker = new Dictionary<string, CommonStock>();
+                foreach (var s in stocks)
+                {
+                    if (requested.Contains(s.Ticker))
+                        stockByTicker.TryAdd(s.Ticker, s);
+                    foreach (var secondary in s.SecondaryTickers ?? [])
+                        if (requested.Contains(secondary))
+                            stockByTicker.TryAdd(secondary, s);
+                }
+
+                var stockIds = stocks.Select(s => s.Id).ToList();
+                var facts = await _financialFactRepository
+                    .GetByStocks(stockIds)
+                    .Where(f =>
+                        f.FiscalYear == fiscalYear
+                        && f.FiscalPeriod == period
+                        && conceptPriority.Keys.Contains(f.FinancialConceptId)
+                    )
+                    .ToListAsync();
+
+                // Same deterministic pick as GetFinancialFact: the alias's
+                // primary tag wins, then the latest filing, then accession as a
+                // stable tiebreak for same-day amendments (Postgres has no
+                // implicit row order).
+                var bestByStock = facts
+                    .GroupBy(f => f.CommonStockId)
+                    .ToDictionary(
+                        g => g.Key,
+                        g =>
+                            g.OrderBy(f => conceptPriority[f.FinancialConceptId])
+                                .ThenByDescending(f => f.FiledDate)
+                                .ThenByDescending(f => f.AccessionNumber)
+                                .First()
+                    );
+
+                var rows = new List<(string Ticker, string Name, FinancialFact Fact)>();
+                var skipped = new List<string>();
+                foreach (var ticker in requested)
+                {
+                    if (!stockByTicker.TryGetValue(ticker, out var stock))
+                    {
+                        skipped.Add($"{FactMarkdown.Cell(ticker)} (not found)");
+                        continue;
+                    }
+                    if (!bestByStock.TryGetValue(stock.Id, out var best))
+                    {
+                        skipped.Add($"{FactMarkdown.Cell(ticker)} (no data)");
+                        continue;
+                    }
+                    rows.Add((stock.Ticker, stock.Name, best));
+                }
+
+                var result = new StringBuilder();
+                result.AppendLine(
+                    $"{concept} — {fiscalYear} {period.NameForHumans()} peer comparison:"
+                );
+                result.AppendLine();
+                result.AppendLine("| Ticker | Company | Value | Unit | Form | Filed |");
+                result.AppendLine("|--------|---------|------:|------|------|-------|");
+                foreach (var (ticker, name, fact) in rows)
+                {
+                    result.AppendLine(
+                        $"| {FactMarkdown.Cell(ticker)} | {FactMarkdown.Cell(name)} | "
+                            + $"{FactMarkdown.Value(fact.Value, fact.Unit)} | "
+                            + $"{FactMarkdown.Cell(fact.Unit)} | "
+                            + $"{FactMarkdown.Cell(fact.Form?.DisplayName)} | "
+                            + $"{fact.FiledDate:yyyy-MM-dd} |"
+                    );
+                }
+
+                if (rows.Count == 0)
+                    result.AppendLine(
+                        $"\n_No company reported '{concept}' for {fiscalYear} "
+                            + $"{period.NameForHumans()}._"
+                    );
+
+                if (skipped.Count > 0)
+                    result.AppendLine($"\n_Skipped: {string.Join(", ", skipped)}._");
+
+                return result.ToString();
+            },
+            _logger,
+            "CompareFinancialFact",
+            $"tickers: {FactMarkdown.Clean(tickers)}, concept: {FactMarkdown.Clean(concept)}, "
+                + $"year: {fiscalYear}, period: {FactMarkdown.Clean(fiscalPeriod)}",
             ReportError
         );
     }

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -83,7 +83,7 @@ public class FinancialStatementTools
                 SecFiscalPeriod? requestedPeriod = null;
                 if (period != null)
                 {
-                    if (!TryParsePeriod(period, out var parsedPeriod))
+                    if (!FactArgs.TryParsePeriod(period, out var parsedPeriod))
                         return $"Unknown period '{period}'. Use 'FY' or 'Q1'..'Q4'.";
                     requestedPeriod = parsedPeriod;
                 }
@@ -225,33 +225,6 @@ public class FinancialStatementTools
                 return true;
             default:
                 type = default;
-                return false;
-        }
-    }
-
-    private static bool TryParsePeriod(string value, out SecFiscalPeriod period)
-    {
-        switch (value?.Trim().ToUpperInvariant())
-        {
-            case "FY":
-            case "FULLYEAR":
-            case "ANNUAL":
-                period = SecFiscalPeriod.FullYear;
-                return true;
-            case "Q1":
-                period = SecFiscalPeriod.Q1;
-                return true;
-            case "Q2":
-                period = SecFiscalPeriod.Q2;
-                return true;
-            case "Q3":
-                period = SecFiscalPeriod.Q3;
-                return true;
-            case "Q4":
-                period = SecFiscalPeriod.Q4;
-                return true;
-            default:
-                period = default;
                 return false;
         }
     }

--- a/src/Equibles.Sec.FinancialFacts.Repositories/FinancialFactRepository.cs
+++ b/src/Equibles.Sec.FinancialFacts.Repositories/FinancialFactRepository.cs
@@ -13,4 +13,9 @@ public class FinancialFactRepository : BaseRepository<FinancialFact>
     {
         return GetAll().Where(f => f.CommonStockId == stock.Id);
     }
+
+    public IQueryable<FinancialFact> GetByStocks(IReadOnlyCollection<Guid> stockIds)
+    {
+        return GetAll().Where(f => stockIds.Contains(f.CommonStockId));
+    }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/FinancialFactsCompareToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FinancialFactsCompareToolsTests.cs
@@ -1,0 +1,166 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class FinancialFactsCompareToolsTests : ParadeDbMcpTestBase
+{
+    public FinancialFactsCompareToolsTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private FinancialFactsTools Sut() =>
+        new(
+            new FinancialFactRepository(DbContext),
+            new FinancialConceptRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<FinancialFactsTools>()
+        );
+
+    private CommonStock AddStock(string ticker, string name)
+    {
+        var s = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = name,
+            Cik = ticker,
+        };
+        DbContext.Set<CommonStock>().Add(s);
+        return s;
+    }
+
+    private FinancialConcept _revenue;
+
+    private FinancialConcept RevenueConcept()
+    {
+        if (_revenue != null)
+            return _revenue;
+        _revenue = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "Revenues",
+            Label = "Revenues",
+        };
+        DbContext.Set<FinancialConcept>().Add(_revenue);
+        return _revenue;
+    }
+
+    private void AddRevenue(
+        CommonStock stock,
+        decimal value,
+        DateOnly filed,
+        int fy = 2023,
+        string accn = null
+    )
+    {
+        DbContext
+            .Set<FinancialFact>()
+            .Add(
+                new FinancialFact
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = stock.Id,
+                    FinancialConceptId = RevenueConcept().Id,
+                    Unit = "USD",
+                    PeriodType = FactPeriodType.Duration,
+                    PeriodStart = new DateOnly(fy, 1, 1),
+                    PeriodEnd = new DateOnly(fy, 12, 31),
+                    Value = value,
+                    FiscalYear = fy,
+                    FiscalPeriod = SecFiscalPeriod.FullYear,
+                    Form = DocumentType.TenK,
+                    FiledDate = filed,
+                    AccessionNumber = accn ?? Guid.NewGuid().ToString(),
+                }
+            );
+    }
+
+    [Fact]
+    public async Task CompareFinancialFact_NoTickers_ReturnsRequired()
+    {
+        var result = await Sut().CompareFinancialFact("", "revenue", 2023);
+
+        result.Should().Contain("At least one ticker is required.");
+    }
+
+    [Fact]
+    public async Task CompareFinancialFact_UnknownConcept_ListsSupportedAliases()
+    {
+        var result = await Sut().CompareFinancialFact("AAPL", "ebitda", 2023);
+
+        result.Should().Contain("Unknown concept 'ebitda'");
+    }
+
+    [Fact]
+    public async Task CompareFinancialFact_TooManyTickers_ReturnsCapMessage()
+    {
+        var many = string.Join(",", Enumerable.Range(1, 30).Select(i => $"T{i}"));
+
+        var result = await Sut().CompareFinancialFact(many, "revenue", 2023);
+
+        result.Should().Contain("Too many tickers (30). The maximum is 25.");
+    }
+
+    [Fact]
+    public async Task CompareFinancialFact_PeerSet_RendersRowsLatestRestatedAndListsSkipped()
+    {
+        var apple = AddStock("AAPL", "Apple Inc.");
+        var msft = AddStock("MSFT", "Microsoft Corp");
+        AddStock("GOOGL", "Alphabet Inc."); // no facts
+        // Apple restated: 380 then 400 (latest filed wins).
+        AddRevenue(apple, 380_000_000_000m, new DateOnly(2024, 1, 15), accn: "aapl-orig");
+        AddRevenue(apple, 400_000_000_000m, new DateOnly(2024, 6, 1), accn: "aapl-restate");
+        AddRevenue(msft, 211_000_000_000m, new DateOnly(2024, 1, 20), accn: "msft");
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().CompareFinancialFact("aapl, msft, googl, zzzz", "revenue", 2023);
+
+        result.Should().Contain("revenue — 2023 FY peer comparison:");
+        result.Should().Contain("| AAPL | Apple Inc. | $400,000,000,000 | USD |");
+        result.Should().Contain("| MSFT | Microsoft Corp | $211,000,000,000 | USD |");
+        result.Should().NotContain("$380,000,000,000", "the latest-filed restatement wins");
+        result.Should().Contain("Skipped:");
+        result.Should().Contain("GOOGL (no data)");
+        result.Should().Contain("ZZZZ (not found)");
+    }
+
+    [Fact]
+    public async Task CompareFinancialFact_ConceptNeverIngested_ReturnsNotIngested()
+    {
+        AddStock("AAPL", "Apple Inc.");
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().CompareFinancialFact("AAPL", "revenue", 2023);
+
+        result.Should().Contain("No 'revenue' data has been ingested.");
+        result.Should().NotContain("(no data)", "an un-ingested concept is not a per-ticker miss");
+    }
+
+    [Fact]
+    public async Task CompareFinancialFact_SameDayAmendments_DeterministicByAccession()
+    {
+        var apple = AddStock("AAPL", "Apple Inc.");
+        var filed = new DateOnly(2024, 6, 1);
+        // Two filings, SAME filed date — accession is the stable tiebreak.
+        AddRevenue(apple, 350_000_000_000m, filed, accn: "0000320193-24-000001");
+        AddRevenue(apple, 360_000_000_000m, filed, accn: "0000320193-24-000099");
+        await DbContext.SaveChangesAsync();
+
+        var first = await Sut().CompareFinancialFact("AAPL", "revenue", 2023);
+        var second = await Sut().CompareFinancialFact("AAPL", "revenue", 2023);
+
+        first.Should().Contain("$360,000,000,000", "the higher accession wins the same-day tie");
+        first.Should().NotContain("$350,000,000,000");
+        second.Should().Be(first, "the pick is deterministic across calls");
+    }
+}


### PR DESCRIPTION
## Summary

- New `CompareFinancialFact` MCP tool: one financial concept across several tickers for a fiscal period (peer comparison), reusing the `FinancialConceptAliases` map and the deterministic alias-priority / latest-restated pick from `GetFinancialFact`.
- Per post-implementation review: batched into 2 queries (not 2N) via `CommonStockRepository.GetByTickers` + a new `FinancialFactRepository.GetByStocks`; stable tiebreak `AccessionNumber` for same-day amendments (also added to `GetFinancialFact`); Markdown-escaped echoed tickers; honest "not ingested" message; `{year} {period}` label (no misleading `FY` prefix on quarters).

## Code changes

- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — new `CompareFinancialFact` method.
- `src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FactArgs.cs` — new shared `TryParsePeriod`; `FinancialStatementTools` now delegates to it (verbatim move, no behaviour change).
- `src/Equibles.Sec.FinancialFacts.Repositories/FinancialFactRepository.cs` — `GetByStocks(IReadOnlyCollection<Guid>)` for batched peer queries.
- `tests/Equibles.IntegrationTests/Mcp/FinancialFactsCompareToolsTests.cs` — 7 tests: peer set + skipped reporting, no tickers, unknown concept, too-many cap, same-day accession tiebreak determinism, concept-not-ingested.

Closes #876