### PR TITLE
refactor(sec-edgar): extract BuildArchiveUrl helper for duplicated archive-URL builder

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -348,12 +348,7 @@ public class SecEdgarClient : ISecEdgarClient
         )
             throw new ArgumentException("cik, accessionNumber and filename are required");
 
-        // Per-file URL uses unpadded CIK and the accession number with dashes removed.
-        // Padded CIK works too but triggers a 301 redirect; skip the extra hop.
-        var unpaddedCik = cik.TrimStart('0');
-        var accessionNoDashes = accessionNumber.Replace("-", string.Empty);
-        var url =
-            $"{FilesBaseUrl}/Archives/edgar/data/{unpaddedCik}/{accessionNoDashes}/{Uri.EscapeDataString(filename)}";
+        var url = BuildArchiveUrl(cik, accessionNumber, Uri.EscapeDataString(filename));
 
         _logger.LogInformation("Requesting filing artifact: {Url}", url);
 
@@ -476,10 +471,7 @@ public class SecEdgarClient : ISecEdgarClient
         if (string.IsNullOrEmpty(cik) || string.IsNullOrEmpty(accessionNumber))
             throw new ArgumentException("cik and accessionNumber are required");
 
-        var unpaddedCik = cik.TrimStart('0');
-        var accessionNoDashes = accessionNumber.Replace("-", string.Empty);
-        var url =
-            $"{FilesBaseUrl}/Archives/edgar/data/{unpaddedCik}/{accessionNoDashes}/index.json";
+        var url = BuildArchiveUrl(cik, accessionNumber, "index.json");
 
         using var response = await SendWithRetryAsync(url, cancellationToken);
         if (response.StatusCode == HttpStatusCode.NotFound)
@@ -770,6 +762,11 @@ public class SecEdgarClient : ISecEdgarClient
     {
         return $"{BaseUrl}{endpoint}";
     }
+
+    // Per-file URL uses unpadded CIK and the accession number with dashes removed.
+    // Padded CIK works too but triggers a 301 redirect; skip the extra hop.
+    private static string BuildArchiveUrl(string cik, string accessionNumber, string suffix) =>
+        $"{FilesBaseUrl}/Archives/edgar/data/{cik.TrimStart('0')}/{accessionNumber.Replace("-", string.Empty)}/{suffix}";
 
     private record CachedResponse(string Url, string Content);
 }


### PR DESCRIPTION
## Summary

- `GetDocumentFileBytes` and `GetFilingArtifactNames` both prefixed their URL construction with the same three lines (`cik.TrimStart('0')`, `accessionNumber.Replace("-", "")`, the `/Archives/edgar/data/{cik}/{accession}/{suffix}` template).
- Lifted into a private static `BuildArchiveUrl(cik, accession, suffix)` and moved the WHY-comment about the unpadded-CIK 301-redirect avoidance next to the helper — the single place it now applies.

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs`
  - New private static `BuildArchiveUrl` alongside the existing `FormatCik` / `BuildUrl` helpers.
  - `GetDocumentFileBytes` and `GetFilingArtifactNames` each shrink to a single `BuildArchiveUrl(cik, accessionNumber, …)` call.

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- `dotnet tool run csharpier check .` — green (1121 files).
- `dotnet test tests/Equibles.UnitTests` — 1391/1391 pass.
- `dotnet test tests/Equibles.IntegrationTests --filter "FullyQualifiedName~SecEdgarClient"` — 24/24 pass (covers `SecEdgarClientGetDocumentFileBytesTests`, `SecEdgarClientDownloadStreamTests`, `SecEdgarClientTests`).