### PR TITLE
docs: add index and planned outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ An open-source, self-hosted mini Bloomberg Terminal for AI agents. Scrapes, stor
 
 Powers [equibles.com](https://equibles.com).
 
+See [`docs/`](docs/README.md) for contributor documentation.
+
 ## What's Included
 
 | Domain | Data Source | Description |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Equibles Documentation
+
+Reference for developers working inside the Equibles codebase. The root [`README.md`](../README.md) is the user-facing front door (install, run, connect AI assistants); the pages here are for contributors and operators who need to reason about the internals.
+
+## Topics
+
+- [Architecture](architecture.md) — modular-monolith composition, the shared `EquiblesDbContext` module system, repo → manager → host data flow.
+- [Hosts](hosts.md) — the three host apps: `Equibles.Web` (MVC portal), `Equibles.Mcp.Server` (MCP transport), `Equibles.Worker.Host` (background scrapers).
+- [Modules](modules.md) — index of the financial-domain modules (SEC, Holdings, Insider, Congress, FRED, Yahoo, FINRA, CFTC, CBOE) with data source, key entities, and scraper entry point per row.
+- [MCP tools](mcp-tools.md) — catalog of the tools exposed by each module's `*.Mcp` project and the wiring path through `Equibles.Mcp` → `Equibles.Mcp.Server`.
+- [Scrapers and integrations](scrapers.md) — `*.HostedService` worker pattern, `Equibles.Integrations.*` client pattern, rate limiting, retry, `ProcessedDataSet` / `ProcessedFiling` bookkeeping.
+- [Web portal](web-portal.md) — `StocksController` tab pattern, `StockTabService`, DaisyUI v5 + Tailwind v4 + Vite, Razor partial conventions.
+- [Migrations and database](migrations.md) — `Equibles.Migrations` design-time factory, ParadeDB extensions (`pgvector`, `pg_search`), `MigrateAsync` on host startup.
+- [Development](development.md) — Docker-first workflow, `dotnet csharpier` formatting, pre-commit hooks, single-test commands, CI gates (`ci.yml` / `functional.yml` / `smoke.yml`).
+- [Operations](operations.md) — environment-variable catalog, `--profile embedding` opt-in, `CHECK_FOR_UPDATES`, auth modes, upgrading.
+
+## Status
+
+All pages above are **planned**. None are written yet. New pages land one per PR via `/update-docs`, in the order listed.


### PR DESCRIPTION
## Summary

- Plants `docs/README.md` as the contributor-docs index. Lists nine planned pages covering architecture, hosts, modules, MCP tools, scrapers, web portal, migrations, development workflow, and operations.
- Adds a one-line link to `docs/README.md` from the root README, immediately after the project tagline.
- Bootstrap step of `/update-docs` — subsequent invocations populate one page from the planned list per PR.

## Code changes

- `docs/README.md` (new) — contributor-docs index with the planned TOC and a Status line marking every page as planned.
- `README.md` — single new line right after the tagline pointing at `docs/`.