### PR TITLE
test(sec): pin FactMarkdown.Value renders per-share USD as cents

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownValuePerShareUsdTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownValuePerShareUsdTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Value(decimal, string) renders a reported fact for the MCP Markdown
+/// surface. The doc-comment specifies: per-share units use cents precision,
+/// USD gets the "$" prefix. The canonical SEC per-share-USD fact is earnings
+/// per share — small magnitudes where the cents are the whole answer. If a
+/// refactor checks isWholeMagnitude (USD → N0) before isPerShare ("/shares"
+/// → N2), an EPS like $0.05 silently renders as "$0" and zeroes the figure
+/// the LLM reads. Pin the combined branch so that regression surfaces here.
+/// </summary>
+public class FactMarkdownValuePerShareUsdTests
+{
+    [Fact]
+    public void Value_UsdPerSharesUnit_RendersCentsWithDollarPrefix()
+    {
+        var result = FactMarkdown.Value(0.05m, "USD/shares");
+
+        result.Should().Be("$0.05");
+    }
+}


### PR DESCRIPTION
## Summary

- `FactMarkdown.Value(decimal, string)` is the MCP renderer for reported facts. Its doc-comment specifies that per-share units (`*/shares`) use cents precision and USD units get the `$` prefix. The canonical per-share-USD fact is earnings-per-share — small magnitudes where the cents *are* the whole answer.
- No existing tests cover this file. A refactor that checks `isWholeMagnitude` (USD → N0 grouped whole) before `isPerShare` ("/shares" → N2 cents) would silently render an EPS of `$0.05` as `$0` and zero the figure the LLM reads. This pin makes that regression fail here.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownValuePerShareUsdTests.cs` — new `[Fact]` asserting `FactMarkdown.Value(0.05m, "USD/shares")` returns `"$0.05"`. Exercises the per-share + USD branch combination simultaneously. No production code changed.