### PR TITLE
docs(technical/web-portal): include New / Sold-Out leaderboards in Activity row

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -26,7 +26,7 @@ Why the indirection through `ViewData` rather than a single `StockDetailViewMode
 |---|---|---|
 | [`StocksController`](../../src/Equibles.Web/Controllers/StocksController.cs) | `~/Stocks/...` | The tab pattern above + landing list + `ShowDocument` + `ShowHolder` per-stock holder detail. |
 | [`ProfilesController`](../../src/Equibles.Web/Controllers/ProfilesController.cs) | `~/Institutions/{cik}`, `~/Insiders/{ownerCik}`, `~/Congress/{id}` | Global (not stock-scoped) profile pages for institutional holders, insider owners, and Congress members. |
-| [`HoldingsActivityController`](../../src/Equibles.Web/Controllers/HoldingsActivityController.cs) | `~/Holdings/Activity` | Market-wide quarterly Top Buys / Top Sells boards aggregated across 13F filers for a `ReportDate`. |
+| [`HoldingsActivityController`](../../src/Equibles.Web/Controllers/HoldingsActivityController.cs) | `~/Holdings/Activity` | Market-wide quarterly leaderboards aggregated across 13F filers for a `ReportDate`: Top Buys, Top Sells, New Positions, Sold-Out Positions. |
 | [`EconomicDataController`](../../src/Equibles.Web/Controllers/EconomicDataController.cs) | `~/Economy/...` | FRED series browsing — category landing + per-series charts. |
 | [`CftcController`](../../src/Equibles.Web/Controllers/CftcController.cs) | `~/Futures/...` | CFTC positioning per contract / category. |
 | [`MarketController`](../../src/Equibles.Web/Controllers/MarketController.cs) | `~/Market/...` | CBOE VIX + put/call ratios. |


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- The `/Holdings/Activity` page now renders four sections (Top Buys, Top Sells, New Positions, Sold-Out Positions per `HoldingsActivityViewModel`), but the controller-table row in `web-portal.md` only mentioned "Top Buys / Top Sells boards". Refresh the description so it matches the rendered page.

## Code changes

- `docs/technical/web-portal.md` — replace the `HoldingsActivityController` row description with the full four-leaderboard list.