### PR TITLE
feat(holdings): add InstitutionalHoldingRepository.GetQuarterlyActivity (1/3)

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
 using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories.Models;
 
 namespace Equibles.Holdings.Repositories;
 
@@ -41,5 +42,37 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     public IQueryable<InstitutionalHolding> GetByAccessionNumber(string accessionNumber)
     {
         return GetAll().Where(h => h.AccessionNumber == accessionNumber);
+    }
+
+    // Per-stock aggregation of 13F activity across two quarters: totals, filer counts,
+    // and the derived deltas drive the Top Buys / Top Sells leaderboards. New /
+    // Sold-out filer-count metrics need a set-difference between holders per stock per
+    // quarter and live in a separate query — see GetQuarterlyNewSoldOut (TODO #1009).
+    // Both quarters are filtered in a single round trip; the conditional Sum / nested
+    // Distinct().Count() forms translate server-side in EF Core.
+    public IQueryable<MarketWideStockActivity> GetQuarterlyActivity(
+        DateOnly current,
+        DateOnly previous
+    )
+    {
+        return GetAll()
+            .Where(h => h.ReportDate == current || h.ReportDate == previous)
+            .GroupBy(h => h.CommonStockId)
+            .Select(g => new MarketWideStockActivity
+            {
+                CommonStockId = g.Key,
+                CurrentShares = g.Sum(h => h.ReportDate == current ? h.Shares : 0L),
+                PreviousShares = g.Sum(h => h.ReportDate == previous ? h.Shares : 0L),
+                CurrentValue = g.Sum(h => h.ReportDate == current ? h.Value : 0L),
+                PreviousValue = g.Sum(h => h.ReportDate == previous ? h.Value : 0L),
+                CurrentFilerCount = g.Where(h => h.ReportDate == current)
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+                PreviousFilerCount = g.Where(h => h.ReportDate == previous)
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+            });
     }
 }

