### PR TITLE
test(cftc): pin SplitCsvLine discards non-whitespace trailer after close

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineTrailingJunkTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineTrailingJunkTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Equibles.Integrations.Cftc;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CftcClientSplitCsvLineTrailingJunkTests
+{
+    private static readonly MethodInfo SplitCsvLineMethod = typeof(CftcClient).GetMethod(
+        "SplitCsvLine",
+        BindingFlags.NonPublic | BindingFlags.Static
+    )!;
+
+    [Fact]
+    public void SplitCsvLine_NonWhitespaceAfterClosingQuote_IsDiscardedFromValue()
+    {
+        // Contract (source comment, CftcClient.cs:251-252): "Characters after a
+        // closing quote (CFTC's trailing padding before the next delimiter) are
+        // likewise not part of the verbatim value." The existing pins cover
+        // padding BEFORE the opening quote, embedded commas, and escaped
+        // quotes — none exercises the post-close discard branch with non-
+        // whitespace. Dropping the `!wasQuoted` guard in the unquoted-char
+        // arm would silently start appending those chars to the field value
+        // and corrupt every CFTC report row whose source padded with anything
+        // other than whitespace. Pin the documented "verbatim from inside the
+        // quotes" guarantee with a non-whitespace trailer so the regression
+        // surfaces here.
+        var line = "\"verbatim\"trailing,next";
+
+        var fields = (string[])SplitCsvLineMethod.Invoke(null, [line])!;
+
+        fields.Should().Equal("verbatim", "next");
+    }
+}


### PR DESCRIPTION
## Summary

- The CFTC CSV parser deliberately discards any characters between a closing quote and the next delimiter (CftcClient.cs:251-252). The existing `SplitCsvLine` tests pin embedded commas, leading padding before the opening quote, and escaped quotes — but no test exercises the post-close discard branch.
- A refactor that drops the `!wasQuoted` guard on the unquoted-character arm would silently start appending those chars and corrupt every CFTC report row whose source padded with anything other than whitespace. This pin makes that regression fail here.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineTrailingJunkTests.cs` — new `[Fact]` asserting `SplitCsvLine("\"verbatim\"trailing,next")` returns `["verbatim", "next"]`. Reflection-invoked private static method, matching the existing `CftcClientSplitCsvLine*Tests` pattern. No production code changed.