### PR TITLE
feat(holdings): add institution portfolio summary calculator + stat-card header

### DIFF
--- a/src/Equibles.Holdings.Repositories/Projections/InstitutionPortfolioSummary.cs
+++ b/src/Equibles.Holdings.Repositories/Projections/InstitutionPortfolioSummary.cs
@@ -1,0 +1,13 @@
+namespace Equibles.Holdings.Repositories.Projections;
+
+public class InstitutionPortfolioSummary
+{
+    public long ReportedAum { get; set; }
+    public int PositionCount { get; set; }
+    public decimal Top10ConcentrationPercent { get; set; }
+    public decimal Top25ConcentrationPercent { get; set; }
+    public decimal? QuarterOverQuarterTurnoverPercent { get; set; }
+    public int QuartersReported { get; set; }
+    public DateOnly? LatestReportDate { get; set; }
+    public DateOnly? PreviousReportDate { get; set; }
+}

--- a/src/Equibles.Holdings.Repositories/Projections/InstitutionPortfolioSummaryCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/Projections/InstitutionPortfolioSummaryCalculator.cs
@@ -1,0 +1,124 @@
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.Holdings.Repositories.Projections;
+
+public static class InstitutionPortfolioSummaryCalculator
+{
+    public static InstitutionPortfolioSummary Calculate(
+        IReadOnlyCollection<InstitutionalHolding> currentHoldings,
+        IReadOnlyCollection<InstitutionalHolding> priorHoldings,
+        int quartersReported,
+        DateOnly? latestReportDate,
+        DateOnly? previousReportDate
+    )
+    {
+        var summary = new InstitutionPortfolioSummary
+        {
+            QuartersReported = quartersReported,
+            LatestReportDate = latestReportDate,
+            PreviousReportDate = previousReportDate,
+        };
+
+        if (currentHoldings.Count == 0)
+            return summary;
+
+        var currentByStock = AggregateByStock(currentHoldings);
+
+        var aum = 0L;
+        foreach (var kv in currentByStock)
+            aum += kv.Value.Value;
+
+        summary.ReportedAum = aum;
+        summary.PositionCount = currentByStock.Count;
+
+        if (aum > 0)
+        {
+            var valuesDescending = currentByStock
+                .Values.Select(p => p.Value)
+                .OrderByDescending(v => v)
+                .ToList();
+            summary.Top10ConcentrationPercent = ConcentrationPercent(valuesDescending, 10, aum);
+            summary.Top25ConcentrationPercent = ConcentrationPercent(valuesDescending, 25, aum);
+        }
+
+        if (priorHoldings.Count == 0 || aum == 0)
+            return summary;
+
+        var priorByStock = AggregateByStock(priorHoldings);
+        summary.QuarterOverQuarterTurnoverPercent = TurnoverPercent(
+            currentByStock,
+            priorByStock,
+            aum
+        );
+
+        return summary;
+    }
+
+    private static Dictionary<Guid, (long Shares, long Value)> AggregateByStock(
+        IReadOnlyCollection<InstitutionalHolding> holdings
+    )
+    {
+        var byStock = new Dictionary<Guid, (long Shares, long Value)>();
+        foreach (var holding in holdings)
+        {
+            byStock.TryGetValue(holding.CommonStockId, out var existing);
+            byStock[holding.CommonStockId] = (
+                existing.Shares + holding.Shares,
+                existing.Value + holding.Value
+            );
+        }
+        return byStock;
+    }
+
+    private static decimal ConcentrationPercent(
+        IReadOnlyList<long> valuesDescending,
+        int topN,
+        long aum
+    )
+    {
+        var top = 0L;
+        var limit = Math.Min(topN, valuesDescending.Count);
+        for (var i = 0; i < limit; i++)
+            top += valuesDescending[i];
+        return (decimal)top / aum * 100m;
+    }
+
+    private static decimal TurnoverPercent(
+        IReadOnlyDictionary<Guid, (long Shares, long Value)> currentByStock,
+        IReadOnlyDictionary<Guid, (long Shares, long Value)> priorByStock,
+        long aum
+    )
+    {
+        var stockIds = new HashSet<Guid>(currentByStock.Keys);
+        foreach (var id in priorByStock.Keys)
+            stockIds.Add(id);
+
+        var dollarChange = 0m;
+        foreach (var stockId in stockIds)
+        {
+            currentByStock.TryGetValue(stockId, out var cur);
+            priorByStock.TryGetValue(stockId, out var prev);
+
+            var sharesDelta = Math.Abs(cur.Shares - prev.Shares);
+            if (sharesDelta == 0)
+                continue;
+
+            var pricePerShare = PricePerShare(cur, prev);
+            dollarChange += sharesDelta * pricePerShare;
+        }
+
+        return dollarChange / (2m * aum) * 100m;
+    }
+
+    private static decimal PricePerShare(
+        (long Shares, long Value) cur,
+        (long Shares, long Value) prev
+    )
+    {
+        if (cur.Shares > 0)
+            return (decimal)cur.Value / cur.Shares;
+        if (prev.Shares > 0)
+            return (decimal)prev.Value / prev.Shares;
+        return 0m;
+    }
+}

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -1,5 +1,7 @@
 using Equibles.Congress.Repositories;
