### PR TITLE
feat(holdings): add /Institutions/Combined consensus-portfolio view (1/2)

### DIFF
--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -286,6 +286,94 @@ public class ProfilesController : BaseController
         return View(viewModel);
     }
 
+    [HttpGet("~/Institutions/Combined")]
+    public async Task<IActionResult> CombinedInstitutions(
+        [FromQuery(Name = "ciks")] string[] ciks = null,
+        [FromQuery(Name = "date")] DateOnly? date = null
+    )
+    {
+        ciks ??= [];
+        var distinctCiks = ciks.Where(c => !string.IsNullOrWhiteSpace(c))
+            .Select(c => c.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (distinctCiks.Count > InstitutionCombinedViewModel.MaxCiks)
+            return BadRequest(
+                $"At most {InstitutionCombinedViewModel.MaxCiks} CIKs may be combined."
+            );
+
+        var viewModel = new InstitutionCombinedViewModel { RequestedCiks = distinctCiks };
+        ViewData["Title"] = "Combined portfolio";
+
+        if (distinctCiks.Count < InstitutionCombinedViewModel.MinCiks)
+            return View(viewModel);
+
+        var holders = new List<InstitutionalHolder>();
+        foreach (var cik in distinctCiks)
+        {
+            var holder = await _institutionalHolderRepository.GetByCik(cik);
+            if (holder == null)
+                viewModel.MissingCiks.Add(cik);
+            else
+                holders.Add(holder);
+        }
+        if (holders.Count < InstitutionCombinedViewModel.MinCiks)
+            return View(viewModel);
+
+        var perHolderDates = new List<List<DateOnly>>();
+        foreach (var holder in holders)
+        {
+            var dates = await _institutionalHoldingRepository
+                .GetHistoryByHolder(holder)
+                .Select(h => h.ReportDate)
+                .Distinct()
+                .OrderByDescending(d => d)
+                .ToListAsync();
+            perHolderDates.Add(dates);
+        }
+        var commonDates = perHolderDates
+            .Skip(1)
+            .Aggregate((IEnumerable<DateOnly>)perHolderDates[0], (acc, next) => acc.Intersect(next))
+            .OrderByDescending(d => d)
+            .ToList();
+        viewModel.CommonReportDates = commonDates;
+        if (commonDates.Count == 0)
+            return View(viewModel);
+
+        var selected = date ?? commonDates[0];
+        if (!commonDates.Contains(selected))
+            selected = commonDates[0];
+        viewModel.SelectedDate = selected;
+
+        var perFund =
+            new List<(InstitutionalHolder Holder, IReadOnlyList<InstitutionalHolding> Holdings)>();
+        foreach (var holder in holders)
+        {
+            var holdings = await _institutionalHoldingRepository
+                .GetByHolder(holder, selected)
+                .Include(h => h.CommonStock)
+                .ToListAsync();
+            perFund.Add((holder, holdings));
+        }
+        viewModel.Overlap = FundOverlapCalculator.Calculate(perFund, selected);
+
+        // Consensus count per stock = number of funds whose slice has Value > 0. This is
+        // the primary sort key for the combined-portfolio view; the calculator already
+        // sorts by combined value, so we apply consensus on top as a stable secondary
+        // re-sort.
+        foreach (var row in viewModel.Overlap.Rows)
+        {
+            var heldBy = row.Slices.Count(s => s.Value > 0);
+            viewModel.FundsHoldingByStock[row.CommonStockId] = heldBy;
+        }
+        viewModel.Overlap.Rows = viewModel
+            .Overlap.Rows.OrderByDescending(r => viewModel.FundsHoldingByStock[r.CommonStockId])
+            .ThenByDescending(r => r.CombinedValue)
+            .ToList();
+
+        return View(viewModel);
+    }
+
     [HttpGet("~/Insiders/{ownerCik}")]
     public async Task<IActionResult> Insider(string ownerCik)
     {

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionCombinedViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionCombinedViewModel.cs
@@ -1,0 +1,19 @@
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Web.ViewModels.Profiles;
+
+public class InstitutionCombinedViewModel
+{
+    public List<string> RequestedCiks { get; set; } = [];
+    public List<string> MissingCiks { get; set; } = [];
+    public List<DateOnly> CommonReportDates { get; set; } = [];
+    public DateOnly? SelectedDate { get; set; }
+    public FundOverlapResult Overlap { get; set; }
+
+    // Pre-computed per-row consensus count (number of funds with Value > 0 in the row's
+    // slices). Ranking sort key — populated alongside Overlap by the controller.
+    public Dictionary<Guid, int> FundsHoldingByStock { get; set; } = [];
+
+    public const int MaxCiks = 25;
+    public const int MinCiks = 2;
+}

--- a/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
@@ -1,0 +1,91 @@
+@model Equibles.Web.ViewModels.Profiles.InstitutionCombinedViewModel
+
+@{
+    ViewData["Title"] = "Combined portfolio";
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold mb-2">Combined portfolio</h1>
+        <p class="text-base-content/60">
+            Pool 2–25 funds into a single combined portfolio. Pass CIKs via <code>?ciks=…&amp;ciks=…</code>.
+            Consensus picks (held by the most funds) appear at the top.
+        </p>
+    </div>
+
+    @if (Model.RequestedCiks.Count < Equibles.Web.ViewModels.Profiles.InstitutionCombinedViewModel.MinCiks) {
+        <div class="card bg-base-100 shadow-sm">
+            <div class="card-body items-center text-center py-12">
+                <div class="text-base-content/30 mb-3">
+                    <icon name="user-group" size="12" />
+                </div>
+                <h3 class="text-base-content/60 mb-2">Pass at least two CIKs to combine</h3>
+                <p class="text-base-content/40 text-sm">Example: <code>/Institutions/Combined?ciks=0001067983&amp;ciks=0001336528&amp;ciks=0001603466</code></p>
+            </div>
+        </div>
+    } else if (Model.MissingCiks.Count > 0 && Model.Overlap == null) {
+        <div class="alert alert-warning" data-testid="combined-missing-ciks">
+            <icon name="exclamation-triangle" size="5" />
+            <span>Could not resolve CIKs: @string.Join(", ", Model.MissingCiks).</span>
+        </div>
+    } else if (Model.Overlap == null) {
+        <div class="alert alert-info" data-testid="combined-no-common-quarter">
+            <icon name="information-circle" size="5" />
+            <span>The selected institutions have no common report date.</span>
+        </div>
+    } else {
+        var overlap = Model.Overlap;
+        <div class="card bg-base-100 shadow-sm mb-6" data-testid="combined-summary">
+            <div class="card-body p-4">
+                <div class="flex flex-wrap items-center gap-3 mb-3 text-xs text-base-content/60">
+                    <span class="badge badge-ghost">Report date: @overlap.ReportDate.ToString("MMM dd, yyyy")</span>
+                    <span class="badge badge-ghost">@overlap.Funds.Count funds combined</span>
+                    <span class="badge badge-ghost">@overlap.UnionPositionCount unique stocks</span>
+                    @if (overlap.IntersectionPositionCount > 0) {
+                        <span class="badge badge-success">@overlap.IntersectionPositionCount held by all</span>
+                    }
+                </div>
+                <ul class="text-sm text-base-content/70 list-disc list-inside">
+                    @foreach (var fund in overlap.Funds) {
+                        <li>@fund.HolderName <span class="text-xs text-base-content/50">CIK @fund.HolderCik</span> — @fund.PositionCount positions, $@fund.TotalValue.ToString("N0")</li>
+                    }
+                </ul>
+            </div>
+        </div>
+
+        <div class="card bg-base-100 shadow-sm" data-testid="combined-portfolio-table">
+            <div class="overflow-x-auto">
+                <table class="table table-zebra table-sm">
+                    <thead>
+                        <tr>
+                            <th>Ticker</th>
+                            <th>Company</th>
+                            <th class="text-right"># Funds</th>
+                            <th class="text-right">Combined Value (USD)</th>
+                            <th class="text-right hidden lg:table-cell">Avg % of portfolio</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var row in overlap.Rows) {
+                            var heldBy = Model.FundsHoldingByStock.TryGetValue(row.CommonStockId, out var n) ? n : 0;
+                            var heldByCss = heldBy == overlap.Funds.Count ? "badge-success" : heldBy >= overlap.Funds.Count / 2.0 ? "badge-info" : "badge-ghost";
+                            // Avg % across only the funds that actually hold the stock — averaging across
+                            // the zero slices would dilute and mislead.
+                            var heldSlices = row.Slices.Where(s => s.Value > 0).ToList();
+                            var avgPercent = heldSlices.Count > 0
+                                ? heldSlices.Average(s => s.PercentOfPortfolio)
+                                : 0;
+                            <tr>
+                                <td class="font-mono">@row.Ticker</td>
+                                <td class="max-w-xs truncate">@row.Name</td>
+                                <td class="text-right"><span class="badge @heldByCss badge-sm">@heldBy / @overlap.Funds.Count</span></td>
+                                <td class="text-right font-mono">$@row.CombinedValue.ToString("N0")</td>
+                                <td class="text-right font-mono hidden lg:table-cell text-base-content/60">@avgPercent.ToString("F1")%</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+</div>

--- a/tests/Equibles.IntegrationTests/Web/ProfilesCombinedInstitutionsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesCombinedInstitutionsTests.cs
@@ -1,0 +1,185 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the Combined Institutions page end-to-end: route resolves, missing CIKs are
+/// reported, three-fund consensus ordering surfaces an all-funds-held stock above a
+/// half-held stock, and the &gt;25 CIKs case returns 400.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class ProfilesCombinedInstitutionsTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public ProfilesCombinedInstitutionsTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetCombined_NoCiks_RendersPromptToProvideCiks()
+    {
+        await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
+
+        var response = await _fixture.Client.GetAsync("/Institutions/Combined");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Pass at least two CIKs");
+    }
+
+    [Fact]
+    public async Task GetCombined_TooManyCiks_Returns400()
+    {
+        await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
+
+        // 26 CIKs (exceeds the 25 cap).
+        var ciks = string.Join("&", Enumerable.Range(1, 26).Select(i => $"ciks=cik{i}"));
+        var response = await _fixture.Client.GetAsync($"/Institutions/Combined?{ciks}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetCombined_ThreeFunds_OrdersConsensusPickFirst()
+    {
+        // AAPL held by all three funds → should rank first.
+        // MSFT held by two of three → second.
+        // NVDA held by one → third.
+        var aaplId = Guid.NewGuid();
+        var msftId = Guid.NewGuid();
+        var nvdaId = Guid.NewGuid();
+        var (cikA, cikB, cikC) = ("0003000001", "0003000002", "0003000003");
+        var idA = Guid.NewGuid();
+        var idB = Guid.NewGuid();
+        var idC = Guid.NewGuid();
+        var date = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.AddRange(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                },
+                new CommonStock
+                {
+                    Id = msftId,
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corp.",
+                    Cik = "0000789019",
+                },
+                new CommonStock
+                {
+                    Id = nvdaId,
+                    Ticker = "NVDA",
+                    Name = "NVIDIA Corp.",
+                    Cik = "0001045810",
+                }
+            );
+            db.AddRange(
+                new InstitutionalHolder
+                {
+                    Id = idA,
+                    Cik = cikA,
+                    Name = "Fund A",
+                },
+                new InstitutionalHolder
+                {
+                    Id = idB,
+                    Cik = cikB,
+                    Name = "Fund B",
+                },
+                new InstitutionalHolder
+                {
+                    Id = idC,
+                    Cik = cikC,
+                    Name = "Fund C",
+                }
+            );
+            // AAPL — all three funds.
+            db.Add(MakeHolding(aaplId, idA, date, value: 1_000_000));
+            db.Add(MakeHolding(aaplId, idB, date, value: 1_500_000));
+            db.Add(MakeHolding(aaplId, idC, date, value: 2_000_000));
+            // MSFT — funds A and B only.
+            db.Add(MakeHolding(msftId, idA, date, value: 500_000));
+            db.Add(MakeHolding(msftId, idB, date, value: 700_000));
+            // NVDA — fund C only.
+            db.Add(MakeHolding(nvdaId, idC, date, value: 800_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/Institutions/Combined?ciks={cikA}&ciks={cikB}&ciks={cikC}"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("data-testid=\"combined-summary\"");
+        html.Should().Contain("data-testid=\"combined-portfolio-table\"");
+
+        var tableStart = html.IndexOf(
+            "data-testid=\"combined-portfolio-table\"",
+            StringComparison.Ordinal
+        );
+        var table = html.Substring(tableStart);
+        var aaplIdx = table.IndexOf("AAPL", StringComparison.Ordinal);
+        var msftIdx = table.IndexOf("MSFT", StringComparison.Ordinal);
+        var nvdaIdx = table.IndexOf("NVDA", StringComparison.Ordinal);
+        aaplIdx.Should().BeLessThan(msftIdx);
+        msftIdx.Should().BeLessThan(nvdaIdx);
+    }
+
+    [Fact]
+    public async Task GetCombined_UnknownCik_ReportsMissing()
+    {
+        var cikA = "0003000004";
+        var idA = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = idA,
+                    Cik = cikA,
+                    Name = "Fund A",
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/Institutions/Combined?ciks={cikA}&ciks=does-not-exist"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Could not resolve CIKs");
+        html.Should().Contain("does-not-exist");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = value / 100,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stockId:N}".Substring(0, 12) + $"-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

- **Slice 1 of 2** for #1015. New compare page at `~/Institutions/Combined?ciks=…` (2–25 CIKs) that pools the selected funds into a single combined portfolio table. Consensus picks (held by the most funds) appear at the top.
- Reuses `FundOverlapCalculator` from #1112 — the calculator's per-stock rows already match the shape needed; the controller re-sorts by consensus count.
- `Refs #1015` — not the closing slice.

## Code changes

- `src/Equibles.Web/ViewModels/Profiles/InstitutionCombinedViewModel.cs` — CIK lists, common dates, overlap result, per-row consensus dictionary, `Min/MaxCiks` (2 / 25).
- `src/Equibles.Web/Controllers/ProfilesController.cs` — `CombinedInstitutions` action at `~/Institutions/Combined`. 2–25 CIKs (>25 → 400), report-date intersection, per-fund materialization, calculator + consensus re-sort.
- `src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml` — summary card + combined portfolio table.
- `tests/Equibles.IntegrationTests/Web/ProfilesCombinedInstitutionsTests.cs` — 4 WebHostFixture tests.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1115 files).
- WebHostFixture integration tests — 4/4 passing.

Refs #1015