### PR TITLE
feat(holdings): add Latest Quarter Activity section to Institution profile (1/2)

### DIFF
--- a/src/Equibles.Holdings.Repositories/HolderQuarterlyActivityCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HolderQuarterlyActivityCalculator.cs
@@ -1,0 +1,130 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Holdings.Repositories;
+
+public static class HolderQuarterlyActivityCalculator
+{
+    // Both inputs must be materialized with the CommonStock navigation populated
+    // (Include(h => h.CommonStock) at the query site) — the calculator only reads
+    // loaded references.
+    public static Dictionary<StockPositionChangeType, List<StockPositionChange>> Group(
+        IReadOnlyList<InstitutionalHolding> currentHoldings,
+        IReadOnlyList<InstitutionalHolding> previousHoldings
+    )
+    {
+        var buckets = new Dictionary<StockPositionChangeType, List<StockPositionChange>>
+        {
+            [StockPositionChangeType.Initiated] = [],
+            [StockPositionChangeType.Increased] = [],
+            [StockPositionChangeType.Reduced] = [],
+            [StockPositionChangeType.Exited] = [],
+            [StockPositionChangeType.Unchanged] = [],
+        };
+
+        var currentByStock = AggregateByStock(currentHoldings);
+        var previousByStock = AggregateByStock(previousHoldings);
+
+        // % of portfolio is computed against the holder's current-quarter total value.
+        // Anchoring on the current side keeps comparisons consistent for all four
+        // movement buckets except Exited; Exited rows show 0% (their current value is 0).
+        var totalCurrentValue = currentByStock.Values.Sum(v => v.Value);
+
+        foreach (var (stockId, current) in currentByStock)
+        {
+            previousByStock.TryGetValue(stockId, out var previous);
+            var changeType = ClassifyChange(current.Shares, previous?.Shares ?? 0);
+            buckets[changeType].Add(BuildChange(current, previous, totalCurrentValue, changeType));
+        }
+
+        foreach (var (stockId, previous) in previousByStock)
+        {
+            if (currentByStock.ContainsKey(stockId))
+                continue;
+            buckets[StockPositionChangeType.Exited]
+                .Add(BuildExitedChange(previous, totalCurrentValue));
+        }
+
+        return buckets;
+    }
+
+    private static StockPositionChangeType ClassifyChange(long currentShares, long previousShares)
+    {
+        if (previousShares == 0)
+            return StockPositionChangeType.Initiated;
+        if (currentShares == previousShares)
+            return StockPositionChangeType.Unchanged;
+        return currentShares > previousShares
+            ? StockPositionChangeType.Increased
+            : StockPositionChangeType.Reduced;
+    }
+
+    private static StockPositionChange BuildChange(
+        StockAggregate current,
+        StockAggregate previous,
+        long totalCurrentValue,
+        StockPositionChangeType changeType
+    )
+    {
+        return new StockPositionChange
+        {
+            CommonStockId = current.StockId,
+            Ticker = current.Ticker,
+            Name = current.Name,
+            CurrentShares = current.Shares,
+            CurrentValue = current.Value,
+            PreviousShares = previous?.Shares ?? 0,
+            PreviousValue = previous?.Value ?? 0,
+            ChangeType = changeType,
+            PercentOfPortfolio =
+                totalCurrentValue > 0 ? (double)current.Value / totalCurrentValue * 100.0 : 0,
+        };
+    }
+
+    private static StockPositionChange BuildExitedChange(
+        StockAggregate previous,
+        long totalCurrentValue
+    )
+    {
+        return new StockPositionChange
+        {
+            CommonStockId = previous.StockId,
+            Ticker = previous.Ticker,
+            Name = previous.Name,
+            CurrentShares = 0,
+            CurrentValue = 0,
+            PreviousShares = previous.Shares,
+            PreviousValue = previous.Value,
+            ChangeType = StockPositionChangeType.Exited,
+            PercentOfPortfolio = 0,
+        };
+    }
+
+    private static Dictionary<Guid, StockAggregate> AggregateByStock(
+        IReadOnlyList<InstitutionalHolding> holdings
+    )
+    {
+        return holdings
+            .GroupBy(h => h.CommonStockId)
+            .ToDictionary(
+                g => g.Key,
+                g => new StockAggregate
+                {
+                    StockId = g.Key,
+                    Ticker = g.First().CommonStock?.Ticker,
+                    Name = g.First().CommonStock?.Name,
+                    Shares = g.Sum(h => h.Shares),
+                    Value = g.Sum(h => h.Value),
+                }
+            );
+    }
+
+    private class StockAggregate
+    {
+        public Guid StockId { get; set; }
+        public string Ticker { get; set; }
+        public string Name { get; set; }
+        public long Shares { get; set; }
+        public long Value { get; set; }
+    }
+}

