### PR TITLE
feat(sec-facts): add FinancialFactDimension schema for XBRL dimensional facts

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260520122021_AddFinancialFactDimensions.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260520122021_AddFinancialFactDimensions.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260520122021_AddFinancialFactDimensions")]
+    partial class AddFinancialFactDimensions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260520122021_AddFinancialFactDimensions.cs
+++ b/src/Equibles.Migrations/Migrations/20260520122021_AddFinancialFactDimensions.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFinancialFactDimensions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FinancialFactDimension",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    FinancialFactId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Axis = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: false
+                    ),
+                    Member = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: false
+                    ),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FinancialFactDimension", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FinancialFactDimension_FinancialFact_FinancialFactId",
+                        column: x => x.FinancialFactId,
+                        principalTable: "FinancialFact",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FinancialFactDimension_Axis_Member",
+                table: "FinancialFactDimension",
+                columns: new[] { "Axis", "Member" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FinancialFactDimension_FinancialFactId_Axis_Member",
+                table: "FinancialFactDimension",
+                columns: new[] { "FinancialFactId", "Axis", "Member" },
+                unique: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "FinancialFactDimension");
+        }
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Data/FinancialFactsModuleConfiguration.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/FinancialFactsModuleConfiguration.cs
@@ -23,6 +23,8 @@ public class FinancialFactsModuleConfiguration : Equibles.Data.IModuleConfigurat
             b.Property(e => e.Form).HasConversion(docTypeConversion);
         });
 
+        builder.Entity<FinancialFactDimension>();
+
         builder.Entity<FinancialFactsSyncStatus>();
     }
 }

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFact.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFact.cs
@@ -90,4 +90,12 @@ public class FinancialFact
     public string Frame { get; set; }
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Explicit XBRL dimensions (axis + member pairs) attached to this fact.
+    /// Empty list = consolidated / no-dimension default context, which is the
+    /// only context the SEC Company Facts API returns; dimensional rows arrive
+    /// exclusively from the iXBRL / standalone-XBRL extractor.
+    /// </summary>
+    public virtual List<FinancialFactDimension> Dimensions { get; set; } = [];
 }

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFactDimension.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFactDimension.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.FinancialFacts.Data.Models;
+
+/// <summary>
+/// One explicit XBRL dimension on a <see cref="FinancialFact"/> — the
+/// (axis, member) pair that disambiguates a segment / product / geography cut
+/// from the consolidated total (e.g. <c>srt:ProductOrServiceAxis</c> →
+/// <c>aapl:IPhoneMember</c>). Facts with no rows here are the consolidated
+/// (no-dimension) default; the SEC Company Facts API only returns facts in
+/// that default context, so dimensional facts arrive exclusively from the
+/// iXBRL / standalone-XBRL extractor (see #877). Axis and member are stored
+/// as full XBRL QNames (<c>prefix:localName</c>).
+/// </summary>
+[Index(nameof(FinancialFactId), nameof(Axis), nameof(Member), IsUnique = true)]
+[Index(nameof(Axis), nameof(Member))]
+public class FinancialFactDimension
+{
+    // Client-generated Guid key — matches the rest of the financial-facts
+    // schema so FlexLabs UpsertRange includes the column on INSERT.
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid FinancialFactId { get; set; }
+    public virtual FinancialFact FinancialFact { get; set; }
+
+    /// <summary>XBRL axis QName, e.g. <c>srt:ProductOrServiceAxis</c>.</summary>
+    [Required]
+    [MaxLength(256)]
+    public string Axis { get; set; }
+
+    /// <summary>XBRL member QName, e.g. <c>aapl:IPhoneMember</c>.</summary>
+    [Required]
+    [MaxLength(256)]
+    public string Member { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}


### PR DESCRIPTION
## Summary

- Slice 1 / 4 of #877 — adds the storage layer for explicit XBRL dimensions (`axis` + `member` QName pairs) attached to a `FinancialFact`.
- API-sourced facts continue to be stored as no-dimension (consolidated total) by absence of dimension rows; dimensional rows will arrive exclusively from the iXBRL / standalone-XBRL extractor introduced in the next slices.
- This is **not** the closing slice — refs #877 only; the issue stays open.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFactDimension.cs` — new entity. Client-generated `Guid` key, FK to `FinancialFact`, `Axis` + `Member` (full XBRL QNames, 256-char cap), `CreationTime`. Composite unique index on `(FinancialFactId, Axis, Member)` (one member per axis per fact); secondary `(Axis, Member)` index for cross-fact dimension lookups.
- `src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFact.cs` — adds `virtual List<FinancialFactDimension> Dimensions { get; set; } = [];` navigation; doc string makes the no-dimension default explicit.
- `src/Equibles.Sec.FinancialFacts.Data/FinancialFactsModuleConfiguration.cs` — registers the new entity in the module's `ConfigureEntities`.
- `src/Equibles.Migrations/Migrations/20260520122021_AddFinancialFactDimensions.cs` (+ Designer) — auto-generated `CreateTable` + two indexes; cascade delete from `FinancialFact`.
- `src/Equibles.Migrations/Migrations/EquiblesDbContextModelSnapshot.cs` — auto-regenerated. Apart from the new entity, also drops stale `ValueGeneratedOnAdd()` entries on three existing FinancialFacts entities — their `[DatabaseGenerated(None)]` attributes were already in place; EF just re-aligned the snapshot with the current model. Not manually edited.