### PR TITLE
refactor(web-indicators): extract duplicated RSI expression into RsiFrom local function

### DIFF
--- a/src/Equibles.Web/Services/TechnicalIndicatorService.cs
+++ b/src/Equibles.Web/Services/TechnicalIndicatorService.cs
@@ -95,17 +95,19 @@ public static class TechnicalIndicatorService
         for (var i = 1; i < period; i++)
             result.Add(null);
 
-        // First RSI value. avgLoss == 0 ⇒ RS is infinite ⇒ RSI is 100 by
-        // definition (a window with no losses is the overbought extreme).
-        result.Add(avgLoss == 0 ? 100m : Math.Round(100m - 100m / (1m + avgGain / avgLoss), 2));
+        // avgLoss == 0 ⇒ RS is infinite ⇒ RSI is 100 by definition (a window
+        // with no losses is the overbought extreme).
+        static decimal RsiFrom(decimal avgGain, decimal avgLoss) =>
+            avgLoss == 0 ? 100m : Math.Round(100m - 100m / (1m + avgGain / avgLoss), 2);
 
-        // Smoothed RSI for remaining values
+        result.Add(RsiFrom(avgGain, avgLoss));
+
         for (var i = period + 1; i < prices.Count; i++)
         {
             avgGain = (avgGain * (period - 1) + gains[i]) / period;
             avgLoss = (avgLoss * (period - 1) + losses[i]) / period;
 
-            result.Add(avgLoss == 0 ? 100m : Math.Round(100m - 100m / (1m + avgGain / avgLoss), 2));
+            result.Add(RsiFrom(avgGain, avgLoss));
         }
 
         return result;


### PR DESCRIPTION
## Summary

- \`TechnicalIndicatorService.ComputeRsi\` computed \`avgLoss == 0 ? 100m : Math.Round(100m - 100m / (1m + avgGain / avgLoss), 2)\` in two places (the first-window seed at line 100 and the smoothed-window loop body at line 108). Both call sites now go through a static local function \`RsiFrom(avgGain, avgLoss)\`.
- Behaviour-preserving by construction: the local function holds the exact same expression, called at the same two points with the same inputs; the pre-existing WHY-comment about \`avgLoss == 0 ⇒ RSI = 100\` moves with the expression and now lives next to the helper definition. Rounding, iteration order, null-padding, and the small-input early-return are untouched.

## Code changes

- \`src/Equibles.Web/Services/TechnicalIndicatorService.cs\` — adds a \`static decimal RsiFrom(decimal avgGain, decimal avgLoss)\` local function inside \`ComputeRsi\`; both \`result.Add(...)\` sites now call it. Comment "Smoothed RSI for remaining values" was pure narration of the loop below it (the loop's purpose is now obvious from the helper name + the smoothing arithmetic) so it's removed too.