--- a/src/Equibles.Holdings.Repositories/Models/StockPositionChange.cs
+++ b/src/Equibles.Holdings.Repositories/Models/StockPositionChange.cs
@@ -1,0 +1,30 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public enum StockPositionChangeType
+{
+    Initiated = 1,
+    Increased = 2,
+    Reduced = 3,
+    Exited = 4,
+    Unchanged = 5,
+}
+
+public class StockPositionChange
+{
+    public Guid CommonStockId { get; set; }
+    public string Ticker { get; set; }
+    public string Name { get; set; }
+
+    public long CurrentShares { get; set; }
+    public long PreviousShares { get; set; }
+    public long CurrentValue { get; set; }
+    public long PreviousValue { get; set; }
+
+    public StockPositionChangeType ChangeType { get; set; }
+
+    // 0 when the holder's reported AUM for the current quarter is 0.
+    public double PercentOfPortfolio { get; set; }
+
+    public long DeltaShares => CurrentShares - PreviousShares;
+    public long DeltaValue => CurrentValue - PreviousValue;
+}

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -44,7 +44,7 @@ public class ProfilesController : BaseController
     }
 
     [HttpGet("~/Institutions/{cik}")]
-    public async Task<IActionResult> Institution(string cik)
+    public async Task<IActionResult> Institution(string cik, DateOnly? activityDate = null)
     {
         var holder = await _institutionalHolderRepository.GetByCik(cik);
         if (holder == null)
@@ -73,6 +73,11 @@ public class ProfilesController : BaseController
             .OrderByDescending(d => d)
             .ToListAsync();
         var (summary, industryAllocation) = await BuildSummaryAndAllocation(holder, distinctDates);
+        var (quarterlyActivity, activityResolved, activityPrior) = await BuildQuarterlyActivity(
+            holder,
+            distinctDates,
+            activityDate
+        );
 
         ViewData["Title"] = holder.Name;
         return View(
@@ -84,8 +89,82 @@ public class ProfilesController : BaseController
                 Holdings = holdings,
                 Summary = summary,
                 IndustryAllocation = industryAllocation,
+                AvailableReportDates = distinctDates,
+                ActivityDate = activityResolved,
+                ActivityPriorDate = activityPrior,
+                QuarterlyActivity = quarterlyActivity,
             }
         );
