### PR TITLE
feat(holdings): backtest service + ~/Institutions/{cik}/Backtest route

### DIFF
--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -5,6 +5,7 @@ using Equibles.Holdings.Repositories.Models;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.Web.Controllers.Abstract;
 using Equibles.Web.Extensions;
+using Equibles.Web.Services;
 using Equibles.Web.ViewModels.Profiles;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -23,6 +24,7 @@ public class ProfilesController : BaseController
     private readonly InsiderTransactionRepository _insiderTransactionRepository;
     private readonly CongressMemberRepository _congressMemberRepository;
     private readonly CongressionalTradeRepository _congressionalTradeRepository;
+    private readonly HoldingsBacktestService _holdingsBacktestService;
 
     public ProfilesController(
         InstitutionalHolderRepository institutionalHolderRepository,
@@ -31,6 +33,7 @@ public class ProfilesController : BaseController
         InsiderTransactionRepository insiderTransactionRepository,
         CongressMemberRepository congressMemberRepository,
         CongressionalTradeRepository congressionalTradeRepository,
+        HoldingsBacktestService holdingsBacktestService,
         ILogger<ProfilesController> logger
     )
         : base(logger)
@@ -41,6 +44,7 @@ public class ProfilesController : BaseController
         _insiderTransactionRepository = insiderTransactionRepository;
         _congressMemberRepository = congressMemberRepository;
         _congressionalTradeRepository = congressionalTradeRepository;
+        _holdingsBacktestService = holdingsBacktestService;
     }
 
     [HttpGet("~/Institutions/{cik}")]
@@ -95,6 +99,22 @@ public class ProfilesController : BaseController
                 QuarterlyActivity = quarterlyActivity,
             }
         );
