### PR TITLE
feat(holdings-mcp): add GetTopBuyersSellers MCP tool (2/2)

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -310,8 +310,193 @@ public class InstitutionalHoldingsTools
         );
     }
 
+    [McpServerTool(Name = "GetTopBuyersSellers")]
+    [Description(
+        "Get the institutions that moved the needle the most on a stock this quarter — biggest absolute share additions (Top Buyers) and biggest absolute share reductions (Top Sellers) versus the previous 13F report date. Includes new positions (Δ = full position) and sold-out positions (Δ = −prior position). Returns a markdown table with two sections. Use this to surface the most actionable quarterly signal from 13F filings."
+    )]
+    public Task<string> GetTopBuyersSellers(
+        [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Report date in YYYY-MM-DD format (defaults to latest available)")]
+            string reportDate = null,
+        [Description("Maximum number of buyers and sellers to return per section (default: 10)")]
+            int maxResults = 10
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                var stock = await _commonStockRepository.GetByTicker(ticker);
+                if (stock == null)
+                    return $"Stock '{ticker}' not found.";
+
+                var reportDates = await _holdingRepository
+                    .GetHistoryByStock(stock)
+                    .Select(h => h.ReportDate)
+                    .Distinct()
+                    .OrderByDescending(d => d)
+                    .ToListAsync();
+
+                DateOnly targetDate;
+                if (
+                    !string.IsNullOrEmpty(reportDate)
+                    && DateOnly.TryParse(reportDate, out var parsed)
+                )
+                {
+                    targetDate = parsed;
+                }
+                else
+                {
+                    targetDate = reportDates.FirstOrDefault();
+                }
+                if (targetDate == default)
+                    return $"No institutional holdings data available for {ticker}.";
+
+                var selectedIndex = reportDates.IndexOf(targetDate);
+                var previousDate =
+                    selectedIndex >= 0 && selectedIndex < reportDates.Count - 1
+                        ? reportDates[selectedIndex + 1]
+                        : (DateOnly?)null;
+
+                var currentHoldings = await _holdingRepository
+                    .GetByStock(stock, targetDate)
+                    .Include(h => h.InstitutionalHolder)
+                    .ToListAsync();
+                var previousHoldings = previousDate.HasValue
+                    ? await _holdingRepository
+                        .GetByStock(stock, previousDate.Value)
+                        .Include(h => h.InstitutionalHolder)
+                        .ToListAsync()
+                    : [];
+
+                // Aggregate by holder (one holder may file multiple 13F rows per quarter).
+                // TODO(#1008): the same aggregation/grouping logic lives in
+                // Equibles.Web.Services.HoldingsPositionGrouper. Consolidate into a shared
+                // Equibles.Holdings.BusinessLogic project once one exists.
+                var currentByHolder = currentHoldings
+                    .GroupBy(h => h.InstitutionalHolderId)
+                    .ToDictionary(
+                        g => g.Key,
+                        g => new HolderAggregate
+                        {
+                            Name = g.First().InstitutionalHolder?.Name ?? "Unknown",
+                            Shares = g.Sum(h => h.Shares),
+                            Value = g.Sum(h => h.Value),
+                        }
+                    );
+                var previousByHolder = previousHoldings
+                    .GroupBy(h => h.InstitutionalHolderId)
+                    .ToDictionary(
+                        g => g.Key,
+                        g => new HolderAggregate
+                        {
+                            Name = g.First().InstitutionalHolder?.Name ?? "Unknown",
+                            Shares = g.Sum(h => h.Shares),
+                            Value = g.Sum(h => h.Value),
+                        }
+                    );
+
+                var allHolderIds = currentByHolder.Keys.Union(previousByHolder.Keys);
+                var movers = allHolderIds
+                    .Select(id =>
+                    {
+                        currentByHolder.TryGetValue(id, out var c);
+                        previousByHolder.TryGetValue(id, out var p);
+                        return new
+                        {
+                            Name = c?.Name ?? p?.Name ?? "Unknown",
+                            CurrentShares = c?.Shares ?? 0,
+                            PreviousShares = p?.Shares ?? 0,
+                            DeltaShares = (c?.Shares ?? 0) - (p?.Shares ?? 0),
+                            DeltaValue = (c?.Value ?? 0) - (p?.Value ?? 0),
+                        };
+                    })
+                    .ToList();
+
+                var topBuyers = movers
+                    .Where(m => m.DeltaShares > 0)
+                    .OrderByDescending(m => m.DeltaShares)
+                    .Take(maxResults)
+                    .ToList();
+                var topSellers = movers
+                    .Where(m => m.DeltaShares < 0)
+                    .OrderBy(m => m.DeltaShares)
+                    .Take(maxResults)
+                    .ToList();
+
+                if (topBuyers.Count == 0 && topSellers.Count == 0)
+                    return $"No quarter-over-quarter movement found for {stock.Name} ({ticker}) as of {targetDate:yyyy-MM-dd}.";
+
+                var result = new StringBuilder();
+                result.AppendLine(
+                    $"Top buyers and sellers of {stock.Name} ({ticker}) as of {targetDate:yyyy-MM-dd}"
+                );
+                if (previousDate.HasValue)
+                    result.AppendLine($"vs prior quarter {previousDate.Value:yyyy-MM-dd}");
+                result.AppendLine();
+
+                result.AppendLine("## Top Buyers");
+                if (topBuyers.Count == 0)
+                {
+                    result.AppendLine("_No buyers this quarter._");
+                }
+                else
+                {
+                    result.AppendLine(
+                        "| # | Institution | Δ Shares | Δ Value ($M) | Prior → New Shares |"
+                    );
+                    result.AppendLine(
+                        "|---|-------------|---------|-------------|------------------|"
+                    );
+                    for (var i = 0; i < topBuyers.Count; i++)
+                    {
+                        var m = topBuyers[i];
+                        result.AppendLine(
+                            $"| {i + 1} | {m.Name} | +{m.DeltaShares:N0} | {m.DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0} | {m.PreviousShares:N0} → {m.CurrentShares:N0} |"
+                        );
+                    }
+                }
+
+                result.AppendLine();
+                result.AppendLine("## Top Sellers");
+                if (topSellers.Count == 0)
+                {
+                    result.AppendLine("_No sellers this quarter._");
+                }
+                else
+                {
+                    result.AppendLine(
+                        "| # | Institution | Δ Shares | Δ Value ($M) | Prior → New Shares |"
+                    );
+                    result.AppendLine(
+                        "|---|-------------|---------|-------------|------------------|"
+                    );
+                    for (var i = 0; i < topSellers.Count; i++)
+                    {
+                        var m = topSellers[i];
+                        result.AppendLine(
+                            $"| {i + 1} | {m.Name} | {m.DeltaShares:N0} | {m.DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0} | {m.PreviousShares:N0} → {m.CurrentShares:N0} |"
+                        );
+                    }
+                }
+
+                return result.ToString();
+            },
+            _logger,
+            "GetTopBuyersSellers",
+            $"ticker: {ticker}",
+            ReportError
+        );
+    }
+
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
+    }
+
+    private class HolderAggregate
+    {
+        public string Name { get; set; }
+        public long Shares { get; set; }
+        public long Value { get; set; }
     }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
