### PR TITLE
feat(holdings): add HoldingsBacktestCalculator + result models

### DIFF
--- a/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
@@ -1,0 +1,211 @@
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Holdings.Repositories;
+
+public static class HoldingsBacktestCalculator
+{
+    // 13F filings are due 45 days after the quarter-end ReportDate; that's the earliest a
+    // cloner could legally have learned the portfolio. Using ReportDate itself would peek.
+    public const int RebalanceDelayDays = 45;
+
+    // Bound memory and rendering cost — a 10y simulation already exceeds 3,600 daily points.
+    public const int MaxYears = 10;
+
+    public const decimal InitialValue = 100m;
+
+    // `priceOf` is expected to forward-fill the last-known close so weekends, holidays, and
+    // post-delisting dates still yield a non-null value. The calculator does not maintain
+    // its own price cache; if priceOf returns null for a held stock on a given day, that
+    // position's contribution is excluded that day.
+    public static BacktestResult Calculate(
+        IReadOnlyList<BacktestQuarterSnapshot> snapshots,
+        DateOnly from,
+        DateOnly to,
+        Func<Guid, DateOnly, decimal?> priceOf,
+        Func<DateOnly, decimal?> benchmarkPriceOf
+    )
+    {
+        var result = new BacktestResult { StartDate = from, EndDate = to };
+
+        if (from > to)
+        {
+            result.Reason = "from must be on or before to";
+            return result;
+        }
+
+        var horizonCap = from.AddYears(MaxYears);
+        if (to > horizonCap)
+            to = horizonCap;
+        result.EndDate = to;
+
+        if (snapshots.Count == 0)
+        {
+            result.Reason = "no quarterly snapshots available";
+            return result;
+        }
+
+        var ordered = snapshots
+            .Select(s => (Snapshot: s, RebalanceDate: s.ReportDate.AddDays(RebalanceDelayDays)))
+            .OrderBy(x => x.RebalanceDate)
+            .ToList();
+
+        // First snapshot whose rebalance date is on or after `from`. If none — the window
+        // sits after the latest filing; fall back to the most recent prior snapshot so the
+        // simulation still has a portfolio to mark to market.
+        var firstIdx = ordered.FindIndex(x => x.RebalanceDate >= from);
+        var snapshotIdx = firstIdx < 0 ? ordered.Count - 1 : firstIdx;
+
+        var startDate = ordered[snapshotIdx].RebalanceDate;
+        if (startDate < from)
+            startDate = from;
+        if (startDate > to)
+        {
+            result.Reason = "no rebalance date falls inside the requested window";
+            return result;
+        }
+        result.StartDate = startDate;
+
+        var benchStart = benchmarkPriceOf(startDate);
+        if (benchStart is null || benchStart.Value <= 0)
+        {
+            result.Reason = $"no benchmark price at {startDate:yyyy-MM-dd}";
+            return result;
+        }
+
+        var holdings = new Dictionary<Guid, decimal>();
+        var portfolioValue = InitialValue;
+
+        Rebalance(holdings, ordered[snapshotIdx].Snapshot, startDate, portfolioValue, priceOf);
+
+        for (var day = startDate; day <= to; day = day.AddDays(1))
+        {
+            // Advance through any rebalance dates that fall on/before `day`. Mark to market
+            // with the prior holdings first so the rebalance uses an honest portfolio value.
+            while (snapshotIdx + 1 < ordered.Count && ordered[snapshotIdx + 1].RebalanceDate <= day)
+            {
+                snapshotIdx++;
+                portfolioValue = MarkToMarket(holdings, day, priceOf, portfolioValue);
+                Rebalance(holdings, ordered[snapshotIdx].Snapshot, day, portfolioValue, priceOf);
+            }
+
+            portfolioValue = MarkToMarket(holdings, day, priceOf, portfolioValue);
+
+            var benchPriceToday = benchmarkPriceOf(day) ?? benchStart.Value;
+            var benchValue = InitialValue * (benchPriceToday / benchStart.Value);
+
+            result.Points.Add(
+                new BacktestPoint
+                {
+                    Date = day,
+                    PortfolioValue = Math.Round(portfolioValue, 4),
+                    BenchmarkValue = Math.Round(benchValue, 4),
+                }
+            );
+        }
+
+        if (result.Points.Count > 0)
+        {
+            result.PortfolioSummary = ComputeSummary(result.Points.Select(p => p.PortfolioValue));
+            result.BenchmarkSummary = ComputeSummary(result.Points.Select(p => p.BenchmarkValue));
+        }
+
+        return result;
+    }
+
+    private static void Rebalance(
+        Dictionary<Guid, decimal> holdings,
+        BacktestQuarterSnapshot snapshot,
+        DateOnly date,
+        decimal currentValue,
+        Func<Guid, DateOnly, decimal?> priceOf
+    )
+    {
+        holdings.Clear();
+        if (currentValue <= 0)
+            return;
+
+        // Aggregate per stock — a holder may report a single stock across multiple rows
+        // when multiple managers share discretion. Options rows are notional and skipped.
+        var positions = snapshot
+            .Positions.Where(p => !p.IsOption && p.Value > 0)
+            .GroupBy(p => p.CommonStockId)
+            .Select(g => (StockId: g.Key, Value: g.Sum(p => p.Value)))
+            .ToList();
+        var totalValue = positions.Sum(p => p.Value);
+        if (totalValue <= 0)
+            return;
+
+        foreach (var (stockId, value) in positions)
+        {
+            var price = priceOf(stockId, date);
+            if (price is null || price.Value <= 0)
+                continue;
+            var weight = (decimal)value / totalValue;
+            var allocation = currentValue * weight;
+            holdings[stockId] = allocation / price.Value;
+        }
+    }
+
+    private static decimal MarkToMarket(
+        Dictionary<Guid, decimal> holdings,
+        DateOnly date,
+        Func<Guid, DateOnly, decimal?> priceOf,
+        decimal fallback
+    )
+    {
+        if (holdings.Count == 0)
+            return fallback;
+        decimal sum = 0;
+        foreach (var (stockId, shares) in holdings)
+        {
+            var price = priceOf(stockId, date);
+            if (price is null || price.Value <= 0)
+                continue;
+            sum += shares * price.Value;
+        }
+        return sum > 0 ? sum : fallback;
+    }
+
+    private static BacktestStrategySummary ComputeSummary(IEnumerable<decimal> series)
+    {
+        var values = series.ToList();
+        if (values.Count == 0)
+            return new BacktestStrategySummary();
+        var initial = values[0];
+        var final = values[^1];
+        if (initial <= 0)
+            return new BacktestStrategySummary();
+
+        var totalReturn = (final / initial - 1m) * 100m;
+
+        var days = (decimal)(values.Count - 1);
+        decimal cagr = 0m;
+        if (days > 0 && final > 0)
+        {
+            var years = (double)days / 365.25;
+            var ratio = (double)(final / initial);
+            cagr = (decimal)(Math.Pow(ratio, 1.0 / years) - 1.0) * 100m;
+        }
+
+        decimal peak = values[0];
+        decimal maxDrawdown = 0m;
+        foreach (var v in values)
+        {
+            if (v > peak)
+                peak = v;
+            if (peak > 0)
+            {
+                var dd = (peak - v) / peak * 100m;
+                if (dd > maxDrawdown)
+                    maxDrawdown = dd;
+            }
+        }
+
+        return new BacktestStrategySummary
+        {
+            TotalReturnPercent = Math.Round(totalReturn, 2),
+            CagrPercent = Math.Round(cagr, 2),
+            MaxDrawdownPercent = Math.Round(maxDrawdown, 2),
+        };
+    }
+}

