### PR TITLE
feat(holdings-mcp): add GetInstitutionSectorAllocation MCP tool (2/2)

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -725,6 +725,82 @@ public class InstitutionalHoldingsTools
         );
     }
 
+    [McpServerTool(Name = "GetInstitutionSectorAllocation")]
+    [Description(
+        "Get an institution's portfolio allocation grouped by industry / sector for its latest 13F report. Returns a markdown table sorted by % of portfolio descending, with stocks lacking an industry classification collapsed into a single 'Unclassified' row at the end. Use this to answer 'is this fund concentrated in tech / energy / generalist?'"
+    )]
+    public Task<string> GetInstitutionSectorAllocation(
+        [Description("Institution name (partial or full — first match wins)")]
+            string institutionName,
+        [Description("Report date in YYYY-MM-DD format (defaults to the holder's latest)")]
+            string reportDate = null
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                var holder = await _holderRepository
+                    .Search(institutionName ?? string.Empty)
+                    .OrderBy(h => h.Name)
+                    .FirstOrDefaultAsync();
+                if (holder == null)
+                    return $"No institution found matching '{institutionName}'.";
+
+                var reportDates = await _holdingRepository
+                    .GetHistoryByHolder(holder)
+                    .Select(h => h.ReportDate)
+                    .Distinct()
+                    .OrderByDescending(d => d)
+                    .ToListAsync();
+                if (reportDates.Count == 0)
+                    return $"No 13F holdings reported by {holder.Name}.";
+
+                DateOnly targetDate;
+                if (
+                    !string.IsNullOrEmpty(reportDate)
+                    && DateOnly.TryParse(reportDate, out var parsed)
+                    && reportDates.Contains(parsed)
+                )
+                    targetDate = parsed;
+                else
+                    targetDate = reportDates[0];
+
+                var holdings = await _holdingRepository
+                    .GetByHolder(holder, targetDate)
+                    .Include(h => h.CommonStock)
+                        .ThenInclude(s => s.Industry)
+                    .ToListAsync();
+                var slices = IndustryAllocationCalculator.Calculate(holdings);
+
+                var result = new StringBuilder();
+                result.AppendLine(
+                    $"Sector allocation — **{holder.Name}** as of {targetDate:yyyy-MM-dd}"
+                );
+                result.AppendLine();
+                if (slices.Count == 0)
+                {
+                    result.AppendLine("_No holdings reported for the selected quarter._");
+                    return result.ToString();
+                }
+
+                result.AppendLine("| # | Industry | # Positions | Value ($M) | % of Portfolio |");
+                result.AppendLine("|---|----------|-------------|------------|----------------|");
+                for (var i = 0; i < slices.Count; i++)
+                {
+                    var s = slices[i];
+                    result.AppendLine(
+                        $"| {i + 1} | {s.IndustryName} | {s.PositionCount:N0} | {s.TotalValue / 1_000_000m:N1} | {s.PercentOfPortfolio:F1}% |"
+                    );
+                }
+                return result.ToString();
+            },
+            _logger,
+            "GetInstitutionSectorAllocation",
+            $"institution: {institutionName}",
+            ReportError
+        );
+    }
+
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests.cs
@@ -1,0 +1,135 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins <c>GetInstitutionSectorAllocation</c>. Resolves the holder via name search,
+/// pulls the latest-quarter holdings with the Industry navigation, and feeds them to
+/// the same <see cref="IndustryAllocationCalculator"/> the web profile uses. Each test
+/// exercises one path so a regression in lookup or the Unclassified-bucket handling
+/// surfaces as a focused assertion.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetInstitutionSectorAllocation_UnknownInstitution_ReportsNotFound()
+    {
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionSectorAllocation("Definitely Not A Fund");
+
+        output.Should().Contain("No institution found");
+    }
+
+    [Fact]
+    public async Task GetInstitutionSectorAllocation_HolderWithNoHoldings_ReportsNoData()
+    {
+        DbContext.Add(new InstitutionalHolder { Cik = "S00010001", Name = "Empty Allocator" });
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionSectorAllocation("Empty");
+
+        output.Should().Contain("No 13F holdings reported by Empty Allocator");
+    }
+
+    [Fact]
+    public async Task GetInstitutionSectorAllocation_MixedIndustriesAndUnclassified_RendersTable()
+    {
+        var software = new Industry { Id = Guid.NewGuid(), Name = "Software" };
+        var energy = new Industry { Id = Guid.NewGuid(), Name = "Energy" };
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+            IndustryId = software.Id,
+        };
+        var xom = new CommonStock
+        {
+            Ticker = "XOM",
+            Name = "Exxon Mobil Corp.",
+            Cik = "0000034088",
+            IndustryId = energy.Id,
+        };
+        var obscure = new CommonStock
+        {
+            Ticker = "OBSCURE",
+            Name = "Obscure Inc.",
+            Cik = "0009999999",
+            IndustryId = null,
+        };
+        var holder = new InstitutionalHolder { Cik = "S00010002", Name = "Allocator LP" };
+        DbContext.AddRange(software, energy, aapl, xom, obscure, holder);
+        var report = new DateOnly(2024, 12, 31);
+        DbContext.Add(MakeHolding(aapl, holder, report, value: 2_000_000));
+        DbContext.Add(MakeHolding(xom, holder, report, value: 500_000));
+        DbContext.Add(MakeHolding(obscure, holder, report, value: 250_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionSectorAllocation("Allocator");
+
+        output.Should().Contain("Sector allocation — **Allocator LP** as of 2024-12-31");
+        output.Should().Contain("Software");
+        output.Should().Contain("Energy");
+        output.Should().Contain("Unclassified");
+        // Order: Software (2M) first, Energy (500k), Unclassified always last.
+        output
+            .IndexOf("Software", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("Energy", StringComparison.Ordinal));
+        output
+            .IndexOf("Energy", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("Unclassified", StringComparison.Ordinal));
+    }
+
+    private InstitutionalHoldingsTools NewSut(Equibles.Data.EquiblesDbContext ctx) =>
+        new(
+            new InstitutionalHoldingRepository(ctx),
+            new InstitutionalHolderRepository(ctx),
+            new CommonStockRepository(ctx),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = value / 100,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -269,6 +269,7 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("GetTopBuyersSellers");
         toolNames.Should().Contain("GetMarketWide13FActivity");
         toolNames.Should().Contain("GetInstitutionSummary");
+        toolNames.Should().Contain("GetInstitutionSectorAllocation");
     }
 
     // ── InsiderTrading module specific ──────────────────────────────────
@@ -361,6 +362,7 @@ public class McpModuleToolDiscoveryTests
                     "GetTopBuyersSellers",
                     "GetMarketWide13FActivity",
                     "GetInstitutionSummary",
+                    "GetInstitutionSectorAllocation",
                 }
             },
             {


### PR DESCRIPTION
## Summary

- **Closing slice (2 of 2)** for #1012. Mirrors the web sector-allocation card landed in #1098 — an MCP tool that returns the per-industry table (positions, $M, percent of portfolio) for a given institution. Unclassified holdings render as a single row at the end.
- Reuses `IndustryAllocationCalculator` from `Equibles.Holdings.Repositories` so web and MCP share the same math.
- Closes #1012.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — new `GetInstitutionSectorAllocation(institutionName, reportDate?)`. Holder name-search first match wins; falls back to the holder's latest report date when the supplied reportDate isn't in history; emits a sorted markdown table.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — module-discovery list updated.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSectorAllocationTests.cs` — 3 ParadeDB tests: unknown-institution, no-holdings, mixed-industries with Unclassified-last ordering.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1100 files).
- New MCP integration tests — 3/3 passing.
- Module-discovery unit tests — 59/59 passing.

Closes #1012