### PR TITLE
test(sec): pin FactArgs.TryParsePeriod Q4 spelling returns Q4

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodTests.cs
@@ -1,0 +1,26 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// FactArgs.TryParsePeriod is the shared parser every FinancialFacts MCP tool
+/// uses to interpret user-supplied period arguments. The Q4 branch is the
+/// canonical SEC <c>fp</c> value for the fourth quarter (per the SEC Company
+/// Facts API), uses no aliases, and is currently unpinned — every other
+/// switch arm (FY/FullYear/Annual, Q1, Q2, Q3) is also uncovered, but
+/// one-test-per-PR. A refactor that swaps the Q4 case to <c>Q3</c> (an easy
+/// copy-paste slip) would compile cleanly and break time-series tools that
+/// rely on this discriminator to align facts to the right period.
+/// </summary>
+public class FactArgsTryParsePeriodTests
+{
+    [Fact]
+    public void TryParsePeriod_Q4_ReturnsTrueAndQ4()
+    {
+        var success = FactArgs.TryParsePeriod("Q4", out var period);
+
+        success.Should().BeTrue();
+        period.Should().Be(SecFiscalPeriod.Q4);
+    }
+}


### PR DESCRIPTION
## Summary

- `FactArgs.TryParsePeriod` is the shared parser every FinancialFacts MCP tool uses to interpret period arguments. It has zero existing tests — every switch arm (FY/FullYear/Annual, Q1, Q2, Q3, Q4) is currently unpinned.
- Pinning one canonical case at a time per `/add-test`'s one-test-per-PR contract. A refactor that swaps the Q4 arm to `SecFiscalPeriod.Q3` (a plausible copy-paste slip) would compile cleanly and break time-series tools that rely on this discriminator to align facts to the right period.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodTests.cs` — new `[Fact]` asserting `FactArgs.TryParsePeriod("Q4", out p)` returns `true` with `p == SecFiscalPeriod.Q4`. No production code changed.