### PR TITLE
test(holdings): pin Filing13FXmlParser.ParseInformationTable empty-amendment tolerance

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserEmptyAmendmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserEmptyAmendmentTests.cs
@@ -1,0 +1,28 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class Filing13FXmlParserEmptyAmendmentTests
+{
+    [Fact]
+    public void ParseInformationTable_WellFormedRootWithNoRows_ReturnsEmptyListAndDoesNotThrow()
+    {
+        // Contract (method XML-doc): ParseInformationTable "tolerates a missing
+        // or empty table (an amendment that removes every position) by returning
+        // an empty list." This is the canonical shape for that case — a real
+        // amendment that zeros out every position ships a well-formed
+        // <informationTable> with zero children. Both the direct-children scan
+        // and the recursive-descent fallback must come up empty without
+        // throwing. A refactor that drops the rows.Count == 0 fallback (or
+        // that .Single()s the rows) would crash the importer on every such
+        // amendment and silently lose the de-listing signal.
+        const string xml = """
+            <informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable">
+            </informationTable>
+            """;
+
+        var holdings = new Filing13FXmlParser().ParseInformationTable(xml);
+
+        holdings.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test pins the doc-commented "tolerates a missing or empty table (an amendment that removes every position) by returning an empty list" contract of `Filing13FXmlParser.ParseInformationTable`.
- Existing tests cover populated tables and the wrapped-root recursive fallback, but the well-formed-root-with-zero-children shape — the canonical amendment-removes-all-positions XML — was unpinned. A refactor that `.Single()`s the rows, drops the `rows.Count == 0` fall-through, or otherwise stops short of an empty-list result would crash the importer on every such amendment and silently lose the de-listing signal.

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/Filing13FXmlParserEmptyAmendmentTests.cs` — new xUnit test `ParseInformationTable_WellFormedRootWithNoRows_ReturnsEmptyListAndDoesNotThrow` parses a namespaced `<informationTable></informationTable>` with zero children and asserts the parser returns an empty list without throwing.