### PR TITLE
refactor(insider-trading): collapse <field><value> XML traversal into GetWrappedValue helper

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -295,37 +295,27 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         bool isAmendment
     )
     {
-        var securityTitle = txElement.Element("securityTitle")?.Element("value")?.Value?.Trim();
-        var transactionDateStr = txElement.Element("transactionDate")?.Element("value")?.Value;
+        var securityTitle = GetWrappedValue(txElement, "securityTitle")?.Trim();
+        var transactionDateStr = GetWrappedValue(txElement, "transactionDate");
         var codeStr = txElement
             .Element("transactionCoding")
             ?.Element("transactionCode")
             ?.Value?.Trim();
-        var sharesStr = txElement
-            .Element("transactionAmounts")
-            ?.Element("transactionShares")
-            ?.Element("value")
-            ?.Value;
-        var priceStr = txElement
-            .Element("transactionAmounts")
-            ?.Element("transactionPricePerShare")
-            ?.Element("value")
-            ?.Value;
-        var adCode = txElement
-            .Element("transactionAmounts")
-            ?.Element("transactionAcquiredDisposedCode")
-            ?.Element("value")
-            ?.Value?.Trim();
-        var sharesAfterStr = txElement
-            .Element("postTransactionAmounts")
-            ?.Element("sharesOwnedFollowingTransaction")
-            ?.Element("value")
-            ?.Value;
-        var ownership = txElement
-            .Element("ownershipNature")
-            ?.Element("directOrIndirectOwnership")
-            ?.Element("value")
-            ?.Value?.Trim();
+        var sharesStr = GetWrappedValue(txElement, "transactionAmounts", "transactionShares");
+        var priceStr = GetWrappedValue(txElement, "transactionAmounts", "transactionPricePerShare");
+        var adCode = GetWrappedValue(
+            txElement,
+            "transactionAmounts",
+            "transactionAcquiredDisposedCode"
+        )
+            ?.Trim();
+        var sharesAfterStr = GetWrappedValue(
+            txElement,
+            "postTransactionAmounts",
+            "sharesOwnedFollowingTransaction"
+        );
+        var ownership = GetWrappedValue(txElement, "ownershipNature", "directOrIndirectOwnership")
+            ?.Trim();
 
         // Form 4 transactionDate is ISO yyyy-MM-dd (ownership XSD). Parse it
         // culture-independently — under a non-Gregorian host culture (e.g.
@@ -368,20 +358,18 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         bool isAmendment
     )
     {
-        var securityTitle = holdingElement
-            .Element("securityTitle")
-            ?.Element("value")
-            ?.Value?.Trim();
-        var sharesStr = holdingElement
-            .Element("postTransactionAmounts")
-            ?.Element("sharesOwnedFollowingTransaction")
-            ?.Element("value")
-            ?.Value;
-        var ownership = holdingElement
-            .Element("ownershipNature")
-            ?.Element("directOrIndirectOwnership")
-            ?.Element("value")
-            ?.Value?.Trim();
+        var securityTitle = GetWrappedValue(holdingElement, "securityTitle")?.Trim();
+        var sharesStr = GetWrappedValue(
+            holdingElement,
+            "postTransactionAmounts",
+            "sharesOwnedFollowingTransaction"
+        );
+        var ownership = GetWrappedValue(
+            holdingElement,
+            "ownershipNature",
+            "directOrIndirectOwnership"
+        )
+            ?.Trim();
 
         return new InsiderTransaction
         {
@@ -399,6 +387,19 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             AccessionNumber = filing.AccessionNumber,
             IsAmendment = isAmendment,
         };
+    }
+
+    // SEC ownership XML wraps each field in <field><value>...</value></field>,
+    // sometimes nested under a grouping element (transactionAmounts, etc.).
+    // Walk the path then read the inner <value>.
+    private static string GetWrappedValue(XElement parent, params string[] path)
+    {
+        var element = parent;
+        foreach (var name in path)
+        {
+            element = element?.Element(name);
+        }
+        return element?.Element("value")?.Value;
     }
 
     internal static string SanitizeXml(string xml)


### PR DESCRIPTION
## Summary

- SEC ownership-document XML (Forms 3 / 4) wraps every leaf in a `<field><value>...</value></field>` envelope, sometimes nested under a grouping element (`transactionAmounts`, `postTransactionAmounts`, `ownershipNature`).
- `ParseTransaction` and `ParseHolding` between them spelled this traversal out 10 times — `parent.Element(name)?.Element("value")?.Value` — making the rule invisible at the call sites and verbose to read.
- Extract one private static `GetWrappedValue(parent, params string[] path)` helper. Callers still apply `.Trim()` exactly as before, so behavior is unchanged: same traversal sequence, same null propagation, same downstream `ParseLong` / `ParseDecimal` / `DateOnly.TryParse(invariant)` inputs.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — add private static `GetWrappedValue` helper with the "EDGAR `<field><value>` envelope" WHY comment; rewrite `ParseTransaction` and `ParseHolding` to call it for `securityTitle`, `transactionDate`, `transactionShares`, `transactionPricePerShare`, `transactionAcquiredDisposedCode`, `sharesOwnedFollowingTransaction`, and `directOrIndirectOwnership`. The non-wrapped `transactionCoding/transactionCode` reads its `.Value` directly and is left untouched.