### PR TITLE
feat(sec): title-case ALL-CAPS company names from the SEC EDGAR feed

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Equibles.CommonStocks.BusinessLogic;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
@@ -195,9 +196,10 @@ public class CompanySyncService : ICompanySyncService
     )
     {
         var existingStock = state.ExistingStocks.First(cs => cs.Cik == secCompany.Cik);
+        var normalizedName = NormalizeCompanyName(secCompany.Name);
         var needsUpdate =
             existingStock.Ticker != primaryTicker
-            || existingStock.Name != secCompany.Name
+            || existingStock.Name != normalizedName
             || !(existingStock.SecondaryTickers ?? []).SequenceEqual(secondaryTickers);
 
         if (!needsUpdate)
@@ -275,7 +277,7 @@ public class CompanySyncService : ICompanySyncService
         try
         {
             existingStock.Ticker = primaryTicker;
-            existingStock.Name = secCompany.Name;
+            existingStock.Name = normalizedName;
             existingStock.SecondaryTickers = secondaryTickers;
             await state.CommonStockManager.Update(existingStock);
 
@@ -371,7 +373,7 @@ public class CompanySyncService : ICompanySyncService
                 new CommonStock
                 {
                     Ticker = primaryTicker,
-                    Name = secCompany.Name,
+                    Name = NormalizeCompanyName(secCompany.Name),
                     Cik = secCompany.Cik,
                     SecondaryTickers = secondaryTickers,
                     Description = $"Company with tickers: {string.Join(", ", secCompany.Tickers)}",
@@ -422,7 +424,7 @@ public class CompanySyncService : ICompanySyncService
                 new CommonStock
                 {
                     Ticker = primaryTicker,
-                    Name = secCompany.Name,
+                    Name = NormalizeCompanyName(secCompany.Name),
                     Cik = secCompany.Cik,
                     SecondaryTickers = secondaryTickers,
                     Description = $"Company with tickers: {string.Join(", ", secCompany.Tickers)}",
@@ -594,6 +596,22 @@ public class CompanySyncService : ICompanySyncService
     private static long ParseCik(string cik)
     {
         return long.TryParse(cik, out var n) ? n : long.MaxValue;
+    }
+
+    // SEC EDGAR returns some names in ALL CAPS (e.g. "AMAZON COM INC",
+    // "MICROSOFT CORP") and others in branded mixed case (e.g. "Apple Inc.",
+    // "Meta Platforms, Inc."). When a name is uniformly upper-cased we treat it
+    // as legacy formatting and convert it to Title Case; mixed-case names are
+    // trusted as-is.
+    private static string NormalizeCompanyName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return name;
+
+        if (name.Any(char.IsLower))
+            return name;
+
+        return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(name.ToLowerInvariant());
     }
 
     private class StockSyncState

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameTests.cs
@@ -10,14 +10,12 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class CompanySyncServiceNormalizeCompanyNameTests
 {
-    private static readonly MethodInfo NormalizeMethod =
-        typeof(CompanySyncService).GetMethod(
-            "NormalizeCompanyName",
-            BindingFlags.NonPublic | BindingFlags.Static
-        );
+    private static readonly MethodInfo NormalizeMethod = typeof(CompanySyncService).GetMethod(
+        "NormalizeCompanyName",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
 
-    private static string Normalize(string name) =>
-        (string)NormalizeMethod.Invoke(null, [name]);
+    private static string Normalize(string name) => (string)NormalizeMethod.Invoke(null, [name]);
 
     [Theory]
     [InlineData("AMAZON COM INC", "Amazon Com Inc")]

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameTests.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the SEC company-name casing rule applied at sync time: ALL-CAPS feed
+/// values are title-cased on the way in, mixed-case names are trusted as-is.
+/// Tested via reflection because the helper is private to CompanySyncService.
+/// </summary>
+public class CompanySyncServiceNormalizeCompanyNameTests
+{
+    private static readonly MethodInfo NormalizeMethod =
+        typeof(CompanySyncService).GetMethod(
+            "NormalizeCompanyName",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static string Normalize(string name) =>
+        (string)NormalizeMethod.Invoke(null, [name]);
+
+    [Theory]
+    [InlineData("AMAZON COM INC", "Amazon Com Inc")]
+    [InlineData("MICROSOFT CORP", "Microsoft Corp")]
+    [InlineData("NVIDIA CORP", "Nvidia Corp")]
+    [InlineData("BERKSHIRE HATHAWAY INC", "Berkshire Hathaway Inc")]
+    public void AllCapsName_IsTitleCased(string input, string expected)
+    {
+        Normalize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Apple Inc.")]
+    [InlineData("Alphabet Inc.")]
+    [InlineData("Meta Platforms, Inc.")]
+    [InlineData("JPMorgan Chase & Co.")]
+    public void MixedCaseName_IsLeftAlone(string input)
+    {
+        Normalize(input).Should().Be(input);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NullOrWhitespace_IsLeftAlone(string input)
+    {
+        Normalize(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void SingleCapitalLetter_IsTitleCased()
+    {
+        // Defensive: a one-character ticker-as-name shouldn't be left
+        // shouting just because there's no lowercase letter to detect.
+        Normalize("X").Should().Be("X");
+    }
+}


### PR DESCRIPTION
## Summary

- SEC's `company_tickers_exchange.json` ships some names in ALL CAPS (`AMAZON COM INC`, `MICROSOFT CORP`, `NVIDIA CORP`) and others in branded mixed case (`Apple Inc.`, `Meta Platforms, Inc.`).
- `CompanySyncService` now title-cases the ALL-CAPS strings on the way in; mixed-case names are trusted as-is.
- Both the `needsUpdate` comparison and all three Name write sites (update / replace / create) read through `NormalizeCompanyName`, so the rule is enforced consistently and rows seeded before this PR get rewritten on the next sync.

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs`
  - Add private `NormalizeCompanyName(string)` helper.
  - Apply at `UpdateExistingStock`, `ReplaceObsoleteStock`, `CreateNewStock`, and the dirty-check comparison.
- `tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameTests.cs`
  - 12 test cases covering ALL-CAPS, mixed-case, null/empty/whitespace, single-letter inputs.

## Test plan

- [x] `dotnet test` filtered to the new file → 12/12 passing
- [x] Existing CompanySyncService tests still build/pass

Follow-up PR in EquiblesCommercial will bump the submodule pointer to this commit.