### PR TITLE
refactor(cftc-import): use BatchPersister.Persist in ImportYear

### DIFF
--- a/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
+++ b/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
@@ -6,6 +6,7 @@ using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Cftc.Contracts;
+using Equibles.Worker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -218,24 +219,33 @@ public class CftcImportService
                 .ToHashSet();
         }
 
-        var batch = new List<CftcPositionReport>(InsertBatchSize);
-        var totalInserted = 0;
+        var totalInserted = await BatchPersister.Persist(
+            MapNewReports(),
+            InsertBatchSize,
+            FlushBatch
+        );
 
-        foreach (var record in filtered)
+        if (totalInserted > 0)
         {
-            var date = ParseDate(record.ReportDate);
-            if (date == null)
-                continue;
+            await UpdateContractMetadata(contractIdMap, cancellationToken);
+        }
 
-            var code = record.ContractMarketCode.Trim();
-            if (!contractIdMap.TryGetValue(code, out var contractId))
-                continue;
+        IEnumerable<CftcPositionReport> MapNewReports()
+        {
+            foreach (var record in filtered)
+            {
+                var date = ParseDate(record.ReportDate);
+                if (date == null)
+                    continue;
 
-            if (existingKeys.Contains((contractId, date.Value)))
-                continue;
+                var code = record.ContractMarketCode.Trim();
+                if (!contractIdMap.TryGetValue(code, out var contractId))
+                    continue;
 
-            batch.Add(
-                new CftcPositionReport
+                if (existingKeys.Contains((contractId, date.Value)))
+                    continue;
+
+                yield return new CftcPositionReport
                 {
                     CftcContractId = contractId,
                     ReportDate = date.Value,
@@ -263,28 +273,8 @@ public class CftcImportService
                     TradersNonCommShort = record.TradersNonCommShort,
                     TradersCommLong = record.TradersCommLong,
                     TradersCommShort = record.TradersCommShort,
-                }
-            );
-
-            if (batch.Count >= InsertBatchSize)
-            {
-                await FlushBatch(batch);
-                totalInserted += batch.Count;
-                batch.Clear();
+                };
             }
-        }
-
-        if (batch.Count > 0)
-        {
-            await FlushBatch(batch);
-            totalInserted += batch.Count;
-            batch.Clear();
-        }
-
-        // Update contract metadata
-        if (totalInserted > 0)
-        {
-            await UpdateContractMetadata(contractIdMap, cancellationToken);
         }
 
         _logger.LogInformation(


### PR DESCRIPTION
## Summary

- \`ImportYear\` inlined the same "filter → map → accumulate batch of \`InsertBatchSize\` → flush on threshold → final flush → tally totalInserted" loop that \`Equibles.Worker.BatchPersister.Persist<T>\` already implements (and that \`FtdImportService\` and \`CboeImportService\` use).
- Move the filter-and-map pipeline into a local iterator method \`MapNewReports()\` that \`yield return\`s mapped \`CftcPositionReport\` entities; hand it to \`BatchPersister.Persist\`. Same skip rules (null \`ReportDate\`, missing contract ID, duplicate \`(contractId, date)\` key), same batch shape, same \`totalInserted\` summary.
- Net 34 lines deleted, 24 added. All 58 Cftc integration + 27 Cftc unit tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.Cftc.HostedService/Services/CftcImportService.cs\` — add \`using Equibles.Worker;\`; replace the inline batch/flush tail in \`ImportYear\` with a \`BatchPersister.Persist(MapNewReports(), InsertBatchSize, FlushBatch)\` call backed by a local-iterator helper that owns the filter-and-map pipeline.