### PR TITLE
feat(common-stocks): Yahoo assetProfile parsing for company profile

### DIFF
--- a/src/Equibles.Integrations.Yahoo/Contracts/IYahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/Contracts/IYahooFinanceClient.cs
@@ -11,4 +11,5 @@ public interface IYahooFinanceClient
     );
     Task<List<RecommendationTrend>> GetRecommendationTrends(string ticker);
     Task<KeyStatistics> GetKeyStatistics(string ticker);
+    Task<CompanyProfile> GetCompanyProfile(string ticker);
 }

--- a/src/Equibles.Integrations.Yahoo/Models/CompanyProfile.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/CompanyProfile.cs
@@ -1,0 +1,12 @@
+namespace Equibles.Integrations.Yahoo.Models;
+
+public class CompanyProfile
+{
+    public string Sector { get; set; }
+
+    public string Industry { get; set; }
+
+    public string LongBusinessSummary { get; set; }
+
+    public string Website { get; set; }
+}

--- a/src/Equibles.Integrations.Yahoo/Models/Responses/YahooQuoteSummaryResponse.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/Responses/YahooQuoteSummaryResponse.cs
@@ -25,6 +25,24 @@ public class QuoteSummaryResult
 
     [JsonProperty("defaultKeyStatistics")]
     public DefaultKeyStatisticsContainer DefaultKeyStatistics { get; set; }
+
+    [JsonProperty("assetProfile")]
+    public AssetProfileContainer AssetProfile { get; set; }
+}
+
+public class AssetProfileContainer
+{
+    [JsonProperty("sector")]
+    public string Sector { get; set; }
+
+    [JsonProperty("industry")]
+    public string Industry { get; set; }
+
+    [JsonProperty("longBusinessSummary")]
+    public string LongBusinessSummary { get; set; }
+
+    [JsonProperty("website")]
+    public string Website { get; set; }
 }
 
 public class DefaultKeyStatisticsContainer

--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -198,6 +198,27 @@ public class YahooFinanceClient : IYahooFinanceClient
         return new KeyStatistics { SharesOutstanding = stats.SharesOutstanding?.Raw ?? 0 };
     }
 
+    public async Task<CompanyProfile> GetCompanyProfile(string ticker)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ticker);
+        var url = $"{QuoteSummaryBaseUrl}/{Uri.EscapeDataString(ticker)}?modules=assetProfile";
+
+        var content = await SendWithRetry(url);
+        var response = JsonConvert.DeserializeObject<YahooQuoteSummaryResponse>(content);
+
+        var profile = response?.QuoteSummary?.Result?.FirstOrDefault()?.AssetProfile;
+        if (profile == null)
+            return null;
+
+        return new CompanyProfile
+        {
+            Sector = profile.Sector,
+            Industry = profile.Industry,
+            LongBusinessSummary = profile.LongBusinessSummary,
+            Website = profile.Website,
+        };
+    }
+
     // ── Session management (mirrors FINRA's token caching pattern) ──
 
     // Acquires the Yahoo crumb/cookie over a self-managed HttpClient. Exposed as

--- a/tests/Equibles.UnitTests/Yahoo/YahooQuoteSummaryResponseTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooQuoteSummaryResponseTests.cs
@@ -81,6 +81,64 @@ public class YahooQuoteSummaryResponseTests
     }
 
     [Fact]
+    public void Deserialize_AssetProfile_ParsesSectorAndIndustryAndCompanyFields()
+    {
+        // Captured from a real Yahoo quoteSummary?modules=assetProfile response.
+        // Confirms the Newtonsoft attribute mapping picks up sector / industry as well
+        // as the secondary fields the worker uses for the company profile.
+        var json = """
+            {
+              "quoteSummary": {
+                "result": [{
+                  "assetProfile": {
+                    "industry": "Consumer Electronics",
+                    "sector": "Technology",
+                    "longBusinessSummary": "Apple Inc. designs, manufactures, and markets smartphones, personal computers, tablets, wearables, and accessories worldwide.",
+                    "website": "https://www.apple.com"
+                  }
+                }],
+                "error": null
+              }
+            }
+            """;
+
+        var response = JsonConvert.DeserializeObject<YahooQuoteSummaryResponse>(json);
+        var profile = response.QuoteSummary.Result[0].AssetProfile;
+
+        profile.Sector.Should().Be("Technology");
+        profile.Industry.Should().Be("Consumer Electronics");
+        profile.LongBusinessSummary.Should().StartWith("Apple Inc.");
+        profile.Website.Should().Be("https://www.apple.com");
+    }
+
+    [Fact]
+    public void Deserialize_AssetProfileMissingFields_LeavesPropertiesNull()
+    {
+        // Yahoo occasionally omits fields when not provided by the issuer (especially
+        // for non-US listings or ETFs). The container must tolerate missing keys.
+        var json = """
+            {
+              "quoteSummary": {
+                "result": [{
+                  "assetProfile": {
+                    "sector": "Energy"
+                  }
+                }],
+                "error": null
+              }
+            }
+            """;
+
+        var response = JsonConvert.DeserializeObject<YahooQuoteSummaryResponse>(json);
+        var profile = response.QuoteSummary.Result[0].AssetProfile;
+
+        profile.Sector.Should().Be("Energy");
+        profile.Industry.Should().BeNull();
+        profile.LongBusinessSummary.Should().BeNull();
+        profile.Website.Should().BeNull();
+    }
+
+    [Fact]
     public void Deserialize_AllZeroCounts_ParsesSuccessfully()
     {
         var json = """


### PR DESCRIPTION
## Summary

PR 2 of 3 for #1019. Intermediate slice — not the closing one.

Adds `GetCompanyProfile(ticker)` to `IYahooFinanceClient`. The new method requests the existing `quoteSummary` endpoint with the `assetProfile` module and returns `Sector`, `Industry`, `LongBusinessSummary`, and `Website`. Slice 3 will wire this into the price-import worker.

Refs #1019

## Code changes

- `Equibles.Integrations.Yahoo/Models/CompanyProfile.cs` — new return type.
- `Equibles.Integrations.Yahoo/Models/Responses/YahooQuoteSummaryResponse.cs` — adds `AssetProfileContainer` and the matching property on `QuoteSummaryResult` (kept in the existing file to match the per-module-container layout already used for `recommendationTrend` and `defaultKeyStatistics`).
- `Equibles.Integrations.Yahoo/Contracts/IYahooFinanceClient.cs` + `YahooFinanceClient.cs` — `GetCompanyProfile` uses the same retry / session / rate-limit pipeline as the other quoteSummary calls; only the `modules=` value changes.
- `tests/Equibles.UnitTests/Yahoo/YahooQuoteSummaryResponseTests.cs` — two cases: complete payload parses every field; partial payload leaves unknown fields null (Yahoo omits keys for some issuers, especially non-US listings and ETFs).