### PR TITLE
feat(holdings): /Holdings/Screener form + result table

### DIFF
--- a/src/Equibles.CommonStocks.Repositories/IndustryRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/IndustryRepository.cs
@@ -1,0 +1,10 @@
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Data;
+
+namespace Equibles.CommonStocks.Repositories;
+
+public class IndustryRepository : BaseRepository<Industry>
+{
+    public IndustryRepository(EquiblesDbContext dbContext)
+        : base(dbContext) { }
+}

--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -1,0 +1,120 @@
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.ViewModels.Holdings;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Web.Controllers;
+
+public class HoldingsScreenerController : BaseController
+{
+    public const int RowCap = 200;
+
+    private readonly InstitutionalHoldingRepository _holdingRepository;
+    private readonly IndustryRepository _industryRepository;
+
+    public HoldingsScreenerController(
+        InstitutionalHoldingRepository holdingRepository,
+        IndustryRepository industryRepository,
+        ILogger<HoldingsScreenerController> logger
+    )
+        : base(logger)
+    {
+        _holdingRepository = holdingRepository;
+        _industryRepository = industryRepository;
+    }
+
+    [HttpGet("~/Holdings/Screener")]
+    public async Task<IActionResult> Screener(
+        [FromQuery] ScreenerCriteriaViewModel filters = null,
+        [FromQuery(Name = "date")] DateOnly? date = null,
+        [FromQuery(Name = "compareDate")] DateOnly? compareDate = null
+    )
+    {
+        filters ??= new ScreenerCriteriaViewModel();
+
+        var reportDates = await _holdingRepository
+            .GetAvailableReportDates()
+            .OrderByDescending(d => d)
+            .ToListAsync();
+
+        var industryOptions = await _industryRepository
+            .GetAll()
+            .OrderBy(i => i.Name)
+            .Select(i => new ScreenerIndustryOption { Id = i.Id, Name = i.Name })
+            .ToListAsync();
+
+        var viewModel = new ScreenerViewModel
+        {
+            Filters = filters,
+            AvailableDates = reportDates,
+            IndustryOptions = industryOptions,
+        };
+
+        if (reportDates.Count < 2)
+        {
+            // Need at least two quarters to compute deltas; surface a friendly message
+            // rather than running the screener against missing data.
+            viewModel.Reason =
+                "At least two distinct 13F report dates are required to run the screener.";
+            return View(viewModel);
+        }
+
+        var selectedDate =
+            date.HasValue && reportDates.Contains(date.Value) ? date.Value : reportDates[0];
+        var comparisonDate =
+            compareDate.HasValue && reportDates.Contains(compareDate.Value)
+                ? compareDate.Value
+                : reportDates[1];
+        viewModel.SelectedDate = selectedDate;
+        viewModel.ComparisonDate = comparisonDate;
+
+        var criteria = ToCriteria(filters);
+        var rows = await _holdingRepository
+            .Screen(criteria, selectedDate, comparisonDate)
+            .OrderByDescending(r => r.CurrentValue)
+            .Take(RowCap)
+            .ToListAsync();
+
+        viewModel.Rows = rows.Select(r => new ScreenerResultRow
+            {
+                CommonStockId = r.CommonStockId,
+                Ticker = r.Ticker,
+                Name = r.Name,
+                IndustryName = r.IndustryName,
+                CurrentFilerCount = r.CurrentFilerCount,
+                PreviousFilerCount = r.PreviousFilerCount,
+                DeltaFilerCount = r.DeltaFilerCount,
+                CurrentValue = r.CurrentValue,
+                PreviousValue = r.PreviousValue,
+                DeltaValue = r.DeltaValue,
+                NewFilerCount = r.NewFilerCount,
+                SoldOutFilerCount = r.SoldOutFilerCount,
+                PercentOfFloat = r.PercentOfFloat,
+            })
+            .ToList();
+        viewModel.TruncatedToCap = rows.Count >= RowCap;
+
+        return View(viewModel);
+    }
+
+    internal static ScreenerCriteria ToCriteria(ScreenerCriteriaViewModel filters) =>
+        new()
+        {
+            MinFilerCount = filters.MinFilerCount,
+            MaxFilerCount = filters.MaxFilerCount,
+            MinDeltaFilerCount = filters.MinDeltaFilerCount,
+            MaxDeltaFilerCount = filters.MaxDeltaFilerCount,
+            MinTotalValue = filters.MinTotalValue,
+            MaxTotalValue = filters.MaxTotalValue,
+            MinDeltaValue = filters.MinDeltaValue,
+            MaxDeltaValue = filters.MaxDeltaValue,
+            MinPctFloat = filters.MinPctFloat,
+            MaxPctFloat = filters.MaxPctFloat,
+            MinNewPositions = filters.MinNewPositions,
+            MinSoldOutPositions = filters.MinSoldOutPositions,
+            IndustryIds = filters.IndustryIds ?? [],
+        };
+}

