### PR TITLE
docs(technical/operations): add operations page

### DIFF
--- a/docs/technical/operations.md
+++ b/docs/technical/operations.md
@@ -44,7 +44,7 @@ Running and maintaining a self-hosted Equibles deployment. Configuration catalog
 
 ## Per-scraper tuning
 
-Each scraper has its own option section. All scraper option binds live in [`src/Equibles.Worker.Host/Program.cs`](../src/Equibles.Worker.Host/Program.cs). The most useful keys:
+Each scraper has its own option section. All scraper option binds live in [`src/Equibles.Worker.Host/Program.cs`](../../src/Equibles.Worker.Host/Program.cs). The most useful keys:
 
 | Section | Purpose |
 |---|---|
@@ -123,7 +123,7 @@ docker compose up -d --build
 ```
 
 - Migrations apply automatically on `web` startup via `MigrateAsync()`. See [Migrations](migrations.md) for details (1-hour command timeout absorbs first-run index rebuilds; BM25 / pgvector indexes can take minutes).
-- Read [`CHANGELOG.md`](../CHANGELOG.md) before a major version bump — breaking changes (rare) get a callout there.
+- Read [`CHANGELOG.md`](../../CHANGELOG.md) before a major version bump — breaking changes (rare) get a callout there.
 - The Web portal's update banner (when `CHECK_FOR_UPDATES=true`) tells you when a newer release is available.
 
 ## Volumes


### PR DESCRIPTION
## Summary

- Populate-lane PR — ninth and final technical TOC entry. Section: `docs/technical/`.
- Renames `docs/operations.md` → `docs/technical/operations.md` and rewrites 2 `../...` link targets to `../../...` (CHANGELOG.md + one src/ reference).
- All nine planned technical pages now live under `docs/technical/`. Top-level `docs/` now holds only the index + `technical/` + `guide/` + `screenshots/`.

## Code changes

- `docs/operations.md` → `docs/technical/operations.md` (rename + 2-line link-depth fix). No source code touched.