### PR TITLE
docs(technical/migrations): tighten BM25 index consumers bullet to active voice

### DIFF
--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -59,7 +59,7 @@ The `Equibles.ParadeDB.EntityFrameworkCore` package provides the `UseParadeDb()`
 The SEC `Chunk` table carries a BM25 index over `(Id, Content, DocumentType, DocumentId, Ticker, ReportingDate)`:
 
 - Declared in `Equibles.Sec.Data.Models.ChunkConfiguration` via the extension method `HasMethod("bm25")` from the ParadeDB EF provider.
-- The index is used by `RagSearchTools` for vector-free keyword search and by `DocumentTextTools.SearchDocumentKeyword` for in-document search.
+- `RagSearchTools` queries it for vector-free keyword search; `DocumentTextTools.SearchDocumentKeyword` queries it for in-document search.
 - First creation is slow (multi-minute on a fully-populated table); subsequent migrations that touch the index incur the same cost.
 
 ## `NULLS NOT DISTINCT` unique indexes


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- BM25 index bullet in `docs/technical/migrations.md` was passive: "The index is used by `RagSearchTools` … and by `DocumentTextTools.SearchDocumentKeyword` …". The technical-docs writing rule prefers active voice ("X reads Y", not "Y is read by X"). Rewrite the bullet so the consumers are the subjects.

## Code changes

- `docs/technical/migrations.md` — replace the passive bullet under "BM25 indexes" with an active-voice equivalent: `RagSearchTools` queries the index for vector-free keyword search; `DocumentTextTools.SearchDocumentKeyword` queries it for in-document search.