### PR TITLE
feat(holdings): link Backtest from institution profile action bar

### DIFF
--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -5,11 +5,22 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">@Model.Name</h1>
-        <p class="text-base-content/60">
-            Institutional holder@(string.IsNullOrWhiteSpace(Model.Location) ? "" : " · " + Model.Location) · CIK @Model.Cik
-        </p>
+    <div class="mb-8 flex flex-wrap items-start justify-between gap-3">
+        <div>
+            <h1 class="text-3xl font-bold mb-2">@Model.Name</h1>
+            <p class="text-base-content/60">
+                Institutional holder@(string.IsNullOrWhiteSpace(Model.Location) ? "" : " · " + Model.Location) · CIK @Model.Cik
+            </p>
+        </div>
+        <!-- Action bar — Backtest link only renders when the holder has at least one 13F
+             snapshot, since the route's first useful response needs a rebalance date. -->
+        @if (Model.AvailableReportDates.Count > 0) {
+            <a asp-action="BacktestInstitution" asp-route-cik="@Model.Cik"
+               class="btn btn-outline btn-sm"
+               data-testid="institution-backtest-link">
+                Backtest
+            </a>
+        }
     </div>
 
     @if (Model.Summary.LatestReportDate.HasValue) {

--- a/tests/Equibles.IntegrationTests/Web/ProfilesInstitutionBacktestLinkTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesInstitutionBacktestLinkTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins that the institution profile's action bar links to the new backtest route when
+/// the holder has at least one 13F snapshot, and omits the link otherwise. Catches a
+/// rename of the BacktestInstitution action or its route (asp-action resolves through
+/// the real router under the in-process Web host).
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class ProfilesInstitutionBacktestLinkTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public ProfilesInstitutionBacktestLinkTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetInstitution_NoSnapshots_DoesNotRenderBacktestLink()
+    {
+        var cik = "0009100001";
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(new InstitutionalHolder { Cik = cik, Name = "Empty Holder" });
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync($"/Institutions/{cik}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().NotContain("data-testid=\"institution-backtest-link\"");
+    }
+
+    [Fact]
+    public async Task GetInstitution_WithSnapshot_RendersBacktestLinkPointingAtRoute()
+    {
+        var cik = "0009100002";
+        var holderId = Guid.NewGuid();
+        var stockId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = cik,
+                    Name = "Snapshot Holder",
+                }
+            );
+            db.Add(MakeHolding(stockId, holderId, new DateOnly(2024, 12, 31), 1_000, 1_000_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync($"/Institutions/{cik}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("data-testid=\"institution-backtest-link\"");
+        // asp-action="BacktestInstitution" must resolve to the new route — if it doesn't,
+        // the tag helper renders an empty href. The link is rendered without an explicit
+        // controller, so the asp-route-cik resolves to the BacktestInstitution route which
+        // attribute-routes to ~/Institutions/{cik}/Backtest.
+        // URL generation lowercases by default — match case-insensitively so the test
+        // doesn't break if a future LinkGenerator setting changes the casing again.
+        html.ToLowerInvariant().Should().Contain($"/institutions/{cik}/backtest");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stockId:N}".Substring(0, 12) + $"-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

Slice 4/4 of #1016 — **closing slice**.

Adds a Backtest action button on the institution profile header, visible only when the holder has at least one 13F snapshot (the backtest route needs at least one rebalance date to produce useful output).

Closes #1016

## Code changes

- `Views/Profiles/Institution.cshtml` — extracts the heading into a flex row with an action-bar column on the right; conditional `<a asp-action="BacktestInstitution" asp-route-cik="@Model.Cik">` renders only when `Model.AvailableReportDates.Count > 0`.
- `tests/Equibles.IntegrationTests/Web/ProfilesInstitutionBacktestLinkTests.cs` — two integration tests: link absent for an empty holder, link present and resolving to `/Institutions/{cik}/Backtest` for a holder with one snapshot.