### PR TITLE
test(holdings): pin Filing13FXmlParser.ParseSecDate ISO historical-filing fallback

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseSecDateIsoFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseSecDateIsoFallbackTests.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Filing13FXmlParserParseSecDateIsoFallbackTests
+{
+    // Adversarial: ParseSecDate's XML-doc-comment promises "Cover-page dates are
+    // MM-DD-YYYY; a few historical filings use ISO." The MM-DD-YYYY branch is
+    // pinned elsewhere; the ISO fallback (the second TryParse) is not. A refactor
+    // that drops the general-TryParse fallback would compile cleanly and silently
+    // return DateOnly.MinValue for those historical filings — the importer treats
+    // MinValue as the "skip this filing" sentinel, so every ISO-dated filing
+    // would vanish without an error.
+    [Fact]
+    public void ParseSecDate_IsoFormat_ParsesViaGeneralTryParseFallback()
+    {
+        var parse = typeof(Filing13FXmlParser).GetMethod(
+            "ParseSecDate",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+        var result = (DateOnly)parse.Invoke(null, ["2024-09-30"])!;
+
+        result.Should().Be(new DateOnly(2024, 9, 30));
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test pins the second-branch ISO fallback of `Filing13FXmlParser.ParseSecDate`. The method's XML-doc-comment is explicit: "Cover-page dates are MM-DD-YYYY; **a few historical filings use ISO**."
- The primary MM-dd-yyyy branch is already pinned by `Filing13FXmlParserParseSecDateTests`; the ISO fallback (general `DateOnly.TryParse` with `InvariantCulture`) is not. A refactor dropping it would compile cleanly and silently return `DateOnly.MinValue` for ISO-formatted historical filings — which the importer treats as the "skip this filing" sentinel, so every such filing would vanish without an error.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseSecDateIsoFallbackTests.cs` — new xUnit test `ParseSecDate_IsoFormat_ParsesViaGeneralTryParseFallback` invokes the private `ParseSecDate` via reflection (same shape as the sibling MM-dd-yyyy test) against `"2024-09-30"`, asserting it returns `DateOnly(2024, 9, 30)`.