### PR TITLE
docs: refit top-level index to the technical / guide split

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,8 @@
 # Equibles Documentation
 
-Reference for developers working inside the Equibles codebase. The root [`README.md`](../README.md) is the user-facing front door (install, run, connect AI assistants); the pages here are for contributors and operators who need to reason about the internals.
+An open-source, self-hosted mini Bloomberg Terminal for AI agents — scrapes, stores, and serves SEC filings, institutional holdings, insider trading, congressional trades, short data, economic indicators, and daily stock prices, and exposes it all via MCP.
 
-## Topics
+## Sections
 
-- [Architecture](architecture.md) — modular-monolith composition, the shared `EquiblesDbContext` module system, repo → manager → host data flow.
-- [Hosts](hosts.md) — the three host apps: `Equibles.Web` (MVC portal), `Equibles.Mcp.Server` (MCP transport), `Equibles.Worker.Host` (background scrapers).
-- [Modules](modules.md) — index of the financial-domain modules (SEC, Holdings, Insider, Congress, FRED, Yahoo, FINRA, CFTC, CBOE) with data source, key entities, and scraper entry point per row.
-- [MCP tools](mcp-tools.md) — catalog of the tools exposed by each module's `*.Mcp` project and the wiring path through `Equibles.Mcp` → `Equibles.Mcp.Server`.
-- [Scrapers and integrations](scrapers.md) — `*.HostedService` worker pattern, `Equibles.Integrations.*` client pattern, rate limiting, retry, `ProcessedDataSet` / `ProcessedFiling` bookkeeping.
-- [Web portal](web-portal.md) — `StocksController` tab pattern, `StockTabService`, DaisyUI v5 + Tailwind v4 + Vite, Razor partial conventions.
-- [Migrations and database](migrations.md) — `Equibles.Migrations` design-time factory, ParadeDB extensions (`pgvector`, `pg_search`), `MigrateAsync` on host startup.
-- [Development](development.md) — Docker-first workflow, `dotnet csharpier` formatting, pre-commit hooks, single-test commands, CI gates (`ci.yml` / `functional.yml` / `smoke.yml`).
-- [Operations](operations.md) — environment-variable catalog, `--profile embedding` opt-in, `CHECK_FOR_UPDATES`, auth modes, upgrading.
-
-## Status
-
-Every page above is written. Subsequent `/update-docs` invocations operate in the maintain lane — one drift fix per PR (stale code reference, missing doc for a module added since the last docs commit, or one unclear sentence).
+- [Technical docs](technical/README.md) — codebase, architecture, modules. For developers.
+- [User guide](guide/README.md) — install, configure, and use the project. For end users.


### PR DESCRIPTION
## Summary

- Maintain-lane PR — biggest pending stale-reference drift. Section: top-level `docs/`.
- `docs/README.md` was still pre-split shape with nine broken links into the (now-relocated) top-level files. Replaces it with the canonical `## Sections` block linking to `technical/README.md` and `guide/README.md` and drops the no-longer-accurate Status paragraph.

## Code changes

- `docs/README.md` — rewrite. 4 lines added, 15 removed, all 9 broken links gone. No source code touched.