### PR TITLE
feat(web): redesign global search with filter sidebar

### DIFF
--- a/src/Equibles.Web/Controllers/SearchController.cs
+++ b/src/Equibles.Web/Controllers/SearchController.cs
@@ -8,8 +8,12 @@ namespace Equibles.Web.Controllers;
 
 public class SearchController : BaseController
 {
-    // Top hits per group on the overview page; "see all" links go to the existing per-module pages.
-    private const int MaxPerProvider = 6;
+    // Top hits per group on the overview page (all categories visible side by side).
+    private const int MaxPerProviderOverview = 6;
+
+    // Hits per group when one category is selected — the user clicked "See all" / picked a
+    // single category, so show enough to feel like a list rather than the overview cap.
+    private const int MaxPerProviderFocused = 50;
 
     private readonly SearchAggregator _searchAggregator;
 
@@ -34,7 +38,7 @@ public class SearchController : BaseController
         // chips can still list all matched categories even when one is selected.
         var groups = await _searchAggregator.Search(
             q,
-            MaxPerProvider,
+            ResolveMaxPerProvider(category),
             HttpContext.RequestAborted,
             sort,
             dateFrom,
@@ -67,7 +71,7 @@ public class SearchController : BaseController
     {
         var groups = await _searchAggregator.Search(
             q,
-            MaxPerProvider,
+            ResolveMaxPerProvider(category),
             HttpContext.RequestAborted,
             sort,
             dateFrom,
@@ -87,4 +91,7 @@ public class SearchController : BaseController
             }
         );
     }
+
+    private static int ResolveMaxPerProvider(string category) =>
+        string.IsNullOrWhiteSpace(category) ? MaxPerProviderOverview : MaxPerProviderFocused;
 }

--- a/src/Equibles.Web/Extensions/SearchCategoryRouteExtensions.cs
+++ b/src/Equibles.Web/Extensions/SearchCategoryRouteExtensions.cs
@@ -59,7 +59,11 @@ public static class SearchCategoryRouteExtensions
         };
     }
 
-    /// <summary>"See all" destination for a group, or null when no browse page exists.</summary>
+    /// <summary>
+    /// "See all" destination for a group. Prefers a dedicated browse page when one exists;
+    /// otherwise falls back to the search page filtered to just that category so users still
+    /// get an expanded result list instead of a dead-end.
+    /// </summary>
     public static string CategoryUrl(this IUrlHelper url, string category, string query)
     {
         return category switch
@@ -67,7 +71,7 @@ public static class SearchCategoryRouteExtensions
             "Stocks" => url.Action("Index", "Stocks", new { search = query }),
             "Economic Indicators" => url.Action("Index", "EconomicData"),
             "Futures" => url.Action("Index", "Cftc"),
-            _ => null,
+            _ => url.Action("Index", "Search", new { q = query, category }),
         };
     }
 }

--- a/src/Equibles.Web/Views/Search/Index.cshtml
+++ b/src/Equibles.Web/Views/Search/Index.cshtml
@@ -5,72 +5,186 @@
 @{
     ViewData["Title"] = "Search";
     ViewData["Description"] = "Search stocks, SEC filings, institutions, insiders, congress members, economic indicators and futures markets.";
+
+    // Maps each search category to its module's Heroicon so sidebar items and result groups
+    // share a single visual language. Unknown categories fall back to the generic glyph.
+    string CategoryIcon(string category) => category switch {
+        "Stocks" => "chart-bar",
+        "SEC Filings" => "document-text",
+        "Economic Indicators" => "presentation-chart-line",
+        "Institutions" => "building-library",
+        "Insiders" => "user-group",
+        "Congress" => "building-office",
+        "Futures" => "cube",
+        _ => "magnifying-glass",
+    };
+
+    // Counts non-default filters in play so the mobile "Filters" button can show a badge.
+    var activeFilterCount =
+        (string.IsNullOrWhiteSpace(Model.ActiveCategory) ? 0 : 1)
+        + (Model.SortBy == SearchSort.Relevance ? 0 : 1)
+        + (Model.DateFrom.HasValue ? 1 : 0)
+        + (Model.DateTo.HasValue ? 1 : 0);
 }
 
