### PR TITLE
refactor(finra-mcp): extract ParseDateOr helper for duplicated date-parsing fallback

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -60,16 +60,11 @@ public class ShortDataTools
 
                 var query = _shortVolumeRepository.GetHistoryByStock(stock);
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 query = query.Where(d => d.Date >= start && d.Date <= end);
 
@@ -130,16 +125,11 @@ public class ShortDataTools
 
                 var query = _shortInterestRepository.GetHistoryByStock(stock);
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 query = query.Where(s => s.SettlementDate >= start && s.SettlementDate <= end);
 
@@ -256,4 +246,7 @@ public class ShortDataTools
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
+
+    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
+        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 }


### PR DESCRIPTION
## Summary

- Collapse four duplicated `IsNullOrEmpty + DateOnly.TryParse + fallback` ternary blocks in `ShortDataTools.GetShortVolume` and `ShortDataTools.GetShortInterest` into a single private static `ParseDateOr(string, DateOnly)` helper.
- Behaviour-preserving: helper performs the same `IsNullOrEmpty` short-circuit then `DateOnly.TryParse(out)`, returning the parsed value on success and the supplied fallback on null/empty/invalid input — identical for every input.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — add `private static DateOnly ParseDateOr(string, DateOnly)`; rewrite the four start/end date blocks to call it, threading the existing default (`AddMonths(-3)`, `AddYears(-1)`, `DateTime.UtcNow`) as the fallback argument. No public-API or signature changes. Full unit-test suite (1365) green.