### PR TITLE
test(sec): pin HeadingConversionStep.IsItalicSpan inline-style detection

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItalicSpanTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItalicSpanTests.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+/// <summary>
+/// IsItalicSpan detects an italic-styled span by either an inline
+/// <c>style="font-style:italic"</c> attribute or an <c>InnerHtml</c> match. It
+/// is the per-span discriminator for the h4 promotion path (all-italic
+/// siblings). Pinned directly so a refactor that drops one of the two probes
+/// (inline vs nested) doesn't silently disable h4 detection.
+/// </summary>
+public class HeadingConversionStepIsItalicSpanTests
+{
+    [Fact]
+    public void IsItalicSpan_InlineStyleFontStyleItalic_ReturnsTrue()
+    {
+        var span = new HtmlParser()
+            .ParseDocument(
+                "<html><body><span style=\"font-style:italic\">Heading</span></body></html>"
+            )
+            .QuerySelector("span")!;
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "IsItalicSpan",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var step = new HeadingConversionStep();
+
+        var result = (bool)method.Invoke(step, [span])!;
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- `HeadingConversionStep.IsItalicSpan` is the per-span discriminator for the h4 promotion path (all-italic siblings). The sibling `IsApart` and `IsAllUppercase` pins exercise the helpers in isolation; this one's inline-style branch was unpinned.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItalicSpanTests.cs` — one `[Fact]`: a `<span style="font-style:italic">` → `IsItalicSpan` returns `true`. Mirrors the reflection style of the sibling private-method tests in the same folder.