### PR TITLE
docs: put User guide before Technical docs in the index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,5 @@ An open-source, self-hosted mini Bloomberg Terminal for AI agents — scrapes, s
 
 ## Sections
 
-- [Technical docs](technical/README.md) — codebase, architecture, modules. For developers.
 - [User guide](guide/README.md) — install, configure, and use the project. For end users.
+- [Technical docs](technical/README.md) — codebase, architecture, modules. For developers.


### PR DESCRIPTION
## Summary

- Maintain-lane PR — one-line drift. Section: top-level `docs/`.
- Swaps the two bullets under `## Sections` in `docs/README.md` so User guide comes first, matching the just-merged `/update-docs` skill change (marketplace 0.17.2).

## Code changes

- `docs/README.md` — two lines swapped.