+using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Projections;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.Web.Controllers.Abstract;
 using Equibles.Web.Extensions;
@@ -48,8 +50,38 @@ public class ProfilesController : BaseController
         if (holder == null)
             return NotFound();
 
-        var holdings = await _institutionalHoldingRepository
-            .GetHistoryByHolder(holder)
+        var holderHistory = _institutionalHoldingRepository.GetHistoryByHolder(holder);
+
+        var reportDates = await holderHistory
+            .Select(holding => holding.ReportDate)
+            .Distinct()
+            .OrderByDescending(date => date)
+            .ToListAsync();
+
+        DateOnly? latestReportDate = reportDates.Count > 0 ? reportDates[0] : null;
+        DateOnly? previousReportDate = reportDates.Count > 1 ? reportDates[1] : null;
+
+        var currentQuarterHoldings = latestReportDate.HasValue
+            ? await _institutionalHoldingRepository
+                .GetByHolder(holder, latestReportDate.Value)
+                .ToListAsync()
+            : new List<InstitutionalHolding>();
+
+        var priorQuarterHoldings = previousReportDate.HasValue
+            ? await _institutionalHoldingRepository
+                .GetByHolder(holder, previousReportDate.Value)
+                .ToListAsync()
+            : new List<InstitutionalHolding>();
+
+        var summary = InstitutionPortfolioSummaryCalculator.Calculate(
+            currentQuarterHoldings,
+            priorQuarterHoldings,
+            reportDates.Count,
+            latestReportDate,
+            previousReportDate
+        );
+
+        var holdings = await holderHistory
             .OrderByDescending(holding => holding.ReportDate)
             .Take(RecentRowLimit)
             .Select(holding => new HoldingRowViewModel
@@ -69,6 +101,7 @@ public class ProfilesController : BaseController
                 Name = holder.Name,
                 Cik = holder.Cik,
                 Location = ProfileFormatting.JoinLocation(holder.City, holder.StateOrCountry),
+                Summary = summary,
                 Holdings = holdings,
             }
         );

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
@@ -1,3 +1,5 @@
+using Equibles.Holdings.Repositories.Projections;
+
 namespace Equibles.Web.ViewModels.Profiles;
 
 public class InstitutionProfileViewModel
@@ -5,5 +7,6 @@ public class InstitutionProfileViewModel
     public string Name { get; set; }
     public string Cik { get; set; }
     public string Location { get; set; }
