### PR TITLE
feat(holdings): add Institution profile sector allocation card (1/2)

### DIFF
--- a/src/Equibles.Holdings.Repositories/IndustryAllocationCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/IndustryAllocationCalculator.cs
@@ -1,0 +1,53 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Holdings.Repositories;
+
+public static class IndustryAllocationCalculator
+{
+    // currentQuarterHoldings MUST be materialized with the CommonStock.Industry navigation
+    // populated (Include(h => h.CommonStock.Industry) at the query site) — the calculator
+    // only reads the loaded references, never triggers lazy loads.
+    public static List<IndustryAllocationSlice> Calculate(
+        IReadOnlyList<InstitutionalHolding> currentQuarterHoldings
+    )
+    {
+        if (currentQuarterHoldings.Count == 0)
+            return [];
+
+        var totalValue = currentQuarterHoldings.Sum(h => h.Value);
+
+        // Group by industry id (null collapses into one bucket); the per-stock aggregation
+        // below ensures a holder reporting the same stock across multiple discretion rows
+        // is counted as ONE position in the allocation, not multiple.
+        var byIndustry = currentQuarterHoldings
+            .GroupBy(h => h.CommonStock?.IndustryId)
+            .Select(industryGroup =>
+            {
+                var industryId = industryGroup.Key;
+                var industryName =
+                    industryGroup.FirstOrDefault()?.CommonStock?.Industry?.Name
+                    ?? IndustryAllocationSlice.UnclassifiedName;
+                var perStock = industryGroup
+                    .GroupBy(h => h.CommonStockId)
+                    .Select(stockGroup => new { Value = stockGroup.Sum(h => h.Value) })
+                    .ToList();
+                var industryValue = perStock.Sum(p => p.Value);
+                return new IndustryAllocationSlice
+                {
+                    IndustryId = industryId,
+                    IndustryName = industryName,
+                    PositionCount = perStock.Count,
+                    TotalValue = industryValue,
+                    PercentOfPortfolio =
+                        totalValue > 0 ? (double)industryValue / totalValue * 100.0 : 0,
+                };
+            })
+            // Unclassified always last, even if its value would otherwise rank it higher.
+            .OrderBy(s => s.IndustryId == null ? 1 : 0)
+            .ThenByDescending(s => s.TotalValue)
+            .ToList();
+
+        return byIndustry;
+    }
+}

--- a/src/Equibles.Holdings.Repositories/Models/IndustryAllocationSlice.cs
+++ b/src/Equibles.Holdings.Repositories/Models/IndustryAllocationSlice.cs
@@ -1,0 +1,14 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class IndustryAllocationSlice
+{
+    // null when the slice represents holdings without an IndustryId — see UnclassifiedName.
+    public Guid? IndustryId { get; set; }
+
+    public string IndustryName { get; set; }
+    public int PositionCount { get; set; }
+    public long TotalValue { get; set; }
+    public double PercentOfPortfolio { get; set; }
+
+    public const string UnclassifiedName = "Unclassified";
+}

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -64,15 +64,15 @@ public class ProfilesController : BaseController
             })
             .ToListAsync();
 
-        // Header strip — pulled with two extra per-quarter materializations so the
-        // existing recent-rows list keeps its top-50 shape.
+        // Header strip + industry allocation — pulled with extra per-quarter
+        // materializations so the existing recent-rows list keeps its top-50 shape.
         var distinctDates = await _institutionalHoldingRepository
             .GetHistoryByHolder(holder)
             .Select(h => h.ReportDate)
             .Distinct()
             .OrderByDescending(d => d)
             .ToListAsync();
-        var summary = await BuildSummary(holder, distinctDates);
+        var (summary, industryAllocation) = await BuildSummaryAndAllocation(holder, distinctDates);
 
         ViewData["Title"] = holder.Name;
         return View(
@@ -83,22 +83,34 @@ public class ProfilesController : BaseController
                 Location = ProfileFormatting.JoinLocation(holder.City, holder.StateOrCountry),
                 Holdings = holdings,
                 Summary = summary,
+                IndustryAllocation = industryAllocation,
             }
         );
     }
 
