### PR TITLE
refactor(holdings-mcp): extract TryParseReportDate helper for 8 duplicated date-parse guards

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -56,10 +56,7 @@ public class InstitutionalHoldingsTools
                     return $"Stock '{ticker}' not found.";
 
                 DateOnly targetDate;
-                if (
-                    !string.IsNullOrEmpty(reportDate)
-                    && DateOnly.TryParse(reportDate, out var parsed)
-                )
+                if (TryParseReportDate(reportDate, out var parsed))
                 {
                     targetDate = parsed;
                 }
@@ -214,10 +211,7 @@ public class InstitutionalHoldingsTools
                 var holder = holders.First();
 
                 DateOnly targetDate;
-                if (
-                    !string.IsNullOrEmpty(reportDate)
-                    && DateOnly.TryParse(reportDate, out var parsed)
-                )
+                if (TryParseReportDate(reportDate, out var parsed))
                 {
                     targetDate = parsed;
                 }
@@ -338,11 +332,9 @@ public class InstitutionalHoldingsTools
                     .OrderByDescending(d => d)
                     .ToListAsync();
 
-                var targetDate =
-                    !string.IsNullOrEmpty(reportDate)
-                    && DateOnly.TryParse(reportDate, out var parsed)
-                        ? parsed
-                        : reportDates.FirstOrDefault();
+                var targetDate = TryParseReportDate(reportDate, out var parsed)
+                    ? parsed
+                    : reportDates.FirstOrDefault();
                 if (targetDate == default)
                     return $"No institutional holdings data available for {ticker}.";
 
@@ -511,10 +503,7 @@ public class InstitutionalHoldingsTools
                     return "No 13F holdings data available.";
 
                 DateOnly targetDate;
-                if (
-                    !string.IsNullOrEmpty(reportDate)
-                    && DateOnly.TryParse(reportDate, out var parsed)
-                )
+                if (TryParseReportDate(reportDate, out var parsed))
                     targetDate = parsed;
                 else
                     targetDate = reportDates[0];
@@ -665,11 +654,7 @@ public class InstitutionalHoldingsTools
                     return $"No 13F holdings reported by {holder.Name}.";
 
                 DateOnly targetDate;
-                if (
-                    !string.IsNullOrEmpty(reportDate)
-                    && DateOnly.TryParse(reportDate, out var parsed)
-                    && reportDates.Contains(parsed)
-                )
+                if (TryParseReportDate(reportDate, out var parsed) && reportDates.Contains(parsed))
                     targetDate = parsed;
                 else
                     targetDate = reportDates[0];
@@ -757,11 +742,7 @@ public class InstitutionalHoldingsTools
                     return $"No 13F holdings reported by {holder.Name}.";
 
                 DateOnly targetDate;
-                if (
-                    !string.IsNullOrEmpty(reportDate)
-                    && DateOnly.TryParse(reportDate, out var parsed)
-                    && reportDates.Contains(parsed)
-                )
+                if (TryParseReportDate(reportDate, out var parsed) && reportDates.Contains(parsed))
                     targetDate = parsed;
                 else
                     targetDate = reportDates[0];
@@ -849,11 +830,7 @@ public class InstitutionalHoldingsTools
                     return $"{holder.Name} has fewer than two reported quarters — no diff available.";
 
                 DateOnly targetDate;
-                if (
-                    !string.IsNullOrEmpty(reportDate)
-                    && DateOnly.TryParse(reportDate, out var parsed)
-                    && reportDates.Contains(parsed)
-                )
+                if (TryParseReportDate(reportDate, out var parsed) && reportDates.Contains(parsed))
                     targetDate = parsed;
                 else
                     targetDate = reportDates[0];
@@ -983,11 +960,7 @@ public class InstitutionalHoldingsTools
                     return $"{holder1.Name} and {holder2.Name} share no common report dates.";
 
                 DateOnly selected;
-                if (
-                    !string.IsNullOrEmpty(reportDate)
-                    && DateOnly.TryParse(reportDate, out var parsed)
-                    && common.Contains(parsed)
-                )
+                if (TryParseReportDate(reportDate, out var parsed) && common.Contains(parsed))
                     selected = parsed;
                 else
                     selected = common[0];
@@ -1059,6 +1032,12 @@ public class InstitutionalHoldingsTools
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
+    }
+
+    private static bool TryParseReportDate(string input, out DateOnly result)
+    {
+        result = default;
+        return !string.IsNullOrEmpty(input) && DateOnly.TryParse(input, out result);
     }
 
     private class HolderAggregate


### PR DESCRIPTION
## Summary

- `InstitutionalHoldingsTools` repeated the `!string.IsNullOrEmpty(reportDate) && DateOnly.TryParse(reportDate, out var parsed)` predicate **eight times** across its MCP tools (mix of `if/else`, ternary, and chained-with-`Contains` forms).
- Extracted into a single private static `TryParseReportDate(string input, out DateOnly result)` helper. Each call site keeps its own surrounding logic (additional `&& reportDates.Contains(parsed)` chain, fallback assignment).
- Out-parameter assignment matches `DateOnly.TryParse`'s contract — `default` on missing/failed input, parsed value on success.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs`
  - New private static `TryParseReportDate` at the bottom of the class.
  - 8 call sites in `GetTopHolders`, `GetInstitutionPortfolio`, `GetTopBuyersSellers`, `GetMarketWide13FActivity`, `GetInstitutionSummary`, `GetInstitutionSectorAllocation`, `GetInstitutionQuarterlyActivity`, `GetFundOverlap` simplified.
  - Net: −37 lines, +16 lines.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet tool run csharpier check .` — green (1113 files).
- `dotnet test tests/Equibles.UnitTests` — 1378/1378 pass.
- `dotnet test tests/Equibles.IntegrationTests --filter "FullyQualifiedName~InstitutionalHoldingsTools"` — 53/53 pass (covers every tool affected).