### PR TITLE
refactor(congress): collapse Fetch{Senate,House}Transactions into FetchChamberTransactions

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs
@@ -55,8 +55,24 @@ public class CongressionalTradeSyncService
 
         var allTransactions = new List<DisclosureTransaction>();
 
-        await FetchSenateTransactions(allTransactions, fromDate, toDate, ct);
-        await FetchHouseTransactions(allTransactions, fromDate, toDate, ct);
+        await FetchChamberTransactions(
+            scope =>
+                scope
+                    .ServiceProvider.GetRequiredService<SenateDisclosureClient>()
+                    .GetRecentTransactions(fromDate, toDate, ct),
+            allTransactions,
+            chamber: "Senate",
+            errorKey: "CongressTrades.SyncSenate"
+        );
+        await FetchChamberTransactions(
+            scope =>
+                scope
+                    .ServiceProvider.GetRequiredService<HouseDisclosureClient>()
+                    .GetRecentTransactions(fromDate, toDate, ct),
+            allTransactions,
+            chamber: "House",
+            errorKey: "CongressTrades.SyncHouse"
+        );
 
         if (allTransactions.Count == 0)
         {
@@ -72,19 +88,17 @@ public class CongressionalTradeSyncService
         await ProcessTransactions(allTransactions, ct);
     }
 
-    private async Task FetchSenateTransactions(
+    private async Task FetchChamberTransactions(
+        Func<IServiceScope, Task<List<DisclosureTransaction>>> fetch,
         List<DisclosureTransaction> target,
-        DateOnly from,
-        DateOnly to,
-        CancellationToken ct
+        string chamber,
+        string errorKey
     )
     {
         try
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
-            var client = scope.ServiceProvider.GetRequiredService<SenateDisclosureClient>();
-            var txns = await client.GetRecentTransactions(from, to, ct);
-            target.AddRange(txns);
+            target.AddRange(await fetch(scope));
         }
         catch (OperationCanceledException)
         {
@@ -92,40 +106,10 @@ public class CongressionalTradeSyncService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to fetch Senate disclosure data");
+            _logger.LogWarning(ex, "Failed to fetch {Chamber} disclosure data", chamber);
             await _errorReporter.Report(
                 ErrorSource.CongressScraper,
-                "CongressTrades.SyncSenate",
-                ex.Message,
-                ex.StackTrace
-            );
-        }
-    }
-
-    private async Task FetchHouseTransactions(
-        List<DisclosureTransaction> target,
-        DateOnly from,
-        DateOnly to,
-        CancellationToken ct
-    )
-    {
-        try
-        {
-            await using var scope = _scopeFactory.CreateAsyncScope();
-            var client = scope.ServiceProvider.GetRequiredService<HouseDisclosureClient>();
-            var txns = await client.GetRecentTransactions(from, to, ct);
-            target.AddRange(txns);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to fetch House disclosure data");
-            await _errorReporter.Report(
-                ErrorSource.CongressScraper,
-                "CongressTrades.SyncHouse",
+                errorKey,
                 ex.Message,
                 ex.StackTrace
             );


### PR DESCRIPTION
## Summary

- `FetchSenateTransactions` and `FetchHouseTransactions` in `CongressionalTradeSyncService` were 29-line near-duplicates, differing only in the resolved client type (`SenateDisclosureClient` / `HouseDisclosureClient`), the chamber name in the log message, and the error-reporter key (`CongressTrades.SyncSenate` / `CongressTrades.SyncHouse`).
- Consolidate into a single `FetchChamberTransactions` helper that takes a `Func<IServiceScope, Task<List<DisclosureTransaction>>>` resolver, the target list, the chamber label, and the error key. Both `SyncAll` call sites now pass a chamber-specific lambda; the scope / try-catch / log-and-report sequence lives in one place.
- Net: 41 lines deleted, 25 added. Existing resilience tests (`CongressionalTradeSyncServiceBothFailTests`, `CongressionalTradeSyncServiceFetchTests`) still green — same `OperationCanceledException` rethrow, same caught-exception log + `ErrorReporter.Report` call.

## Code changes

- `src/Equibles.Congress.HostedService/Services/CongressionalTradeSyncService.cs` — replace the two per-chamber fetch methods with a single helper called from `SyncAll`; the per-chamber log message preserves the original rendered text via the `{Chamber}` template placeholder.