### PR TITLE
feat(holdings): group Stock Holdings tab by quarterly position change (2/2)

### DIFF
--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -71,63 +71,38 @@ public class StockTabService
 
         if (selectedDate != default)
         {
-            var allHoldings = _institutionalHoldingRepository.GetByStock(stock, selectedDate);
-            var totalHolderCount = await allHoldings
-                .Select(h => h.InstitutionalHolderId)
-                .Distinct()
-                .CountAsync();
-            var totalShares = await allHoldings.SumAsync(h => h.Shares);
-            var totalValue = await allHoldings.SumAsync(h => h.Value);
-
-            var holdings = await allHoldings
+            // Materialize the full current quarter once: drives header stats AND the
+            // position-change grouping. Previously this was two round trips (sum/count
+            // aggregates + a top-100 fetch); the bucketed view needs every holder anyway,
+            // so the in-memory aggregates are cheaper than re-querying.
+            var allCurrent = await _institutionalHoldingRepository
+                .GetByStock(stock, selectedDate)
                 .Include(h => h.InstitutionalHolder)
-                .OrderByDescending(h => h.Value)
-                .Take(100)
                 .ToListAsync();
 
-            // Fetch previous quarter's shares for change % calculation
-            var previousSharesByHolder = new Dictionary<Guid, long>();
             var selectedIndex = reportDates.IndexOf(selectedDate);
             var previousDate =
                 selectedIndex >= 0 && selectedIndex < reportDates.Count - 1
                     ? reportDates[selectedIndex + 1]
                     : (DateOnly?)null;
-            if (previousDate.HasValue)
-            {
-                var holderIds = holdings.Select(h => h.InstitutionalHolderId).ToList();
-                previousSharesByHolder = await _institutionalHoldingRepository
-                    .GetByStock(stock, previousDate.Value)
-                    .Where(h => holderIds.Contains(h.InstitutionalHolderId))
-                    .GroupBy(h => h.InstitutionalHolderId)
-                    .ToDictionaryAsync(g => g.Key, g => g.Sum(h => h.Shares));
-            }
-
-            // Full per-quarter holdings (current + previous) for position-change grouping.
-            // Separate from the top-100 query above so the existing tile rendering is unchanged.
-            var allCurrent = await _institutionalHoldingRepository
-                .GetByStock(stock, selectedDate)
-                .Include(h => h.InstitutionalHolder)
-                .ToListAsync();
             var allPrevious = previousDate.HasValue
                 ? await _institutionalHoldingRepository
                     .GetByStock(stock, previousDate.Value)
                     .Include(h => h.InstitutionalHolder)
                     .ToListAsync()
                 : [];
+
             var grouped = HoldingsPositionGrouper.Group(allCurrent, allPrevious);
             var bucketCounts = grouped.ToDictionary(g => g.Key, g => g.Value.Count);
 
             return new HoldingsTabViewModel
             {
-                Holdings = holdings,
                 AvailableDates = reportDates,
                 SelectedDate = selectedDate,
                 Ticker = stock.Ticker,
-                TotalValue = totalValue,
-                TotalShares = totalShares,
-                HolderCount = totalHolderCount,
-                DisplayedCount = holdings.Count,
-                PreviousSharesByHolder = previousSharesByHolder,
+                TotalValue = allCurrent.Sum(h => h.Value),
+                TotalShares = allCurrent.Sum(h => h.Shares),
+                HolderCount = allCurrent.Select(h => h.InstitutionalHolderId).Distinct().Count(),
                 GroupedHolders = grouped,
                 BucketCounts = bucketCounts,
             };

--- a/src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs
@@ -1,18 +1,13 @@
-using Equibles.Holdings.Data.Models;
-
 namespace Equibles.Web.ViewModels.Stocks;
 
 public class HoldingsTabViewModel
 {
-    public List<InstitutionalHolding> Holdings { get; set; } = [];
     public List<DateOnly> AvailableDates { get; set; } = [];
     public DateOnly SelectedDate { get; set; }
     public string Ticker { get; set; }
     public long TotalValue { get; set; }
     public long TotalShares { get; set; }
     public int HolderCount { get; set; }
-    public int DisplayedCount { get; set; }
-    public Dictionary<Guid, long> PreviousSharesByHolder { get; set; } = [];
 
     public Dictionary<PositionChangeType, List<HolderPositionChange>> GroupedHolders { get; set; } =
     [];

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -1,4 +1,32 @@
-@model Equibles.Web.ViewModels.Stocks.HoldingsTabViewModel
+@using Equibles.Web.ViewModels.Stocks
+@model HoldingsTabViewModel
+
+@functions {
+    record BucketDisplay(PositionChangeType Type, string Label, string BadgeCss, bool OpenByDefault);
+
+    static readonly BucketDisplay[] Buckets = new[]
+    {
+        new BucketDisplay(PositionChangeType.New, "New", "badge-success", true),
+        new BucketDisplay(PositionChangeType.Increased, "Increased", "badge-info", true),
+        new BucketDisplay(PositionChangeType.Reduced, "Reduced", "badge-warning", true),
+        new BucketDisplay(PositionChangeType.SoldOut, "Sold out", "badge-error", true),
+        new BucketDisplay(PositionChangeType.Unchanged, "Unchanged", "badge-ghost", false),
+    };
+
+    static IEnumerable<HolderPositionChange> SortBucket(PositionChangeType type, IEnumerable<HolderPositionChange> entries)
+    {
+        // SoldOut has no current value — sort by what they used to hold.
+        // For change buckets, surface the biggest absolute movement first.
+        // For New/Unchanged, sort by current value desc.
+        return type switch
+        {
+            PositionChangeType.SoldOut => entries.OrderByDescending(e => e.PreviousValue),
+            PositionChangeType.Increased or PositionChangeType.Reduced =>
+                entries.OrderByDescending(e => Math.Abs(e.DeltaShares)),
+            _ => entries.OrderByDescending(e => e.CurrentValue),
+        };
+    }
+}
 
 @if (Model.AvailableDates.Count == 0) {
     <div class="card bg-base-100 shadow-sm">
@@ -32,71 +60,65 @@
             <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Value:</span> <strong>$@Model.TotalValue.ToString("N0")</strong></div>
             <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Shares:</span> <strong>@Model.TotalShares.ToString("N0")</strong></div>
         </div>
-        @if (Model.DisplayedCount < Model.HolderCount) {
-            <div class="text-xs text-base-content/50">Showing top @Model.DisplayedCount of @Model.HolderCount.ToString("N0") holders by value</div>
-        }
     </div>
 
-    <div class="card bg-base-100 shadow-sm">
-        <div class="overflow-x-auto">
-            <table class="table table-zebra table-sm">
-                <thead>
-                    <tr>
-                        <th>Holder</th>
-                        <th class="text-right">Value (USD)</th>
-                        <th class="text-right">Shares</th>
-                        <th class="text-right hidden md:table-cell">Change</th>
-                        <th class="hidden lg:table-cell">Type</th>
-                        <th class="hidden lg:table-cell">Discretion</th>
-                        <th class="hidden lg:table-cell">Filed</th>
-                        <th class="text-right">Action</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @foreach (var h in Model.Holdings) {
-                        var hasPrevious = Model.PreviousSharesByHolder.TryGetValue(h.InstitutionalHolderId, out var previousShares);
-                        var changePercent = hasPrevious && previousShares > 0
-                            ? (double)(h.Shares - previousShares) / previousShares * 100
-                            : (double?)null;
-                        <tr>
-                            <td class="max-w-xs truncate">@(h.InstitutionalHolder?.Name ?? "Unknown")</td>
-                            <td class="text-right font-mono">$@h.Value.ToString("N0")</td>
-                            <td class="text-right font-mono">@h.Shares.ToString("N0")</td>
-                            <td class="text-right font-mono hidden md:table-cell">
-                                @if (changePercent.HasValue) {
-                                    var css = changePercent.Value > 0 ? "text-success" : changePercent.Value < 0 ? "text-error" : "";
-                                    var sign = changePercent.Value > 0 ? "+" : "";
-                                    <span class="@css">@sign@changePercent.Value.ToString("F1")%</span>
-                                } else if (!hasPrevious) {
-                                    <span class="badge badge-success badge-xs">New</span>
-                                } else {
-                                    <span>—</span>
+    <!-- Position-change buckets -->
+    @foreach (var bucket in Buckets) {
+        var count = Model.BucketCounts.TryGetValue(bucket.Type, out var c) ? c : 0;
+        var entries = Model.GroupedHolders.TryGetValue(bucket.Type, out var list) ? list : new List<HolderPositionChange>();
+        var sorted = SortBucket(bucket.Type, entries).ToList();
+        var ariaTestId = $"holdings-bucket-{bucket.Type.ToString().ToLowerInvariant()}";
+
+        <div class="collapse collapse-arrow bg-base-100 shadow-sm mb-3" data-testid="@ariaTestId">
+            <input type="checkbox" @(bucket.OpenByDefault && count > 0 ? "checked" : "") />
+            <div class="collapse-title flex items-center gap-2 text-base font-medium">
+                <span>@bucket.Label</span>
+                <span class="badge @bucket.BadgeCss badge-sm">@count.ToString("N0")</span>
+            </div>
+            <div class="collapse-content p-0">
+                @if (count == 0) {
+                    <div class="px-4 pb-4 text-xs text-base-content/50">No holders in this bucket.</div>
+                } else {
+                    <div class="overflow-x-auto">
+                        <table class="table table-zebra table-sm">
+                            <thead>
+                                <tr>
+                                    <th>Holder</th>
+                                    <th class="text-right">Current Shares</th>
+                                    <th class="text-right hidden md:table-cell">Previous Shares</th>
+                                    <th class="text-right">Δ Shares</th>
+                                    <th class="text-right hidden lg:table-cell">Current Value (USD)</th>
+                                    <th class="text-right">Δ Value (USD)</th>
+                                    <th class="text-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var e in sorted) {
+                                    var deltaSharesCss = e.DeltaShares > 0 ? "text-success" : e.DeltaShares < 0 ? "text-error" : "";
+                                    var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
+                                    var deltaSharesSign = e.DeltaShares > 0 ? "+" : "";
+                                    var deltaValueSign = e.DeltaValue > 0 ? "+" : "";
+                                    <tr>
+                                        <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
+                                        <td class="text-right font-mono">@e.CurrentShares.ToString("N0")</td>
+                                        <td class="text-right font-mono hidden md:table-cell">@e.PreviousShares.ToString("N0")</td>
+                                        <td class="text-right font-mono @deltaSharesCss">@deltaSharesSign@e.DeltaShares.ToString("N0")</td>
+                                        <td class="text-right font-mono hidden lg:table-cell">$@e.CurrentValue.ToString("N0")</td>
+                                        <td class="text-right font-mono @deltaValueCss">@deltaValueSign$@e.DeltaValue.ToString("N0")</td>
+                                        <td class="text-right">
+                                            @if (e.InstitutionalHolder?.Cik != null) {
+                                                <a asp-controller="Stocks" asp-action="ShowHolder"
+                                                   asp-route-ticker="@Model.Ticker" asp-route-cik="@e.InstitutionalHolder.Cik"
+                                                   class="btn btn-ghost btn-sm">View</a>
+                                            }
+                                        </td>
+                                    </tr>
                                 }
-                            </td>
-                            <td class="hidden lg:table-cell">
-                                @switch (h.OptionType) {
-                                    case Equibles.Holdings.Data.Models.OptionType.Call:
-                                        <span class="badge badge-sm badge-success">Call</span>
-                                        break;
-                                    case Equibles.Holdings.Data.Models.OptionType.Put:
-                                        <span class="badge badge-sm badge-error">Put</span>
-                                        break;
-                                    default:
-                                        @h.ShareType
-                                        break;
-                                }
-                            </td>
-                            <td class="hidden lg:table-cell">@h.InvestmentDiscretion</td>
-                            <td class="hidden lg:table-cell text-base-content/60">@h.FilingDate.ToString("yyyy-MM-dd")</td>
-                            <td class="text-right">
-                                <a asp-controller="Stocks" asp-action="ShowHolder"
-                                   asp-route-ticker="@Model.Ticker" asp-route-cik="@h.InstitutionalHolder?.Cik"
-                                   class="btn btn-ghost btn-sm">View</a>
-                            </td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
+                            </tbody>
+                        </table>
+                    </div>
+                }
+            </div>
         </div>
-    </div>
+    }
 }

--- a/tests/Equibles.FunctionalTests/Tests/StocksHoldingsSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksHoldingsSeededTests.cs
@@ -21,22 +21,21 @@ public class StocksHoldingsSeededTests
     }
 
     [Fact]
-    public async Task Holdings_GetForStockWithMultipleQuartersAndManyHolders_RendersDateSelectorAndTopHundredByValue()
+    public async Task Holdings_GetForStockWithMultipleQuartersAndManyHolders_RendersPositionChangeBuckets()
     {
         // Seeds 4 quarter-end report dates × 200 distinct InstitutionalHolders = 800
-        // InstitutionalHolding rows so the page has substantially more data than
-        // StockTabService.LoadHoldingsTab's Top-100 cap and more than one ReportDate.
-        // The assertion pins five behaviours that the existing empty-state test cannot prove
-        // together: (a) the date selector lists every distinct ReportDate, (b) the most-recent
-        // quarter is selected when no ?date= query string is supplied, (c) the distinct
-        // HolderCount aggregation reflects all 200 holders for that quarter, (d) the
-        // OrderByDescending(Value).Take(100) end-to-end keeps the highest-Value holder at the
-        // top of the rendered table (the InstitutionalHolder.Include is exercised — without it
-        // the first column would render "Unknown"), and (e) the "Showing top X of Y" caption
-        // appears once DisplayedCount < HolderCount. AutoDetectChangesEnabled is disabled
-        // during the bulk insert so the per-row change-tracker cost stays off the O(n²) path.
+        // InstitutionalHolding rows so the page exercises the position-change grouping
+        // across substantially more than one ReportDate. Every holder reports the same
+        // share count in every quarter, so for the most-recent quarter (vs the one before)
+        // all 200 holders land in the Unchanged bucket and the other four buckets are empty.
+        // The assertion pins: (a) the date selector lists every distinct ReportDate,
+        // (b) the most-recent quarter is selected when no ?date= query string is supplied,
+        // (c) all five position-change panels render with the correct counts, (d) the
+        // Unchanged bucket's table contains a row per seeded holder (the
+        // .Include(h => h.InstitutionalHolder) executes — without it the first column
+        // would render "Unknown"). AutoDetectChangesEnabled is disabled during the bulk
+        // insert so the per-row change-tracker cost stays off the O(n²) path.
         const int holderCount = 200;
-        const int displayedRowCap = 100;
         var stockId = Guid.NewGuid();
         var reportDates = new[]
         {
@@ -108,30 +107,36 @@ public class StocksHoldingsSeededTests
         await Assertions.Expect(dateSelect.Locator("option")).ToHaveCountAsync(reportDates.Length);
         await Assertions.Expect(dateSelect).ToHaveValueAsync(mostRecentDate.ToString("yyyy-MM-dd"));
 
-        var rows = page.Locator("table tbody tr");
-        await Assertions.Expect(rows).ToHaveCountAsync(displayedRowCap);
-
-        // The view renders OrderByDescending(Value), so the first row's holder name must be
-        // the highest-Value seeded holder (i = holderCount - 1 → "Test Holder 200"). This
-        // proves the .Include(h => h.InstitutionalHolder) executes against the populated
-        // table — without it the cell would render the "Unknown" fallback.
+        // All five position-change panels are present.
         await Assertions
-            .Expect(rows.First.Locator("td").First)
-            .ToHaveTextAsync($"Test Holder {holderCount:D3}");
+            .Expect(page.Locator("[data-testid^='holdings-bucket-']"))
+            .ToHaveCountAsync(5);
 
-        // Caption only renders when DisplayedCount < HolderCount — pins both the Top-100 cap
-        // and the distinct-holder aggregation across the 200 seeded rows for this quarter.
+        // Bucket counts: 200 Unchanged, 0 in the other four buckets.
         await Assertions
             .Expect(
-                page.Locator("div.text-xs")
-                    .Filter(
-                        new()
-                        {
-                            HasTextString =
-                                $"Showing top {displayedRowCap} of {holderCount:N0} holders by value",
-                        }
-                    )
+                page.Locator("[data-testid='holdings-bucket-unchanged'] .collapse-title .badge")
             )
-            .ToHaveCountAsync(1);
+            .ToHaveTextAsync("200");
+        foreach (var emptyBucket in new[] { "new", "increased", "reduced", "soldout" })
+        {
+            await Assertions
+                .Expect(
+                    page.Locator(
+                        $"[data-testid='holdings-bucket-{emptyBucket}'] .collapse-title .badge"
+                    )
+                )
+                .ToHaveTextAsync("0");
+        }
+
+        // Unchanged panel's table renders one row per seeded holder, and the
+        // .Include(h => h.InstitutionalHolder) populates the holder name (no "Unknown").
+        var unchangedRows = page.Locator(
+            "[data-testid='holdings-bucket-unchanged'] table tbody tr"
+        );
+        await Assertions.Expect(unchangedRows).ToHaveCountAsync(holderCount);
+        await Assertions
+            .Expect(unchangedRows.First.Locator("td").First)
+            .Not.ToHaveTextAsync("Unknown");
     }
 }

--- a/tests/Equibles.IntegrationTests/Web/StockTabServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServiceTests.cs
@@ -20,6 +20,7 @@ using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Services;
+using Equibles.Web.ViewModels.Stocks;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Data.Models;
 using Equibles.Yahoo.Repositories;
@@ -832,11 +833,12 @@ public class StockTabServiceTests : IDisposable
         var result = await _service.LoadHoldingsTab(stock, null);
 
         result.SelectedDate.Should().Be(new DateOnly(2025, 3, 31));
-        result.Holdings.Should().HaveCount(1);
-        result.Holdings.Single().Shares.Should().Be(11_000);
         result.TotalShares.Should().Be(11_000);
         result.TotalValue.Should().Be(600_000);
         result.HolderCount.Should().Be(1);
+        // No prior quarter, so the single holder lands in the New bucket.
+        result.BucketCounts[PositionChangeType.New].Should().Be(1);
+        result.GroupedHolders[PositionChangeType.New].Single().CurrentShares.Should().Be(11_000);
     }
 
     [Fact]
@@ -877,8 +879,10 @@ public class StockTabServiceTests : IDisposable
         var result = await _service.LoadHoldingsTab(stock, new DateOnly(2024, 12, 31));
 
         result.SelectedDate.Should().Be(new DateOnly(2024, 12, 31));
-        result.Holdings.Should().HaveCount(1);
-        result.Holdings.Single().Shares.Should().Be(10_000);
+        // The 2025-Q1 holding is not in this quarter's bucket; 2024-Q4 has no prior
+        // quarter loaded, so the single 10_000-share holding lands in New.
+        result.BucketCounts[PositionChangeType.New].Should().Be(1);
+        result.GroupedHolders[PositionChangeType.New].Single().CurrentShares.Should().Be(10_000);
     }
 
     [Fact]
