### PR TITLE
refactor(holdings-mcp): collapse duplicated holder aggregation into AggregateByHolder local function

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
+using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Mcp;
 using Microsoft.EntityFrameworkCore;
@@ -365,28 +366,23 @@ public class InstitutionalHoldingsTools
                 // TODO(#1008): the same aggregation/grouping logic lives in
                 // Equibles.Web.Services.HoldingsPositionGrouper. Consolidate into a shared
                 // Equibles.Holdings.BusinessLogic project once one exists.
-                var currentByHolder = currentHoldings
-                    .GroupBy(h => h.InstitutionalHolderId)
-                    .ToDictionary(
-                        g => g.Key,
-                        g => new HolderAggregate
-                        {
-                            Name = g.First().InstitutionalHolder?.Name ?? "Unknown",
-                            Shares = g.Sum(h => h.Shares),
-                            Value = g.Sum(h => h.Value),
-                        }
-                    );
-                var previousByHolder = previousHoldings
-                    .GroupBy(h => h.InstitutionalHolderId)
-                    .ToDictionary(
-                        g => g.Key,
-                        g => new HolderAggregate
-                        {
-                            Name = g.First().InstitutionalHolder?.Name ?? "Unknown",
-                            Shares = g.Sum(h => h.Shares),
-                            Value = g.Sum(h => h.Value),
-                        }
-                    );
+                static Dictionary<Guid, HolderAggregate> AggregateByHolder(
+                    List<InstitutionalHolding> holdings
+                ) =>
+                    holdings
+                        .GroupBy(h => h.InstitutionalHolderId)
+                        .ToDictionary(
+                            g => g.Key,
+                            g => new HolderAggregate
+                            {
+                                Name = g.First().InstitutionalHolder?.Name ?? "Unknown",
+                                Shares = g.Sum(h => h.Shares),
+                                Value = g.Sum(h => h.Value),
+                            }
+                        );
+
+                var currentByHolder = AggregateByHolder(currentHoldings);
+                var previousByHolder = AggregateByHolder(previousHoldings);
 
                 var allHolderIds = currentByHolder.Keys.Union(previousByHolder.Keys);
                 var movers = allHolderIds


### PR DESCRIPTION
## Summary

- `GetTopBuyersSellers` built two `Dictionary<Guid, HolderAggregate>` projections (one for the current quarter, one for the prior) with byte-for-byte identical `GroupBy → ToDictionary` shapes — only the source list differed.
- Collapsed both into a single `static` local function `AggregateByHolder(List<InstitutionalHolding>)`, called twice. Pure structural extraction — no observable behavior change (same key/value expressions, same null handling, same enumeration semantics).

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs`
  - Added `using Equibles.Holdings.Data.Models;` so the local function can type its parameter.
  - Replaced the two 11-line projection blocks with a single `static Dictionary<Guid, HolderAggregate> AggregateByHolder(List<InstitutionalHolding>)` local function plus two one-line calls.
  - Preserved the existing `// TODO(#1008): …` comment that tracks consolidating with `HoldingsPositionGrouper`.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet tool run csharpier check .` — green (1090 files).
- `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj --no-build -c Release` — 1352/1352 pass.
- Integration tests (`InstitutionalHoldingsToolsGetTopBuyersSellersTests`) require Docker / Testcontainers; CI will run them on this PR.