### PR TITLE
docs(technical/mcp-tools): list GetInstitutionSummary under Holdings

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -24,6 +24,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `SearchInstitutions` — name-search returning matching `InstitutionalHolder` rows.
 - `GetTopBuyersSellers` — biggest absolute share additions and reductions for a ticker vs. the prior `ReportDate`; flags new and sold-out positions.
 - `GetMarketWide13FActivity` — market-wide leaderboard for a quarter, selected by `bucket`: `top-buys`, `top-sells`, `new-positions`, `sold-out-positions`.
+- `GetInstitutionSummary` — portfolio header for one filer at a `ReportDate`: AUM, position count, top-10 / top-25 concentration, QoQ turnover, latest / prior dates.
 
 ### `mcp.AddInsiderTrading()` — Form 3 / 4
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- `GetInstitutionSummary` (added in #1094) is missing from the Holdings section of `docs/technical/mcp-tools.md`. Add the catalog bullet so the catalog matches the code.

## Code changes

- `docs/technical/mcp-tools.md` — append one bullet under `mcp.AddHoldings()` → `InstitutionalHoldingsTools` describing `GetInstitutionSummary` (portfolio header — AUM, position count, top-10 / top-25 concentration, QoQ turnover, latest / prior dates).