### PR TITLE
test(sec): pin HeadingConversionStep.IsItalicSpan InnerHtml fallback detects nested italic

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItalicSpanInnerHtmlTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItalicSpanInnerHtmlTests.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+/// <summary>
+/// IsItalicSpan's doc-comment promises detection "by either an inline
+/// style attribute OR an InnerHtml match." The InnerHtml-fallback arm fires
+/// when the italic styling lives on a nested child rather than the span
+/// itself — a common SEC pattern where the outer span carries no style and
+/// the emphasis tag inside it does. A refactor dropping the nested probe
+/// (keeping only the inline-style check pinned elsewhere) would compile
+/// cleanly and silently disable h4 promotion for nested-italic headings.
+/// </summary>
+public class HeadingConversionStepIsItalicSpanInnerHtmlTests
+{
+    [Fact]
+    public void IsItalicSpan_NestedChildWithFontStyleItalic_ReturnsTrue()
+    {
+        var span = new HtmlParser()
+            .ParseDocument(
+                "<html><body><span><em style=\"font-style:italic\">Heading</em></span></body></html>"
+            )
+            .QuerySelector("span")!;
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "IsItalicSpan",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var step = new HeadingConversionStep();
+
+        var result = (bool)method.Invoke(step, [span])!;
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test pins the InnerHtml fallback arm of `HeadingConversionStep.IsItalicSpan`. The doc-comment promises detection "by either an inline style attribute **or** an InnerHtml match" — but the existing `HeadingConversionStepIsItalicSpanTests` only covers the inline-style branch.
- The InnerHtml arm fires when the italic styling lives on a nested child (e.g. `<span><em style="font-style:italic">…</em></span>`) — a common SEC HTML pattern where the outer span carries no style and the emphasis tag inside does. A refactor dropping the nested probe would silently disable h4 promotion for those headings.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItalicSpanInnerHtmlTests.cs` — new xUnit test `IsItalicSpan_NestedChildWithFontStyleItalic_ReturnsTrue` invokes the private `IsItalicSpan` (via reflection, mirroring sibling tests) against a span whose only italic styling lives on a nested `<em>` child, asserting it returns `true`.