--- a/src/Equibles.Web/ViewModels/Holdings/ScreenerCriteriaViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/ScreenerCriteriaViewModel.cs
@@ -1,0 +1,30 @@
+namespace Equibles.Web.ViewModels.Holdings;
+
+public class ScreenerCriteriaViewModel
+{
+    public int? MinFilerCount { get; set; }
+
+    public int? MaxFilerCount { get; set; }
+
+    public int? MinDeltaFilerCount { get; set; }
+
+    public int? MaxDeltaFilerCount { get; set; }
+
+    public long? MinTotalValue { get; set; }
+
+    public long? MaxTotalValue { get; set; }
+
+    public long? MinDeltaValue { get; set; }
+
+    public long? MaxDeltaValue { get; set; }
+
+    public double? MinPctFloat { get; set; }
+
+    public double? MaxPctFloat { get; set; }
+
+    public int? MinNewPositions { get; set; }
+
+    public int? MinSoldOutPositions { get; set; }
+
+    public List<Guid> IndustryIds { get; set; } = [];
+}

--- a/src/Equibles.Web/ViewModels/Holdings/ScreenerIndustryOption.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/ScreenerIndustryOption.cs
@@ -1,0 +1,8 @@
+namespace Equibles.Web.ViewModels.Holdings;
+
+public class ScreenerIndustryOption
+{
+    public Guid Id { get; set; }
+
+    public string Name { get; set; }
+}

--- a/src/Equibles.Web/ViewModels/Holdings/ScreenerResultRow.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/ScreenerResultRow.cs
@@ -1,0 +1,30 @@
+namespace Equibles.Web.ViewModels.Holdings;
+
+public class ScreenerResultRow
+{
+    public Guid CommonStockId { get; set; }
+
+    public string Ticker { get; set; }
+
+    public string Name { get; set; }
+
+    public string IndustryName { get; set; }
+
+    public int CurrentFilerCount { get; set; }
+
+    public int PreviousFilerCount { get; set; }
+
+    public int DeltaFilerCount { get; set; }
+
+    public long CurrentValue { get; set; }
+
+    public long PreviousValue { get; set; }
+
+    public long DeltaValue { get; set; }
+
+    public int NewFilerCount { get; set; }
+
+    public int SoldOutFilerCount { get; set; }
+
+    public double? PercentOfFloat { get; set; }
+}

--- a/src/Equibles.Web/ViewModels/Holdings/ScreenerViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/ScreenerViewModel.cs
@@ -1,0 +1,20 @@
+namespace Equibles.Web.ViewModels.Holdings;
+
+public class ScreenerViewModel
+{
+    public ScreenerCriteriaViewModel Filters { get; set; } = new();
+
+    public List<DateOnly> AvailableDates { get; set; } = [];
+
+    public DateOnly SelectedDate { get; set; }
+
+    public DateOnly ComparisonDate { get; set; }
+
+    public List<ScreenerIndustryOption> IndustryOptions { get; set; } = [];
+
+    public List<ScreenerResultRow> Rows { get; set; } = [];
+
+    public bool TruncatedToCap { get; set; }
+
+    public string Reason { get; set; }
+}

