### PR TITLE
feat(holdings): add /Holdings/Activity page with Top Buys / Top Sells boards (2/3)

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -1,0 +1,119 @@
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Repositories;
+using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.ViewModels.Holdings;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Web.Controllers;
+
+public class HoldingsActivityController : BaseController
+{
+    private readonly InstitutionalHoldingRepository _holdingRepository;
+    private readonly CommonStockRepository _commonStockRepository;
+
+    public HoldingsActivityController(
+        InstitutionalHoldingRepository holdingRepository,
+        CommonStockRepository commonStockRepository,
+        ILogger<HoldingsActivityController> logger
+    )
+        : base(logger)
+    {
+        _holdingRepository = holdingRepository;
+        _commonStockRepository = commonStockRepository;
+    }
+
+    [HttpGet("~/Holdings/Activity")]
+    public async Task<IActionResult> Activity(DateOnly? date)
+    {
+        var reportDates = await _holdingRepository
+            .GetAvailableReportDates()
+            .OrderByDescending(d => d)
+            .ToListAsync();
+
+        var viewModel = new HoldingsActivityViewModel { AvailableDates = reportDates };
+        if (reportDates.Count == 0)
+            return View(viewModel);
+
+        var selectedDate = date ?? reportDates[0];
+        var selectedIndex = reportDates.IndexOf(selectedDate);
+        if (selectedIndex < 0)
+        {
+            selectedDate = reportDates[0];
+            selectedIndex = 0;
+        }
+        viewModel.SelectedDate = selectedDate;
+
+        var previousDate =
+            selectedIndex < reportDates.Count - 1
+                ? reportDates[selectedIndex + 1]
+                : (DateOnly?)null;
+        viewModel.PreviousDate = previousDate;
+        if (!previousDate.HasValue)
+            return View(viewModel);
+
+        // Pull the top N stocks by absolute Δ value in each direction. The cap is
+        // applied server-side so the controller never materializes the full per-stock
+        // aggregation for the whole universe.
+        var movers = _holdingRepository
+            .GetQuarterlyActivity(selectedDate, previousDate.Value)
+            .Where(a => a.CurrentShares != a.PreviousShares);
+
+        var topBuysAgg = await movers
+            .Where(a => a.CurrentShares > a.PreviousShares)
+            .OrderByDescending(a => a.CurrentValue - a.PreviousValue)
+            .Take(HoldingsActivityViewModel.RowCap)
+            .ToListAsync();
+        var topSellsAgg = await movers
+            .Where(a => a.CurrentShares < a.PreviousShares)
+            .OrderBy(a => a.CurrentValue - a.PreviousValue)
+            .Take(HoldingsActivityViewModel.RowCap)
+            .ToListAsync();
+
+        var stockIds = topBuysAgg
+            .Concat(topSellsAgg)
+            .Select(a => a.CommonStockId)
+            .Distinct()
+            .ToList();
+        var stocks = await _commonStockRepository
+            .GetAll()
+            .Where(s => stockIds.Contains(s.Id))
+            .Select(s => new StockLabel
+            {
+                Id = s.Id,
+                Ticker = s.Ticker,
+                Name = s.Name,
+            })
+            .ToDictionaryAsync(s => s.Id);
+
+        viewModel.TopBuys = topBuysAgg.Select(a => MapRow(a, stocks)).ToList();
+        viewModel.TopSells = topSellsAgg.Select(a => MapRow(a, stocks)).ToList();
+
+        return View(viewModel);
+    }
+
+    private static HoldingsActivityRow MapRow(
+        Equibles.Holdings.Repositories.Models.MarketWideStockActivity activity,
+        IDictionary<Guid, StockLabel> stocks
+    )
+    {
+        stocks.TryGetValue(activity.CommonStockId, out var stock);
+        return new HoldingsActivityRow
+        {
+            CommonStockId = activity.CommonStockId,
+            Ticker = stock?.Ticker ?? "—",
+            Name = stock?.Name ?? "Unknown",
+            DeltaShares = activity.DeltaShares,
+            DeltaValue = activity.DeltaValue,
+            CurrentFilerCount = activity.CurrentFilerCount,
+            PreviousFilerCount = activity.PreviousFilerCount,
+        };
+    }
+
+    private class StockLabel
+    {
+        public Guid Id { get; set; }
+        public string Ticker { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsActivityRow.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsActivityRow.cs
@@ -1,0 +1,12 @@
+namespace Equibles.Web.ViewModels.Holdings;
+
+public class HoldingsActivityRow
+{
+    public Guid CommonStockId { get; set; }
+    public string Ticker { get; set; }
+    public string Name { get; set; }
+    public long DeltaShares { get; set; }
+    public long DeltaValue { get; set; }
+    public int CurrentFilerCount { get; set; }
+    public int PreviousFilerCount { get; set; }
+}

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsActivityViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsActivityViewModel.cs
@@ -1,0 +1,13 @@
+namespace Equibles.Web.ViewModels.Holdings;
+
+public class HoldingsActivityViewModel
+{
+    public List<DateOnly> AvailableDates { get; set; } = [];
+    public DateOnly SelectedDate { get; set; }
+    public DateOnly? PreviousDate { get; set; }
+
+    public List<HoldingsActivityRow> TopBuys { get; set; } = [];
+    public List<HoldingsActivityRow> TopSells { get; set; } = [];
+
+    public const int RowCap = 20;
+}

--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -1,0 +1,107 @@
+@using Equibles.Web.ViewModels.Holdings
+@model HoldingsActivityViewModel
+@{
+    ViewData["Title"] = "13F Quarterly Activity";
+    ViewData["Menu"] = "Holdings";
+}
+
+@if (Model.AvailableDates.Count == 0) {
+    <div class="card bg-base-100 shadow-sm">
+        <div class="card-body items-center text-center py-12">
+            <div class="text-base-content/30 mb-3">
+                <icon name="building-office" size="12" />
+            </div>
+            <h3 class="text-base-content/60 mb-2">No 13F data yet</h3>
+            <p class="text-base-content/40 text-sm">Once at least one quarter of 13F filings has been ingested, the market-wide activity boards appear here.</p>
+        </div>
+    </div>
+} else {
+    <!-- ReportDate selector + comparison subtitle -->
+    <div class="mb-4 text-sm">
+        <div class="flex flex-wrap items-center gap-x-5 gap-y-2 mb-1">
+            <div class="flex items-center gap-2 shrink-0">
+                <span class="text-base-content/60 whitespace-nowrap">Report Date:</span>
+                <select id="activity-date" class="select select-bordered select-sm"
+                    onchange="window.location.href='Activity?date=' + this.value">
+                    @foreach (var date in Model.AvailableDates) {
+                        var isSelected = date == Model.SelectedDate;
+                        if (isSelected) {
+                            <option value="@date.ToString("yyyy-MM-dd")" selected>@date.ToString("MMM dd, yyyy")</option>
+                        } else {
+                            <option value="@date.ToString("yyyy-MM-dd")">@date.ToString("MMM dd, yyyy")</option>
+                        }
+                    }
+                </select>
+            </div>
+            @if (Model.PreviousDate.HasValue) {
+                <div class="text-xs text-base-content/50">vs prior quarter @Model.PreviousDate.Value.ToString("MMM dd, yyyy")</div>
+            } else {
+                <div class="text-xs text-base-content/50">No prior quarter available — buy/sell ranking needs two quarters.</div>
+            }
+        </div>
+    </div>
+
+    @if (!Model.PreviousDate.HasValue) {
+        <!-- Single-quarter case: nothing to rank by Δ. The empty state above is the report. -->
+    } else {
+        <!-- Two stacked cards: Top Buys, Top Sells. New / Sold-out leaderboards land in a follow-up slice. -->
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            @{
+                var boards = new[]
+                {
+                    new { Label = "Top Buys", Rows = Model.TopBuys, BadgeCss = "badge-success", TestId = "activity-top-buys" },
+                    new { Label = "Top Sells", Rows = Model.TopSells, BadgeCss = "badge-error", TestId = "activity-top-sells" },
+                };
+            }
+            @foreach (var board in boards) {
+                <div class="card bg-base-100 shadow-sm" data-testid="@board.TestId">
+                    <div class="card-body p-4">
+                        <div class="flex items-center gap-2 mb-2">
+                            <h3 class="text-base font-medium m-0">@board.Label</h3>
+                            <span class="badge @board.BadgeCss badge-sm">@board.Rows.Count.ToString("N0")</span>
+                        </div>
+                        @if (board.Rows.Count == 0) {
+                            <div class="text-xs text-base-content/50">No stocks in this bucket for the selected quarter.</div>
+                        } else {
+                            <div class="overflow-x-auto">
+                                <table class="table table-sm">
+                                    <thead>
+                                        <tr>
+                                            <th>Ticker</th>
+                                            <th>Company</th>
+                                            <th class="text-right">Δ Shares</th>
+                                            <th class="text-right hidden md:table-cell">Δ Value (USD)</th>
+                                            <th class="text-right hidden lg:table-cell"># Filers</th>
+                                            <th class="text-right">Action</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var row in board.Rows) {
+                                            var deltaSharesCss = row.DeltaShares > 0 ? "text-success" : row.DeltaShares < 0 ? "text-error" : "";
+                                            var deltaValueCss = row.DeltaValue > 0 ? "text-success" : row.DeltaValue < 0 ? "text-error" : "";
+                                            var deltaSharesSign = row.DeltaShares > 0 ? "+" : "";
+                                            var deltaValueSign = row.DeltaValue > 0 ? "+" : "";
+                                            <tr>
+                                                <td class="font-mono">@row.Ticker</td>
+                                                <td class="max-w-xs truncate">@row.Name</td>
+                                                <td class="text-right font-mono @deltaSharesCss">@deltaSharesSign@row.DeltaShares.ToString("N0")</td>
+                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss">@deltaValueSign$@row.DeltaValue.ToString("N0")</td>
+                                                <td class="text-right font-mono hidden lg:table-cell text-base-content/60">@row.PreviousFilerCount.ToString("N0") → @row.CurrentFilerCount.ToString("N0")</td>
+                                                <td class="text-right">
+                                                    <a asp-controller="Stocks" asp-action="Holdings"
+                                                       asp-route-ticker="@row.Ticker"
+                                                       asp-route-date="@Model.SelectedDate.ToString("yyyy-MM-dd")"
+                                                       class="btn btn-ghost btn-sm">View</a>
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </div>
+                </div>
+            }
+        </div>
+    }
+}

--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerTests.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the Holdings/Activity route end-to-end: route resolves, the controller
+/// composes the per-stock activity rows from <c>GetQuarterlyActivity</c>, and
+/// the rendered HTML carries the Top Buys / Top Sells panels with the right
+/// stock identities. The seed forces one stock into each direction so a regression
+/// in the controller's filter / orderby would surface as missing markup.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HoldingsActivityControllerTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HoldingsActivityControllerTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetActivity_NoHoldings_RendersEmptyState()
+    {
+        await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Activity");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("No 13F data yet");
+        html.Should().NotContain("activity-top-buys");
+        html.Should().NotContain("activity-top-sells");
+    }
+
+    [Fact]
+    public async Task GetActivity_SingleQuarter_RendersNoPriorQuarterNotice()
+    {
+        var stockId = Guid.NewGuid();
+        var holderId = Guid.NewGuid();
+        var only = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "1",
+                    Name = "Single Filer",
+                }
+            );
+            db.Add(
+                new InstitutionalHolding
+                {
+                    CommonStockId = stockId,
+                    InstitutionalHolderId = holderId,
+                    ReportDate = only,
+                    FilingDate = only.AddDays(45),
+                    Shares = 10_000,
+                    Value = 1_000_000,
+                    ShareType = ShareType.Shares,
+                    InvestmentDiscretion = InvestmentDiscretion.Sole,
+                    AccessionNumber = "acc-1",
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Activity");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("No prior quarter available");
+        // The Top Buys / Top Sells cards must NOT render without a prior quarter.
+        html.Should().NotContain("data-testid=\"activity-top-buys\"");
+        html.Should().NotContain("data-testid=\"activity-top-sells\"");
+    }
+
+    [Fact]
+    public async Task GetActivity_TwoQuartersWithMovement_RendersTopBuysAndTopSells()
+    {
+        var aaplId = Guid.NewGuid();
+        var msftId = Guid.NewGuid();
+        var holderId = Guid.NewGuid();
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.AddRange(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                },
+                new CommonStock
+                {
+                    Id = msftId,
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corp.",
+                    Cik = "0000789019",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "1",
+                    Name = "Big Fund LP",
+                }
+            );
+            // AAPL: increased (Δ +5_000 shares / +500_000 value) → Top Buys.
+            db.Add(MakeHolding(aaplId, holderId, prior, shares: 10_000, value: 1_000_000));
+            db.Add(MakeHolding(aaplId, holderId, current, shares: 15_000, value: 1_500_000));
+            // MSFT: reduced (Δ -3_000 shares / -300_000 value) → Top Sells.
+            db.Add(MakeHolding(msftId, holderId, prior, shares: 8_000, value: 800_000));
+            db.Add(MakeHolding(msftId, holderId, current, shares: 5_000, value: 500_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Activity");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        // Both panels render.
+        html.Should().Contain("data-testid=\"activity-top-buys\"");
+        html.Should().Contain("data-testid=\"activity-top-sells\"");
+        // The AAPL row lives in the buys panel; MSFT in the sells panel.
+        var buysAnchor = html.IndexOf(
+            "data-testid=\"activity-top-buys\"",
+            StringComparison.Ordinal
+        );
+        var sellsAnchor = html.IndexOf(
+            "data-testid=\"activity-top-sells\"",
+            StringComparison.Ordinal
+        );
+        buysAnchor.Should().BeGreaterThan(-1);
+        sellsAnchor.Should().BeGreaterThan(buysAnchor);
+        var buysSection = html.Substring(buysAnchor, sellsAnchor - buysAnchor);
+        var sellsSection = html.Substring(sellsAnchor);
+        buysSection.Should().Contain("AAPL");
+        buysSection.Should().NotContain("MSFT");
+        sellsSection.Should().Contain("MSFT");
+        sellsSection.Should().NotContain("AAPL");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            // AccessionNumber column caps at 32 chars; first 8 hex of the Guid + the date keep us well under.
+            AccessionNumber = $"acc-{stockId:N}".Substring(0, 12) + $"-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

- **Slice 2 of 3** for #1009. Wires the `GetQuarterlyActivity` aggregation landed in #1078 into a user-visible market-wide leaderboard at `~/Holdings/Activity?date=…`.
- Two side-by-side DaisyUI cards: **Top Buys** (Δ shares > 0, ranked by Δ value desc) and **Top Sells** (Δ shares < 0, ranked by Δ value asc). 20 rows per card; cap applied server-side via `Take(20)`.
- **New Positions / Sold-out Positions** leaderboards need a set-difference of filers per stock across quarters — added alongside the MCP tool in the closing slice.
- `Refs #1009` — not the closing slice.

## Code changes

- `src/Equibles.Web/ViewModels/Holdings/HoldingsActivityViewModel.cs` + `HoldingsActivityRow.cs` — per-row projection + the parent view model with `TopBuys` / `TopSells` lists and report-date selector state.
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — new controller at `~/Holdings/Activity`. Resolves the selected `ReportDate` against the available distinct dates, picks the immediately-prior date as the comparison base, pulls two server-side `IQueryable<>` projections, decorates with ticker + display name via a small `CommonStock` dictionary lookup.
- `src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml` — empty-state ("no 13F data"), single-quarter notice (no prior to compare), and two cards with Δ Shares / Δ Value / filer-count columns plus a View action that deep-links into the per-stock Holdings tab for the selected quarter. Each panel carries a `data-testid` for stable e2e selection.
- `tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerTests.cs` — 3 `WebHostFixture`-backed integration tests: empty state, single-quarter notice, two-quarters-with-movement (AAPL → Top Buys, MSFT → Top Sells via section-anchor slicing).

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1087 files).
- New ParadeDB integration tests — 3/3 passing.

Refs #1009