-    private async Task<InstitutionPortfolioSummary> BuildSummary(
+    private async Task<(
+        InstitutionPortfolioSummary Summary,
+        List<IndustryAllocationSlice> Allocation
+    )> BuildSummaryAndAllocation(
         InstitutionalHolder holder,
         IReadOnlyList<DateOnly> distinctReportDates
     )
     {
         if (distinctReportDates.Count == 0)
-            return new InstitutionPortfolioSummary { QuartersReported = 0 };
+            return (new InstitutionPortfolioSummary { QuartersReported = 0 }, []);
 
         var latest = distinctReportDates[0];
         var previous = distinctReportDates.Count > 1 ? distinctReportDates[1] : (DateOnly?)null;
+        // Current quarter loaded twice — shallow for the summary calculator and again with
+        // the Industry navigation for the allocation calculator. Kept separate so the
+        // summary path doesn't pay the Industry join cost.
         var currentHoldings = await _institutionalHoldingRepository
             .GetByHolder(holder, latest)
+            .ToListAsync();
+        var currentHoldingsWithIndustry = await _institutionalHoldingRepository
+            .GetByHolder(holder, latest)
+            .Include(h => h.CommonStock)
+                .ThenInclude(s => s.Industry)
             .ToListAsync();
         var previousHoldings = previous.HasValue
             ? await _institutionalHoldingRepository
@@ -106,13 +118,15 @@ public class ProfilesController : BaseController
                 .ToListAsync()
             : [];
 
-        return InstitutionPortfolioSummaryCalculator.Calculate(
+        var summary = InstitutionPortfolioSummaryCalculator.Calculate(
             currentHoldings,
             previousHoldings,
             distinctReportDates.Count,
             latest,
             previous
         );
+        var allocation = IndustryAllocationCalculator.Calculate(currentHoldingsWithIndustry);
+        return (summary, allocation);
     }
 
     [HttpGet("~/Insiders/{ownerCik}")]

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
@@ -9,4 +9,5 @@ public class InstitutionProfileViewModel
     public string Location { get; set; }
     public List<HoldingRowViewModel> Holdings { get; set; } = [];
     public InstitutionPortfolioSummary Summary { get; set; } = new();
+    public List<IndustryAllocationSlice> IndustryAllocation { get; set; } = [];
 }

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -49,6 +49,46 @@
         </div>
     }
 