-<div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Search</h1>
+<div class="max-w-7xl mx-auto px-4 lg:px-6 py-8 lg:py-12">
+    <!-- Page heading + primary search box. The big query input stays on the main canvas
+         (not in the sidebar) so it remains the obvious focal point on every viewport. -->
+    <div class="mb-6">
+        <h1 class="text-3xl font-bold mb-1">Search</h1>
         <p class="text-base-content/60">Stocks, filings, institutions, insiders, congress, economic indicators and futures</p>
     </div>
 
-    <!-- Search: scope selector + query. instant-search.js progressively enhances this into
-         debounced as-you-type results; without JS the form still submits a normal GET. -->
     <form id="global-search-form" method="get" asp-controller="Search" asp-action="Index"
-          data-results-url="@Url.Action("Results")" class="mb-6">
-        <div class="join w-full max-w-2xl">
-            <select name="category" class="select select-bordered join-item w-auto"
-                    aria-label="Limit search to a category">
-                <option value="">All categories</option>
-                @foreach (var category in SearchCategories.All) {
-                    <option value="@category"
-                            selected="@(string.Equals(category, Model.ActiveCategory, StringComparison.OrdinalIgnoreCase))">
-                        @category
-                    </option>
-                }
-            </select>
-            <label class="input input-bordered join-item grow flex items-center gap-2">
-                <input type="search" name="q" value="@Model.Query" class="grow"
-                       aria-label="Search everything"
-                       placeholder="Search for a ticker, company, filing, indicator..." autofocus />
-                <button type="button" id="search-clear"
-                        class="btn btn-ghost btn-xs btn-circle @(string.IsNullOrEmpty(Model.Query) ? "hidden" : "")"
-                        aria-label="Clear search" title="Clear search">
-                    <icon name="x-mark" size="4" />
+          data-results-url="@Url.Action("Results")">
+        <!-- Sticky search bar: stays visible while the user scrolls through long result lists.
+             instant-search.js progressively enhances this; without JS it submits a normal GET. -->
+        <div class="mb-6 sticky top-14 z-30 bg-base-200/80 backdrop-blur-md -mx-4 lg:-mx-6 px-4 lg:px-6 py-3 border-b border-base-200">
+            <div class="flex items-center gap-2 max-w-3xl">
+                <label class="input input-bordered flex-1 flex items-center gap-3 h-12">
+                    <icon name="magnifying-glass" size="5" class="text-base-content/40" />
+                    <input type="search" name="q" value="@Model.Query" class="grow text-base"
+                           aria-label="Search everything"
+                           placeholder="Search for a ticker, company, filing, indicator..." autofocus />
+                    <button type="button" id="search-clear"
+                            class="btn btn-ghost btn-xs btn-circle @(string.IsNullOrEmpty(Model.Query) ? "hidden" : "")"
+                            aria-label="Clear search" title="Clear search">
+                        <icon name="x-mark" size="4" />
+                    </button>
+                </label>
+                <button type="submit" class="btn btn-primary h-12 px-5" aria-label="Search" title="Search">
+                    <icon name="magnifying-glass" size="5" />
                 </button>