+    }
+
+    [HttpGet("~/Institutions/{cik}/Backtest")]
+    public async Task<IActionResult> BacktestInstitution(
+        string cik,
+        [FromQuery(Name = "from")] DateOnly? from = null,
+        [FromQuery(Name = "to")] DateOnly? to = null,
+        [FromQuery(Name = "benchmark")] string benchmark = null
+    )
+    {
+        var viewModel = await _holdingsBacktestService.Execute(cik, from, to, benchmark);
+        if (viewModel.HolderNotFound)
+            return NotFound();
+
+        ViewData["Title"] = viewModel.HolderName + " · Backtest";
+        return View(viewModel);
     }
 
     private async Task<(

--- a/src/Equibles.Web/Services/HoldingsBacktestService.cs
+++ b/src/Equibles.Web/Services/HoldingsBacktestService.cs
@@ -1,0 +1,257 @@
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.AutoWiring;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+using Equibles.Web.ViewModels.Profiles;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Web.Services;
+
+[Service]
+public class HoldingsBacktestService
+{
+    public const string DefaultBenchmark = "SPY";
+
+    // Tickers offered in the form's dropdown — kept small so the picker is curated rather
+    // than letting users type arbitrary symbols that may not have full price history.
+    private static readonly string[] CandidateBenchmarks =
+    [
+        "SPY",
+        "QQQ",
+        "IWM",
+        "DIA",
+        "VTI",
+        "VOO",
+    ];
+
+    private readonly InstitutionalHolderRepository _holderRepository;
+    private readonly InstitutionalHoldingRepository _holdingRepository;
+    private readonly CommonStockRepository _stockRepository;
+    private readonly DailyStockPriceRepository _priceRepository;
+
+    public HoldingsBacktestService(
+        InstitutionalHolderRepository holderRepository,
+        InstitutionalHoldingRepository holdingRepository,
+        CommonStockRepository stockRepository,
+        DailyStockPriceRepository priceRepository
+    )
+    {
+        _holderRepository = holderRepository;
+        _holdingRepository = holdingRepository;
+        _stockRepository = stockRepository;
+        _priceRepository = priceRepository;
+    }
+
+    public async Task<BacktestViewModel> Execute(
+        string cik,
+        DateOnly? from,
+        DateOnly? to,
+        string benchmark
+    )
+    {
+        var viewModel = new BacktestViewModel
+        {
+            Cik = cik,
+            Benchmark = string.IsNullOrWhiteSpace(benchmark)
+                ? DefaultBenchmark
+                : benchmark.Trim().ToUpperInvariant(),
+            RequestedFrom = from,
+            RequestedTo = to,
+        };
+        viewModel.BenchmarkOptions = await LoadBenchmarkOptions();
+
+        var holder = await _holderRepository.GetByCik(cik);
+        if (holder == null)
+        {
+            viewModel.HolderNotFound = true;
+            return viewModel;
+        }
+        viewModel.HolderName = holder.Name;
+
+        var benchmarkStock = await _stockRepository.GetByTicker(viewModel.Benchmark);
+        if (benchmarkStock == null)
+        {
+            viewModel.BenchmarkNotFound = true;
+            viewModel.ErrorMessage = $"Benchmark ticker '{viewModel.Benchmark}' is not known.";
+            return viewModel;
+        }
+        viewModel.BenchmarkName = benchmarkStock.Name;
+
+        var reportDates = await _holdingRepository
+            .GetHistoryByHolder(holder)
+            .Select(h => h.ReportDate)
+            .Distinct()
+            .OrderBy(d => d)
+            .ToListAsync();
+        if (reportDates.Count == 0)
+        {
+            viewModel.Result.Reason = "Holder has no 13F snapshots on file.";
+            return viewModel;
+        }
+
+        var resolvedTo = to ?? DateOnly.FromDateTime(DateTime.UtcNow);
+        var firstRebalance = reportDates[0].AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
+        var resolvedFrom = from ?? firstRebalance;
+
+        // Determine which snapshots feed the simulation: all whose rebalance date falls in
+        // [resolvedFrom, resolvedTo], plus the latest one whose rebalance date precedes
+        // resolvedFrom so the simulation can open with an initial portfolio.
+        var relevant = new List<DateOnly>();
+        DateOnly? lastBeforeWindow = null;
+        foreach (var date in reportDates)
+        {
+            var rebalance = date.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
+            if (rebalance < resolvedFrom)
+                lastBeforeWindow = date;
+            else if (rebalance <= resolvedTo)
+                relevant.Add(date);
+        }
+        if (lastBeforeWindow.HasValue && !relevant.Contains(lastBeforeWindow.Value))
+            relevant.Insert(0, lastBeforeWindow.Value);
+
+        if (relevant.Count == 0)
+        {
+            viewModel.Result.Reason =
+                "No 13F snapshot's rebalance date falls inside the requested window.";
+            return viewModel;
+        }
+
+        var holdings = await _holdingRepository
+            .GetHistoryByHolder(holder)
+            .Where(h => relevant.Contains(h.ReportDate))
+            .Select(h => new BacktestHoldingRow(
+                h.ReportDate,
+                h.CommonStockId,
+                h.Shares,
+                h.Value,
+                h.OptionType
+            ))
+            .ToListAsync();
+
+        var snapshots = holdings
+            .GroupBy(h => h.ReportDate)
+            .OrderBy(g => g.Key)
+            .Select(g => new BacktestQuarterSnapshot
+            {
+                ReportDate = g.Key,
+                Positions = g.Select(h => new BacktestPosition
+                    {
+                        CommonStockId = h.CommonStockId,
+                        Shares = h.Shares,
+                        Value = h.Value,
+                        IsOption = h.OptionType != null,
+                    })
+                    .ToList(),
+            })
+            .ToList();
+
+        // Forward-fill needs a few days of pre-window prices so day-zero of the simulation
+        // resolves to the last trading day's close even on a weekend or holiday.
+        var priceWindowFrom = resolvedFrom.AddDays(-14);
+
+        var stockIds = holdings
+            .Where(h => h.OptionType == null && h.Value > 0)
+            .Select(h => h.CommonStockId)
+            .Distinct()
+            .ToList();
+
+        // OrderBy() needs to precede the projection — EF can't translate an OrderBy keyed
+        // off the projected record's property because the constructor isn't translatable.
+        var priceRows =
+            stockIds.Count == 0
+                ? []
+                : await _priceRepository
+                    .GetByStocks(stockIds, priceWindowFrom, resolvedTo)
+                    .OrderBy(p => p.Date)
+                    .Select(p => new BacktestPriceRow(p.CommonStockId, p.Date, p.AdjustedClose))
+                    .ToListAsync();
+
+        var pricesByStock = priceRows
+            .GroupBy(p => p.StockId)
+            .ToDictionary(g => g.Key, g => g.ToArray());
+
+        var benchmarkPrices = await _priceRepository
+            .GetByStock(benchmarkStock, priceWindowFrom, resolvedTo)
+            .OrderBy(p => p.Date)
+            .Select(p => new BacktestPriceRow(p.CommonStockId, p.Date, p.AdjustedClose))
+            .ToListAsync();
+
+        if (benchmarkPrices.Count == 0)
+        {
+            viewModel.Result.Reason =
+                $"No price data available for benchmark {viewModel.Benchmark} in the requested window.";
+            return viewModel;
+        }
+
+        var benchmarkArray = benchmarkPrices.ToArray();
+
+        viewModel.Result = HoldingsBacktestCalculator.Calculate(
+            snapshots,
+            resolvedFrom,
+            resolvedTo,
+            priceOf: (stockId, date) => ForwardFill(pricesByStock, stockId, date),
+            benchmarkPriceOf: date => ForwardFill(benchmarkArray, date)
+        );
+
+        return viewModel;
+    }
+
+    private async Task<List<BacktestBenchmarkOption>> LoadBenchmarkOptions()
+    {
+        var options = new List<BacktestBenchmarkOption>();
+        foreach (var ticker in CandidateBenchmarks)
+        {
+            var stock = await _stockRepository.GetByTicker(ticker);
+            if (stock != null)
+                options.Add(new BacktestBenchmarkOption { Ticker = ticker, Name = stock.Name });
+        }
+        return options;
+    }
+
+    private static decimal? ForwardFill(
+        Dictionary<Guid, BacktestPriceRow[]> pricesByStock,
+        Guid stockId,
+        DateOnly date
+    )
+    {
+        return pricesByStock.TryGetValue(stockId, out var series)
+            ? ForwardFill(series, date)
+            : null;
+    }
+
+    private static decimal? ForwardFill(BacktestPriceRow[] series, DateOnly date)
+    {
+        if (series.Length == 0)
+            return null;
+        // Binary search for the largest Date <= the requested date.
+        var lo = 0;
+        var hi = series.Length - 1;
+        var matchIdx = -1;
+        while (lo <= hi)
+        {
+            var mid = (lo + hi) >>> 1;
+            var midDate = series[mid].Date;
+            if (midDate <= date)
+            {
+                matchIdx = mid;
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+        return matchIdx < 0 ? null : series[matchIdx].Price;
+    }
+
+    private readonly record struct BacktestHoldingRow(
+        DateOnly ReportDate,
+        Guid CommonStockId,
+        long Shares,
+        long Value,
+        Holdings.Data.Models.OptionType? OptionType
+    );
+
+    private readonly record struct BacktestPriceRow(Guid StockId, DateOnly Date, decimal Price);
+}

--- a/src/Equibles.Web/ViewModels/Profiles/BacktestBenchmarkOption.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/BacktestBenchmarkOption.cs
@@ -1,0 +1,8 @@
+namespace Equibles.Web.ViewModels.Profiles;
+
+public class BacktestBenchmarkOption
+{
+    public string Ticker { get; set; }
+
+    public string Name { get; set; }
+}

--- a/src/Equibles.Web/ViewModels/Profiles/BacktestViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/BacktestViewModel.cs
@@ -1,0 +1,30 @@
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Web.ViewModels.Profiles;
+
+public class BacktestViewModel
+{
+    public string Cik { get; set; }
+
+    public string HolderName { get; set; }
+
+    public string Benchmark { get; set; }
+
+    public string BenchmarkName { get; set; }
+
+    public DateOnly? RequestedFrom { get; set; }
+
+    public DateOnly? RequestedTo { get; set; }
+
+    public BacktestResult Result { get; set; } = new();
+
+    public bool HolderNotFound { get; set; }
+
+    public bool BenchmarkNotFound { get; set; }
+
+    // The benchmark picker only suggests symbols the database can actually price —
+    // populated by the service from `CommonStockRepository.GetByTicker` lookups.
+    public List<BacktestBenchmarkOption> BenchmarkOptions { get; set; } = [];
+
+    public string ErrorMessage { get; set; }
+}

--- a/src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml
@@ -1,0 +1,114 @@
+@model Equibles.Web.ViewModels.Profiles.BacktestViewModel
+
+@{
+    ViewData["Title"] = (Model.HolderName ?? "Institution") + " · Backtest";
+    var hasPoints = Model.Result.Points.Count > 0;
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <div class="mb-6">
+        <h1 class="text-3xl font-bold mb-1" data-testid="backtest-heading">@Model.HolderName Backtest</h1>
+        <p class="text-base-content/60 text-sm">
+            Simulates cloning the institution's quarterly 13F portfolio · rebalanced 45 days after each ReportDate (the latest legal filing deadline) · option positions skipped.
+        </p>
+    </div>
+
+    <!-- Filter form — date range + benchmark. Submits via GET so the URL captures the request. -->
+    <div class="card bg-base-100 shadow-sm mb-6" data-testid="backtest-filters">
+        <div class="card-body p-4">
+            <form method="get" class="grid grid-cols-1 md:grid-cols-4 gap-3">
+                <fieldset class="fieldset">
+                    <legend class="fieldset-legend">From</legend>
+                    <input type="date" name="from" value="@(Model.RequestedFrom?.ToString("yyyy-MM-dd"))" class="input input-bordered w-full" />
+                </fieldset>
+                <fieldset class="fieldset">
+                    <legend class="fieldset-legend">To</legend>
+                    <input type="date" name="to" value="@(Model.RequestedTo?.ToString("yyyy-MM-dd"))" class="input input-bordered w-full" />
+                </fieldset>
+                <fieldset class="fieldset">
+                    <legend class="fieldset-legend">Benchmark</legend>
+                    <select name="benchmark" class="select select-bordered w-full">
+                        @foreach (var option in Model.BenchmarkOptions) {
+                            var isSelected = string.Equals(option.Ticker, Model.Benchmark, StringComparison.OrdinalIgnoreCase);
+                            <option value="@option.Ticker" selected="@(isSelected ? "selected" : null)">@option.Ticker — @option.Name</option>
+                        }
+                    </select>
+                </fieldset>
+                <div class="flex items-end">
+                    <button type="submit" class="btn btn-primary w-full">Run</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    @if (Model.BenchmarkNotFound) {
+        <div class="alert alert-error mb-6" data-testid="backtest-benchmark-error">
+            <span>@Model.ErrorMessage</span>
+        </div>
+    } else if (!string.IsNullOrWhiteSpace(Model.Result.Reason)) {
+        <div class="alert alert-warning mb-6" data-testid="backtest-reason">
+            <span>@Model.Result.Reason</span>
+        </div>
+    } else if (hasPoints) {
+        <!-- Summary cards: portfolio vs benchmark, identical layout for visual comparison. -->
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+            @{
+                var rows = new[] {
+                    new { Label = "Portfolio (cloned)", Summary = Model.Result.PortfolioSummary, TestId = "backtest-portfolio-summary" },
+                    new { Label = "Benchmark (" + Model.Benchmark + ")", Summary = Model.Result.BenchmarkSummary, TestId = "backtest-benchmark-summary" },
+                };
+            }
+            @foreach (var row in rows) {
+                <div class="card bg-base-100 shadow-sm" data-testid="@row.TestId">
+                    <div class="card-body p-4">
+                        <h3 class="text-base font-medium mb-2">@row.Label</h3>
+                        <div class="stats stats-vertical sm:stats-horizontal shadow-sm bg-base-200 w-full">
+                            <div class="stat">
+                                <div class="stat-title">Total return</div>
+                                <div class="stat-value text-2xl font-mono">@row.Summary.TotalReturnPercent.ToString("F2")%</div>
+                            </div>
+                            <div class="stat">
+                                <div class="stat-title">CAGR</div>
+                                <div class="stat-value text-2xl font-mono">@row.Summary.CagrPercent.ToString("F2")%</div>
+                            </div>
+                            <div class="stat">
+                                <div class="stat-title">Max drawdown</div>
+                                <div class="stat-value text-2xl font-mono">@row.Summary.MaxDrawdownPercent.ToString("F2")%</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+
+        <!-- Slice 2 surfaces the series as a table; slice 3 will replace this with a Chart.js line chart. -->
+        <div class="card bg-base-100 shadow-sm" data-testid="backtest-series-table">
+            <div class="card-body p-4">
+                <div class="flex items-baseline justify-between mb-2">
+                    <h3 class="text-base font-medium m-0">Daily series</h3>
+                    <span class="text-xs text-base-content/60">@Model.Result.StartDate.ToString("yyyy-MM-dd") → @Model.Result.EndDate.ToString("yyyy-MM-dd") · @Model.Result.Points.Count.ToString("N0") days</span>
+                </div>
+                <div class="overflow-x-auto" style="max-height: 400px;">
+                    <table class="table table-zebra table-sm">
+                        <thead class="sticky top-0 bg-base-100">
+                            <tr>
+                                <th>Date</th>
+                                <th class="text-right">Portfolio (=100)</th>
+                                <th class="text-right">Benchmark (=100)</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var point in Model.Result.Points) {
+                                <tr>
+                                    <td class="font-mono">@point.Date.ToString("yyyy-MM-dd")</td>
+                                    <td class="text-right font-mono">@point.PortfolioValue.ToString("F2")</td>
+                                    <td class="text-right font-mono">@point.BenchmarkValue.ToString("F2")</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    }
+</div>

--- a/src/Equibles.Yahoo.Repositories/DailyStockPriceRepository.cs
+++ b/src/Equibles.Yahoo.Repositories/DailyStockPriceRepository.cs
@@ -24,6 +24,18 @@ public class DailyStockPriceRepository : BaseRepository<DailyStockPrice>
             .Where(p => p.CommonStockId == stock.Id && p.Date >= startDate && p.Date <= endDate);
     }
 
+    public IQueryable<DailyStockPrice> GetByStocks(
+        IEnumerable<Guid> stockIds,
+        DateOnly startDate,
+        DateOnly endDate
+    )
+    {
+        return GetAll()
+            .Where(p =>
+                stockIds.Contains(p.CommonStockId) && p.Date >= startDate && p.Date <= endDate
+            );
+    }
+
     public IQueryable<DateOnly> GetLatestDate(CommonStock stock)
     {
         return GetAll()

--- a/tests/Equibles.IntegrationTests/Web/ProfilesInstitutionBacktestTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesInstitutionBacktestTests.cs
@@ -1,0 +1,155 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data.Models;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the new /Institutions/{cik}/Backtest route end-to-end: route → controller →
+/// HoldingsBacktestService → calculator → view. Asserts the page renders the heading,
+/// filter form, summary cards, and the slice-2 daily-series table.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class ProfilesInstitutionBacktestTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public ProfilesInstitutionBacktestTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetBacktest_UnknownHolder_Returns404()
+    {
+        await _fixture.ResetAndSeedAsync();
+
+        var response = await _fixture.Client.GetAsync("/Institutions/0009999999/Backtest");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetBacktest_HolderWithoutBenchmark_RendersBenchmarkNotFoundAlert()
+    {
+        var holderCik = "0002000001";
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(new InstitutionalHolder { Cik = holderCik, Name = "No Benchmark Capital" });
+            await Task.CompletedTask;
+        });
+
+        // SPY isn't seeded — service should flag the benchmark as missing.
+        var response = await _fixture.Client.GetAsync($"/Institutions/{holderCik}/Backtest");
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, html);
+        html.Should().Contain("data-testid=\"backtest-heading\"");
+        html.Should().Contain("data-testid=\"backtest-benchmark-error\"");
+    }
+
+    [Fact]
+    public async Task GetBacktest_HolderWithSnapshotsAndPrices_RendersSummaryCardsAndSeriesTable()
+    {
+        var holderCik = "0002000002";
+        var holderId = Guid.NewGuid();
+        var aaplId = Guid.NewGuid();
+        var spyId = Guid.NewGuid();
+        var q1 = new DateOnly(2024, 3, 31);
+        var q2 = new DateOnly(2024, 6, 30);
+        var rebalanceQ1 = q1.AddDays(45);
+        var rebalanceQ2 = q2.AddDays(45);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.AddRange(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                },
+                new CommonStock
+                {
+                    Id = spyId,
+                    Ticker = "SPY",
+                    Name = "SPDR S&P 500 ETF",
+                    Cik = "0000884394",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = holderCik,
+                    Name = "Backtest Capital",
+                }
+            );
+            db.Add(MakeHolding(aaplId, holderId, q1, shares: 10_000, value: 1_000_000));
+            db.Add(MakeHolding(aaplId, holderId, q2, shares: 10_000, value: 1_500_000));
+
+            // Daily prices — flat $100 AAPL, flat $400 SPY across both rebalance windows.
+            // Forward-fill on the rebalance dates resolves to these closes.
+            for (var d = rebalanceQ1.AddDays(-7); d <= rebalanceQ2.AddDays(7); d = d.AddDays(1))
+            {
+                db.Add(MakePrice(aaplId, d, 100m));
+                db.Add(MakePrice(spyId, d, 400m));
+            }
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/Institutions/{holderCik}/Backtest?from={rebalanceQ1:yyyy-MM-dd}&to={rebalanceQ2.AddDays(7):yyyy-MM-dd}"
+        );
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, html);
+        html.Should().Contain("data-testid=\"backtest-heading\"");
+        html.Should().Contain("Backtest Capital");
+        html.Should().Contain("data-testid=\"backtest-filters\"");
+        html.Should().Contain("data-testid=\"backtest-portfolio-summary\"");
+        html.Should().Contain("data-testid=\"backtest-benchmark-summary\"");
+        html.Should().Contain("data-testid=\"backtest-series-table\"");
+        html.Should().Contain("Total return");
+        html.Should().Contain("Max drawdown");
+        // Flat prices → both series stay at the initial 100 normalized value. Allow either
+        // culture's decimal separator (`100.00` US, `100,00` ES/PT/FR) so the test passes
+        // regardless of the host culture.
+        var hasInitialPoint = html.Contains("100.00") || html.Contains("100,00");
+        hasInitialPoint.Should().BeTrue(html);
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stockId:N}".Substring(0, 12) + $"-{reportDate:yyyyMMdd}",
+        };
+
+    private static DailyStockPrice MakePrice(Guid stockId, DateOnly date, decimal close) =>
+        new()
+        {
+            CommonStockId = stockId,
+            Date = date,
+            Open = close,
+            High = close,
+            Low = close,
+            Close = close,
+            AdjustedClose = close,
+            Volume = 1_000_000,
+        };
+}


