### PR TITLE
feat(sec-facts): add InlineXbrlParser for iXBRL dimensional fact extraction

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Equibles.Sec.FinancialFacts.BusinessLogic.csproj
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Equibles.Sec.FinancialFacts.BusinessLogic.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" />
     <PackageReference Include="Equibles.Core.AutoWiring" />
   </ItemGroup>
 

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -1,0 +1,389 @@
+using System.Globalization;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using Equibles.Core.AutoWiring;
+using Equibles.Sec.FinancialFacts.BusinessLogic.Models;
+
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+/// <summary>
+/// Extracts financial facts from an <strong>inline XBRL (iXBRL)</strong>
+/// document — the primary <c>.htm</c> filings post the 2019–2021 phase-in
+/// embed in the SGML envelope. Walks <c>ix:nonFraction</c> elements, resolves
+/// each one's <c>contextRef</c> to its <c>xbrli:context</c> (period +
+/// <c>xbrldi:explicitMember</c> dimensions) and <c>unitRef</c> to its
+/// <c>xbrli:unit</c>, then decodes the human-readable value text (thousands
+/// separators, parenthesised negatives, dashes-as-zero) and applies the
+/// iXBRL <c>scale</c> / <c>sign</c> attributes.
+///
+/// <para>
+/// <strong>Not wired into the worker pipeline yet.</strong> The contexts /
+/// units / fact elements live inside <c>ix:header</c>, which
+/// <see cref="Equibles.Sec.BusinessLogic.Normalizers.XbrlStripStep"/> deletes
+/// before normalisation reaches downstream consumers. The wiring requires
+/// either (a) running this parser on the raw envelope <em>before</em>
+/// stripping, or (b) persisting the raw envelope for later extraction —
+/// see GH-1118. Until that lands, this parser ships as library-only
+/// infrastructure with unit-test coverage.
+/// </para>
+///
+/// <para>
+/// Scope: <c>ix:nonFraction</c> (numeric) only. Narrative
+/// <c>ix:nonNumeric</c>, <c>continuation</c> elements, fragmented values,
+/// and <c>typedMember</c> dimensions are out of scope for this first
+/// iteration; <c>decimals="INF"</c> resolves to <see cref="int.MaxValue"/>.
+/// </para>
+/// </summary>
+[Service]
+public class InlineXbrlParser
+{
+    private const string NonFractionLocalName = "ix:nonfraction";
+    private const string ContextLocalName = "xbrli:context";
+    private const string UnitLocalName = "xbrli:unit";
+    private const string PeriodLocalName = "xbrli:period";
+    private const string InstantLocalName = "xbrli:instant";
+    private const string StartDateLocalName = "xbrli:startdate";
+    private const string EndDateLocalName = "xbrli:enddate";
+    private const string MeasureLocalName = "xbrli:measure";
+    private const string DivideLocalName = "xbrli:divide";
+    private const string NumeratorLocalName = "xbrli:unitnumerator";
+    private const string DenominatorLocalName = "xbrli:unitdenominator";
+    private const string ExplicitMemberLocalName = "xbrldi:explicitmember";
+
+    private readonly HtmlParser _parser = new(
+        new HtmlParserOptions { IsAcceptingCustomElementsEverywhere = true }
+    );
+
+    public List<ParsedXbrlFact> Parse(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return [];
+
+        var document = _parser.ParseDocument(html);
+        if (document?.DocumentElement == null)
+            return [];
+
+        var contexts = BuildContextMap(document);
+        var units = BuildUnitMap(document);
+
+        var facts = new List<ParsedXbrlFact>();
+        foreach (var element in FindByLocalName(document, NonFractionLocalName))
+        {
+            if (TryParseFact(element, contexts, units, out var fact))
+                facts.Add(fact);
+        }
+        return facts;
+    }
+
+    private static IEnumerable<IElement> FindByLocalName(IParentNode root, string localName) =>
+        root.QuerySelectorAll("*")
+            .Where(e => string.Equals(e.LocalName, localName, StringComparison.OrdinalIgnoreCase));
+
+    private static Dictionary<
+        string,
+        (bool IsInstant, DateOnly Start, DateOnly End, List<ParsedXbrlDimension> Dimensions)
+    > BuildContextMap(IDocument document)
+    {
+        var contexts = new Dictionary<
+            string,
+            (bool, DateOnly, DateOnly, List<ParsedXbrlDimension>)
+        >(StringComparer.Ordinal);
+
+        foreach (var contextElement in FindByLocalName(document, ContextLocalName))
+        {
+            var id = contextElement.GetAttribute("id");
+            if (string.IsNullOrEmpty(id))
+                continue;
+
+            var period = FindFirstChildByLocalName(contextElement, PeriodLocalName);
+            if (period == null)
+                continue;
+
+            if (!TryParsePeriod(period, out var isInstant, out var start, out var end))
+                continue;
+
+            var dimensions = ExtractDimensions(contextElement);
+            contexts[id] = (isInstant, start, end, dimensions);
+        }
+
+        return contexts;
+    }
+
+    private static IElement FindFirstChildByLocalName(IElement parent, string localName) =>
+        parent.Children.FirstOrDefault(c =>
+            string.Equals(c.LocalName, localName, StringComparison.OrdinalIgnoreCase)
+        );
+
+    private static bool TryParsePeriod(
+        IElement period,
+        out bool isInstant,
+        out DateOnly start,
+        out DateOnly end
+    )
+    {
+        var instant = FindFirstChildByLocalName(period, InstantLocalName);
+        if (instant != null && DateOnly.TryParse(instant.TextContent.Trim(), out var instantDate))
+        {
+            isInstant = true;
+            start = instantDate;
+            end = instantDate;
+            return true;
+        }
+
+        var startElement = FindFirstChildByLocalName(period, StartDateLocalName);
+        var endElement = FindFirstChildByLocalName(period, EndDateLocalName);
+        if (
+            startElement != null
+            && endElement != null
+            && DateOnly.TryParse(startElement.TextContent.Trim(), out var startDate)
+            && DateOnly.TryParse(endElement.TextContent.Trim(), out var endDate)
+        )
+        {
+            isInstant = false;
+            start = startDate;
+            end = endDate;
+            return true;
+        }
+
+        isInstant = false;
+        start = default;
+        end = default;
+        return false;
+    }
+
+    private static List<ParsedXbrlDimension> ExtractDimensions(IElement contextElement)
+    {
+        var dimensions = new List<ParsedXbrlDimension>();
+        foreach (var member in FindByLocalName(contextElement, ExplicitMemberLocalName))
+        {
+            var axis = member.GetAttribute("dimension");
+            var memberValue = member.TextContent?.Trim();
+            if (string.IsNullOrEmpty(axis) || string.IsNullOrEmpty(memberValue))
+                continue;
+            dimensions.Add(new ParsedXbrlDimension { Axis = axis, Member = memberValue });
+        }
+        return dimensions;
+    }
+
+    private static Dictionary<string, string> BuildUnitMap(IDocument document)
+    {
+        var units = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var unitElement in FindByLocalName(document, UnitLocalName))
+        {
+            var id = unitElement.GetAttribute("id");
+            if (string.IsNullOrEmpty(id))
+                continue;
+            var resolved = ResolveUnit(unitElement);
+            if (resolved == null)
+                continue;
+            units[id] = resolved;
+        }
+        return units;
+    }
+
+    private static string ResolveUnit(IElement unitElement)
+    {
+        var divide = FindFirstChildByLocalName(unitElement, DivideLocalName);
+        if (divide != null)
+        {
+            var numerator = FindFirstChildByLocalName(divide, NumeratorLocalName);
+            var denominator = FindFirstChildByLocalName(divide, DenominatorLocalName);
+            var numeratorMeasure =
+                numerator == null
+                    ? null
+                    : FindFirstChildByLocalName(numerator, MeasureLocalName)?.TextContent;
+            var denominatorMeasure =
+                denominator == null
+                    ? null
+                    : FindFirstChildByLocalName(denominator, MeasureLocalName)?.TextContent;
+            if (string.IsNullOrEmpty(numeratorMeasure) || string.IsNullOrEmpty(denominatorMeasure))
+                return null;
+            return $"{StripPrefix(numeratorMeasure.Trim())}/{StripPrefix(denominatorMeasure.Trim())}";
+        }
+
+        var measure = FindFirstChildByLocalName(unitElement, MeasureLocalName);
+        var measureValue = measure?.TextContent?.Trim();
+        return string.IsNullOrEmpty(measureValue) ? null : StripPrefix(measureValue);
+    }
+
+    private static string StripPrefix(string qname)
+    {
+        var colonIdx = qname.IndexOf(':');
+        return colonIdx >= 0 ? qname.Substring(colonIdx + 1) : qname;
+    }
+
+    private static bool TryParseFact(
+        IElement element,
+        Dictionary<
+            string,
+            (bool IsInstant, DateOnly Start, DateOnly End, List<ParsedXbrlDimension> Dimensions)
+        > contexts,
+        Dictionary<string, string> units,
+        out ParsedXbrlFact fact
+    )
+    {
+        fact = null;
+
+        var contextRef = element.GetAttribute("contextRef") ?? element.GetAttribute("contextref");
+        var unitRef = element.GetAttribute("unitRef") ?? element.GetAttribute("unitref");
+        var name = element.GetAttribute("name");
+        if (
+            string.IsNullOrEmpty(contextRef)
+            || string.IsNullOrEmpty(unitRef)
+            || string.IsNullOrEmpty(name)
+        )
+            return false;
+
+        // xsi:nil="true" appears as a flat attribute in HTML-parsed iXBRL —
+        // AngleSharp doesn't preserve the xsi: prefix on attributes the way
+        // it does on elements, so check both shapes defensively.
+        var nilAttribute = element.GetAttribute("xsi:nil") ?? element.GetAttribute("nil");
+        if (string.Equals(nilAttribute, "true", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var colonIdx = name.IndexOf(':');
+        if (colonIdx <= 0 || colonIdx >= name.Length - 1)
+            return false;
+        var taxonomy = name.Substring(0, colonIdx);
+        var tag = name.Substring(colonIdx + 1);
+
+        if (!contexts.TryGetValue(contextRef, out var context))
+            return false;
+        if (!units.TryGetValue(unitRef, out var unit))
+            return false;
+
+        if (!TryDecodeValue(element, out var value))
+            return false;
+
+        fact = new ParsedXbrlFact
+        {
+            Taxonomy = taxonomy,
+            Tag = tag,
+            Unit = unit,
+            Value = value,
+            IsInstant = context.IsInstant,
+            PeriodStart = context.Start,
+            PeriodEnd = context.End,
+            Dimensions = context.Dimensions,
+            Decimals = ParseDecimals(element.GetAttribute("decimals")),
+        };
+        return true;
+    }
+
+    private static bool TryDecodeValue(IElement element, out decimal value)
+    {
+        value = 0m;
+
+        var raw = element.TextContent?.Trim();
+        if (string.IsNullOrEmpty(raw))
+            return false;
+
+        var format = element.GetAttribute("format") ?? string.Empty;
+
+        // Format hints that the value is a hard-coded zero (numdash → "—",
+        // fixed-zero → literal 0). The Inline XBRL Transformations spec
+        // emits these for placeholders; consumers expect 0, not a parse
+        // failure on the dash glyph.
+        if (
+            format.EndsWith("numdash", StringComparison.OrdinalIgnoreCase)
+            || format.EndsWith("fixed-zero", StringComparison.OrdinalIgnoreCase)
+            || format.EndsWith("fixedzero", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            value = ApplyScaleAndSign(0m, element);
+            return true;
+        }
+
+        var parenthesised = raw.StartsWith('(') && raw.EndsWith(')');
+        if (parenthesised)
+            raw = raw.Substring(1, raw.Length - 2).Trim();
+
+        var commaDecimal = format.EndsWith("numcommadecimal", StringComparison.OrdinalIgnoreCase);
+
+        var cleaned = NormaliseDigits(raw, commaDecimal);
+        if (string.IsNullOrEmpty(cleaned))
+            return false;
+
+        if (
+            !decimal.TryParse(
+                cleaned,
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out var parsed
+            )
+        )
+            return false;
+
+        if (parenthesised)
+            parsed = -parsed;
+
+        value = ApplyScaleAndSign(parsed, element);
+        return true;
+    }
+
+    private static string NormaliseDigits(string raw, bool commaDecimal)
+    {
+        // Strip currency / spacing glyphs filers routinely use ($, NBSP,
+        // narrow NBSP, thin spaces). Then collapse thousands separators
+        // and align the decimal separator to '.' so InvariantCulture
+        // parsing succeeds regardless of the document's locale.
+        var buffer = new System.Text.StringBuilder(raw.Length);
+        foreach (var ch in raw)
+        {
+            switch (ch)
+            {
+                case ' ':
+                case ' ':
+                case ' ':
+                case ' ':
+                case '$':
+                case '€':
+                case '£':
+                case '¥':
+                    continue;
+            }
+            buffer.Append(ch);
+        }
+        var stripped = buffer.ToString();
+
+        if (commaDecimal)
+        {
+            stripped = stripped.Replace(".", string.Empty).Replace(',', '.');
+        }
+        else
+        {
+            stripped = stripped.Replace(",", string.Empty);
+        }
+
+        return stripped;
+    }
+
+    private static decimal ApplyScaleAndSign(decimal parsed, IElement element)
+    {
+        var scaleAttribute = element.GetAttribute("scale");
+        if (!string.IsNullOrEmpty(scaleAttribute) && int.TryParse(scaleAttribute, out var scale))
+        {
+            // Positive scale shifts the value up; negative shifts down.
+            // We use Pow over a literal multiplier so non-trivial scales
+            // (e.g. 6 for "in millions") survive without precision loss.
+            parsed *= (decimal)Math.Pow(10, scale);
+        }
+
+        var signAttribute = element.GetAttribute("sign");
+        if (string.Equals(signAttribute, "-", StringComparison.Ordinal))
+        {
+            parsed = -parsed;
+        }
+
+        return parsed;
+    }
+
+    private static int? ParseDecimals(string decimalsAttribute)
+    {
+        if (string.IsNullOrEmpty(decimalsAttribute))
+            return null;
+        if (string.Equals(decimalsAttribute, "INF", StringComparison.OrdinalIgnoreCase))
+            return int.MaxValue;
+        return int.TryParse(decimalsAttribute, out var value) ? value : null;
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserTests.cs
@@ -1,0 +1,303 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the inline iXBRL parser's extraction contract for #877. Fixtures
+/// are inlined per test so the asserted document shape stays adjacent to
+/// the behaviour it pins. The wrapper always carries the namespaces every
+/// iXBRL fixture needs (xbrli, xbrldi, ix, ixt, and the taxonomies under
+/// test) so each test only states the iXBRL fragment that matters.
+/// </summary>
+public class InlineXbrlParserTests
+{
+    private const string DocOpen =
+        "<html "
+        + "xmlns=\"http://www.w3.org/1999/xhtml\" "
+        + "xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\" "
+        + "xmlns:ixt=\"http://www.xbrl.org/inlineXBRL/transformation/2015-02-26\" "
+        + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+        + "xmlns:xbrldi=\"http://xbrl.org/2006/xbrldi\" "
+        + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+        + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2018-01-31\" "
+        + "xmlns:dei=\"http://xbrl.sec.gov/dei/2018-01-31\" "
+        + "xmlns:srt=\"http://fasb.org/srt/2018-01-31\" "
+        + "xmlns:aapl=\"http://www.apple.com/20180929\""
+        + "><body><div style=\"display:none\"><ix:header><ix:resources>";
+
+    private const string ResourcesEnd = "</ix:resources></ix:header></div>";
+
+    private const string DocClose = "</body></html>";
+
+    [Fact]
+    public void Parse_NonFractionInstantContext_ExtractsConceptAndValue()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2018-09-29</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"usd\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<p>Total: <ix:nonFraction name=\"us-gaap:Assets\" contextRef=\"C1\" unitRef=\"usd\" decimals=\"-6\">365725000000</ix:nonFraction></p>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Taxonomy.Should().Be("us-gaap");
+        fact.Tag.Should().Be("Assets");
+        fact.Unit.Should().Be("USD");
+        fact.Value.Should().Be(365_725_000_000m);
+        fact.IsInstant.Should().BeTrue();
+        fact.PeriodStart.Should().Be(new DateOnly(2018, 9, 29));
+        fact.Decimals.Should().Be(-6);
+        fact.Dimensions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_ScaleAttribute_MultipliesValue()
+    {
+        // scale="6" + raw "265,595" → 265,595 × 10^6 = 265,595,000,000.
+        // Common pattern for "$ in millions" tables.
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"D1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:startDate>2017-10-01</xbrli:startDate><xbrli:endDate>2018-09-29</xbrli:endDate></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"us-gaap:Revenues\" contextRef=\"D1\" unitRef=\"u\" decimals=\"-6\" scale=\"6\" format=\"ixt:numdotdecimal\">265,595</ix:nonFraction>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Value.Should().Be(265_595_000_000m);
+        fact.IsInstant.Should().BeFalse();
+        fact.PeriodEnd.Should().Be(new DateOnly(2018, 9, 29));
+    }
+
+    [Fact]
+    public void Parse_ParenthesisedValue_IsNegated()
+    {
+        // "(1,234)" is the accounting-format negative; parser must flip
+        // the sign even without an explicit sign="-" attribute.
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"us-gaap:NetIncomeLoss\" contextRef=\"C1\" unitRef=\"u\">(1,234)</ix:nonFraction>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Value.Should().Be(-1234m);
+    }
+
+    [Fact]
+    public void Parse_SignAttributeNegative_NegatesValue()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"us-gaap:NetIncomeLoss\" contextRef=\"C1\" unitRef=\"u\" sign=\"-\">500</ix:nonFraction>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Value.Should().Be(-500m);
+    }
+
+    [Fact]
+    public void Parse_NumDashFormat_ReturnsZero()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"us-gaap:Revenues\" contextRef=\"C1\" unitRef=\"u\" format=\"ixt:numdash\">&#8212;</ix:nonFraction>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Value.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Parse_ExplicitMemberInSegment_ExtractsDimension()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity>"
+            + "    <xbrli:identifier scheme=\"x\">0</xbrli:identifier>"
+            + "    <xbrli:segment>"
+            + "      <xbrldi:explicitMember dimension=\"srt:ProductOrServiceAxis\">aapl:IPhoneMember</xbrldi:explicitMember>"
+            + "    </xbrli:segment>"
+            + "  </xbrli:entity>"
+            + "  <xbrli:period><xbrli:startDate>2017-10-01</xbrli:startDate><xbrli:endDate>2018-09-29</xbrli:endDate></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"us-gaap:Revenues\" contextRef=\"C1\" unitRef=\"u\">164888</ix:nonFraction>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        var dimension = fact.Dimensions.Should().ContainSingle().Subject;
+        dimension.Axis.Should().Be("srt:ProductOrServiceAxis");
+        dimension.Member.Should().Be("aapl:IPhoneMember");
+    }
+
+    [Fact]
+    public void Parse_DivideUnit_ResolvesAsNumeratorOverDenominator()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"usdPerShare\">"
+            + "  <xbrli:divide>"
+            + "    <xbrli:unitNumerator><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unitNumerator>"
+            + "    <xbrli:unitDenominator><xbrli:measure>xbrli:shares</xbrli:measure></xbrli:unitDenominator>"
+            + "  </xbrli:divide>"
+            + "</xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"us-gaap:EarningsPerShareBasic\" contextRef=\"C1\" unitRef=\"usdPerShare\" decimals=\"2\">12.01</ix:nonFraction>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Unit.Should().Be("USD/shares");
+        fact.Value.Should().Be(12.01m);
+    }
+
+    [Fact]
+    public void Parse_DecimalsInf_MapsToIntMaxValue()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>xbrli:shares</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"dei:EntityCommonStockSharesOutstanding\" contextRef=\"C1\" unitRef=\"u\" decimals=\"INF\">1000</ix:nonFraction>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Decimals.Should().Be(int.MaxValue);
+    }
+
+    [Fact]
+    public void Parse_ContextRefMissing_SkipsFact()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"us-gaap:Revenues\" contextRef=\"missing\" unitRef=\"u\">1</ix:nonFraction>"
+            + DocClose;
+
+        new InlineXbrlParser().Parse(html).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_NameAttributeMissing_SkipsFact()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction contextRef=\"C1\" unitRef=\"u\">1</ix:nonFraction>"
+            + DocClose;
+
+        new InlineXbrlParser().Parse(html).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_NumCommaDecimalFormat_HandlesEuropeanDecimal()
+    {
+        // European format: "1.234,56" means 1234.56 — dot is thousands,
+        // comma is decimal. Parser must NOT treat the dot as decimal.
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:EUR</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"ifrs-full:Revenue\" contextRef=\"C1\" unitRef=\"u\" format=\"ixt:numcommadecimal\">1.234,56</ix:nonFraction>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Value.Should().Be(1234.56m);
+        fact.Taxonomy.Should().Be("ifrs-full");
+    }
+
+    [Fact]
+    public void Parse_CurrencyAndNbspGlyphs_AreStripped()
+    {
+        // U+00A0 NBSP between digit groups and an explicit '$' prefix are
+        // common formatting filers paste in. Both must drop out before
+        // decimal parsing.
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"us-gaap:Revenues\" contextRef=\"C1\" unitRef=\"u\">$ 1 234</ix:nonFraction>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Value.Should().Be(1234m);
+    }
+
+    [Fact]
+    public void Parse_EmptyOrNullInput_ReturnsEmpty()
+    {
+        var parser = new InlineXbrlParser();
+        parser.Parse(null).Should().BeEmpty();
+        parser.Parse("").Should().BeEmpty();
+        parser.Parse("   ").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_NoFactsInDocument_ReturnsEmpty()
+    {
+        new InlineXbrlParser()
+            .Parse("<html><body><p>Just regular HTML</p></body></html>")
+            .Should()
+            .BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 3 / 4 of #877 — inline iXBRL parser, sibling to the standalone parser merged in #1125.
- Library only — **not wired into the pipeline**. \`ix:header\` (where contexts / units / fact elements live) is removed by \`XbrlStripStep\` before normalisation reaches downstream consumers; wiring requires raw-envelope preservation per #1118.
- 14 unit tests pin the extraction contract end-to-end. Not the closing slice — refs #877 only.

## Code changes

- \`src/Equibles.Sec.FinancialFacts.BusinessLogic/Equibles.Sec.FinancialFacts.BusinessLogic.csproj\` — adds \`AngleSharp\` \`PackageReference\` (matches the existing \`XbrlStripStep\` approach in \`Equibles.Sec.BusinessLogic\`).
- \`src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs\` — \`[Service]\`. Parses the iXBRL HTML with AngleSharp's \`HtmlParser\` (\`IsAcceptingCustomElementsEverywhere = true\`), walks descendant \`xbrli:context\` / \`xbrli:unit\` to build resolver maps, then iterates \`ix:nonFraction\` elements:
  - **Concept identity**: \`name="us-gaap:Revenues"\` → \`Taxonomy="us-gaap"\`, \`Tag="Revenues"\`.
  - **Period / dimensions**: same shape as the standalone parser, resolved via the embedded \`xbrli:context\`.
  - **Unit resolution**: single \`xbrli:measure\` → local name; \`xbrli:divide\` → \`numerator/denominator\`.
  - **Value decoding**: strips thousands separators (\`,\`, NBSP U+00A0, narrow NBSP U+202F, thin space U+2009) and currency glyphs (\`$\`, \`€\`, \`£\`, \`¥\`). Parenthesised values are negated. \`format=\"ixt:numdash\"\` / \`fixedzero\` resolve to \`0\` directly. \`format=\"ixt:numcommadecimal\"\` handles European \`1.234,56\` → \`1234.56\`. \`scale=\"N\"\` multiplies by \`10^N\`; \`sign=\"-\"\` negates; \`decimals=\"INF\"\` → \`int.MaxValue\`. Missing context / unit / name and \`xsi:nil=\"true\"\` all skip the fact.
  - Class-level XML doc states the not-wired status and links #1118.
- \`tests/Equibles.UnitTests/Sec/InlineXbrlParserTests.cs\` — 14 tests covering: instant + duration periods, scale-6 ("in millions"), parenthesised negative, \`sign=\"-\"\`, \`numdash\` → 0, segment dimension, divide unit, \`INF\` decimals, missing-context skip, missing-name skip, European comma-decimal, currency + NBSP glyph stripping, null/empty/HTML-only inputs.