### PR TITLE
docs(technical/mcp-tools): list GetInstitutionSectorAllocation under Holdings

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -25,6 +25,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetTopBuyersSellers` — biggest absolute share additions and reductions for a ticker vs. the prior `ReportDate`; flags new and sold-out positions.
 - `GetMarketWide13FActivity` — market-wide leaderboard for a quarter, selected by `bucket`: `top-buys`, `top-sells`, `new-positions`, `sold-out-positions`.
 - `GetInstitutionSummary` — portfolio header for one filer at a `ReportDate`: AUM, position count, top-10 / top-25 concentration, QoQ turnover, latest / prior dates.
+- `GetInstitutionSectorAllocation` — one filer's portfolio grouped by industry / sector for its latest 13F report; stocks lacking a classification collapse into an "Unclassified" row.
 
 ### `mcp.AddInsiderTrading()` — Form 3 / 4
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- `GetInstitutionSectorAllocation` (added in #1103) is missing from the Holdings section of `docs/technical/mcp-tools.md`. Add the catalog bullet so the docs match the code.

## Code changes

- `docs/technical/mcp-tools.md` — append one bullet under `mcp.AddHoldings()` → `InstitutionalHoldingsTools` describing `GetInstitutionSectorAllocation` (portfolio grouped by industry / sector for the latest 13F report; stocks without a classification collapse into one "Unclassified" row).