+    public InstitutionPortfolioSummary Summary { get; set; } = new();
     public List<HoldingRowViewModel> Holdings { get; set; } = [];
 }

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -2,15 +2,63 @@
 
 @{
     ViewData["Title"] = Model.Name;
+    var summary = Model.Summary;
+    var hasSummary = summary.LatestReportDate.HasValue;
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
+    <div class="mb-6">
         <h1 class="text-3xl font-bold mb-2">@Model.Name</h1>
         <p class="text-base-content/60">
             Institutional holder@(string.IsNullOrWhiteSpace(Model.Location) ? "" : " · " + Model.Location) · CIK @Model.Cik
         </p>
     </div>
+
+    @if (hasSummary) {
+        <div data-testid="portfolio-summary"
+             class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-100 mb-8 w-full">
+            <div class="stat">
+                <div class="stat-title">Reported AUM</div>
+                <div class="stat-value text-2xl" data-testid="summary-aum">
+                    $@((summary.ReportedAum / 1_000_000m).ToString("N1"))M
+                </div>
+                <div class="stat-desc">As of @summary.LatestReportDate?.ToString("yyyy-MM-dd")</div>
+            </div>
+            <div class="stat">
+                <div class="stat-title">Positions</div>
+                <div class="stat-value text-2xl" data-testid="summary-position-count">@summary.PositionCount.ToString("N0")</div>
+                <div class="stat-desc">Distinct stocks held</div>
+            </div>
+            <div class="stat">
+                <div class="stat-title">Top 10 concentration</div>
+                <div class="stat-value text-2xl" data-testid="summary-top10">@summary.Top10ConcentrationPercent.ToString("F1")%</div>
+                <div class="stat-desc">Top 25: @summary.Top25ConcentrationPercent.ToString("F1")%</div>
+            </div>
+            <div class="stat">
+                <div class="stat-title">QoQ turnover</div>
+                <div class="stat-value text-2xl" data-testid="summary-turnover"
+                     title="(Σ |Δshares × current price proxy|) ÷ (2 × AUM). A proxy for portfolio change quarter over quarter.">
+                    @(summary.QuarterOverQuarterTurnoverPercent.HasValue
+                        ? summary.QuarterOverQuarterTurnoverPercent.Value.ToString("F1") + "%"
+                        : "—")
+                </div>
+                <div class="stat-desc">
+                    @(summary.PreviousReportDate.HasValue
+                        ? "vs " + summary.PreviousReportDate.Value.ToString("yyyy-MM-dd")
+                        : "No prior quarter")
+                </div>
+            </div>
+            <div class="stat">
+                <div class="stat-title">Quarters reported</div>
+                <div class="stat-value text-2xl" data-testid="summary-quarters-reported">@summary.QuartersReported.ToString("N0")</div>
+                <div class="stat-desc">
+                    @(summary.PreviousReportDate.HasValue
+                        ? "Prior: " + summary.PreviousReportDate.Value.ToString("yyyy-MM-dd")
+                        : "Latest only")
+                </div>
+            </div>
+        </div>
+    }
 
     <h2 class="text-xl font-semibold mb-3">Recent holdings</h2>
     @if (Model.Holdings.Count == 0) {

--- a/tests/Equibles.IntegrationTests/Web/ProfilesControllerViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesControllerViewRenderingTests.cs
@@ -59,6 +59,57 @@ public class ProfilesControllerViewRenderingTests
     }
 
     [Fact]
+    public async Task GetInstitution_SingleHolding_RendersPortfolioSummaryStatStrip()
+    {
+        // Pin the issue #1011 header strip: the institution profile must render
+        // the AUM / position-count / concentration / turnover stat cards above
+        // the recent-holdings table. A regression that dropped the summary
+        // computation (or hid the strip behind a stale model property) would
+        // leave the page intact except for the stats — assert each card's
+        // data-testid plus the formatted AUM so the failure points at the
+        // broken metric, not at the whole view.
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
+            var holder = new InstitutionalHolder
+            {
+                Cik = "0000002000",
+                Name = "SUMMARY TEST FUND",
+                City = "Boston",
+                StateOrCountry = "MA",
+            };
+            db.Add(stock);
+            db.Add(holder);
+            db.Add(
+                new InstitutionalHolding
+                {
+                    InstitutionalHolder = holder,
+                    CommonStock = stock,
+                    ReportDate = new DateOnly(2024, 9, 30),
+                    FilingDate = new DateOnly(2024, 11, 14),
+                    Shares = 1_000,
+                    Value = 5_000_000,
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Institutions/0000002000");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should()
+            .Contain("data-testid=\"portfolio-summary\"")
+            .And.Contain("data-testid=\"summary-aum\"")
+            .And.Contain("data-testid=\"summary-position-count\"")
+            .And.Contain("data-testid=\"summary-top10\"")
+            .And.Contain("data-testid=\"summary-turnover\"")
+            .And.Contain("data-testid=\"summary-quarters-reported\"")
+            .And.Contain("$5.0M")
+            .And.Contain("Reported AUM");
+    }
+
+    [Fact]
     public async Task GetInsider_KnownOwnerCikWithTransaction_RendersOwnerRoleAndTradeRow()
     {
         await _fixture.ResetAndSeedAsync(async db =>

--- a/tests/Equibles.UnitTests/Holdings/InstitutionPortfolioSummaryCalculatorTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionPortfolioSummaryCalculatorTests.cs
@@ -1,0 +1,193 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories.Projections;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins the InstitutionPortfolioSummaryCalculator contract — the pure function
+/// that produces the AUM / position-count / concentration / turnover stat strip
+/// shown on the institution profile page (issue #1011) and the equivalent MCP
+/// summary tool. A regression here would silently misreport fund metrics on
+/// both surfaces, so each metric and each documented edge case is fixed in a
+/// separate test.
+/// </summary>
+public class InstitutionPortfolioSummaryCalculatorTests
+{
+    private static readonly DateOnly Q4_2024 = new(2024, 12, 31);
+    private static readonly DateOnly Q3_2024 = new(2024, 9, 30);
+
+    [Fact]
+    public void Calculate_EmptyCurrentQuarter_ReturnsZeroedSummaryWithMetadataPreserved()
+    {
+        // Edge case: a holder row exists but no holdings are recorded. The
+        // calculator must not divide by zero AUM and must still expose the
+        // metadata fields the view binds to (quartersReported + the report-date
+        // chips).
+        var summary = InstitutionPortfolioSummaryCalculator.Calculate(
+            [],
+            [],
+            quartersReported: 0,
+            latestReportDate: null,
+            previousReportDate: null
+        );
+
+        summary.ReportedAum.Should().Be(0);
+        summary.PositionCount.Should().Be(0);
+        summary.Top10ConcentrationPercent.Should().Be(0m);
+        summary.Top25ConcentrationPercent.Should().Be(0m);
+        summary.QuarterOverQuarterTurnoverPercent.Should().BeNull();
+        summary.QuartersReported.Should().Be(0);
+        summary.LatestReportDate.Should().BeNull();
+        summary.PreviousReportDate.Should().BeNull();
+    }
+
+    [Fact]
+    public void Calculate_SinglePosition_ReportsAumPositionCountAndOneHundredPercentConcentration()
+    {
+        // A single-stock portfolio is the smallest non-empty case. AUM equals
+        // the row value, position count equals 1, and top-10 / top-25
+        // concentration must round to exactly 100% — anything else means the
+        // calculator double-counted or under-summed the lone position.
+        var stockId = Guid.NewGuid();
+        var summary = InstitutionPortfolioSummaryCalculator.Calculate(
+            [Holding(stockId, shares: 1_000, value: 5_000_000)],
+            [],
+            quartersReported: 1,
+            latestReportDate: Q4_2024,
+            previousReportDate: null
+        );
+
+        summary.ReportedAum.Should().Be(5_000_000);
+        summary.PositionCount.Should().Be(1);
+        summary.Top10ConcentrationPercent.Should().Be(100m);
+        summary.Top25ConcentrationPercent.Should().Be(100m);
+        summary.QuarterOverQuarterTurnoverPercent.Should().BeNull();
+    }
+
+    [Fact]
+    public void Calculate_TopTenConcentration_IsValueOfTopTenStocksDividedByAum()
+    {
+        // Build 15 distinct positions with descending values so the top-10
+        // concentration ratio is exact. This pins the ranking + slice + ratio
+        // logic in one shot: a regression that took the bottom 10 or rounded
+        // the ratio prematurely would fail this assertion.
+        var holdings = new List<InstitutionalHolding>();
+        for (var i = 1; i <= 15; i++)
+        {
+            holdings.Add(Holding(Guid.NewGuid(), shares: 100, value: i * 1_000_000L));
+        }
+
+        var summary = InstitutionPortfolioSummaryCalculator.Calculate(
+            holdings,
+            [],
+            quartersReported: 1,
+            latestReportDate: Q4_2024,
+            previousReportDate: null
+        );
+
+        // sum 1..15 = 120; top 10 (6..15) = 105; 105/120 = 87.5%
+        summary.ReportedAum.Should().Be(120_000_000);
+        summary.PositionCount.Should().Be(15);
+        summary.Top10ConcentrationPercent.Should().BeApproximately(87.5m, 0.01m);
+        // top 25 with only 15 positions == 100%
+        summary.Top25ConcentrationPercent.Should().Be(100m);
+    }
+
+    [Fact]
+    public void Calculate_MultipleRowsForSameStock_AggregatesAcrossRowsForPositionCount()
+    {
+        // 13F filings can carry multiple rows for the same stock (different
+        // share classes, options legs, manager attribution). The position
+        // count is documented as COUNT(DISTINCT CommonStockId), so two rows
+        // for the same stock collapse to one position and combine into AUM.
+        var stockId = Guid.NewGuid();
+        var summary = InstitutionPortfolioSummaryCalculator.Calculate(
+            [
+                Holding(stockId, shares: 100, value: 1_000_000),
+                Holding(stockId, shares: 50, value: 500_000),
+            ],
+            [],
+            quartersReported: 1,
+            latestReportDate: Q4_2024,
+            previousReportDate: null
+        );
+
+        summary.PositionCount.Should().Be(1);
+        summary.ReportedAum.Should().Be(1_500_000);
+    }
+
+    [Fact]
+    public void Calculate_NoPriorQuarter_TurnoverIsNull()
+    {
+        // Documented contract: the QoQ turnover field is "—" on the UI when
+        // there's no prior quarter to compare. The calculator must return null
+        // (not zero) so the view can distinguish "0% turnover this quarter"
+        // from "no prior quarter to compute against".
+        var summary = InstitutionPortfolioSummaryCalculator.Calculate(
+            [Holding(Guid.NewGuid(), shares: 100, value: 1_000_000)],
+            [],
+            quartersReported: 1,
+            latestReportDate: Q4_2024,
+            previousReportDate: null
+        );
+
+        summary.QuarterOverQuarterTurnoverPercent.Should().BeNull();
+    }
+
+    [Fact]
+    public void Calculate_PortfolioUnchanged_TurnoverIsZero()
+    {
+        // Same positions and share counts in both quarters → no dollar change,
+        // so turnover must be exactly zero (not null — there IS a prior
+        // quarter). A regression that priced the unchanged shares against
+        // themselves would still return zero, but any sign error or absolute-
+        // value bug would surface here.
+        var stockA = Guid.NewGuid();
+        var stockB = Guid.NewGuid();
+        var holdings = new[]
+        {
+            Holding(stockA, shares: 100, value: 1_000_000),
+            Holding(stockB, shares: 200, value: 2_000_000),
+        };
+
+        var summary = InstitutionPortfolioSummaryCalculator.Calculate(
+            holdings,
+            holdings,
+            quartersReported: 2,
+            latestReportDate: Q4_2024,
+            previousReportDate: Q3_2024
+        );
+
+        summary.QuarterOverQuarterTurnoverPercent.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Calculate_FullPortfolioRotation_TurnoverIsOneHundredPercent()
+    {
+        // The two-sided turnover formula (Σ|Δshares × price| / (2 × AUM)) caps
+        // at 100% when every dollar is reallocated to entirely new positions.
+        // Stock A is fully exited; Stock B is freshly initiated with the same
+        // dollar value. Total dollar movement = 2 × AUM → turnover = 100%.
+        var stockA = Guid.NewGuid();
+        var stockB = Guid.NewGuid();
+
+        var summary = InstitutionPortfolioSummaryCalculator.Calculate(
+            [Holding(stockB, shares: 200, value: 2_000_000)],
+            [Holding(stockA, shares: 100, value: 2_000_000)],
+            quartersReported: 2,
+            latestReportDate: Q4_2024,
+            previousReportDate: Q3_2024
+        );
+
+        summary.QuarterOverQuarterTurnoverPercent.Should().BeApproximately(100m, 0.01m);
+    }
+
+    private static InstitutionalHolding Holding(Guid stockId, long shares, long value) =>
+        new()
+        {
+            CommonStockId = stockId,
+            Shares = shares,
+            Value = value,
+            ReportDate = Q4_2024,
+        };
+}


### PR DESCRIPTION
## Summary

Slice 1/2 of #1011. Adds a pure-function `InstitutionPortfolioSummaryCalculator` (in `Equibles.Holdings.Repositories.Projections`) that computes AUM, position count, top-10 / top-25 concentration, QoQ turnover, and quarters-reported for an institutional holder's latest 13F quarter. The institution profile view (`~/Institutions/{cik}`) now renders these metrics as a DaisyUI `stat` header strip above the existing recent-holdings table. Slice 2 will reuse the same calculator from the MCP server tool.

This is **not** the closing slice — `Refs #1011`, not `Closes`.

## Code changes

- `src/Equibles.Holdings.Repositories/Projections/InstitutionPortfolioSummary.cs` — projection DTO with AUM / position count / top-N concentration percents / QoQ turnover percent (nullable) / quarters reported / latest + previous report date.
- `src/Equibles.Holdings.Repositories/Projections/InstitutionPortfolioSummaryCalculator.cs` — static pure function `Calculate(current, prior, quartersReported, latestDate, previousDate)`. Aggregates holdings by stock id, computes top-N concentration over per-stock totals, and uses the two-sided turnover formula `Σ|Δshares × price proxy| / (2 × AUM)` with the current-quarter implied price as the proxy (falls back to prior-quarter price for exited positions).
- `src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs` — adds `Summary` property of the new projection type.
- `src/Equibles.Web/Controllers/ProfilesController.cs::Institution` — fetches all distinct report dates for the holder, materialises current + prior quarter holdings, runs the calculator, and passes the result to the view alongside the existing recent-holdings list.
- `src/Equibles.Web/Views/Profiles/Institution.cshtml` — adds a `stats stats-vertical lg:stats-horizontal` strip with five cards (Reported AUM, Positions, Top 10 concentration, QoQ turnover, Quarters reported); the turnover formula is in the `title` tooltip; `data-testid` attributes pin each card for tests.
- `tests/Equibles.UnitTests/Holdings/InstitutionPortfolioSummaryCalculatorTests.cs` — 7 unit tests covering the empty-portfolio guard, single-position 100% concentration, top-10 ranking with 15 positions (87.5%), multi-row aggregation for the same stock, missing-prior-quarter → null turnover, unchanged-portfolio → zero turnover, full-rotation → 100% turnover.
- `tests/Equibles.IntegrationTests/Web/ProfilesControllerViewRenderingTests.cs` — adds a view-rendering test that seeds one holder + holding, GETs `/Institutions/{cik}`, and asserts the rendered HTML contains all five `data-testid` markers plus the formatted `$5.0M` AUM.

## Verified locally

- Build: green.
- Lint: `dotnet csharpier check .` green tree-wide.
- Unit tests: 1318/1318 pass (including the 7 new calculator tests).
- Integration tests: locally blocked by an unresponsive Docker Desktop privileged prompt; the new view-rendering test is included and will exercise on CI.