### PR TITLE
test(sec): pin HeadingConversionStep.IsBoldSpan inline-style detection

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsBoldSpanTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsBoldSpanTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+/// <summary>
+/// IsBoldSpan is one arm of the OR predicate that promotes a span row to
+/// &lt;h3&gt;. Pinned directly so a refactor dropping the inline-style probe
+/// (and leaving only the InnerHtml fallback) doesn't silently disable h3
+/// detection for the common SEC pattern <c>style="font-weight:bold"</c>.
+/// </summary>
+public class HeadingConversionStepIsBoldSpanTests
+{
+    [Fact]
+    public void IsBoldSpan_InlineStyleFontWeightBold_ReturnsTrue()
+    {
+        var span = new HtmlParser()
+            .ParseDocument(
+                "<html><body><span style=\"font-weight:bold\">Section</span></body></html>"
+            )
+            .QuerySelector("span")!;
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "IsBoldSpan",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var step = new HeadingConversionStep();
+
+        var result = (bool)method.Invoke(step, [span])!;
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- `HeadingConversionStep.IsBoldSpan` is one arm of the OR predicate that promotes a span row to `<h3>`. Sibling pins (`IsApart`, `IsItalicSpan`) exist; this one's inline-style branch was unpinned.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsBoldSpanTests.cs` — one `[Fact]`: a `<span style="font-weight:bold">` → `IsBoldSpan` returns `true`. Mirrors the reflection style of the sibling private-method tests.