+    @if (Model.IndustryAllocation.Count > 0) {
+        <!-- Sector / industry allocation for the latest reported quarter. Unclassified
+             stocks (no IndustryId on CommonStock) collapse into a single row at the end. -->
+        <div class="card bg-base-100 shadow-sm mb-8" data-testid="institution-industry-allocation">
+            <div class="card-body p-4">
+                <div class="flex items-center justify-between mb-3">
+                    <h3 class="text-base font-medium m-0">Sector allocation</h3>
+                    <span class="text-xs text-base-content/50">@Model.IndustryAllocation.Count slices</span>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="table table-zebra table-sm">
+                        <thead>
+                            <tr>
+                                <th>Industry</th>
+                                <th class="text-right"># Positions</th>
+                                <th class="text-right">Value (USD)</th>
+                                <th class="text-right">% of portfolio</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var slice in Model.IndustryAllocation) {
+                                <tr>
+                                    <td>
+                                        @slice.IndustryName
+                                        @if (slice.IndustryId == null) {
+                                            <span class="badge badge-ghost badge-xs ml-2">no industry</span>
+                                        }
+                                    </td>
+                                    <td class="text-right font-mono">@slice.PositionCount.ToString("N0")</td>
+                                    <td class="text-right font-mono">$@slice.TotalValue.ToString("N0")</td>
+                                    <td class="text-right font-mono">@slice.PercentOfPortfolio.ToString("F1")%</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    }
+
     <h2 class="text-xl font-semibold mb-3">Recent holdings</h2>
     @if (Model.Holdings.Count == 0) {
         <div class="text-base-content/60 py-8">No reported holdings.</div>

--- a/tests/Equibles.IntegrationTests/Web/ProfilesInstitutionIndustryAllocationTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesInstitutionIndustryAllocationTests.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the Institution profile's sector-allocation card end-to-end: the controller
+/// joins through CommonStock.Industry, the calculator's Unclassified bucket collapses
+/// nullable IndustryIds, and the view renders one row per industry plus the
+/// Unclassified row when the seed contains industry-less stocks.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class ProfilesInstitutionIndustryAllocationTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public ProfilesInstitutionIndustryAllocationTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetInstitution_WithMixedIndustriesAndUnclassified_RendersAllSlices()
+    {
+        var holderCik = "0001500001";
+        var holderId = Guid.NewGuid();
+        var softwareId = Guid.NewGuid();
+        var energyId = Guid.NewGuid();
+        var aaplId = Guid.NewGuid();
+        var msftId = Guid.NewGuid();
+        var xomId = Guid.NewGuid();
+        var unclassifiedId = Guid.NewGuid();
+        var reportDate = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.AddRange(
+                new Industry { Id = softwareId, Name = "Software" },
+                new Industry { Id = energyId, Name = "Energy" }
+            );
+            db.AddRange(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                    IndustryId = softwareId,
+                },
+                new CommonStock
+                {
+                    Id = msftId,
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corp.",
+                    Cik = "0000789019",
+                    IndustryId = softwareId,
+                },
+                new CommonStock
+                {
+                    Id = xomId,
+                    Ticker = "XOM",
+                    Name = "Exxon Mobil Corp.",
+                    Cik = "0000034088",
+                    IndustryId = energyId,
+                },
+                new CommonStock
+                {
+                    Id = unclassifiedId,
+                    Ticker = "OBSCURE",
+                    Name = "Obscure Inc.",
+                    Cik = "0009999999",
+                    IndustryId = null,
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = holderCik,
+                    Name = "Allocator LP",
+                }
+            );
+            db.Add(MakeHolding(aaplId, holderId, reportDate, value: 2_000_000));
+            db.Add(MakeHolding(msftId, holderId, reportDate, value: 1_000_000));
+            db.Add(MakeHolding(xomId, holderId, reportDate, value: 500_000));
+            db.Add(MakeHolding(unclassifiedId, holderId, reportDate, value: 250_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync($"/Institutions/{holderCik}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("data-testid=\"institution-industry-allocation\"");
+        html.Should().Contain("Sector allocation");
+        html.Should().Contain("Software");
+        html.Should().Contain("Energy");
+        html.Should().Contain("Unclassified");
+        html.Should().Contain("no industry"); // the badge attached to the Unclassified row
+
+        // Software's 3M leads, then Energy's 500k, then Unclassified's 250k (always last).
+        // Anchor the substring search inside the allocation card so unrelated occurrences
+        // (e.g. industry names embedded in JS bundle paths) don't confuse the order check.
+        var cardStart = html.IndexOf(
+            "data-testid=\"institution-industry-allocation\"",
+            StringComparison.Ordinal
+        );
+        var cardEnd = html.IndexOf("Recent holdings", cardStart, StringComparison.Ordinal);
+        var card = html.Substring(cardStart, cardEnd - cardStart);
+        var softwareIdx = card.IndexOf("Software", StringComparison.Ordinal);
+        var energyIdx = card.IndexOf("Energy", StringComparison.Ordinal);
+        var unclassifiedIdx = card.IndexOf("Unclassified", StringComparison.Ordinal);
+        softwareIdx.Should().BeLessThan(energyIdx);
+        energyIdx.Should().BeLessThan(unclassifiedIdx);
+    }
+
+    [Fact]
+    public async Task GetInstitution_NoHoldings_DoesNotRenderAllocationCard()
+    {
+        var holderCik = "0001500002";
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(new InstitutionalHolder { Cik = holderCik, Name = "Empty LP" });
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync($"/Institutions/{holderCik}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().NotContain("data-testid=\"institution-industry-allocation\"");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = value / 100,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stockId:N}".Substring(0, 12) + $"-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Holdings/IndustryAllocationCalculatorTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/IndustryAllocationCalculatorTests.cs
@@ -1,0 +1,132 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class IndustryAllocationCalculatorTests
+{
+    [Fact]
+    public void Calculate_EmptyHoldings_ReturnsEmptyList()
+    {
+        var result = IndustryAllocationCalculator.Calculate([]);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Calculate_SingleIndustry_IsOneHundredPercent()
+    {
+        var industry = new Industry { Name = "Software" };
+        var stock = MakeStock(industry);
+        var holding = MakeHolding(stock, value: 1_000_000);
+
+        var result = IndustryAllocationCalculator.Calculate([holding]);
+
+        result.Should().ContainSingle();
+        result[0].IndustryName.Should().Be("Software");
+        result[0].PositionCount.Should().Be(1);
+        result[0].TotalValue.Should().Be(1_000_000);
+        result[0].PercentOfPortfolio.Should().Be(100.0);
+    }
+
+    [Fact]
+    public void Calculate_MultipleIndustries_OrderedByValueDescending()
+    {
+        var software = new Industry { Id = Guid.NewGuid(), Name = "Software" };
+        var energy = new Industry { Id = Guid.NewGuid(), Name = "Energy" };
+        var holdings = new[]
+        {
+            MakeHolding(MakeStock(software), value: 1_000_000),
+            MakeHolding(MakeStock(software), value: 500_000),
+            MakeHolding(MakeStock(energy), value: 300_000),
+        };
+
+        var result = IndustryAllocationCalculator.Calculate(holdings);
+
+        result.Should().HaveCount(2);
+        result[0].IndustryName.Should().Be("Software");
+        result[0].TotalValue.Should().Be(1_500_000);
+        result[0].PositionCount.Should().Be(2);
+        result[1].IndustryName.Should().Be("Energy");
+        result[1].TotalValue.Should().Be(300_000);
+        // 1.5M / 1.8M ≈ 83.33%
+        result[0].PercentOfPortfolio.Should().BeApproximately(83.33, precision: 0.01);
+        result[1].PercentOfPortfolio.Should().BeApproximately(16.67, precision: 0.01);
+    }
+
+    [Fact]
+    public void Calculate_NullIndustry_ProducesUnclassifiedSlice()
+    {
+        var holding = MakeHolding(MakeStock(industry: null), value: 250_000);
+
+        var result = IndustryAllocationCalculator.Calculate([holding]);
+
+        result.Should().ContainSingle();
+        result[0].IndustryId.Should().BeNull();
+        result[0].IndustryName.Should().Be(IndustryAllocationSlice.UnclassifiedName);
+    }
+
+    [Fact]
+    public void Calculate_UnclassifiedAlwaysLast_EvenWhenItHoldsTheLargestValue()
+    {
+        var energy = new Industry { Id = Guid.NewGuid(), Name = "Energy" };
+        var classified = MakeHolding(MakeStock(energy), value: 100_000);
+        var unclassified1 = MakeHolding(MakeStock(industry: null), value: 5_000_000);
+        var unclassified2 = MakeHolding(MakeStock(industry: null), value: 2_000_000);
+
+        var result = IndustryAllocationCalculator.Calculate([
+            classified,
+            unclassified1,
+            unclassified2,
+        ]);
+
+        result.Should().HaveCount(2);
+        result[0].IndustryName.Should().Be("Energy");
+        result[1].IndustryName.Should().Be(IndustryAllocationSlice.UnclassifiedName);
+        result[1].PositionCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Calculate_MultipleRowsSameStock_CountsOnePosition()
+    {
+        var industry = new Industry { Id = Guid.NewGuid(), Name = "Software" };
+        var stock = MakeStock(industry);
+        // Same stock reported twice with different InstitutionalHolderIds (multi-manager case).
+        var holding1 = MakeHolding(stock, value: 300_000);
+        var holding2 = MakeHolding(stock, value: 700_000);
+
+        var result = IndustryAllocationCalculator.Calculate([holding1, holding2]);
+
+        result.Should().ContainSingle();
+        result[0].PositionCount.Should().Be(1);
+        result[0].TotalValue.Should().Be(1_000_000);
+    }
+
+    private static CommonStock MakeStock(Industry industry) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "STOCK",
+            Name = "Test Corp.",
+            Cik = "C" + Guid.NewGuid().ToString("N")[..7],
+            IndustryId = industry?.Id,
+            Industry = industry,
+        };
+
+    private static InstitutionalHolding MakeHolding(CommonStock stock, long value) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            CommonStock = stock,
+            InstitutionalHolderId = Guid.NewGuid(),
+            FilingDate = new DateOnly(2025, 1, 15),
+            ReportDate = new DateOnly(2024, 12, 31),
+            Shares = value / 100,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+        };
+}


### PR DESCRIPTION
## Summary

- **Slice 1 of 2** for #1012. Adds a Sector Allocation card to `/Institutions/{cik}` that aggregates the latest reported quarter's holdings by `CommonStock.Industry`, rendering an industry × position-count × value × percent-of-portfolio table. Holdings without an `IndustryId` collapse into a single Unclassified row that's always rendered last.
- Backing calculator is a pure static helper in `Equibles.Holdings.Repositories` — reused by the MCP tool in slice 2.
- `Refs #1012` — not the closing slice.

## Code changes

- `src/Equibles.Holdings.Repositories/Models/IndustryAllocationSlice.cs` — projection (industry id nullable, name, position count, value, percent, `Unclassified` constant).
- `src/Equibles.Holdings.Repositories/IndustryAllocationCalculator.cs` — pure `Calculate(currentQuarterHoldings)`. Per-stock aggregation inside each industry so multi-manager rows don't inflate the position count; null `IndustryId` routes into Unclassified; sort puts classified industries first by value desc and Unclassified last.
- `src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs` — `IndustryAllocation` list.
- `src/Equibles.Web/Controllers/ProfilesController.cs` — current quarter re-materialized with `Include(CommonStock).ThenInclude(Industry)` so the calculator only reads loaded references; existing summary path keeps the shallow load.
- `src/Equibles.Web/Views/Profiles/Institution.cshtml` — DaisyUI card with a zebra-striped table; the Unclassified row carries a small `no industry` badge.
- `tests/Equibles.UnitTests/Holdings/IndustryAllocationCalculatorTests.cs` — 6 unit tests covering empty, single industry, multi-industry sort, null → Unclassified, Unclassified-always-last, multi-row aggregation.
- `tests/Equibles.IntegrationTests/Web/ProfilesInstitutionIndustryAllocationTests.cs` — 2 `WebHostFixture` tests: mixed-industries with Unclassified row order (anchored inside the card to avoid false matches), and no-holdings path that hides the card.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1099 files).
- Calculator unit tests — 6/6 passing.
- WebHostFixture integration tests — 2/2 passing.

Refs #1012