-            </label>
-            <button type="submit" class="btn btn-primary join-item" aria-label="Search" title="Search">
-                <icon name="magnifying-glass" size="5" />
-            </button>
-        </div>
-        <!-- Sort + date range. instant-search.js submits these alongside q + category
-             and re-renders. The date range only narrows date-aware results (SEC filings). -->
-        <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-base-content/60">
-            <div class="flex items-center gap-2">
-                <label for="search-sort">Sort by</label>
-                <select id="search-sort" name="sort" class="select select-bordered select-sm w-auto"
-                        aria-label="Sort results">
-                    @foreach (var option in Html.GetEnumSelectList<SearchSort>()) {
-                        <option value="@option.Value"
-                                selected="@(option.Value == ((int)Model.SortBy).ToString())">
-                            @option.Text
-                        </option>
+                <!-- Mobile-only: opens the filter drawer (the lg+ sidebar is always visible). -->
+                <button type="button" id="search-filters-toggle"
+                        class="btn btn-ghost border border-base-300 h-12 px-3 lg:hidden"
+                        aria-label="Show filters" title="Filters">
+                    <icon name="adjustments-horizontal" size="5" />
+                    @if (activeFilterCount > 0) {
+                        <span class="badge badge-primary badge-sm">@activeFilterCount</span>
                     }
-                </select>
+                </button>
             </div>
-            <div class="flex items-center gap-2">
-                <label for="search-date-from">Filed between</label>
-                <input id="search-date-from" type="date" name="dateFrom"
-                       value="@(Model.DateFrom?.ToString("yyyy-MM-dd"))"
-                       class="input input-bordered input-sm w-auto" aria-label="Filed on or after" />
-                <span aria-hidden="true">–</span>
-                <input id="search-date-to" type="date" name="dateTo"
-                       value="@(Model.DateTo?.ToString("yyyy-MM-dd"))"
-                       class="input input-bordered input-sm w-auto" aria-label="Filed on or before" />
+        </div>
+
+        <!-- Two-column shell: filters on the left, results on the right.
+             On mobile the sidebar is hidden behind an off-canvas drawer (toggled above). -->
+        <div class="lg:grid lg:grid-cols-[16rem_minmax(0,1fr)] lg:gap-6">
+            <!-- Filter sidebar — visible from lg, off-canvas drawer below.
+                 instant-search.js sets role="dialog" + aria-modal when it acts as a mobile drawer. -->
+            <aside id="search-filters" class="hidden lg:block" aria-label="Search filters">
+                <div class="lg:sticky lg:top-32 space-y-5">
+                    <div class="bg-base-100 rounded-xl shadow-sm border border-base-200/60 p-5 space-y-5">
+                        <div class="flex items-center justify-between">
+                            <h2 class="text-sm font-semibold uppercase tracking-wider text-base-content/60">Filters</h2>
+                            <a id="search-clear-filters"
+                               asp-action="Index" asp-route-q="@Model.Query"
+                               class="text-xs link link-hover text-base-content/60 hover:text-primary @(activeFilterCount == 0 ? "invisible" : "")">
+                                Clear all
+                            </a>
+                        </div>
+
+                        <!-- Category picker: radio-style list (only one category narrows the view at a time).
+                             Each option shows its module icon for fast visual scanning. -->
+                        <fieldset class="space-y-1">
+                            <legend class="text-xs font-semibold text-base-content/50 mb-2">Category</legend>
+                            <label class="flex items-center gap-2 px-2 py-1.5 rounded-lg cursor-pointer hover:bg-base-200 transition-colors focus-within:ring-2 focus-within:ring-primary/40 @(string.IsNullOrWhiteSpace(Model.ActiveCategory) ? "bg-primary/10 text-primary font-medium" : "")">
+                                <input type="radio" name="category" value=""
+                                       class="radio radio-xs radio-primary"
+                                       checked="@string.IsNullOrWhiteSpace(Model.ActiveCategory)" />
+                                <icon name="squares-2x2" size="4" />
+                                <span class="text-sm">All categories</span>
+                            </label>
+                            @foreach (var category in SearchCategories.All) {
+                                var isActive = string.Equals(category, Model.ActiveCategory, StringComparison.OrdinalIgnoreCase);
+                                <label class="flex items-center gap-2 px-2 py-1.5 rounded-lg cursor-pointer hover:bg-base-200 transition-colors focus-within:ring-2 focus-within:ring-primary/40 @(isActive ? "bg-primary/10 text-primary font-medium" : "")">
+                                    <input type="radio" name="category" value="@category"
+                                           class="radio radio-xs radio-primary"
+                                           checked="@isActive" />
+                                    <icon name="@CategoryIcon(category)" size="4" />
+                                    <span class="text-sm">@category</span>
+                                </label>
+                            }
+                        </fieldset>
+
+                        <!-- Sort order: applied centrally by the aggregator across all groups. -->
+                        <fieldset>
+                            <legend class="text-xs font-semibold text-base-content/50 mb-2">Sort by</legend>
+                            <select name="sort" id="search-sort" class="select select-bordered select-sm w-full"
+                                    aria-label="Sort results">
+                                @foreach (var option in Html.GetEnumSelectList<SearchSort>()) {
+                                    <option value="@option.Value"
+                                            selected="@(option.Value == ((int)Model.SortBy).ToString())">
+                                        @option.Text
+                                    </option>
+                                }
+                            </select>
+                        </fieldset>
+
+                        <!-- Date range: only narrows date-aware groups (currently SEC Filings).
+                             Other providers ignore these values, so they stay opt-in here. -->
+                        <fieldset>
+                            <legend class="text-xs font-semibold text-base-content/50 mb-2">Filed between</legend>
+                            <div class="space-y-2">
+                                <div>
+                                    <label class="text-[11px] uppercase tracking-wide text-base-content/40" for="search-date-from">From</label>
+                                    <input id="search-date-from" type="date" name="dateFrom"
+                                           value="@(Model.DateFrom?.ToString("yyyy-MM-dd"))"
+                                           class="input input-bordered input-sm w-full"
+                                           aria-label="Filed on or after" />
+                                </div>
+                                <div>
+                                    <label class="text-[11px] uppercase tracking-wide text-base-content/40" for="search-date-to">To</label>
+                                    <input id="search-date-to" type="date" name="dateTo"
+                                           value="@(Model.DateTo?.ToString("yyyy-MM-dd"))"
+                                           class="input input-bordered input-sm w-full"
+                                           aria-label="Filed on or before" />
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+            </aside>
+
+            <!-- Results column. -->
+            <div id="search-results" aria-live="polite" aria-busy="false" class="min-w-0">
+                <partial name="_Results" model="Model" />
             </div>
         </div>
     </form>
-
-    <div id="search-results" aria-live="polite" aria-busy="false">
-        <partial name="_Results" model="Model" />
-    </div>
 </div>
+
+<!-- Mobile filter drawer backdrop. instant-search.js toggles the .open class. -->
+<div id="search-filters-backdrop"
+     class="fixed inset-0 bg-black/40 z-40 hidden lg:!hidden"
+     aria-hidden="true"></div>
+
+@section Styles {
+    <style>
+        /* Mobile drawer: the same #search-filters element doubles as the slide-in panel.
+           lg breakpoint resets it to the static sidebar via the inline classes above. */
+        @@media (max-width: 1023.98px) {
+            #search-filters {
+                position: fixed;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                width: min(20rem, 90vw);
+                background: var(--color-base-100);
+                z-index: 50;
+                padding: 1rem;
+                overflow-y: auto;
+                transform: translateX(100%);
+                transition: transform 0.2s ease-out;
+                box-shadow: -8px 0 24px rgba(0, 0, 0, 0.08);
+            }
+            #search-filters.open {
+                display: block !important;
+                transform: translateX(0);
+            }
+            #search-filters-backdrop.open {
+                display: block;
+            }
+        }
+    </style>
+}

