### PR TITLE
feat(holdings): screener repository (Screen) + criteria/row models

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -1,4 +1,5 @@
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
 using Equibles.Data;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories.Models;
@@ -119,5 +120,145 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
                     .Distinct()
                     .Count(),
             });
+    }
+
+    // Cross-sectional 13F screener. Aggregates per-stock filer-count / total-value /
+    // new-position / sold-out-position metrics across the two snapshots in a single SQL
+    // round trip, joins CommonStock + Industry for display columns and the % of float
+    // calculation, and applies each non-null criterion as a server-side filter so result
+    // pagination stays cheap. Caller materializes with ToListAsync.
+    public IQueryable<ScreenerRow> Screen(
+        ScreenerCriteria criteria,
+        DateOnly current,
+        DateOnly previous
+    )
+    {
+        var aggregated = GetAll()
+            .Where(h => h.ReportDate == current || h.ReportDate == previous)
+            .GroupBy(h => h.CommonStockId)
+            .Select(g => new
+            {
+                CommonStockId = g.Key,
+                CurrentValue = g.Sum(h => h.ReportDate == current ? h.Value : 0L),
+                PreviousValue = g.Sum(h => h.ReportDate == previous ? h.Value : 0L),
+                CurrentShares = g.Sum(h => h.ReportDate == current ? h.Shares : 0L),
+                CurrentFilerCount = g.Where(h => h.ReportDate == current)
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+                PreviousFilerCount = g.Where(h => h.ReportDate == previous)
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+                NewFilerCount = g.Where(h =>
+                        h.ReportDate == current
+                        && !DbContext
+                            .Set<InstitutionalHolding>()
+                            .Any(p =>
+                                p.ReportDate == previous
+                                && p.CommonStockId == h.CommonStockId
+                                && p.InstitutionalHolderId == h.InstitutionalHolderId
+                            )
+                    )
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+                SoldOutFilerCount = g.Where(h =>
+                        h.ReportDate == previous
+                        && !DbContext
+                            .Set<InstitutionalHolding>()
+                            .Any(c =>
+                                c.ReportDate == current
+                                && c.CommonStockId == h.CommonStockId
+                                && c.InstitutionalHolderId == h.InstitutionalHolderId
+                            )
+                    )
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+            });
+
+        if (criteria.MinFilerCount.HasValue)
+            aggregated = aggregated.Where(r => r.CurrentFilerCount >= criteria.MinFilerCount.Value);
+        if (criteria.MaxFilerCount.HasValue)
+            aggregated = aggregated.Where(r => r.CurrentFilerCount <= criteria.MaxFilerCount.Value);
+        if (criteria.MinDeltaFilerCount.HasValue)
+            aggregated = aggregated.Where(r =>
+                r.CurrentFilerCount - r.PreviousFilerCount >= criteria.MinDeltaFilerCount.Value
+            );
+        if (criteria.MaxDeltaFilerCount.HasValue)
+            aggregated = aggregated.Where(r =>
+                r.CurrentFilerCount - r.PreviousFilerCount <= criteria.MaxDeltaFilerCount.Value
+            );
+        if (criteria.MinTotalValue.HasValue)
+            aggregated = aggregated.Where(r => r.CurrentValue >= criteria.MinTotalValue.Value);
+        if (criteria.MaxTotalValue.HasValue)
+            aggregated = aggregated.Where(r => r.CurrentValue <= criteria.MaxTotalValue.Value);
+        if (criteria.MinDeltaValue.HasValue)
+            aggregated = aggregated.Where(r =>
+                r.CurrentValue - r.PreviousValue >= criteria.MinDeltaValue.Value
+            );
+        if (criteria.MaxDeltaValue.HasValue)
+            aggregated = aggregated.Where(r =>
+                r.CurrentValue - r.PreviousValue <= criteria.MaxDeltaValue.Value
+            );
+        if (criteria.MinNewPositions.HasValue)
+            aggregated = aggregated.Where(r => r.NewFilerCount >= criteria.MinNewPositions.Value);
+        if (criteria.MinSoldOutPositions.HasValue)
+            aggregated = aggregated.Where(r =>
+                r.SoldOutFilerCount >= criteria.MinSoldOutPositions.Value
+            );
+
+        var joined = aggregated.Join(
+            DbContext.Set<CommonStock>(),
+            agg => agg.CommonStockId,
+            cs => cs.Id,
+            (agg, cs) => new { agg, cs }
+        );
+
+        if (criteria.IndustryIds.Count > 0)
+            joined = joined.Where(j =>
+                j.cs.IndustryId != null && criteria.IndustryIds.Contains(j.cs.IndustryId.Value)
+            );
+
+        // SharesOutStanding == 0 means "unknown" in the current schema; any % filter
+        // excludes those stocks rather than treating them as 100% held (false positive).
+        if (criteria.MinPctFloat.HasValue)
+        {
+            var min = criteria.MinPctFloat.Value;
+            joined = joined.Where(j =>
+                j.cs.SharesOutStanding > 0
+                && (double)j.agg.CurrentShares / j.cs.SharesOutStanding * 100.0 >= min
+            );
+        }
+        if (criteria.MaxPctFloat.HasValue)
+        {
+            var max = criteria.MaxPctFloat.Value;
+            joined = joined.Where(j =>
+                j.cs.SharesOutStanding > 0
+                && (double)j.agg.CurrentShares / j.cs.SharesOutStanding * 100.0 <= max
+            );
+        }
+
+        return joined.Select(j => new ScreenerRow
+        {
+            CommonStockId = j.agg.CommonStockId,
+            Ticker = j.cs.Ticker,
+            Name = j.cs.Name,
+            IndustryId = j.cs.IndustryId,
+            IndustryName = j.cs.Industry != null ? j.cs.Industry.Name : null,
+            SharesOutStanding = j.cs.SharesOutStanding,
+            CurrentFilerCount = j.agg.CurrentFilerCount,
+            PreviousFilerCount = j.agg.PreviousFilerCount,
+            CurrentValue = j.agg.CurrentValue,
+            PreviousValue = j.agg.PreviousValue,
+            CurrentShares = j.agg.CurrentShares,
+            NewFilerCount = j.agg.NewFilerCount,
+            SoldOutFilerCount = j.agg.SoldOutFilerCount,
+            PercentOfFloat =
+                j.cs.SharesOutStanding > 0
+                    ? (double?)((double)j.agg.CurrentShares / j.cs.SharesOutStanding * 100.0)
+                    : null,
+        });
     }
 }

