### PR TITLE
refactor(sec-sync): collapse five duplicated ErrorReporter.Report calls into ReportError helper

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -226,13 +226,7 @@ public class CompanySyncService : ICompanySyncService
                         "Error removing obsolete company for ticker {Ticker}",
                         primaryTicker
                     );
-                    await _errorReporter.Report(
-                        ErrorSource.DocumentScraper,
-                        "CompanySync.RemoveObsolete",
-                        ex.Message,
-                        ex.StackTrace,
-                        $"ticker: {primaryTicker}"
-                    );
+                    await ReportError("CompanySync.RemoveObsolete", ex, $"ticker: {primaryTicker}");
                     return;
                 }
             }
@@ -293,11 +287,9 @@ public class CompanySyncService : ICompanySyncService
                 secCompany.Name,
                 secCompany.Cik
             );
-            await _errorReporter.Report(
-                ErrorSource.DocumentScraper,
+            await ReportError(
                 "CompanySync.UpdateStock",
-                ex.Message,
-                ex.StackTrace,
+                ex,
                 $"ticker: {primaryTicker}, cik: {secCompany.Cik}"
             );
         }
@@ -379,11 +371,9 @@ public class CompanySyncService : ICompanySyncService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error replacing company for ticker {Ticker}", primaryTicker);
-            await _errorReporter.Report(
-                ErrorSource.DocumentScraper,
+            await ReportError(
                 "CompanySync.ReplaceStock",
-                ex.Message,
-                ex.StackTrace,
+                ex,
                 $"ticker: {primaryTicker}, cik: {secCompany.Cik}"
             );
         }
@@ -439,11 +429,9 @@ public class CompanySyncService : ICompanySyncService
                 secCompany.Name,
                 secCompany.Cik
             );
-            await _errorReporter.Report(
-                ErrorSource.DocumentScraper,
+            await ReportError(
                 "CompanySync.CreateStock",
-                ex.Message,
-                ex.StackTrace,
+                ex,
                 $"ticker: {primaryTicker}, cik: {secCompany.Cik}"
             );
         }
@@ -532,11 +520,9 @@ public class CompanySyncService : ICompanySyncService
                 incoming.Cik,
                 incumbent.Cik
             );
-            await _errorReporter.Report(
-                ErrorSource.DocumentScraper,
+            await ReportError(
                 "CompanySync.ResolveTickerCollision",
-                ex.Message,
-                ex.StackTrace,
+                ex,
                 $"ticker: {ticker}, incoming: {incoming.Cik}, incumbent: {incumbent.Cik}"
             );
         }
@@ -621,6 +607,15 @@ public class CompanySyncService : ICompanySyncService
         }
         return secondaryCikToParent;
     }
+
+    private Task ReportError(string operation, Exception ex, string context) =>
+        _errorReporter.Report(
+            ErrorSource.DocumentScraper,
+            operation,
+            ex.Message,
+            ex.StackTrace,
+            context
+        );
 
     private class StockSyncState
     {


### PR DESCRIPTION
## Summary

- Five catch blocks in `CompanySyncService` each invoked `_errorReporter.Report(ErrorSource.DocumentScraper, "CompanySync.X", ex.Message, ex.StackTrace, "...context...")` with the same constant arguments and only the operation name and context string varying.
- Extracted a private `ReportError(operation, ex, context)` helper that forwards those constants verbatim, collapsing the five 6-line invocations into one-liners. Same arguments, same order, same awaited semantics — no behavior change.

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — added a private `ReportError` helper near the other private helpers; updated five call sites (`CompanySync.RemoveObsolete`, `CompanySync.UpdateStock`, `CompanySync.ReplaceStock`, `CompanySync.CreateStock`, `CompanySync.ResolveTickerCollision`) to use it.