### PR TITLE
refactor(media): drop narration comments in FileManager.SaveFile

### DIFF
--- a/src/Equibles.Media.BusinessLogic/FileManager.cs
+++ b/src/Equibles.Media.BusinessLogic/FileManager.cs
@@ -47,10 +47,7 @@ public class FileManager : IFileManager
      */
     public Task<File> SaveFile(byte[] content, string fileName, bool protect = false)
     {
-        // Gets the file extension from the file name
         var fileExtension = Path.GetExtension(fileName)?.TrimStart('.');
-
-        // Gets the file name without extension
         var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
 
         if (string.IsNullOrEmpty(fileExtension))
@@ -68,7 +65,6 @@ public class FileManager : IFileManager
             );
         }
 
-        // Get the content type from the file extension
         var contentType = MimeTypeMap.GetMimeType(fileExtension);
         if (string.IsNullOrEmpty(contentType))
         {


### PR DESCRIPTION
## Summary

- Delete three narration comments in `FileManager.SaveFile` that just restated the immediately-following self-explanatory `Path.GetExtension` / `Path.GetFileNameWithoutExtension` / `MimeTypeMap.GetMimeType` calls.
- Behaviour-preserving: only comment lines removed; no executable code changes. The existing WHY-comment about the allowlist enforcement is preserved.

## Code changes

- `src/Equibles.Media.BusinessLogic/FileManager.cs` — remove three `// Gets the … from …` lines whose information is already conveyed by the variable name on the next line. Net -4 lines (the blank lines between deleted comments and code collapse). Media unit tests (3) pass.