### PR TITLE
test(yahoo): pin ToUnixTimestamp epoch-zero and round-trip

### DIFF
--- a/tests/Equibles.UnitTests/Yahoo/YahooFinanceClientToUnixTimestampTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooFinanceClientToUnixTimestampTests.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Equibles.Integrations.Yahoo;
+
+namespace Equibles.UnitTests.Yahoo;
+
+public class YahooFinanceClientToUnixTimestampTests
+{
+    private static readonly MethodInfo ToUnix = typeof(YahooFinanceClient).GetMethod(
+        "ToUnixTimestamp",
+        BindingFlags.NonPublic | BindingFlags.Static
+    )!;
+    private static readonly MethodInfo FromUnix = typeof(YahooFinanceClient).GetMethod(
+        "FromUnixTimestamp",
+        BindingFlags.NonPublic | BindingFlags.Static
+    )!;
+
+    // Contract: ToUnixTimestamp anchors a DateOnly at UTC midnight relative to
+    // 1970-01-01Z, so 1970-01-01 must be exactly 0 and the conversion must
+    // round-trip (price-range building converts dates → timestamps → dates).
+    // A local-time or off-by-one anchor would break either invariant.
+    [Fact]
+    public void ToUnixTimestamp_EpochIsZeroAndRoundTripsViaFromUnixTimestamp()
+    {
+        ((long)ToUnix.Invoke(null, [new DateOnly(1970, 1, 1)])!).Should().Be(0L);
+
+        var date = new DateOnly(2021, 7, 19);
+        var ts = (long)ToUnix.Invoke(null, [date])!;
+        ((DateOnly)FromUnix.Invoke(null, [ts])!).Should().Be(date);
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `YahooFinanceClient.ToUnixTimestamp` (untested; the existing UTC-date test only covers `FromUnixTimestamp` one-way): pins that `1970-01-01` maps to exactly `0` and that a date round-trips through `ToUnixTimestamp` → `FromUnixTimestamp` unchanged.
- Behavior confirmed correct (UTC-anchored epoch math); the test locks the epoch anchor and round-trip invariant that price-range building relies on against a local-time or off-by-one regression.

## Code changes

- `tests/Equibles.UnitTests/Yahoo/YahooFinanceClientToUnixTimestampTests.cs` — new single-`[Fact]` test invoking the private statics `ToUnixTimestamp`/`FromUnixTimestamp` via reflection (the repo's established pattern). No production code touched.