### PR TITLE
feat(common-stocks): write market cap from Yahoo summaryDetail

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -175,23 +175,44 @@ public class YahooPriceImportService
     )
     {
         var stats = await _yahooClient.GetKeyStatistics(ticker);
-        if (stats == null || stats.SharesOutstanding == 0)
+        if (stats == null)
+            return;
+        // Nothing to write if Yahoo returned both fields as zero (missing/unknown).
+        if (stats.SharesOutstanding == 0 && stats.MarketCapitalization == 0)
             return;
 
         using var scope = _scopeFactory.CreateScope();
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
 
         var stock = await stockRepo.Get(commonStockId);
-        if (stock.SharesOutStanding == stats.SharesOutstanding)
-            return;
 
-        stock.SharesOutStanding = stats.SharesOutstanding;
+        // Per-field conservative writes: only update on actual change, and never
+        // overwrite a known value with 0 (treated as Yahoo "unknown" by the rest of
+        // the codebase).
+        var changed = false;
+        if (stats.SharesOutstanding != 0 && stock.SharesOutStanding != stats.SharesOutstanding)
+        {
+            stock.SharesOutStanding = stats.SharesOutstanding;
+            changed = true;
+        }
+        if (
+            stats.MarketCapitalization != 0
+            && stock.MarketCapitalization != stats.MarketCapitalization
+        )
+        {
+            stock.MarketCapitalization = stats.MarketCapitalization;
+            changed = true;
+        }
+
+        if (!changed)
+            return;
         await stockRepo.SaveChanges();
 
         _logger.LogDebug(
-            "Updated shares outstanding for {Ticker}: {Shares}",
+            "Updated key stats for {Ticker}: shares={Shares} marketCap={MarketCap}",
             ticker,
-            stats.SharesOutstanding
+            stats.SharesOutstanding,
+            stats.MarketCapitalization
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -560,4 +560,75 @@ public class YahooPriceImportServiceTests : IDisposable
         var updated = _stockRepo.GetAll().Single(s => s.Ticker == "KST");
         updated.SharesOutStanding.Should().Be(5_000_000);
     }
+
+    [Fact]
+    public async Task Import_KeyStatisticsMarketCapDiffers_UpdatesStockMarketCapitalization()
+    {
+        var stock = CreateStock("MKT", "MarketCap Co.");
+        await SeedStocks(stock);
+
+        _yahooClient
+            .GetHistoricalPrices("MKT", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns([]);
+        _yahooClient
+            .GetKeyStatistics("MKT")
+            .Returns(
+                new KeyStatistics
+                {
+                    SharesOutstanding = 10_000_000,
+                    MarketCapitalization = 1_500_000_000d,
+                }
+            );
+
+        await _service.Import(CancellationToken.None);
+
+        var updated = _stockRepo.GetAll().Single(s => s.Ticker == "MKT");
+        updated.MarketCapitalization.Should().Be(1_500_000_000d);
+        updated.SharesOutStanding.Should().Be(10_000_000);
+    }
+
+    [Fact]
+    public async Task Import_KeyStatisticsMarketCapZero_LeavesExistingMarketCapUntouched()
+    {
+        // Yahoo returns 0 when market cap is unknown — the worker must not overwrite a
+        // previously-known value with that sentinel.
+        var stock = CreateStock("MKT0", "MarketCap Zero Co.");
+        stock.MarketCapitalization = 9_876_543_210d;
+        await SeedStocks(stock);
+
+        _yahooClient
+            .GetHistoricalPrices("MKT0", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns([]);
+        _yahooClient
+            .GetKeyStatistics("MKT0")
+            .Returns(new KeyStatistics { SharesOutstanding = 42, MarketCapitalization = 0 });
+
+        await _service.Import(CancellationToken.None);
+
+        var updated = _stockRepo.GetAll().Single(s => s.Ticker == "MKT0");
+        updated.MarketCapitalization.Should().Be(9_876_543_210d);
+        updated.SharesOutStanding.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task Import_KeyStatisticsBothZero_LeavesStockUntouched()
+    {
+        var stock = CreateStock("ZERO", "All Zero Co.");
+        stock.SharesOutStanding = 100;
+        stock.MarketCapitalization = 200d;
+        await SeedStocks(stock);
+
+        _yahooClient
+            .GetHistoricalPrices("ZERO", Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns([]);
+        _yahooClient
+            .GetKeyStatistics("ZERO")
+            .Returns(new KeyStatistics { SharesOutstanding = 0, MarketCapitalization = 0 });
+
+        await _service.Import(CancellationToken.None);
+
+        var updated = _stockRepo.GetAll().Single(s => s.Ticker == "ZERO");
+        updated.SharesOutStanding.Should().Be(100);
+        updated.MarketCapitalization.Should().Be(200d);
+    }
 }


### PR DESCRIPTION
## Summary

PR 2 of 2 for #1020 — **closing slice**.

Wires the slice-1 `KeyStatistics.MarketCapitalization` field (PR #1166) into the daily Yahoo worker. `SyncKeyStatistics` now writes both `SharesOutStanding` and `MarketCapitalization` in the same scope-resolved save, only on actual change, and never overwriting a known value with `0`.

Closes #1020

## Code changes

- `Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs` — `SyncKeyStatistics` refactored to per-field conservative writes: zero is Yahoo's "unknown" sentinel, so the worker keeps the previous stock value intact when Yahoo returns `0` for a field. Both-zero payload skips `SaveChanges` entirely. Single log line for the combined change.
- `tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs` — three new cases: market-cap write on change, market-cap zero leaves the stored value untouched, both-zero payload no-ops. Existing shares-only test stays green.