### PR TITLE
refactor(search-controller): collapse Index / Results view-model build into helper

### DIFF
--- a/src/Equibles.Web/Controllers/SearchController.cs
+++ b/src/Equibles.Web/Controllers/SearchController.cs
@@ -33,35 +33,26 @@ public class SearchController : BaseController
     )
     {
         ViewData["Title"] = "Search";
-
-        // Aggregator returns every non-empty group; the view filters for display so the category
-        // chips can still list all matched categories even when one is selected.
-        var groups = await _searchAggregator.Search(
-            q,
-            ResolveMaxPerProvider(category),
-            HttpContext.RequestAborted,
-            sort,
-            dateFrom,
-            dateTo
-        );
-
-        return View(
-            new GlobalSearchViewModel
-            {
-                Query = q,
-                Groups = groups,
-                ActiveCategory = category,
-                SortBy = sort,
-                DateFrom = dateFrom,
-                DateTo = dateTo,
-            }
-        );
+        return View(await BuildViewModel(q, category, sort, dateFrom, dateTo));
     }
 
     // Results-only fragment for instant (as-you-type) search. instant-search.js fetches this
     // and swaps it into the page; the markup is identical to Index's results region.
     [HttpGet]
     public async Task<IActionResult> Results(
+        string q,
+        string category,
+        SearchSort sort,
+        DateOnly? dateFrom,
+        DateOnly? dateTo
+    )
+    {
+        return PartialView("_Results", await BuildViewModel(q, category, sort, dateFrom, dateTo));
+    }
+
+    // Aggregator returns every non-empty group; the view filters for display so the category
+    // chips can still list all matched categories even when one is selected.
+    private async Task<GlobalSearchViewModel> BuildViewModel(
         string q,
         string category,
         SearchSort sort,
@@ -78,18 +69,15 @@ public class SearchController : BaseController
             dateTo
         );
 
-        return PartialView(
-            "_Results",
-            new GlobalSearchViewModel
-            {
-                Query = q,
-                Groups = groups,
-                ActiveCategory = category,
-                SortBy = sort,
-                DateFrom = dateFrom,
-                DateTo = dateTo,
-            }
-        );
+        return new GlobalSearchViewModel
+        {
+            Query = q,
+            Groups = groups,
+            ActiveCategory = category,
+            SortBy = sort,
+            DateFrom = dateFrom,
+            DateTo = dateTo,
+        };
     }
 
     private static int ResolveMaxPerProvider(string category) =>


### PR DESCRIPTION
## Summary

- \`SearchController.Index\` and \`SearchController.Results\` both invoked \`_searchAggregator.Search\` with the same five parameters and constructed an identical \`GlobalSearchViewModel\` — the only differences were \`View\` vs \`PartialView("_Results", ...)\` and \`ViewData["Title"] = "Search"\` (Index only).
- Extracts a private async helper \`BuildViewModel(q, category, sort, dateFrom, dateTo)\` that both actions delegate to. The pre-existing WHY-comment about the aggregator returning every non-empty group moves with the helper.
- Behaviour-preserving by construction: same aggregator args, same \`HttpContext.RequestAborted\` token, same view-model fields, same view names. Aligns with \`dotnet-standards\`' "thin controllers" guidance.

## Code changes

- \`src/Equibles.Web/Controllers/SearchController.cs\` — adds \`BuildViewModel\`; \`Index\` and \`Results\` shrink to two-statement and one-statement action bodies respectively. Net -12 / +5.