### PR TITLE
feat(web): add CsvExportService

### DIFF
--- a/src/Equibles.Web/Services/CsvExportService.cs
+++ b/src/Equibles.Web/Services/CsvExportService.cs
@@ -1,0 +1,55 @@
+using System.Globalization;
+using System.Text;
+
+namespace Equibles.Web.Services;
+
+/// <summary>
+/// Minimal RFC-4180 CSV writer. No external dependency; values that contain a comma,
+/// double-quote, newline, or carriage return are wrapped in quotes and any inner
+/// double-quotes are doubled. Numeric / DateOnly conversions use the invariant culture
+/// so the output is stable across hosts regardless of the request thread's culture.
+/// </summary>
+public static class CsvExportService
+{
+    public static string BuildCsv(
+        IReadOnlyList<string> headers,
+        IEnumerable<IReadOnlyList<string>> rows
+    )
+    {
+        var sb = new StringBuilder();
+        AppendRow(sb, headers);
+        foreach (var row in rows)
+            AppendRow(sb, row);
+        return sb.ToString();
+    }
+
+    public static string EscapeField(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+        var needsQuoting = value.IndexOfAny(['"', ',', '\n', '\r']) >= 0;
+        if (!needsQuoting)
+            return value;
+        return "\"" + value.Replace("\"", "\"\"") + "\"";
+    }
+
+    public static string Format(long value) => value.ToString(CultureInfo.InvariantCulture);
+
+    public static string Format(double value) =>
+        value.ToString("G17", CultureInfo.InvariantCulture);
+
+    public static string Format(decimal value) => value.ToString(CultureInfo.InvariantCulture);
+
+    public static string Format(DateOnly date) => date.ToString("yyyy-MM-dd");
+
+    private static void AppendRow(StringBuilder sb, IReadOnlyList<string> fields)
+    {
+        for (var i = 0; i < fields.Count; i++)
+        {
+            if (i > 0)
+                sb.Append(',');
+            sb.Append(EscapeField(fields[i]));
+        }
+        sb.Append('\n');
+    }
+}

--- a/tests/Equibles.UnitTests/Web/CsvExportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Web/CsvExportServiceTests.cs
@@ -1,0 +1,100 @@
+using System.Globalization;
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+public class CsvExportServiceTests
+{
+    [Fact]
+    public void EscapeField_PlainText_ReturnsUnquoted()
+    {
+        CsvExportService.EscapeField("AAPL").Should().Be("AAPL");
+    }
+
+    [Fact]
+    public void EscapeField_Empty_ReturnsEmpty()
+    {
+        CsvExportService.EscapeField(string.Empty).Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void EscapeField_Null_ReturnsEmpty()
+    {
+        CsvExportService.EscapeField(null).Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void EscapeField_ContainsComma_WrapsInQuotes()
+    {
+        CsvExportService.EscapeField("Apple, Inc.").Should().Be("\"Apple, Inc.\"");
+    }
+
+    [Fact]
+    public void EscapeField_ContainsDoubleQuote_DoublesQuoteAndWraps()
+    {
+        // RFC-4180: a `"` inside the field becomes `""`, and the whole field is quoted.
+        CsvExportService
+            .EscapeField("Acme \"Special\" Co.")
+            .Should()
+            .Be("\"Acme \"\"Special\"\" Co.\"");
+    }
+
+    [Fact]
+    public void EscapeField_ContainsNewline_WrapsInQuotes()
+    {
+        CsvExportService.EscapeField("Line1\nLine2").Should().Be("\"Line1\nLine2\"");
+    }
+
+    [Fact]
+    public void EscapeField_ContainsCarriageReturn_WrapsInQuotes()
+    {
+        CsvExportService.EscapeField("Line1\rLine2").Should().Be("\"Line1\rLine2\"");
+    }
+
+    [Fact]
+    public void Format_LongCultureInvariant_NoThousandSeparator()
+    {
+        // Pinning culture-invariance: even on a host with PT-PT default culture (uses
+        // space as thousand separator, comma as decimal) the output stays "1500000".
+        var prev = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("pt-PT");
+            CsvExportService.Format(1_500_000L).Should().Be("1500000");
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = prev;
+        }
+    }
+
+    [Fact]
+    public void Format_DateOnly_UsesIsoFormat()
+    {
+        CsvExportService.Format(new DateOnly(2024, 6, 30)).Should().Be("2024-06-30");
+    }
+
+    [Fact]
+    public void BuildCsv_HeadersAndRows_EmitsCanonicalCsv()
+    {
+        var csv = CsvExportService.BuildCsv(
+            ["Ticker", "Name", "Shares"],
+            new[]
+            {
+                new[] { "AAPL", "Apple, Inc.", "10000" },
+                new[] { "MSFT", "Microsoft", "20000" },
+            }
+        );
+
+        csv.Should()
+            .Be("Ticker,Name,Shares\n" + "AAPL,\"Apple, Inc.\",10000\n" + "MSFT,Microsoft,20000\n");
+    }
+
+    [Fact]
+    public void BuildCsv_NoRows_StillEmitsHeader()
+    {
+        var csv = CsvExportService.BuildCsv(["Ticker"], []);
+
+        csv.Should().Be("Ticker\n");
+    }
+}


### PR DESCRIPTION
## Summary

PR 1 of 4 for #1018. Intermediate slice — not the closing one.

Adds a minimal RFC-4180 CSV writer in `Equibles.Web.Services`. No external dependency; the writer handles comma / double-quote / newline / carriage-return escaping in plain C#. Number and `DateOnly` conversions use the invariant culture so the output is stable regardless of the request thread's culture.

The next three slices wire this into per-stock holders, institution portfolio, and market-wide activity download endpoints.

Refs #1018

## Code changes

- `Equibles.Web/Services/CsvExportService.cs` — `EscapeField`, `BuildCsv(headers, rows)`, and culture-invariant `Format` overloads for `long` / `double` / `decimal` / `DateOnly`.
- `tests/Equibles.UnitTests/Web/CsvExportServiceTests.cs` — 11 cases: each escape case (plain / empty / null / comma / double-quote / newline / carriage return), invariant-culture `long` formatting pinned against a pt-PT host culture, `DateOnly` ISO format, `BuildCsv` happy-path, and no-rows still emits the header line.