### PR TITLE
feat(holdings): add Top Buyers / Top Sellers cards on Stock Holdings tab (1/2)

### DIFF
--- a/src/Equibles.Web/Services/HoldingsTopMoversSelector.cs
+++ b/src/Equibles.Web/Services/HoldingsTopMoversSelector.cs
@@ -1,0 +1,56 @@
+using Equibles.Web.ViewModels.Stocks;
+
+namespace Equibles.Web.Services;
+
+public static class HoldingsTopMoversSelector
+{
+    public static (List<HolderPositionChange> Buyers, List<HolderPositionChange> Sellers) Select(
+        Dictionary<PositionChangeType, List<HolderPositionChange>> groupedHolders,
+        int max
+    )
+    {
+        if (max <= 0)
+            return ([], []);
+
+        var buyers = EnumerateOrEmpty(groupedHolders, PositionChangeType.New)
+            .Concat(EnumerateOrEmpty(groupedHolders, PositionChangeType.Increased))
+            .OrderByDescending(e => e.DeltaShares)
+            .Take(max)
+            .ToList();
+
+        var sellers = EnumerateOrEmpty(groupedHolders, PositionChangeType.Reduced)
+            .Concat(EnumerateOrEmpty(groupedHolders, PositionChangeType.SoldOut))
+            .OrderBy(e => e.DeltaShares)
+            .Take(max)
+            .ToList();
+
+        return (buyers, sellers);
+    }
+
+    public static int CountBuyers(
+        Dictionary<PositionChangeType, List<HolderPositionChange>> groupedHolders
+    ) => CountIn(groupedHolders, PositionChangeType.New, PositionChangeType.Increased);
+
+    public static int CountSellers(
+        Dictionary<PositionChangeType, List<HolderPositionChange>> groupedHolders
+    ) => CountIn(groupedHolders, PositionChangeType.Reduced, PositionChangeType.SoldOut);
+
+    private static int CountIn(
+        Dictionary<PositionChangeType, List<HolderPositionChange>> groupedHolders,
+        params PositionChangeType[] types
+    )
+    {
+        var total = 0;
+        foreach (var type in types)
+        {
+            if (groupedHolders.TryGetValue(type, out var list))
+                total += list.Count;
+        }
+        return total;
+    }
+
+    private static IEnumerable<HolderPositionChange> EnumerateOrEmpty(
+        Dictionary<PositionChangeType, List<HolderPositionChange>> groupedHolders,
+        PositionChangeType type
+    ) => groupedHolders.TryGetValue(type, out var list) ? list : [];
+}

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -94,6 +94,10 @@ public class StockTabService
 
             var grouped = HoldingsPositionGrouper.Group(allCurrent, allPrevious);
             var bucketCounts = grouped.ToDictionary(g => g.Key, g => g.Value.Count);
+            var (topBuyers, topSellers) = HoldingsTopMoversSelector.Select(
+                grouped,
+                HoldingsTabViewModel.TopMoversPreviewCount
+            );
 
             return new HoldingsTabViewModel
             {
@@ -105,6 +109,10 @@ public class StockTabService
                 HolderCount = allCurrent.Select(h => h.InstitutionalHolderId).Distinct().Count(),
                 GroupedHolders = grouped,
                 BucketCounts = bucketCounts,
+                TopBuyers = topBuyers,
+                TopSellers = topSellers,
+                TotalBuyerCount = HoldingsTopMoversSelector.CountBuyers(grouped),
+                TotalSellerCount = HoldingsTopMoversSelector.CountSellers(grouped),
             };
         }
 

--- a/src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs
@@ -12,4 +12,13 @@ public class HoldingsTabViewModel
     public Dictionary<PositionChangeType, List<HolderPositionChange>> GroupedHolders { get; set; } =
     [];
     public Dictionary<PositionChangeType, int> BucketCounts { get; set; } = [];
+
+    // Top movers for the selected quarter — pre-sorted, capped to TopMoversPreviewCount.
+    // Buyers = New ∪ Increased (Δ shares > 0), Sellers = Reduced ∪ Sold out (Δ shares < 0).
+    public List<HolderPositionChange> TopBuyers { get; set; } = [];
+    public List<HolderPositionChange> TopSellers { get; set; } = [];
+    public int TotalBuyerCount { get; set; }
+    public int TotalSellerCount { get; set; }
+
+    public const int TopMoversPreviewCount = 5;
 }

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -62,6 +62,80 @@
         </div>
     </div>
 
