### PR TITLE
docs(technical/web-portal): add Institutions/{cik}/Backtest route

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -25,7 +25,7 @@ Why the indirection through `ViewData` rather than a single `StockDetailViewMode
 | Controller | Route | Role |
 |---|---|---|
 | [`StocksController`](../../src/Equibles.Web/Controllers/StocksController.cs) | `~/Stocks/...` | The tab pattern above + landing list + `ShowDocument` + `ShowHolder` per-stock holder detail. |
-| [`ProfilesController`](../../src/Equibles.Web/Controllers/ProfilesController.cs) | `~/Institutions/{cik}`, `~/Institutions/Compare`, `~/Institutions/Combined`, `~/Insiders/{ownerCik}`, `~/Congress/{id}` | Global (not stock-scoped) profile pages for institutional holders, insider owners, and Congress members; plus side-by-side overlap and consensus-portfolio views across multiple 13F filers. |
+| [`ProfilesController`](../../src/Equibles.Web/Controllers/ProfilesController.cs) | `~/Institutions/{cik}`, `~/Institutions/{cik}/Backtest`, `~/Institutions/Compare`, `~/Institutions/Combined`, `~/Insiders/{ownerCik}`, `~/Congress/{id}` | Global (not stock-scoped) profile pages for institutional holders, insider owners, and Congress members; plus a per-filer backtest view, and side-by-side overlap and consensus-portfolio views across multiple 13F filers. |
 | [`HoldingsActivityController`](../../src/Equibles.Web/Controllers/HoldingsActivityController.cs) | `~/Holdings/Activity` | Market-wide quarterly leaderboards aggregated across 13F filers for a `ReportDate`: Top Buys, Top Sells, New Positions, Sold-Out Positions. |
 | [`EconomicDataController`](../../src/Equibles.Web/Controllers/EconomicDataController.cs) | `~/Economy/...` | FRED series browsing — category landing + per-series charts. |
 | [`CftcController`](../../src/Equibles.Web/Controllers/CftcController.cs) | `~/Futures/...` | CFTC positioning per contract / category. |


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- `ProfilesController` now also serves `~/Institutions/{cik}/Backtest` (added in #1142, per-filer backtest view with the Chart.js cumulative-return chart from #1144), but the controllers table in `web-portal.md` doesn't list it. Refresh the row.

## Code changes

- `docs/technical/web-portal.md` — add `~/Institutions/{cik}/Backtest` to the `ProfilesController` row's Routes column and extend the Role description with a per-filer backtest view clause.