### PR TITLE
test(sec): add skipped repro for GH-969 — HeadingConversionStep.IsAllUppercase

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsAllUppercaseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsAllUppercaseTests.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+/// <summary>
+/// IsAllUppercase decides whether a span is "shouting in caps" and should
+/// therefore be promoted to an &lt;h3&gt; heading. A span with NO letters at all
+/// (a stray figure like "1,234,567") is not uppercase text and must not be
+/// treated as a heading — otherwise numeric lines corrupt the normalised SEC
+/// document structure. Contract derived from the method name and its role as a
+/// heading discriminator, before reading the body.
+/// </summary>
+public class HeadingConversionStepIsAllUppercaseTests
+{
+    [Fact(
+        Skip = "GH-969 — IsAllUppercase returns true for letter-less spans (vacuous All on empty)"
+    )]
+    public void IsAllUppercase_LetterlessText_ReturnsFalse()
+    {
+        var span = new HtmlParser()
+            .ParseDocument("<html><body><span>1,234,567</span></body></html>")
+            .QuerySelector("span")!;
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "IsAllUppercase",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var step = new HeadingConversionStep();
+
+        var result = (bool)method.Invoke(step, [span])!;
+
+        result
+            .Should()
+            .BeFalse(
+                "a span with no letters is not uppercase text and must not be promoted to a heading"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `HeadingConversionStep.IsAllUppercase` discovered a real defect: it returns `true` for spans containing no letters (vacuous `Enumerable.All` over an empty letter sequence), so a purely numeric span can be wrongly promoted to an `<h3>` heading in normalised SEC documents.
- Test committed as `[Skip]` pending the fix — see GH-969.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsAllUppercaseTests.cs` — new `[Fact(Skip = "GH-969 …")]` asserting `IsAllUppercase` returns `false` for letter-less text (`<span>1,234,567</span>`). Skipped — see GH-969; un-skip as part of the fix. No production code changed.