### PR TITLE
refactor(sec-facts): replace ClosestTo manual loop with MinBy

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
@@ -117,19 +117,6 @@ internal static class FiscalPeriodResolver
         return new DateOnly(year, month, Math.Min(day, maxDay));
     }
 
-    private static DateOnly ClosestTo(DateOnly[] candidates, DateOnly target)
-    {
-        var best = candidates[0];
-        var bestDistance = Math.Abs(best.DayNumber - target.DayNumber);
-        for (var i = 1; i < candidates.Length; i++)
-        {
-            var distance = Math.Abs(candidates[i].DayNumber - target.DayNumber);
-            if (distance < bestDistance)
-            {
-                best = candidates[i];
-                bestDistance = distance;
-            }
-        }
-        return best;
-    }
+    private static DateOnly ClosestTo(DateOnly[] candidates, DateOnly target) =>
+        candidates.MinBy(c => Math.Abs(c.DayNumber - target.DayNumber));
 }


### PR DESCRIPTION
## Summary

- Collapse the 13-line manual min-distance loop in `FiscalPeriodResolver.ClosestTo` into a single `candidates.MinBy(c => Math.Abs(c.DayNumber - target.DayNumber))` expression.
- Behaviour-preserving: `Enumerable.MinBy` returns the first element with the minimum key in source order; the original loop only updated `best` on strictly-less-than, also keeping the first candidate on ties. Same winner for every input.

## Code changes

- `src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs` — replace explicit accumulator loop with `MinBy`. 19 `FiscalPeriodResolver` unit tests pass; full unit-test suite (1346) green.