### PR TITLE
docs(technical/mcp-tools): list GetMarketWide13FActivity under Holdings

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -23,6 +23,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetInstitutionPortfolio` — full portfolio of one institution for a `ReportDate`.
 - `SearchInstitutions` — name-search returning matching `InstitutionalHolder` rows.
 - `GetTopBuyersSellers` — biggest absolute share additions and reductions for a ticker vs. the prior `ReportDate`; flags new and sold-out positions.
+- `GetMarketWide13FActivity` — market-wide leaderboard for a quarter, selected by `bucket`: `top-buys`, `top-sells`, `new-positions`, `sold-out-positions`.
 
 ### `mcp.AddInsiderTrading()` — Form 3 / 4
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- `GetMarketWide13FActivity` (added in #1082) is missing from the Holdings section of `docs/technical/mcp-tools.md`. Add the catalog row so docs match the code.

## Code changes

- `docs/technical/mcp-tools.md` — append one bullet under `mcp.AddHoldings()` → `InstitutionalHoldingsTools` describing `GetMarketWide13FActivity` and its `bucket` argument (`top-buys`, `top-sells`, `new-positions`, `sold-out-positions`).