### PR TITLE
refactor(sec): extract ParseInvariantDateOr helper in MapToFilingData

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -693,26 +693,8 @@ public class SecEdgarClient : ISecEdgarClient
                 {
                     Cik = cik,
                     AccessionNumber = accessionNumber,
-                    // SEC submissions feed dates are ISO yyyy-MM-dd. Parse them
-                    // culture-independently — under a non-Gregorian host culture
-                    // (e.g. ar-SA Umm al-Qura) culture-sensitive TryParse fails
-                    // and every filing would be stamped DateOnly.MinValue.
-                    FilingDate = DateOnly.TryParse(
-                        recent.FilingDate[i],
-                        System.Globalization.CultureInfo.InvariantCulture,
-                        System.Globalization.DateTimeStyles.None,
-                        out var fd
-                    )
-                        ? fd
-                        : DateOnly.MinValue,
-                    ReportDate = DateOnly.TryParse(
-                        recent.ReportDate[i],
-                        System.Globalization.CultureInfo.InvariantCulture,
-                        System.Globalization.DateTimeStyles.None,
-                        out var rd
-                    )
-                        ? rd
-                        : DateOnly.MinValue,
+                    FilingDate = ParseInvariantDateOr(recent.FilingDate[i], DateOnly.MinValue),
+                    ReportDate = ParseInvariantDateOr(recent.ReportDate[i], DateOnly.MinValue),
                     Form = recent.Form[i],
                     PrimaryDocument = recent.PrimaryDocument[i],
                     Description = recent.PrimaryDocDescription[i],
@@ -723,6 +705,19 @@ public class SecEdgarClient : ISecEdgarClient
 
         return filings;
     }
+
+    // SEC submissions feed dates are ISO yyyy-MM-dd. Parse them culture-independently —
+    // under a non-Gregorian host culture (e.g. ar-SA Umm al-Qura) culture-sensitive
+    // TryParse fails and every filing would be stamped with the fallback.
+    private static DateOnly ParseInvariantDateOr(string text, DateOnly fallback) =>
+        DateOnly.TryParse(
+            text,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None,
+            out var parsed
+        )
+            ? parsed
+            : fallback;
 
     private static List<FilingData> FilterFilings(
         List<FilingData> filings,


### PR DESCRIPTION
## Summary

- Collapse two identical `DateOnly.TryParse` blocks (`FilingDate` and `ReportDate`) in `MapToFilingData` into a single private static helper `ParseInvariantDateOr`.
- Mirrors the `ParseDateOr` pattern already used in `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` (#1108).
- Behavior-preserving: same `DateOnly.TryParse(text, InvariantCulture, DateTimeStyles.None, out _)` call, same `DateOnly.MinValue` fallback at both call sites; the WHY-comment about Hijri-culture parsing is preserved next to the helper.

## Code changes

- ``src/Equibles.Integrations.Sec/SecEdgarClient.cs`` — extract `ParseInvariantDateOr(string text, DateOnly fallback)` from the duplicated `FilingDate` / `ReportDate` parse blocks; net -5 lines.