### PR DESCRIPTION
## Summary

Slice 2/4 of #1016. Intermediate — not the closing slice.

Wires the slice-1 calculator into a controller-callable service and exposes it at `~/Institutions/{cik}/Backtest`. View for this slice is a minimal table of the daily series + summary cards; slice 3 will replace the table with a Chart.js line chart.

Refs #1016

## Code changes

- `Services/HoldingsBacktestService.cs` — `[Service]`-tagged; loads holder snapshots and forward-fillable daily prices for every held stock + the chosen benchmark, hands them to the calculator. Benchmark options curated (SPY/QQQ/IWM/DIA/VTI/VOO), filtered to tickers actually in the DB.
- `Yahoo.Repositories/DailyStockPriceRepository.GetByStocks(stockIds, from, to)` — batch range query for the new service.
- `ProfilesController.BacktestInstitution` — `[HttpGet("~/Institutions/{cik}/Backtest")]`. Returns 404 for an unknown CIK; benchmark-missing and no-rebalance-in-window render inline alerts.
- `ViewModels/Profiles/BacktestViewModel.cs` + `BacktestBenchmarkOption.cs`
- `Views/Profiles/BacktestInstitution.cshtml` — heading, filter form (from/to/benchmark), summary cards (portfolio + benchmark CAGR/TotalReturn/MaxDrawdown), daily-series table
- `tests/Equibles.IntegrationTests/Web/ProfilesInstitutionBacktestTests.cs` — 3 cases: 404 for unknown holder, benchmark-missing alert, full happy-path with seeded holdings + prices