### PR TITLE
test(sec): add skipped repro for GH-981 — IsPartHeading NBSP

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingNbspTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingNbspTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+/// <summary>
+/// IsPartHeading classifies SEC 10-K "PART N" section headings. SEC EDGAR
+/// HTML routinely renders these with a non-breaking space (U+00A0) between
+/// "Part" and the roman numeral — e.g. <c>Part&amp;nbsp;IV</c>. The canonical
+/// heading is the same regardless of which Unicode whitespace the renderer
+/// chose, so IsPartHeading must accept the NBSP variant (the sister method
+/// IsItemHeading was fixed for the identical pattern under GH-975). Contract
+/// derived from the SEC 10-K part-heading convention before reading the body.
+/// </summary>
+public class HeadingConversionStepIsPartHeadingNbspTests
+{
+    [Fact(
+        Skip = "GH-981 — IsPartHeading rejects NBSP-separated 'Part N' headings (StartsWith requires U+0020)"
+    )]
+    public void IsPartHeading_NonBreakingSpaceSeparator_ReturnsTrue()
+    {
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "IsPartHeading",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var step = new HeadingConversionStep();
+
+        // Explicit U+00A0 between "Part" and "IV" — what SEC EDGAR emits.
+        var result = (bool)method.Invoke(step, ["Part\u00A0IV"])!;
+
+        result
+            .Should()
+            .BeTrue(
+                "SEC EDGAR renders 'Part IV' with a non-breaking space; the heading is the same canonical SEC 10-K part heading regardless of which whitespace separates 'Part' from the numeral"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `HeadingConversionStep.IsPartHeading` discovered the same NBSP defect that GH-975 fixed in the sibling `IsItemHeading`: `StartsWith("PART ")` is an ordinal compare against U+0020, so SEC EDGAR's `<span>Part&nbsp;IV</span>` renderings silently fail the prefix check and are never promoted to `<h1>`.
- GH-975's PR (#980) intentionally scoped its fix to `IsItemHeading` only (one bug per PR). This test surfaces the matching gap in `IsPartHeading` so the same `char.IsWhiteSpace(upperText[4])` treatment can be applied as a follow-up.
- Test committed as `[Skip]` pending the fix — see GH-981.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingNbspTests.cs` — new `[Fact(Skip = "GH-981 …")]` asserting `IsPartHeading("Part IV")` returns `true`. Skipped — see GH-981; un-skip as part of the fix. No production code changed.