### PR TITLE
docs(index): refresh Status section now that every planned page exists

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,4 +16,4 @@ Reference for developers working inside the Equibles codebase. The root [`README
 
 ## Status
 
-All pages above are **planned**. None are written yet. New pages land one per PR via `/update-docs`, in the order listed.
+Every page above is written. Subsequent `/update-docs` invocations operate in the maintain lane — one drift fix per PR (stale code reference, missing doc for a module added since the last docs commit, or one unclear sentence).


### PR DESCRIPTION
## Summary

- Maintain-lane PR — first run after every planned page has been populated.
- Fixes a one-sentence stale reference in `docs/README.md`: the Status section claimed all pages were planned and none written, but all nine populate-lane PRs (#1031–#1039) have since landed.
- Replaces the sentence with a one-line description of the lane the command now runs in.

## Code changes

- `docs/README.md` — single-line edit to the `## Status` paragraph.