### PR TITLE
fix(sec): reject letter-less spans in IsAllUppercase

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -109,7 +109,8 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
         if (string.IsNullOrWhiteSpace(node.TextContent))
             return false;
 
-        return node.TextContent.Trim().Where(char.IsLetter).All(char.IsUpper);
+        var letters = node.TextContent.Trim().Where(char.IsLetter).ToList();
+        return letters.Count > 0 && letters.All(char.IsUpper);
     }
 
     private bool IsPartHeading(string text)

--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsAllUppercaseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsAllUppercaseTests.cs
@@ -14,9 +14,7 @@ namespace Equibles.UnitTests.Sec.Normalizers;
 /// </summary>
 public class HeadingConversionStepIsAllUppercaseTests
 {
-    [Fact(
-        Skip = "GH-969 — IsAllUppercase returns true for letter-less spans (vacuous All on empty)"
-    )]
+    [Fact]
     public void IsAllUppercase_LetterlessText_ReturnsFalse()
     {
         var span = new HtmlParser()


### PR DESCRIPTION
## Summary

- `HeadingConversionStep.IsAllUppercase` returned `true` for spans containing no letters because `Enumerable.All` is vacuously true on an empty sequence — a purely numeric span (e.g. `1,234,567`) was wrongly promoted to an `<h3>` heading, corrupting normalised SEC document structure.
- Fixes #969 at the root cause; un-skips the regression test added under that issue.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs` — `IsAllUppercase` now materialises the letters and returns `false` when there are none (`letters.Count > 0 && letters.All(char.IsUpper)`). Behaviour is unchanged for any text containing ≥1 letter.
- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsAllUppercaseTests.cs` — removed `[Fact(Skip = …)]`; the GH-969 regression test now runs (fails pre-fix, passes post-fix). Full 68-test normalizer suite green.