### PR TITLE
feat(holdings): add position-change grouping for institutional holders (1/2)

### DIFF
--- a/src/Equibles.Web/Services/HoldingsPositionGrouper.cs
+++ b/src/Equibles.Web/Services/HoldingsPositionGrouper.cs
@@ -1,0 +1,104 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Web.ViewModels.Stocks;
+
+namespace Equibles.Web.Services;
+
+public static class HoldingsPositionGrouper
+{
+    public static Dictionary<PositionChangeType, List<HolderPositionChange>> Group(
+        IReadOnlyList<InstitutionalHolding> currentHoldings,
+        IReadOnlyList<InstitutionalHolding> previousHoldings
+    )
+    {
+        var currentByHolder = AggregateByHolder(currentHoldings);
+        var previousByHolder = AggregateByHolder(previousHoldings);
+
+        var result = new Dictionary<PositionChangeType, List<HolderPositionChange>>
+        {
+            [PositionChangeType.New] = [],
+            [PositionChangeType.Increased] = [],
+            [PositionChangeType.Reduced] = [],
+            [PositionChangeType.Unchanged] = [],
+            [PositionChangeType.SoldOut] = [],
+        };
+
+        foreach (var (holderId, current) in currentByHolder)
+        {
+            previousByHolder.TryGetValue(holderId, out var previous);
+
+            var change = new HolderPositionChange
+            {
+                InstitutionalHolderId = holderId,
+                InstitutionalHolder = current.Holder,
+                CurrentHolding = current.LatestHolding,
+                CurrentShares = current.TotalShares,
+                CurrentValue = current.TotalValue,
+                PreviousShares = previous?.TotalShares ?? 0,
+                PreviousValue = previous?.TotalValue ?? 0,
+                ChangeType = ClassifyChange(current.TotalShares, previous?.TotalShares ?? 0),
+            };
+
+            result[change.ChangeType].Add(change);
+        }
+
+        foreach (var (holderId, previous) in previousByHolder)
+        {
+            if (currentByHolder.ContainsKey(holderId))
+                continue;
+
+            result[PositionChangeType.SoldOut]
+                .Add(
+                    new HolderPositionChange
+                    {
+                        InstitutionalHolderId = holderId,
+                        InstitutionalHolder = previous.Holder,
+                        CurrentHolding = null,
+                        CurrentShares = 0,
+                        CurrentValue = 0,
+                        PreviousShares = previous.TotalShares,
+                        PreviousValue = previous.TotalValue,
+                        ChangeType = PositionChangeType.SoldOut,
+                    }
+                );
+        }
+
+        return result;
+    }
+
+    private static PositionChangeType ClassifyChange(long currentShares, long previousShares)
+    {
+        if (previousShares == 0)
+            return PositionChangeType.New;
+        if (currentShares == previousShares)
+            return PositionChangeType.Unchanged;
+        return currentShares > previousShares
+            ? PositionChangeType.Increased
+            : PositionChangeType.Reduced;
+    }
+
+    private static Dictionary<Guid, HolderAggregate> AggregateByHolder(
+        IReadOnlyList<InstitutionalHolding> holdings
+    )
+    {
+        return holdings
+            .GroupBy(h => h.InstitutionalHolderId)
+            .ToDictionary(
+                g => g.Key,
+                g => new HolderAggregate
+                {
+                    Holder = g.First().InstitutionalHolder,
+                    LatestHolding = g.OrderByDescending(h => h.FilingDate).First(),
+                    TotalShares = g.Sum(h => h.Shares),
+                    TotalValue = g.Sum(h => h.Value),
+                }
+            );
+    }
+
+    private class HolderAggregate
+    {
+        public InstitutionalHolder Holder { get; set; }
+        public InstitutionalHolding LatestHolding { get; set; }
+        public long TotalShares { get; set; }
+        public long TotalValue { get; set; }
+    }
+}

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -88,16 +88,34 @@ public class StockTabService
             // Fetch previous quarter's shares for change % calculation
             var previousSharesByHolder = new Dictionary<Guid, long>();
             var selectedIndex = reportDates.IndexOf(selectedDate);
