### PR TITLE
refactor(financial-facts): replace per-pair label scan in ResolveConcepts with one-pass index

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -219,15 +219,19 @@ public class FinancialFactsImportService
     {
         var pairs = parsed.Select(p => (p.Taxonomy, p.Tag)).ToHashSet();
 
+        // Pre-index labels in one pass so the per-pair lookup is O(1); the
+        // prior per-pair scan was O(pairs * parsed) on multi-thousand-fact filings.
+        var firstLabelByPair = parsed
+            .Where(p => !string.IsNullOrEmpty(p.Label))
+            .GroupBy(p => (p.Taxonomy, p.Tag))
+            .ToDictionary(g => g.Key, g => g.First().Label);
+
         var concepts = pairs
             .Select(pair => new FinancialConcept
             {
                 Taxonomy = pair.Taxonomy,
                 Tag = pair.Tag,
-                Label = parsed
-                    .Where(p => p.Taxonomy == pair.Taxonomy && p.Tag == pair.Tag)
-                    .Select(p => p.Label)
-                    .FirstOrDefault(l => !string.IsNullOrEmpty(l)),
+                Label = firstLabelByPair.GetValueOrDefault(pair),
             })
             .ToList();
 


### PR DESCRIPTION
## Summary

- `ResolveConcepts` built a `HashSet<(Taxonomy, Tag)>` of unique pairs and then, for each pair, scanned the full `parsed` list (`parsed.Where(...).FirstOrDefault(non-empty Label)`) — O(pairs × parsed). On multi-thousand-fact company filings this is a real hot-loop.
- Pre-build a `(Taxonomy, Tag) → first non-empty Label` dictionary in **one** `parsed` pass via `Where(non-empty Label).GroupBy.ToDictionary(g => g.First().Label)`, then look up per pair. Same label-resolution semantics (first non-empty match in document order, `null` if none).

## Code changes

- `src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs`
  - Inside `ResolveConcepts`, replace the per-pair `parsed.Where(...).FirstOrDefault(...)` projection with a pre-computed `firstLabelByPair` dictionary; the `concepts` projection now does `firstLabelByPair.GetValueOrDefault(pair)`.
  - One-line WHY comment on the new lookup explains the prior quadratic cost.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet tool run csharpier check .` — green (1116 files).
- `dotnet test tests/Equibles.UnitTests` — 1378/1378 pass.
- `dotnet test tests/Equibles.IntegrationTests --filter "FullyQualifiedName~FinancialFacts"` — 21/21 pass (covers `FinancialFactsImportServiceIdempotencyTests`, `…EmptyFactsTests`, `…DedupTests`).