### PR TITLE
fix(congress): make PurchaseTypeRegex case-insensitive

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -360,7 +360,7 @@ public partial class HouseDisclosureClient
     private static partial Regex SaleTypeRegex();
 
     // House purchase type at end of text (before date)
-    [GeneratedRegex(@"\bP\s*$")]
+    [GeneratedRegex(@"\bP\s*$", RegexOptions.IgnoreCase)]
     private static partial Regex PurchaseTypeRegex();
 
     private record HouseFiling(

--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientExtractTransactionTypeLowercaseTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientExtractTransactionTypeLowercaseTests.cs
@@ -15,9 +15,7 @@ namespace Equibles.UnitTests.Congress;
 /// </summary>
 public class HouseDisclosureClientExtractTransactionTypeLowercaseTests
 {
-    [Fact(
-        Skip = "GH-993 — PurchaseTypeRegex omits RegexOptions.IgnoreCase, asymmetric to SaleTypeRegex"
-    )]
+    [Fact]
     public void ExtractTransactionType_LowercasePurchaseP_StillReturnsPurchaseViaIgnoreCase()
     {
         var method = typeof(HouseDisclosureClient).GetMethod(


### PR DESCRIPTION
## Summary

- `HouseDisclosureClient.PurchaseTypeRegex` was declared `[GeneratedRegex(@"\bP\s*$")]` with no flags, while the sister `SaleTypeRegex` carried `RegexOptions.IgnoreCase`. Lowercase `p` transaction markers silently returned `null` from `ExtractTransactionType` and stayed un-stripped by `RemoveTrailingTransactionType`, breaking the precedent pinned by `ExtractTransactionType_LowercaseSaleS_StillReturnsSaleViaIgnoreCase`.
- Add `RegexOptions.IgnoreCase` to the attribute so both helpers recognise lowercase `p` identically to their Sale counterparts. The source generator regenerates the `Regex` with the flag — no other changes needed.
- Un-skip the GH-993 regression test stub merged via #994.

closes #993

## Code changes

- `src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs` — add `RegexOptions.IgnoreCase` to the `[GeneratedRegex]` on `PurchaseTypeRegex`. All other tests stay green: the uppercase `P` pin (`ExtractTransactionType_PurchaseTrailingP_ReturnsPurchase`) and the uppercase strip pin (`RemoveTrailingTransactionType_PurchaseTrailingP_StripsSuffix`) use uppercase inputs that match both before and after; the lowercase Sale pin is unaffected.
- `tests/Equibles.UnitTests/Congress/HouseDisclosureClientExtractTransactionTypeLowercaseTests.cs` — remove the `Skip = "..."` argument so the regression test executes. 24 unit + 7 integration tests on `HouseDisclosureClient` green.