### PR TITLE
refactor(congress): extract ParseAmount helper from ParseAmountRange

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -258,15 +258,11 @@ public static partial class DisclosureParsingHelper
         var matches = AmountRegex().Matches(amount);
 
         if (matches.Count >= 2)
-        {
-            long.TryParse(matches[0].Groups[1].Value.Replace(",", ""), out var from);
-            long.TryParse(matches[1].Groups[1].Value.Replace(",", ""), out var to);
-            return (from, to);
-        }
+            return (ParseAmount(matches[0]), ParseAmount(matches[1]));
 
         if (matches.Count == 1)
         {
-            long.TryParse(matches[0].Groups[1].Value.Replace(",", ""), out var val);
+            var val = ParseAmount(matches[0]);
             // A single amount is an open-ended lower bound when phrased as
             // "Over $X" or the House top bracket "$X +" (>= $X) — both map to
             // (val, val). Otherwise it is an upper bound, e.g. "Under $X".
@@ -277,6 +273,12 @@ public static partial class DisclosureParsingHelper
         }
 
         return (0, 0);
+    }
+
+    private static long ParseAmount(Match match)
+    {
+        long.TryParse(match.Groups[1].Value.Replace(",", ""), out var val);
+        return val;
     }
 
     public static bool IsValidDisclosureUrl(string url, string expectedBaseUrl)


### PR DESCRIPTION
## Summary

- `ParseAmountRange` in `DisclosureParsingHelper` spelled out the same `long.TryParse(matches[N].Groups[1].Value.Replace(",", ""), out var X)` step three times — twice in the two-match branch (`from`, `to`) and once in the single-match branch.
- Extract one `private static long ParseAmount(Match)` helper. Same value comes back: `long.TryParse` writes `0` to the out-var on failure, which is exactly what the helper returns by reading the same var. The open-top-bracket logic, match-count branching, and (0, 0) defaults are untouched.

## Code changes

- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — add private static `ParseAmount(Match)`; rewrite the three inline `long.TryParse(... .Replace(",", ""), out var ...)` lines in `ParseAmountRange` to call it. Net +2 lines, three redundant local outs removed.