--- a/src/Equibles.Web/Views/Search/_Results.cshtml
+++ b/src/Equibles.Web/Views/Search/_Results.cshtml
@@ -9,8 +9,7 @@
     // Maps each search category to its module's Heroicon so result groups are
     // scannable at a glance instead of being seven near-identical text cards.
     // Unknown categories fall back to the generic search glyph.
-    string CategoryIcon(string category) => category switch
-    {
+    string CategoryIcon(string category) => category switch {
         "Stocks" => "chart-bar",
         "SEC Filings" => "document-text",
         "Economic Indicators" => "presentation-chart-line",
@@ -20,10 +19,14 @@
         "Futures" => "cube",
         _ => "magnifying-glass",
     };
+
+    // Pin one group per row only when the user has narrowed to a single category — the
+    // focused view shows long lists, so a two-up grid would just make each row half-empty.
+    var isFocused = !string.IsNullOrWhiteSpace(Model.ActiveCategory);
 }
 
 @if (string.IsNullOrWhiteSpace(Model.Query)) {
-    <div class="flex flex-col items-center text-center py-16 gap-5">
+    <div class="flex flex-col items-center text-center py-16 lg:py-24 gap-5">
         <icon name="magnifying-glass" size="10" class="text-base-content/30" />
         <p class="text-base-content/70 max-w-md">
             Search stocks, SEC filings, institutions, insiders, congress members,
@@ -34,7 +37,10 @@
             <div class="flex flex-wrap justify-center gap-2 max-w-xl">
                 @foreach (var category in Equibles.Web.Search.SearchCategories.All) {
                     <a asp-action="Index" asp-route-category="@category"
-                       class="badge badge-ghost badge-lg transition-colors hover:badge-primary">@category</a>
+                       class="badge badge-ghost badge-lg gap-1 transition-colors hover:badge-primary">
+                        <icon name="@CategoryIcon(category)" size="3" />
+                        @category
+                    </a>
                 }
             </div>
         </div>
@@ -46,7 +52,7 @@
         </div>
     </div>
 } else if (!Model.HasResults) {
-    <div class="flex flex-col items-center text-center py-16 gap-3">
+    <div class="flex flex-col items-center text-center py-16 lg:py-24 gap-3">
         <icon name="magnifying-glass" size="10" class="text-base-content/30" />
         <p class="text-base-content/70">
             No results for <span class="font-semibold text-base-content">@Model.Query</span>.
@@ -54,18 +60,27 @@
         <p class="text-sm text-base-content/50">Try a ticker symbol, company name, or filing type.</p>
     </div>
 } else {
-    <!-- Result count: visibility of system status — tells the user how broad the
-         match is before they scan the groups. -->
-    <p class="text-sm text-base-content/60 mb-3">
-        <span class="font-semibold text-base-content">@visibleGroups.Sum(g => g.Hits.Count)</span>
-        @(visibleGroups.Sum(g => g.Hits.Count) == 1 ? "result" : "results") for
-        <span class="font-semibold text-base-content">@Model.Query</span>
-        in @(string.IsNullOrWhiteSpace(Model.ActiveCategory)
-            ? (visibleGroups.Count == 1 ? "1 category" : $"{visibleGroups.Count} categories")
-            : Model.ActiveCategory)
-    </p>
+    var totalHits = visibleGroups.Sum(g => g.Hits.Count);
 
-    <!-- Category filter chips -->
+    <!-- Result count + chips give the user a quick read on breadth before scanning groups. -->
+    <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <p class="text-sm text-base-content/60">
+            <span class="font-semibold text-base-content">@totalHits</span>
+            @(totalHits == 1 ? "result" : "results") for
+            <span class="font-semibold text-base-content">@Model.Query</span>
+            in @(string.IsNullOrWhiteSpace(Model.ActiveCategory)
+                ? (visibleGroups.Count == 1 ? "1 category" : $"{visibleGroups.Count} categories")
+                : Model.ActiveCategory)
+        </p>
+    </div>
+
+    <!-- Category chips: a faster way to swap categories than scrolling to the sidebar.
+         The "All" chip clears the category filter; the others mirror the radios in the sidebar.
+         Includes the active category even when it has zero hits so the user can see it's still
+         selected and pivot away with one click instead of hunting in the sidebar. -->
+    var hasActiveGroup = string.IsNullOrWhiteSpace(Model.ActiveCategory)
+        || Model.Groups.Any(g => string.Equals(g.Category, Model.ActiveCategory, StringComparison.OrdinalIgnoreCase));
+
     <div class="flex flex-wrap gap-2 mb-6">
         <a asp-action="Index" asp-route-q="@Model.Query"
            class="badge badge-lg transition-colors hover:badge-primary @(string.IsNullOrWhiteSpace(Model.ActiveCategory) ? "badge-primary" : "badge-ghost")">
@@ -75,6 +90,12 @@
             <a asp-action="Index" asp-route-q="@Model.Query" asp-route-category="@group.Category"
                class="badge badge-lg transition-colors hover:badge-primary @(string.Equals(group.Category, Model.ActiveCategory, StringComparison.OrdinalIgnoreCase) ? "badge-primary" : "badge-ghost")">
                 @group.Category (@group.Hits.Count)
+            </a>
+        }
+        @if (!hasActiveGroup) {
+            <a asp-action="Index" asp-route-q="@Model.Query" asp-route-category="@Model.ActiveCategory"
+               class="badge badge-lg badge-primary">
+                @Model.ActiveCategory (0)
             </a>
         }
     </div>