@@ -890,7 +894,7 @@ public class StockTabServiceTests : IDisposable
         var result = await _service.LoadHoldingsTab(stock, null);
 
         result.Ticker.Should().Be("AAPL");
-        result.Holdings.Should().BeEmpty();
+        result.GroupedHolders.Should().BeEmpty();
         result.AvailableDates.Should().BeEmpty();
         result.TotalShares.Should().Be(0);
         result.TotalValue.Should().Be(0);
@@ -898,7 +902,7 @@ public class StockTabServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task LoadHoldingsTab_NoPreviousQuarter_PreviousSharesByHolderIsEmpty()
+    public async Task LoadHoldingsTab_NoPreviousQuarter_AllHoldersInNewBucket()
     {
         var stock = CreateStock();
         var holder = CreateInstitutionalHolder("Fidelity", "0004445556");
@@ -924,7 +928,12 @@ public class StockTabServiceTests : IDisposable
 
         var result = await _service.LoadHoldingsTab(stock, new DateOnly(2024, 12, 31));
 
-        result.PreviousSharesByHolder.Should().BeEmpty();
+        // With no prior quarter, every current holder is classified New.
+        result.BucketCounts[PositionChangeType.New].Should().Be(1);
+        result.BucketCounts[PositionChangeType.SoldOut].Should().Be(0);
+        result.BucketCounts[PositionChangeType.Increased].Should().Be(0);
+        result.BucketCounts[PositionChangeType.Reduced].Should().Be(0);
+        result.BucketCounts[PositionChangeType.Unchanged].Should().Be(0);
     }
 
     [Fact]
