### PR TITLE
feat(holdings): screener CSV export

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Models;
@@ -98,6 +100,86 @@ public class HoldingsScreenerController : BaseController
         viewModel.TruncatedToCap = rows.Count >= RowCap;
 
         return View(viewModel);
+    }
+
+    [HttpGet("~/Holdings/Screener/Export.csv")]
+    public async Task<IActionResult> ExportCsv(
+        [FromQuery] ScreenerCriteriaViewModel filters = null,
+        [FromQuery(Name = "date")] DateOnly? date = null,
+        [FromQuery(Name = "compareDate")] DateOnly? compareDate = null
+    )
+    {
+        filters ??= new ScreenerCriteriaViewModel();
+
+        var reportDates = await _holdingRepository
+            .GetAvailableReportDates()
+            .OrderByDescending(d => d)
+            .ToListAsync();
+        if (reportDates.Count < 2)
+            return NotFound();
+
+        var selectedDate =
+            date.HasValue && reportDates.Contains(date.Value) ? date.Value : reportDates[0];
+        var comparisonDate =
+            compareDate.HasValue && reportDates.Contains(compareDate.Value)
+                ? compareDate.Value
+                : reportDates[1];
+
+        var criteria = ToCriteria(filters);
+        // CSV export bypasses the UI row cap — analysts who download a CSV expect every
+        // matching row, not the first 200. Materializing the full result set here is fine:
+        // the Screen query is already filtered server-side, so the row count is bounded by
+        // the user's criteria rather than the universe.
+        var rows = await _holdingRepository
+            .Screen(criteria, selectedDate, comparisonDate)
+            .OrderByDescending(r => r.CurrentValue)
+            .ToListAsync();
+
+        var csv = BuildCsv(rows);
+        var filename = $"screener-{selectedDate:yyyyMMdd}-vs-{comparisonDate:yyyyMMdd}.csv";
+        return File(Encoding.UTF8.GetBytes(csv), "text/csv", filename);
+    }
+
+    internal static string BuildCsv(IReadOnlyList<ScreenerRow> rows)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(
+            "Ticker,Name,Industry,CurrentFilerCount,PreviousFilerCount,DeltaFilerCount,"
+                + "CurrentValue,PreviousValue,DeltaValue,NewFilerCount,SoldOutFilerCount,PercentOfFloat"
+        );
+        foreach (var r in rows)
+        {
+            sb.Append(EscapeCsvField(r.Ticker)).Append(',');
+            sb.Append(EscapeCsvField(r.Name)).Append(',');
+            sb.Append(EscapeCsvField(r.IndustryName)).Append(',');
+            sb.Append(r.CurrentFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(r.PreviousFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(r.DeltaFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(r.CurrentValue.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(r.PreviousValue.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(r.DeltaValue.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(r.NewFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(r.SoldOutFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
+            sb.Append(
+                r.PercentOfFloat.HasValue
+                    ? r.PercentOfFloat.Value.ToString("F4", CultureInfo.InvariantCulture)
+                    : string.Empty
+            );
+            sb.AppendLine();
+        }
+        return sb.ToString();
+    }
+
+    // RFC 4180 escape: wrap a field in quotes when it contains a quote, comma, or newline;
+    // double any embedded quotes. Empty string passes through unwrapped.
+    private static string EscapeCsvField(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+        var needsQuoting = value.IndexOfAny(['"', ',', '\n', '\r']) >= 0;
+        if (!needsQuoting)
+            return value;
+        return "\"" + value.Replace("\"", "\"\"") + "\"";
     }
 
     internal static ScreenerCriteria ToCriteria(ScreenerCriteriaViewModel filters) =>

--- a/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
+++ b/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
@@ -106,6 +106,13 @@
                     <div class="md:col-span-3 lg:col-span-4 flex flex-wrap gap-2 mt-2">
                         <button type="submit" class="btn btn-primary">Apply filters</button>
                         <a href="@Url.Action(nameof(Equibles.Web.Controllers.HoldingsScreenerController.Screener))" class="btn btn-ghost">Reset</a>
+                        <!-- CSV export receives the same query string so the download
+                             reflects the current filters; bypasses the 200-row UI cap. -->
+                        <a href="@($"{Url.Action(nameof(Equibles.Web.Controllers.HoldingsScreenerController.ExportCsv))}{Context.Request.QueryString}")"
+                           class="btn btn-outline ml-auto"
+                           data-testid="screener-export-csv">
+                            Download CSV
+                        </a>
                     </div>
                 </form>
             </div>

--- a/tests/Equibles.IntegrationTests/Web/HoldingsScreenerExportCsvTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsScreenerExportCsvTests.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the /Holdings/Screener/Export.csv route end-to-end: route → controller →
+/// repository → CSV writer. Asserts content-type, filename, header row, and that the
+/// same filters that apply to the form also apply to the export.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HoldingsScreenerExportCsvTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HoldingsScreenerExportCsvTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task ExportCsv_WithLessThanTwoQuarters_Returns404()
+    {
+        await _fixture.ResetAndSeedAsync();
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Screener/Export.csv");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ExportCsv_TwoQuartersOfHoldings_ReturnsCsvWithHeaderAndDataRow()
+    {
+        var q1 = new DateOnly(2024, 9, 30);
+        var q2 = new DateOnly(2024, 12, 31);
+        var holderId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "0008000001",
+                    Name = "Export Holder",
+                }
+            );
+            var stock = new CommonStock
+            {
+                Ticker = "EXPT",
+                Name = "Export Corp.",
+                Cik = "0000099991",
+            };
+            db.Add(stock);
+            db.Add(MakeHolding(stock.Id, holderId, q1, 100, 100_000));
+            db.Add(MakeHolding(stock.Id, holderId, q2, 150, 150_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Screener/Export.csv");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/csv");
+        response.Content.Headers.ContentDisposition!.FileName.Should().EndWith(".csv");
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should()
+            .Contain(
+                "Ticker,Name,Industry,CurrentFilerCount,PreviousFilerCount,DeltaFilerCount,"
+                    + "CurrentValue,PreviousValue,DeltaValue,NewFilerCount,SoldOutFilerCount,PercentOfFloat"
+            );
+        body.Should().Contain("EXPT,Export Corp.,");
+        // Δ value = 150_000 - 100_000 = 50_000 — culture-invariant integer with no separator.
+        body.Should().Contain("50000");
+    }
+
+    [Fact]
+    public async Task ExportCsv_NameWithComma_IsQuotedAndDoubleQuotesAreEscaped()
+    {
+        var q1 = new DateOnly(2024, 9, 30);
+        var q2 = new DateOnly(2024, 12, 31);
+        var holderId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "0008000002",
+                    Name = "Comma Holder",
+                }
+            );
+            var stock = new CommonStock
+            {
+                Ticker = "CMA",
+                // Company name contains a comma + a double quote — both must be escaped.
+                Name = "Acme, \"Special\" Co.",
+                Cik = "0000099992",
+            };
+            db.Add(stock);
+            db.Add(MakeHolding(stock.Id, holderId, q1, 1, 1));
+            db.Add(MakeHolding(stock.Id, holderId, q2, 1, 1));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Screener/Export.csv");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Field gets wrapped in quotes; embedded double-quote is doubled per RFC 4180.
+        body.Should().Contain("\"Acme, \"\"Special\"\" Co.\"");
+    }
+
+    [Fact]
+    public async Task ExportCsv_FiltersApplyToDownloadSameAsForm()
+    {
+        var q1 = new DateOnly(2024, 9, 30);
+        var q2 = new DateOnly(2024, 12, 31);
+        var holderId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "0008000003",
+                    Name = "Filter Export Holder",
+                }
+            );
+            var big = new CommonStock
+            {
+                Ticker = "EXBIG",
+                Name = "Export Big",
+                Cik = "0000099993",
+            };
+            var small = new CommonStock
+            {
+                Ticker = "EXSML",
+                Name = "Export Small",
+                Cik = "0000099994",
+            };
+            db.AddRange(big, small);
+            db.Add(MakeHolding(big.Id, holderId, q1, 1, 9_000_000));
+            db.Add(MakeHolding(big.Id, holderId, q2, 1, 10_000_000));
+            db.Add(MakeHolding(small.Id, holderId, q1, 1, 1_000));
+            db.Add(MakeHolding(small.Id, holderId, q2, 1, 1_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            "/Holdings/Screener/Export.csv?MinTotalValue=5000000"
+        );
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().Contain("EXBIG");
+        body.Should().NotContain("EXSML");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stockId:N}".Substring(0, 12) + $"-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

PR 3 of 3 for #1017 — **closing slice**.

Adds `~/Holdings/Screener/Export.csv` returning the same filtered rows as `text/csv`, with a filename keyed off the selected vs comparison report dates. A Download CSV button on the form view carries the current query string so the export reflects exactly what the user sees.

Closes #1017

## Code changes

- `Equibles.Web/Controllers/HoldingsScreenerController.cs` — `ExportCsv` action returns `text/csv` via `File(...)`. The form's 200-row UI cap is intentionally lifted on the export; the underlying `Screen` query is already filtered server-side, so the row count is bounded by the user's criteria. `BuildCsv` writes culture-invariant integers and `F4` percentages; `EscapeCsvField` applies RFC-4180 quoting (comma, embedded quote, newline).
- `Equibles.Web/Views/HoldingsScreener/Screener.cshtml` — Download CSV button on the form action bar; preserves the live `Context.Request.QueryString` so the export receives the same filter values.
- `tests/Equibles.IntegrationTests/Web/HoldingsScreenerExportCsvTests.cs` — 4 cases: 404 when fewer than two report dates exist, happy-path content-type / filename / header + row, RFC-4180 escaping of a name with a comma and embedded quotes, and a filter that applies identically to the export and the form.