### PR TITLE
test(sec): add skipped repro for GH-975 — IsItemHeading NBSP

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItemHeadingTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItemHeadingTests.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+/// <summary>
+/// IsItemHeading classifies SEC 10-K "Item N" section headings. SEC EDGAR
+/// HTML routinely renders these with a non-breaking space (U+00A0) between
+/// "Item" and the number — e.g. <c>Item&amp;nbsp;1A. Risk Factors</c>. The
+/// canonical heading is the same regardless of which Unicode whitespace the
+/// renderer chose, so IsItemHeading must accept the NBSP variant. Contract
+/// derived from the SEC 10-K item-heading convention before reading the body.
+/// </summary>
+public class HeadingConversionStepIsItemHeadingTests
+{
+    [Fact(
+        Skip = "GH-975 — IsItemHeading rejects NBSP-separated 'Item N' headings (StartsWith requires U+0020)"
+    )]
+    public void IsItemHeading_NonBreakingSpaceSeparator_ReturnsTrue()
+    {
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "IsItemHeading",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var step = new HeadingConversionStep();
+
+        // Explicit U+00A0 between "Item" and "1A" — what SEC EDGAR emits.
+        var result = (bool)method.Invoke(step, ["Item\u00A01A. Risk Factors"])!;
+
+        result
+            .Should()
+            .BeTrue(
+                "SEC EDGAR renders 'Item 1A' with a non-breaking space; the heading is the same canonical SEC 10-K item heading regardless of which whitespace separates 'Item' from the number"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `HeadingConversionStep.IsItemHeading` discovered a real defect: it rejects SEC 10-K item headings when "Item" is separated from the number by a non-breaking space (U+00A0) — the `StartsWith("ITEM ")` check is an ordinal compare that requires U+0020. SEC EDGAR HTML routinely emits `<span>Item&nbsp;1A. Risk Factors</span>`, so the heading is silently not promoted to `<h2>`.
- The Part-heading discriminator (`IsPartHeading`) has the same gap on `"PART "`.
- Test committed as `[Skip]` pending the fix — see GH-975.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItemHeadingTests.cs` — new `[Fact(Skip = "GH-975 …")]` asserting `IsItemHeading("Item 1A. Risk Factors")` returns `true`. Skipped — see GH-975; un-skip as part of the fix. No production code changed.