### PR TITLE
fix(sec): accept NBSP-separated 'Part N' headings in IsPartHeading

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -120,7 +120,11 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
 
         var upperText = text.ToUpperInvariant().Trim();
 
-        if (upperText.StartsWith("PART "))
+        // SEC EDGAR renders "Part N" with a non-breaking space (U+00A0)
+        // between word and numeral, so accept any Unicode whitespace after
+        // "PART" — not just the literal U+0020 that StartsWith("PART ") demands.
+        // Mirrors the GH-975 fix applied to IsItemHeading below.
+        if (upperText.StartsWith("PART") && upperText.Length > 5 && char.IsWhiteSpace(upperText[4]))
         {
             var afterPart = upperText.Substring(5).Trim();
             if (!string.IsNullOrEmpty(afterPart))

--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingNbspTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingNbspTests.cs
@@ -14,9 +14,7 @@ namespace Equibles.UnitTests.Sec.Normalizers;
 /// </summary>
 public class HeadingConversionStepIsPartHeadingNbspTests
 {
-    [Fact(
-        Skip = "GH-981 — IsPartHeading rejects NBSP-separated 'Part N' headings (StartsWith requires U+0020)"
-    )]
+    [Fact]
     public void IsPartHeading_NonBreakingSpaceSeparator_ReturnsTrue()
     {
         var method = typeof(HeadingConversionStep).GetMethod(


### PR DESCRIPTION
## Summary

- `HeadingConversionStep.IsPartHeading` used an ordinal `StartsWith(\"PART \")` against U+0020, so SEC EDGAR 10-K part labels rendered with a non-breaking space (`Part&nbsp;IV`) were not promoted to `<h1>`.
- Mirror the GH-975 fix already applied to the sibling `IsItemHeading`: check that the character at position 4 is `char.IsWhiteSpace`, accepting any Unicode whitespace including U+00A0.
- Un-skip the regression test `HeadingConversionStepIsPartHeadingNbspTests` that was committed alongside the issue; it now fails before the fix and passes after.

closes #981

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs` — replace the literal-space `StartsWith(\"PART \")` discriminator with the same whitespace-tolerant check `IsItemHeading` uses (`StartsWith(\"PART\") && Length > 5 && char.IsWhiteSpace(upperText[4])`). `Substring(5).Trim()` continues to yield the numeric/letter remainder unchanged.
- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingNbspTests.cs` — remove `Skip = ...` from the `[Fact]` so the regression test executes; the existing positive/negative coverage in `HeadingConversionStepIsPartHeadingTests` still passes, confirming `Participants` keeps rejecting.