### PR TITLE
test(sec): pin FactMarkdown.Value bare non-USD currency renders without dollar prefix

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownValueBareCurrencyTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownValueBareCurrencyTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// FactMarkdown.Value's doc-comment says: "Only USD is prefixed with '$';
+/// other currencies (EUR/GBP for 20-F / 40-F filers) are conveyed by the
+/// unit column rather than mislabelled with a dollar sign." A bare three-
+/// letter currency code like "EUR" must therefore render as a grouped whole
+/// number with no "$" prefix — the unit column carries the currency. A
+/// refactor that generalises the USD branch into "is currency" (e.g. routing
+/// IsBareCurrency through the isUsd predicate, or applying the prefix
+/// whenever isWholeMagnitude is true) would compile cleanly and silently
+/// mislabel every foreign-filer figure as dollars in the table the LLM reads.
+/// </summary>
+public class FactMarkdownValueBareCurrencyTests
+{
+    [Fact]
+    public void Value_BareNonUsdCurrencyUnit_RendersGroupedWholeWithoutDollarPrefix()
+    {
+        var result = FactMarkdown.Value(1234567m, "EUR");
+
+        result.Should().Be("1,234,567");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test pins the doc-commented branch in `FactMarkdown.Value(decimal, string)` that says "Only USD is prefixed with '$'; other currencies (EUR/GBP for 20-F / 40-F filers) are conveyed by the unit column rather than mislabelled with a dollar sign."
- A bare 3-letter currency code like `EUR` must render as a grouped whole number with **no** `$` prefix.
- Existing tests covered `USD/shares`, pipe/newline escaping, and CR/LF stripping but left this branch unpinned — a refactor that generalises the USD branch into "is currency" would silently mislabel every foreign-filer figure as dollars in the table the LLM consumes.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownValueBareCurrencyTests.cs` — new xUnit test `Value_BareNonUsdCurrencyUnit_RendersGroupedWholeWithoutDollarPrefix` asserting `FactMarkdown.Value(1234567m, "EUR")` returns `"1,234,567"`.