### PR TITLE
feat(holdings-mcp): add GetConsensusHoldings MCP tool (2/2)

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1056,6 +1056,141 @@ public class InstitutionalHoldingsTools
         );
     }
 
+    [McpServerTool(Name = "GetConsensusHoldings")]
+    [Description(
+        "Get the consensus / combined portfolio of 2-25 institutions for their latest common report date. Returns stocks ranked by how many of the supplied funds hold them (descending), then by combined value. Filter by `minFunds` to only show stocks held by at least that many funds. Use this to answer 'what do these funds agree on?' or 'show me the top picks across these N investors combined.'"
+    )]
+    public Task<string> GetConsensusHoldings(
+        [Description(
+            "Comma- or semicolon-separated institution names (partial or full — first match wins per name). 2-25 names."
+        )]
+            string institutionNames,
+        [Description("Report date in YYYY-MM-DD format (defaults to latest common quarter)")]
+            string reportDate = null,
+        [Description("Minimum number of funds a stock must be held by to appear (default: 1)")]
+            int minFunds = 1,
+        [Description("Maximum number of stocks to return (default: 30)")] int maxResults = 30
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                var names = (institutionNames ?? string.Empty)
+                    .Split(
+                        [',', ';'],
+                        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+                    )
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+                if (names.Count < 2)
+                    return "Pass at least two institution names (comma-separated).";
+                if (names.Count > 25)
+                    return "At most 25 institutions can be combined.";
+
+                var holders = new List<InstitutionalHolder>();
+                var missing = new List<string>();
+                foreach (var name in names)
+                {
+                    var holder = await _holderRepository
+                        .Search(name)
+                        .OrderBy(h => h.Name)
+                        .FirstOrDefaultAsync();
+                    if (holder == null)
+                        missing.Add(name);
+                    else
+                        holders.Add(holder);
+                }
+                if (holders.Count < 2)
+                    return $"Could not resolve enough institutions. Missing: {string.Join(", ", missing)}.";
+
+                var perHolderDates = new List<List<DateOnly>>();
+                foreach (var holder in holders)
+                {
+                    var dates = await _holdingRepository
+                        .GetHistoryByHolder(holder)
+                        .Select(h => h.ReportDate)
+                        .Distinct()
+                        .OrderByDescending(d => d)
+                        .ToListAsync();
+                    perHolderDates.Add(dates);
+                }
+                var common = perHolderDates
+                    .Skip(1)
+                    .Aggregate(
+                        (IEnumerable<DateOnly>)perHolderDates[0],
+                        (acc, next) => acc.Intersect(next)
+                    )
+                    .OrderByDescending(d => d)
+                    .ToList();
+                if (common.Count == 0)
+                    return "The selected institutions share no common report dates.";
+
+                DateOnly selected;
+                if (
+                    !string.IsNullOrEmpty(reportDate)
+                    && DateOnly.TryParse(reportDate, out var parsed)
+                    && common.Contains(parsed)
+                )
+                    selected = parsed;
+                else
+                    selected = common[0];
+
+                var perFund =
+                    new List<(
+                        InstitutionalHolder Holder,
+                        IReadOnlyList<InstitutionalHolding> Holdings
+                    )>();
+                foreach (var holder in holders)
+                {
+                    var holdings = await _holdingRepository
+                        .GetByHolder(holder, selected)
+                        .Include(h => h.CommonStock)
+                        .ToListAsync();
+                    perFund.Add((holder, holdings));
+                }
+                var overlap = FundOverlapCalculator.Calculate(perFund, selected);
+
+                var rowsWithConsensus = overlap
+                    .Rows.Select(r => new { Row = r, HeldBy = r.Slices.Count(s => s.Value > 0) })
+                    .Where(x => x.HeldBy >= Math.Max(1, minFunds))
+                    .OrderByDescending(x => x.HeldBy)
+                    .ThenByDescending(x => x.Row.CombinedValue)
+                    .Take(maxResults)
+                    .ToList();
+
+                var result = new StringBuilder();
+                result.AppendLine(
+                    $"Consensus holdings — **{holders.Count} funds** as of {selected:yyyy-MM-dd}"
+                );
+                if (missing.Count > 0)
+                    result.AppendLine($"_Could not resolve: {string.Join(", ", missing)}._");
+                result.AppendLine();
+                result.AppendLine("Funds:");
+                foreach (var h in holders)
+                    result.AppendLine($"- {h.Name} (CIK {h.Cik})");
+                result.AppendLine();
+
+                if (rowsWithConsensus.Count == 0)
+                    return result.ToString() + "_No stocks meet the minFunds threshold._";
+
+                result.AppendLine("| # | Ticker | Company | # Funds | Combined ($M) |");
+                result.AppendLine("|---|--------|---------|---------|---------------|");
+                for (var i = 0; i < rowsWithConsensus.Count; i++)
+                {
+                    var x = rowsWithConsensus[i];
+                    result.AppendLine(
+                        $"| {i + 1} | {x.Row.Ticker} | {x.Row.Name} | {x.HeldBy}/{holders.Count} | {x.Row.CombinedValue / 1_000_000m:N1} |"
+                    );
+                }
+                return result.ToString();
+            },
+            _logger,
+            "GetConsensusHoldings",
+            $"names: {institutionNames}",
+            ReportError
+        );
+    }
+
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs
@@ -1,0 +1,175 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins <c>GetConsensusHoldings</c>. Each test exercises one path: too-few-names guard,
+/// no-common-quarter, multi-fund consensus ordering, and the <c>minFunds</c> filter.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetConsensusHoldingsTests : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetConsensusHoldingsTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetConsensusHoldings_OnlyOneName_ReportsTooFew()
+    {
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetConsensusHoldings("Solo Fund");
+
+        output.Should().Contain("at least two institution names");
+    }
+
+    [Fact]
+    public async Task GetConsensusHoldings_ThreeFunds_RanksConsensusFirst()
+    {
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var msft = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+        };
+        var nvda = new CommonStock
+        {
+            Ticker = "NVDA",
+            Name = "NVIDIA Corp.",
+            Cik = "0001045810",
+        };
+        var fundA = new InstitutionalHolder { Cik = "CH00001", Name = "Consensus A LP" };
+        var fundB = new InstitutionalHolder { Cik = "CH00002", Name = "Consensus B LP" };
+        var fundC = new InstitutionalHolder { Cik = "CH00003", Name = "Consensus C LP" };
+        DbContext.AddRange(aapl, msft, nvda, fundA, fundB, fundC);
+        var date = new DateOnly(2024, 12, 31);
+        DbContext.Add(MakeHolding(aapl, fundA, date, value: 1_000_000));
+        DbContext.Add(MakeHolding(aapl, fundB, date, value: 1_500_000));
+        DbContext.Add(MakeHolding(aapl, fundC, date, value: 2_000_000));
+        DbContext.Add(MakeHolding(msft, fundA, date, value: 500_000));
+        DbContext.Add(MakeHolding(msft, fundB, date, value: 700_000));
+        DbContext.Add(MakeHolding(nvda, fundC, date, value: 800_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetConsensusHoldings("Consensus A, Consensus B, Consensus C");
+
+        output.Should().Contain("Consensus holdings — **3 funds**");
+        output.Should().Contain("AAPL");
+        output.Should().Contain("MSFT");
+        output.Should().Contain("NVDA");
+        output
+            .IndexOf("AAPL", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("MSFT", StringComparison.Ordinal));
+        output
+            .IndexOf("MSFT", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("NVDA", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetConsensusHoldings_MinFundsFilter_ExcludesBelowThreshold()
+    {
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var nvda = new CommonStock
+        {
+            Ticker = "NVDA",
+            Name = "NVIDIA Corp.",
+            Cik = "0001045810",
+        };
+        var fundA = new InstitutionalHolder { Cik = "CH00004", Name = "Filter A LP" };
+        var fundB = new InstitutionalHolder { Cik = "CH00005", Name = "Filter B LP" };
+        DbContext.AddRange(aapl, nvda, fundA, fundB);
+        var date = new DateOnly(2024, 12, 31);
+        // AAPL held by both. NVDA only by Fund B.
+        DbContext.Add(MakeHolding(aapl, fundA, date, value: 1_000_000));
+        DbContext.Add(MakeHolding(aapl, fundB, date, value: 500_000));
+        DbContext.Add(MakeHolding(nvda, fundB, date, value: 300_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetConsensusHoldings("Filter A, Filter B", minFunds: 2);
+
+        output.Should().Contain("AAPL");
+        output.Should().NotContain("NVDA");
+    }
+
+    [Fact]
+    public async Task GetConsensusHoldings_NoCommonQuarter_ReportsNoOverlap()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var fundA = new InstitutionalHolder { Cik = "CH00006", Name = "Mismatch A LP" };
+        var fundB = new InstitutionalHolder { Cik = "CH00007", Name = "Mismatch B LP" };
+        DbContext.AddRange(stock, fundA, fundB);
+        DbContext.Add(MakeHolding(stock, fundA, new DateOnly(2024, 3, 31), value: 100_000));
+        DbContext.Add(MakeHolding(stock, fundB, new DateOnly(2024, 6, 30), value: 100_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetConsensusHoldings("Mismatch A, Mismatch B");
+
+        output.Should().Contain("share no common report dates");
+    }
+
+    private InstitutionalHoldingsTools NewSut(Equibles.Data.EquiblesDbContext ctx) =>
+        new(
+            new InstitutionalHoldingRepository(ctx),
+            new InstitutionalHolderRepository(ctx),
+            new CommonStockRepository(ctx),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = value / 100,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -272,6 +272,7 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("GetInstitutionSectorAllocation");
         toolNames.Should().Contain("GetInstitutionQuarterlyActivity");
         toolNames.Should().Contain("GetFundOverlap");
+        toolNames.Should().Contain("GetConsensusHoldings");
     }
 
     // ── InsiderTrading module specific ──────────────────────────────────
@@ -367,6 +368,7 @@ public class McpModuleToolDiscoveryTests
                     "GetInstitutionSectorAllocation",
                     "GetInstitutionQuarterlyActivity",
                     "GetFundOverlap",
+                    "GetConsensusHoldings",
                 }
             },
             {


### PR DESCRIPTION
## Summary

- **Closing slice (2 of 2)** for #1015. Mirrors the combined-portfolio page landed in #1119 — pools 2–25 institutions and returns a consensus-ordered markdown table (`# funds holding` desc, then combined value). Supports a `minFunds` filter.
- Reuses `FundOverlapCalculator` from `Equibles.Holdings.Repositories`.
- Closes #1015.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — new `GetConsensusHoldings(institutionNames, reportDate?, minFunds?, max?)`. Comma/semicolon-separated names, holder resolution, date intersection, calculator + consensus re-sort + filter.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — module-discovery list updated.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetConsensusHoldingsTests.cs` — 4 ParadeDB tests.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet csharpier check .` — clean (1116 files).
- New MCP integration tests — 4/4 passing.
- Module-discovery unit tests — 59/59 passing.

Closes #1015