--- a/src/Equibles.Holdings.Repositories/Models/MarketWideStockActivity.cs
+++ b/src/Equibles.Holdings.Repositories/Models/MarketWideStockActivity.cs
@@ -1,0 +1,15 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class MarketWideStockActivity
+{
+    public Guid CommonStockId { get; set; }
+    public long CurrentShares { get; set; }
+    public long PreviousShares { get; set; }
+    public long CurrentValue { get; set; }
+    public long PreviousValue { get; set; }
+    public int CurrentFilerCount { get; set; }
+    public int PreviousFilerCount { get; set; }
+
+    public long DeltaShares => CurrentShares - PreviousShares;
+    public long DeltaValue => CurrentValue - PreviousValue;
+}

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryQuarterlyActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryQuarterlyActivityTests.cs
@@ -1,0 +1,217 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Pins <c>InstitutionalHoldingRepository.GetQuarterlyActivity</c>. The query runs
+/// server-side against ParadeDB so the conditional-Sum pattern and the nested
+/// <c>Where().Select().Distinct().Count()</c> filer-count must translate end-to-end.
+/// Each <see cref="Fact"/> seeds a fresh stock-and-quarter pair so the assertions
+/// are isolated from other fixture data.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingRepositoryQuarterlyActivityTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<Equibles.Data.EquiblesDbContext> _contexts = [];
+
+    public InstitutionalHoldingRepositoryQuarterlyActivityTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Equibles.Data.EquiblesDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private static readonly DateOnly Prior = new(2024, 9, 30);
+    private static readonly DateOnly Current = new(2024, 12, 31);
+
+    [Fact]
+    public async Task GetQuarterlyActivity_HolderIncreasedPosition_ProducesPositiveDeltaForStock()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, ticker: "AAPL");
+        var holder = await SeedHolder(seed, cik: "1");
+        seed.Add(MakeHolding(stock, holder, Prior, shares: 1_000, value: 1_000_000));
+        seed.Add(MakeHolding(stock, holder, Current, shares: 1_500, value: 1_650_000));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var result = await sut.GetQuarterlyActivity(Current, Prior)
+            .Where(a => a.CommonStockId == stock.Id)
+            .ToListAsync();
+
+        result.Should().ContainSingle();
+        var row = result[0];
+        row.CurrentShares.Should().Be(1_500);
+        row.PreviousShares.Should().Be(1_000);
+        row.DeltaShares.Should().Be(500);
+        row.DeltaValue.Should().Be(650_000);
+        row.CurrentFilerCount.Should().Be(1);
+        row.PreviousFilerCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetQuarterlyActivity_HolderReducedPosition_ProducesNegativeDeltaForStock()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, ticker: "MSFT");
+        var holder = await SeedHolder(seed, cik: "2");
+        seed.Add(MakeHolding(stock, holder, Prior, shares: 1_000, value: 1_000_000));
+        seed.Add(MakeHolding(stock, holder, Current, shares: 600, value: 660_000));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var row = await sut.GetQuarterlyActivity(Current, Prior)
+            .SingleAsync(a => a.CommonStockId == stock.Id);
+
+        row.DeltaShares.Should().Be(-400);
+        row.DeltaValue.Should().Be(-340_000);
+        row.CurrentFilerCount.Should().Be(1);
+        row.PreviousFilerCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetQuarterlyActivity_NewPositionThisQuarter_PreviousFieldsAreZero()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, ticker: "NVDA");
+        var holder = await SeedHolder(seed, cik: "3");
+        // No prior-quarter row; current quarter only.
+        seed.Add(MakeHolding(stock, holder, Current, shares: 750, value: 825_000));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var row = await sut.GetQuarterlyActivity(Current, Prior)
+            .SingleAsync(a => a.CommonStockId == stock.Id);
+
+        row.PreviousShares.Should().Be(0);
+        row.PreviousValue.Should().Be(0);
+        row.CurrentShares.Should().Be(750);
+        row.CurrentValue.Should().Be(825_000);
+        row.PreviousFilerCount.Should().Be(0);
+        row.CurrentFilerCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetQuarterlyActivity_SoldOutPosition_CurrentFieldsAreZero()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, ticker: "TSLA");
+        var holder = await SeedHolder(seed, cik: "4");
+        // Prior quarter only; current quarter empty.
+        seed.Add(MakeHolding(stock, holder, Prior, shares: 500, value: 500_000));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var row = await sut.GetQuarterlyActivity(Current, Prior)
+            .SingleAsync(a => a.CommonStockId == stock.Id);
+
+        row.CurrentShares.Should().Be(0);
+        row.CurrentValue.Should().Be(0);
+        row.PreviousShares.Should().Be(500);
+        row.DeltaShares.Should().Be(-500);
+        row.CurrentFilerCount.Should().Be(0);
+        row.PreviousFilerCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetQuarterlyActivity_MultipleFilersPerStock_CountsDistinctHolders()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, ticker: "GOOG");
+        var h1 = await SeedHolder(seed, cik: "5");
+        var h2 = await SeedHolder(seed, cik: "6");
+        var h3 = await SeedHolder(seed, cik: "7");
+        seed.Add(MakeHolding(stock, h1, Prior, shares: 100, value: 100_000));
+        seed.Add(MakeHolding(stock, h2, Prior, shares: 200, value: 200_000));
+        seed.Add(MakeHolding(stock, h1, Current, shares: 150, value: 150_000));
+        seed.Add(MakeHolding(stock, h2, Current, shares: 250, value: 250_000));
+        seed.Add(MakeHolding(stock, h3, Current, shares: 50, value: 50_000));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var row = await sut.GetQuarterlyActivity(Current, Prior)
+            .SingleAsync(a => a.CommonStockId == stock.Id);
+
+        row.PreviousFilerCount.Should().Be(2);
+        row.CurrentFilerCount.Should().Be(3);
+        row.PreviousShares.Should().Be(300);
+        row.CurrentShares.Should().Be(450);
+    }
+
+    private static async Task<CommonStock> SeedStock(
+        Equibles.Data.EquiblesDbContext ctx,
+        string ticker
+    )
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Test Corp.",
+            Cik = $"C{Guid.NewGuid().GetHashCode() & int.MaxValue:D8}",
+        };
+        ctx.Add(stock);
+        await ctx.SaveChangesAsync();
+        return stock;
+    }
+
+    private static async Task<InstitutionalHolder> SeedHolder(
+        Equibles.Data.EquiblesDbContext ctx,
+        string cik
+    )
+    {
+        var holder = new InstitutionalHolder { Cik = cik, Name = $"Holder {cik}" };
+        ctx.Add(holder);
+        await ctx.SaveChangesAsync();
+        return holder;
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

- **Slice 1 of 3** for #1009. Adds the per-stock cross-quarter aggregation that the upcoming market-wide 13F activity page will rank.
- New `InstitutionalHoldingRepository.GetQuarterlyActivity(current, previous)` returns `IQueryable<MarketWideStockActivity>` — per-stock totals + distinct filer counts for each of the two quarters, with derived `Δ shares` / `Δ value`.
- Single `GROUP BY CommonStockId` with conditional `Sum()` and nested `Where().Select().Distinct().Count()` filer counts — translates server-side end-to-end (verified against ParadeDB).
- New / Sold-out filer-count metrics (set difference of filers per stock between quarters) are deliberately scoped out and will land alongside the controller in a follow-up slice.
- `Refs #1009` — **not** the closing slice.

## Code changes

- `src/Equibles.Holdings.Repositories/Models/MarketWideStockActivity.cs` — projection (totals + filer counts + derived `DeltaShares` / `DeltaValue`).
- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — new `GetQuarterlyActivity(current, previous)` method.
- `tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryQuarterlyActivityTests.cs` — 5 ParadeDB integration tests covering Increased, Reduced, New (no prior row), Sold out (no current row), and multi-filer aggregation per stock.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1083 files).
- New ParadeDB integration tests — 5/5 passing.

Refs #1009