### PR TITLE
feat(common-stocks): parse market cap from Yahoo summaryDetail

### DIFF
--- a/src/Equibles.Integrations.Yahoo/Models/KeyStatistics.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/KeyStatistics.cs
@@ -3,4 +3,6 @@ namespace Equibles.Integrations.Yahoo.Models;
 public class KeyStatistics
 {
     public long SharesOutstanding { get; set; }
+
+    public double MarketCapitalization { get; set; }
 }

--- a/src/Equibles.Integrations.Yahoo/Models/Responses/YahooQuoteSummaryResponse.cs
+++ b/src/Equibles.Integrations.Yahoo/Models/Responses/YahooQuoteSummaryResponse.cs
@@ -28,6 +28,15 @@ public class QuoteSummaryResult
 
     [JsonProperty("assetProfile")]
     public AssetProfileContainer AssetProfile { get; set; }
+
+    [JsonProperty("summaryDetail")]
+    public SummaryDetailContainer SummaryDetail { get; set; }
+}
+
+public class SummaryDetailContainer
+{
+    [JsonProperty("marketCap")]
+    public YahooRawValue MarketCap { get; set; }
 }
 
 public class AssetProfileContainer

--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -185,17 +185,27 @@ public class YahooFinanceClient : IYahooFinanceClient
     public async Task<KeyStatistics> GetKeyStatistics(string ticker)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ticker);
+        // Request defaultKeyStatistics + summaryDetail together — Yahoo returns both
+        // modules in a single HTTP round-trip when separated by a comma, so this costs
+        // nothing extra over the previous shares-only call.
         var url =
-            $"{QuoteSummaryBaseUrl}/{Uri.EscapeDataString(ticker)}?modules=defaultKeyStatistics";
+            $"{QuoteSummaryBaseUrl}/{Uri.EscapeDataString(ticker)}"
+            + "?modules=defaultKeyStatistics,summaryDetail";
 
         var content = await SendWithRetry(url);
         var response = JsonConvert.DeserializeObject<YahooQuoteSummaryResponse>(content);
 
-        var stats = response?.QuoteSummary?.Result?.FirstOrDefault()?.DefaultKeyStatistics;
-        if (stats == null)
+        var result = response?.QuoteSummary?.Result?.FirstOrDefault();
+        if (result == null)
+            return null;
+        if (result.DefaultKeyStatistics == null && result.SummaryDetail == null)
             return null;
 
-        return new KeyStatistics { SharesOutstanding = stats.SharesOutstanding?.Raw ?? 0 };
+        return new KeyStatistics
+        {
+            SharesOutstanding = result.DefaultKeyStatistics?.SharesOutstanding?.Raw ?? 0,
+            MarketCapitalization = result.SummaryDetail?.MarketCap?.Raw ?? 0,
+        };
     }
 
     public async Task<CompanyProfile> GetCompanyProfile(string ticker)

--- a/tests/Equibles.UnitTests/Yahoo/YahooQuoteSummaryResponseTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooQuoteSummaryResponseTests.cs
@@ -81,6 +81,52 @@ public class YahooQuoteSummaryResponseTests
     }
 
     [Fact]
+    public void Deserialize_SummaryDetailMarketCap_ParsesRawValue()
+    {
+        // Captured shape of a real summaryDetail payload: marketCap is a Yahoo "raw"
+        // value object. The container reads `raw` as a long so trillion-dollar mega-caps
+        // round-trip without overflow.
+        var json = """
+            {
+              "quoteSummary": {
+                "result": [{
+                  "summaryDetail": {
+                    "marketCap": { "raw": 2950000000000, "fmt": "2.95T", "longFmt": "2,950,000,000,000" }
+                  }
+                }],
+                "error": null
+              }
+            }
+            """;
+
+        var response = JsonConvert.DeserializeObject<YahooQuoteSummaryResponse>(json);
+        var detail = response.QuoteSummary.Result[0].SummaryDetail;
+
+        detail.MarketCap.Raw.Should().Be(2_950_000_000_000L);
+    }
+
+    [Fact]
+    public void Deserialize_SummaryDetailMissingMarketCap_LeavesPropertyNull()
+    {
+        // Yahoo omits keys for issuers without coverage (some ETFs, foreign listings);
+        // the container must tolerate the missing marketCap field without throwing.
+        var json = """
+            {
+              "quoteSummary": {
+                "result": [{ "summaryDetail": { } }],
+                "error": null
+              }
+            }
+            """;
+
+        var response = JsonConvert.DeserializeObject<YahooQuoteSummaryResponse>(json);
+        var detail = response.QuoteSummary.Result[0].SummaryDetail;
+
+        detail.Should().NotBeNull();
+        detail.MarketCap.Should().BeNull();
+    }
+
+    [Fact]
     public void Deserialize_AssetProfile_ParsesSectorAndIndustryAndCompanyFields()
     {
         // Captured from a real Yahoo quoteSummary?modules=assetProfile response.


### PR DESCRIPTION
## Summary

PR 1 of 2 for #1020. Intermediate slice — not the closing one.

Extends `KeyStatistics` with a `MarketCapitalization` field and requests `defaultKeyStatistics + summaryDetail` together so the existing daily key-stats call returns both shares outstanding and market cap in a single HTTP round-trip. Slice 2 will wire the worker write.

Refs #1020

## Code changes

- `Equibles.Integrations.Yahoo/Models/KeyStatistics.cs` — adds `MarketCapitalization` (double, matching `CommonStock.MarketCapitalization`'s shape).
- `Equibles.Integrations.Yahoo/Models/Responses/YahooQuoteSummaryResponse.cs` — new `SummaryDetailContainer` with `marketCap` mapped through the existing `YahooRawValue`; the new container is wired onto `QuoteSummaryResult`.
- `Equibles.Integrations.Yahoo/YahooFinanceClient.cs` — `GetKeyStatistics` URL now requests `defaultKeyStatistics,summaryDetail`. Returns `null` only when both modules are missing; otherwise maps each module's value independently (a partial payload still surfaces what Yahoo did return).
- `tests/Equibles.UnitTests/Yahoo/YahooQuoteSummaryResponseTests.cs` — two cases: full `marketCap.raw` payload parses; missing `marketCap` leaves the property null.