@@ -93,54 +114,58 @@
                 Show all results
             </a>
         </div>
-    }
-
-    <!-- Result groups -->
-    <div class="grid gap-6 md:grid-cols-2 items-start">
-        @foreach (var group in visibleGroups) {
-            var seeAll = Url.CategoryUrl(group.Category, Model.Query);
-            <div class="card bg-base-100 shadow-sm transition-shadow hover:shadow-md">
-                <div class="card-body p-4 lg:p-6">
-                    <div class="flex items-center justify-between mb-3">
-                        <div class="flex items-center gap-3 min-w-0">
-                            <span class="flex items-center justify-center size-9 rounded-lg bg-primary/10 text-primary shrink-0">
-                                <icon name="@CategoryIcon(group.Category)" size="5" />
-                            </span>
-                            <h2 class="card-title text-lg truncate">@group.Category</h2>
-                            <span class="badge badge-ghost badge-sm shrink-0">@group.Hits.Count</span>
+    } else {
+        <div class="grid gap-5 @(isFocused ? "grid-cols-1" : "md:grid-cols-2") items-start">
+            @foreach (var group in visibleGroups) {
+                var seeAll = Url.CategoryUrl(group.Category, Model.Query);
+                <div class="card bg-base-100 shadow-sm border border-base-200/60 transition-shadow hover:shadow-md">
+                    <div class="card-body p-4 lg:p-5">
+                        <div class="flex items-center justify-between mb-3 gap-3">
+                            <div class="flex items-center gap-3 min-w-0">
+                                <span class="flex items-center justify-center size-9 rounded-lg bg-primary/10 text-primary shrink-0">
+                                    <icon name="@CategoryIcon(group.Category)" size="5" />
+                                </span>
+                                <h2 class="card-title text-lg truncate">@group.Category</h2>
+                                <span class="badge badge-ghost badge-sm shrink-0">@group.Hits.Count</span>
+                            </div>
+                            @if (seeAll != null && !isFocused) {
+                                <!-- "See all" lives on the overview only; in the focused view the card already
+                                     shows the expanded list, so the link would be a no-op. -->
+                                <a href="@seeAll" class="link link-primary text-sm shrink-0 flex items-center gap-1">
+                                    See all
+                                    <icon name="arrow-right" size="3" />
+                                </a>
+                            }
                         </div>
-                        @if (seeAll != null) {
-                            <a href="@seeAll" class="link link-primary text-sm shrink-0">See all</a>
-                        }
-                    </div>
-                    <ul class="divide-y divide-base-200">
-                        @foreach (var hit in group.Hits) {
-                            var hitUrl = Url.HitUrl(hit);
-                            <li>
-                                @if (hitUrl != null) {
-                                    <a href="@hitUrl" class="group flex items-center gap-3 hover:bg-base-200 rounded-lg px-3 -mx-3 py-2.5 transition-colors">
-                                        <span class="min-w-0 grow">
+                        <ul class="divide-y divide-base-200">
+                            @foreach (var hit in group.Hits) {
+                                var hitUrl = Url.HitUrl(hit);
+                                <li>
+                                    @if (hitUrl != null) {
+                                        <a href="@hitUrl" class="group flex items-center gap-3 hover:bg-base-200 rounded-lg px-3 -mx-3 py-2.5 transition-colors">
+                                            <span class="min-w-0 grow">
+                                                <span class="block font-medium truncate">@hit.Title</span>
+                                                @if (!string.IsNullOrWhiteSpace(hit.Subtitle)) {
+                                                    <span class="block text-sm text-base-content/60 truncate">@hit.Subtitle</span>
+                                                }
+                                            </span>
+                                            <icon name="chevron-right" size="4"
+                                                  class="text-base-content/30 shrink-0 opacity-0 -translate-x-1 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
+                                        </a>
+                                    } else {
+                                        <div class="px-3 -mx-3 py-2.5">
                                             <span class="block font-medium truncate">@hit.Title</span>
                                             @if (!string.IsNullOrWhiteSpace(hit.Subtitle)) {
                                                 <span class="block text-sm text-base-content/60 truncate">@hit.Subtitle</span>
                                             }
-                                        </span>
-                                        <icon name="chevron-right" size="4"
-                                              class="text-base-content/30 shrink-0 opacity-0 -translate-x-1 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
-                                    </a>
-                                } else {
-                                    <div class="px-3 -mx-3 py-2.5">
-                                        <span class="block font-medium truncate">@hit.Title</span>
-                                        @if (!string.IsNullOrWhiteSpace(hit.Subtitle)) {
-                                            <span class="block text-sm text-base-content/60 truncate">@hit.Subtitle</span>
-                                        }
-                                    </div>
-                                }
-                            </li>
-                        }
-                    </ul>
+                                        </div>
+                                    }
+                                </li>
+                            }
+                        </ul>
+                    </div>
                 </div>
-            </div>
-        }
-    </div>
+            }
+        </div>
+    }
 }