+    }
+
+    private async Task<(
+        Dictionary<StockPositionChangeType, List<StockPositionChange>> Buckets,
+        DateOnly? Selected,
+        DateOnly? Prior
+    )> BuildQuarterlyActivity(
+        InstitutionalHolder holder,
+        IReadOnlyList<DateOnly> distinctReportDates,
+        DateOnly? requestedDate
+    )
+    {
+        if (distinctReportDates.Count < 2)
+            return (
+                new Dictionary<StockPositionChangeType, List<StockPositionChange>>(),
+                distinctReportDates.Count == 1 ? distinctReportDates[0] : (DateOnly?)null,
+                null
+            );
+
+        DateOnly selected;
+        var selectedIndex = -1;
+        if (requestedDate.HasValue)
+        {
+            for (var i = 0; i < distinctReportDates.Count; i++)
+            {
+                if (distinctReportDates[i] != requestedDate.Value)
+                    continue;
+                selectedIndex = i;
+                break;
+            }
+        }
+        if (selectedIndex < 0)
+        {
+            selected = distinctReportDates[0];
+            selectedIndex = 0;
+        }
+        else
+        {
+            selected = distinctReportDates[selectedIndex];
+        }
+        if (selectedIndex >= distinctReportDates.Count - 1)
+            return (
+                new Dictionary<StockPositionChangeType, List<StockPositionChange>>(),
+                selected,
+                null
+            );
+
+        var prior = distinctReportDates[selectedIndex + 1];
+        var currentHoldings = await _institutionalHoldingRepository
+            .GetByHolder(holder, selected)
+            .Include(h => h.CommonStock)
+            .ToListAsync();
+        var previousHoldings = await _institutionalHoldingRepository
+            .GetByHolder(holder, prior)
+            .Include(h => h.CommonStock)
+            .ToListAsync();
+
+        var grouped = HolderQuarterlyActivityCalculator.Group(currentHoldings, previousHoldings);
+
+        // Cap each bucket and pre-sort by |Δ value| desc so the view renders the
+        // largest movers first per section.
+        var capped = grouped.ToDictionary(
+            kv => kv.Key,
+            kv =>
+                kv.Value.OrderByDescending(r => Math.Abs(r.DeltaValue))
+                    .Take(InstitutionProfileViewModel.ActivityRowCap)
+                    .ToList()
+        );
+
+        return (capped, selected, prior);
     }
 
     private async Task<(

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
@@ -10,4 +10,14 @@ public class InstitutionProfileViewModel
     public List<HoldingRowViewModel> Holdings { get; set; } = [];
     public InstitutionPortfolioSummary Summary { get; set; } = new();
     public List<IndustryAllocationSlice> IndustryAllocation { get; set; } = [];
+
+    public List<DateOnly> AvailableReportDates { get; set; } = [];
+    public DateOnly? ActivityDate { get; set; }
+    public DateOnly? ActivityPriorDate { get; set; }
+    public Dictionary<
+        StockPositionChangeType,
+        List<StockPositionChange>
+    > QuarterlyActivity { get; set; } = [];
+
+    public const int ActivityRowCap = 50;
 }

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -89,6 +89,115 @@
         </div>
     }
 
