### PR TITLE
docs(technical/web-portal): list HoldingsActivityController in controller table

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -26,6 +26,7 @@ Why the indirection through `ViewData` rather than a single `StockDetailViewMode
 |---|---|---|
 | [`StocksController`](../../src/Equibles.Web/Controllers/StocksController.cs) | `~/Stocks/...` | The tab pattern above + landing list + `ShowDocument` + `ShowHolder` per-stock holder detail. |
 | [`ProfilesController`](../../src/Equibles.Web/Controllers/ProfilesController.cs) | `~/Institutions/{cik}`, `~/Insiders/{ownerCik}`, `~/Congress/{id}` | Global (not stock-scoped) profile pages for institutional holders, insider owners, and Congress members. |
+| [`HoldingsActivityController`](../../src/Equibles.Web/Controllers/HoldingsActivityController.cs) | `~/Holdings/Activity` | Market-wide quarterly Top Buys / Top Sells boards aggregated across 13F filers for a `ReportDate`. |
 | [`EconomicDataController`](../../src/Equibles.Web/Controllers/EconomicDataController.cs) | `~/Economy/...` | FRED series browsing — category landing + per-series charts. |
 | [`CftcController`](../../src/Equibles.Web/Controllers/CftcController.cs) | `~/Futures/...` | CFTC positioning per contract / category. |
 | [`MarketController`](../../src/Equibles.Web/Controllers/MarketController.cs) | `~/Market/...` | CBOE VIX + put/call ratios. |


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- `HoldingsActivityController` (`~/Holdings/Activity`, added in #1080) was missing from the controllers table in `docs/technical/web-portal.md`. The table is meant to enumerate every web-portal controller — add the row so the catalog matches the code.

## Code changes

- `docs/technical/web-portal.md` — append one row to the "Other controllers" table for `HoldingsActivityController` at `~/Holdings/Activity`, describing the market-wide quarterly Top Buys / Top Sells boards aggregated across 13F filers.