--- a/src/Equibles.Web/src/js/instant-search.js
+++ b/src/Equibles.Web/src/js/instant-search.js
@@ -7,10 +7,17 @@
     if (!form || !results || !window.fetch || !window.AbortController) return;
 
     const input = form.querySelector('input[name="q"]');
-    const scope = form.querySelector('select[name="category"]');
+    // Category is a list of same-name radios in the sidebar; the checked one is "active".
+    const categoryRadios = form.querySelectorAll('input[name="category"]');
     const sort = form.querySelector('select[name="sort"]');
     const dateFrom = form.querySelector('input[name="dateFrom"]');
     const dateTo = form.querySelector('input[name="dateTo"]');
+    const clearButton = document.getElementById('search-clear');
+    const clearFilters = document.getElementById('search-clear-filters');
+    // Mobile drawer controls.
+    const filtersPanel = document.getElementById('search-filters');
+    const filtersToggle = document.getElementById('search-filters-toggle');
+    const filtersBackdrop = document.getElementById('search-filters-backdrop');
     if (!input) return;
 
     const resultsUrl = form.dataset.resultsUrl || '/Search/Results';
@@ -18,13 +25,21 @@
     let timer;
     let controller;
 
-    // Fetch the results partial for the current query + scope and swap it in.
+    // Returns the currently selected category radio value, or '' for "all".
+    function getCategory() {
+        for (const radio of categoryRadios) {
+            if (radio.checked) return radio.value;
+        }
+        return '';
+    }
+
+    // Fetch the results partial for the current query + filters and swap it in.
     // push=true adds a history entry (explicit submit); otherwise the URL is replaced
     // so typing doesn't flood the back stack.
     async function run(push) {
         const params = new URLSearchParams();
         const q = input.value.trim();
-        const category = scope ? scope.value : '';
+        const category = getCategory();
         const sortBy = sort ? sort.value : '';
         if (q) params.set('q', q);
         if (category) params.set('category', category);
@@ -46,6 +61,8 @@
             results.innerHTML = await response.text();
             const url = params.toString() ? `${action}?${params}` : action;
             window.history[push ? 'pushState' : 'replaceState'](null, '', url);
+            // Toggle the inline "clear input" button visibility to track input state.
+            if (clearButton) clearButton.classList.toggle('hidden', q.length === 0);
         } catch (error) {
             if (error.name !== 'AbortError') console.error('[instant-search]', error);
         } finally {
@@ -54,12 +71,12 @@
         }
     }
 