--- a/src/Equibles.Holdings.Repositories/Models/ScreenerCriteria.cs
+++ b/src/Equibles.Holdings.Repositories/Models/ScreenerCriteria.cs
@@ -1,0 +1,33 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class ScreenerCriteria
+{
+    public int? MinFilerCount { get; set; }
+
+    public int? MaxFilerCount { get; set; }
+
+    public int? MinDeltaFilerCount { get; set; }
+
+    public int? MaxDeltaFilerCount { get; set; }
+
+    public long? MinTotalValue { get; set; }
+
+    public long? MaxTotalValue { get; set; }
+
+    public long? MinDeltaValue { get; set; }
+
+    public long? MaxDeltaValue { get; set; }
+
+    // % of float. SharesOutStanding == 0 in the current schema means "unknown" — stocks
+    // matching that are excluded from any % filter rather than treated as having 100% float
+    // held (which would be a misleading false positive).
+    public double? MinPctFloat { get; set; }
+
+    public double? MaxPctFloat { get; set; }
+
+    public int? MinNewPositions { get; set; }
+
+    public int? MinSoldOutPositions { get; set; }
+
+    public List<Guid> IndustryIds { get; set; } = [];
+}

--- a/src/Equibles.Holdings.Repositories/Models/ScreenerRow.cs
+++ b/src/Equibles.Holdings.Repositories/Models/ScreenerRow.cs
@@ -1,0 +1,39 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class ScreenerRow
+{
+    public Guid CommonStockId { get; set; }
+
+    public string Ticker { get; set; }
+
+    public string Name { get; set; }
+
+    public Guid? IndustryId { get; set; }
+
+    public string IndustryName { get; set; }
+
+    public long SharesOutStanding { get; set; }
+
+    public int CurrentFilerCount { get; set; }
+
+    public int PreviousFilerCount { get; set; }
+
+    public int DeltaFilerCount => CurrentFilerCount - PreviousFilerCount;
+
+    public long CurrentValue { get; set; }
+
+    public long PreviousValue { get; set; }
+
+    public long DeltaValue => CurrentValue - PreviousValue;
+
+    public long CurrentShares { get; set; }
+
+    public int NewFilerCount { get; set; }
+
+    public int SoldOutFilerCount { get; set; }
+
+    // Percent of float held by 13F filers, derived in-controller after materialization.
+    // Repository projection cannot compute it without a translatable conditional divide,
+    // and the value is null whenever SharesOutStanding == 0 (unknown).
+    public double? PercentOfFloat { get; set; }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryScreenTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryScreenTests.cs
@@ -1,0 +1,294 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Pins <c>InstitutionalHoldingRepository.Screen</c>. The query runs server-side
+/// against ParadeDB so every filter must translate end-to-end. Each test seeds its
+/// own stocks + holders so the assertions don't fight over fixture data.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingRepositoryScreenTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<Equibles.Data.EquiblesDbContext> _contexts = [];
+
+    private static readonly DateOnly Prior = new(2024, 9, 30);
+    private static readonly DateOnly Current = new(2024, 12, 31);
+
+    public InstitutionalHoldingRepositoryScreenTests(ParadeDbFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Equibles.Data.EquiblesDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    [Fact]
+    public async Task Screen_NoFilters_ProjectsFilerCountsAndValuesForBothQuarters()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, ticker: "AAPL");
+        var h1 = await SeedHolder(seed, cik: "h1");
+        var h2 = await SeedHolder(seed, cik: "h2");
+        seed.Add(MakeHolding(stock, h1, Prior, shares: 1_000, value: 1_000_000));
+        seed.Add(MakeHolding(stock, h2, Prior, shares: 500, value: 500_000));
+        seed.Add(MakeHolding(stock, h1, Current, shares: 1_500, value: 1_500_000));
+        seed.Add(MakeHolding(stock, h2, Current, shares: 800, value: 800_000));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var row = await sut.Screen(new ScreenerCriteria(), Current, Prior)
+            .SingleAsync(r => r.CommonStockId == stock.Id);
+
+        row.CurrentFilerCount.Should().Be(2);
+        row.PreviousFilerCount.Should().Be(2);
+        row.DeltaFilerCount.Should().Be(0);
+        row.CurrentValue.Should().Be(2_300_000);
+        row.PreviousValue.Should().Be(1_500_000);
+        row.DeltaValue.Should().Be(800_000);
+        row.CurrentShares.Should().Be(2_300);
+        row.NewFilerCount.Should().Be(0);
+        row.SoldOutFilerCount.Should().Be(0);
+        row.Ticker.Should().Be("AAPL");
+    }
+
+    [Fact]
+    public async Task Screen_NewAndSoldOutCountsReflectPerStockChurn()
+    {
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, ticker: "NVDA");
+        var continuingHolder = await SeedHolder(seed, cik: "cont");
+        var initiatingHolder = await SeedHolder(seed, cik: "init");
+        var exitingHolder = await SeedHolder(seed, cik: "exit");
+
+        // Continuing holder: holds in both quarters.
+        seed.Add(MakeHolding(stock, continuingHolder, Prior, shares: 100, value: 100_000));
+        seed.Add(MakeHolding(stock, continuingHolder, Current, shares: 100, value: 100_000));
+        // Initiating holder: first appears in Current.
+        seed.Add(MakeHolding(stock, initiatingHolder, Current, shares: 200, value: 200_000));
+        // Exiting holder: appears in Prior only.
+        seed.Add(MakeHolding(stock, exitingHolder, Prior, shares: 50, value: 50_000));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var row = await sut.Screen(new ScreenerCriteria(), Current, Prior)
+            .SingleAsync(r => r.CommonStockId == stock.Id);
+
+        row.NewFilerCount.Should().Be(1);
+        row.SoldOutFilerCount.Should().Be(1);
+        row.CurrentFilerCount.Should().Be(2);
+        row.PreviousFilerCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Screen_MinFilerCount_FiltersStocksBelowThreshold()
+    {
+        await using var seed = FreshContext();
+        var hot = await SeedStock(seed, ticker: "HOT");
+        var cold = await SeedStock(seed, ticker: "COLD");
+        var h1 = await SeedHolder(seed, cik: "fa");
+        var h2 = await SeedHolder(seed, cik: "fb");
+        seed.Add(MakeHolding(hot, h1, Current, shares: 1, value: 1));
+        seed.Add(MakeHolding(hot, h2, Current, shares: 1, value: 1));
+        seed.Add(MakeHolding(cold, h1, Current, shares: 1, value: 1));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var rows = await sut.Screen(new ScreenerCriteria { MinFilerCount = 2 }, Current, Prior)
+            .Where(r => r.Ticker == "HOT" || r.Ticker == "COLD")
+            .ToListAsync();
+
+        rows.Should().ContainSingle();
+        rows[0].Ticker.Should().Be("HOT");
+    }
+
+    [Fact]
+    public async Task Screen_MinDeltaValue_FiltersStocksWithoutGrowth()
+    {
+        await using var seed = FreshContext();
+        var growing = await SeedStock(seed, ticker: "GROW");
+        var flat = await SeedStock(seed, ticker: "FLAT");
+        var h = await SeedHolder(seed, cik: "gh");
+        seed.Add(MakeHolding(growing, h, Prior, shares: 100, value: 100_000));
+        seed.Add(MakeHolding(growing, h, Current, shares: 100, value: 500_000));
+        seed.Add(MakeHolding(flat, h, Prior, shares: 100, value: 100_000));
+        seed.Add(MakeHolding(flat, h, Current, shares: 100, value: 110_000));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var rows = await sut.Screen(
+                new ScreenerCriteria { MinDeltaValue = 100_000 },
+                Current,
+                Prior
+            )
+            .Where(r => r.Ticker == "GROW" || r.Ticker == "FLAT")
+            .ToListAsync();
+
+        rows.Should().ContainSingle();
+        rows[0].Ticker.Should().Be("GROW");
+    }
+
+    [Fact]
+    public async Task Screen_MinNewPositions_FiltersStocksWithoutEnoughInitiators()
+    {
+        await using var seed = FreshContext();
+        var trending = await SeedStock(seed, ticker: "TREND");
+        var quiet = await SeedStock(seed, ticker: "QUIET");
+        var h1 = await SeedHolder(seed, cik: "p1");
+        var h2 = await SeedHolder(seed, cik: "p2");
+        var h3 = await SeedHolder(seed, cik: "p3");
+        // TREND: 2 initiators in Current
+        seed.Add(MakeHolding(trending, h1, Current, shares: 10, value: 10));
+        seed.Add(MakeHolding(trending, h2, Current, shares: 10, value: 10));
+        // QUIET: 1 continuing holder, 0 initiators
+        seed.Add(MakeHolding(quiet, h3, Prior, shares: 10, value: 10));
+        seed.Add(MakeHolding(quiet, h3, Current, shares: 10, value: 10));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var rows = await sut.Screen(new ScreenerCriteria { MinNewPositions = 2 }, Current, Prior)
+            .Where(r => r.Ticker == "TREND" || r.Ticker == "QUIET")
+            .ToListAsync();
+
+        rows.Should().ContainSingle();
+        rows[0].Ticker.Should().Be("TREND");
+    }
+
+    [Fact]
+    public async Task Screen_IndustryIds_FiltersToSelectedIndustriesOnly()
+    {
+        await using var seed = FreshContext();
+        var tech = new Industry { Name = "Software" };
+        var energy = new Industry { Name = "Energy" };
+        seed.AddRange(tech, energy);
+        await seed.SaveChangesAsync();
+        var techStock = await SeedStock(seed, ticker: "TECH", industryId: tech.Id);
+        var energyStock = await SeedStock(seed, ticker: "OIL", industryId: energy.Id);
+        var holder = await SeedHolder(seed, cik: "ind1");
+        seed.Add(MakeHolding(techStock, holder, Current, shares: 1, value: 1));
+        seed.Add(MakeHolding(energyStock, holder, Current, shares: 1, value: 1));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var rows = await sut.Screen(
+                new ScreenerCriteria { IndustryIds = [tech.Id] },
+                Current,
+                Prior
+            )
+            .Where(r => r.Ticker == "TECH" || r.Ticker == "OIL")
+            .ToListAsync();
+
+        rows.Should().ContainSingle();
+        rows[0].Ticker.Should().Be("TECH");
+        rows[0].IndustryName.Should().Be("Software");
+    }
+
+    [Fact]
+    public async Task Screen_MinPctFloat_FiltersStocksOutsideFloatThresholdAndExcludesUnknownShares()
+    {
+        await using var seed = FreshContext();
+        // Heavily held — 80% of float
+        var dense = await SeedStock(seed, ticker: "DENSE", sharesOutStanding: 1_000);
+        // Lightly held — 5% of float
+        var sparse = await SeedStock(seed, ticker: "SPARSE", sharesOutStanding: 1_000);
+        // Unknown float — SharesOutStanding == 0
+        var unknown = await SeedStock(seed, ticker: "UNK", sharesOutStanding: 0);
+        var holder = await SeedHolder(seed, cik: "pf");
+        seed.Add(MakeHolding(dense, holder, Current, shares: 800, value: 800));
+        seed.Add(MakeHolding(sparse, holder, Current, shares: 50, value: 50));
+        seed.Add(MakeHolding(unknown, holder, Current, shares: 999, value: 999));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var rows = await sut.Screen(new ScreenerCriteria { MinPctFloat = 50.0 }, Current, Prior)
+            .Where(r => r.Ticker == "DENSE" || r.Ticker == "SPARSE" || r.Ticker == "UNK")
+            .ToListAsync();
+
+        rows.Should().ContainSingle();
+        rows[0].Ticker.Should().Be("DENSE");
+        rows[0].PercentOfFloat.Should().BeApproximately(80.0, 0.01);
+    }
+
+    private static async Task<CommonStock> SeedStock(
+        Equibles.Data.EquiblesDbContext ctx,
+        string ticker,
+        Guid? industryId = null,
+        long sharesOutStanding = 0
+    )
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Test Corp.",
+            Cik = $"C{Guid.NewGuid().GetHashCode() & int.MaxValue:D8}",
+            IndustryId = industryId,
+            SharesOutStanding = sharesOutStanding,
+        };
+        ctx.Add(stock);
+        await ctx.SaveChangesAsync();
+        return stock;
+    }
+
+    private static async Task<InstitutionalHolder> SeedHolder(
+        Equibles.Data.EquiblesDbContext ctx,
+        string cik
+    )
+    {
+        var holder = new InstitutionalHolder { Cik = cik, Name = $"Holder {cik}" };
+        ctx.Add(holder);
+        await ctx.SaveChangesAsync();
+        return holder;
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

PR 1 of 3 for #1017. Intermediate slice — not the closing one.

Cross-sectional 13F screener at the repository layer. Aggregates per-stock filer-count, total-value, new-position, and sold-out-position metrics across two snapshots in a single SQL round trip; joins `CommonStock` + `Industry` for display columns and the % of float calculation; applies each non-null criterion as a server-side filter.

Market-cap-bucket filter is intentionally deferred until `CommonStock.MarketCapitalization` is ingested (tracked in #1020).

Refs #1017

## Code changes

- `Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — `Screen(criteria, current, prior) → IQueryable<ScreenerRow>`. Uses conditional Sum + nested `Distinct().Count()` + `NOT EXISTS` subqueries, all translatable by EF Core. Joins `CommonStock` and projects `Industry.Name`. `%` of float is computed as `(double)CurrentShares / SharesOutStanding * 100`, with `SharesOutStanding == 0` treated as "unknown" (excluded from any % filter, projected as `null`).
- `Equibles.Holdings.Repositories/Models/ScreenerCriteria.cs` — DTO with nullable min/max bounds + industry list.
- `Equibles.Holdings.Repositories/Models/ScreenerRow.cs` — result shape; `DeltaFilerCount` / `DeltaValue` are computed properties.
- `tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryScreenTests.cs` — 7 cases covering no-filter projection, churn counts, min-filer threshold, min-delta-value, min-new-positions, industry multi-select, and the %-of-float threshold with the unknown-shares exclusion.