### PR TITLE
docs(technical/mcp-tools): list GetConsensusHoldings under Holdings

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -28,6 +28,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetInstitutionSectorAllocation` — one filer's portfolio grouped by industry / sector for its latest 13F report; stocks lacking a classification collapse into an "Unclassified" row.
 - `GetInstitutionQuarterlyActivity` — one filer's position changes vs. the prior quarter, bucketed into Initiated / Increased / Reduced / Exited; optional `bucket` filter to a single bucket.
 - `GetFundOverlap` — 13F portfolio overlap between two filers at their latest common `ReportDate`: Jaccard similarity, dollar-weighted overlap, and a side-by-side stock table with per-fund shares + percent of portfolio.
+- `GetConsensusHoldings` — combined portfolio of 2-25 filers at their latest common `ReportDate`; stocks ranked by holder count then combined value, with optional `minFunds` floor.
 
 ### `mcp.AddInsiderTrading()` — Form 3 / 4
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- `GetConsensusHoldings` (added in the Holdings MCP toolset) is missing from the Holdings section of `docs/technical/mcp-tools.md`. Tool inventory check: 40 `[McpServerTool]` methods in src vs. 39 catalog entries — `GetConsensusHoldings` is the gap.

## Code changes

- `docs/technical/mcp-tools.md` — append one bullet under `mcp.AddHoldings()` → `InstitutionalHoldingsTools` describing `GetConsensusHoldings` (combined portfolio of 2-25 filers at the latest common `ReportDate`, ranked by holder count then combined value, with optional `minFunds` floor).