### PR TITLE
docs(readme): list Stock Prices under MCP Server tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ The MCP server exposes financial data tools for AI assistants (Claude, ChatGPT, 
 - **Congressional Trading** — Trades for a ticker, trades by one member, member search
 - **SEC Documents** — Full-text search, semantic search, document browsing, keyword search within filings
 - **Economic Indicators** — FRED data lookup, latest macro snapshot, indicator search across categories
+- **Stock Prices** — Daily OHLCV history with adjusted close, plus latest close across one or more tickers
 - **Futures Positioning** — COT positioning data, latest snapshot across all contracts, contract search
 - **Market Indicators** — VIX historical data, put/call ratios by type (equity, index, total, VIX, ETP)
 


### PR DESCRIPTION
## Summary

- Lane: **README — drift fix**.
- The README's "What's Included" table lists Stock Prices as a supported domain and the MCP catalog exposes `GetStockPrices` + `GetLatestPrices`, but the MCP Server bullet list in README didn't mention them. Add the missing bullet so the two lists agree.

## Code changes

- `README.md` — add a `**Stock Prices**` bullet between Economic Indicators and Futures Positioning under the MCP Server section (daily OHLCV with adjusted close + latest close across one or more tickers).