### PR TITLE
feat(holdings-mcp): add GetInstitutionSummary MCP tool (2/2)

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -637,6 +637,98 @@ public class InstitutionalHoldingsTools
         );
     }
 
+    [McpServerTool(Name = "GetInstitutionSummary")]
+    [Description(
+        "Get the portfolio summary header for an institutional 13F filer — Reported AUM, position count, top-10 / top-25 concentration, QoQ turnover, and the latest / prior report dates with the count of quarters reported. Use this to answer 'how big and how concentrated is this fund?' or to compare two funds at a glance. Search resolves by institution name (closest match)."
+    )]
+    public Task<string> GetInstitutionSummary(
+        [Description("Institution name (partial or full — first match wins)")]
+            string institutionName,
+        [Description("Report date in YYYY-MM-DD format (defaults to the holder's latest)")]
+            string reportDate = null
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                var holder = await _holderRepository
+                    .Search(institutionName ?? string.Empty)
+                    .OrderBy(h => h.Name)
+                    .FirstOrDefaultAsync();
+                if (holder == null)
+                    return $"No institution found matching '{institutionName}'.";
+
+                var reportDates = await _holdingRepository
+                    .GetHistoryByHolder(holder)
+                    .Select(h => h.ReportDate)
+                    .Distinct()
+                    .OrderByDescending(d => d)
+                    .ToListAsync();
+                if (reportDates.Count == 0)
+                    return $"No 13F holdings reported by {holder.Name}.";
+
+                DateOnly targetDate;
+                if (
+                    !string.IsNullOrEmpty(reportDate)
+                    && DateOnly.TryParse(reportDate, out var parsed)
+                    && reportDates.Contains(parsed)
+                )
+                    targetDate = parsed;
+                else
+                    targetDate = reportDates[0];
+                var targetIndex = reportDates.IndexOf(targetDate);
+                var previousDate =
+                    targetIndex < reportDates.Count - 1
+                        ? reportDates[targetIndex + 1]
+                        : (DateOnly?)null;
+
+                var currentHoldings = await _holdingRepository
+                    .GetByHolder(holder, targetDate)
+                    .ToListAsync();
+                var previousHoldings = previousDate.HasValue
+                    ? await _holdingRepository.GetByHolder(holder, previousDate.Value).ToListAsync()
+                    : [];
+                var summary = InstitutionPortfolioSummaryCalculator.Calculate(
+                    currentHoldings,
+                    previousHoldings,
+                    reportDates.Count,
+                    targetDate,
+                    previousDate
+                );
+
+                var result = new StringBuilder();
+                result.AppendLine(
+                    $"Portfolio summary — **{holder.Name}** as of {targetDate:yyyy-MM-dd}"
+                );
+                if (previousDate.HasValue)
+                    result.AppendLine($"vs prior quarter {previousDate.Value:yyyy-MM-dd}");
+                result.AppendLine();
+                result.AppendLine("| Metric | Value |");
+                result.AppendLine("|--------|-------|");
+                result.AppendLine($"| Reported AUM | ${summary.ReportedAum:N0} |");
+                result.AppendLine($"| # Positions | {summary.PositionCount:N0} |");
+                result.AppendLine(
+                    $"| Top 10 concentration | {summary.Top10ConcentrationPercent:F1}% |"
+                );
+                result.AppendLine(
+                    $"| Top 25 concentration | {summary.Top25ConcentrationPercent:F1}% |"
+                );
+                result.AppendLine($"| QoQ turnover | {summary.QoQTurnoverPercent:F1}% |");
+                result.AppendLine($"| Quarters reported | {summary.QuartersReported} |");
+                result.AppendLine();
+                result.AppendLine(
+                    "_QoQ turnover = (Σ |Δ shares × current price proxy|) / (2 × AUM), where the per-share price proxy is the current quarter's Value / Shares._"
+                );
+
+                return result.ToString();
+            },
+            _logger,
+            "GetInstitutionSummary",
+            $"institution: {institutionName}",
+            ReportError
+        );
+    }
+
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs
@@ -1,0 +1,151 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins <c>GetInstitutionSummary</c>. Resolves the holder via the name-search query,
+/// pulls current + prior quarter holdings, and feeds them to the same
+/// <see cref="InstitutionPortfolioSummaryCalculator"/> the web profile uses. Each
+/// <see cref="Fact"/> exercises one path so a regression in lookup or calculation
+/// surfaces as a focused assertion.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetInstitutionSummaryTests : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetInstitutionSummaryTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetInstitutionSummary_UnknownInstitution_ReportsNotFound()
+    {
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionSummary("Definitely Not A Fund");
+
+        output.Should().Contain("No institution found");
+    }
+
+    [Fact]
+    public async Task GetInstitutionSummary_HolderWithNoHoldings_ReportsNoData()
+    {
+        DbContext.Add(new InstitutionalHolder { Cik = "00010001", Name = "Brand New Capital LP" });
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionSummary("Brand New");
+
+        output.Should().Contain("No 13F holdings reported by Brand New Capital LP");
+    }
+
+    [Fact]
+    public async Task GetInstitutionSummary_TwoQuarterHolder_RendersAllMetricsAndCaption()
+    {
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var msft = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+        };
+        var holder = new InstitutionalHolder { Cik = "00010002", Name = "Big Fund LP" };
+        DbContext.AddRange(aapl, msft, holder);
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        // Prior + current with movement on AAPL.
+        DbContext.Add(MakeHolding(aapl, holder, prior, shares: 1_000, value: 1_000_000));
+        DbContext.Add(MakeHolding(msft, holder, prior, shares: 500, value: 500_000));
+        DbContext.Add(MakeHolding(aapl, holder, current, shares: 1_500, value: 1_500_000));
+        DbContext.Add(MakeHolding(msft, holder, current, shares: 500, value: 500_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionSummary("Big Fund");
+
+        output.Should().Contain("Portfolio summary — **Big Fund LP** as of 2024-12-31");
+        output.Should().Contain("vs prior quarter 2024-09-30");
+        output.Should().Contain("Reported AUM");
+        output.Should().Contain("# Positions");
+        output.Should().Contain("Top 10 concentration");
+        output.Should().Contain("Top 25 concentration");
+        output.Should().Contain("QoQ turnover");
+        output.Should().Contain("Quarters reported");
+        output.Should().Contain("_QoQ turnover = (");
+    }
+
+    [Fact]
+    public async Task GetInstitutionSummary_ExplicitReportDate_HonorsArgumentWhenItMatches()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "TSLA",
+            Name = "Tesla Inc.",
+            Cik = "0001318605",
+        };
+        var holder = new InstitutionalHolder { Cik = "00010003", Name = "Targeted Capital" };
+        DbContext.AddRange(stock, holder);
+        var q3 = new DateOnly(2024, 9, 30);
+        var q4 = new DateOnly(2024, 12, 31);
+        DbContext.Add(MakeHolding(stock, holder, q3, shares: 100, value: 100_000));
+        DbContext.Add(MakeHolding(stock, holder, q4, shares: 500, value: 500_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionSummary("Targeted Capital", reportDate: "2024-09-30");
+
+        output.Should().Contain("as of 2024-09-30");
+        // No prior quarter further back, so the "vs prior" line MUST be absent.
+        output.Should().NotContain("vs prior quarter");
+    }
+
+    private InstitutionalHoldingsTools NewSut(Equibles.Data.EquiblesDbContext ctx) =>
+        new(
+            new InstitutionalHoldingRepository(ctx),
+            new InstitutionalHolderRepository(ctx),
+            new CommonStockRepository(ctx),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -268,6 +268,7 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("SearchInstitutions");
         toolNames.Should().Contain("GetTopBuyersSellers");
         toolNames.Should().Contain("GetMarketWide13FActivity");
+        toolNames.Should().Contain("GetInstitutionSummary");
     }
 
     // ── InsiderTrading module specific ──────────────────────────────────
@@ -359,6 +360,7 @@ public class McpModuleToolDiscoveryTests
                     "SearchInstitutions",
                     "GetTopBuyersSellers",
                     "GetMarketWide13FActivity",
+                    "GetInstitutionSummary",
                 }
             },
             {


### PR DESCRIPTION
## Summary

- **Closing slice (2 of 2)** for #1011. Mirrors the web profile header strip landed in #1090 — an MCP tool that resolves an institution by name and returns the same five metrics (AUM, position count, top-10 / top-25 concentration, QoQ turnover) plus quarters-reported and latest / prior report dates, as a markdown table.
- Reuses the `InstitutionPortfolioSummaryCalculator` from `Equibles.Holdings.Repositories` so web and MCP share the same math without duplication.
- Closes #1011.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — new `GetInstitutionSummary(institutionName, reportDate?)`. Resolves the holder via the existing `Search` query (first match wins), falls back to the holder's latest report date when the supplied `reportDate` isn't in the holder's history, and emits a markdown table + a one-line caption explaining the QoQ turnover formula.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — module-discovery list updated.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs` — 4 ParadeDB tests: unknown-institution, holder with no holdings, two-quarter holder full-render, explicit `reportDate` honored with no prior further back.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1095 files).
- New MCP integration tests — 4/4 passing.
- Module-discovery unit tests — 59/59 passing.

Closes #1011