--- a/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
+++ b/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
@@ -1,0 +1,170 @@
+@using Equibles.Web.ViewModels.Holdings
+@model ScreenerViewModel
+@{
+    ViewData["Title"] = "13F Stock Screener";
+    ViewData["Menu"] = "Holdings";
+    var filters = Model.Filters;
+    var selectedIndustryIds = new HashSet<Guid>(filters.IndustryIds ?? []);
+}
+
+<div class="max-w-7xl mx-auto px-6 py-8">
+    <div class="mb-6">
+        <h1 class="text-3xl font-bold mb-1" data-testid="screener-heading">13F Stock Screener</h1>
+        <p class="text-base-content/60 text-sm">
+            Cross-sectional filters on institutional-ownership metrics. Filer counts and value totals come from the selected quarter; Δ columns compare to the prior quarter.
+        </p>
+    </div>
+
+    @if (Model.AvailableDates.Count < 2 || !string.IsNullOrWhiteSpace(Model.Reason)) {
+        <div class="alert alert-warning" data-testid="screener-no-data">
+            <span>@(Model.Reason ?? "At least two distinct 13F report dates are required to run the screener.")</span>
+        </div>
+    } else {
+        <!-- Filter form. GET so each filter combo gets its own URL — that makes it shareable
+             and integration tests can round-trip values cleanly. -->
+        <div class="card bg-base-100 shadow-sm mb-6" data-testid="screener-filters">
+            <div class="card-body p-4">
+                <form method="get" class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-3">
+                    <fieldset class="fieldset">
+                        <legend class="fieldset-legend">Report quarter</legend>
+                        <select name="date" class="select select-bordered w-full">
+                            @foreach (var date in Model.AvailableDates) {
+                                var isSelected = date == Model.SelectedDate;
+                                <option value="@date.ToString("yyyy-MM-dd")" selected="@(isSelected ? "selected" : null)">@date.ToString("MMM dd, yyyy")</option>
+                            }
+                        </select>
+                    </fieldset>
+                    <fieldset class="fieldset">
+                        <legend class="fieldset-legend">Comparison quarter</legend>
+                        <select name="compareDate" class="select select-bordered w-full">
+                            @foreach (var date in Model.AvailableDates) {
+                                var isSelected = date == Model.ComparisonDate;
+                                <option value="@date.ToString("yyyy-MM-dd")" selected="@(isSelected ? "selected" : null)">@date.ToString("MMM dd, yyyy")</option>
+                            }
+                        </select>
+                    </fieldset>
+
+                    <fieldset class="fieldset">
+                        <legend class="fieldset-legend">Filers (min / max)</legend>
+                        <div class="flex gap-2">
+                            <input type="number" name="MinFilerCount" value="@filters.MinFilerCount" placeholder="min" class="input input-bordered w-1/2" />
+                            <input type="number" name="MaxFilerCount" value="@filters.MaxFilerCount" placeholder="max" class="input input-bordered w-1/2" />
+                        </div>
+                    </fieldset>
+                    <fieldset class="fieldset">
+                        <legend class="fieldset-legend">Δ Filers (min / max)</legend>
+                        <div class="flex gap-2">
+                            <input type="number" name="MinDeltaFilerCount" value="@filters.MinDeltaFilerCount" placeholder="min" class="input input-bordered w-1/2" />
+                            <input type="number" name="MaxDeltaFilerCount" value="@filters.MaxDeltaFilerCount" placeholder="max" class="input input-bordered w-1/2" />
+                        </div>
+                    </fieldset>
+
+                    <fieldset class="fieldset">
+                        <legend class="fieldset-legend">Total $ value (min / max)</legend>
+                        <div class="flex gap-2">
+                            <input type="number" name="MinTotalValue" value="@filters.MinTotalValue" placeholder="min" class="input input-bordered w-1/2" />
+                            <input type="number" name="MaxTotalValue" value="@filters.MaxTotalValue" placeholder="max" class="input input-bordered w-1/2" />
+                        </div>
+                    </fieldset>
+                    <fieldset class="fieldset">
+                        <legend class="fieldset-legend">Δ $ value (min / max)</legend>
+                        <div class="flex gap-2">
+                            <input type="number" name="MinDeltaValue" value="@filters.MinDeltaValue" placeholder="min" class="input input-bordered w-1/2" />
+                            <input type="number" name="MaxDeltaValue" value="@filters.MaxDeltaValue" placeholder="max" class="input input-bordered w-1/2" />
+                        </div>
+                    </fieldset>
+
+                    <fieldset class="fieldset">
+                        <legend class="fieldset-legend">% of float (min / max)</legend>
+                        <div class="flex gap-2">
+                            <input type="number" step="0.1" name="MinPctFloat" value="@filters.MinPctFloat" placeholder="min" class="input input-bordered w-1/2" />
+                            <input type="number" step="0.1" name="MaxPctFloat" value="@filters.MaxPctFloat" placeholder="max" class="input input-bordered w-1/2" />
+                        </div>
+                    </fieldset>
+
+                    <fieldset class="fieldset">
+                        <legend class="fieldset-legend">New positions (min)</legend>
+                        <input type="number" name="MinNewPositions" value="@filters.MinNewPositions" placeholder="min" class="input input-bordered w-full" />
+                    </fieldset>
+                    <fieldset class="fieldset">
+                        <legend class="fieldset-legend">Sold-out positions (min)</legend>
+                        <input type="number" name="MinSoldOutPositions" value="@filters.MinSoldOutPositions" placeholder="min" class="input input-bordered w-full" />
+                    </fieldset>
+
+                    @if (Model.IndustryOptions.Count > 0) {
+                        <fieldset class="fieldset md:col-span-3 lg:col-span-4">
+                            <legend class="fieldset-legend">Industry (multi-select)</legend>
+                            <select name="IndustryIds" multiple size="6" class="select select-bordered w-full" data-testid="screener-industry-select">
+                                @foreach (var option in Model.IndustryOptions) {
+                                    var isSelected = selectedIndustryIds.Contains(option.Id);
+                                    <option value="@option.Id" selected="@(isSelected ? "selected" : null)">@option.Name</option>
+                                }
+                            </select>
+                        </fieldset>
+                    }
+
+                    <div class="md:col-span-3 lg:col-span-4 flex flex-wrap gap-2 mt-2">
+                        <button type="submit" class="btn btn-primary">Apply filters</button>
+                        <a href="@Url.Action(nameof(Equibles.Web.Controllers.HoldingsScreenerController.Screener))" class="btn btn-ghost">Reset</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <!-- Result table -->
+        <div class="card bg-base-100 shadow-sm" data-testid="screener-results">
+            <div class="card-body p-4">
+                <div class="flex items-baseline justify-between mb-2">
+                    <h3 class="text-base font-medium m-0">@Model.Rows.Count.ToString("N0") matching stocks</h3>
+                    <span class="text-xs text-base-content/60">
+                        @Model.SelectedDate.ToString("MMM dd, yyyy") vs @Model.ComparisonDate.ToString("MMM dd, yyyy")@(Model.TruncatedToCap ? " · truncated to first " + Equibles.Web.Controllers.HoldingsScreenerController.RowCap.ToString("N0") : "")
+                    </span>
+                </div>
+                @if (Model.Rows.Count == 0) {
+                    <div class="text-xs text-base-content/50 py-6 text-center">No stocks matched the selected filters.</div>
+                } else {
+                    <div class="overflow-x-auto">
+                        <table class="table table-zebra table-sm">
+                            <thead>
+                                <tr>
+                                    <th>Ticker</th>
+                                    <th>Name</th>
+                                    <th>Industry</th>
+                                    <th class="text-right">Filers</th>
+                                    <th class="text-right">Δ Filers</th>
+                                    <th class="text-right">Total $ value</th>
+                                    <th class="text-right">Δ $ value</th>
+                                    <th class="text-right">New</th>
+                                    <th class="text-right">Sold out</th>
+                                    <th class="text-right">% float</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var row in Model.Rows) {
+                                    var deltaFilerCss = row.DeltaFilerCount > 0 ? "text-success" : row.DeltaFilerCount < 0 ? "text-error" : "";
+                                    var deltaValueCss = row.DeltaValue > 0 ? "text-success" : row.DeltaValue < 0 ? "text-error" : "";
+                                    var deltaFilerText = (row.DeltaFilerCount > 0 ? "+" : row.DeltaFilerCount < 0 ? "-" : "") + Math.Abs(row.DeltaFilerCount).ToString("N0");
+                                    var deltaValueText = (row.DeltaValue > 0 ? "+$" : row.DeltaValue < 0 ? "-$" : "$") + Math.Abs(row.DeltaValue).ToString("N0");
+                                    <tr>
+                                        <td class="font-mono">
+                                            <a asp-controller="Stocks" asp-action="Holdings" asp-route-ticker="@row.Ticker" class="link link-hover">@row.Ticker</a>
+                                        </td>
+                                        <td class="max-w-xs truncate">@row.Name</td>
+                                        <td class="max-w-xs truncate text-base-content/70">@row.IndustryName</td>
+                                        <td class="text-right font-mono">@row.CurrentFilerCount.ToString("N0")</td>
+                                        <td class="text-right font-mono @deltaFilerCss">@deltaFilerText</td>
+                                        <td class="text-right font-mono">$@row.CurrentValue.ToString("N0")</td>
+                                        <td class="text-right font-mono @deltaValueCss">@deltaValueText</td>
+                                        <td class="text-right font-mono">@row.NewFilerCount.ToString("N0")</td>
+                                        <td class="text-right font-mono">@row.SoldOutFilerCount.ToString("N0")</td>
+                                        <td class="text-right font-mono">@(row.PercentOfFloat.HasValue ? row.PercentOfFloat.Value.ToString("F1") + "%" : "—")</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+            </div>
+        </div>
+    }
+</div>

--- a/tests/Equibles.IntegrationTests/Web/HoldingsScreenerControllerTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsScreenerControllerTests.cs
@@ -1,0 +1,214 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the /Holdings/Screener route end-to-end: route → controller → repository
+/// (Screen) → view. Asserts the page renders, the filter form survives a round-trip,
+/// and seeded stocks appear / disappear correctly based on filter values.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HoldingsScreenerControllerTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HoldingsScreenerControllerTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetScreener_WithLessThanTwoQuarters_RendersNoDataAlert()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            var stock = new CommonStock
+            {
+                Ticker = "ONEQ",
+                Name = "Only One Quarter Corp.",
+                Cik = "0000000700",
+            };
+            var holder = new InstitutionalHolder { Cik = "0007000001", Name = "Solo Holder" };
+            db.Add(stock);
+            db.Add(holder);
+            db.Add(MakeHolding(stock.Id, holder.Id, new DateOnly(2024, 12, 31), 100, 100));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Screener");
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, html);
+        html.Should().Contain("data-testid=\"screener-heading\"");
+        html.Should().Contain("data-testid=\"screener-no-data\"");
+    }
+
+    [Fact]
+    public async Task GetScreener_NoFilters_RendersAllStocksAcrossTwoQuarters()
+    {
+        var q1 = new DateOnly(2024, 9, 30);
+        var q2 = new DateOnly(2024, 12, 31);
+        var holderId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "0007000002",
+                    Name = "Two Quarter Holder",
+                }
+            );
+            var aapl = new CommonStock
+            {
+                Ticker = "AAPL",
+                Name = "Apple Inc.",
+                Cik = "0000320193",
+            };
+            var msft = new CommonStock
+            {
+                Ticker = "MSFT",
+                Name = "Microsoft Corp.",
+                Cik = "0000789019",
+            };
+            db.AddRange(aapl, msft);
+            db.Add(MakeHolding(aapl.Id, holderId, q1, 1_000, 1_000_000));
+            db.Add(MakeHolding(aapl.Id, holderId, q2, 1_500, 1_500_000));
+            db.Add(MakeHolding(msft.Id, holderId, q1, 500, 500_000));
+            db.Add(MakeHolding(msft.Id, holderId, q2, 600, 600_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Screener");
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, html);
+        html.Should().Contain("data-testid=\"screener-filters\"");
+        html.Should().Contain("data-testid=\"screener-results\"");
+        html.Should().Contain(">AAPL<");
+        html.Should().Contain(">MSFT<");
+    }
+
+    [Fact]
+    public async Task GetScreener_MinTotalValueFilter_FiltersResultsAndRoundTripsValue()
+    {
+        var q1 = new DateOnly(2024, 9, 30);
+        var q2 = new DateOnly(2024, 12, 31);
+        var holderId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "0007000003",
+                    Name = "Filter Holder",
+                }
+            );
+            var big = new CommonStock
+            {
+                Ticker = "BIG",
+                Name = "Big Co.",
+                Cik = "0000007777",
+            };
+            var small = new CommonStock
+            {
+                Ticker = "SML",
+                Name = "Small Co.",
+                Cik = "0000007778",
+            };
+            db.AddRange(big, small);
+            db.Add(MakeHolding(big.Id, holderId, q1, 1, 9_000_000));
+            db.Add(MakeHolding(big.Id, holderId, q2, 1, 10_000_000));
+            db.Add(MakeHolding(small.Id, holderId, q1, 1, 1_000));
+            db.Add(MakeHolding(small.Id, holderId, q2, 1, 1_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Screener?MinTotalValue=5000000");
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, html);
+        html.Should().Contain(">BIG<");
+        html.Should().NotContain(">SML<");
+        // Filter value round-trips into the form so reload-from-URL works.
+        html.Should().Contain("value=\"5000000\"");
+    }
+
+    [Fact]
+    public async Task GetScreener_IndustryListPopulatesMultiSelectAndFilters()
+    {
+        var q1 = new DateOnly(2024, 9, 30);
+        var q2 = new DateOnly(2024, 12, 31);
+        var holderId = Guid.NewGuid();
+        var techId = Guid.NewGuid();
+        var energyId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(new Industry { Id = techId, Name = "Software-Test" });
+            db.Add(new Industry { Id = energyId, Name = "Energy-Test" });
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "0007000004",
+                    Name = "Industry Holder",
+                }
+            );
+            var techStock = new CommonStock
+            {
+                Ticker = "TKR1",
+                Name = "Tech Stock Inc.",
+                Cik = "0000008881",
+                IndustryId = techId,
+            };
+            var energyStock = new CommonStock
+            {
+                Ticker = "TKR2",
+                Name = "Energy Stock Inc.",
+                Cik = "0000008882",
+                IndustryId = energyId,
+            };
+            db.AddRange(techStock, energyStock);
+            db.Add(MakeHolding(techStock.Id, holderId, q1, 1, 1));
+            db.Add(MakeHolding(techStock.Id, holderId, q2, 1, 1));
+            db.Add(MakeHolding(energyStock.Id, holderId, q1, 1, 1));
+            db.Add(MakeHolding(energyStock.Id, holderId, q2, 1, 1));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync($"/Holdings/Screener?IndustryIds={techId}");
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, html);
+        html.Should().Contain("data-testid=\"screener-industry-select\"");
+        html.Should().Contain("Software-Test");
+        html.Should().Contain(">TKR1<");
+        html.Should().NotContain(">TKR2<");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stockId:N}".Substring(0, 12) + $"-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

