### PR TITLE
feat(holdings): add /Institutions/Compare side-by-side overlap view (1/2)

### DIFF
--- a/src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs
@@ -1,0 +1,151 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Holdings.Repositories;
+
+public static class FundOverlapCalculator
+{
+    // Each tuple is (holder, holder's holdings for the shared report date). Holdings
+    // must be materialized with CommonStock populated (Include(h => h.CommonStock) at
+    // the query site).
+    public static FundOverlapResult Calculate(
+        IReadOnlyList<(
+            InstitutionalHolder Holder,
+            IReadOnlyList<InstitutionalHolding> Holdings
+        )> funds,
+        DateOnly reportDate
+    )
+    {
+        var result = new FundOverlapResult { ReportDate = reportDate };
+        if (funds.Count == 0)
+            return result;
+
+        // Aggregate each fund's positions per stock. The aggregation collapses multiple
+        // discretion rows for the same stock so the per-fund slice is one entry per
+        // CommonStockId.
+        var fundAggregates = funds
+            .Select(f =>
+            {
+                var perStock = f
+                    .Holdings.GroupBy(h => h.CommonStockId)
+                    .ToDictionary(
+                        g => g.Key,
+                        g => new FundStockAggregate
+                        {
+                            CommonStockId = g.Key,
+                            Ticker = g.First().CommonStock?.Ticker,
+                            Name = g.First().CommonStock?.Name,
+                            Shares = g.Sum(h => h.Shares),
+                            Value = g.Sum(h => h.Value),
+                        }
+                    );
+                return new FundAggregate { Holder = f.Holder, PerStock = perStock };
+            })
+            .ToList();
+
+        foreach (var fund in fundAggregates)
+        {
+            result.Funds.Add(
+                new FundOverlapFund
+                {
+                    HolderId = fund.Holder.Id,
+                    HolderCik = fund.Holder.Cik,
+                    HolderName = fund.Holder.Name,
+                    PositionCount = fund.PerStock.Count,
+                    TotalValue = fund.PerStock.Values.Sum(s => s.Value),
+                }
+            );
+        }
+
+        // Union of stock ids; build one row per stock, with one slice per fund.
+        var allStockIds = fundAggregates.SelectMany(f => f.PerStock.Keys).Distinct().ToList();
+
+        long dollarWeightedNumerator = 0;
+        long dollarWeightedDenominator = 0;
+        var intersectionCount = 0;
+
+        foreach (var stockId in allStockIds)
+        {
+            string ticker = null;
+            string name = null;
+            var slices = new List<FundOverlapRowSlice>();
+            long combinedValue = 0;
+            long minValue = long.MaxValue;
+            long maxValue = 0;
+            var allHaveIt = true;
+            foreach (var fund in fundAggregates)
+            {
+                fund.PerStock.TryGetValue(stockId, out var perStock);
+                ticker ??= perStock?.Ticker;
+                name ??= perStock?.Name;
+                var fundTotal = fund.PerStock.Values.Sum(s => s.Value);
+                var slice = new FundOverlapRowSlice
+                {
+                    HolderId = fund.Holder.Id,
+                    Shares = perStock?.Shares ?? 0,
+                    Value = perStock?.Value ?? 0,
+                    PercentOfPortfolio =
+                        fundTotal > 0 && perStock != null
+                            ? (double)perStock.Value / fundTotal * 100.0
+                            : 0,
+                };
+                slices.Add(slice);
+                combinedValue += slice.Value;
+                if (perStock == null)
+                    allHaveIt = false;
+                else
+                {
+                    if (perStock.Value < minValue)
+                        minValue = perStock.Value;
+                    if (perStock.Value > maxValue)
+                        maxValue = perStock.Value;
+                }
+            }
+            if (allHaveIt)
+            {
+                intersectionCount++;
+                dollarWeightedNumerator += minValue;
+            }
+            dollarWeightedDenominator += maxValue;
+
+            result.Rows.Add(
+                new FundOverlapRow
+                {
+                    CommonStockId = stockId,
+                    Ticker = ticker,
+                    Name = name,
+                    Slices = slices,
+                    IsCommon = allHaveIt,
+                    CombinedValue = combinedValue,
+                }
+            );
+        }
+
+        result.UnionPositionCount = allStockIds.Count;
+        result.IntersectionPositionCount = intersectionCount;
+        result.JaccardSimilarityPercent =
+            allStockIds.Count > 0 ? (double)intersectionCount / allStockIds.Count * 100.0 : 0;
+        result.DollarWeightedOverlapPercent =
+            dollarWeightedDenominator > 0
+                ? (double)dollarWeightedNumerator / dollarWeightedDenominator * 100.0
+                : 0;
+
+        result.Rows = result.Rows.OrderByDescending(r => r.CombinedValue).ToList();
+        return result;
+    }
+
+    private class FundAggregate
+    {
+        public InstitutionalHolder Holder { get; set; }
+        public Dictionary<Guid, FundStockAggregate> PerStock { get; set; }
+    }
+
+    private class FundStockAggregate
+    {
+        public Guid CommonStockId { get; set; }
+        public string Ticker { get; set; }
+        public string Name { get; set; }
+        public long Shares { get; set; }
+        public long Value { get; set; }
+    }
+}

