### PR TITLE
docs(guide): drop stale Status block from the section index

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -23,7 +23,3 @@ Task-focused recipes for someone who has Equibles running.
 - [Upgrade to the latest release](how-to-upgrade.md)
 - [Back up and restore your database](how-to-back-up-and-restore.md)
 - [Check worker health and recent errors](how-to-view-status-and-errors.md)
-
-## Status
-
-All pages above are **planned**. None are written yet. New pages land one per PR via `/update-docs`, in the order listed (tutorials first, then how-to guides).


### PR DESCRIPTION
## Summary

- Maintain-lane PR — stale-reference drift. Section: `docs/guide/`.
- The Status paragraph claimed all pages were still planned with none written, but all two tutorials and eight how-tos now exist.
- Drops the four-line block; leaves the rest of the index untouched.

## Code changes

- `docs/guide/README.md` — remove `## Status` heading + paragraph (4 lines).