### PR TITLE
feat(holdings-mcp): add GetFundOverlap MCP tool (2/2)

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -938,6 +938,124 @@ public class InstitutionalHoldingsTools
         );
     }
 
+    [McpServerTool(Name = "GetFundOverlap")]
+    [Description(
+        "Get the 13F portfolio overlap between two institutions for their latest common report date — Jaccard similarity, dollar-weighted overlap, and a side-by-side table of stocks with per-fund shares + percent of portfolio. Use this to answer 'do these two funds own the same stocks?' or 'where do their portfolios diverge?'"
+    )]
+    public Task<string> GetFundOverlap(
+        [Description("First institution name (partial or full — first match wins)")]
+            string institutionName1,
+        [Description("Second institution name (partial or full — first match wins)")]
+            string institutionName2,
+        [Description("Report date in YYYY-MM-DD format (defaults to latest common quarter)")]
+            string reportDate = null,
+        [Description("Maximum number of stocks to return (default: 30)")] int maxResults = 30
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                var holder1 = await _holderRepository
+                    .Search(institutionName1 ?? string.Empty)
+                    .OrderBy(h => h.Name)
+                    .FirstOrDefaultAsync();
+                if (holder1 == null)
+                    return $"No institution found matching '{institutionName1}'.";
+                var holder2 = await _holderRepository
+                    .Search(institutionName2 ?? string.Empty)
+                    .OrderBy(h => h.Name)
+                    .FirstOrDefaultAsync();
+                if (holder2 == null)
+                    return $"No institution found matching '{institutionName2}'.";
+
+                var dates1 = await _holdingRepository
+                    .GetHistoryByHolder(holder1)
+                    .Select(h => h.ReportDate)
+                    .Distinct()
+                    .ToListAsync();
+                var dates2 = await _holdingRepository
+                    .GetHistoryByHolder(holder2)
+                    .Select(h => h.ReportDate)
+                    .Distinct()
+                    .ToListAsync();
+                var common = dates1.Intersect(dates2).OrderByDescending(d => d).ToList();
+                if (common.Count == 0)
+                    return $"{holder1.Name} and {holder2.Name} share no common report dates.";
+
+                DateOnly selected;
+                if (
+                    !string.IsNullOrEmpty(reportDate)
+                    && DateOnly.TryParse(reportDate, out var parsed)
+                    && common.Contains(parsed)
+                )
+                    selected = parsed;
+                else
+                    selected = common[0];
+
+                var holdings1 = await _holdingRepository
+                    .GetByHolder(holder1, selected)
+                    .Include(h => h.CommonStock)
+                    .ToListAsync();
+                var holdings2 = await _holdingRepository
+                    .GetByHolder(holder2, selected)
+                    .Include(h => h.CommonStock)
+                    .ToListAsync();
+                var overlap = FundOverlapCalculator.Calculate(
+                    [
+                        (holder1, (IReadOnlyList<InstitutionalHolding>)holdings1),
+                        (holder2, (IReadOnlyList<InstitutionalHolding>)holdings2),
+                    ],
+                    selected
+                );
+
+                var result = new StringBuilder();
+                result.AppendLine(
+                    $"Portfolio overlap — **{holder1.Name}** vs **{holder2.Name}** as of {selected:yyyy-MM-dd}"
+                );
+                result.AppendLine();
+                result.AppendLine("| Metric | Value |");
+                result.AppendLine("|--------|-------|");
+                result.AppendLine($"| Union positions | {overlap.UnionPositionCount:N0} |");
+                result.AppendLine($"| Shared positions | {overlap.IntersectionPositionCount:N0} |");
+                result.AppendLine(
+                    $"| Jaccard similarity | {overlap.JaccardSimilarityPercent:F1}% |"
+                );
+                result.AppendLine(
+                    $"| $-weighted overlap | {overlap.DollarWeightedOverlapPercent:F1}% |"
+                );
+                result.AppendLine();
+
+                if (overlap.Rows.Count == 0)
+                {
+                    result.AppendLine("_Neither fund reports any positions for this date._");
+                    return result.ToString();
+                }
+
+                result.AppendLine(
+                    "| # | Ticker | Company | A Shares | A % | B Shares | B % | Combined ($M) |"
+                );
+                result.AppendLine(
+                    "|---|--------|---------|---------|-----|---------|-----|---------------|"
+                );
+                var rendered = overlap.Rows.Take(maxResults).ToList();
+                for (var i = 0; i < rendered.Count; i++)
+                {
+                    var row = rendered[i];
+                    var a = row.Slices[0];
+                    var b = row.Slices[1];
+                    result.AppendLine(
+                        $"| {i + 1} | {row.Ticker} | {row.Name} | {(a.Shares > 0 ? a.Shares.ToString("N0") : "—")} | {(a.Value > 0 ? a.PercentOfPortfolio.ToString("F1") + "%" : "—")} | {(b.Shares > 0 ? b.Shares.ToString("N0") : "—")} | {(b.Value > 0 ? b.PercentOfPortfolio.ToString("F1") + "%" : "—")} | {row.CombinedValue / 1_000_000m:N1} |"
+                    );
+                }
+                return result.ToString();
+            },
+            _logger,
+            "GetFundOverlap",
+            $"funds: {institutionName1}, {institutionName2}",
+            ReportError
+        );
+    }
+
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetFundOverlapTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetFundOverlapTests.cs
@@ -1,0 +1,165 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins <c>GetFundOverlap</c>. Each test exercises one path: unknown lookups on either
+/// side, no-common-quarter, two-fund partial overlap, and the explicit reportDate
+/// argument.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetFundOverlapTests : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetFundOverlapTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetFundOverlap_UnknownFirstInstitution_ReportsNotFound()
+    {
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetFundOverlap("Nobody", "Anybody");
+
+        output.Should().Contain("No institution found matching 'Nobody'");
+    }
+
+    [Fact]
+    public async Task GetFundOverlap_NoCommonQuarter_ReportsNoOverlap()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var fundA = new InstitutionalHolder { Cik = "FO00001", Name = "Fund A LP" };
+        var fundB = new InstitutionalHolder { Cik = "FO00002", Name = "Fund B LP" };
+        DbContext.AddRange(stock, fundA, fundB);
+        DbContext.Add(MakeHolding(stock, fundA, new DateOnly(2024, 3, 31), value: 100_000));
+        DbContext.Add(MakeHolding(stock, fundB, new DateOnly(2024, 6, 30), value: 100_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetFundOverlap("Fund A", "Fund B");
+
+        output.Should().Contain("share no common report dates");
+    }
+
+    [Fact]
+    public async Task GetFundOverlap_TwoFundsWithPartialOverlap_RendersStatsAndTable()
+    {
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var msft = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+        };
+        var nvda = new CommonStock
+        {
+            Ticker = "NVDA",
+            Name = "NVIDIA Corp.",
+            Cik = "0001045810",
+        };
+        var fundA = new InstitutionalHolder { Cik = "FO00003", Name = "Overlap A LP" };
+        var fundB = new InstitutionalHolder { Cik = "FO00004", Name = "Overlap B LP" };
+        DbContext.AddRange(aapl, msft, nvda, fundA, fundB);
+        var date = new DateOnly(2024, 12, 31);
+        // Fund A: AAPL + MSFT. Fund B: AAPL + NVDA. Union = 3, intersection = 1 (AAPL).
+        DbContext.Add(MakeHolding(aapl, fundA, date, value: 1_000_000));
+        DbContext.Add(MakeHolding(msft, fundA, date, value: 500_000));
+        DbContext.Add(MakeHolding(aapl, fundB, date, value: 800_000));
+        DbContext.Add(MakeHolding(nvda, fundB, date, value: 300_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetFundOverlap("Overlap A", "Overlap B");
+
+        output.Should().Contain("Portfolio overlap — **Overlap A LP** vs **Overlap B LP**");
+        output.Should().Contain("Union positions");
+        output.Should().Contain("Shared positions");
+        output.Should().Contain("Jaccard similarity");
+        // Each of the three tickers appears in the side-by-side table.
+        output.Should().Contain("AAPL");
+        output.Should().Contain("MSFT");
+        output.Should().Contain("NVDA");
+    }
+
+    [Fact]
+    public async Task GetFundOverlap_ExplicitReportDate_HonorsArgument()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "TSLA",
+            Name = "Tesla Inc.",
+            Cik = "0001318605",
+        };
+        var fundA = new InstitutionalHolder { Cik = "FO00005", Name = "Dated A LP" };
+        var fundB = new InstitutionalHolder { Cik = "FO00006", Name = "Dated B LP" };
+        DbContext.AddRange(stock, fundA, fundB);
+        var q3 = new DateOnly(2024, 9, 30);
+        var q4 = new DateOnly(2024, 12, 31);
+        // Both funds report Q3 and Q4.
+        DbContext.Add(MakeHolding(stock, fundA, q3, value: 100_000));
+        DbContext.Add(MakeHolding(stock, fundA, q4, value: 500_000));
+        DbContext.Add(MakeHolding(stock, fundB, q3, value: 200_000));
+        DbContext.Add(MakeHolding(stock, fundB, q4, value: 700_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetFundOverlap("Dated A LP", "Dated B LP", reportDate: "2024-09-30");
+
+        output.Should().Contain("as of 2024-09-30");
+    }
+
+    private InstitutionalHoldingsTools NewSut(Equibles.Data.EquiblesDbContext ctx) =>
+        new(
+            new InstitutionalHoldingRepository(ctx),
+            new InstitutionalHolderRepository(ctx),
+            new CommonStockRepository(ctx),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = value / 100,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -271,6 +271,7 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("GetInstitutionSummary");
         toolNames.Should().Contain("GetInstitutionSectorAllocation");
         toolNames.Should().Contain("GetInstitutionQuarterlyActivity");
+        toolNames.Should().Contain("GetFundOverlap");
     }
 
     // ── InsiderTrading module specific ──────────────────────────────────
@@ -365,6 +366,7 @@ public class McpModuleToolDiscoveryTests
                     "GetInstitutionSummary",
                     "GetInstitutionSectorAllocation",
                     "GetInstitutionQuarterlyActivity",
+                    "GetFundOverlap",
                 }
             },
             {


### PR DESCRIPTION
## Summary

- **Closing slice (2 of 2)** for #1014. Mirrors the Compare Institutions page landed in #1112 — diffs two institutions for their latest common report date and returns Jaccard / dollar-weighted overlap stats plus a side-by-side stocks table as markdown.
- Reuses `FundOverlapCalculator` from `Equibles.Holdings.Repositories`.
- Closes #1014.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — new `GetFundOverlap(institutionName1, institutionName2, reportDate?, max?)`. Resolves both holders by name, intersects their report dates, runs the calculator, renders the stats card + a capped side-by-side markdown table.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — module-discovery list updated.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetFundOverlapTests.cs` — 4 ParadeDB tests.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1113 files).
- New MCP integration tests — 4/4 passing.
- Module-discovery unit tests — 59/59 passing.

Closes #1014