--- a/src/Equibles.Holdings.Repositories/Models/FundOverlapResult.cs
+++ b/src/Equibles.Holdings.Repositories/Models/FundOverlapResult.cs
@@ -1,0 +1,49 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class FundOverlapResult
+{
+    public DateOnly ReportDate { get; set; }
+    public List<FundOverlapFund> Funds { get; set; } = [];
+    public List<FundOverlapRow> Rows { get; set; } = [];
+
+    // Counts and intersection-based stats across the union of the funds' positions.
+    public int UnionPositionCount { get; set; }
+    public int IntersectionPositionCount { get; set; }
+    public double JaccardSimilarityPercent { get; set; }
+
+    // Dollar-weighted overlap: SUM over shared stocks of min(per-fund value across the
+    // funds), divided by SUM over the union of max value. Approximates "if you held the
+    // overlap, how much of the average-sized fund would that be?"
+    public double DollarWeightedOverlapPercent { get; set; }
+}
+
+public class FundOverlapFund
+{
+    public Guid HolderId { get; set; }
+    public string HolderCik { get; set; }
+    public string HolderName { get; set; }
+    public int PositionCount { get; set; }
+    public long TotalValue { get; set; }
+}
+
+public class FundOverlapRow
+{
+    public Guid CommonStockId { get; set; }
+    public string Ticker { get; set; }
+    public string Name { get; set; }
+
+    // Per-fund slice indexed by the same order as FundOverlapResult.Funds.
+    public List<FundOverlapRowSlice> Slices { get; set; } = [];
+
+    // True when every listed fund reports this stock.
+    public bool IsCommon { get; set; }
+    public long CombinedValue { get; set; }
+}
+
+public class FundOverlapRowSlice
+{
+    public Guid HolderId { get; set; }
+    public long Shares { get; set; }
+    public long Value { get; set; }
+    public double PercentOfPortfolio { get; set; }
+}

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -208,6 +208,84 @@ public class ProfilesController : BaseController
         return (summary, allocation);
     }
 
