### PR TITLE
refactor(holdings-mcp): extract GetReportDatesByHolder helper

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -217,12 +217,7 @@ public class InstitutionalHoldingsTools
                 }
                 else
                 {
-                    var latestDate = await _holdingRepository
-                        .GetHistoryByHolder(holder)
-                        .Select(h => h.ReportDate)
-                        .Distinct()
-                        .OrderByDescending(d => d)
-                        .FirstOrDefaultAsync();
+                    var latestDate = await GetReportDatesByHolder(holder).FirstOrDefaultAsync();
 
                     if (latestDate == default)
                         return $"No holdings data for {holder.Name}.";
@@ -635,12 +630,7 @@ public class InstitutionalHoldingsTools
                 if (holder == null)
                     return $"No institution found matching '{institutionName}'.";
 
-                var reportDates = await _holdingRepository
-                    .GetHistoryByHolder(holder)
-                    .Select(h => h.ReportDate)
-                    .Distinct()
-                    .OrderByDescending(d => d)
-                    .ToListAsync();
+                var reportDates = await GetReportDatesByHolder(holder).ToListAsync();
                 if (reportDates.Count == 0)
                     return $"No 13F holdings reported by {holder.Name}.";
 
@@ -719,12 +709,7 @@ public class InstitutionalHoldingsTools
                 if (holder == null)
                     return $"No institution found matching '{institutionName}'.";
 
-                var reportDates = await _holdingRepository
-                    .GetHistoryByHolder(holder)
-                    .Select(h => h.ReportDate)
-                    .Distinct()
-                    .OrderByDescending(d => d)
-                    .ToListAsync();
+                var reportDates = await GetReportDatesByHolder(holder).ToListAsync();
                 if (reportDates.Count == 0)
                     return $"No 13F holdings reported by {holder.Name}.";
 
@@ -803,12 +788,7 @@ public class InstitutionalHoldingsTools
                 if (holder == null)
                     return $"No institution found matching '{institutionName}'.";
 
-                var reportDates = await _holdingRepository
-                    .GetHistoryByHolder(holder)
-                    .Select(h => h.ReportDate)
-                    .Distinct()
-                    .OrderByDescending(d => d)
-                    .ToListAsync();
+                var reportDates = await GetReportDatesByHolder(holder).ToListAsync();
                 if (reportDates.Count < 2)
                     return $"{holder.Name} has fewer than two reported quarters — no diff available.";
 
@@ -1050,12 +1030,7 @@ public class InstitutionalHoldingsTools
                 var perHolderDates = new List<List<DateOnly>>();
                 foreach (var holder in holders)
                 {
-                    var dates = await _holdingRepository
-                        .GetHistoryByHolder(holder)
-                        .Select(h => h.ReportDate)
-                        .Distinct()
-                        .OrderByDescending(d => d)
-                        .ToListAsync();
+                    var dates = await GetReportDatesByHolder(holder).ToListAsync();
                     perHolderDates.Add(dates);
                 }
                 var common = perHolderDates
@@ -1139,6 +1114,13 @@ public class InstitutionalHoldingsTools
 
     private Task<InstitutionalHolder> FindHolderByName(string name) =>
         _holderRepository.Search(name ?? string.Empty).OrderBy(h => h.Name).FirstOrDefaultAsync();
+
+    private IQueryable<DateOnly> GetReportDatesByHolder(InstitutionalHolder holder) =>
+        _holdingRepository
+            .GetHistoryByHolder(holder)
+            .Select(h => h.ReportDate)
+            .Distinct()
+            .OrderByDescending(d => d);
 
     private static bool TryParseReportDate(string input, out DateOnly result)
     {


### PR DESCRIPTION
## Summary

- Five call sites in `InstitutionalHoldingsTools` composed the same `_holdingRepository.GetHistoryByHolder(holder).Select(h => h.ReportDate).Distinct().OrderByDescending(d => d)` chain before materializing it with `ToListAsync` or `FirstOrDefaultAsync`.
- Collapse the shared chain into a single private helper returning `IQueryable<DateOnly>`; each call site keeps its own terminal materialization.
- Same LINQ expression tree, same generated SQL — no behavior change. Sites at lines 904/909 (two-fund overlap) keep their inline form because their chain omits `OrderByDescending` (different semantics) and would change behavior if folded into the helper.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — add `GetReportDatesByHolder` private helper next to `FindHolderByName`; replace five inline `.GetHistoryByHolder(...).Select(...).Distinct().OrderByDescending(...)` blocks in `GetInstitutionPortfolio`, `GetInstitutionSummary`, `GetInstitutionSectorAllocation`, `GetInstitutionQuarterlyActivity` and `GetConsensusHoldings` with calls to the helper. Net −18 lines.