### PR TITLE
test(sec): pin HeadingConversionStep.IsApart parenthetical-aside detection

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsApartTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsApartTests.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+/// <summary>
+/// IsApart filters spans that are pure parenthetical asides — "(continued)",
+/// "(in millions)" — from the all-siblings heading-match checks. The
+/// IsAllUppercase / IsBoldSpan / IsItalicSpan tests cover the positive arms
+/// directly, but the IsApart helper itself only fires inside AllSiblingsMatch.
+/// Pin its parenthetical-recognition contract so a refactor that drops the
+/// EndsWith(')') guard (and starts matching open-only "(footnote") doesn't
+/// silently break the heading sweep.
+/// </summary>
+public class HeadingConversionStepIsApartTests
+{
+    [Fact]
+    public void IsApart_TextWrappedInParentheses_ReturnsTrue()
+    {
+        var span = new HtmlParser()
+            .ParseDocument("<html><body><span>(continued)</span></body></html>")
+            .QuerySelector("span")!;
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "IsApart",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var step = new HeadingConversionStep();
+
+        var result = (bool)method.Invoke(step, [span])!;
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- `HeadingConversionStep.IsApart` filters parenthetical asides like `(continued)` and `(in millions)` from the all-siblings heading-match checks. The sibling `IsAllUppercase` / `IsItalicSpan` etc. helpers have dedicated pins; `IsApart` itself was only exercised transitively and the literal `EndsWith(')')` guard was unhit.
- Pins the contract directly so a refactor dropping the closing-paren guard (and starting to match open-only `(footnote`) doesn't silently break the heading sweep.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsApartTests.cs` — one `[Fact]`: a `<span>(continued)</span>` → `IsApart` returns `true`, mirroring the existing reflection-based style of the sibling private-method pins in this folder.