@@ -166,6 +166,71 @@ public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTes
     }
 
     [Fact]
+    public async Task GetTopBuyersSellers_StockExistsButHasNoHoldings_ReportsNoData()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "TSLA",
+            Name = "Tesla Inc.",
+            Cik = "0001318605",
+        };
+        DbContext.Add(stock);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var output = await sut.GetTopBuyersSellers("TSLA");
+
+        output.Should().Contain("No institutional holdings data");
+    }
+
+    [Fact]
+    public async Task GetTopBuyersSellers_OnlyUnchangedHolders_ReportsNoMovement()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "NVDA",
+            Name = "NVIDIA Corp.",
+            Cik = "0001045810",
+        };
+        var holder = new InstitutionalHolder { Cik = "30", Name = "Steady State Capital" };
+        DbContext.Add(stock);
+        DbContext.Add(holder);
+
+        var prior = new DateOnly(2024, 9, 30);
+        var latest = new DateOnly(2024, 12, 31);
+        // Same shares in both quarters → only the Unchanged bucket → no movers.
+        DbContext.Add(MakeHolding(stock, holder, prior, shares: 1_000));
+        DbContext.Add(MakeHolding(stock, holder, latest, shares: 1_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var output = await sut.GetTopBuyersSellers("NVDA");
+
+        // No buyers and no sellers — early-return message, not the per-section tables.
+        output.Should().Contain("No quarter-over-quarter movement found");
+        output.Should().NotContain("## Top Buyers");
+        output.Should().NotContain("## Top Sellers");
+    }
+
+    [Fact]
     public async Task GetTopBuyersSellers_ExplicitReportDate_HonorsArgument()
     {
         var stock = new CommonStock

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
@@ -1,0 +1,223 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins <c>GetTopBuyersSellers</c>. The tool ranks institutions by absolute Δ shares
+/// versus the immediately prior 13F report date — buyers (Δ &gt; 0) descending, sellers
+/// (Δ &lt; 0) ascending — and handles four boundary cases that the implementation has to
+/// get right: a fresh new position (no prior row), a sold-out position (no current row),
+/// an unchanged position (Δ = 0 → must be excluded from both lists), and the
+/// no-prior-quarter case (every holder is a "new" buyer because the prior quarter is
+/// empty).
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetTopBuyersSellersTests : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetTopBuyersSellersTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetTopBuyersSellers_TickerWithQoQMovement_RanksBuyersDescAndSellersAsc()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var increaser = new InstitutionalHolder { Cik = "1", Name = "Increaser Inc." };
+        var reducer = new InstitutionalHolder { Cik = "2", Name = "Reducer LLC" };
+        var soldOut = new InstitutionalHolder { Cik = "3", Name = "Sold-Out Capital" };
+        var newcomer = new InstitutionalHolder { Cik = "4", Name = "Newcomer Partners" };
+        var steady = new InstitutionalHolder { Cik = "5", Name = "Steady Hands LP" };
+        DbContext.Add(stock);
+        DbContext.AddRange(increaser, reducer, soldOut, newcomer, steady);
+
+        var prior = new DateOnly(2024, 9, 30);
+        var latest = new DateOnly(2024, 12, 31);
+
+        // Prior quarter: increaser/reducer/soldOut/steady each hold 1_000 shares.
+        DbContext.Add(MakeHolding(stock, increaser, prior, shares: 1_000));
+        DbContext.Add(MakeHolding(stock, reducer, prior, shares: 1_000));
+        DbContext.Add(MakeHolding(stock, soldOut, prior, shares: 1_000));
+        DbContext.Add(MakeHolding(stock, steady, prior, shares: 1_000));
+
+        // Latest quarter: increaser → 1_500 (Δ +500), reducer → 800 (Δ -200),
+        // soldOut → gone (Δ -1_000), newcomer → 2_000 (Δ +2_000), steady → 1_000 (Δ 0).
+        DbContext.Add(MakeHolding(stock, increaser, latest, shares: 1_500));
+        DbContext.Add(MakeHolding(stock, reducer, latest, shares: 800));
+        DbContext.Add(MakeHolding(stock, newcomer, latest, shares: 2_000));
+        DbContext.Add(MakeHolding(stock, steady, latest, shares: 1_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var output = await sut.GetTopBuyersSellers("AAPL");
+
+        // Headline + sections
+        output.Should().Contain("Top buyers and sellers of Apple Inc. (AAPL) as of 2024-12-31");
+        output.Should().Contain("vs prior quarter 2024-09-30");
+        output.Should().Contain("## Top Buyers");
+        output.Should().Contain("## Top Sellers");
+
+        // Buyers: Newcomer first (Δ +2_000), then Increaser (Δ +500). Steady excluded (Δ 0).
+        var buyersSection = output.Substring(
+            output.IndexOf("## Top Buyers"),
+            output.IndexOf("## Top Sellers") - output.IndexOf("## Top Buyers")
+        );
+        buyersSection
+            .IndexOf("Newcomer Partners")
+            .Should()
+            .BeLessThan(buyersSection.IndexOf("Increaser Inc."));
+        buyersSection.Should().Contain("+2,000");
+        buyersSection.Should().Contain("+500");
+        buyersSection.Should().NotContain("Steady Hands LP");
+
+        // Sellers: Sold-Out first (Δ -1_000), then Reducer (Δ -200). Steady excluded.
+        var sellersSection = output.Substring(output.IndexOf("## Top Sellers"));
+        sellersSection
+            .IndexOf("Sold-Out Capital")
+            .Should()
+            .BeLessThan(sellersSection.IndexOf("Reducer LLC"));
+        sellersSection.Should().Contain("-1,000");
+        sellersSection.Should().Contain("-200");
+        sellersSection.Should().NotContain("Steady Hands LP");
+    }
+
+    [Fact]
+    public async Task GetTopBuyersSellers_NoPriorQuarter_TreatsAllHoldersAsBuyers()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+        };
+        var a = new InstitutionalHolder { Cik = "10", Name = "Alpha Capital" };
+        var b = new InstitutionalHolder { Cik = "11", Name = "Beta Capital" };
+        DbContext.Add(stock);
+        DbContext.AddRange(a, b);
+
+        var only = new DateOnly(2024, 12, 31);
+        DbContext.Add(MakeHolding(stock, a, only, shares: 5_000));
+        DbContext.Add(MakeHolding(stock, b, only, shares: 3_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var output = await sut.GetTopBuyersSellers("MSFT");
+
+        // No prior quarter → both holders surface as buyers with their full positions.
+        var buyersSection = output.Substring(
+            output.IndexOf("## Top Buyers"),
+            output.IndexOf("## Top Sellers") - output.IndexOf("## Top Buyers")
+        );
+        buyersSection
+            .IndexOf("Alpha Capital")
+            .Should()
+            .BeLessThan(buyersSection.IndexOf("Beta Capital"));
+        buyersSection.Should().Contain("+5,000");
+        buyersSection.Should().Contain("+3,000");
+
+        // No sellers when there is no prior quarter.
+        output.Should().Contain("_No sellers this quarter._");
+    }
+
+    [Fact]
+    public async Task GetTopBuyersSellers_UnknownTicker_ReportsStockNotFound()
+    {
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        var output = await sut.GetTopBuyersSellers("DOESNOTEXIST");
+
+        output.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task GetTopBuyersSellers_ExplicitReportDate_HonorsArgument()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "GOOG",
+            Name = "Alphabet Inc.",
+            Cik = "0001652044",
+        };
+        var holder = new InstitutionalHolder { Cik = "20", Name = "Targeted Capital" };
+        DbContext.Add(stock);
+        DbContext.Add(holder);
+
+        var q3 = new DateOnly(2024, 9, 30);
+        var q4 = new DateOnly(2024, 12, 31);
+        DbContext.Add(MakeHolding(stock, holder, q3, shares: 100));
+        DbContext.Add(MakeHolding(stock, holder, q4, shares: 500));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        // Explicit Q4 date — Δ is +400 vs the immediately prior Q3 row.
+        var output = await sut.GetTopBuyersSellers("GOOG", reportDate: "2024-12-31");
+
+        output.Should().Contain("as of 2024-12-31");
+        output.Should().Contain("vs prior quarter 2024-09-30");
+        output.Should().Contain("+400");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = shares * 100,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -266,6 +266,7 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("GetOwnershipHistory");
         toolNames.Should().Contain("GetInstitutionPortfolio");
         toolNames.Should().Contain("SearchInstitutions");
+        toolNames.Should().Contain("GetTopBuyersSellers");
     }
 
     // ── InsiderTrading module specific ──────────────────────────────────
@@ -355,6 +356,7 @@ public class McpModuleToolDiscoveryTests
                     "GetOwnershipHistory",
                     "GetInstitutionPortfolio",
                     "SearchInstitutions",
+                    "GetTopBuyersSellers",
                 }
             },
             {


### PR DESCRIPTION
## Summary

- **Closing slice (2 of 2)** for #1008. Adds the MCP-side counterpart to the Top Buyers / Top Sellers web cards landed in #1052: a new `GetTopBuyersSellers` tool that returns the institutions which moved the needle the most on a stock this quarter.
- Markdown response with two ranked sections — `## Top Buyers` (Δ shares > 0 desc) and `## Top Sellers` (Δ shares < 0 asc). New positions (Δ = full position) and sold-out positions (Δ = −prior position) are included; unchanged holders (Δ = 0) are excluded from both lists.
- Closes #1008.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — new `GetTopBuyersSellers(ticker, reportDate?, maxResults?)` method following the existing `GetTopHolders` / `GetInstitutionPortfolio` pattern (default `maxResults` = 10 per section). Aggregates holders inline (one filer may emit multiple 13F rows per quarter); carries a `TODO(#1008)` to consolidate the holder aggregation with `Equibles.Web.Services.HoldingsPositionGrouper` once a shared `Equibles.Holdings.BusinessLogic` project exists.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs` — 4 integration tests against the ParadeDB fixture:
  - Quarter-over-quarter movement: ranks buyers desc and sellers asc; excludes unchanged holders; surfaces sold-out and new positions.
  - No prior quarter: every current holder is a buyer; sellers section reads "No sellers this quarter."
  - Explicit `reportDate` argument is honored and the prior-quarter line reflects the chosen quarter.
  - Unknown ticker returns "not found."

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1077 files).
- New MCP integration tests — 4/4 passing on the ParadeDB fixture.

Closes #1008