### PR TITLE
test(holdings): pin Filing13FXmlParser IsAmendment numeric "1" recognised as amendment

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserIsAmendmentNumericTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserIsAmendmentNumericTests.cs
@@ -1,0 +1,46 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class Filing13FXmlParserIsAmendmentNumericTests
+{
+    [Fact]
+    public void ParseCoverPage_IsAmendmentNumericOne_RecognisedAsAmendment()
+    {
+        // IsAmendmentValue accepts four truthy aliases — true, y, yes, 1 — to
+        // tolerate variations across SEC's historical encodings. Existing tests
+        // pin only the "true" branch; the "1" branch is the lone non-Equals
+        // comparison in the chain, easy to drop in a "simplify to true/false"
+        // refactor. Losing it silently re-classifies every amendment that uses
+        // EDGAR's numeric flag as an original filing — breaking the amendment
+        // delete-by-period path the importer relies on.
+        const string xml = """
+            <edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler">
+              <headerData>
+                <filerInfo>
+                  <filer><credentials><cik>0001067983</cik></credentials></filer>
+                </filerInfo>
+              </headerData>
+              <formData>
+                <coverPage>
+                  <reportCalendarOrQuarter>09-30-2025</reportCalendarOrQuarter>
+                  <isAmendment>1</isAmendment>
+                  <filingManager><name>BIG FUND</name></filingManager>
+                  <form13FFileNumber>028-1</form13FFileNumber>
+                </coverPage>
+              </formData>
+            </edgarSubmission>
+            """;
+
+        var parser = new Filing13FXmlParser();
+
+        var filing = parser.ParseCoverPage(
+            xml,
+            accessionNumber: "0001067983-25-000900",
+            cik: "0001067983",
+            filingDate: new DateOnly(2025, 11, 20)
+        );
+
+        filing.IsAmendment.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test pins the `"1"` branch of `Filing13FXmlParser.IsAmendmentValue`. The helper accepts four truthy aliases — `true`, `y`, `yes`, `1` — for cross-era SEC encoding tolerance.
- Existing cover-page tests pin only `<isAmendment>true</isAmendment>` and the missing-element default. The `"1"` arm is the lone non-`Equals` comparison in the chain and easy to drop in a "simplify to true/false" refactor. Losing it silently re-classifies every numeric-flag amendment as an original, breaking the importer's amendment delete-by-period path.

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserIsAmendmentNumericTests.cs` — new xUnit test `ParseCoverPage_IsAmendmentNumericOne_RecognisedAsAmendment` feeds a `primary_doc.xml` whose `<isAmendment>1</isAmendment>` uses the numeric flag, then asserts `filing.IsAmendment` is `true`.