### PR TITLE
refactor(sec): drop narration comments in CompanySyncService

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -47,7 +47,6 @@ public class CompanySyncService : ICompanySyncService
                 secCompanies.Count
             );
 
-            // Filter by configured tickers if specified
             if (_workerOptions.TickersToSync?.Count > 0)
             {
                 secCompanies = secCompanies
@@ -67,7 +66,6 @@ public class CompanySyncService : ICompanySyncService
             var commonStockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
             var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
 
-            // Get all CIKs from SEC companies
             var secCiks = secCompanies.Select(c => c.Cik).ToHashSet();
 
             // Load every existing stock so we can detect subsidiaries already attached
@@ -200,7 +198,6 @@ public class CompanySyncService : ICompanySyncService
             state.PrimaryTickerToStock.TryGetValue(primaryTicker, out var tickerHolder);
             if (tickerHolder != null && !state.SecCiks.Contains(tickerHolder.Cik))
             {
-                // Old holder is no longer in SEC data - remove it
                 try
                 {
                     state.CommonStockRepository.Delete(tickerHolder);
@@ -260,7 +257,6 @@ public class CompanySyncService : ICompanySyncService
             existingStock.SecondaryTickers = secondaryTickers;
             await state.CommonStockManager.Update(existingStock);
 
-            // Update tracking sets on success
             if (oldTicker != primaryTicker)
             {
                 state.ExistingPrimaryTickers.Remove(oldTicker);
@@ -336,7 +332,6 @@ public class CompanySyncService : ICompanySyncService
             return;
         }
 
-        // Old company no longer in SEC data - replace it
         try
         {
             state.CommonStockRepository.Delete(obsoleteStock);


### PR DESCRIPTION
## Summary

- Drop five comments in `CompanySyncService` that just restated the immediately-following code (filter step, CIK-set construction, two "remove/replace" section labels, tracking-set update label).
- Same hygiene pass as #1134 (FileManager.SaveFile narration deletions). All WHY-comments — subsidiary loading scope, primary-vs-secondary ticker semantics, collision routing, rollback/detach reasoning — are preserved.

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — 5 narration comments removed; no code changes, no signature changes.