+    @if (Model.QuarterlyActivity.Count > 0 && Model.ActivityPriorDate.HasValue) {
+        <!-- Latest-quarter activity — pivots #1007's per-stock buckets on the holder:
+             Initiated / Increased / Reduced / Exited, capped at 50 rows per bucket.
+             A quarter selector lets the user browse past quarters; submission re-loads
+             with ?activityDate=YYYY-MM-DD. The oldest quarter has no prior to compare
+             against and is omitted from the selector. -->
+        <div class="card bg-base-100 shadow-sm mb-8" data-testid="institution-quarterly-activity">
+            <div class="card-body p-4">
+                <div class="flex flex-wrap items-center justify-between gap-3 mb-3">
+                    <h3 class="text-base font-medium m-0">Latest quarter activity</h3>
+                    @if (Model.AvailableReportDates.Count > 1) {
+                        <div class="flex items-center gap-2 text-sm">
+                            <span class="text-base-content/60">Quarter:</span>
+                            <select class="select select-bordered select-sm"
+                                onchange="window.location.href='?activityDate=' + this.value">
+                                @foreach (var date in Model.AvailableReportDates) {
+                                    if (date == Model.AvailableReportDates[^1]) { continue; }
+                                    var isSelected = date == Model.ActivityDate;
+                                    if (isSelected) {
+                                        <option value="@date.ToString("yyyy-MM-dd")" selected>@date.ToString("MMM dd, yyyy")</option>
+                                    } else {
+                                        <option value="@date.ToString("yyyy-MM-dd")">@date.ToString("MMM dd, yyyy")</option>
+                                    }
+                                }
+                            </select>
+                        </div>
+                    }
+                </div>
+                <div class="text-xs text-base-content/50 mb-3">
+                    Comparing @Model.ActivityDate?.ToString("MMM dd, yyyy") vs prior @Model.ActivityPriorDate.Value.ToString("MMM dd, yyyy").
+                </div>
+                @{
+                    var buckets = new[]
+                    {
+                        new {
+                            Type = Equibles.Holdings.Repositories.Models.StockPositionChangeType.Initiated,
+                            Label = "Initiated",
+                            BadgeCss = "badge-success",
+                            TestId = "activity-bucket-initiated",
+                        },
+                        new {
+                            Type = Equibles.Holdings.Repositories.Models.StockPositionChangeType.Increased,
+                            Label = "Increased",
+                            BadgeCss = "badge-info",
+                            TestId = "activity-bucket-increased",
+                        },
+                        new {
+                            Type = Equibles.Holdings.Repositories.Models.StockPositionChangeType.Reduced,
+                            Label = "Reduced",
+                            BadgeCss = "badge-warning",
+                            TestId = "activity-bucket-reduced",
+                        },
+                        new {
+                            Type = Equibles.Holdings.Repositories.Models.StockPositionChangeType.Exited,
+                            Label = "Exited",
+                            BadgeCss = "badge-error",
+                            TestId = "activity-bucket-exited",
+                        },
+                    };
+                }
+                <div class="grid grid-cols-1 gap-4">
+                    @foreach (var bucket in buckets) {
+                        var rows = Model.QuarterlyActivity.TryGetValue(bucket.Type, out var list) ? list : new List<Equibles.Holdings.Repositories.Models.StockPositionChange>();
+                        <div class="rounded-md border border-base-200 p-3" data-testid="@bucket.TestId">
+                            <div class="flex items-center gap-2 mb-2">
+                                <h4 class="text-sm font-medium m-0">@bucket.Label</h4>
+                                <span class="badge @bucket.BadgeCss badge-sm">@rows.Count.ToString("N0")</span>
+                            </div>
+                            @if (rows.Count == 0) {
+                                <div class="text-xs text-base-content/50">No stocks in this bucket for the selected quarter.</div>
+                            } else {
+                                <div class="overflow-x-auto">
+                                    <table class="table table-xs">
+                                        <thead>
+                                            <tr>
+                                                <th>Ticker</th>
+                                                <th>Company</th>
+                                                <th class="text-right">Prior</th>
+                                                <th class="text-right">New</th>
+                                                <th class="text-right">Δ Shares</th>
+                                                <th class="text-right">Δ Value (USD)</th>
+                                                <th class="text-right">% Portfolio</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            @foreach (var row in rows) {
+                                                var deltaSharesCss = row.DeltaShares > 0 ? "text-success" : row.DeltaShares < 0 ? "text-error" : "";
+                                                var deltaValueCss = row.DeltaValue > 0 ? "text-success" : row.DeltaValue < 0 ? "text-error" : "";
+                                                <tr>
+                                                    <td class="font-mono">@row.Ticker</td>
+                                                    <td class="max-w-xs truncate">@row.Name</td>
+                                                    <td class="text-right font-mono">@row.PreviousShares.ToString("N0")</td>
+                                                    <td class="text-right font-mono">@row.CurrentShares.ToString("N0")</td>
+                                                    <td class="text-right font-mono @deltaSharesCss">@(row.DeltaShares > 0 ? "+" : "")@row.DeltaShares.ToString("N0")</td>
+                                                    <td class="text-right font-mono @deltaValueCss">@(row.DeltaValue > 0 ? "+" : "")$@row.DeltaValue.ToString("N0")</td>
+                                                    <td class="text-right font-mono">@row.PercentOfPortfolio.ToString("F1")%</td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+    }
+
     <h2 class="text-xl font-semibold mb-3">Recent holdings</h2>
     @if (Model.Holdings.Count == 0) {
         <div class="text-base-content/60 py-8">No reported holdings.</div>

--- a/tests/Equibles.IntegrationTests/Web/ProfilesInstitutionQuarterlyActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesInstitutionQuarterlyActivityTests.cs
@@ -1,0 +1,167 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the Institution profile's quarterly-activity section: when the holder has
+/// at least two quarters of data the controller diffs the latest pair, the view
+/// renders one panel per bucket with the right counts (verified by the badge span
+/// inside each bucket's panel), and the page renders a single panel per change
+/// type even when only a subset of buckets have rows.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class ProfilesInstitutionQuarterlyActivityTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public ProfilesInstitutionQuarterlyActivityTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetInstitution_SingleQuarter_DoesNotRenderActivityCard()
+    {
+        var holderCik = "0001700001";
+        var holderId = Guid.NewGuid();
+        var stockId = Guid.NewGuid();
+        var only = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = holderCik,
+                    Name = "Single-Quarter Holder",
+                }
+            );
+            db.Add(MakeHolding(stockId, holderId, only, shares: 1_000, value: 1_000_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync($"/Institutions/{holderCik}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().NotContain("data-testid=\"institution-quarterly-activity\"");
+    }
+
+    [Fact]
+    public async Task GetInstitution_TwoQuartersWithMovement_RendersAllFourBucketPanels()
+    {
+        var holderCik = "0001700002";
+        var holderId = Guid.NewGuid();
+        var increasedId = Guid.NewGuid();
+        var reducedId = Guid.NewGuid();
+        var initiatedId = Guid.NewGuid();
+        var exitedId = Guid.NewGuid();
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.AddRange(
+                new CommonStock
+                {
+                    Id = increasedId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                },
+                new CommonStock
+                {
+                    Id = reducedId,
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corp.",
+                    Cik = "0000789019",
+                },
+                new CommonStock
+                {
+                    Id = initiatedId,
+                    Ticker = "NVDA",
+                    Name = "NVIDIA Corp.",
+                    Cik = "0001045810",
+                },
+                new CommonStock
+                {
+                    Id = exitedId,
+                    Ticker = "TSLA",
+                    Name = "Tesla Inc.",
+                    Cik = "0001318605",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = holderCik,
+                    Name = "Active Allocator LP",
+                }
+            );
+            // Prior quarter: AAPL + MSFT + TSLA.
+            db.Add(MakeHolding(increasedId, holderId, prior, shares: 1_000, value: 1_000_000));
+            db.Add(MakeHolding(reducedId, holderId, prior, shares: 500, value: 500_000));
+            db.Add(MakeHolding(exitedId, holderId, prior, shares: 100, value: 100_000));
+            // Current quarter: AAPL increased, MSFT reduced, TSLA exited, NVDA initiated.
+            db.Add(MakeHolding(increasedId, holderId, current, shares: 1_500, value: 1_500_000));
+            db.Add(MakeHolding(reducedId, holderId, current, shares: 200, value: 200_000));
+            db.Add(MakeHolding(initiatedId, holderId, current, shares: 50, value: 50_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync($"/Institutions/{holderCik}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("data-testid=\"institution-quarterly-activity\"");
+        // One panel per bucket, regardless of whether it's empty (the panel still renders
+        // the count badge and the empty-state copy).
+        html.Should().Contain("data-testid=\"activity-bucket-initiated\"");
+        html.Should().Contain("data-testid=\"activity-bucket-increased\"");
+        html.Should().Contain("data-testid=\"activity-bucket-reduced\"");
+        html.Should().Contain("data-testid=\"activity-bucket-exited\"");
+        // The four target tickers each appear in the activity card.
+        var sectionStart = html.IndexOf(
+            "data-testid=\"institution-quarterly-activity\"",
+            StringComparison.Ordinal
+        );
+        var sectionEnd = html.IndexOf("Recent holdings", sectionStart, StringComparison.Ordinal);
+        var section = html.Substring(sectionStart, sectionEnd - sectionStart);
+        section.Should().Contain("AAPL");
+        section.Should().Contain("MSFT");
+        section.Should().Contain("NVDA");
+        section.Should().Contain("TSLA");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stockId:N}".Substring(0, 12) + $"-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Holdings/HolderQuarterlyActivityCalculatorTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HolderQuarterlyActivityCalculatorTests.cs
@@ -1,0 +1,144 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HolderQuarterlyActivityCalculatorTests
+{
+    [Fact]
+    public void Group_BothInputsEmpty_ReturnsEmptyBuckets()
+    {
+        var result = HolderQuarterlyActivityCalculator.Group([], []);
+
+        result[StockPositionChangeType.Initiated].Should().BeEmpty();
+        result[StockPositionChangeType.Increased].Should().BeEmpty();
+        result[StockPositionChangeType.Reduced].Should().BeEmpty();
+        result[StockPositionChangeType.Exited].Should().BeEmpty();
+        result[StockPositionChangeType.Unchanged].Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Group_OnlyCurrent_AllStocksAreInitiated()
+    {
+        var aapl = MakeStock("AAPL", "Apple Inc.");
+        var msft = MakeStock("MSFT", "Microsoft Corp.");
+
+        var result = HolderQuarterlyActivityCalculator.Group(
+            [
+                MakeHolding(aapl, shares: 1_000, value: 1_000_000),
+                MakeHolding(msft, shares: 500, value: 500_000),
+            ],
+            []
+        );
+
+        result[StockPositionChangeType.Initiated].Should().HaveCount(2);
+        result[StockPositionChangeType.Exited].Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Group_OnlyPrevious_AllStocksAreExited()
+    {
+        var aapl = MakeStock("AAPL", "Apple Inc.");
+
+        var result = HolderQuarterlyActivityCalculator.Group(
+            [],
+            [MakeHolding(aapl, shares: 1_000, value: 1_000_000)]
+        );
+
+        result[StockPositionChangeType.Exited].Should().ContainSingle();
+        result[StockPositionChangeType.Exited][0].PreviousShares.Should().Be(1_000);
+        result[StockPositionChangeType.Exited][0].CurrentShares.Should().Be(0);
+        result[StockPositionChangeType.Exited][0].DeltaShares.Should().Be(-1_000);
+    }
+
+    [Fact]
+    public void Group_HigherCurrentShares_ClassifiesAsIncreased()
+    {
+        var aapl = MakeStock("AAPL", "Apple Inc.");
+
+        var result = HolderQuarterlyActivityCalculator.Group(
+            [MakeHolding(aapl, shares: 1_500, value: 1_500_000)],
+            [MakeHolding(aapl, shares: 1_000, value: 1_000_000)]
+        );
+
+        result[StockPositionChangeType.Increased].Should().ContainSingle();
+        result[StockPositionChangeType.Increased][0].DeltaShares.Should().Be(500);
+    }
+
+    [Fact]
+    public void Group_LowerCurrentShares_ClassifiesAsReduced()
+    {
+        var aapl = MakeStock("AAPL", "Apple Inc.");
+
+        var result = HolderQuarterlyActivityCalculator.Group(
+            [MakeHolding(aapl, shares: 600, value: 600_000)],
+            [MakeHolding(aapl, shares: 1_000, value: 1_000_000)]
+        );
+
+        result[StockPositionChangeType.Reduced].Should().ContainSingle();
+        result[StockPositionChangeType.Reduced][0].DeltaShares.Should().Be(-400);
+    }
+
+    [Fact]
+    public void Group_PercentOfPortfolio_DividesByCurrentQuarterTotalValue()
+    {
+        var aapl = MakeStock("AAPL", "Apple Inc.");
+        var msft = MakeStock("MSFT", "Microsoft Corp.");
+
+        var result = HolderQuarterlyActivityCalculator.Group(
+            [
+                MakeHolding(aapl, shares: 1_000, value: 700_000),
+                MakeHolding(msft, shares: 500, value: 300_000),
+            ],
+            []
+        );
+
+        var aaplRow = result[StockPositionChangeType.Initiated].Single(r => r.Ticker == "AAPL");
+        var msftRow = result[StockPositionChangeType.Initiated].Single(r => r.Ticker == "MSFT");
+        aaplRow.PercentOfPortfolio.Should().Be(70.0);
+        msftRow.PercentOfPortfolio.Should().Be(30.0);
+    }
+
+    [Fact]
+    public void Group_MultipleRowsSameStock_AggregatedIntoOneEntry()
+    {
+        var aapl = MakeStock("AAPL", "Apple Inc.");
+
+        var result = HolderQuarterlyActivityCalculator.Group(
+            [
+                MakeHolding(aapl, shares: 600, value: 600_000),
+                MakeHolding(aapl, shares: 400, value: 400_000),
+            ],
+            [MakeHolding(aapl, shares: 1_000, value: 1_000_000)]
+        );
+
+        // 600 + 400 = 1_000 = prior → Unchanged.
+        result[StockPositionChangeType.Unchanged].Should().ContainSingle();
+        result[StockPositionChangeType.Unchanged][0].CurrentShares.Should().Be(1_000);
+    }
+
+    private static CommonStock MakeStock(string ticker, string name) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = name,
+            Cik = "C" + Guid.NewGuid().ToString("N")[..7],
+        };
+
+    private static InstitutionalHolding MakeHolding(CommonStock stock, long shares, long value) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            CommonStock = stock,
+            InstitutionalHolderId = Guid.NewGuid(),
+            FilingDate = new DateOnly(2025, 1, 15),
+            ReportDate = new DateOnly(2024, 12, 31),
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+        };
+}


### PR DESCRIPTION
## Summary

- **Slice 1 of 2** for #1013. Pivots #1007's per-stock position-change diff onto a single holder: for the latest reported quarter and the immediately prior quarter, classifies each stock as Initiated / Increased / Reduced / Exited and renders one card with four sub-tables.
- A `?activityDate=YYYY-MM-DD` query param lets the user browse past quarters.
- Backing calculator is a pure static helper in `Equibles.Holdings.Repositories` — reused by the MCP tool in slice 2.
- `Refs #1013` — not the closing slice.

## Code changes

- `src/Equibles.Holdings.Repositories/Models/StockPositionChange.cs` — per-stock projection.
- `src/Equibles.Holdings.Repositories/HolderQuarterlyActivityCalculator.cs` — pure `Group(currentHoldings, previousHoldings)`. Aggregates by `CommonStockId` so multi-manager rows collapse; exited rows carry prior shares/value and 0%.
- `src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs` — `AvailableReportDates` + `ActivityDate` + `ActivityPriorDate` + bucket dictionary + `ActivityRowCap` (50).
- `src/Equibles.Web/Controllers/ProfilesController.cs` — `Institution` action gains optional `activityDate` param; helper resolves the requested date, materializes current + prior quarter with `Include(CommonStock)`, runs calculator, caps each bucket at 50 by `|Δ value|` desc.
- `src/Equibles.Web/Views/Profiles/Institution.cshtml` — new card with Quarter selector, comparing-X-vs-Y caption, four bucket sub-tables. The oldest reported quarter is excluded from the selector.
- `tests/Equibles.UnitTests/Holdings/HolderQuarterlyActivityCalculatorTests.cs` — 7 unit tests.
- `tests/Equibles.IntegrationTests/Web/ProfilesInstitutionQuarterlyActivityTests.cs` — 2 WebHostFixture tests.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1104 files).
- Calculator unit tests — 7/7 passing.
- WebHostFixture integration tests — 2/2 passing.

Refs #1013