### PR TITLE
docs(readme): fix docs/ pointer to mention guide and technical sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An open-source, self-hosted mini Bloomberg Terminal for AI agents. Scrapes, stor
 
 Powers [equibles.com](https://equibles.com).
 
-See [`docs/`](docs/README.md) for contributor documentation.
+See [`docs/`](docs/README.md) for the user guide and technical documentation.
 
 ## What's Included
 


### PR DESCRIPTION
## Summary

- Root README pointed to `docs/` as "contributor documentation", but the docs index now surfaces both a user guide and a technical section.
- Update the one-liner so end users browsing the README know they belong in `docs/` too.

## Code changes

- `README.md` — reword the `docs/` pointer line from "contributor documentation" to "the user guide and technical documentation".