### PR TITLE
feat(common-stocks): write Sector + Industry from Yahoo assetProfile

### DIFF
--- a/src/Equibles.CommonStocks.Repositories/SectorRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/SectorRepository.cs
@@ -1,0 +1,10 @@
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Data;
+
+namespace Equibles.CommonStocks.Repositories;
+
+public class SectorRepository : BaseRepository<Sector>
+{
+    public SectorRepository(EquiblesDbContext dbContext)
+        : base(dbContext) { }
+}

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -65,6 +65,7 @@ public class YahooPriceImportService
                 var inserted = await ImportTicker(ticker, commonStockId, today, cancellationToken);
                 totalInserted += inserted;
                 await SyncKeyStatistics(ticker, commonStockId, cancellationToken);
+                await SyncCompanyProfile(ticker, commonStockId, cancellationToken);
             }
             catch (HttpRequestException ex)
             {
@@ -192,6 +193,103 @@ public class YahooPriceImportService
             ticker,
             stats.SharesOutstanding
         );
+    }
+
+    private async Task SyncCompanyProfile(
+        string ticker,
+        Guid commonStockId,
+        CancellationToken cancellationToken
+    )
+    {
+        var profile = await _yahooClient.GetCompanyProfile(ticker);
+        if (profile == null || string.IsNullOrWhiteSpace(profile.Industry))
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var industryRepo = scope.ServiceProvider.GetRequiredService<IndustryRepository>();
+        var sectorRepo = scope.ServiceProvider.GetRequiredService<SectorRepository>();
+
+        // Upsert by case-insensitive name. Yahoo uses a small stable vocabulary, so
+        // collisions are rare and a flat scan over Sector/Industry is fine — both tables
+        // hold tens of rows at steady state. Materialize the lookup once per call.
+        var sectorId = await UpsertSectorIfPresent(sectorRepo, profile.Sector, cancellationToken);
+        var industry = await UpsertIndustry(
+            industryRepo,
+            profile.Industry,
+            sectorId,
+            cancellationToken
+        );
+
+        var stock = await stockRepo.Get(commonStockId);
+        if (stock.IndustryId == industry.Id)
+            return;
+
+        stock.IndustryId = industry.Id;
+        await stockRepo.SaveChanges();
+
+        _logger.LogDebug(
+            "Updated industry for {Ticker}: {Industry} (sector {Sector})",
+            ticker,
+            profile.Industry,
+            profile.Sector ?? "?"
+        );
+    }
+
+    private static async Task<Guid?> UpsertSectorIfPresent(
+        SectorRepository sectorRepo,
+        string sectorName,
+        CancellationToken cancellationToken
+    )
+    {
+        if (string.IsNullOrWhiteSpace(sectorName))
+            return null;
+
+        var existing = await sectorRepo
+            .GetAll()
+            .FirstOrDefaultAsync(s => s.Name.ToLower() == sectorName.ToLower(), cancellationToken);
+        if (existing != null)
+            return existing.Id;
+
+        var sector = new Equibles.CommonStocks.Data.Models.Taxonomies.Sector { Name = sectorName };
+        sectorRepo.Add(sector);
+        await sectorRepo.SaveChanges();
+        return sector.Id;
+    }
+
+    private static async Task<Equibles.CommonStocks.Data.Models.Taxonomies.Industry> UpsertIndustry(
+        IndustryRepository industryRepo,
+        string industryName,
+        Guid? sectorId,
+        CancellationToken cancellationToken
+    )
+    {
+        var existing = await industryRepo
+            .GetAll()
+            .FirstOrDefaultAsync(
+                i => i.Name.ToLower() == industryName.ToLower(),
+                cancellationToken
+            );
+        if (existing != null)
+        {
+            // Backfill the sector link if it was missing — newly-imported industries that
+            // pre-dated the Sector taxonomy would otherwise stay unlinked.
+            if (sectorId.HasValue && existing.SectorId != sectorId)
+            {
+                existing.SectorId = sectorId;
+                await industryRepo.SaveChanges();
+            }
+            return existing;
+        }
+
+        var industry = new Equibles.CommonStocks.Data.Models.Taxonomies.Industry
+        {
+            Name = industryName,
+            SectorId = sectorId,
+        };
+        industryRepo.Add(industry);
+        await industryRepo.SaveChanges();
+        return industry;
     }
 
     private async Task<DateOnly> GetSyncStartDate(

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileTests.cs
@@ -1,0 +1,191 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Yahoo.Contracts;
+using Equibles.Integrations.Yahoo.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Worker;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.HostedService.Services;
+using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Yahoo;
+
+/// <summary>
+/// Pins <c>YahooPriceImportService.SyncCompanyProfile</c>. Yahoo's assetProfile
+/// payload feeds the Sector + Industry upsert and links the CommonStock to the
+/// matching Industry row. Each fact runs end-to-end through the service's
+/// scope-resolved repositories.
+/// </summary>
+public class YahooPriceImportServiceCompanyProfileTests : IDisposable
+{
+    private readonly EquiblesDbContext _dbContext;
+    private readonly CommonStockRepository _stockRepo;
+    private readonly IndustryRepository _industryRepo;
+    private readonly SectorRepository _sectorRepo;
+    private readonly IYahooFinanceClient _yahooClient;
+    private readonly YahooPriceImportService _service;
+
+    public YahooPriceImportServiceCompanyProfileTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new YahooModuleConfiguration()
+        );
+        _stockRepo = new CommonStockRepository(_dbContext);
+        _industryRepo = new IndustryRepository(_dbContext);
+        _sectorRepo = new SectorRepository(_dbContext);
+        var priceRepo = new DailyStockPriceRepository(_dbContext);
+
+        _yahooClient = Substitute.For<IYahooFinanceClient>();
+        var errorReporter = Substitute.For<ErrorReporter>(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(DailyStockPriceRepository), priceRepo),
+            (typeof(CommonStockRepository), _stockRepo),
+            (typeof(IndustryRepository), _industryRepo),
+            (typeof(SectorRepository), _sectorRepo)
+        );
+
+        _service = new YahooPriceImportService(
+            scopeFactory,
+            Substitute.For<ILogger<YahooPriceImportService>>(),
+            _yahooClient,
+            new TickerMapService(scopeFactory),
+            errorReporter,
+            Options.Create(new WorkerOptions())
+        );
+
+        _yahooClient
+            .GetHistoricalPrices(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns([]);
+        _yahooClient.GetKeyStatistics(Arg.Any<string>()).Returns((KeyStatistics)null);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task Import_FirstRun_CreatesSectorIndustryAndLinksToStock()
+    {
+        var stock = SeedStock("AAPL");
+        _yahooClient
+            .GetCompanyProfile("AAPL")
+            .Returns(
+                new CompanyProfile { Sector = "Technology", Industry = "Consumer Electronics" }
+            );
+
+        await _service.Import(CancellationToken.None);
+
+        var sectors = _sectorRepo.GetAll().ToList();
+        var industries = _industryRepo.GetAll().ToList();
+        sectors.Should().ContainSingle().Which.Name.Should().Be("Technology");
+        industries.Should().ContainSingle().Which.Name.Should().Be("Consumer Electronics");
+        industries[0].SectorId.Should().Be(sectors[0].Id);
+
+        var refreshed = _stockRepo.GetAll().Single(s => s.Id == stock.Id);
+        refreshed.IndustryId.Should().Be(industries[0].Id);
+    }
+
+    [Fact]
+    public async Task Import_SecondRun_DoesNotDuplicateSectorOrIndustry()
+    {
+        // First run with AAPL → seeds rows. Second run with MSFT in the same sector +
+        // industry should reuse the existing rows.
+        SeedStock("AAPL");
+        _yahooClient
+            .GetCompanyProfile("AAPL")
+            .Returns(new CompanyProfile { Sector = "Technology", Industry = "Software" });
+        await _service.Import(CancellationToken.None);
+
+        SeedStock("MSFT");
+        _yahooClient
+            .GetCompanyProfile("MSFT")
+            .Returns(new CompanyProfile { Sector = "Technology", Industry = "Software" });
+        await _service.Import(CancellationToken.None);
+
+        _sectorRepo.GetAll().Count().Should().Be(1);
+        _industryRepo.GetAll().Count().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Import_SectorNameCaseDiffers_TreatedAsSameRow()
+    {
+        // Yahoo has been observed to lower-case sectors occasionally for some issuers.
+        // The upsert must be case-insensitive so the taxonomy stays canonical.
+        SeedStock("STOCK1");
+        _yahooClient
+            .GetCompanyProfile("STOCK1")
+            .Returns(new CompanyProfile { Sector = "ENERGY", Industry = "Oil & Gas E&P" });
+        await _service.Import(CancellationToken.None);
+
+        SeedStock("STOCK2");
+        _yahooClient
+            .GetCompanyProfile("STOCK2")
+            .Returns(new CompanyProfile { Sector = "energy", Industry = "Oil & Gas Midstream" });
+        await _service.Import(CancellationToken.None);
+
+        _sectorRepo.GetAll().Count().Should().Be(1);
+        _industryRepo.GetAll().Count().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Import_NullProfile_LeavesStockIndustryUntouched()
+    {
+        var stock = SeedStock("UNKNOWN");
+        _yahooClient.GetCompanyProfile("UNKNOWN").Returns((CompanyProfile)null);
+
+        await _service.Import(CancellationToken.None);
+
+        var refreshed = _stockRepo.GetAll().Single(s => s.Id == stock.Id);
+        refreshed.IndustryId.Should().BeNull();
+        _sectorRepo.GetAll().Should().BeEmpty();
+        _industryRepo.GetAll().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Import_IndustryAlreadyExistsWithoutSector_BackfillsTheSectorLink()
+    {
+        // Existing industry rows that pre-date the Sector taxonomy: the worker must
+        // populate their SectorId when a fresh profile carries the link.
+        var sectorless = new Industry { Name = "Semiconductors" };
+        _industryRepo.Add(sectorless);
+        await _industryRepo.SaveChanges();
+
+        SeedStock("NVDA");
+        _yahooClient
+            .GetCompanyProfile("NVDA")
+            .Returns(new CompanyProfile { Sector = "Technology", Industry = "Semiconductors" });
+
+        await _service.Import(CancellationToken.None);
+
+        var refreshed = _industryRepo.GetAll().Single(i => i.Id == sectorless.Id);
+        refreshed.SectorId.Should().NotBeNull();
+        _sectorRepo.GetAll().Single().Name.Should().Be("Technology");
+    }
+
+    private CommonStock SeedStock(string ticker)
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = $"{ticker} Inc.",
+            Cik = $"CIK-{ticker}",
+        };
+        _stockRepo.Add(stock);
+        _stockRepo.SaveChanges().GetAwaiter().GetResult();
+        return stock;
+    }
+}


### PR DESCRIPTION
## Summary

PR 3 of 3 for #1019 — **closing slice**.

Wires the Yahoo company-profile parsing (PR #1157) into the daily Yahoo worker. Each ticker's profile feeds a case-insensitive upsert into the `Sector` and `Industry` taxonomies; `CommonStock.IndustryId` is set only when it actually changes — same conservative write pattern as `SharesOutStanding`.

No backfill job: the existing worker iterates every tracked ticker daily, so the field fills in over the first cycle after deploy.

Closes #1019

## Code changes

- `Equibles.CommonStocks.Repositories/SectorRepository.cs` — minimal `BaseRepository<Sector>` so the upsert stays inside the repository layer.
- `Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs` — `SyncCompanyProfile` resolves repositories per scope and runs after the existing `SyncKeyStatistics` call. Upsert is case-insensitive on `Name`; a fresh profile with a known `Industry` but a previously-missing `SectorId` backfills the FK link.
- `tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileTests.cs` — five cases: first-run seeds Sector + Industry + links stock; second run on a different ticker reuses both rows; case-only differences collapse to the same Sector row; null profile leaves the stock and taxonomy untouched; existing Industry without a SectorId is backfilled.