-    // Debounce typing; react immediately to a scope change or explicit submit.
+    // Debounce typing; react immediately to filter changes or explicit submit.
     input.addEventListener('input', () => {
         clearTimeout(timer);
         timer = setTimeout(() => run(false), 250);
     });
-    scope?.addEventListener('change', () => run(false));
+    categoryRadios.forEach((radio) => radio.addEventListener('change', () => run(false)));
     sort?.addEventListener('change', () => run(false));
     dateFrom?.addEventListener('change', () => run(false));
     dateTo?.addEventListener('change', () => run(false));
@@ -69,11 +86,67 @@
         run(true);
     });
 
+    // Inline "X" inside the search input — clear the query and re-fetch immediately.
+    clearButton?.addEventListener('click', () => {
+        input.value = '';
+        input.focus();
+        run(false);
+    });
+
+    // "Clear all" link in the sidebar — reset every filter to its default and re-fetch
+    // instead of letting the link's GET round-trip the page.
+    clearFilters?.addEventListener('click', (event) => {
+        event.preventDefault();
+        categoryRadios.forEach((radio) => {
+            radio.checked = radio.value === '';
+        });
+        if (sort) sort.value = '0';
+        if (dateFrom) dateFrom.value = '';
+        if (dateTo) dateTo.value = '';
+        run(false);
+    });
+
+    // Mobile filter drawer: open via the navbar button, close via backdrop tap or Escape.
+    // Manages focus + modal semantics so screen readers and keyboard users don't get stuck.
+    function setFiltersOpen(open) {
+        if (!filtersPanel) return;
+        filtersPanel.classList.toggle('open', open);
+        filtersBackdrop?.classList.toggle('open', open);
+        document.body.style.overflow = open ? 'hidden' : '';
+        if (open) {
+            filtersPanel.setAttribute('role', 'dialog');
+            filtersPanel.setAttribute('aria-modal', 'true');
+            // Move focus into the panel; falls back to the panel itself if it has no
+            // focusable descendant (shouldn't happen, but defensive).
+            const firstFocusable = filtersPanel.querySelector(
+                'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+            );
+            firstFocusable?.focus();
+        } else {
+            filtersPanel.removeAttribute('role');
+            filtersPanel.removeAttribute('aria-modal');
+            // Return focus to the trigger so keyboard users keep their place.
+            filtersToggle?.focus();
+        }
+    }
+    filtersToggle?.addEventListener('click', () => setFiltersOpen(true));
+    filtersBackdrop?.addEventListener('click', () => setFiltersOpen(false));
+    document.addEventListener('keydown', (event) => {
+        // Only react when the drawer is actually open — otherwise Escape would
+        // unstick body overflow that an unrelated modal had set.
+        if (event.key === 'Escape' && filtersPanel?.classList.contains('open')) {
+            setFiltersOpen(false);
+        }
+    });
+
     // Back/forward: re-sync the inputs from the URL and refresh the results.
     window.addEventListener('popstate', () => {
         const params = new URLSearchParams(window.location.search);
         input.value = params.get('q') || '';
-        if (scope) scope.value = params.get('category') || '';
+        const category = params.get('category') || '';
+        categoryRadios.forEach((radio) => {
+            radio.checked = radio.value === category;
+        });
         if (sort) sort.value = params.get('sort') || '0';
         if (dateFrom) dateFrom.value = params.get('dateFrom') || '';
         if (dateTo) dateTo.value = params.get('dateTo') || '';

--- a/tests/Equibles.UnitTests/Search/SearchCategoryUrlTests.cs
+++ b/tests/Equibles.UnitTests/Search/SearchCategoryUrlTests.cs
@@ -8,17 +8,17 @@ namespace Equibles.UnitTests.Search;
 public class SearchCategoryUrlTests
 {
     [Fact]
-    public void CategoryUrl_ShippedGroupWithNoBrowsePage_ReturnsNull()
+    public void CategoryUrl_ShippedGroupWithNoBrowsePage_FallsBackToSearchPage()
     {
-        // Contract (XML doc): CategoryUrl is the "See all" destination for a group,
-        // "or null when no browse page exists". "Insiders" is a real shipped search
-        // group (InsiderOwnerSearchProvider.Category) with no browse page, so it must
-        // return null even though the URL helper can resolve any action.
+        // Contract (XML doc): CategoryUrl returns a "See all" destination for every shipped
+        // category. Groups with a dedicated browse page resolve to that page; the rest
+        // ("Insiders", "Institutions", "Congress", "SEC Filings") fall back to the search
+        // page filtered to just that category so users always get an expanded result list.
         var url = Substitute.For<IUrlHelper>();
         url.Action(Arg.Any<UrlActionContext>()).Returns("/resolved/path");
 
         var result = url.CategoryUrl("Insiders", "berkshire");
 
-        result.Should().BeNull();
+        result.Should().Be("/resolved/path");
     }
 }


### PR DESCRIPTION
## Summary
- Replace the inline filter strip on `/Search` with a sticky left sidebar (Category radio list, Sort, date range, Clear all). Mobile: filters collapse into an off-canvas drawer with focus management, `role=\"dialog\"` + `aria-modal`, and Escape-to-close guarded so it can't unstick body overflow set by unrelated modals.
- \"See all\" now works for every shipped category. Groups without a dedicated browse page (Institutions, Insiders, Congress, SEC Filings) fall back to a category-filtered search URL instead of returning `null`, so every result card has a working link.
- `SearchController` raises the per-provider cap from 6 → 50 when a single category is active, so clicking \"See all\" actually expands the list rather than showing the same overview cap.

## Code changes
- **`Controllers/SearchController.cs`** — added `ResolveMaxPerProvider(category)`: 6 hits per group in overview mode, 50 when one category is filtered.
- **`Extensions/SearchCategoryRouteExtensions.cs`** — `CategoryUrl` always returns a URL; the previously-`null` branches fall back to `Url.Action(\"Index\", \"Search\", new { q, category })`.
- **`Views/Search/Index.cshtml`** — full rewrite: two-column layout (`grid-cols-[16rem_minmax(0,1fr)]`), sticky search bar, sidebar with sectioned filters, mobile filter button with active-count badge, off-canvas drawer with backdrop.
- **`Views/Search/_Results.cshtml`** — single-column cards in focused mode; \"See all\" hidden in focused view; chip strip now retains the active category even at zero hits so the user can pivot off the dead-end.
- **`src/js/instant-search.js`** — radio-list category handling, drawer open/close with focus return to the trigger, inline search-clear button, sidebar \"Clear all\" link.
- **`tests/Equibles.UnitTests/Search/SearchCategoryUrlTests.cs`** — pinned the new contract: every shipped category resolves to a URL.

## Test plan
- [ ] `/Search?q=apple` shows the new sidebar layout on desktop.
- [ ] Each result group has a working \"See all\" link.
- [ ] Selecting a single category in the sidebar narrows results live (instant-search) and expands to up to 50 hits.
- [ ] Mobile drawer opens, traps focus, closes on backdrop tap or Escape; focus returns to the toggle button.
- [ ] \"Clear all\" resets every filter and re-fetches without a page reload.