### PR TITLE
refactor(fund-overlap): replace explicit min/max guard ifs with Math.Min/Math.Max

### DIFF
--- a/src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs
@@ -92,13 +92,13 @@ public static class FundOverlapCalculator
                 slices.Add(slice);
                 combinedValue += slice.Value;
                 if (perStock == null)
+                {
                     allHaveIt = false;
+                }
                 else
                 {
-                    if (perStock.Value < minValue)
-                        minValue = perStock.Value;
-                    if (perStock.Value > maxValue)
-                        maxValue = perStock.Value;
+                    minValue = Math.Min(minValue, perStock.Value);
+                    maxValue = Math.Max(maxValue, perStock.Value);
                 }
             }
             if (allHaveIt)


### PR DESCRIPTION
## Summary

- Replace the two explicit `if (perStock.Value < minValue) minValue = perStock.Value` / `if (perStock.Value > maxValue) maxValue = perStock.Value` guards inside `FundOverlapCalculator.Calculate`'s inner per-fund loop with `Math.Min(minValue, perStock.Value)` / `Math.Max(maxValue, perStock.Value)`.
- Behaviour-preserving: on `long`, `Math.Min(a, b)` is identical to `a < b ? a : b` and `Math.Max(a, b)` to `a > b ? a : b`; same final `minValue`/`maxValue` for every input, and the surrounding `perStock == null → allHaveIt = false` guard keeps the existing null-skip behaviour.

## Code changes

- `src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs` — collapse 4 lines of explicit comparisons into 2 `Math.Min`/`Math.Max` calls. Net no-op size (+4 / -4 because of brace placement preserving csharpier output). 6 `FundOverlapCalculator` unit tests pass; full unit-test suite (1378) green.