### PR TITLE
refactor(cboe-client): inject IRateLimiter and move tests to unit tier

### DIFF
--- a/src/Equibles.Cboe.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Cboe.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,10 @@
 using Equibles.Cboe.HostedService.Services;
 using Equibles.Core.AutoWiring;
+using Equibles.Integrations.Cboe;
+using Equibles.Integrations.Cboe.Contracts;
+using Equibles.Integrations.Common.RateLimiter;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Equibles.Cboe.HostedService.Extensions;
 
@@ -9,7 +13,15 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddCboeWorker(this IServiceCollection services)
     {
         services.AutoWireServicesFrom<CboeImportService>();
-        services.AutoWireServicesFrom<Equibles.Integrations.Cboe.CboeClient>();
+
+        // CboeClient needs a single rate-limit budget shared across every scope in
+        // the host. Capture one limiter here and inject it into the per-scope client.
+        var cboeRateLimiter = new RateLimiter(maxRequests: 10, timeWindow: TimeSpan.FromMinutes(1));
+        services.AddScoped<ICboeClient>(sp => new CboeClient(
+            sp.GetRequiredService<HttpClient>(),
+            sp.GetRequiredService<ILoggerFactory>().CreateLogger<CboeClient>(),
+            cboeRateLimiter
+        ));
 
         services.AddHostedService<CboeScraperWorker>();
 

--- a/src/Equibles.Integrations.Cboe/CboeClient.cs
+++ b/src/Equibles.Integrations.Cboe/CboeClient.cs
@@ -1,15 +1,12 @@
 using System.Globalization;
 using System.Net;
-using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Cboe.Contracts;
 using Equibles.Integrations.Cboe.Models;
 using Equibles.Integrations.Common.RateLimiter;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Equibles.Integrations.Cboe;
 
-[Service(ServiceLifetime.Scoped, typeof(ICboeClient))]
 public class CboeClient : ICboeClient
 {
     private const string PutCallBaseUrl =
@@ -17,11 +14,6 @@ public class CboeClient : ICboeClient
     private const string VixUrl =
         "https://cdn.cboe.com/api/global/us_indices/daily_prices/VIX_History.csv";
     private const int MaxRetries = 3;
-
-    private static readonly IRateLimiter RateLimiter = new Common.RateLimiter.RateLimiter(
-        maxRequests: 10,
-        timeWindow: TimeSpan.FromMinutes(1)
-    );
 
     private static readonly Dictionary<CboePutCallCsvType, string> CsvFileNames = new()
     {
@@ -34,11 +26,13 @@ public class CboeClient : ICboeClient
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<CboeClient> _logger;
+    private readonly IRateLimiter _rateLimiter;
 
-    public CboeClient(HttpClient httpClient, ILogger<CboeClient> logger)
+    public CboeClient(HttpClient httpClient, ILogger<CboeClient> logger, IRateLimiter rateLimiter)
     {
         _httpClient = httpClient;
         _logger = logger;
+        _rateLimiter = rateLimiter;
     }
 
     public async Task<List<CboePutCallRecord>> DownloadPutCallRatios(CboePutCallCsvType csvType)
@@ -63,7 +57,7 @@ public class CboeClient : ICboeClient
     {
         for (var attempt = 0; attempt <= MaxRetries; attempt++)
         {
-            await RateLimiter.WaitAsync();
+            await _rateLimiter.WaitAsync();
 
             using var response = await _httpClient.GetAsync(url);
 
@@ -76,7 +70,7 @@ public class CboeClient : ICboeClient
                     attempt + 1,
                     MaxRetries
                 );
-                RateLimiter.PauseFor(delay);
+                _rateLimiter.PauseFor(delay);
                 await Task.Delay(delay);
                 continue;
             }

--- a/tests/Equibles.UnitTests/Cboe/CboeClientTests.cs
+++ b/tests/Equibles.UnitTests/Cboe/CboeClientTests.cs
@@ -1,10 +1,11 @@
 using System.Net;
 using Equibles.Integrations.Cboe;
 using Equibles.Integrations.Cboe.Models;
+using Equibles.Integrations.Common.RateLimiter;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 
-namespace Equibles.IntegrationTests.Cboe;
+namespace Equibles.UnitTests.Cboe;
 
 public class CboeClientTests
 {
@@ -32,7 +33,7 @@ public class CboeClientTests
             "Date,Call Volume,Put Volume,Total Volume,P/C Ratio\n"
             + "01/15/2025,100000,80000,200000,0.80\n";
         var handler = new ScriptedHandler((HttpStatusCode.OK, csv));
-        var sut = new CboeClient(new HttpClient(handler), Substitute.For<ILogger<CboeClient>>());
+        var sut = CreateSut(handler);
 
         var result = await sut.DownloadPutCallRatios(csvType);
 
@@ -54,7 +55,7 @@ public class CboeClientTests
         // VIX ingest in production. Asserting on the requested URL fixes the contract.
         var csv = "DATE,OPEN,HIGH,LOW,CLOSE\n" + "01/03/2020,13.72,14.49,13.51,14.02\n";
         var handler = new ScriptedHandler((HttpStatusCode.OK, csv));
-        var sut = new CboeClient(new HttpClient(handler), Substitute.For<ILogger<CboeClient>>());
+        var sut = CreateSut(handler);
 
         var result = await sut.DownloadVixHistory();
 
@@ -83,7 +84,8 @@ public class CboeClientTests
         // first CBOE 429 of the day would abort the whole ingest. The initial
         // delay is 2^(0+1) = 2s, so this test pays a real 2s wait — keep it to
         // a single retry. The success on attempt #2 also proves the loop EXITS
-        // the retry branch instead of looping forever.
+        // the retry branch instead of looping forever. The fake limiter records
+        // PauseFor so we can assert the 429 path called it (vs the 5xx path).
         var csv =
             "Date,Call Volume,Put Volume,Total Volume,P/C Ratio\n"
             + "01/15/2025,100000,80000,200000,0.80\n";
@@ -91,12 +93,14 @@ public class CboeClientTests
             (HttpStatusCode.TooManyRequests, ""),
             (HttpStatusCode.OK, csv)
         );
-        var sut = new CboeClient(new HttpClient(handler), Substitute.For<ILogger<CboeClient>>());
+        var rateLimiter = Substitute.For<IRateLimiter>();
+        var sut = CreateSut(handler, rateLimiter);
 
         var result = await sut.DownloadPutCallRatios(CboePutCallCsvType.Total);
 
         handler.Requests.Should().HaveCount(2);
         result.Should().ContainSingle();
+        rateLimiter.Received(1).PauseFor(Arg.Any<TimeSpan>());
     }
 
     [Fact]
@@ -111,12 +115,14 @@ public class CboeClientTests
             (HttpStatusCode.BadGateway, ""),
             (HttpStatusCode.OK, csv)
         );
-        var sut = new CboeClient(new HttpClient(handler), Substitute.For<ILogger<CboeClient>>());
+        var rateLimiter = Substitute.For<IRateLimiter>();
+        var sut = CreateSut(handler, rateLimiter);
 
         var result = await sut.DownloadVixHistory();
 
         handler.Requests.Should().HaveCount(2);
         result.Should().ContainSingle();
+        rateLimiter.DidNotReceive().PauseFor(Arg.Any<TimeSpan>());
     }
 
     [Fact]
