### PR TITLE
test(sec): pin TryExtractPaperPdfFilename rejects whitespace-only FILENAME tag

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserWhitespaceFilenameTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserWhitespaceFilenameTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentEnvelopeParserWhitespaceFilenameTests
+{
+    // Pins the whitespace-only FILENAME branch of TryExtractSgmlTagValue (reached
+    // via TryExtractPaperPdfFilename). Existing path-traversal / null / multi-doc
+    // pins all carry concrete filenames, so the inner Trim() empty-check after
+    // the tag is unhit. A real-world variant: a malformed envelope where the
+    // SGML FILENAME header is present but blank. The probe must safely return
+    // false without inferring a stray PDF filename.
+    [Fact]
+    public void TryExtractPaperPdfFilename_FilenameTagWithWhitespaceOnlyValue_ReturnsFalse()
+    {
+        var envelope =
+            "<SEC-DOCUMENT>\n<DOCUMENT>\n<TYPE>PAPER\n<FILENAME>   \n</DOCUMENT>\n</SEC-DOCUMENT>";
+
+        var ok = SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(envelope, out var filename);
+
+        ok.Should().BeFalse();
+        filename.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Closes the remaining-uncovered whitespace-only branch of `TryExtractSgmlTagValue` (reached through `TryExtractPaperPdfFilename`). Existing pins cover URL-encoded traversal, backslash separators, leading-dot, missing end tag, multi-doc, null — all with concrete filenames; the inner `raw.Length == 0` check after `Trim()` was unhit.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserWhitespaceFilenameTests.cs` — one `[Fact]`: an envelope whose `<FILENAME>` carries only whitespace before the next `<` must yield `false` and an empty filename, not infer a stray PDF.