### PR TITLE
feat(holdings-mcp): add GetInstitutionQuarterlyActivity MCP tool (2/2)

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -5,6 +5,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
 using Equibles.Mcp;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -796,6 +797,142 @@ public class InstitutionalHoldingsTools
             },
             _logger,
             "GetInstitutionSectorAllocation",
+            $"institution: {institutionName}",
+            ReportError
+        );
+    }
+
+    [McpServerTool(Name = "GetInstitutionQuarterlyActivity")]
+    [Description(
+        "Get an institution's quarterly position-change activity — Initiated / Increased / Reduced / Exited stocks diffed against the immediately prior quarter. Returns the buckets as one markdown section per bucket, sorted by absolute Δ value desc. Use `bucket` to filter to a single bucket. Use this to answer 'what did this fund do this quarter?'"
+    )]
+    public Task<string> GetInstitutionQuarterlyActivity(
+        [Description("Institution name (partial or full — first match wins)")]
+            string institutionName,
+        [Description("Report date in YYYY-MM-DD format (defaults to the holder's latest)")]
+            string reportDate = null,
+        [Description(
+            "Filter to a single bucket: initiated, increased, reduced, exited (omit for all four)"
+        )]
+            string bucket = null,
+        [Description("Maximum number of stocks to return per bucket (default: 20)")]
+            int maxResults = 20
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                var normalizedBucket = bucket?.Trim().ToLowerInvariant();
+                if (
+                    !string.IsNullOrEmpty(normalizedBucket)
+                    && normalizedBucket != "initiated"
+                    && normalizedBucket != "increased"
+                    && normalizedBucket != "reduced"
+                    && normalizedBucket != "exited"
+                )
+                    return "Unknown bucket. Use one of: initiated, increased, reduced, exited (or omit).";
+
+                var holder = await _holderRepository
+                    .Search(institutionName ?? string.Empty)
+                    .OrderBy(h => h.Name)
+                    .FirstOrDefaultAsync();
+                if (holder == null)
+                    return $"No institution found matching '{institutionName}'.";
+
+                var reportDates = await _holdingRepository
+                    .GetHistoryByHolder(holder)
+                    .Select(h => h.ReportDate)
+                    .Distinct()
+                    .OrderByDescending(d => d)
+                    .ToListAsync();
+                if (reportDates.Count < 2)
+                    return $"{holder.Name} has fewer than two reported quarters — no diff available.";
+
+                DateOnly targetDate;
+                if (
+                    !string.IsNullOrEmpty(reportDate)
+                    && DateOnly.TryParse(reportDate, out var parsed)
+                    && reportDates.Contains(parsed)
+                )
+                    targetDate = parsed;
+                else
+                    targetDate = reportDates[0];
+                var targetIndex = reportDates.IndexOf(targetDate);
+                if (targetIndex >= reportDates.Count - 1)
+                    return $"{targetDate:yyyy-MM-dd} is the oldest reported quarter for {holder.Name} — no prior to compare against.";
+
+                var priorDate = reportDates[targetIndex + 1];
+                var currentHoldings = await _holdingRepository
+                    .GetByHolder(holder, targetDate)
+                    .Include(h => h.CommonStock)
+                    .ToListAsync();
+                var previousHoldings = await _holdingRepository
+                    .GetByHolder(holder, priorDate)
+                    .Include(h => h.CommonStock)
+                    .ToListAsync();
+                var grouped = HolderQuarterlyActivityCalculator.Group(
+                    currentHoldings,
+                    previousHoldings
+                );
+
+                var sections = new (StockPositionChangeType Type, string Label)[]
+                {
+                    (StockPositionChangeType.Initiated, "Initiated"),
+                    (StockPositionChangeType.Increased, "Increased"),
+                    (StockPositionChangeType.Reduced, "Reduced"),
+                    (StockPositionChangeType.Exited, "Exited"),
+                };
+
+                var result = new StringBuilder();
+                result.AppendLine(
+                    $"Quarterly activity — **{holder.Name}** as of {targetDate:yyyy-MM-dd}"
+                );
+                result.AppendLine($"vs prior quarter {priorDate:yyyy-MM-dd}");
+                result.AppendLine();
+
+                var rendered = 0;
+                foreach (var section in sections)
+                {
+                    if (
+                        !string.IsNullOrEmpty(normalizedBucket)
+                        && section.Label.ToLowerInvariant() != normalizedBucket
+                    )
+                        continue;
+                    var rows = grouped[section.Type]
+                        .OrderByDescending(r => Math.Abs(r.DeltaValue))
+                        .Take(maxResults)
+                        .ToList();
+                    result.AppendLine($"## {section.Label}");
+                    if (rows.Count == 0)
+                    {
+                        result.AppendLine("_No stocks in this bucket this quarter._");
+                        result.AppendLine();
+                        continue;
+                    }
+                    result.AppendLine(
+                        "| # | Ticker | Company | Prior | New | Δ Shares | Δ Value ($M) |"
+                    );
+                    result.AppendLine(
+                        "|---|--------|---------|-------|-----|---------|-------------|"
+                    );
+                    for (var i = 0; i < rows.Count; i++)
+                    {
+                        var r = rows[i];
+                        var sign = r.DeltaShares > 0 ? "+" : "";
+                        result.AppendLine(
+                            $"| {i + 1} | {r.Ticker} | {r.Name} | {r.PreviousShares:N0} | {r.CurrentShares:N0} | {sign}{r.DeltaShares:N0} | {r.DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0} |"
+                        );
+                    }
+                    result.AppendLine();
+                    rendered++;
+                }
+
+                if (rendered == 0)
+                    result.AppendLine("_No matching buckets._");
+                return result.ToString();
+            },
+            _logger,
+            "GetInstitutionQuarterlyActivity",
             $"institution: {institutionName}",
             ReportError
         );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests.cs
