### PR TITLE
fix(holdings): render negative Δ value as -$X not $-X

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -79,13 +79,13 @@
                                         @foreach (var row in board.Rows) {
                                             var deltaSharesCss = row.DeltaShares > 0 ? "text-success" : row.DeltaShares < 0 ? "text-error" : "";
                                             var deltaValueCss = row.DeltaValue > 0 ? "text-success" : row.DeltaValue < 0 ? "text-error" : "";
-                                            var deltaSharesSign = row.DeltaShares > 0 ? "+" : "";
-                                            var deltaValueSign = row.DeltaValue > 0 ? "+" : "";
+                                            var deltaSharesText = (row.DeltaShares > 0 ? "+" : row.DeltaShares < 0 ? "-" : "") + Math.Abs(row.DeltaShares).ToString("N0");
+                                            var deltaValueText = (row.DeltaValue > 0 ? "+$" : row.DeltaValue < 0 ? "-$" : "$") + Math.Abs(row.DeltaValue).ToString("N0");
                                             <tr>
                                                 <td class="font-mono">@row.Ticker</td>
                                                 <td class="max-w-xs truncate">@row.Name</td>
-                                                <td class="text-right font-mono @deltaSharesCss">@deltaSharesSign@row.DeltaShares.ToString("N0")</td>
-                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss">@deltaValueSign$@row.DeltaValue.ToString("N0")</td>
+                                                <td class="text-right font-mono @deltaSharesCss">@deltaSharesText</td>
+                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss">@deltaValueText</td>
                                                 <td class="text-right font-mono hidden lg:table-cell text-base-content/60">@row.PreviousFilerCount.ToString("N0") → @row.CurrentFilerCount.ToString("N0")</td>
                                                 <td class="text-right">
                                                     <a asp-controller="Stocks" asp-action="Holdings"

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -182,8 +182,8 @@
                                                     <td class="max-w-xs truncate">@row.Name</td>
                                                     <td class="text-right font-mono">@row.PreviousShares.ToString("N0")</td>
                                                     <td class="text-right font-mono">@row.CurrentShares.ToString("N0")</td>
-                                                    <td class="text-right font-mono @deltaSharesCss">@(row.DeltaShares > 0 ? "+" : "")@row.DeltaShares.ToString("N0")</td>
-                                                    <td class="text-right font-mono @deltaValueCss">@(row.DeltaValue > 0 ? "+" : "")$@row.DeltaValue.ToString("N0")</td>
+                                                    <td class="text-right font-mono @deltaSharesCss">@((row.DeltaShares > 0 ? "+" : row.DeltaShares < 0 ? "-" : "") + Math.Abs(row.DeltaShares).ToString("N0"))</td>
+                                                    <td class="text-right font-mono @deltaValueCss">@((row.DeltaValue > 0 ? "+$" : row.DeltaValue < 0 ? "-$" : "$") + Math.Abs(row.DeltaValue).ToString("N0"))</td>
                                                     <td class="text-right font-mono">@row.PercentOfPortfolio.ToString("F1")%</td>
                                                 </tr>
                                             }

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -117,12 +117,12 @@
                                         @foreach (var e in card.Entries) {
                                             var deltaSharesCss = e.DeltaShares > 0 ? "text-success" : e.DeltaShares < 0 ? "text-error" : "";
                                             var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
-                                            var deltaSharesSign = e.DeltaShares > 0 ? "+" : "";
-                                            var deltaValueSign = e.DeltaValue > 0 ? "+" : "";
+                                            var deltaSharesText = (e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "") + Math.Abs(e.DeltaShares).ToString("N0");
+                                            var deltaValueText = (e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$") + Math.Abs(e.DeltaValue).ToString("N0");
                                             <tr>
                                                 <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
-                                                <td class="text-right font-mono @deltaSharesCss">@deltaSharesSign@e.DeltaShares.ToString("N0")</td>
-                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss">@deltaValueSign$@e.DeltaValue.ToString("N0")</td>
+                                                <td class="text-right font-mono @deltaSharesCss">@deltaSharesText</td>
+                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss">@deltaValueText</td>
                                                 <td class="text-right font-mono hidden lg:table-cell text-base-content/60">@e.PreviousShares.ToString("N0") → @e.CurrentShares.ToString("N0")</td>
                                             </tr>
                                         }
@@ -170,15 +170,15 @@
                                 @foreach (var e in sorted) {
                                     var deltaSharesCss = e.DeltaShares > 0 ? "text-success" : e.DeltaShares < 0 ? "text-error" : "";
                                     var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
-                                    var deltaSharesSign = e.DeltaShares > 0 ? "+" : "";
-                                    var deltaValueSign = e.DeltaValue > 0 ? "+" : "";
+                                    var deltaSharesText = (e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "") + Math.Abs(e.DeltaShares).ToString("N0");
+                                    var deltaValueText = (e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$") + Math.Abs(e.DeltaValue).ToString("N0");
                                     <tr>
                                         <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
                                         <td class="text-right font-mono">@e.CurrentShares.ToString("N0")</td>
                                         <td class="text-right font-mono hidden md:table-cell">@e.PreviousShares.ToString("N0")</td>
-                                        <td class="text-right font-mono @deltaSharesCss">@deltaSharesSign@e.DeltaShares.ToString("N0")</td>
+                                        <td class="text-right font-mono @deltaSharesCss">@deltaSharesText</td>
                                         <td class="text-right font-mono hidden lg:table-cell">$@e.CurrentValue.ToString("N0")</td>
-                                        <td class="text-right font-mono @deltaValueCss">@deltaValueSign$@e.DeltaValue.ToString("N0")</td>
+                                        <td class="text-right font-mono @deltaValueCss">@deltaValueText</td>
                                         <td class="text-right">
                                             @if (e.InstitutionalHolder?.Cik != null) {
                                                 <a asp-controller="Stocks" asp-action="ShowHolder"


### PR DESCRIPTION
## Summary

The Holdings tab and related boards were rendering negative dollar deltas as `$-2,000,000` — currency symbol before the sign — instead of the conventional `-$2,000,000`. Caught during UI verification of the recent holdings-activity slices.

## Code changes

- `Views/Stocks/_HoldingsTab.cshtml` — replaced split sign + raw `ToString("N0")` with a single `deltaValueText` string built using `Math.Abs` and an upfront `+$ / -$ / $` prefix; applied to both the Top Buyers/Sellers cards and the bucket panels.
- `Views/HoldingsActivity/Activity.cshtml` — same pattern in the market-wide buyers/sellers/churn boards.
- `Views/Profiles/Institution.cshtml` — same pattern in the institution's quarterly activity grid.

Δ Shares now also renders sign-first (`-150,000` instead of `-150,000` from a naive `+` prefix). Positives still render with `+`, zero with no sign.