### PR TITLE
test(sec): pin FactMarkdown.Cell escapes pipe and replaces newline

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownCellEscapingTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownCellEscapingTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// FactMarkdown.Cell's doc-comment says "Escapes the Markdown table delimiters
+/// so a value containing '|' or a newline (e.g. some ADR/fund names) can't
+/// break the table the LLM reads." Both classes of input — pipe and newline —
+/// are the canonical attack vectors that corrupt a row's column count and
+/// terminate the table early. A refactor that swaps backslash-escape for HTML
+/// entity escape (which Markdown table parsers don't decode inside cells), or
+/// forgets one of the two replacements, would compile cleanly and silently
+/// produce a malformed table the LLM consumes as data.
+/// </summary>
+public class FactMarkdownCellEscapingTests
+{
+    [Fact]
+    public void Cell_PipeAndNewline_ProduceMarkdownTableSafeOutput()
+    {
+        var result = FactMarkdown.Cell("a|b\nc");
+
+        result.Should().Be("a\\|b c");
+    }
+}


### PR DESCRIPTION
## Summary

- `FactMarkdown.Cell` is the Markdown-table escaper for FinancialFacts MCP output ("can't break the table the LLM reads"). It has zero existing tests. Pipe and newline are the two canonical breakage vectors that corrupt a row's column count or terminate the table early — both must be neutralised in the same call.
- A refactor that swaps backslash-escape for HTML entity escape (which Markdown table parsers don't decode inside cells), drops the CR replacement, or normalises with a single delimiter, would compile cleanly and silently emit a malformed table the LLM consumes as data.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownCellEscapingTests.cs` — new `[Fact]` asserting `FactMarkdown.Cell("a|b\nc")` returns `"a\\|b c"`. Exercises both escape arms (pipe + newline) in one call. No production code changed.