### PR TITLE
feat(holdings): add New / Sold-out leaderboards and GetMarketWide13FActivity MCP tool (3/3)

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -488,6 +488,162 @@ public class InstitutionalHoldingsTools
         );
     }
 
+    [McpServerTool(Name = "GetMarketWide13FActivity")]
+    [Description(
+        "Get the market-wide 13F leaderboards for a given quarter — which stocks were most bought, most sold, most initiated, or most exited across all 13F filers vs the prior quarter. The `bucket` argument selects one of: top-buys (Δ shares > 0 ranked by Δ value desc), top-sells (Δ shares < 0 ranked by Δ value asc), new-positions (stocks ranked by count of filers initiating a position), sold-out-positions (stocks ranked by count of filers exiting). Use this to answer 'what's the consensus 13F move this quarter?'"
+    )]
+    public Task<string> GetMarketWide13FActivity(
+        [Description("Bucket: top-buys, top-sells, new-positions, or sold-out-positions")]
+            string bucket,
+        [Description("Report date in YYYY-MM-DD format (defaults to latest available)")]
+            string reportDate = null,
+        [Description("Maximum number of stocks to return (default: 20)")] int maxResults = 20
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                var normalizedBucket = (bucket ?? string.Empty).Trim().ToLowerInvariant();
+                if (
+                    normalizedBucket != "top-buys"
+                    && normalizedBucket != "top-sells"
+                    && normalizedBucket != "new-positions"
+                    && normalizedBucket != "sold-out-positions"
+                )
+                    return "Unknown bucket. Use one of: top-buys, top-sells, new-positions, sold-out-positions.";
+
+                var reportDates = await _holdingRepository
+                    .GetAvailableReportDates()
+                    .Distinct()
+                    .OrderByDescending(d => d)
+                    .ToListAsync();
+                if (reportDates.Count == 0)
+                    return "No 13F holdings data available.";
+
+                DateOnly targetDate;
+                if (
+                    !string.IsNullOrEmpty(reportDate)
+                    && DateOnly.TryParse(reportDate, out var parsed)
+                )
+                    targetDate = parsed;
+                else
+                    targetDate = reportDates[0];
+                var targetIndex = reportDates.IndexOf(targetDate);
+                if (targetIndex < 0)
+                    return $"Report date {targetDate:yyyy-MM-dd} not found. Available dates: {string.Join(", ", reportDates.Take(5).Select(d => d.ToString("yyyy-MM-dd")))}{(reportDates.Count > 5 ? "…" : "")}.";
+
+                var previousDate =
+                    targetIndex < reportDates.Count - 1
+                        ? reportDates[targetIndex + 1]
+                        : (DateOnly?)null;
+                if (!previousDate.HasValue)
+                    return $"No prior quarter to compare against for {targetDate:yyyy-MM-dd}.";
+
+                // Headline + comparison subtitle.
+                var result = new StringBuilder();
+                result.AppendLine(
+                    $"Market-wide 13F **{normalizedBucket}** for {targetDate:yyyy-MM-dd}"
+                );
+                result.AppendLine($"vs prior quarter {previousDate.Value:yyyy-MM-dd}");
+                result.AppendLine();
+
+                if (normalizedBucket is "top-buys" or "top-sells")
+                {
+                    var activity = _holdingRepository.GetQuarterlyActivity(
+                        targetDate,
+                        previousDate.Value
+                    );
+                    var movers = activity.Where(a => a.CurrentShares != a.PreviousShares);
+                    var rows =
+                        normalizedBucket == "top-buys"
+                            ? await movers
+                                .Where(a => a.CurrentShares > a.PreviousShares)
+                                .OrderByDescending(a => a.CurrentValue - a.PreviousValue)
+                                .Take(maxResults)
+                                .ToListAsync()
+                            : await movers
+                                .Where(a => a.CurrentShares < a.PreviousShares)
+                                .OrderBy(a => a.CurrentValue - a.PreviousValue)
+                                .Take(maxResults)
+                                .ToListAsync();
+                    if (rows.Count == 0)
+                        return result.ToString()
+                            + "_No stocks moved in this direction this quarter._";
+
+                    var stockIds = rows.Select(r => r.CommonStockId).ToList();
+                    var stocks = await _commonStockRepository
+                        .GetAll()
+                        .Where(s => stockIds.Contains(s.Id))
+                        .ToDictionaryAsync(s => s.Id);
+
+                    result.AppendLine("| # | Ticker | Company | Δ Shares | Δ Value ($M) |");
+                    result.AppendLine("|---|--------|---------|---------|-------------|");
+                    for (var i = 0; i < rows.Count; i++)
+                    {
+                        var r = rows[i];
+                        stocks.TryGetValue(r.CommonStockId, out var s);
+                        var sign = r.DeltaShares > 0 ? "+" : "";
+                        result.AppendLine(
+                            $"| {i + 1} | {s?.Ticker ?? "—"} | {s?.Name ?? "Unknown"} | {sign}{r.DeltaShares:N0} | {r.DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0} |"
+                        );
+                    }
+                    return result.ToString();
+                }
+                else
+                {
+                    var churn = _holdingRepository.GetQuarterlyNewSoldOutPositions(
+                        targetDate,
+                        previousDate.Value
+                    );
+                    var rows =
+                        normalizedBucket == "new-positions"
+                            ? await churn
+                                .Where(c => c.NewFilerCount > 0)
+                                .OrderByDescending(c => c.NewFilerCount)
+                                .Take(maxResults)
+                                .ToListAsync()
+                            : await churn
+                                .Where(c => c.SoldOutFilerCount > 0)
+                                .OrderByDescending(c => c.SoldOutFilerCount)
+                                .Take(maxResults)
+                                .ToListAsync();
+                    if (rows.Count == 0)
+                        return result.ToString() + "_No stocks in this bucket this quarter._";
+
+                    var stockIds = rows.Select(r => r.CommonStockId).ToList();
+                    var stocks = await _commonStockRepository
+                        .GetAll()
+                        .Where(s => stockIds.Contains(s.Id))
+                        .ToDictionaryAsync(s => s.Id);
+
+                    var label =
+                        normalizedBucket == "new-positions"
+                            ? "# Filers Initiated"
+                            : "# Filers Exited";
+                    result.AppendLine($"| # | Ticker | Company | {label} |");
+                    result.AppendLine("|---|--------|---------|-------------|");
+                    for (var i = 0; i < rows.Count; i++)
+                    {
+                        var r = rows[i];
+                        stocks.TryGetValue(r.CommonStockId, out var s);
+                        var count =
+                            normalizedBucket == "new-positions"
+                                ? r.NewFilerCount
+                                : r.SoldOutFilerCount;
+                        result.AppendLine(
+                            $"| {i + 1} | {s?.Ticker ?? "—"} | {s?.Name ?? "Unknown"} | {count:N0} |"
+                        );
+                    }
+                    return result.ToString();
+                }
+            },
+            _logger,
+            "GetMarketWide13FActivity",
+            $"bucket: {bucket}",
+            ReportError
+        );
+    }
+
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -46,8 +46,9 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
 
     // Per-stock aggregation of 13F activity across two quarters: totals, filer counts,
     // and the derived deltas drive the Top Buys / Top Sells leaderboards. New /