--- a/src/Equibles.Holdings.Repositories/Models/BacktestPoint.cs
+++ b/src/Equibles.Holdings.Repositories/Models/BacktestPoint.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class BacktestPoint
+{
+    public DateOnly Date { get; set; }
+
+    public decimal PortfolioValue { get; set; }
+
+    public decimal BenchmarkValue { get; set; }
+}

--- a/src/Equibles.Holdings.Repositories/Models/BacktestPosition.cs
+++ b/src/Equibles.Holdings.Repositories/Models/BacktestPosition.cs
@@ -1,0 +1,12 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class BacktestPosition
+{
+    public Guid CommonStockId { get; set; }
+
+    public long Shares { get; set; }
+
+    public long Value { get; set; }
+
+    public bool IsOption { get; set; }
+}

--- a/src/Equibles.Holdings.Repositories/Models/BacktestQuarterSnapshot.cs
+++ b/src/Equibles.Holdings.Repositories/Models/BacktestQuarterSnapshot.cs
@@ -1,0 +1,8 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class BacktestQuarterSnapshot
+{
+    public DateOnly ReportDate { get; set; }
+
+    public List<BacktestPosition> Positions { get; set; } = [];
+}

--- a/src/Equibles.Holdings.Repositories/Models/BacktestResult.cs
+++ b/src/Equibles.Holdings.Repositories/Models/BacktestResult.cs
@@ -1,0 +1,16 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class BacktestResult
+{
+    public DateOnly StartDate { get; set; }
+
+    public DateOnly EndDate { get; set; }
+
+    public List<BacktestPoint> Points { get; set; } = [];
+
+    public BacktestStrategySummary PortfolioSummary { get; set; } = new();
+
+    public BacktestStrategySummary BenchmarkSummary { get; set; } = new();
+
+    public string Reason { get; set; }
+}

