### PR TITLE
refactor(insider-trading): collapse derivative/non-derivative XML walks into WalkTable

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -209,33 +209,19 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             transactions.Add(tx);
         }
 
-        var nonDerivTable = root.Element("nonDerivativeTable");
-        if (nonDerivTable != null)
+        void WalkTable(string tableName, string txName, string holdingName)
         {
-            foreach (var txElement in nonDerivTable.Elements("nonDerivativeTransaction"))
-            {
+            var table = root.Element(tableName);
+            if (table == null)
+                return;
+            foreach (var txElement in table.Elements(txName))
                 AddParsed(ParseTransaction(txElement, owner, companyId, filing, isAmendment));
-            }
-
-            foreach (var holdingElement in nonDerivTable.Elements("nonDerivativeHolding"))
-            {
+            foreach (var holdingElement in table.Elements(holdingName))
                 AddParsed(ParseHolding(holdingElement, owner, companyId, filing, isAmendment));
-            }
         }
 
-        var derivTable = root.Element("derivativeTable");
-        if (derivTable != null)
-        {
-            foreach (var txElement in derivTable.Elements("derivativeTransaction"))
-            {
-                AddParsed(ParseTransaction(txElement, owner, companyId, filing, isAmendment));
-            }
-
-            foreach (var holdingElement in derivTable.Elements("derivativeHolding"))
-            {
-                AddParsed(ParseHolding(holdingElement, owner, companyId, filing, isAmendment));
-            }
-        }
+        WalkTable("nonDerivativeTable", "nonDerivativeTransaction", "nonDerivativeHolding");
+        WalkTable("derivativeTable", "derivativeTransaction", "derivativeHolding");
 
         if (transactions.Count == 0)
         {


### PR DESCRIPTION
## Summary

- `InsiderTradingFilingProcessor.Process` had two structurally identical 12-line blocks walking `nonDerivativeTable` then `derivativeTable`, differing only in the table and child element names.
- Lifted both into a single local function `WalkTable(tableName, txName, holdingName)` invoked twice. The function captures `root`, `owner`, `companyId`, `filing`, `isAmendment`, and the outer `AddParsed` — same iteration order (table-by-table, transactions then holdings) and same `TransactionOrder` assignment.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs`
  - New local `WalkTable(string, string, string)` inside `Process` owns the `root.Element(table) → Elements(txName)/Elements(holdingName)` walk and the `AddParsed(ParseTransaction|ParseHolding)` dispatch.
  - Two call sites replace the two inlined blocks.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet tool run csharpier check .` — green (1105 files).
- `dotnet test tests/Equibles.UnitTests` — 1372/1372 pass (covers `InsiderTradingFilingProcessorTests`, `…ParseTransactionCultureTests`, `…SanitizeXml*Tests`).
- `dotnet test tests/Equibles.IntegrationTests --filter "FullyQualifiedName~InsiderTrading"` — 123/123 pass.