@@ -1015,10 +1024,13 @@ public class StockTabServiceTests : IDisposable
         result.TotalShares.Should().Be(16_000);
         result.TotalValue.Should().Be(800_000);
         result.HolderCount.Should().Be(2);
-        result.DisplayedCount.Should().Be(2);
-        result.Holdings.Should().HaveCount(2);
-        // Ordered by value descending
-        result.Holdings.First().Value.Should().Be(500_000);
-        result.Holdings.Last().Value.Should().Be(300_000);
+        // Both holders are new (no prior quarter loaded for this stock).
+        result.BucketCounts[PositionChangeType.New].Should().Be(2);
+        var byValue = result
+            .GroupedHolders[PositionChangeType.New]
+            .OrderByDescending(e => e.CurrentValue)
+            .ToList();
+        byValue[0].CurrentValue.Should().Be(500_000);
+        byValue[1].CurrentValue.Should().Be(300_000);
     }
 }


### PR DESCRIPTION
## Summary

- **Closing slice (2 of 2)** for #1007 — wires the position-change grouping landed in #1047 into the user-visible Stock Holdings tab.
- Replaces the flat top-100 holders table with **five collapsible DaisyUI panels** keyed by `PositionChangeType` — `New`, `Increased`, `Reduced`, `Sold out` (open by default), and `Unchanged` (collapsed). Each panel renders its own sortable table with a bucket count badge in the header and Δ shares / Δ value columns.
- Removes the obsolete top-100 cap; every institutional holder for the selected quarter is now reachable through its bucket.
- Closes #1007.

