### PR TITLE
test(sec): pin FactMarkdown.Clean strips CR/LF (log-injection defense)

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownCleanLogInjectionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownCleanLogInjectionTests.cs
@@ -1,0 +1,29 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// FactMarkdown.Clean's doc-comment says "Strips control chars from untrusted
+/// args before they reach logs / the error store". The canonical log-injection
+/// attack is an attacker injecting <c>\r\n</c> into a user-supplied value to
+/// forge a new log entry. CR (U+000D) and LF (U+000A) are both C0 control
+/// chars, so a refactor that swaps <c>char.IsControl</c> for a narrower
+/// whitelist (e.g. only stripping ASCII C0 below space, or only filtering
+/// non-printable categories) must still kill both — otherwise log entries
+/// become attacker-controlled.
+/// </summary>
+public class FactMarkdownCleanLogInjectionTests
+{
+    [Fact]
+    public void Clean_CarriageReturnAndLineFeed_AreStrippedFromValue()
+    {
+        var result = FactMarkdown.Clean("alert\r\nbadhost");
+
+        result
+            .Should()
+            .Be(
+                "alertbadhost",
+                "CR and LF are control chars and must be stripped to prevent log-injection forgery"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- `FactMarkdown.Clean`'s doc-comment promises "Strips control chars from untrusted args before they reach logs / the error store" — i.e. it's the log-injection defense for the FinancialFacts MCP tools. The canonical attack is an attacker-supplied `\r\n` forging a new log entry. Both CR (U+000D) and LF (U+000A) are C0 control chars, so the contract requires stripping them.
- No existing tests pin this. A refactor that narrows `char.IsControl` to a less-permissive whitelist (e.g. only filtering U+0000–U+001F below space, or only the "Control" Unicode category) could compile cleanly and silently let `\r\n` through.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownCleanLogInjectionTests.cs` — new `[Fact]` asserting `FactMarkdown.Clean("alert\r\nbadhost")` returns `"alertbadhost"`. No production code changed.