### PR TITLE
refactor(cboe-client): extract EnumerateCsvRows iterator from ParsePutCallCsv and ParseVixCsv

### DIFF
--- a/src/Equibles.Integrations.Cboe/CboeClient.cs
+++ b/src/Equibles.Integrations.Cboe/CboeClient.cs
@@ -105,20 +105,8 @@ public class CboeClient : ICboeClient
     private static List<CboePutCallRecord> ParsePutCallCsv(string content)
     {
         var records = new List<CboePutCallRecord>();
-        using var reader = new StringReader(content);
-
-        // Skip header line
-        reader.ReadLine();
-
-        while (reader.ReadLine() is { } line)
+        foreach (var fields in EnumerateCsvRows(content, minFields: 5))
         {
-            if (string.IsNullOrWhiteSpace(line))
-                continue;
-
-            var fields = line.Split(',');
-            if (fields.Length < 5)
-                continue;
-
             if (
                 !DateOnly.TryParseExact(
                     fields[0].Trim(),
@@ -141,27 +129,14 @@ public class CboeClient : ICboeClient
                 }
             );
         }
-
         return records;
     }
 
     private static List<CboeVixRecord> ParseVixCsv(string content)
     {
         var records = new List<CboeVixRecord>();
-        using var reader = new StringReader(content);
-
-        // Skip header line
-        reader.ReadLine();
-
-        while (reader.ReadLine() is { } line)
+        foreach (var fields in EnumerateCsvRows(content, minFields: 5))
         {
-            if (string.IsNullOrWhiteSpace(line))
-                continue;
-
-            var fields = line.Split(',');
-            if (fields.Length < 5)
-                continue;
-
             if (
                 !DateOnly.TryParseExact(
                     fields[0].Trim(),
@@ -193,8 +168,26 @@ public class CboeClient : ICboeClient
                 }
             );
         }
-
         return records;
+    }
+
+    // First line is the header; subsequent blank or short rows are skipped.
+    private static IEnumerable<string[]> EnumerateCsvRows(string content, int minFields)
+    {
+        using var reader = new StringReader(content);
+        reader.ReadLine();
+
+        while (reader.ReadLine() is { } line)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            var fields = line.Split(',');
+            if (fields.Length < minFields)
+                continue;
+
+            yield return fields;
+        }
     }
 
     private static long? ParseLong(string value)


### PR DESCRIPTION
## Summary

- \`ParsePutCallCsv\` and \`ParseVixCsv\` duplicated the same per-line boilerplate: open \`StringReader\`, skip the header, \`ReadLine\` loop, blank-line skip, \`Split(',')\`, minimum-fields guard. Only the per-field decimal/long parsing and the record shape differed.
- Lift the shared iteration into a private \`EnumerateCsvRows(content, minFields)\` iterator that \`yield return\`s validated \`string[]\` rows. Each parser keeps its own schema-specific date / decimal \`TryParse\`-and-continue logic inline, so identical CSV inputs produce identical records in the same order.
- Net 28 lines deleted, 21 added. All 10 Cboe unit + 53 Cboe integration tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.Integrations.Cboe/CboeClient.cs\` — add private \`EnumerateCsvRows\` iterator helper; rewrite \`ParsePutCallCsv\` and \`ParseVixCsv\` to iterate over its yielded field arrays instead of re-opening a \`StringReader\` and re-implementing the skip-header / blank-line / min-fields guard each time.