-            if (selectedIndex >= 0 && selectedIndex < reportDates.Count - 1)
+            var previousDate =
+                selectedIndex >= 0 && selectedIndex < reportDates.Count - 1
+                    ? reportDates[selectedIndex + 1]
+                    : (DateOnly?)null;
+            if (previousDate.HasValue)
             {
-                var previousDate = reportDates[selectedIndex + 1];
                 var holderIds = holdings.Select(h => h.InstitutionalHolderId).ToList();
                 previousSharesByHolder = await _institutionalHoldingRepository
-                    .GetByStock(stock, previousDate)
+                    .GetByStock(stock, previousDate.Value)
                     .Where(h => holderIds.Contains(h.InstitutionalHolderId))
                     .GroupBy(h => h.InstitutionalHolderId)
                     .ToDictionaryAsync(g => g.Key, g => g.Sum(h => h.Shares));
             }
+
+            // Full per-quarter holdings (current + previous) for position-change grouping.
+            // Separate from the top-100 query above so the existing tile rendering is unchanged.
+            var allCurrent = await _institutionalHoldingRepository
+                .GetByStock(stock, selectedDate)
+                .Include(h => h.InstitutionalHolder)
+                .ToListAsync();
+            var allPrevious = previousDate.HasValue
+                ? await _institutionalHoldingRepository
+                    .GetByStock(stock, previousDate.Value)
+                    .Include(h => h.InstitutionalHolder)
+                    .ToListAsync()
+                : [];
+            var grouped = HoldingsPositionGrouper.Group(allCurrent, allPrevious);
+            var bucketCounts = grouped.ToDictionary(g => g.Key, g => g.Value.Count);
 
             return new HoldingsTabViewModel
             {
@@ -110,6 +128,8 @@ public class StockTabService
                 HolderCount = totalHolderCount,
                 DisplayedCount = holdings.Count,
                 PreviousSharesByHolder = previousSharesByHolder,
+                GroupedHolders = grouped,
+                BucketCounts = bucketCounts,
             };
         }
 

--- a/src/Equibles.Web/ViewModels/Stocks/HolderPositionChange.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/HolderPositionChange.cs
@@ -1,0 +1,22 @@
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.Web.ViewModels.Stocks;
+
+public class HolderPositionChange
+{
+    public Guid InstitutionalHolderId { get; set; }
+    public InstitutionalHolder InstitutionalHolder { get; set; }
+
+    // null when SoldOut — the holder reported nothing this quarter.
+    public InstitutionalHolding CurrentHolding { get; set; }
+
+    public long CurrentShares { get; set; }
+    public long PreviousShares { get; set; }
+    public long CurrentValue { get; set; }
+    public long PreviousValue { get; set; }
+
+    public PositionChangeType ChangeType { get; set; }
+
+    public long DeltaShares => CurrentShares - PreviousShares;
+    public long DeltaValue => CurrentValue - PreviousValue;
+}

--- a/src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs
@@ -13,4 +13,8 @@ public class HoldingsTabViewModel
     public int HolderCount { get; set; }
     public int DisplayedCount { get; set; }
     public Dictionary<Guid, long> PreviousSharesByHolder { get; set; } = [];
+
+    public Dictionary<PositionChangeType, List<HolderPositionChange>> GroupedHolders { get; set; } =
+    [];
+    public Dictionary<PositionChangeType, int> BucketCounts { get; set; } = [];
 }

--- a/src/Equibles.Web/ViewModels/Stocks/PositionChangeType.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/PositionChangeType.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Web.ViewModels.Stocks;
+
+public enum PositionChangeType
+{
+    [Display(Name = "New")]
+    New = 1,
+
+    [Display(Name = "Increased")]
+    Increased = 2,
+
+    [Display(Name = "Reduced")]
+    Reduced = 3,
+
+    [Display(Name = "Unchanged")]
+    Unchanged = 4,
+
+    [Display(Name = "Sold out")]
+    SoldOut = 5,
+}