PR 2 of 3 for #1017. Intermediate slice — not the closing one.

Wires the slice-1 repository method (PR #1150) into a public route at `~/Holdings/Screener` with a DaisyUI filter form and a sortable result table. Each filter combo gets a shareable URL via `[FromQuery]` binding.

Refs #1017

## Code changes

- `Equibles.Web/Controllers/HoldingsScreenerController.cs` — `[HttpGet("~/Holdings/Screener")]`, binds `ScreenerCriteriaViewModel` from query, maps to `ScreenerCriteria`, calls `InstitutionalHoldingRepository.Screen`. Result rows truncated to 200 by `CurrentValue` desc; the view shows a truncation note when the cap is hit. Renders an alert when fewer than two distinct report dates exist.
- `Equibles.CommonStocks.Repositories/IndustryRepository.cs` — minimal `BaseRepository<Industry>` so the multi-select can populate without controllers reaching past the repository layer.
- `Equibles.Web/ViewModels/Holdings/ScreenerViewModel.cs` + `ScreenerCriteriaViewModel.cs` + `ScreenerIndustryOption.cs` + `ScreenerResultRow.cs`.
- `Equibles.Web/Views/HoldingsScreener/Screener.cshtml` — filter form with date pickers, min/max number inputs per metric, industry multi-select, and the result table; ticker cells link to the stock's Holdings tab.
- `tests/Equibles.IntegrationTests/Web/HoldingsScreenerControllerTests.cs` — 4 cases: no-data alert, no-filter render across two quarters, `MinTotalValue` filter (with URL round-trip assertion), and industry multi-select filter.