### PR TITLE
refactor(holdings-import): collapse three duplicated unique-key interpolations into BuildHoldingKey helper

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -492,8 +492,13 @@ public class HoldingsImportService
 
             var shareType = ParseShareType(GetValue(row, "SSHPRNAMTTYPE"));
             var optionType = ParseOptionType(GetValue(row, "PUTCALL"));
-            var uniqueKey =
-                $"{commonStockId}|{holderId}|{reportDate}|{(int)shareType}|{optionType?.ToString() ?? ""}";
+            var uniqueKey = BuildHoldingKey(
+                commonStockId,
+                holderId,
+                reportDate,
+                shareType,
+                optionType
+            );
 
             var isAmendment =
                 context.CoverPages.TryGetValue(accession, out var cp)
@@ -612,8 +617,13 @@ public class HoldingsImportService
         var entriesByKey = new Dictionary<string, List<HoldingManagerEntry>>();
         foreach (var h in holdings)
         {
-            var key =
-                $"{h.CommonStockId}|{h.InstitutionalHolderId}|{h.ReportDate}|{(int)h.ShareType}|{h.OptionType?.ToString() ?? ""}";
+            var key = BuildHoldingKey(
+                h.CommonStockId,
+                h.InstitutionalHolderId,
+                h.ReportDate,
+                h.ShareType,
+                h.OptionType
+            );
             entriesByKey[key] = h.ManagerEntries.ToList();
             h.ManagerEntries.Clear();
         }
@@ -658,8 +668,13 @@ public class HoldingsImportService
 
         foreach (var dbHolding in dbHoldings)
         {
-            var key =
-                $"{dbHolding.CommonStockId}|{dbHolding.InstitutionalHolderId}|{dbHolding.ReportDate}|{(int)dbHolding.ShareType}|{dbHolding.OptionType?.ToString() ?? ""}";
+            var key = BuildHoldingKey(
+                dbHolding.CommonStockId,
+                dbHolding.InstitutionalHolderId,
+                dbHolding.ReportDate,
+                dbHolding.ShareType,
+                dbHolding.OptionType
+            );
             if (entriesByKey.TryGetValue(key, out var entries))
             {
                 dbHolding.ManagerEntries.Clear();
@@ -671,4 +686,12 @@ public class HoldingsImportService
 
         return holdings.Count;
     }
+
+    private static string BuildHoldingKey(
+        Guid commonStockId,
+        Guid holderId,
+        DateOnly reportDate,
+        ShareType shareType,
+        OptionType? optionType
+    ) => $"{commonStockId}|{holderId}|{reportDate}|{(int)shareType}|{optionType?.ToString() ?? ""}";
 }


### PR DESCRIPTION
## Summary

- `HoldingsImportService` built the same five-field unique-key string (`{commonStockId}|{holderId}|{reportDate}|{(int)shareType}|{optionType?.ToString() ?? ""}`) in three places: once in `StreamAndInsertHoldings` while consolidating rows, and twice in `FlushBatch` (write side and read-back side) when re-attaching `ManagerEntries` to the upserted rows.
- Extracted a private static `BuildHoldingKey(commonStockId, holderId, reportDate, shareType, optionType)` helper. Each call site now resolves to a byte-for-byte identical string, so the dictionary keys match exactly as before.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — added a private static `BuildHoldingKey` helper; replaced three inline interpolations in `StreamAndInsertHoldings` and `FlushBatch` (both passes) with calls to it.