### PR TITLE
refactor(sec-normalizer): hoist HeadingConversionStep.Execute heading tag to a single replace call

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -33,37 +33,32 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
             if (string.IsNullOrEmpty(combinedText))
                 continue;
 
+            string headingTag = null;
             if (
                 IsPartHeading(combinedText)
                 && AllSiblingsMatch(siblingSpans, s => IsPartHeading(s.TextContent))
             )
-            {
-                ReplaceNodeWithHeading(parent, "h1", doc);
-                processedParents.Add(parent);
-            }
+                headingTag = "h1";
             else if (
                 IsItemHeading(combinedText)
                 && AllSiblingsMatch(siblingSpans, s => IsItemHeading(s.TextContent))
             )
-            {
-                ReplaceNodeWithHeading(parent, "h2", doc);
-                processedParents.Add(parent);
-            }
+                headingTag = "h2";
             else if (
                 AllSiblingsMatch(
                     siblingSpans,
                     s => !IsApart(s) && (IsBoldSpan(s) || IsAllUppercase(s) || IsCenterAligned(s))
                 )
             )
-            {
-                ReplaceNodeWithHeading(parent, "h3", doc);
-                processedParents.Add(parent);
-            }
+                headingTag = "h3";
             else if (AllSiblingsMatch(siblingSpans, s => IsItalicSpan(s) && !IsApart(s)))
-            {
-                ReplaceNodeWithHeading(parent, "h4", doc);
-                processedParents.Add(parent);
-            }
+                headingTag = "h4";
+
+            if (headingTag == null)
+                continue;
+
+            ReplaceNodeWithHeading(parent, headingTag, doc);
+            processedParents.Add(parent);
         }
     }
 


### PR DESCRIPTION
## Summary

- The `Execute` loop in `HeadingConversionStep` had four near-identical if/else branches that each called `ReplaceNodeWithHeading(parent, "h?", doc)` followed by `processedParents.Add(parent)`.
- Hoist the chosen tag into a local and perform the replace + add exactly once after the chain — behavior is unchanged (same predicate order, same arguments, same side effects on a match).

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs` — bind the matched heading tag in the if/else chain, then call `ReplaceNodeWithHeading` and `processedParents.Add` once. `continue` when no tag matched.