+    <!-- Top movers — most actionable quarterly signal at a glance.
+         Buyers = New + Increased ranked by Δ shares desc; Sellers = Reduced + Sold out, ranked by Δ shares asc.
+         Each card's "View all" jumps to the corresponding bucket panel below. -->
+    @if (Model.TopBuyers.Count > 0 || Model.TopSellers.Count > 0) {
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+            @{
+                var movers = new[]
+                {
+                    new {
+                        Label = "Top Buyers",
+                        Entries = Model.TopBuyers,
+                        Total = Model.TotalBuyerCount,
+                        Anchor = "holdings-bucket-increased",
+                        BadgeCss = "badge-success",
+                        TestId = "holdings-top-buyers",
+                    },
+                    new {
+                        Label = "Top Sellers",
+                        Entries = Model.TopSellers,
+                        Total = Model.TotalSellerCount,
+                        Anchor = "holdings-bucket-reduced",
+                        BadgeCss = "badge-error",
+                        TestId = "holdings-top-sellers",
+                    },
+                };
+            }
+            @foreach (var card in movers) {
+                <div class="card bg-base-100 shadow-sm" data-testid="@card.TestId">
+                    <div class="card-body p-4">
+                        <div class="flex items-center justify-between mb-2">
+                            <div class="flex items-center gap-2">
+                                <h3 class="text-base font-medium m-0">@card.Label</h3>
+                                <span class="badge @card.BadgeCss badge-sm">@card.Total.ToString("N0")</span>
+                            </div>
+                            @if (card.Total > card.Entries.Count) {
+                                <a href="#@card.Anchor" class="link link-hover text-xs">View all</a>
+                            }
+                        </div>
+                        @if (card.Entries.Count == 0) {
+                            <div class="text-xs text-base-content/50">No movers in this direction.</div>
+                        } else {
+                            <div class="overflow-x-auto">
+                                <table class="table table-sm">
+                                    <thead>
+                                        <tr>
+                                            <th>Institution</th>
+                                            <th class="text-right">Δ Shares</th>
+                                            <th class="text-right hidden md:table-cell">Δ Value (USD)</th>
+                                            <th class="text-right hidden lg:table-cell">Prior → New</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var e in card.Entries) {
+                                            var deltaSharesCss = e.DeltaShares > 0 ? "text-success" : e.DeltaShares < 0 ? "text-error" : "";
+                                            var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
+                                            var deltaSharesSign = e.DeltaShares > 0 ? "+" : "";
+                                            var deltaValueSign = e.DeltaValue > 0 ? "+" : "";
+                                            <tr>
+                                                <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
+                                                <td class="text-right font-mono @deltaSharesCss">@deltaSharesSign@e.DeltaShares.ToString("N0")</td>
+                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss">@deltaValueSign$@e.DeltaValue.ToString("N0")</td>
+                                                <td class="text-right font-mono hidden lg:table-cell text-base-content/60">@e.PreviousShares.ToString("N0") → @e.CurrentShares.ToString("N0")</td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </div>
+                </div>
+            }
+        </div>
+    }
+
     <!-- Position-change buckets -->
     @foreach (var bucket in Buckets) {
         var count = Model.BucketCounts.TryGetValue(bucket.Type, out var c) ? c : 0;
@@ -69,7 +143,7 @@
         var sorted = SortBucket(bucket.Type, entries).ToList();
         var ariaTestId = $"holdings-bucket-{bucket.Type.ToString().ToLowerInvariant()}";
 
-        <div class="collapse collapse-arrow bg-base-100 shadow-sm mb-3" data-testid="@ariaTestId">
+        <div class="collapse collapse-arrow bg-base-100 shadow-sm mb-3" id="@ariaTestId" data-testid="@ariaTestId">
             <input type="checkbox" @(bucket.OpenByDefault && count > 0 ? "checked" : "") />
             <div class="collapse-title flex items-center gap-2 text-base font-medium">
                 <span>@bucket.Label</span>

--- a/tests/Equibles.FunctionalTests/Tests/StocksHoldingsSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksHoldingsSeededTests.cs
@@ -138,5 +138,141 @@ public class StocksHoldingsSeededTests
         await Assertions
             .Expect(unchangedRows.First.Locator("td").First)
             .Not.ToHaveTextAsync("Unknown");
+
+        // No movers in this fixture (every holder reports the same shares quarter over
+        // quarter), so the Top Buyers / Top Sellers cards must NOT render.
+        await Assertions
+            .Expect(page.Locator("[data-testid='holdings-top-buyers']"))
+            .ToHaveCountAsync(0);
+        await Assertions
+            .Expect(page.Locator("[data-testid='holdings-top-sellers']"))
+            .ToHaveCountAsync(0);
+    }
+
+    [Fact]
+    public async Task Holdings_GetForStockWithQuarterlyMovement_RendersTopBuyersAndTopSellersCards()
+    {
+        // Seeds two quarters with explicit movement so the Top Buyers / Top Sellers
+        // cards have something to rank:
+        //   Q1 (prior): holders 1..4 hold 1_000 shares each. Holder 5 does not exist.
+        //   Q2 (latest): holder 1 → 1_500 (Increased Δ +500),
+        //                holder 2 → 800   (Reduced Δ -200),
+        //                holder 3 → gone  (Sold out Δ -1_000),
+        //                holder 4 → 1_000 (Unchanged),
+        //                holder 5 → 2_000 (New Δ +2_000).
+        // Expected Top Buyers: Holder 5 (+2_000), Holder 1 (+500).
+        // Expected Top Sellers: Holder 3 (-1_000), Holder 2 (-200).
+        var stockId = Guid.NewGuid();
+        var prior = new DateOnly(2025, 6, 30);
+        var latest = new DateOnly(2025, 9, 30);
+
+        await _web.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corp.",
+                    Cik = "0000789019",
+                }
+            );
+
+            var holders = new InstitutionalHolder[5];
+            for (var i = 0; i < holders.Length; i++)
+            {
+                holders[i] = new InstitutionalHolder
+                {
+                    Cik = $"M{i + 1:D7}",
+                    Name = $"Mover Holder {i + 1}",
+                };
+                db.Add(holders[i]);
+            }
+
+            // Q1 (prior) — holders 1..4 only
+            for (var i = 0; i < 4; i++)
+            {
+                db.Add(
+                    new InstitutionalHolding
+                    {
+                        CommonStockId = stockId,
+                        InstitutionalHolderId = holders[i].Id,
+                        ReportDate = prior,
+                        FilingDate = prior.AddDays(45),
+                        Value = 1_000_000,
+                        Shares = 1_000,
+                        ShareType = ShareType.Shares,
+                        InvestmentDiscretion = InvestmentDiscretion.Sole,
+                    }
+                );
+            }
+
+            // Q2 (latest)
+            var latestShares = new long[]
+            {
+                1_500,
+                800, /* holder 3 sold out */
+                0,
+                1_000,
+                2_000,
+            };
+            for (var i = 0; i < holders.Length; i++)
+            {
+                if (latestShares[i] == 0)
+                    continue;
+                db.Add(
+                    new InstitutionalHolding
+                    {
+                        CommonStockId = stockId,
+                        InstitutionalHolderId = holders[i].Id,
+                        ReportDate = latest,
+                        FilingDate = latest.AddDays(45),
+                        Value = latestShares[i] * 1_000,
+                        Shares = latestShares[i],
+                        ShareType = ShareType.Shares,
+                        InvestmentDiscretion = InvestmentDiscretion.Sole,
+                    }
+                );
+            }
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/stocks/msft/holdings");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        // Cards present.
+        await Assertions
+            .Expect(page.Locator("[data-testid='holdings-top-buyers']"))
+            .ToHaveCountAsync(1);
+        await Assertions
+            .Expect(page.Locator("[data-testid='holdings-top-sellers']"))
+            .ToHaveCountAsync(1);
+
+        // Buyer count badge (2 = New + Increased) and seller count badge (2 = Reduced + Sold out).
+        await Assertions
+            .Expect(page.Locator("[data-testid='holdings-top-buyers'] .badge").First)
+            .ToHaveTextAsync("2");
+        await Assertions
+            .Expect(page.Locator("[data-testid='holdings-top-sellers'] .badge").First)
+            .ToHaveTextAsync("2");
+
+        // Top buyer row is Holder 5 (+2_000); top seller row is Holder 3 (-1_000).
+        await Assertions
+            .Expect(
+                page.Locator("[data-testid='holdings-top-buyers'] table tbody tr")
+                    .First.Locator("td")
+                    .First
+            )
+            .ToHaveTextAsync("Mover Holder 5");
+        await Assertions
+            .Expect(
+                page.Locator("[data-testid='holdings-top-sellers'] table tbody tr")
+                    .First.Locator("td")
+                    .First
+            )
+            .ToHaveTextAsync("Mover Holder 3");
     }
 }

