### PR TITLE
refactor(insider-trading-mcp): use switch expression for transaction type label

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -76,13 +76,13 @@ public class InsiderTradingTools
                 foreach (var t in transactions)
                 {
                     var role = GetRole(t.InsiderOwner);
-                    var type = t.AcquiredDisposed == AcquiredDisposed.Acquired ? "Buy" : "Sell";
-                    if (t.TransactionCode == TransactionCode.Award)
-                        type = "Award";
-                    if (t.TransactionCode == TransactionCode.Gift)
-                        type = "Gift";
-                    if (t.TransactionCode == TransactionCode.Exercise)
-                        type = "Exercise";
+                    var type = t.TransactionCode switch
+                    {
+                        TransactionCode.Award => "Award",
+                        TransactionCode.Gift => "Gift",
+                        TransactionCode.Exercise => "Exercise",
+                        _ => t.AcquiredDisposed == AcquiredDisposed.Acquired ? "Buy" : "Sell",
+                    };
 
                     var value = t.Shares * t.PricePerShare;
                     result.AppendLine(


### PR DESCRIPTION
## Summary

- \`GetInsiderTransactions\` computed the row's transaction-type label via "default Buy/Sell, then overwrite to Award / Gift / Exercise" — a four-step assign-then-override ladder on a mutable \`type\` variable.
- Replace with a single switch expression on \`TransactionCode\`: the three explicit codes short-circuit to their literals; every other code falls to the default case \`Acquired ? "Buy" : "Sell"\`, which is exactly what the original assigned before the \`if\`s. Same labels for every input.
- Mutable assignment becomes a const-assigned local. Tests pin "Buy"/"Sell"/"Award"/"Gift" — all 19 \`InsiderTradingTools\` integration tests green locally.

## Code changes

- \`src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs\` — collapse the four-line type-assignment chain in \`GetInsiderTransactions\` to a single switch expression on \`t.TransactionCode\`.