### PR TITLE
docs(migrations): replace "the relevant module" with the concrete name

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -72,7 +72,7 @@ NpgsqlIndexBuilderExtensions.AreNullsDistinct(
     false);
 ```
 
-Without this, `OptionType=NULL` rows wouldn't conflict with each other, and the import pipeline would happily insert duplicate "no option" 13F holdings. The fluent index is declared in the relevant module's `IModuleConfiguration.ConfigureEntities`, not in the entity attribute (Postgres index syntax doesn't have an `[Index]` analogue for this flag).
+Without this, `OptionType=NULL` rows wouldn't conflict with each other, and the import pipeline would happily insert duplicate "no option" 13F holdings. The fluent index is declared in the owning module's `IModuleConfiguration.ConfigureEntities` (`HoldingsModuleConfiguration` for the index above), not in the entity attribute (Postgres index syntax doesn't have an `[Index]` analogue for this flag).
 
 ## Migration history
 


### PR DESCRIPTION
## Summary

- Maintain-lane PR — one unclear-sentence drift fix.
- `docs/migrations.md`'s NULLS NOT DISTINCT paragraph said "declared in the relevant module's IModuleConfiguration" — the exact vague phrasing the docs writing rules forbid. The example index right above it is the InstitutionalHolding unique key, owned by `HoldingsModuleConfiguration`. Name it.

## Code changes

- `docs/migrations.md` — single-sentence edit: \"the relevant module's\" → \"the owning module's (`HoldingsModuleConfiguration` for the index above)\".