### PR TITLE
refactor(sec-facts): extract within-batch dedup into CollapseToNaturalKey

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -115,24 +115,7 @@ public class FinancialFactsImportService
                 );
             }
 
-            // SEC emits the same (concept, unit, period, accession) tuple more
-            // than once (frame vs non-frame duplicates, restatement re-emits).
-            // Postgres ON CONFLICT DO UPDATE rejects a batch that targets the
-            // same row twice, so collapse to one row per unique-index key,
-            // keeping the latest-filed value.
-            var facts = built
-                .GroupBy(f =>
-                    (
-                        f.CommonStockId,
-                        f.FinancialConceptId,
-                        f.Unit,
-                        f.PeriodStart,
-                        f.PeriodEnd,
-                        f.AccessionNumber
-                    )
-                )
-                .Select(g => g.OrderByDescending(f => f.FiledDate).First())
-                .ToList();
+            var facts = CollapseToNaturalKey(built);
 
             // SyncStatus is advanced only here, after a successful persist, so a
             // failure leaves the checkpoint un-advanced and the company is
@@ -457,6 +440,26 @@ public class FinancialFactsImportService
                 return false;
         }
     }
+
+    // SEC emits the same (concept, unit, period, accession) tuple more
+    // than once (frame vs non-frame duplicates, restatement re-emits).
+    // Postgres ON CONFLICT DO UPDATE rejects a batch that targets the
+    // same row twice, so collapse to one row per unique-index key,
+    // keeping the latest-filed value.
+    private static List<FinancialFact> CollapseToNaturalKey(List<FinancialFact> built) =>
+        built
+            .GroupBy(f =>
+                (
+                    f.CommonStockId,
+                    f.FinancialConceptId,
+                    f.Unit,
+                    f.PeriodStart,
+                    f.PeriodEnd,
+                    f.AccessionNumber
+                )
+            )
+            .Select(g => g.OrderByDescending(f => f.FiledDate).First())
+            .ToList();
 
     private sealed class ParsedFact
     {


### PR DESCRIPTION
## Summary

- Pulls the within-batch dedup LINQ chain out of \`FinancialFactsImportService.Import\` (15 lines: \`GroupBy(...).OrderByDescending(FiledDate).First().ToList()\`) into a private static helper \`CollapseToNaturalKey\`.
- Behaviour-preserving by construction: same composite grouping key \`(CommonStockId, FinancialConceptId, Unit, PeriodStart, PeriodEnd, AccessionNumber)\`, same \`OrderByDescending(FiledDate).First()\` selection, same \`.ToList()\` materialisation. The pre-existing WHY-comment about Postgres \`ON CONFLICT DO UPDATE\` rejecting same-target rows moves with it.
- \`Import\` body's collapse step becomes a one-liner; the helper's name documents the contract better than the inline chain did.

## Code changes

- \`src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs\` — extracts \`CollapseToNaturalKey(List<FinancialFact>)\` next to the other private helpers at the bottom of the class. Call site at line 118 collapses to a single statement.