### PR TITLE
refactor(cftc-mcp): extract ParseDateOr helper for duplicated date-parsing fallback

### DIFF
--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -60,16 +60,11 @@ public class CftcTools
                 if (contract == null)
                     return $"Contract '{marketCode}' not found. Use SearchCftcMarkets to find available contracts.";
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var reports = await _reportRepository
                     .GetByContract(contract, start, end)
@@ -240,4 +235,7 @@ public class CftcTools
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
+
+    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
+        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 }


### PR DESCRIPTION
## Summary

- Collapse two near-identical `!string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var x) ? x : fallback` blocks (for `start` and `end`) in `GetCftcPositioning` into a single private static `ParseDateOr` helper.
- Mirrors the existing pattern in `Equibles.Finra.Mcp/Tools/ShortDataTools.cs` (#1108).
- Behavior is preserved: the helper performs the same null/empty check and `DateOnly.TryParse` call, returning the caller-supplied fallback when the input is empty or unparseable.

## Code changes

- ``src/Equibles.Cftc.Mcp/Tools/CftcTools.cs`` — replace the two duplicated date-parse blocks in `GetCftcPositioning` with `ParseDateOr` calls and add the helper alongside `ReportError` (net -2 lines).