+    [HttpGet("~/Institutions/Compare")]
+    public async Task<IActionResult> CompareInstitutions(
+        [FromQuery(Name = "ciks")] string[] ciks = null,
+        [FromQuery(Name = "date")] DateOnly? date = null
+    )
+    {
+        ciks ??= [];
+        var distinctCiks = ciks.Where(c => !string.IsNullOrWhiteSpace(c))
+            .Select(c => c.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (distinctCiks.Count > InstitutionCompareViewModel.MaxCiks)
+            return BadRequest(
+                $"At most {InstitutionCompareViewModel.MaxCiks} CIKs may be compared."
+            );
+
+        var viewModel = new InstitutionCompareViewModel { RequestedCiks = distinctCiks };
+        ViewData["Title"] = "Compare institutions";
+
+        if (distinctCiks.Count < InstitutionCompareViewModel.MinCiks)
+            return View(viewModel);
+
+        var holders = new List<InstitutionalHolder>();
+        foreach (var cik in distinctCiks)
+        {
+            var holder = await _institutionalHolderRepository.GetByCik(cik);
+            if (holder == null)
+                viewModel.MissingCiks.Add(cik);
+            else
+                holders.Add(holder);
+        }
+        if (holders.Count < InstitutionCompareViewModel.MinCiks)
+            return View(viewModel);
+
+        // Common report dates = intersection of each holder's distinct report dates.
+        // First pass collects per-holder sorted distinct dates; intersection happens in
+        // memory so we keep the descending order from the first holder.
+        var perHolderDates = new List<List<DateOnly>>();
+        foreach (var holder in holders)
+        {
+            var dates = await _institutionalHoldingRepository
+                .GetHistoryByHolder(holder)
+                .Select(h => h.ReportDate)
+                .Distinct()
+                .OrderByDescending(d => d)
+                .ToListAsync();
+            perHolderDates.Add(dates);
+        }
+        var commonDates = perHolderDates
+            .Skip(1)
+            .Aggregate((IEnumerable<DateOnly>)perHolderDates[0], (acc, next) => acc.Intersect(next))
+            .OrderByDescending(d => d)
+            .ToList();
+        viewModel.CommonReportDates = commonDates;
+        if (commonDates.Count == 0)
+            return View(viewModel);
+
+        var selected = date ?? commonDates[0];
+        if (!commonDates.Contains(selected))
+            selected = commonDates[0];
+        viewModel.SelectedDate = selected;
+
+        // Pull each fund's holdings for the selected date (one query per fund — the
+        // funds-side cardinality is bounded to 4).
+        var perFund =
+            new List<(InstitutionalHolder Holder, IReadOnlyList<InstitutionalHolding> Holdings)>();
+        foreach (var holder in holders)
+        {
+            var holdings = await _institutionalHoldingRepository
+                .GetByHolder(holder, selected)
+                .Include(h => h.CommonStock)
+                .ToListAsync();
+            perFund.Add((holder, holdings));
+        }
+        viewModel.Overlap = FundOverlapCalculator.Calculate(perFund, selected);
+        return View(viewModel);
+    }
+
     [HttpGet("~/Insiders/{ownerCik}")]
     public async Task<IActionResult> Insider(string ownerCik)
     {

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionCompareViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionCompareViewModel.cs
@@ -1,0 +1,15 @@
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Web.ViewModels.Profiles;
+
+public class InstitutionCompareViewModel
+{
+    public List<string> RequestedCiks { get; set; } = [];
+    public List<string> MissingCiks { get; set; } = [];
+    public List<DateOnly> CommonReportDates { get; set; } = [];
+    public DateOnly? SelectedDate { get; set; }
+    public FundOverlapResult Overlap { get; set; }
+
+    public const int MaxCiks = 4;
+    public const int MinCiks = 2;
+}

--- a/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
@@ -1,0 +1,106 @@
+@model Equibles.Web.ViewModels.Profiles.InstitutionCompareViewModel
+
+@{
+    ViewData["Title"] = "Compare institutions";
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold mb-2">Compare institutions</h1>
+        <p class="text-base-content/60">
+            Side-by-side 13F portfolio overlap. Pass 2–4 CIKs via <code>?ciks=…&amp;ciks=…</code>.
+        </p>
+    </div>
+
+    @if (Model.RequestedCiks.Count < Equibles.Web.ViewModels.Profiles.InstitutionCompareViewModel.MinCiks) {
+        <div class="card bg-base-100 shadow-sm">
+            <div class="card-body items-center text-center py-12">
+                <div class="text-base-content/30 mb-3">
+                    <icon name="user-group" size="12" />
+                </div>
+                <h3 class="text-base-content/60 mb-2">Pass at least two CIKs to compare</h3>
+                <p class="text-base-content/40 text-sm">Example: <code>/Institutions/Compare?ciks=0001067983&amp;ciks=0001603466</code></p>
+            </div>
+        </div>
+    } else if (Model.MissingCiks.Count > 0 && Model.Overlap == null) {
+        <div class="alert alert-warning" data-testid="compare-missing-ciks">
+            <icon name="exclamation-triangle" size="5" />
+            <span>Could not resolve CIKs: @string.Join(", ", Model.MissingCiks).</span>
+        </div>
+    } else if (Model.Overlap == null) {
+        <div class="alert alert-info" data-testid="compare-no-common-quarter">
+            <icon name="information-circle" size="5" />
+            <span>The selected institutions have no common report date.</span>
+        </div>
+    } else {
+        var overlap = Model.Overlap;
+        <!-- Overlap summary header. -->
+        <div class="card bg-base-100 shadow-sm mb-6" data-testid="compare-overlap-summary">
+            <div class="card-body p-4">
+                <div class="flex flex-wrap items-center gap-3 mb-3 text-xs text-base-content/60">
+                    <span class="badge badge-ghost">Report date: @overlap.ReportDate.ToString("MMM dd, yyyy")</span>
+                    @if (Model.CommonReportDates.Count > 1) {
+                        <span class="badge badge-ghost">@Model.CommonReportDates.Count common quarters</span>
+                    }
+                </div>
+                <div class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200 w-full">
+                    <div class="stat">
+                        <div class="stat-title">Union positions</div>
+                        <div class="stat-value text-2xl font-mono">@overlap.UnionPositionCount.ToString("N0")</div>
+                    </div>
+                    <div class="stat">
+                        <div class="stat-title">Shared positions</div>
+                        <div class="stat-value text-2xl font-mono">@overlap.IntersectionPositionCount.ToString("N0")</div>
+                    </div>
+                    <div class="stat" title="|A ∩ B| / |A ∪ B|">
+                        <div class="stat-title">Jaccard similarity</div>
+                        <div class="stat-value text-2xl font-mono">@overlap.JaccardSimilarityPercent.ToString("F1")%</div>
+                    </div>
+                    <div class="stat" title="Σ min(value)/Σ max(value) across shared stocks">
+                        <div class="stat-title">$-weighted overlap</div>
+                        <div class="stat-value text-2xl font-mono">@overlap.DollarWeightedOverlapPercent.ToString("F1")%</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Side-by-side stocks table — one row per stock in the union, one column-group per fund. -->
+        <div class="card bg-base-100 shadow-sm" data-testid="compare-overlap-table">
+            <div class="overflow-x-auto">
+                <table class="table table-zebra table-sm">
+                    <thead>
+                        <tr>
+                            <th rowspan="2">Ticker</th>
+                            <th rowspan="2">Company</th>
+                            @foreach (var fund in overlap.Funds) {
+                                <th colspan="2" class="text-center border-x border-base-300">
+                                    @fund.HolderName <span class="text-xs text-base-content/50">CIK @fund.HolderCik</span>
+                                </th>
+                            }
+                            <th rowspan="2" class="text-right">Combined value</th>
+                        </tr>
+                        <tr>
+                            @foreach (var fund in overlap.Funds) {
+                                <th class="text-right text-xs">Shares</th>
+                                <th class="text-right text-xs">% Port.</th>
+                            }
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var row in overlap.Rows) {
+                            <tr>
+                                <td class="font-mono">@row.Ticker</td>
+                                <td class="max-w-xs truncate">@row.Name</td>
+                                @foreach (var slice in row.Slices) {
+                                    <td class="text-right font-mono">@(slice.Shares > 0 ? slice.Shares.ToString("N0") : "—")</td>
+                                    <td class="text-right font-mono text-base-content/60">@(slice.Value > 0 ? slice.PercentOfPortfolio.ToString("F1") + "%" : "—")</td>
+                                }
+                                <td class="text-right font-mono">$@row.CombinedValue.ToString("N0")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+</div>

--- a/tests/Equibles.IntegrationTests/Web/ProfilesCompareInstitutionsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesCompareInstitutionsTests.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the Compare Institutions page end-to-end: route resolves, missing CIKs are
+/// reported, two-fund overlap renders the summary stats card and the side-by-side
+/// stocks table, and the &gt;4 CIKs case returns 400.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class ProfilesCompareInstitutionsTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public ProfilesCompareInstitutionsTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetCompare_NoCiks_RendersPromptToProvideCiks()
+    {
+        await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
+
+        var response = await _fixture.Client.GetAsync("/Institutions/Compare");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Pass at least two CIKs");
+    }
+
+    [Fact]
+    public async Task GetCompare_TooManyCiks_Returns400()
+    {
+        await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
+
+        var response = await _fixture.Client.GetAsync(
+            "/Institutions/Compare?ciks=A&ciks=B&ciks=C&ciks=D&ciks=E"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetCompare_TwoFundsWithCommonQuarter_RendersOverlapTable()
+    {
+        var aaplId = Guid.NewGuid();
+        var msftId = Guid.NewGuid();
+        var fundACik = "0002000001";
+        var fundBCik = "0002000002";
+        var fundAId = Guid.NewGuid();
+        var fundBId = Guid.NewGuid();
+        var reportDate = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.AddRange(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                },
+                new CommonStock
+                {
+                    Id = msftId,
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corp.",
+                    Cik = "0000789019",
+                }
+            );
+            db.AddRange(
+                new InstitutionalHolder
+                {
+                    Id = fundAId,
+                    Cik = fundACik,
+                    Name = "Fund A LP",
+                },
+                new InstitutionalHolder
+                {
+                    Id = fundBId,
+                    Cik = fundBCik,
+                    Name = "Fund B LP",
+                }
+            );
+            // Both funds hold AAPL; only Fund A holds MSFT.
+            db.Add(MakeHolding(aaplId, fundAId, reportDate, value: 1_000_000));
+            db.Add(MakeHolding(msftId, fundAId, reportDate, value: 500_000));
+            db.Add(MakeHolding(aaplId, fundBId, reportDate, value: 800_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/Institutions/Compare?ciks={fundACik}&ciks={fundBCik}"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("data-testid=\"compare-overlap-summary\"");
+        html.Should().Contain("data-testid=\"compare-overlap-table\"");
+        html.Should().Contain("Jaccard similarity");
+        html.Should().Contain("Fund A LP");
+        html.Should().Contain("Fund B LP");
+        html.Should().Contain("AAPL");
+        html.Should().Contain("MSFT");
+    }
+
+    [Fact]
+    public async Task GetCompare_UnknownCik_ReportsMissing()
+    {
+        var fundACik = "0002000003";
+        var fundAId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = fundAId,
+                    Cik = fundACik,
+                    Name = "Fund A LP",
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        // Fund A exists, Fund B does not.
+        var response = await _fixture.Client.GetAsync(
+            $"/Institutions/Compare?ciks={fundACik}&ciks=does-not-exist"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Could not resolve CIKs");
+        html.Should().Contain("does-not-exist");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = value / 100,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stockId:N}".Substring(0, 12) + $"-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Holdings/FundOverlapCalculatorTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundOverlapCalculatorTests.cs
@@ -1,0 +1,215 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class FundOverlapCalculatorTests
+{
+    private static readonly DateOnly Report = new(2024, 12, 31);
+
+    [Fact]
+    public void Calculate_NoFunds_ReturnsEmptyResult()
+    {
+        var result = FundOverlapCalculator.Calculate([], Report);
+
+        result.Funds.Should().BeEmpty();
+        result.Rows.Should().BeEmpty();
+        result.UnionPositionCount.Should().Be(0);
+        result.JaccardSimilarityPercent.Should().Be(0);
+    }
+
+    [Fact]
+    public void Calculate_TwoIdenticalFunds_JaccardIsOneHundredPercent()
+    {
+        var aapl = MakeStock("AAPL", "Apple Inc.");
+        var msft = MakeStock("MSFT", "Microsoft Corp.");
+        var fundA = MakeHolder("Fund A", "C001");
+        var fundB = MakeHolder("Fund B", "C002");
+
+        var result = FundOverlapCalculator.Calculate(
+            [
+                (
+                    fundA,
+                    (IReadOnlyList<InstitutionalHolding>)
+                        [
+                            MakeHolding(fundA, aapl, shares: 1_000, value: 1_000_000),
+                            MakeHolding(fundA, msft, shares: 500, value: 500_000),
+                        ]
+                ),
+                (
+                    fundB,
+                    (IReadOnlyList<InstitutionalHolding>)
+                        [
+                            MakeHolding(fundB, aapl, shares: 800, value: 800_000),
+                            MakeHolding(fundB, msft, shares: 200, value: 200_000),
+                        ]
+                ),
+            ],
+            Report
+        );
+
+        result.UnionPositionCount.Should().Be(2);
+        result.IntersectionPositionCount.Should().Be(2);
+        result.JaccardSimilarityPercent.Should().Be(100.0);
+        result.Rows.Should().AllSatisfy(r => r.IsCommon.Should().BeTrue());
+    }
+
+    [Fact]
+    public void Calculate_TwoDisjointFunds_JaccardIsZero()
+    {
+        var aapl = MakeStock("AAPL", "Apple Inc.");
+        var msft = MakeStock("MSFT", "Microsoft Corp.");
+        var fundA = MakeHolder("Fund A", "C001");
+        var fundB = MakeHolder("Fund B", "C002");
+
+        var result = FundOverlapCalculator.Calculate(
+            [
+                (
+                    fundA,
+                    (IReadOnlyList<InstitutionalHolding>)
+                        [MakeHolding(fundA, aapl, shares: 1_000, value: 1_000_000)]
+                ),
+                (
+                    fundB,
+                    (IReadOnlyList<InstitutionalHolding>)
+                        [MakeHolding(fundB, msft, shares: 500, value: 500_000)]
+                ),
+            ],
+            Report
+        );
+
+        result.UnionPositionCount.Should().Be(2);
+        result.IntersectionPositionCount.Should().Be(0);
+        result.JaccardSimilarityPercent.Should().Be(0);
+        result.DollarWeightedOverlapPercent.Should().Be(0);
+    }
+
+    [Fact]
+    public void Calculate_PartialOverlap_ProducesCorrectJaccard()
+    {
+        var aapl = MakeStock("AAPL", "Apple Inc.");
+        var msft = MakeStock("MSFT", "Microsoft Corp.");
+        var nvda = MakeStock("NVDA", "NVIDIA Corp.");
+        var fundA = MakeHolder("Fund A", "C001");
+        var fundB = MakeHolder("Fund B", "C002");
+
+        var result = FundOverlapCalculator.Calculate(
+            [
+                (
+                    fundA,
+                    (IReadOnlyList<InstitutionalHolding>)
+                        [
+                            MakeHolding(fundA, aapl, shares: 1_000, value: 1_000_000),
+                            MakeHolding(fundA, msft, shares: 500, value: 500_000),
+                        ]
+                ),
+                (
+                    fundB,
+                    (IReadOnlyList<InstitutionalHolding>)
+                        [
+                            MakeHolding(fundB, aapl, shares: 800, value: 800_000),
+                            MakeHolding(fundB, nvda, shares: 300, value: 300_000),
+                        ]
+                ),
+            ],
+            Report
+        );
+
+        // Union = {AAPL, MSFT, NVDA} → 3; Intersection = {AAPL} → 1; Jaccard = 1/3 ≈ 33.33%.
+        result.UnionPositionCount.Should().Be(3);
+        result.IntersectionPositionCount.Should().Be(1);
+        result.JaccardSimilarityPercent.Should().BeApproximately(33.33, precision: 0.01);
+    }
+
+    [Fact]
+    public void Calculate_RowsOrderedByCombinedValueDesc()
+    {
+        var aapl = MakeStock("AAPL", "Apple Inc.");
+        var msft = MakeStock("MSFT", "Microsoft Corp.");
+        var fundA = MakeHolder("Fund A", "C001");
+
+        var result = FundOverlapCalculator.Calculate(
+            [
+                (
+                    fundA,
+                    (IReadOnlyList<InstitutionalHolding>)
+                        [
+                            MakeHolding(fundA, msft, shares: 500, value: 500_000),
+                            MakeHolding(fundA, aapl, shares: 1_000, value: 1_000_000),
+                        ]
+                ),
+            ],
+            Report
+        );
+
+        result.Rows.Should().HaveCount(2);
+        result.Rows[0].Ticker.Should().Be("AAPL");
+        result.Rows[1].Ticker.Should().Be("MSFT");
+    }
+
+    [Fact]
+    public void Calculate_PercentOfPortfolio_DividesByFundTotalValue()
+    {
+        var aapl = MakeStock("AAPL", "Apple Inc.");
+        var msft = MakeStock("MSFT", "Microsoft Corp.");
+        var fundA = MakeHolder("Fund A", "C001");
+
+        var result = FundOverlapCalculator.Calculate(
+            [
+                (
+                    fundA,
+                    (IReadOnlyList<InstitutionalHolding>)
+                        [
+                            MakeHolding(fundA, aapl, shares: 1_000, value: 700_000),
+                            MakeHolding(fundA, msft, shares: 500, value: 300_000),
+                        ]
+                ),
+            ],
+            Report
+        );
+
+        var aaplRow = result.Rows.Single(r => r.Ticker == "AAPL");
+        var msftRow = result.Rows.Single(r => r.Ticker == "MSFT");
+        aaplRow.Slices[0].PercentOfPortfolio.Should().Be(70.0);
+        msftRow.Slices[0].PercentOfPortfolio.Should().Be(30.0);
+    }
+
+    private static CommonStock MakeStock(string ticker, string name) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = name,
+            Cik = "C" + Guid.NewGuid().ToString("N")[..7],
+        };
+
+    private static InstitutionalHolder MakeHolder(string name, string cik) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Cik = cik,
+        };
+
+    private static InstitutionalHolding MakeHolding(
+        InstitutionalHolder holder,
+        CommonStock stock,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            CommonStock = stock,
+            InstitutionalHolderId = holder.Id,
+            InstitutionalHolder = holder,
+            FilingDate = Report.AddDays(45),
+            ReportDate = Report,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+        };
+}


### PR DESCRIPTION
## Summary

- **Slice 1 of 2** for #1014. New compare page at `~/Institutions/Compare?ciks=…&ciks=…` (2–4 CIKs) that renders an overlap summary card (union / intersection counts, Jaccard similarity, dollar-weighted overlap) plus a side-by-side stocks table.
- Backing calculator is pure and lives in `Equibles.Holdings.Repositories` so the MCP tool in slice 2 reuses the same math.
- `Refs #1014` — not the closing slice.

## Code changes

- `src/Equibles.Holdings.Repositories/Models/FundOverlapResult.cs` — projection trio: top-level result + per-fund summary + per-stock row with per-fund slice.
- `src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs` — pure `Calculate(funds, reportDate)`.
- `src/Equibles.Web/ViewModels/Profiles/InstitutionCompareViewModel.cs` — requested / missing CIKs + common report dates + overlap + `Min/MaxCiks` constants.
- `src/Equibles.Web/Controllers/ProfilesController.cs` — `CompareInstitutions` action at `~/Institutions/Compare`. Resolves 2–4 CIKs (>4 → 400), intersects report dates, materializes holdings, runs calculator.
- `src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml` — stats card + two-row-header table with one column-group per fund.
- `tests/Equibles.UnitTests/Holdings/FundOverlapCalculatorTests.cs` — 6 unit tests.
- `tests/Equibles.IntegrationTests/Web/ProfilesCompareInstitutionsTests.cs` — 4 WebHostFixture tests.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1110 files).
- Calculator unit tests — 6/6 passing.
- WebHostFixture integration tests — 4/4 passing.

Refs #1014