@@ -1,0 +1,196 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins <c>GetInstitutionQuarterlyActivity</c>. Each test exercises one path: unknown
+/// institution, single-quarter holder (no diff possible), all-four-buckets diff, and
+/// the explicit <c>bucket</c> filter that limits the response to one section.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetInstitutionQuarterlyActivity_UnknownInstitution_ReportsNotFound()
+    {
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionQuarterlyActivity("Definitely Not A Fund");
+
+        output.Should().Contain("No institution found");
+    }
+
+    [Fact]
+    public async Task GetInstitutionQuarterlyActivity_SingleQuarterHolder_ReportsTooFewQuarters()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var holder = new InstitutionalHolder { Cik = "Q00010001", Name = "Single Quarter LP" };
+        DbContext.AddRange(stock, holder);
+        DbContext.Add(
+            MakeHolding(stock, holder, new DateOnly(2024, 12, 31), shares: 1_000, value: 1_000_000)
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionQuarterlyActivity("Single Quarter");
+
+        output.Should().Contain("fewer than two reported quarters");
+    }
+
+    [Fact]
+    public async Task GetInstitutionQuarterlyActivity_TwoQuartersWithMovement_RendersAllSections()
+    {
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var msft = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+        };
+        var nvda = new CommonStock
+        {
+            Ticker = "NVDA",
+            Name = "NVIDIA Corp.",
+            Cik = "0001045810",
+        };
+        var tsla = new CommonStock
+        {
+            Ticker = "TSLA",
+            Name = "Tesla Inc.",
+            Cik = "0001318605",
+        };
+        var holder = new InstitutionalHolder { Cik = "Q00010002", Name = "Active Allocator LP" };
+        DbContext.AddRange(aapl, msft, nvda, tsla, holder);
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        // Same shape as #1013 view test: AAPL increased, MSFT reduced, NVDA initiated, TSLA exited.
+        DbContext.Add(MakeHolding(aapl, holder, prior, shares: 1_000, value: 1_000_000));
+        DbContext.Add(MakeHolding(msft, holder, prior, shares: 500, value: 500_000));
+        DbContext.Add(MakeHolding(tsla, holder, prior, shares: 100, value: 100_000));
+        DbContext.Add(MakeHolding(aapl, holder, current, shares: 1_500, value: 1_500_000));
+        DbContext.Add(MakeHolding(msft, holder, current, shares: 200, value: 200_000));
+        DbContext.Add(MakeHolding(nvda, holder, current, shares: 50, value: 50_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionQuarterlyActivity("Active Allocator");
+
+        output.Should().Contain("Quarterly activity — **Active Allocator LP**");
+        output.Should().Contain("## Initiated");
+        output.Should().Contain("## Increased");
+        output.Should().Contain("## Reduced");
+        output.Should().Contain("## Exited");
+        output.Should().Contain("NVDA"); // initiated
+        output.Should().Contain("AAPL"); // increased
+        output.Should().Contain("MSFT"); // reduced
+        output.Should().Contain("TSLA"); // exited
+    }
+
+    [Fact]
+    public async Task GetInstitutionQuarterlyActivity_BucketFilter_LimitsToOneSection()
+    {
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var msft = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+        };
+        var holder = new InstitutionalHolder { Cik = "Q00010003", Name = "Filtered LP" };
+        DbContext.AddRange(aapl, msft, holder);
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        DbContext.Add(MakeHolding(aapl, holder, prior, shares: 1_000, value: 1_000_000));
+        DbContext.Add(MakeHolding(aapl, holder, current, shares: 1_500, value: 1_500_000));
+        DbContext.Add(MakeHolding(msft, holder, current, shares: 100, value: 100_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionQuarterlyActivity("Filtered LP", bucket: "increased");
+
+        output.Should().Contain("## Increased");
+        output.Should().NotContain("## Initiated");
+        output.Should().NotContain("## Reduced");
+        output.Should().NotContain("## Exited");
+        output.Should().Contain("AAPL");
+        output.Should().NotContain("MSFT");
+    }
+
+    [Fact]
+    public async Task GetInstitutionQuarterlyActivity_UnknownBucket_ReportsValidValues()
+    {
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionQuarterlyActivity("Anything", bucket: "garbage");
+
+        output.Should().Contain("Unknown bucket");
+        output.Should().Contain("initiated");
+        output.Should().Contain("exited");
+    }
+
+    private InstitutionalHoldingsTools NewSut(Equibles.Data.EquiblesDbContext ctx) =>
+        new(
+            new InstitutionalHoldingRepository(ctx),
+            new InstitutionalHolderRepository(ctx),
+            new CommonStockRepository(ctx),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -270,6 +270,7 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("GetMarketWide13FActivity");
         toolNames.Should().Contain("GetInstitutionSummary");
         toolNames.Should().Contain("GetInstitutionSectorAllocation");
+        toolNames.Should().Contain("GetInstitutionQuarterlyActivity");
     }
 
     // ── InsiderTrading module specific ──────────────────────────────────
@@ -363,6 +364,7 @@ public class McpModuleToolDiscoveryTests
                     "GetMarketWide13FActivity",
                     "GetInstitutionSummary",
                     "GetInstitutionSectorAllocation",
+                    "GetInstitutionQuarterlyActivity",
                 }
             },
             {


### PR DESCRIPTION
## Summary

- **Closing slice (2 of 2)** for #1013. Mirrors the web quarterly-activity card landed in #1107 — diffs an institution's latest quarter against the immediately prior quarter and returns Initiated / Increased / Reduced / Exited stocks as markdown sections.
- A `bucket` argument filters to one section.
- Reuses `HolderQuarterlyActivityCalculator` from `Equibles.Holdings.Repositories`.
- Closes #1013.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — new `GetInstitutionQuarterlyActivity(institutionName, reportDate?, bucket?, max?)`. Resolves holder + dates via existing queries, runs the calculator, sorts each bucket by `|Δ value|` desc, emits one markdown section per bucket.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — module-discovery list updated.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionQuarterlyActivityTests.cs` — 5 ParadeDB tests.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1105 files).
- New MCP integration tests — 5/5 passing.
- Module-discovery unit tests — 59/59 passing.

Closes #1013