## Code changes

- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml` — new bucket layout. Each panel carries `data-testid="holdings-bucket-{new|increased|reduced|soldout|unchanged}"` for stable e2e selection. Sort within bucket: Sold out by previous value desc, Increased/Reduced by `|Δ shares|` desc, New/Unchanged by current value desc.
- `src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs` — drops `Holdings`, `PreviousSharesByHolder`, and `DisplayedCount` (no remaining consumers).
- `src/Equibles.Web/Services/StockTabService.cs` — `LoadHoldingsTab` collapses the prior two current-quarter queries (sum/count aggregates + top-100 fetch) into a single full-quarter materialization that feeds both the header stats and the grouper.
- `tests/Equibles.IntegrationTests/Web/StockTabServiceTests.cs` — re-pins the four impacted scenarios against the new shape (`GroupedHolders` / `BucketCounts`); the prior-quarter-empty case now asserts every holder lands in the `New` bucket.
- `tests/Equibles.FunctionalTests/Tests/StocksHoldingsSeededTests.cs` — Playwright e2e rewritten for the new view: asserts the five panels exist, bucket counts match the seeded data (200 `Unchanged`, 0 in the other four when shares are stable across quarters), and the Unchanged table renders one row per holder with the holder name populated (proves `Include(h => h.InstitutionalHolder)` still fires).

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1074 files).
- `tests/Equibles.UnitTests` Holdings grouper — 8/8 passing.
- `tests/Equibles.IntegrationTests` Holdings + Stocks (`--filter "Category!=Functional&Category!=Live&(FullyQualifiedName~Holdings|FullyQualifiedName~Stocks)"`) — 298/298 passing.
- Functional e2e covered by the rewritten Playwright test in this PR; gated on `functional.yml`.

Closes #1007