--- a/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperTests.cs
@@ -1,0 +1,176 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Web.Services;
+using Equibles.Web.ViewModels.Stocks;
+
+namespace Equibles.UnitTests.Web;
+
+public class HoldingsPositionGrouperTests
+{
+    [Fact]
+    public void Group_BothInputsEmpty_ReturnsEmptyBuckets()
+    {
+        var result = HoldingsPositionGrouper.Group([], []);
+
+        result.Should().ContainKey(PositionChangeType.New).WhoseValue.Should().BeEmpty();
+        result.Should().ContainKey(PositionChangeType.Increased).WhoseValue.Should().BeEmpty();
+        result.Should().ContainKey(PositionChangeType.Reduced).WhoseValue.Should().BeEmpty();
+        result.Should().ContainKey(PositionChangeType.Unchanged).WhoseValue.Should().BeEmpty();
+        result.Should().ContainKey(PositionChangeType.SoldOut).WhoseValue.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Group_CurrentOnly_ClassifiesAsNew()
+    {
+        var holderId = Guid.NewGuid();
+        var current = Holding(holderId, shares: 100, value: 1000);
+
+        var result = HoldingsPositionGrouper.Group([current], []);
+
+        result[PositionChangeType.New].Should().HaveCount(1);
+        result[PositionChangeType.New][0].InstitutionalHolderId.Should().Be(holderId);
+        result[PositionChangeType.New][0].CurrentShares.Should().Be(100);
+        result[PositionChangeType.New][0].PreviousShares.Should().Be(0);
+        result[PositionChangeType.New][0].DeltaShares.Should().Be(100);
+        result[PositionChangeType.New][0].DeltaValue.Should().Be(1000);
+    }
+
+    [Fact]
+    public void Group_PreviousOnly_ClassifiesAsSoldOut()
+    {
+        var holderId = Guid.NewGuid();
+        var previous = Holding(holderId, shares: 100, value: 1000);
+
+        var result = HoldingsPositionGrouper.Group([], [previous]);
+
+        result[PositionChangeType.SoldOut].Should().HaveCount(1);
+        var entry = result[PositionChangeType.SoldOut][0];
+        entry.InstitutionalHolderId.Should().Be(holderId);
+        entry.CurrentHolding.Should().BeNull();
+        entry.CurrentShares.Should().Be(0);
+        entry.PreviousShares.Should().Be(100);
+        entry.DeltaShares.Should().Be(-100);
+        entry.DeltaValue.Should().Be(-1000);
+    }
+
+    [Fact]
+    public void Group_HigherShareCount_ClassifiesAsIncreased()
+    {
+        var holderId = Guid.NewGuid();
+        var current = Holding(holderId, shares: 150, value: 1500);
+        var previous = Holding(holderId, shares: 100, value: 1000);
+
+        var result = HoldingsPositionGrouper.Group([current], [previous]);
+
+        result[PositionChangeType.Increased].Should().HaveCount(1);
+        result[PositionChangeType.Increased][0].DeltaShares.Should().Be(50);
+    }
+
+    [Fact]
+    public void Group_LowerShareCount_ClassifiesAsReduced()
+    {
+        var holderId = Guid.NewGuid();
+        var current = Holding(holderId, shares: 60, value: 600);
+        var previous = Holding(holderId, shares: 100, value: 1000);
+
+        var result = HoldingsPositionGrouper.Group([current], [previous]);
+
+        result[PositionChangeType.Reduced].Should().HaveCount(1);
+        result[PositionChangeType.Reduced][0].DeltaShares.Should().Be(-40);
+    }
+
+    [Fact]
+    public void Group_EqualShareCount_ClassifiesAsUnchanged()
+    {
+        var holderId = Guid.NewGuid();
+        var current = Holding(holderId, shares: 100, value: 1100);
+        var previous = Holding(holderId, shares: 100, value: 1000);
+
+        var result = HoldingsPositionGrouper.Group([current], [previous]);
+
+        result[PositionChangeType.Unchanged].Should().HaveCount(1);
+        result[PositionChangeType.Unchanged][0].DeltaShares.Should().Be(0);
+        result[PositionChangeType.Unchanged][0].DeltaValue.Should().Be(100);
+    }
+
+    [Fact]
+    public void Group_MultipleFilingsPerHolder_AggregatesShares()
+    {
+        var holderId = Guid.NewGuid();
+        var current1 = Holding(holderId, shares: 30, value: 300);
+        var current2 = Holding(holderId, shares: 70, value: 700);
+        var previous = Holding(holderId, shares: 100, value: 1000);
+
+        var result = HoldingsPositionGrouper.Group([current1, current2], [previous]);
+
+        // Two filings sum to 100 shares — same as previous → Unchanged.
+        result[PositionChangeType.Unchanged].Should().HaveCount(1);
+        result[PositionChangeType.Unchanged][0].CurrentShares.Should().Be(100);
+    }
+
+    [Fact]
+    public void Group_AllBucketsAtOnce_SplitsCorrectly()
+    {
+        var newId = Guid.NewGuid();
+        var increasedId = Guid.NewGuid();
+        var reducedId = Guid.NewGuid();
+        var unchangedId = Guid.NewGuid();
+        var soldOutId = Guid.NewGuid();
+
+        var current = new[]
+        {
+            Holding(newId, 50, 500),
+            Holding(increasedId, 200, 2000),
+            Holding(reducedId, 50, 500),
+            Holding(unchangedId, 100, 1000),
+        };
+        var previous = new[]
+        {
+            Holding(increasedId, 100, 1000),
+            Holding(reducedId, 100, 1000),
+            Holding(unchangedId, 100, 1000),
+            Holding(soldOutId, 100, 1000),
+        };
+
+        var result = HoldingsPositionGrouper.Group(current, previous);
+
+        result[PositionChangeType.New]
+            .Should()
+            .ContainSingle()
+            .Which.InstitutionalHolderId.Should()
+            .Be(newId);
+        result[PositionChangeType.Increased]
+            .Should()
+            .ContainSingle()
+            .Which.InstitutionalHolderId.Should()
+            .Be(increasedId);
+        result[PositionChangeType.Reduced]
+            .Should()
+            .ContainSingle()
+            .Which.InstitutionalHolderId.Should()
+            .Be(reducedId);
+        result[PositionChangeType.Unchanged]
+            .Should()
+            .ContainSingle()
+            .Which.InstitutionalHolderId.Should()
+            .Be(unchangedId);
+        result[PositionChangeType.SoldOut]
+            .Should()
+            .ContainSingle()
+            .Which.InstitutionalHolderId.Should()
+            .Be(soldOutId);
+    }
+
+    private static InstitutionalHolding Holding(Guid holderId, long shares, long value)
+    {
+        return new InstitutionalHolding
+        {
+            Id = Guid.NewGuid(),
+            InstitutionalHolderId = holderId,
+            InstitutionalHolder = new InstitutionalHolder { Id = holderId, Name = "Test Holder" },
+            Shares = shares,
+            Value = value,
+            FilingDate = new DateOnly(2025, 1, 15),
+            ReportDate = new DateOnly(2024, 12, 31),
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 1 of 2 for #1007 — adds the domain layer that classifies institutional holders by quarter-over-quarter position change (`New` / `Increased` / `Reduced` / `Unchanged` / `Sold out`).
- The Stock Holdings tab keeps rendering its current top-100 flat table; the grouped buckets are now computed and exposed on the view model so slice 2 can swap the view over.
- Refs #1007 — **not** the closing slice. Issue closes when slice 2 (UI) lands.

## Code changes

- `src/Equibles.Web/ViewModels/Stocks/PositionChangeType.cs` — enum with `[Display]` labels.
- `src/Equibles.Web/ViewModels/Stocks/HolderPositionChange.cs` — per-bucket projection (current holding ref, holder, current/previous shares + value, derived `DeltaShares` / `DeltaValue`).
- `src/Equibles.Web/Services/HoldingsPositionGrouper.cs` — pure static grouper. Aggregates by holder across multiple filings; classifies via share-count delta; promotes prior-quarter-only holders to `Sold out` with the previous values preserved.
- `src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs` — adds `GroupedHolders` and `BucketCounts`.
- `src/Equibles.Web/Services/StockTabService.cs` — `LoadHoldingsTab` fetches full current + previous-quarter holdings and populates the new fields alongside the existing top-100 query, leaving the existing tile rendering untouched.
- `tests/Equibles.UnitTests/Web/HoldingsPositionGrouperTests.cs` — 8 unit tests covering each bucket, both-empty case, and multi-filing aggregation per holder.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean.
- New unit tests — 8/8 passing.
- Holdings + Stocks integration tier (`--filter "Category!=Functional&Category!=Live&(FullyQualifiedName~Holdings|FullyQualifiedName~Stocks)"`) — 298/298 passing.

Refs #1007