### PR TITLE
refactor(holdings-mcp): collapse GetInstitutionalHistory date if/else into a ternary

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -336,18 +336,11 @@ public class InstitutionalHoldingsTools
                     .OrderByDescending(d => d)
                     .ToListAsync();
 
-                DateOnly targetDate;
-                if (
+                var targetDate =
                     !string.IsNullOrEmpty(reportDate)
                     && DateOnly.TryParse(reportDate, out var parsed)
-                )
-                {
-                    targetDate = parsed;
-                }
-                else
-                {
-                    targetDate = reportDates.FirstOrDefault();
-                }
+                        ? parsed
+                        : reportDates.FirstOrDefault();
                 if (targetDate == default)
                     return $"No institutional holdings data available for {ticker}.";
 


### PR DESCRIPTION
## Summary

- Replaces a 12-line \`DateOnly targetDate; if (!empty && TryParse) parsed else reportDates.FirstOrDefault()\` block in \`InstitutionalHoldingsTools.GetInstitutionalHistory\` with a single conditional assignment.
- Same boolean condition, same branch values, same downstream \`targetDate == default\` guard — behaviour-preserving by construction.
- Resolves CodeQL alert #359 (\`cs/missed-ternary-operator\`).

## Code changes

- \`src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs\` — collapses the if/else at lines 339-350 into a ternary expression; net -10 / +3 lines.