### PR TITLE
refactor(finra-client): extract duplicated settlement-date pagination into CollectSettlementDates

### DIFF
--- a/src/Equibles.Integrations.Finra/FinraClient.cs
+++ b/src/Equibles.Integrations.Finra/FinraClient.cs
@@ -209,43 +209,13 @@ public class FinraClient : IFinraClient
 
     public async Task<List<DateOnly>> GetShortInterestSettlementDates()
     {
-        // Query distinct settlement dates via the data endpoint (the /partitions GET returns 403).
-        // Sort descending and extract unique dates across pages.
-        var dates = new HashSet<DateOnly>();
-        var offset = 0;
-
-        while (true)
+        // /partitions GET returns 403; the /data endpoint exposes the same dates by paging.
+        var dates = await CollectSettlementDates(offset => new
         {
-            var query = new
-            {
-                fields = new[] { "settlementDate" },
-                limit = MaxPageSize,
-                offset,
-            };
-
-            var records = await PostQuery<ShortInterestRecord>(
-                "OTCMarket",
-                "consolidatedShortInterest",
-                query
-            );
-            if (records.Count == 0)
-                break;
-
-            foreach (var record in records)
-            {
-                if (
-                    !string.IsNullOrEmpty(record.SettlementDate)
-                    && DateOnly.TryParse(record.SettlementDate, out var date)
-                )
-                {
-                    dates.Add(date);
-                }
-            }
-
-            if (records.Count < MaxPageSize)
-                break;
-            offset += records.Count;
-        }
+            fields = new[] { "settlementDate" },
+            limit = MaxPageSize,
+            offset,
+        });
 
         _logger.LogDebug("Fetched {Count} distinct settlement dates", dates.Count);
         return dates.OrderBy(d => d).ToList();
@@ -258,31 +228,41 @@ public class FinraClient : IFinraClient
 
         _logger.LogDebug("Discovering settlement dates after {Date}", afterDate);
 
+        var dates = await CollectSettlementDates(offset => new
+        {
+            fields = new[] { "settlementDate" },
+            dateRangeFilters = new[]
+            {
+                new
+                {
+                    fieldName = "settlementDate",
+                    startDate = startDateStr,
+                    endDate = endDateStr,
+                },
+            },
+            limit = MaxPageSize,
+            offset,
+        });
+
+        _logger.LogDebug(
+            "Discovered {Count} new settlement dates after {Date}",
+            dates.Count,
+            afterDate
+        );
+        return dates.OrderBy(d => d).ToList();
+    }
+
+    private async Task<HashSet<DateOnly>> CollectSettlementDates(Func<int, object> buildQuery)
+    {
         var dates = new HashSet<DateOnly>();
         var offset = 0;
 
         while (true)
         {
-            var query = new
-            {
-                fields = new[] { "settlementDate" },
-                dateRangeFilters = new[]
-                {
-                    new
-                    {
-                        fieldName = "settlementDate",
-                        startDate = startDateStr,
-                        endDate = endDateStr,
-                    },
-                },
-                limit = MaxPageSize,
-                offset,
-            };
-
             var records = await PostQuery<ShortInterestRecord>(
                 "OTCMarket",
                 "consolidatedShortInterest",
-                query
+                buildQuery(offset)
             );
             if (records.Count == 0)
                 break;
@@ -303,12 +283,7 @@ public class FinraClient : IFinraClient
             offset += records.Count;
         }
 
-        _logger.LogDebug(
-            "Discovered {Count} new settlement dates after {Date}",
-            dates.Count,
-            afterDate
-        );
-        return dates.OrderBy(d => d).ToList();
+        return dates;
     }
 
     private async Task<List<T>> PostQuery<T>(string group, string name, object query)


### PR DESCRIPTION
## Summary

- `GetShortInterestSettlementDates` and `GetShortInterestSettlementDatesAfter` shared a byte-for-byte identical paginate-and-collect-dates loop, differing only in the query-body shape and one log line.
- Extracted the loop into `private async Task<HashSet<DateOnly>> CollectSettlementDates(Func<int, object> buildQuery)`; each public method keeps its own query shape and logging.
- Trimmed a stale `// Sort descending …` narration on the unfiltered method — the code sorts ascending (`OrderBy(d => d)`) and always has. The genuine WHY (`/partitions` GET returns 403) is preserved.

## Code changes

- `src/Equibles.Integrations.Finra/FinraClient.cs`
  - New `CollectSettlementDates(Func<int, object> buildQuery)` private helper owns the pagination loop, the empty-page break, the offset increment, and the date-parse-and-add.
  - Each caller now invokes the helper with a `Func<int, object>` returning its query-shape — closures capture `startDateStr`/`endDateStr` in the filtered overload, exactly as the inlined form did.
  - Same iteration order, same null/empty handling, same exception semantics.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet tool run csharpier check .` — green (1099 files).
- `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj` — 1365/1365 pass.
- `dotnet test tests/Equibles.IntegrationTests --filter "FullyQualifiedName~Finra|…ShortInterest|…ShortVolume|…SettlementDates"` — 100/100 pass (covers `FinraClientSettlementDatesPaginationTests`, `FinraClientSettlementDatesAfterTests`, `FinraClientSettlementDatesAllTests` etc.).