### PR TITLE
fix(sec): accept NBSP-separated 'Part N' headings in IsPartHeading

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -120,7 +120,11 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
 
         var upperText = text.ToUpperInvariant().Trim();
 
-        if (upperText.StartsWith("PART "))
+        // SEC EDGAR renders "Part N" with a non-breaking space (U+00A0)
+        // between word and numeral, so accept any Unicode whitespace after
+        // "PART" — not just the literal U+0020 that StartsWith("PART ") demands.
+        // Mirrors the GH-975 fix applied to IsItemHeading.
+        if (upperText.StartsWith("PART") && upperText.Length > 4 && char.IsWhiteSpace(upperText[4]))
         {
             var afterPart = upperText.Substring(5).Trim();
             if (!string.IsNullOrEmpty(afterPart))

--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingNbspTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingNbspTests.cs
@@ -14,9 +14,7 @@ namespace Equibles.UnitTests.Sec.Normalizers;
 /// </summary>
 public class HeadingConversionStepIsPartHeadingNbspTests
 {
-    [Fact(
-        Skip = "GH-981 — IsPartHeading rejects NBSP-separated 'Part N' headings (StartsWith requires U+0020)"
-    )]
+    [Fact]
     public void IsPartHeading_NonBreakingSpaceSeparator_ReturnsTrue()
     {
         var method = typeof(HeadingConversionStep).GetMethod(


### PR DESCRIPTION
## Summary

- `HeadingConversionStep.IsPartHeading` used `StartsWith("PART ")` — an ordinal compare against U+0020 — so SEC EDGAR renderings with a non-breaking space (`<span>Part&nbsp;IV</span>`) silently failed the prefix check and were never promoted to `<h1>`. Mirrors the GH-975 fix applied to the sister `IsItemHeading`.
- Fixes #981 at the root cause; un-skips the GH-981 regression test.
- All existing positive (`PART I` with U+0020) and negative (`Participants` rejected via the word-boundary letter check) cases stay green — the fix only flips NBSP/other-whitespace cases from false to true.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs` — `IsPartHeading` prefix check is now `StartsWith("PART") && Length > 4 && char.IsWhiteSpace(upperText[4])`. The downstream `Substring(5).Trim()` and `firstWord.All(char.IsLetter)` logic is untouched, so the existing rejection of `Participants` (whitespace check at idx 4 fails on `'I'`) and of `PART 1` (digit fails `IsLetter`) is preserved.
- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingNbspTests.cs` — removed `[Fact(Skip = "GH-981 …")]`; the regression test now runs (fails pre-fix, passes post-fix). Full 70-test normalizer suite green.