### PR TITLE
refactor(status-controller): extract LoadErrorOrFlashNotFound from Show/MarkAsSeen/Delete

### DIFF
--- a/src/Equibles.Web/Controllers/StatusController.cs
+++ b/src/Equibles.Web/Controllers/StatusController.cs
@@ -76,12 +76,9 @@ public class StatusController : BaseController
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> Show(Guid id)
     {
-        var error = await _errorRepository.Get(id);
+        var error = await LoadErrorOrFlashNotFound(id);
         if (error == null)
-        {
-            _flashMessage.Error("Error not found.");
             return RedirectToAction(nameof(Index));
-        }
 
         return View(error);
     }
@@ -90,12 +87,9 @@ public class StatusController : BaseController
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> MarkAsSeen(Guid id)
     {
-        var error = await _errorRepository.Get(id);
+        var error = await LoadErrorOrFlashNotFound(id);
         if (error == null)
-        {
-            _flashMessage.Error("Error not found.");
             return RedirectToAction(nameof(Index));
-        }
 
         await _errorManager.MarkAsSeen(error);
 
@@ -107,17 +101,22 @@ public class StatusController : BaseController
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Delete(Guid id)
     {
-        var error = await _errorRepository.Get(id);
+        var error = await LoadErrorOrFlashNotFound(id);
         if (error == null)
-        {
-            _flashMessage.Error("Error not found.");
             return RedirectToAction(nameof(Index));
-        }
 
         await _errorManager.Delete(error);
 
         _flashMessage.Success("Error deleted.");
         return RedirectToAction(nameof(Index));
+    }
+
+    private async Task<Error> LoadErrorOrFlashNotFound(Guid id)
+    {
+        var error = await _errorRepository.Get(id);
+        if (error == null)
+            _flashMessage.Error("Error not found.");
+        return error;
     }
 
     [HttpGet]


### PR DESCRIPTION
## Summary

- \`Show\`, \`MarkAsSeen\`, and \`Delete\` each opened with an identical 5-line "load error by id; flash 'Error not found.' and bail" prologue. Lift the lookup + flash into a private \`LoadErrorOrFlashNotFound\` helper.
- Callers keep their own \`RedirectToAction(nameof(Index))\` so the redirect destination — and the action body's intent — stay explicit.
- Same \`_errorRepository.Get(id)\` lookup, same \`_flashMessage.Error("Error not found.")\` on the null branch, same downstream behavior on the happy paths.

## Code changes

- \`src/Equibles.Web/Controllers/StatusController.cs\` — replace three duplicated 5-line preludes with a one-liner that calls \`LoadErrorOrFlashNotFound(id)\` and short-circuits on null; helper is a private \`Task<Error>\`-returning method.