### PR TITLE
docs(technical/web-portal): add Institutions/Compare and /Combined routes

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -25,7 +25,7 @@ Why the indirection through `ViewData` rather than a single `StockDetailViewMode
 | Controller | Route | Role |
 |---|---|---|
 | [`StocksController`](../../src/Equibles.Web/Controllers/StocksController.cs) | `~/Stocks/...` | The tab pattern above + landing list + `ShowDocument` + `ShowHolder` per-stock holder detail. |
-| [`ProfilesController`](../../src/Equibles.Web/Controllers/ProfilesController.cs) | `~/Institutions/{cik}`, `~/Insiders/{ownerCik}`, `~/Congress/{id}` | Global (not stock-scoped) profile pages for institutional holders, insider owners, and Congress members. |
+| [`ProfilesController`](../../src/Equibles.Web/Controllers/ProfilesController.cs) | `~/Institutions/{cik}`, `~/Institutions/Compare`, `~/Institutions/Combined`, `~/Insiders/{ownerCik}`, `~/Congress/{id}` | Global (not stock-scoped) profile pages for institutional holders, insider owners, and Congress members; plus side-by-side overlap and consensus-portfolio views across multiple 13F filers. |
 | [`HoldingsActivityController`](../../src/Equibles.Web/Controllers/HoldingsActivityController.cs) | `~/Holdings/Activity` | Market-wide quarterly leaderboards aggregated across 13F filers for a `ReportDate`: Top Buys, Top Sells, New Positions, Sold-Out Positions. |
 | [`EconomicDataController`](../../src/Equibles.Web/Controllers/EconomicDataController.cs) | `~/Economy/...` | FRED series browsing — category landing + per-series charts. |
 | [`CftcController`](../../src/Equibles.Web/Controllers/CftcController.cs) | `~/Futures/...` | CFTC positioning per contract / category. |


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- `ProfilesController` now also serves `~/Institutions/Compare` (added in #1112, side-by-side overlap view) and `~/Institutions/Combined` (added in #1119, consensus-portfolio view), but the controllers table in `web-portal.md` still only listed `~/Institutions/{cik}`, `~/Insiders/{ownerCik}`, and `~/Congress/{id}`. Refresh the row.

## Code changes

- `docs/technical/web-portal.md` — add `~/Institutions/Compare` and `~/Institutions/Combined` to the `ProfilesController` row's Routes column and append a clause to the Role column for the side-by-side overlap and consensus-portfolio views.