--- a/tests/Equibles.UnitTests/Web/HoldingsTopMoversSelectorTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsTopMoversSelectorTests.cs
@@ -1,0 +1,169 @@
+using Equibles.Web.Services;
+using Equibles.Web.ViewModels.Stocks;
+
+namespace Equibles.UnitTests.Web;
+
+public class HoldingsTopMoversSelectorTests
+{
+    [Fact]
+    public void Select_EmptyDictionary_ReturnsEmptyLists()
+    {
+        var (buyers, sellers) = HoldingsTopMoversSelector.Select([], 5);
+
+        buyers.Should().BeEmpty();
+        sellers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Select_MaxZero_ReturnsEmptyLists()
+    {
+        var grouped = new Dictionary<PositionChangeType, List<HolderPositionChange>>
+        {
+            [PositionChangeType.New] = [Mover(deltaShares: 100, currentShares: 100)],
+        };
+
+        var (buyers, sellers) = HoldingsTopMoversSelector.Select(grouped, 0);
+
+        buyers.Should().BeEmpty();
+        sellers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Select_BuyersRankedByDeltaSharesDescending()
+    {
+        var grouped = new Dictionary<PositionChangeType, List<HolderPositionChange>>
+        {
+            [PositionChangeType.Increased] =
+            [
+                Mover(deltaShares: 50, currentShares: 150),
+                Mover(deltaShares: 200, currentShares: 300),
+            ],
+            [PositionChangeType.New] = [Mover(deltaShares: 100, currentShares: 100)],
+        };
+
+        var (buyers, _) = HoldingsTopMoversSelector.Select(grouped, 5);
+
+        buyers.Should().HaveCount(3);
+        buyers.Select(b => b.DeltaShares).Should().ContainInOrder(200, 100, 50);
+    }
+
+    [Fact]
+    public void Select_SellersRankedByDeltaSharesAscending()
+    {
+        var grouped = new Dictionary<PositionChangeType, List<HolderPositionChange>>
+        {
+            [PositionChangeType.Reduced] =
+            [
+                Mover(deltaShares: -50, currentShares: 100, previousShares: 150),
+                Mover(deltaShares: -200, currentShares: 50, previousShares: 250),
+            ],
+            [PositionChangeType.SoldOut] =
+            [
+                Mover(deltaShares: -100, currentShares: 0, previousShares: 100),
+            ],
+        };
+
+        var (_, sellers) = HoldingsTopMoversSelector.Select(grouped, 5);
+
+        sellers.Should().HaveCount(3);
+        // Most-negative first.
+        sellers.Select(s => s.DeltaShares).Should().ContainInOrder(-200, -100, -50);
+    }
+
+    [Fact]
+    public void Select_CapsAtMax()
+    {
+        var grouped = new Dictionary<PositionChangeType, List<HolderPositionChange>>
+        {
+            [PositionChangeType.New] = Enumerable
+                .Range(1, 10)
+                .Select(i => Mover(deltaShares: i * 100, currentShares: i * 100))
+                .ToList(),
+            [PositionChangeType.Reduced] = Enumerable
+                .Range(1, 10)
+                .Select(i =>
+                    Mover(deltaShares: -i * 100, currentShares: 0, previousShares: i * 100)
+                )
+                .ToList(),
+        };
+
+        var (buyers, sellers) = HoldingsTopMoversSelector.Select(grouped, 5);
+
+        buyers.Should().HaveCount(5);
+        // Top buyer should be the largest Δ shares from the New list.
+        buyers[0].DeltaShares.Should().Be(1000);
+        sellers.Should().HaveCount(5);
+        sellers[0].DeltaShares.Should().Be(-1000);
+    }
+
+    [Fact]
+    public void Select_OnlySellersExist_BuyersIsEmpty()
+    {
+        var grouped = new Dictionary<PositionChangeType, List<HolderPositionChange>>
+        {
+            [PositionChangeType.SoldOut] =
+            [
+                Mover(deltaShares: -500, currentShares: 0, previousShares: 500),
+            ],
+        };
+
+        var (buyers, sellers) = HoldingsTopMoversSelector.Select(grouped, 5);
+
+        buyers.Should().BeEmpty();
+        sellers.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void CountBuyers_SumsNewAndIncreased()
+    {
+        var grouped = new Dictionary<PositionChangeType, List<HolderPositionChange>>
+        {
+            [PositionChangeType.New] = [Mover(deltaShares: 100, currentShares: 100)],
+            [PositionChangeType.Increased] =
+            [
+                Mover(deltaShares: 50, currentShares: 150),
+                Mover(deltaShares: 75, currentShares: 175),
+            ],
+            [PositionChangeType.Reduced] = [Mover(deltaShares: -10, currentShares: 90)],
+        };
+
+        HoldingsTopMoversSelector.CountBuyers(grouped).Should().Be(3);
+    }
+
+    [Fact]
+    public void CountSellers_SumsReducedAndSoldOut()
+    {
+        var grouped = new Dictionary<PositionChangeType, List<HolderPositionChange>>
+        {
+            [PositionChangeType.Reduced] = [Mover(deltaShares: -10, currentShares: 90)],
+            [PositionChangeType.SoldOut] =
+            [
+                Mover(deltaShares: -100, currentShares: 0, previousShares: 100),
+                Mover(deltaShares: -50, currentShares: 0, previousShares: 50),
+            ],
+            [PositionChangeType.New] = [Mover(deltaShares: 100, currentShares: 100)],
+        };
+
+        HoldingsTopMoversSelector.CountSellers(grouped).Should().Be(3);
+    }
+
+    private static HolderPositionChange Mover(
+        long deltaShares,
+        long currentShares,
+        long previousShares = 0,
+        long currentValue = 0,
+        long previousValue = 0
+    )
+    {
+        // deltaShares is asserted via the Current/Previous delta — keep them consistent.
+        previousShares = currentShares - deltaShares;
+        return new HolderPositionChange
+        {
+            InstitutionalHolderId = Guid.NewGuid(),
+            CurrentShares = currentShares,
+            PreviousShares = previousShares,
+            CurrentValue = currentValue,
+            PreviousValue = previousValue,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- **Slice 1 of 2** for #1008. Surfaces the most actionable quarterly signal — biggest absolute share additions and reductions — directly above the position-change bucket panels landed in #1007.
- Two side-by-side DaisyUI cards on `/stocks/{ticker}/Holdings`: **Top Buyers** (`New ∪ Increased`, ranked by `Δ shares` desc) and **Top Sellers** (`Reduced ∪ Sold out`, ranked by `Δ shares` asc). 5 rows per card, "View all" jumps to the matching bucket. Cards stay hidden when there are no movers.
- No new DB query — pure projection over the `GroupedHolders` map already built by `StockTabService.LoadHoldingsTab` after #1007.
- `Refs #1008` — **not** the closing slice. Issue closes when slice 2 (MCP `GetTopBuyersSellers`) lands.

## Code changes

- `src/Equibles.Web/Services/HoldingsTopMoversSelector.cs` — pure static helper, returns `(Buyers, Sellers)` capped at `max`, with `CountBuyers` / `CountSellers` totals.
- `src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs` — `TopBuyers` / `TopSellers` preview lists + `TotalBuyerCount` / `TotalSellerCount` for the badge.
- `src/Equibles.Web/Services/StockTabService.cs` — populates the new fields from the same grouped data already in scope.
- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml` — two `card` panels above the bucket list; bucket panels gain `id` matching their `data-testid` so "View all" can anchor.
- `tests/Equibles.UnitTests/Web/HoldingsTopMoversSelectorTests.cs` — 8 unit tests (empty, max=0, buyer rank desc, seller rank asc, max cap, one-sided, count helpers).
- `tests/Equibles.FunctionalTests/Tests/StocksHoldingsSeededTests.cs` — extended with a new fixture that seeds explicit Q1→Q2 movement covering all bucket transitions (New / Increased / Reduced / Sold out / Unchanged) and asserts both cards render with correct counts + ordering. The existing all-Unchanged fixture also asserts the cards do **not** render when there are no movers.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1076 files).
- `tests/Equibles.UnitTests` Holdings grouper + top movers — 16/16 passing.
- `tests/Equibles.IntegrationTests` Holdings + Stocks (`--filter "Category!=Functional&Category!=Live&(FullyQualifiedName~Holdings|FullyQualifiedName~Stocks)"`) — 298/298 passing.

Refs #1008