### PR TITLE
test(congress): add skipped repro for GH-993 — PurchaseTypeRegex IgnoreCase

### DIFF
--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientExtractTransactionTypeLowercaseTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientExtractTransactionTypeLowercaseTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Sister to <see cref="HouseDisclosureClientTests.ExtractTransactionType_LowercaseSaleS_StillReturnsSaleViaIgnoreCase"/>
+/// — that test pins the case-insensitive behaviour of SaleTypeRegex as a
+/// feature ("StillReturnsSale**ViaIgnoreCase**"). PurchaseTypeRegex omits the
+/// matching `RegexOptions.IgnoreCase` flag, so by the precedent the Sale test
+/// established, a lowercase 'p' transaction marker is currently misclassified
+/// as "no transaction type" instead of Purchase. Contract derived from the
+/// existing Sale test's documented expectation before reading PurchaseTypeRegex.
+/// </summary>
+public class HouseDisclosureClientExtractTransactionTypeLowercaseTests
+{
+    [Fact(
+        Skip = "GH-993 — PurchaseTypeRegex omits RegexOptions.IgnoreCase, asymmetric to SaleTypeRegex"
+    )]
+    public void ExtractTransactionType_LowercasePurchaseP_StillReturnsPurchaseViaIgnoreCase()
+    {
+        var method = typeof(HouseDisclosureClient).GetMethod(
+            "ExtractTransactionType",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+        var result = (CongressTransactionType?)method.Invoke(null, ["AAPL p"]);
+
+        result
+            .Should()
+            .Be(
+                CongressTransactionType.Purchase,
+                "the Sale-side test pins lowercase 's' as a feature; the same case-insensitive treatment should apply to Purchase"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `HouseDisclosureClient.ExtractTransactionType` discovered a real defect: `PurchaseTypeRegex` (`\bP\s*$`) omits `RegexOptions.IgnoreCase` while its sibling `SaleTypeRegex` carries it. The existing pin `HouseDisclosureClientTests.ExtractTransactionType_LowercaseSaleS_StillReturnsSaleViaIgnoreCase` documents the case-insensitive Sale-side behaviour as a feature; by that precedent the asymmetric Purchase side silently misclassifies a lowercase `'p'` transaction marker as "no transaction type" instead of Purchase. `RemoveTrailingTransactionType` inherits the same bug for free (it uses both regexes).
- Test committed as `[Skip]` pending the fix — see GH-993.

## Code changes

- `tests/Equibles.UnitTests/Congress/HouseDisclosureClientExtractTransactionTypeLowercaseTests.cs` — new `[Fact(Skip = "GH-993 …")]` asserting `ExtractTransactionType("AAPL p")` returns `CongressTransactionType.Purchase`. Reflection-invoked private static method, matching the existing `HouseDisclosureClientTests` pattern. Skipped — see GH-993; un-skip as part of the fix. No production code changed.