### PR TITLE
docs(technical/mcp-tools): list GetTopBuyersSellers under Holdings

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -22,6 +22,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetOwnershipHistory` — historical ownership trend (shares, value, holder count) per quarter.
 - `GetInstitutionPortfolio` — full portfolio of one institution for a `ReportDate`.
 - `SearchInstitutions` — name-search returning matching `InstitutionalHolder` rows.
+- `GetTopBuyersSellers` — biggest absolute share additions and reductions for a ticker vs. the prior `ReportDate`; flags new and sold-out positions.
 
 ### `mcp.AddInsiderTrading()` — Form 3 / 4
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- `GetTopBuyersSellers` was added to `InstitutionalHoldingsTools` in #1054 but the Holdings section of `docs/technical/mcp-tools.md` still only listed four tools. Add the missing bullet so the catalog matches the code.

## Code changes

- `docs/technical/mcp-tools.md` — append one bullet under the `mcp.AddHoldings()` → `InstitutionalHoldingsTools` list describing `GetTopBuyersSellers` (biggest absolute share additions/reductions vs. the prior `ReportDate`, flags new and sold-out positions).