### PR TITLE
fix(congress): match lowercase 'p' in PurchaseTypeRegex via IgnoreCase

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -359,8 +359,10 @@ public partial class HouseDisclosureClient
     [GeneratedRegex(@"\bS\s*(\((?:partial|full)\))?\s*$", RegexOptions.IgnoreCase)]
     private static partial Regex SaleTypeRegex();
 
-    // House purchase type at end of text (before date)
-    [GeneratedRegex(@"\bP\s*$")]
+    // House purchase type at end of text (before date). IgnoreCase mirrors
+    // SaleTypeRegex; without it, a lowercase 'p' marker falls through both
+    // ExtractTransactionType and RemoveTrailingTransactionType.
+    [GeneratedRegex(@"\bP\s*$", RegexOptions.IgnoreCase)]
     private static partial Regex PurchaseTypeRegex();
 
     private record HouseFiling(

--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientExtractTransactionTypeLowercaseTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientExtractTransactionTypeLowercaseTests.cs
@@ -15,9 +15,7 @@ namespace Equibles.UnitTests.Congress;
 /// </summary>
 public class HouseDisclosureClientExtractTransactionTypeLowercaseTests
 {
-    [Fact(
-        Skip = "GH-993 — PurchaseTypeRegex omits RegexOptions.IgnoreCase, asymmetric to SaleTypeRegex"
-    )]
+    [Fact]
     public void ExtractTransactionType_LowercasePurchaseP_StillReturnsPurchaseViaIgnoreCase()
     {
         var method = typeof(HouseDisclosureClient).GetMethod(


### PR DESCRIPTION
## Summary

- `HouseDisclosureClient.PurchaseTypeRegex` was `[GeneratedRegex(@"\bP\s*$")]` — case-sensitive, asymmetric to its sibling `SaleTypeRegex` which carries `RegexOptions.IgnoreCase`. Any House PTR line ending in a lowercase `'p'` marker fell through both `ExtractTransactionType` (returned null) and `RemoveTrailingTransactionType` (left the trailer attached to the asset name).
- Fixes #993 at the root cause; un-skips the GH-993 regression test.
- Uppercase 'P' behavior is unchanged (`ExtractTransactionType_PurchaseTrailingP_ReturnsPurchase` still green); only previously-null lowercase cases now correctly return `Purchase`. Full 180-test Congress unit suite green.

## Code changes

- `src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs` — added `RegexOptions.IgnoreCase` to `PurchaseTypeRegex`'s `[GeneratedRegex]` attribute (mirrors `SaleTypeRegex`).
- `tests/Equibles.UnitTests/Congress/HouseDisclosureClientExtractTransactionTypeLowercaseTests.cs` — removed `[Fact(Skip = "GH-993 …")]`; the regression test now runs (fails pre-fix, passes post-fix).