### PR TITLE
docs(technical/operations): tighten EmbeddingConfig consumers sentence to active voice

### DIFF
--- a/docs/technical/operations.md
+++ b/docs/technical/operations.md
@@ -87,7 +87,7 @@ Embedding-related variables (override only if running Ollama elsewhere):
 | `Embedding__ModelName` | `bge-m3` |
 | `Embedding__BatchSize` | `10` |
 
-The same `EmbeddingConfig` binding is read by the MCP server's `RagManager` (for query-time embedding) and the worker (for chunk-time embedding). Without both bound to a working endpoint, `RagSearchTools` returns empty results.
+The MCP server's `RagManager` reads the same `EmbeddingConfig` binding for query-time embedding; the worker reads it for chunk-time embedding. Without both bound to a working endpoint, `RagSearchTools` returns empty results.
 
 ## Logging
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The EmbeddingConfig consumers sentence in `docs/technical/operations.md` was passive: "The same EmbeddingConfig binding is read by the MCP server's RagManager … and the worker …". The technical-docs writing rule prefers active voice ("X reads Y"). Rewrite so the consumers are the subjects.

## Code changes

- `docs/technical/operations.md` — replace the passive sentence under the "Embedding profile (opt-in)" section with an active-voice equivalent: `RagManager` reads it for query-time embedding; the worker reads it for chunk-time embedding.