--- a/src/Equibles.Holdings.Repositories/Models/BacktestStrategySummary.cs
+++ b/src/Equibles.Holdings.Repositories/Models/BacktestStrategySummary.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class BacktestStrategySummary
+{
+    public decimal TotalReturnPercent { get; set; }
+
+    public decimal CagrPercent { get; set; }
+
+    public decimal MaxDrawdownPercent { get; set; }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorTests.cs
@@ -1,0 +1,289 @@
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsBacktestCalculatorTests
+{
+    private static readonly Guid StockA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid StockB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void Calculate_EmptySnapshots_ReturnsReasonAndNoPoints()
+    {
+        var result = HoldingsBacktestCalculator.Calculate(
+            [],
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2024, 12, 31),
+            (_, _) => 100m,
+            _ => 100m
+        );
+
+        result.Points.Should().BeEmpty();
+        result.Reason.Should().Contain("no quarterly snapshots");
+    }
+
+    [Fact]
+    public void Calculate_FromAfterTo_ReturnsReason()
+    {
+        var result = HoldingsBacktestCalculator.Calculate(
+            [SingleStockSnapshot(new DateOnly(2024, 3, 31), StockA, 1_000_000)],
+            new DateOnly(2024, 12, 31),
+            new DateOnly(2024, 1, 1),
+            (_, _) => 100m,
+            _ => 100m
+        );
+
+        result.Points.Should().BeEmpty();
+        result.Reason.Should().Contain("from must be on or before to");
+    }
+
+    [Fact]
+    public void Calculate_NoBenchmarkPrice_ReturnsReason()
+    {
+        var snapshot = SingleStockSnapshot(new DateOnly(2024, 3, 31), StockA, 1_000_000);
+
+        var result = HoldingsBacktestCalculator.Calculate(
+            [snapshot],
+            new DateOnly(2024, 5, 15),
+            new DateOnly(2024, 5, 20),
+            (_, _) => 100m,
+            _ => null
+        );
+
+        result.Reason.Should().Contain("no benchmark price");
+        result.Points.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Calculate_FlatPrices_PortfolioMatchesInitialValueEveryDay()
+    {
+        // Single stock, prices flat at $100, benchmark flat at $400 — portfolio and
+        // benchmark series should both stay pinned to InitialValue across the window.
+        var snapshot = SingleStockSnapshot(new DateOnly(2024, 3, 31), StockA, 1_000_000);
+        var rebalanceDate = new DateOnly(2024, 5, 15); // 2024-03-31 + 45d
+
+        var result = HoldingsBacktestCalculator.Calculate(
+            [snapshot],
+            from: rebalanceDate,
+            to: rebalanceDate.AddDays(30),
+            priceOf: (_, _) => 100m,
+            benchmarkPriceOf: _ => 400m
+        );
+
+        result.Points.Should().HaveCount(31);
+        result.Points.Should().AllSatisfy(p => p.PortfolioValue.Should().Be(100m));
+        result.Points.Should().AllSatisfy(p => p.BenchmarkValue.Should().Be(100m));
+        result.PortfolioSummary.TotalReturnPercent.Should().Be(0m);
+        result.PortfolioSummary.MaxDrawdownPercent.Should().Be(0m);
+        result.BenchmarkSummary.TotalReturnPercent.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Calculate_PriceDoublesAcrossWindow_PortfolioReturns100Percent()
+    {
+        var snapshot = SingleStockSnapshot(new DateOnly(2024, 3, 31), StockA, 1_000_000);
+        var rebalanceDate = new DateOnly(2024, 5, 15);
+        var endDate = rebalanceDate.AddDays(60);
+
+        var result = HoldingsBacktestCalculator.Calculate(
+            [snapshot],
+            from: rebalanceDate,
+            to: endDate,
+            priceOf: (_, day) => day == rebalanceDate ? 100m : 200m,
+            benchmarkPriceOf: day => day == rebalanceDate ? 50m : 50m
+        );
+
+        result.Points.First().PortfolioValue.Should().Be(100m);
+        result.Points.Last().PortfolioValue.Should().Be(200m);
+        result.PortfolioSummary.TotalReturnPercent.Should().Be(100m);
+        result.PortfolioSummary.MaxDrawdownPercent.Should().Be(0m);
+        result.BenchmarkSummary.TotalReturnPercent.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Calculate_PriceDrop_RecordsMaxDrawdown()
+    {
+        // Day 0: 100, Day 1-3: 75, Day 4-...: 100 → max drawdown = 25%.
+        var snapshot = SingleStockSnapshot(new DateOnly(2024, 3, 31), StockA, 1_000_000);
+        var rebalanceDate = new DateOnly(2024, 5, 15);
+
+        var result = HoldingsBacktestCalculator.Calculate(
+            [snapshot],
+            from: rebalanceDate,
+            to: rebalanceDate.AddDays(5),
+            priceOf: (_, day) =>
+            {
+                var offset = day.DayNumber - rebalanceDate.DayNumber;
+                if (offset == 0)
+                    return 100m;
+                if (offset is 1 or 2 or 3)
+                    return 75m;
+                return 100m;
+            },
+            benchmarkPriceOf: _ => 1m
+        );
+
+        result.PortfolioSummary.MaxDrawdownPercent.Should().Be(25m);
+        result.PortfolioSummary.TotalReturnPercent.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Calculate_OptionPositionsAreSkipped()
+    {
+        // Snapshot has stock A common ($1M) and a put on stock B ($10M notional).
+        // The put must be skipped — only stock A drives the portfolio.
+        var snapshot = new BacktestQuarterSnapshot
+        {
+            ReportDate = new DateOnly(2024, 3, 31),
+            Positions =
+            {
+                new BacktestPosition
+                {
+                    CommonStockId = StockA,
+                    Shares = 10_000,
+                    Value = 1_000_000,
+                    IsOption = false,
+                },
+                new BacktestPosition
+                {
+                    CommonStockId = StockB,
+                    Shares = 100_000,
+                    Value = 10_000_000,
+                    IsOption = true,
+                },
+            },
+        };
+        var rebalanceDate = new DateOnly(2024, 5, 15);
+
+        // Stock A doubles, stock B (option) would have crashed — if options were counted
+        // the portfolio would be -90%. With options skipped portfolio returns +100%.
+        var result = HoldingsBacktestCalculator.Calculate(
+            [snapshot],
+            from: rebalanceDate,
+            to: rebalanceDate.AddDays(30),
+            priceOf: (stockId, day) =>
+            {
+                if (stockId == StockA)
+                    return day == rebalanceDate ? 100m : 200m;
+                return day == rebalanceDate ? 100m : 10m;
+            },
+            benchmarkPriceOf: _ => 100m
+        );
+
+        result.PortfolioSummary.TotalReturnPercent.Should().Be(100m);
+    }
+
+    [Fact]
+    public void Calculate_HorizonCappedAtTenYears()
+    {
+        var snapshot = SingleStockSnapshot(new DateOnly(2024, 3, 31), StockA, 1_000_000);
+        var from = new DateOnly(2024, 5, 15);
+        var requestedTo = from.AddYears(25);
+
+        var result = HoldingsBacktestCalculator.Calculate(
+            [snapshot],
+            from: from,
+            to: requestedTo,
+            priceOf: (_, _) => 100m,
+            benchmarkPriceOf: _ => 100m
+        );
+
+        // Cap at 10 years from `from` — last point must be at most that far out.
+        result.EndDate.Should().Be(from.AddYears(HoldingsBacktestCalculator.MaxYears));
+        result.Points.Last().Date.Should().BeOnOrBefore(result.EndDate);
+    }
+
+    [Fact]
+    public void Calculate_DelistedStockPriceNull_HeldContributionDrops()
+    {
+        // Stock A delisted on day 1: price null afterwards. The held contribution drops
+        // to zero for that day, mark-to-market falls back to the prior portfolio value
+        // (the contract documented on the calculator) — so the series remains flat at 100
+        // rather than crashing to 0.
+        var snapshot = SingleStockSnapshot(new DateOnly(2024, 3, 31), StockA, 1_000_000);
+        var rebalanceDate = new DateOnly(2024, 5, 15);
+
+        var result = HoldingsBacktestCalculator.Calculate(
+            [snapshot],
+            from: rebalanceDate,
+            to: rebalanceDate.AddDays(3),
+            priceOf: (_, day) => day == rebalanceDate ? 100m : null,
+            benchmarkPriceOf: _ => 50m
+        );
+
+        result.Points.Should().AllSatisfy(p => p.PortfolioValue.Should().Be(100m));
+    }
+
+    [Fact]
+    public void Calculate_RebalancesOnNextSnapshotsRebalanceDate()
+    {
+        // Two snapshots. The first holds stock A flat — second rotates into stock B which
+        // doubles. The portfolio must reflect the rotation only after the second
+        // rebalance date (Q2 ReportDate 2024-06-30 + 45d = 2024-08-14).
+        var q1 = SingleStockSnapshot(new DateOnly(2024, 3, 31), StockA, 1_000_000);
+        var q2 = SingleStockSnapshot(new DateOnly(2024, 6, 30), StockB, 1_000_000);
+        var firstRebalance = new DateOnly(2024, 5, 15);
+        var secondRebalance = new DateOnly(2024, 8, 14);
+
+        var result = HoldingsBacktestCalculator.Calculate(
+            [q1, q2],
+            from: firstRebalance,
+            to: secondRebalance.AddDays(10),
+            priceOf: (stockId, day) =>
+            {
+                if (stockId == StockA)
+                    return 100m;
+                // Stock B trades at 100 on the rebalance close (the cloner's entry price)
+                // and 200 afterwards — so the portfolio doubles only after rotating in.
+                return day > secondRebalance ? 200m : 100m;
+            },
+            benchmarkPriceOf: _ => 100m
+        );
+
+        result.Points.First(p => p.Date == firstRebalance).PortfolioValue.Should().Be(100m);
+        // First day of stock B holding: portfolio still 100 (rebalances at the same close).
+        result.Points.First(p => p.Date == secondRebalance).PortfolioValue.Should().Be(100m);
+        // 10 days later stock B has doubled relative to the rebalance price → portfolio doubled.
+        result.Points.Last().PortfolioValue.Should().Be(200m);
+    }
+
+    [Fact]
+    public void Calculate_WindowEntirelyBeforeAnyRebalance_ReturnsReason()
+    {
+        var snapshot = SingleStockSnapshot(new DateOnly(2024, 3, 31), StockA, 1_000_000);
+
+        var result = HoldingsBacktestCalculator.Calculate(
+            [snapshot],
+            from: new DateOnly(2023, 1, 1),
+            to: new DateOnly(2023, 12, 31),
+            priceOf: (_, _) => 100m,
+            benchmarkPriceOf: _ => 100m
+        );
+
+        result.Reason.Should().Contain("no rebalance date falls inside");
+        result.Points.Should().BeEmpty();
+    }
+
+    private static BacktestQuarterSnapshot SingleStockSnapshot(
+        DateOnly reportDate,
+        Guid stockId,
+        long value
+    )
+    {
+        return new BacktestQuarterSnapshot
+        {
+            ReportDate = reportDate,
+            Positions =
+            {
+                new BacktestPosition
+                {
+                    CommonStockId = stockId,
+                    Shares = 10_000,
+                    Value = value,
+                    IsOption = false,
+                },
+            },
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Slice 1/4 of #1016 (13F portfolio backtester). Intermediate slice — not the closing one.

Pure static calculator that simulates cloning an institutional holder's quarterly 13F portfolio against a benchmark. Lives in `Equibles.Holdings.Repositories` so both the upcoming web service and any future MCP tool can reuse it.

Contract:
- Rebalance date = `ReportDate + 45 days` (latest legal 13F filing deadline — using `ReportDate` itself would peek)
- Skips option positions (`OptionType != null`)
- Caps horizon at 10 years
- Daily portfolio + benchmark series normalized to 100 at start
- Per-strategy summary: TotalReturn%, CAGR%, MaxDrawdown%
- Forward-filled prices are the caller's responsibility; null-price positions drop their contribution that day (calculator falls back to prior portfolio value rather than crashing to 0)

Refs #1016

## Code changes

- `src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs` — pure static calculator
- `src/Equibles.Holdings.Repositories/Models/BacktestPosition.cs`
- `src/Equibles.Holdings.Repositories/Models/BacktestQuarterSnapshot.cs`
- `src/Equibles.Holdings.Repositories/Models/BacktestPoint.cs`
- `src/Equibles.Holdings.Repositories/Models/BacktestStrategySummary.cs`
- `src/Equibles.Holdings.Repositories/Models/BacktestResult.cs`
- `tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorTests.cs` — 11 cases covering empty snapshots, flat prices, doubling, drawdown, option skipping, horizon cap, delisted/null prices, rotation across quarters, and out-of-window