### PR TITLE
fix(sec): accept NBSP-separated 'Item N' headings in IsItemHeading

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -143,7 +143,12 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
 
         var upperText = text.ToUpperInvariant().Trim();
 
-        return upperText.StartsWith("ITEM ") && upperText.Length > 5;
+        // SEC EDGAR renders "Item N" with a non-breaking space (U+00A0)
+        // between word and number, so accept any Unicode whitespace after
+        // "ITEM" — not just the literal U+0020 that StartsWith("ITEM ") demands.
+        return upperText.StartsWith("ITEM")
+            && upperText.Length > 5
+            && char.IsWhiteSpace(upperText[4]);
     }
 
     private bool IsItalicSpan(IElement span)

--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItemHeadingTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItemHeadingTests.cs
@@ -13,9 +13,7 @@ namespace Equibles.UnitTests.Sec.Normalizers;
 /// </summary>
 public class HeadingConversionStepIsItemHeadingTests
 {
-    [Fact(
-        Skip = "GH-975 — IsItemHeading rejects NBSP-separated 'Item N' headings (StartsWith requires U+0020)"
-    )]
+    [Fact]
     public void IsItemHeading_NonBreakingSpaceSeparator_ReturnsTrue()
     {
         var method = typeof(HeadingConversionStep).GetMethod(


### PR DESCRIPTION
## Summary

- `HeadingConversionStep.IsItemHeading` used `StartsWith("ITEM ")` — an ordinal compare against U+0020 — so SEC EDGAR renderings with a non-breaking space (`<span>Item&nbsp;1A. Risk Factors</span>`) silently failed the prefix check and were never promoted to `<h2>`.
- Fixes #975 at the root cause; un-skips the regression test added under that issue.
- The sibling `IsPartHeading` has the same `StartsWith("PART ")` pattern but is a separate unreported bug — intentionally NOT touched here (one bug per PR); follow-up if the team wants the same fix applied there.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs` — `IsItemHeading` now checks `StartsWith("ITEM") && Length > 5 && char.IsWhiteSpace(upperText[4])`. For any text with U+0020 the result is identical (`IsWhiteSpace(' ')` is true); only NBSP and other Unicode whitespace cases flip from false to true.
- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItemHeadingTests.cs` — removed `[Fact(Skip = "GH-975 …")]`; the GH-975 regression test now runs (fails pre-fix, passes post-fix). Full 69-test normalizer suite green.