### PR TITLE
docs(technical/hosts): add hosts page

### DIFF
--- a/docs/technical/hosts.md
+++ b/docs/technical/hosts.md
@@ -2,12 +2,12 @@
 
 Three host applications compose the shared module assembly into runnable services. They share the same startup spine (see [Architecture](architecture.md)) and differ only in what they wire on top.
 
-## Web — [`src/Equibles.Web`](../src/Equibles.Web)
+## Web — [`src/Equibles.Web`](../../src/Equibles.Web)
 
 The MVC portal for browsing data in a browser.
 
-- Entry: [`Program.cs`](../src/Equibles.Web/Program.cs) (`public partial class Program`, `Main` → `ConfigureServices` → `Build` → `ApplyMigrationsAsync` → `ConfigurePipeline` → `RunAsync`).
-- Container: [`Dockerfile`](../src/Equibles.Web/Dockerfile) — base image `dotnet/aspnet:10.0`, `EXPOSE 8080`. `docker-compose.yml` maps `8080:8080`.
+- Entry: [`Program.cs`](../../src/Equibles.Web/Program.cs) (`public partial class Program`, `Main` → `ConfigureServices` → `Build` → `ApplyMigrationsAsync` → `ConfigurePipeline` → `RunAsync`).
+- Container: [`Dockerfile`](../../src/Equibles.Web/Dockerfile) — base image `dotnet/aspnet:10.0`, `EXPOSE 8080`. `docker-compose.yml` maps `8080:8080`.
 - Razor + DaisyUI v5 + Tailwind v4 + Vite. Razor runtime compilation is on (`AddRazorRuntimeCompilation()`) so view edits don't require a rebuild in dev.
 - `AddEquiblesSearch()` is wired only here — global search lives in the portal, not the MCP server or worker.
 - `AddDataProtection().PersistKeysToFileSystem(/app/keys)` — the `web-keys` volume in `docker-compose.yml` makes anti-forgery / cookie keys survive container restarts.
@@ -15,24 +15,24 @@ The MVC portal for browsing data in a browser.
 - Health endpoint `/healthz` is mapped anonymously so the compose health checks (`web` is a dependency of `mcp`) succeed without auth.
 - `ApplyMigrationsAsync` runs `dbContext.Database.MigrateAsync()` with a 1-hour command timeout to absorb index rebuilds on first run.
 
-## MCP Server — [`src/Equibles.Mcp.Server`](../src/Equibles.Mcp.Server)
+## MCP Server — [`src/Equibles.Mcp.Server`](../../src/Equibles.Mcp.Server)
 
 The MCP transport exposing financial-domain tools to AI assistants.
 
-- Entry: [`Program.cs`](../src/Equibles.Mcp.Server/Program.cs) (`public partial class Program`).
-- Container: [`Dockerfile`](../src/Equibles.Mcp.Server/Dockerfile) — `dotnet/aspnet:10.0`, `EXPOSE 8080`. Compose maps `8081:8080` so the public endpoint is `http://localhost:8081/mcp`.
+- Entry: [`Program.cs`](../../src/Equibles.Mcp.Server/Program.cs) (`public partial class Program`).
+- Container: [`Dockerfile`](../../src/Equibles.Mcp.Server/Dockerfile) — `dotnet/aspnet:10.0`, `EXPOSE 8080`. Compose maps `8081:8080` so the public endpoint is `http://localhost:8081/mcp`.
 - `AddEquiblesMcp(mcp => …)` registers per-module tool sets: `mcp.AddHoldings()`, `AddInsiderTrading()`, `AddFred()`, `AddSec()`, `AddFinancialFacts()`, `AddCftc()`, `AddCboe()`, `AddCongress()`, `AddShortData()`, `AddStockPrices()`. Every module shipping a `.Mcp` project gets one of these calls.
 - `ConfigurePipeline` mounts the MCP transport at `/mcp` via `app.MapMcp("/mcp")` and wraps that path in `ApiKeyMiddleware` (under `UseWhen`, so the rest of the app stays open for health checks).
 - `IApiKeyValidator` resolves to `SimpleApiKeyValidator`, which reads `McpApiKey` from configuration. Empty / unset = auth disabled.
 - Wires `Equibles.Sec.BusinessLogic.Search.RagManager` via `AutoWireServicesFrom<T>` so MCP SEC tools can run semantic search. Requires the `Embedding` config section to be bound to `EmbeddingConfig`; without that, `EmbeddingConfig.Enabled` is false and semantic search no-ops.
 - Does **not** run migrations — the `mcp` compose service depends on `web` being healthy, and `web` owns migration application.
 
-## Worker Host — [`src/Equibles.Worker.Host`](../src/Equibles.Worker.Host)
+## Worker Host — [`src/Equibles.Worker.Host`](../../src/Equibles.Worker.Host)
 
 The background-scraper host. Plain `Host.CreateApplicationBuilder` (not `WebApplication`) — no HTTP surface.
 
-- Entry: [`Program.cs`](../src/Equibles.Worker.Host/Program.cs) (top-level statements, not a partial class).
-- Container: [`Dockerfile`](../src/Equibles.Worker.Host/Dockerfile) — `dotnet/aspnet:10.0` (for shared runtime), `ENTRYPOINT ["dotnet", "Equibles.Worker.Host.dll"]`, no ports exposed.
+- Entry: [`Program.cs`](../../src/Equibles.Worker.Host/Program.cs) (top-level statements, not a partial class).
+- Container: [`Dockerfile`](../../src/Equibles.Worker.Host/Dockerfile) — `dotnet/aspnet:10.0` (for shared runtime), `ENTRYPOINT ["dotnet", "Equibles.Worker.Host.dll"]`, no ports exposed.
 - `AddMessaging(builder.Configuration)` configures MassTransit on the Postgres SQL transport with the EF outbox sitting inside `EquiblesDbContext`. The transport connection comes from `ConnectionStrings__TransportConnection`; `MassTransit__RunMigration=true` makes the worker apply the transport schema on first run.
 - One scraper-options bind per source (`WorkerOptions`, `DocumentScraperOptions`, `FinraOptions` + `FinraScraperOptions`, `FredOptions` + `FredScraperOptions`, `FtdScraperOptions`, `FinancialFactsScraperOptions`, `YahooPriceScraperOptions`, `CftcScraperOptions`, `CboeScraperOptions`). Each scraper reads its own section so per-source tuning never leaks across modules.
 - `AddSecWorker()`, `AddSecFinancialFactsWorker()`, `AddFinraWorker()`, `AddFredWorker()`, `AddYahooWorker()`, `AddCftcWorker()`, `AddCboeWorker()`, `AddCongressWorker()`, `AddHoldingsWorker()` register the `BackgroundService` workers from each `.HostedService` project. `AddWorkerServices()` wires the cross-cutting worker plumbing (`SyncDateResolver`, etc.).


### PR DESCRIPTION
## Summary

- Populate-lane PR — second technical TOC entry. Section: `docs/technical/`.
- Renames `docs/hosts.md` → `docs/technical/hosts.md` and rewrites nine `../src/...` link targets to `../../src/...`. Sibling refs to `architecture.md` already sit alongside in `docs/technical/`.

## Code changes

- `docs/hosts.md` → `docs/technical/hosts.md` (rename + 9-line link-depth fix). No source code touched.