### PR TITLE
docs(readme): list Congressional Trading under MCP Server tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The MCP server exposes financial data tools for AI assistants (Claude, ChatGPT, 
 
 - **Institutional Holdings** — Top holders, ownership history, institution portfolios, institution search
 - **Insider Trading** — Insider transactions, ownership summary, insider search
+- **Congressional Trading** — Trades for a ticker, trades by one member, member search
 - **SEC Documents** — Full-text search, semantic search, document browsing, keyword search within filings
 - **Economic Indicators** — FRED data lookup, latest macro snapshot, indicator search across categories
 - **Futures Positioning** — COT positioning data, latest snapshot across all contracts, contract search


### PR DESCRIPTION
## Summary

- Lane: **README — drift fix**.
- The README's "What's Included" table lists Congressional Trading as one of the supported domains, but the MCP Server bullet list below omits it. Add the missing category bullet so the two lists agree.

## Code changes

- `README.md` — add a `**Congressional Trading** — Trades for a ticker, trades by one member, member search` bullet between Insider Trading and SEC Documents under the MCP Server section.