-    // Sold-out filer-count metrics need a set-difference between holders per stock per
-    // quarter and live in a separate query — see GetQuarterlyNewSoldOut (TODO #1009).
+    // Sold-out filer-count metrics live in GetQuarterlyNewSoldOutPositions — they need
+    // a set-difference between (stock, holder) pairs across the two quarters and don't
+    // fit cleanly inside this single GROUP BY.
     // Both quarters are filtered in a single round trip; the conditional Sum / nested
     // Distinct().Count() forms translate server-side in EF Core.
     public IQueryable<MarketWideStockActivity> GetQuarterlyActivity(
@@ -70,6 +71,50 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
                     .Distinct()
                     .Count(),
                 PreviousFilerCount = g.Where(h => h.ReportDate == previous)
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+            });
+    }
+
+    // Per-stock churn between two 13F quarters: how many filers initiated a position
+    // (in current, not in prior) and how many exited (in prior, not in current).
+    // Implemented as two NOT-EXISTS subqueries against the same table — EF Core
+    // translates the `!DbContext.Set<>().Any(...)` form to a SQL `NOT EXISTS` clause.
+    public IQueryable<MarketWideStockChurn> GetQuarterlyNewSoldOutPositions(
+        DateOnly current,
+        DateOnly previous
+    )
+    {
+        return GetAll()
+            .Where(h => h.ReportDate == current || h.ReportDate == previous)
+            .GroupBy(h => h.CommonStockId)
+            .Select(g => new MarketWideStockChurn
+            {
+                CommonStockId = g.Key,
+                NewFilerCount = g.Where(h =>
+                        h.ReportDate == current
+                        && !DbContext
+                            .Set<InstitutionalHolding>()
+                            .Any(p =>
+                                p.ReportDate == previous
+                                && p.CommonStockId == h.CommonStockId
+                                && p.InstitutionalHolderId == h.InstitutionalHolderId
+                            )
+                    )
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+                SoldOutFilerCount = g.Where(h =>
+                        h.ReportDate == previous
+                        && !DbContext
+                            .Set<InstitutionalHolding>()
+                            .Any(c =>
+                                c.ReportDate == current
+                                && c.CommonStockId == h.CommonStockId
+                                && c.InstitutionalHolderId == h.InstitutionalHolderId
+                            )
+                    )
                     .Select(h => h.InstitutionalHolderId)
                     .Distinct()
                     .Count(),

--- a/src/Equibles.Holdings.Repositories/Models/MarketWideStockChurn.cs
+++ b/src/Equibles.Holdings.Repositories/Models/MarketWideStockChurn.cs
@@ -1,0 +1,12 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class MarketWideStockChurn
+{
+    public Guid CommonStockId { get; set; }
+
+    // Filers who reported a position in the current quarter but not in the prior quarter.
+    public int NewFilerCount { get; set; }
+
+    // Filers who reported a position in the prior quarter but not in the current quarter.
+    public int SoldOutFilerCount { get; set; }
+}

--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -70,9 +70,29 @@ public class HoldingsActivityController : BaseController
             .Take(HoldingsActivityViewModel.RowCap)
             .ToListAsync();
 
+        // New / Sold-out per-stock churn — runs as a separate aggregation because the
+        // set-difference of (stock, holder) pairs across quarters can't live inside the
+        // same GROUP BY as the share/value totals.
+        var churn = _holdingRepository.GetQuarterlyNewSoldOutPositions(
+            selectedDate,
+            previousDate.Value
+        );
+        var newPositionsAgg = await churn
+            .Where(c => c.NewFilerCount > 0)
+            .OrderByDescending(c => c.NewFilerCount)
+            .Take(HoldingsActivityViewModel.RowCap)
+            .ToListAsync();
+        var soldOutPositionsAgg = await churn
+            .Where(c => c.SoldOutFilerCount > 0)
+            .OrderByDescending(c => c.SoldOutFilerCount)
+            .Take(HoldingsActivityViewModel.RowCap)
+            .ToListAsync();
+
         var stockIds = topBuysAgg
             .Concat(topSellsAgg)
             .Select(a => a.CommonStockId)
+            .Concat(newPositionsAgg.Select(c => c.CommonStockId))
+            .Concat(soldOutPositionsAgg.Select(c => c.CommonStockId))
             .Distinct()
             .ToList();
         var stocks = await _commonStockRepository
@@ -88,8 +108,28 @@ public class HoldingsActivityController : BaseController
 
         viewModel.TopBuys = topBuysAgg.Select(a => MapRow(a, stocks)).ToList();
         viewModel.TopSells = topSellsAgg.Select(a => MapRow(a, stocks)).ToList();
+        viewModel.NewPositions = newPositionsAgg.Select(c => MapChurnRow(c, stocks)).ToList();
+        viewModel.SoldOutPositions = soldOutPositionsAgg
+            .Select(c => MapChurnRow(c, stocks))
+            .ToList();
 
         return View(viewModel);
+    }
+
+    private static HoldingsActivityRow MapChurnRow(
+        Equibles.Holdings.Repositories.Models.MarketWideStockChurn churn,
+        IDictionary<Guid, StockLabel> stocks
+    )
+    {
+        stocks.TryGetValue(churn.CommonStockId, out var stock);
+        return new HoldingsActivityRow
+        {
+            CommonStockId = churn.CommonStockId,
+            Ticker = stock?.Ticker ?? "—",
+            Name = stock?.Name ?? "Unknown",
+            NewFilerCount = churn.NewFilerCount,
+            SoldOutFilerCount = churn.SoldOutFilerCount,
+        };
     }
 
     private static HoldingsActivityRow MapRow(

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsActivityRow.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsActivityRow.cs
@@ -9,4 +9,9 @@ public class HoldingsActivityRow
     public long DeltaValue { get; set; }
     public int CurrentFilerCount { get; set; }
     public int PreviousFilerCount { get; set; }
+
+    // Only populated for the New / Sold-out boards; left zero on Top Buys / Top Sells rows
+    // where the value-delta ranking carries the signal.
+    public int NewFilerCount { get; set; }
+    public int SoldOutFilerCount { get; set; }
 }

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsActivityViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsActivityViewModel.cs
@@ -8,6 +8,8 @@ public class HoldingsActivityViewModel
 
     public List<HoldingsActivityRow> TopBuys { get; set; } = [];
     public List<HoldingsActivityRow> TopSells { get; set; } = [];
+    public List<HoldingsActivityRow> NewPositions { get; set; } = [];
+    public List<HoldingsActivityRow> SoldOutPositions { get; set; } = [];
 
     public const int RowCap = 20;
 }

--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -44,16 +44,16 @@
     @if (!Model.PreviousDate.HasValue) {
         <!-- Single-quarter case: nothing to rank by Δ. The empty state above is the report. -->
     } else {
-        <!-- Two stacked cards: Top Buys, Top Sells. New / Sold-out leaderboards land in a follow-up slice. -->
+        <!-- Four cards: Top Buys / Top Sells (Δ value), New Positions / Sold-out Positions (filer count). -->
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
             @{
-                var boards = new[]
+                var deltaBoards = new[]
                 {
                     new { Label = "Top Buys", Rows = Model.TopBuys, BadgeCss = "badge-success", TestId = "activity-top-buys" },
                     new { Label = "Top Sells", Rows = Model.TopSells, BadgeCss = "badge-error", TestId = "activity-top-sells" },
                 };
             }
-            @foreach (var board in boards) {
+            @foreach (var board in deltaBoards) {
                 <div class="card bg-base-100 shadow-sm" data-testid="@board.TestId">
                     <div class="card-body p-4">
                         <div class="flex items-center gap-2 mb-2">
@@ -87,6 +87,55 @@
                                                 <td class="text-right font-mono @deltaSharesCss">@deltaSharesSign@row.DeltaShares.ToString("N0")</td>
                                                 <td class="text-right font-mono hidden md:table-cell @deltaValueCss">@deltaValueSign$@row.DeltaValue.ToString("N0")</td>
                                                 <td class="text-right font-mono hidden lg:table-cell text-base-content/60">@row.PreviousFilerCount.ToString("N0") → @row.CurrentFilerCount.ToString("N0")</td>
+                                                <td class="text-right">
+                                                    <a asp-controller="Stocks" asp-action="Holdings"
+                                                       asp-route-ticker="@row.Ticker"
+                                                       asp-route-date="@Model.SelectedDate.ToString("yyyy-MM-dd")"
+                                                       class="btn btn-ghost btn-sm">View</a>
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </div>
+                </div>
+            }
+
+            @{
+                var churnBoards = new[]
+                {
+                    new { Label = "New Positions", Rows = Model.NewPositions, BadgeCss = "badge-info", FilerLabel = "# Filers Initiated", FilerSelector = (Func<HoldingsActivityRow, int>)(r => r.NewFilerCount), TestId = "activity-new-positions" },
+                    new { Label = "Sold-Out Positions", Rows = Model.SoldOutPositions, BadgeCss = "badge-warning", FilerLabel = "# Filers Exited", FilerSelector = (Func<HoldingsActivityRow, int>)(r => r.SoldOutFilerCount), TestId = "activity-sold-out-positions" },
+                };
+            }
+            @foreach (var board in churnBoards) {
+                <div class="card bg-base-100 shadow-sm" data-testid="@board.TestId">
+                    <div class="card-body p-4">
+                        <div class="flex items-center gap-2 mb-2">
+                            <h3 class="text-base font-medium m-0">@board.Label</h3>
+                            <span class="badge @board.BadgeCss badge-sm">@board.Rows.Count.ToString("N0")</span>
+                        </div>
+                        @if (board.Rows.Count == 0) {
+                            <div class="text-xs text-base-content/50">No stocks in this bucket for the selected quarter.</div>
+                        } else {
+                            <div class="overflow-x-auto">
+                                <table class="table table-sm">
+                                    <thead>
+                                        <tr>
+                                            <th>Ticker</th>
+                                            <th>Company</th>
+                                            <th class="text-right">@board.FilerLabel</th>
+                                            <th class="text-right">Action</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var row in board.Rows) {
+                                            <tr>
+                                                <td class="font-mono">@row.Ticker</td>
+                                                <td class="max-w-xs truncate">@row.Name</td>
+                                                <td class="text-right font-mono">@board.FilerSelector(row).ToString("N0")</td>
                                                 <td class="text-right">
                                                     <a asp-controller="Stocks" asp-action="Holdings"
                                                        asp-route-ticker="@row.Ticker"

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryNewSoldOutTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryNewSoldOutTests.cs
@@ -1,0 +1,177 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Pins <c>InstitutionalHoldingRepository.GetQuarterlyNewSoldOutPositions</c>. The query
+/// uses two NOT-EXISTS subqueries against the same table and MUST translate server-side
+/// — the in-memory provider does not exercise the same SQL path, so this fixture runs
+/// against ParadeDB.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingRepositoryNewSoldOutTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<Equibles.Data.EquiblesDbContext> _contexts = [];
+
+    public InstitutionalHoldingRepositoryNewSoldOutTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Equibles.Data.EquiblesDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private static readonly DateOnly Prior = new(2024, 9, 30);
+    private static readonly DateOnly Current = new(2024, 12, 31);
+
+    [Fact]
+    public async Task GetQuarterlyNewSoldOutPositions_HolderAppearsOnlyInCurrent_CountsAsNew()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, "AAPL");
+        var holder = await SeedHolder(seed, "1");
+        seed.Add(MakeHolding(stock, holder, Current, shares: 1_000));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var row = await sut.GetQuarterlyNewSoldOutPositions(Current, Prior)
+            .SingleAsync(r => r.CommonStockId == stock.Id);
+
+        row.NewFilerCount.Should().Be(1);
+        row.SoldOutFilerCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetQuarterlyNewSoldOutPositions_HolderAppearsOnlyInPrior_CountsAsSoldOut()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, "MSFT");
+        var holder = await SeedHolder(seed, "2");
+        seed.Add(MakeHolding(stock, holder, Prior, shares: 1_000));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var row = await sut.GetQuarterlyNewSoldOutPositions(Current, Prior)
+            .SingleAsync(r => r.CommonStockId == stock.Id);
+
+        row.NewFilerCount.Should().Be(0);
+        row.SoldOutFilerCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetQuarterlyNewSoldOutPositions_HolderInBothQuarters_CountsAsNeither()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, "NVDA");
+        var holder = await SeedHolder(seed, "3");
+        seed.Add(MakeHolding(stock, holder, Prior, shares: 1_000));
+        seed.Add(MakeHolding(stock, holder, Current, shares: 1_500));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var row = await sut.GetQuarterlyNewSoldOutPositions(Current, Prior)
+            .SingleAsync(r => r.CommonStockId == stock.Id);
+
+        row.NewFilerCount.Should().Be(0);
+        row.SoldOutFilerCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetQuarterlyNewSoldOutPositions_MixedFilersPerStock_CountsBothBuckets()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, "TSLA");
+        var newcomer1 = await SeedHolder(seed, "4");
+        var newcomer2 = await SeedHolder(seed, "5");
+        var exiter = await SeedHolder(seed, "6");
+        var steady = await SeedHolder(seed, "7");
+        // Prior: exiter + steady.
+        seed.Add(MakeHolding(stock, exiter, Prior, shares: 100));
+        seed.Add(MakeHolding(stock, steady, Prior, shares: 200));
+        // Current: newcomer1 + newcomer2 + steady (exiter dropped out).
+        seed.Add(MakeHolding(stock, newcomer1, Current, shares: 500));
+        seed.Add(MakeHolding(stock, newcomer2, Current, shares: 600));
+        seed.Add(MakeHolding(stock, steady, Current, shares: 200));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var row = await sut.GetQuarterlyNewSoldOutPositions(Current, Prior)
+            .SingleAsync(r => r.CommonStockId == stock.Id);
+
+        row.NewFilerCount.Should().Be(2);
+        row.SoldOutFilerCount.Should().Be(1);
+    }
+
+    private static async Task<CommonStock> SeedStock(
+        Equibles.Data.EquiblesDbContext ctx,
+        string ticker
+    )
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Test Corp.",
+            Cik = $"C{Guid.NewGuid().GetHashCode() & int.MaxValue:D8}",
+        };
+        ctx.Add(stock);
+        await ctx.SaveChangesAsync();
+        return stock;
+    }
+
+    private static async Task<InstitutionalHolder> SeedHolder(
+        Equibles.Data.EquiblesDbContext ctx,
+        string cik
+    )
+    {
+        var holder = new InstitutionalHolder { Cik = cik, Name = $"Holder {cik}" };
+        ctx.Add(holder);
+        await ctx.SaveChangesAsync();
+        return holder;
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = shares * 100,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityTests.cs
@@ -1,0 +1,167 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins <c>GetMarketWide13FActivity</c>. The tool dispatches by `bucket` argument over
+/// the same `InstitutionalHoldingRepository.GetQuarterlyActivity` /
+/// `GetQuarterlyNewSoldOutPositions` queries used by the web page; each `Fact` exercises
+/// one bucket to keep its assertions narrow.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetMarketWide13FActivityTests : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetMarketWide13FActivityTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetMarketWide13FActivity_UnknownBucket_ReportsValidValues()
+    {
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetMarketWide13FActivity(bucket: "garbage");
+
+        output.Should().Contain("Unknown bucket");
+        output.Should().Contain("top-buys");
+        output.Should().Contain("sold-out-positions");
+    }
+
+    [Fact]
+    public async Task GetMarketWide13FActivity_NoData_ReportsNoHoldings()
+    {
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetMarketWide13FActivity(bucket: "top-buys");
+
+        output.Should().Contain("No 13F holdings data");
+    }
+
+    [Fact]
+    public async Task GetMarketWide13FActivity_TopBuysBucket_RanksByDeltaValueDescending()
+    {
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "C1",
+        };
+        var msft = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "C2",
+        };
+        var holder = new InstitutionalHolder { Cik = "1", Name = "Big Fund" };
+        DbContext.AddRange(aapl, msft, holder);
+        // AAPL: Δ +500_000 value
+        DbContext.Add(MakeHolding(aapl, holder, prior, shares: 1_000, value: 1_000_000));
+        DbContext.Add(MakeHolding(aapl, holder, current, shares: 1_500, value: 1_500_000));
+        // MSFT: Δ +200_000 value
+        DbContext.Add(MakeHolding(msft, holder, prior, shares: 500, value: 500_000));
+        DbContext.Add(MakeHolding(msft, holder, current, shares: 700, value: 700_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetMarketWide13FActivity(bucket: "top-buys");
+
+        output.Should().Contain("Market-wide 13F **top-buys**");
+        output.Should().Contain("for 2024-12-31");
+        output
+            .IndexOf("AAPL", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("MSFT", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetMarketWide13FActivity_NewPositionsBucket_RanksByInitiatedCount()
+    {
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "C1",
+        };
+        var msft = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "C2",
+        };
+        DbContext.AddRange(aapl, msft);
+        // AAPL gets 3 new filers (none in prior), MSFT gets 1 new filer.
+        for (var i = 0; i < 3; i++)
+        {
+            var h = new InstitutionalHolder { Cik = $"newAAPL{i}", Name = $"New AAPL {i}" };
+            DbContext.Add(h);
+            DbContext.Add(MakeHolding(aapl, h, current, shares: 100, value: 10_000));
+        }
+        var msftNew = new InstitutionalHolder { Cik = "newMSFT", Name = "New MSFT" };
+        DbContext.Add(msftNew);
+        DbContext.Add(MakeHolding(msft, msftNew, current, shares: 100, value: 10_000));
+        // Seed at least one prior-quarter row anywhere so the prior date exists in distinct dates.
+        var anchor = new InstitutionalHolder { Cik = "anchor", Name = "Anchor" };
+        DbContext.Add(anchor);
+        DbContext.Add(MakeHolding(aapl, anchor, prior, shares: 1, value: 100));
+        DbContext.Add(MakeHolding(aapl, anchor, current, shares: 1, value: 100));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetMarketWide13FActivity(bucket: "new-positions");
+
+        output.Should().Contain("new-positions");
+        output.Should().Contain("# Filers Initiated");
+        output
+            .IndexOf("AAPL", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("MSFT", StringComparison.Ordinal));
+    }
+
+    private InstitutionalHoldingsTools NewSut(Equibles.Data.EquiblesDbContext ctx) =>
+        new(
+            new InstitutionalHoldingRepository(ctx),
+            new InstitutionalHolderRepository(ctx),
+            new CommonStockRepository(ctx),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -267,6 +267,7 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("GetInstitutionPortfolio");
         toolNames.Should().Contain("SearchInstitutions");
         toolNames.Should().Contain("GetTopBuyersSellers");
+        toolNames.Should().Contain("GetMarketWide13FActivity");
     }
 
     // ── InsiderTrading module specific ──────────────────────────────────
@@ -357,6 +358,7 @@ public class McpModuleToolDiscoveryTests
                     "GetInstitutionPortfolio",
                     "SearchInstitutions",
                     "GetTopBuyersSellers",
+                    "GetMarketWide13FActivity",
                 }
             },
             {


### PR DESCRIPTION
## Summary

- **Closing slice (3 of 3)** for #1009. Adds the two missing buckets to the market-wide 13F activity surface and exposes the full four-leaderboard set via MCP, so an AI assistant can answer "what's the consensus 13F move this quarter?" with the same data the web page renders.
- New / Sold-out per-stock counts come from a single `GROUP BY CommonStockId` with two `NOT EXISTS` subqueries — `!DbContext.Set<>().Any(...)` translates server-side in EF Core.
- Web page now renders all four cards (Top Buys, Top Sells, New Positions, Sold-out Positions); MCP adds `GetMarketWide13FActivity(bucket, reportDate?, max?)` that dispatches by bucket name.
- Closes #1009.

## Code changes

- `src/Equibles.Holdings.Repositories/Models/MarketWideStockChurn.cs` — per-stock projection: `NewFilerCount` + `SoldOutFilerCount`.
- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — new `GetQuarterlyNewSoldOutPositions(current, previous)`.
- `src/Equibles.Web/ViewModels/Holdings/{HoldingsActivityRow,HoldingsActivityViewModel}.cs` — row now carries `NewFilerCount` / `SoldOutFilerCount`; parent view model gets `NewPositions` / `SoldOutPositions` lists.
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — pulls churn rankings (`Take 20` by filer count) server-side; reuses the same `StockLabel` dictionary lookup as Top Buys / Top Sells.
- `src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml` — adds two more cards (New / Sold-out) to complete the four-card grid; each carries a stable `data-testid`.
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — new `GetMarketWide13FActivity` tool. Bucket argument dispatches to the matching repository query and renders a markdown table; unknown bucket returns a usage hint listing the four valid options.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — module-discovery list updated (both `Contain` assertion and the `Theory`'s expected-tool array).
- `tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryNewSoldOutTests.cs` — 4 ParadeDB tests: only-in-current → New, only-in-prior → Sold-out, in both → neither, mixed multi-filer fixture.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityTests.cs` — 4 tests: unknown-bucket usage hint, no-data path, top-buys ranking, new-positions ranking.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1090 files).
- ParadeDB integration tests for the four impacted areas — **16/16 passing**.
- Module-discovery unit tests — 59/59 passing.

Closes #1009