### PR TITLE
feat(sec-facts): add StandaloneXbrlParser for dimensional fact extraction

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -153,6 +153,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.SmokeTests", "test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Sec.FinancialFacts.Mcp", "src\Equibles.Sec.FinancialFacts.Mcp\Equibles.Sec.FinancialFacts.Mcp.csproj", "{2E08AC17-1840-4BBE-A914-6133F83BB43B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Sec.FinancialFacts.BusinessLogic", "src\Equibles.Sec.FinancialFacts.BusinessLogic\Equibles.Sec.FinancialFacts.BusinessLogic.csproj", "{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1039,6 +1041,18 @@ Global
 		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Release|x64.Build.0 = Release|Any CPU
 		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Release|x86.ActiveCfg = Release|Any CPU
 		{2E08AC17-1840-4BBE-A914-6133F83BB43B}.Release|x86.Build.0 = Release|Any CPU
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Debug|x64.Build.0 = Debug|Any CPU
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Debug|x86.Build.0 = Debug|Any CPU
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Release|x64.ActiveCfg = Release|Any CPU
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Release|x64.Build.0 = Release|Any CPU
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Release|x86.ActiveCfg = Release|Any CPU
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1117,6 +1131,7 @@ Global
 		{CC59BCF3-6989-44DD-999A-95EEDF297F47} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{A15FB700-5BF7-4284-B695-FE04E80D258F} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{2E08AC17-1840-4BBE-A914-6133F83BB43B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Equibles.Sec.FinancialFacts.BusinessLogic.csproj
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Equibles.Sec.FinancialFacts.BusinessLogic.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <InternalsVisibleTo Include="Equibles.UnitTests" />
+    <InternalsVisibleTo Include="Equibles.IntegrationTests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Equibles.Core.AutoWiring" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Data\Equibles.Sec.FinancialFacts.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/ParsedXbrlDimension.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/ParsedXbrlDimension.cs
@@ -1,0 +1,17 @@
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.Models;
+
+/// <summary>
+/// One explicit XBRL dimension on a parsed fact — the (axis, member) pair
+/// extracted from an <c>xbrldi:explicitMember</c> element inside an
+/// <c>xbrli:context</c>'s segment/scenario. Both sides are full QNames
+/// (<c>prefix:localName</c>) preserved exactly as the source document
+/// declared them, since member prefixes routinely point at filer-specific
+/// extension namespaces (<c>aapl:</c>, <c>msft:</c>, …) the consumer is
+/// expected to interpret.
+/// </summary>
+public class ParsedXbrlDimension
+{
+    public string Axis { get; init; }
+
+    public string Member { get; init; }
+}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/ParsedXbrlFact.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/ParsedXbrlFact.cs
@@ -1,0 +1,54 @@
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.Models;
+
+/// <summary>
+/// A single financial fact extracted from an XBRL instance. Holds the raw
+/// concept identity (taxonomy prefix + tag), the numeric value, the unit,
+/// the reporting period, and any explicit XBRL dimensions on the context.
+/// Consumers map the QName-shaped <see cref="Taxonomy"/> to the persisted
+/// <c>FactTaxonomy</c> enum (or keep the raw prefix for filer-extension
+/// concepts the enum does not enumerate).
+/// </summary>
+public class ParsedXbrlFact
+{
+    /// <summary>
+    /// QName prefix of the concept's element (e.g. <c>us-gaap</c>,
+    /// <c>dei</c>, <c>srt</c>, <c>ifrs-full</c>, <c>aapl</c>). Preserved
+    /// verbatim from the source so filer-extension namespaces survive.
+    /// </summary>
+    public string Taxonomy { get; init; }
+
+    /// <summary>Local name of the concept element (e.g. <c>Revenues</c>).</summary>
+    public string Tag { get; init; }
+
+    /// <summary>
+    /// Resolved unit string — single measures collapse to their local name
+    /// (<c>iso4217:USD</c> → <c>USD</c>); divide units are emitted as
+    /// <c>numerator/denominator</c> (e.g. <c>USD/shares</c>).
+    /// </summary>
+    public string Unit { get; init; }
+
+    public decimal Value { get; init; }
+
+    /// <summary>True when the context carries <c>xbrli:instant</c>; otherwise the period is a duration.</summary>
+    public bool IsInstant { get; init; }
+
+    /// <summary>For instant facts, equals <see cref="PeriodEnd"/>.</summary>
+    public DateOnly PeriodStart { get; init; }
+
+    public DateOnly PeriodEnd { get; init; }
+
+    /// <summary>
+    /// Explicit XBRL dimensions on this fact's context (axis + member
+    /// QNames from <c>xbrldi:explicitMember</c>). Empty list = consolidated
+    /// / no-dimension default context — the only context the SEC Company
+    /// Facts API returns.
+    /// </summary>
+    public List<ParsedXbrlDimension> Dimensions { get; init; } = [];
+
+    /// <summary>
+    /// XBRL <c>decimals</c> attribute, when present — the reported
+    /// precision (positive for fractional digits, negative for rounding
+    /// magnitude, <c>INF</c> → <c>int.MaxValue</c>). Null when absent.
+    /// </summary>
+    public int? Decimals { get; init; }
+}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
@@ -1,0 +1,289 @@
+using System.Globalization;
+using System.Xml.Linq;
+using Equibles.Core.AutoWiring;
+using Equibles.Sec.FinancialFacts.BusinessLogic.Models;
+
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+/// <summary>
+/// Extracts financial facts from a <strong>standalone</strong> XBRL instance
+/// document — the dedicated <c>.xml</c> artifact older filings ship alongside
+/// the human-readable HTML (e.g. <c>aapl-20180929.xml</c>). Resolves
+/// <c>contextRef</c> to its <c>xbrli:context</c> (period + any
+/// <c>xbrldi:explicitMember</c> dimensions) and <c>unitRef</c> to its
+/// <c>xbrli:unit</c>; emits one <see cref="ParsedXbrlFact"/> per numeric fact
+/// element under the root <c>xbrli:xbrl</c>.
+///
+/// <para>
+/// <strong>Not wired into the worker pipeline yet.</strong> Persisting raw
+/// standalone-XBRL artifacts at ingest time is tracked in GH-1118; until that
+/// lands, running this parser at scale would require re-downloading every
+/// historical filing on each cycle. The parser ships now as reusable
+/// infrastructure with full unit-test coverage; the hosted-service wiring
+/// follows GH-1118.
+/// </para>
+///
+/// <para>
+/// Scope: numeric facts only (elements with both <c>contextRef</c> and
+/// <c>unitRef</c>). Narrative <c>nonNumeric</c> facts, the <c>scale</c>
+/// attribute, and <c>typedMember</c> dimensions are out of scope for the
+/// first iteration; <c>decimals="INF"</c> resolves to
+/// <see cref="int.MaxValue"/>.
+/// </para>
+/// </summary>
+[Service]
+public class StandaloneXbrlParser
+{
+    private const string XbrliNamespace = "http://www.xbrl.org/2003/instance";
+    private const string XbrldiNamespace = "http://xbrl.org/2006/xbrldi";
+    private const string XsiNamespace = "http://www.w3.org/2001/XMLSchema-instance";
+
+    private static readonly XName XbrlRoot = XName.Get("xbrl", XbrliNamespace);
+    private static readonly XName ContextElement = XName.Get("context", XbrliNamespace);
+    private static readonly XName UnitElement = XName.Get("unit", XbrliNamespace);
+    private static readonly XName PeriodElement = XName.Get("period", XbrliNamespace);
+    private static readonly XName InstantElement = XName.Get("instant", XbrliNamespace);
+    private static readonly XName StartDateElement = XName.Get("startDate", XbrliNamespace);
+    private static readonly XName EndDateElement = XName.Get("endDate", XbrliNamespace);
+    private static readonly XName MeasureElement = XName.Get("measure", XbrliNamespace);
+    private static readonly XName DivideElement = XName.Get("divide", XbrliNamespace);
+    private static readonly XName NumeratorElement = XName.Get("unitNumerator", XbrliNamespace);
+    private static readonly XName DenominatorElement = XName.Get("unitDenominator", XbrliNamespace);
+    private static readonly XName ExplicitMemberElement = XName.Get(
+        "explicitMember",
+        XbrldiNamespace
+    );
+    private static readonly XName XsiNil = XName.Get("nil", XsiNamespace);
+
+    public List<ParsedXbrlFact> Parse(string xml)
+    {
+        if (string.IsNullOrWhiteSpace(xml))
+            return [];
+
+        XDocument document;
+        try
+        {
+            document = XDocument.Parse(xml);
+        }
+        catch (System.Xml.XmlException)
+        {
+            return [];
+        }
+
+        var root = document.Root;
+        if (root == null || root.Name != XbrlRoot)
+            return [];
+
+        var contexts = BuildContextMap(root);
+        var units = BuildUnitMap(root);
+
+        var facts = new List<ParsedXbrlFact>();
+        foreach (var element in root.Elements())
+        {
+            if (TryParseFact(element, contexts, units, out var fact))
+                facts.Add(fact);
+        }
+
+        return facts;
+    }
+
+    private static Dictionary<
+        string,
+        (bool IsInstant, DateOnly Start, DateOnly End, List<ParsedXbrlDimension> Dimensions)
+    > BuildContextMap(XElement root)
+    {
+        var contexts = new Dictionary<
+            string,
+            (bool, DateOnly, DateOnly, List<ParsedXbrlDimension>)
+        >(StringComparer.Ordinal);
+
+        foreach (var contextElement in root.Elements(ContextElement))
+        {
+            var id = (string)contextElement.Attribute("id");
+            if (string.IsNullOrEmpty(id))
+                continue;
+
+            var period = contextElement.Element(PeriodElement);
+            if (period == null)
+                continue;
+
+            if (!TryParsePeriod(period, out var isInstant, out var start, out var end))
+                continue;
+
+            var dimensions = ExtractDimensions(contextElement);
+            contexts[id] = (isInstant, start, end, dimensions);
+        }
+
+        return contexts;
+    }
+
+    private static bool TryParsePeriod(
+        XElement period,
+        out bool isInstant,
+        out DateOnly start,
+        out DateOnly end
+    )
+    {
+        var instant = period.Element(InstantElement);
+        if (instant != null && DateOnly.TryParse(instant.Value, out var instantDate))
+        {
+            isInstant = true;
+            start = instantDate;
+            end = instantDate;
+            return true;
+        }
+
+        var startElement = period.Element(StartDateElement);
+        var endElement = period.Element(EndDateElement);
+        if (
+            startElement != null
+            && endElement != null
+            && DateOnly.TryParse(startElement.Value, out var startDate)
+            && DateOnly.TryParse(endElement.Value, out var endDate)
+        )
+        {
+            isInstant = false;
+            start = startDate;
+            end = endDate;
+            return true;
+        }
+
+        isInstant = false;
+        start = default;
+        end = default;
+        return false;
+    }
+
+    private static List<ParsedXbrlDimension> ExtractDimensions(XElement contextElement)
+    {
+        // Per the XBRL spec, explicitMember can appear under entity/segment
+        // and/or under scenario — both are valid and both contribute dimensions
+        // to the same fact. A descendant scan picks up either placement
+        // without depending on the filer's structural choice.
+        var dimensions = new List<ParsedXbrlDimension>();
+        foreach (var member in contextElement.Descendants(ExplicitMemberElement))
+        {
+            var axis = (string)member.Attribute("dimension");
+            var memberValue = member.Value?.Trim();
+            if (string.IsNullOrEmpty(axis) || string.IsNullOrEmpty(memberValue))
+                continue;
+
+            dimensions.Add(new ParsedXbrlDimension { Axis = axis, Member = memberValue });
+        }
+
+        return dimensions;
+    }
+
+    private static Dictionary<string, string> BuildUnitMap(XElement root)
+    {
+        var units = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var unitElement in root.Elements(UnitElement))
+        {
+            var id = (string)unitElement.Attribute("id");
+            if (string.IsNullOrEmpty(id))
+                continue;
+
+            var resolved = ResolveUnit(unitElement);
+            if (resolved == null)
+                continue;
+
+            units[id] = resolved;
+        }
+
+        return units;
+    }
+
+    private static string ResolveUnit(XElement unitElement)
+    {
+        var divide = unitElement.Element(DivideElement);
+        if (divide != null)
+        {
+            var numerator = divide.Element(NumeratorElement);
+            var denominator = divide.Element(DenominatorElement);
+            var numeratorMeasure = numerator?.Element(MeasureElement)?.Value;
+            var denominatorMeasure = denominator?.Element(MeasureElement)?.Value;
+            if (string.IsNullOrEmpty(numeratorMeasure) || string.IsNullOrEmpty(denominatorMeasure))
+                return null;
+            return $"{StripPrefix(numeratorMeasure)}/{StripPrefix(denominatorMeasure)}";
+        }
+
+        var measure = unitElement.Element(MeasureElement);
+        var measureValue = measure?.Value;
+        return string.IsNullOrEmpty(measureValue) ? null : StripPrefix(measureValue);
+    }
+
+    private static string StripPrefix(string qname)
+    {
+        var colonIdx = qname.IndexOf(':');
+        return colonIdx >= 0 ? qname.Substring(colonIdx + 1) : qname;
+    }
+
+    private static bool TryParseFact(
+        XElement element,
+        Dictionary<
+            string,
+            (bool IsInstant, DateOnly Start, DateOnly End, List<ParsedXbrlDimension> Dimensions)
+        > contexts,
+        Dictionary<string, string> units,
+        out ParsedXbrlFact fact
+    )
+    {
+        fact = null;
+
+        // xbrli: namespace elements (context, unit, …) are XBRL machinery, not facts.
+        if (element.Name.NamespaceName == XbrliNamespace)
+            return false;
+
+        var contextRef = (string)element.Attribute("contextRef");
+        var unitRef = (string)element.Attribute("unitRef");
+        if (string.IsNullOrEmpty(contextRef) || string.IsNullOrEmpty(unitRef))
+            return false;
+
+        var nilAttribute = (string)element.Attribute(XsiNil);
+        if (string.Equals(nilAttribute, "true", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (!contexts.TryGetValue(contextRef, out var context))
+            return false;
+        if (!units.TryGetValue(unitRef, out var unit))
+            return false;
+
+        if (
+            !decimal.TryParse(
+                element.Value,
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out var value
+            )
+        )
+            return false;
+
+        var taxonomy = element.GetPrefixOfNamespace(element.Name.Namespace);
+        if (string.IsNullOrEmpty(taxonomy))
+            return false;
+
+        fact = new ParsedXbrlFact
+        {
+            Taxonomy = taxonomy,
+            Tag = element.Name.LocalName,
+            Unit = unit,
+            Value = value,
+            IsInstant = context.IsInstant,
+            PeriodStart = context.Start,
+            PeriodEnd = context.End,
+            Dimensions = context.Dimensions,
+            Decimals = ParseDecimals((string)element.Attribute("decimals")),
+        };
+        return true;
+    }
+
+    private static int? ParseDecimals(string decimalsAttribute)
+    {
+        if (string.IsNullOrEmpty(decimalsAttribute))
+            return null;
+        if (string.Equals(decimalsAttribute, "INF", StringComparison.OrdinalIgnoreCase))
+            return int.MaxValue;
+        return int.TryParse(decimalsAttribute, out var value) ? value : null;
+    }
+}

--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -40,6 +40,7 @@
     <ProjectReference Include="..\..\src\Equibles.Errors.Repositories\Equibles.Errors.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Sec.HostedService\Equibles.Sec.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Sec.FinancialFacts.HostedService\Equibles.Sec.FinancialFacts.HostedService.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Sec.FinancialFacts.BusinessLogic\Equibles.Sec.FinancialFacts.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Media.Data\Equibles.Media.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Media.BusinessLogic\Equibles.Media.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Congress.HostedService\Equibles.Congress.HostedService.csproj" />

--- a/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserTests.cs
@@ -1,0 +1,242 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the standalone XBRL parser's extraction contract for #877. Fixtures
+/// are inlined per test so the asserted XBRL shape stays adjacent to the
+/// behaviour it pins (and so the test file is self-contained).
+/// </summary>
+public class StandaloneXbrlParserTests
+{
+    private const string Namespaces =
+        "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+        + "xmlns:xbrldi=\"http://xbrl.org/2006/xbrldi\" "
+        + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+        + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2018-01-31\" "
+        + "xmlns:srt=\"http://fasb.org/srt/2018-01-31\" "
+        + "xmlns:aapl=\"http://www.apple.com/20180929\"";
+
+    [Fact]
+    public void Parse_NumericFactWithInstantContext_ResolvesContextAndUnit()
+    {
+        var xml =
+            $"<xbrli:xbrl {Namespaces}>"
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"http://www.sec.gov/CIK\">0000320193</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2018-09-29</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"usd\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + "<us-gaap:Assets contextRef=\"C1\" unitRef=\"usd\" decimals=\"-6\">365725000000</us-gaap:Assets>"
+            + "</xbrli:xbrl>";
+
+        var facts = new StandaloneXbrlParser().Parse(xml);
+
+        var fact = facts.Should().ContainSingle().Subject;
+        fact.Taxonomy.Should().Be("us-gaap");
+        fact.Tag.Should().Be("Assets");
+        fact.Unit.Should().Be("USD");
+        fact.Value.Should().Be(365_725_000_000m);
+        fact.IsInstant.Should().BeTrue();
+        fact.PeriodStart.Should().Be(new DateOnly(2018, 9, 29));
+        fact.PeriodEnd.Should().Be(new DateOnly(2018, 9, 29));
+        fact.Decimals.Should().Be(-6);
+        fact.Dimensions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_DurationPeriod_PreservesStartAndEnd()
+    {
+        var xml =
+            $"<xbrli:xbrl {Namespaces}>"
+            + "<xbrli:context id=\"D1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:startDate>2017-10-01</xbrli:startDate><xbrli:endDate>2018-09-29</xbrli:endDate></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + "<us-gaap:Revenues contextRef=\"D1\" unitRef=\"u\">265595000000</us-gaap:Revenues>"
+            + "</xbrli:xbrl>";
+
+        var fact = new StandaloneXbrlParser().Parse(xml).Should().ContainSingle().Subject;
+
+        fact.IsInstant.Should().BeFalse();
+        fact.PeriodStart.Should().Be(new DateOnly(2017, 10, 1));
+        fact.PeriodEnd.Should().Be(new DateOnly(2018, 9, 29));
+    }
+
+    [Fact]
+    public void Parse_ExplicitMemberInSegment_ExtractsDimension()
+    {
+        var xml =
+            $"<xbrli:xbrl {Namespaces}>"
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity>"
+            + "    <xbrli:identifier scheme=\"x\">0</xbrli:identifier>"
+            + "    <xbrli:segment>"
+            + "      <xbrldi:explicitMember dimension=\"srt:ProductOrServiceAxis\">aapl:IPhoneMember</xbrldi:explicitMember>"
+            + "    </xbrli:segment>"
+            + "  </xbrli:entity>"
+            + "  <xbrli:period><xbrli:startDate>2017-10-01</xbrli:startDate><xbrli:endDate>2018-09-29</xbrli:endDate></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + "<us-gaap:Revenues contextRef=\"C1\" unitRef=\"u\">164888000000</us-gaap:Revenues>"
+            + "</xbrli:xbrl>";
+
+        var fact = new StandaloneXbrlParser().Parse(xml).Should().ContainSingle().Subject;
+
+        var dimension = fact.Dimensions.Should().ContainSingle().Subject;
+        dimension.Axis.Should().Be("srt:ProductOrServiceAxis");
+        dimension.Member.Should().Be("aapl:IPhoneMember");
+    }
+
+    [Fact]
+    public void Parse_MultipleExplicitMembers_AllExtracted()
+    {
+        var xml =
+            $"<xbrli:xbrl {Namespaces}>"
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity>"
+            + "    <xbrli:identifier scheme=\"x\">0</xbrli:identifier>"
+            + "    <xbrli:segment>"
+            + "      <xbrldi:explicitMember dimension=\"srt:ProductOrServiceAxis\">aapl:IPhoneMember</xbrldi:explicitMember>"
+            + "      <xbrldi:explicitMember dimension=\"srt:StatementGeographicalAxis\">aapl:AmericasMember</xbrldi:explicitMember>"
+            + "    </xbrli:segment>"
+            + "  </xbrli:entity>"
+            + "  <xbrli:period><xbrli:startDate>2017-10-01</xbrli:startDate><xbrli:endDate>2018-09-29</xbrli:endDate></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + "<us-gaap:Revenues contextRef=\"C1\" unitRef=\"u\">1000</us-gaap:Revenues>"
+            + "</xbrli:xbrl>";
+
+        var fact = new StandaloneXbrlParser().Parse(xml).Should().ContainSingle().Subject;
+
+        fact.Dimensions.Should()
+            .HaveCount(2)
+            .And.Contain(d =>
+                d.Axis == "srt:ProductOrServiceAxis" && d.Member == "aapl:IPhoneMember"
+            )
+            .And.Contain(d =>
+                d.Axis == "srt:StatementGeographicalAxis" && d.Member == "aapl:AmericasMember"
+            );
+    }
+
+    [Fact]
+    public void Parse_DivideUnit_ResolvesAsNumeratorOverDenominator()
+    {
+        var xml =
+            $"<xbrli:xbrl {Namespaces}>"
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2018-09-29</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"usdPerShare\">"
+            + "  <xbrli:divide>"
+            + "    <xbrli:unitNumerator><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unitNumerator>"
+            + "    <xbrli:unitDenominator><xbrli:measure>xbrli:shares</xbrli:measure></xbrli:unitDenominator>"
+            + "  </xbrli:divide>"
+            + "</xbrli:unit>"
+            + "<us-gaap:EarningsPerShareBasic contextRef=\"C1\" unitRef=\"usdPerShare\" decimals=\"2\">12.01</us-gaap:EarningsPerShareBasic>"
+            + "</xbrli:xbrl>";
+
+        var fact = new StandaloneXbrlParser().Parse(xml).Should().ContainSingle().Subject;
+
+        fact.Unit.Should().Be("USD/shares");
+        fact.Value.Should().Be(12.01m);
+    }
+
+    [Fact]
+    public void Parse_DecimalsInf_MapsToIntMaxValue()
+    {
+        var xml =
+            $"<xbrli:xbrl {Namespaces}>"
+            + "<xbrli:context id=\"C1\"><xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period></xbrli:context>"
+            + "<xbrli:unit id=\"shares\"><xbrli:measure>xbrli:shares</xbrli:measure></xbrli:unit>"
+            + "<dei:EntityCommonStockSharesOutstanding xmlns:dei=\"http://xbrl.sec.gov/dei/2018-01-31\" "
+            + "contextRef=\"C1\" unitRef=\"shares\" decimals=\"INF\">1000</dei:EntityCommonStockSharesOutstanding>"
+            + "</xbrli:xbrl>";
+
+        var fact = new StandaloneXbrlParser().Parse(xml).Should().ContainSingle().Subject;
+
+        fact.Decimals.Should().Be(int.MaxValue);
+    }
+
+    [Fact]
+    public void Parse_ContextRefMissing_SkipsFact()
+    {
+        var xml =
+            $"<xbrli:xbrl {Namespaces}>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + "<us-gaap:Revenues contextRef=\"DoesNotExist\" unitRef=\"u\">1</us-gaap:Revenues>"
+            + "</xbrli:xbrl>";
+
+        new StandaloneXbrlParser().Parse(xml).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_UnitRefMissing_SkipsFact()
+    {
+        var xml =
+            $"<xbrli:xbrl {Namespaces}>"
+            + "<xbrli:context id=\"C1\"><xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period></xbrli:context>"
+            + "<us-gaap:Revenues contextRef=\"C1\" unitRef=\"missing\">1</us-gaap:Revenues>"
+            + "</xbrli:xbrl>";
+
+        new StandaloneXbrlParser().Parse(xml).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_XsiNilTrue_SkipsFact()
+    {
+        var xml =
+            $"<xbrli:xbrl {Namespaces}>"
+            + "<xbrli:context id=\"C1\"><xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period></xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + "<us-gaap:Revenues contextRef=\"C1\" unitRef=\"u\" xsi:nil=\"true\"/>"
+            + "</xbrli:xbrl>";
+
+        new StandaloneXbrlParser().Parse(xml).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_FilerExtensionTaxonomy_PreservesPrefix()
+    {
+        var xml =
+            $"<xbrli:xbrl {Namespaces}>"
+            + "<xbrli:context id=\"C1\"><xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period></xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + "<aapl:CustomMetric contextRef=\"C1\" unitRef=\"u\">42</aapl:CustomMetric>"
+            + "</xbrli:xbrl>";
+
+        var fact = new StandaloneXbrlParser().Parse(xml).Should().ContainSingle().Subject;
+
+        fact.Taxonomy.Should().Be("aapl");
+        fact.Tag.Should().Be("CustomMetric");
+    }
+
+    [Fact]
+    public void Parse_InvalidXml_ReturnsEmpty()
+    {
+        new StandaloneXbrlParser().Parse("<not-xbrl><broken</not-xbrl>").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_NullOrWhitespace_ReturnsEmpty()
+    {
+        var parser = new StandaloneXbrlParser();
+        parser.Parse(null).Should().BeEmpty();
+        parser.Parse("").Should().BeEmpty();
+        parser.Parse("   ").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_WrongRoot_ReturnsEmpty()
+    {
+        new StandaloneXbrlParser().Parse("<not-the-root xmlns=\"x\"/>").Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 2 / 4 of #877 — standalone-XBRL-instance parser.
- Library only — **not wired into the pipeline**. The prerequisite (persisting raw XBRL artifacts at ingest time) is tracked in #1118; until that lands, running the parser at scale would require re-downloading every historical filing on each cycle. Shipping now as reusable infrastructure with full unit-test coverage.
- 13 unit tests pin the extraction contract end-to-end. Not the closing slice — refs #877 only.

## Code changes

- `src/Equibles.Sec.FinancialFacts.BusinessLogic/` — new project (added to `Equibles.sln`). `Microsoft.NET.Sdk`, references `Equibles.Core.AutoWiring` + `Equibles.Sec.FinancialFacts.Data`.
  - `Parsers/StandaloneXbrlParser.cs` — \`[Service]\`. Walks the XBRL instance under \`xbrli:xbrl\`, builds (context-id → period + dimensions) and (unit-id → resolved unit string) maps, then emits one \`ParsedXbrlFact\` per numeric element with both \`contextRef\` + \`unitRef\`. Resolves single measures to their local name (\`iso4217:USD\` → \`USD\`) and \`xbrli:divide\` units to \`numerator/denominator\` (\`USD/shares\`). \`xbrldi:explicitMember\` dimensions are picked up via a descendant scan so segment / scenario placement is irrelevant. \`xsi:nil=\"true\"\`, missing context, missing unit, non-numeric values, and the \`xbrli:\` machinery namespace are all filtered. \`decimals=\"INF\"\` → \`int.MaxValue\`. Class-level XML doc states the not-wired status and links #1118.
  - \`Models/ParsedXbrlFact.cs\` — POCO output. Holds taxonomy QName prefix (preserved verbatim so filer extensions like \`aapl:\` survive), tag, resolved unit, value, instant/duration period, dimensions, and the XBRL \`decimals\` attribute.
  - \`Models/ParsedXbrlDimension.cs\` — POCO. Axis + Member as full QNames.
- \`tests/Equibles.UnitTests/Equibles.UnitTests.csproj\` — adds a \`ProjectReference\` to the new BusinessLogic project.
- \`tests/Equibles.UnitTests/Sec/StandaloneXbrlParserTests.cs\` — 13 tests: instant + duration periods, single-axis + multi-axis dimensions, divide units, \`INF\` decimals, missing-context skip, missing-unit skip, \`xsi:nil=\"true\"\` skip, filer-extension prefix preservation, invalid XML / null / whitespace / wrong-root all return \`[]\`. Fixtures inlined per test so the asserted XBRL shape stays adjacent to the behaviour.