@@ -128,13 +134,20 @@ public class CboeClientTests
         // window (e.g. "retry on any error") isn't shipped silently:
         // retrying a permanent 404 burns the rate-limit budget for nothing.
         var handler = new ScriptedHandler((HttpStatusCode.NotFound, ""));
-        var sut = new CboeClient(new HttpClient(handler), Substitute.For<ILogger<CboeClient>>());
+        var sut = CreateSut(handler);
 
         var act = async () => await sut.DownloadPutCallRatios(CboePutCallCsvType.Total);
 
         await act.Should().ThrowAsync<HttpRequestException>();
         handler.Requests.Should().ContainSingle();
     }
+
+    private static CboeClient CreateSut(ScriptedHandler handler, IRateLimiter rateLimiter = null) =>
+        new(
+            new HttpClient(handler),
+            Substitute.For<ILogger<CboeClient>>(),
+            rateLimiter ?? Substitute.For<IRateLimiter>()
+        );
 
     private sealed class ScriptedHandler : HttpMessageHandler
     {


### PR DESCRIPTION
## Summary

- Fixes a flaky `Test Run Aborted` in the integration suite. `CboeClient` held its `RateLimiter` as `static readonly`, so its in-window request queue and pause-until timestamp leaked across every test in the process. Under host load (parallel agents, Testcontainers contention) one CBOE test waited up to ~60s for the oldest entry to age out and the runner aborted.
- `CboeClient` now takes `IRateLimiter` via its constructor. `AddCboeWorker` captures a single limiter as a closure and injects it into the per-scope client — same shared-across-scopes wire behavior as the previous static, but no longer process-global.
- Tests no longer depend on real time and have no DB / host dependency, so they move from `tests/Equibles.IntegrationTests/Cboe/` to `tests/Equibles.UnitTests/Cboe/` with a substituted `IRateLimiter`. Suite runtime drops from ~60s to ~4s.

## Code changes

- `src/Equibles.Integrations.Cboe/CboeClient.cs` — drop the `[Service]` attribute and the static `RateLimiter` field; add `IRateLimiter` constructor parameter; use the injected instance in `DownloadWithRetry`. No other behavior changes.
- `src/Equibles.Cboe.HostedService/Extensions/ServiceCollectionExtensions.cs` — replace the auto-wired registration with an explicit factory that captures one `RateLimiter(10/min)` and constructs `CboeClient` per scope.
- `tests/Equibles.UnitTests/Cboe/CboeClientTests.cs` — moved from the integration tier (`git mv` preserves history). Constructor calls now go through a `CreateSut` helper; the two retry tests assert on `IRateLimiter.PauseFor` to pin the 429-vs-5xx branching that was previously implicit. The 2s exponential-backoff waits stay — they pin real retry behavior per the existing test comments.

## Follow-up

The same `static readonly RateLimiter` pattern lives in seven other clients (`SecEdgarClient`, `FinraClient`, `FredClient`, `YahooFinanceClient`, `CftcClient`, `SenateDisclosureClient`, `HouseDisclosureClient`). Their tests can abort the same way under load. A follow-up sweep can apply the same refactor.