### PR TITLE
feat(holdings): CSV download for per-stock holders

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -1,0 +1,100 @@
+using System.Text;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Repositories;
+using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Web.Controllers;
+
+public class HoldingsExportController : BaseController
+{
+    private readonly CommonStockRepository _stockRepository;
+    private readonly InstitutionalHoldingRepository _holdingRepository;
+
+    public HoldingsExportController(
+        CommonStockRepository stockRepository,
+        InstitutionalHoldingRepository holdingRepository,
+        ILogger<HoldingsExportController> logger
+    )
+        : base(logger)
+    {
+        _stockRepository = stockRepository;
+        _holdingRepository = holdingRepository;
+    }
+
+    [HttpGet("~/Holdings/Export/Holders")]
+    public async Task<IActionResult> Holders(string ticker, DateOnly? date)
+    {
+        if (string.IsNullOrWhiteSpace(ticker))
+            return NotFound();
+
+        var stock = await _stockRepository.GetByTicker(ticker.ToUpperInvariant());
+        if (stock == null)
+            return NotFound();
+
+        var reportDates = await _holdingRepository
+            .GetHistoryByStock(stock)
+            .Select(h => h.ReportDate)
+            .Distinct()
+            .OrderByDescending(d => d)
+            .ToListAsync();
+        if (reportDates.Count == 0)
+            return NotFound();
+
+        var selectedDate =
+            date.HasValue && reportDates.Contains(date.Value) ? date.Value : reportDates[0];
+
+        var holdings = await _holdingRepository
+            .GetByStock(stock, selectedDate)
+            .Include(h => h.InstitutionalHolder)
+            .OrderByDescending(h => h.Value)
+            .Select(h => new
+            {
+                HolderName = h.InstitutionalHolder.Name,
+                HolderCik = h.InstitutionalHolder.Cik,
+                h.Shares,
+                h.Value,
+                h.ShareType,
+                h.OptionType,
+                h.AccessionNumber,
+            })
+            .ToListAsync();
+
+        string[] headers =
+        [
+            "Ticker",
+            "CompanyName",
+            "ReportDate",
+            "InstitutionalHolderName",
+            "InstitutionalHolderCik",
+            "Shares",
+            "Value",
+            "ShareType",
+            "OptionType",
+            "AccessionNumber",
+        ];
+
+        var rows = holdings.Select(h =>
+            new[]
+            {
+                stock.Ticker,
+                stock.Name,
+                CsvExportService.Format(selectedDate),
+                h.HolderName,
+                h.HolderCik,
+                CsvExportService.Format(h.Shares),
+                CsvExportService.Format(h.Value),
+                h.ShareType.ToString(),
+                h.OptionType?.ToString() ?? string.Empty,
+                h.AccessionNumber,
+            }
+        );
+
+        var csv = CsvExportService.BuildCsv(headers, rows);
+        var filename = $"{stock.Ticker}-13F-{selectedDate:yyyy-MM-dd}.csv";
+        Response.Headers.CacheControl = "no-store";
+        return File(Encoding.UTF8.GetBytes(csv), "text/csv", filename);
+    }
+}

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -59,6 +59,13 @@
             <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Holders:</span> <strong>@Model.HolderCount.ToString("N0")</strong></div>
             <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Value:</span> <strong>$@Model.TotalValue.ToString("N0")</strong></div>
             <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Shares:</span> <strong>@Model.TotalShares.ToString("N0")</strong></div>
+            <!-- CSV download — same ticker + selected date as the page. -->
+            <a class="btn btn-outline btn-sm ml-auto"
+               asp-controller="HoldingsExport" asp-action="Holders"
+               asp-route-ticker="@Model.Ticker" asp-route-date="@Model.SelectedDate.ToString("yyyy-MM-dd")"
+               data-testid="holdings-export-csv">
+                Download CSV
+            </a>
         </div>
     </div>
 

--- a/tests/Equibles.IntegrationTests/Web/HoldingsExportHoldersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsExportHoldersTests.cs
@@ -1,0 +1,200 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins /Holdings/Export/Holders end-to-end: route → controller → repository →
+/// CsvExportService. Asserts content-type, filename, header row, RFC-4180 escaping for
+/// holder names with commas, and the Download CSV link rendering on the Holdings tab.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HoldingsExportHoldersTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HoldingsExportHoldersTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task ExportHolders_UnknownTicker_Returns404()
+    {
+        await _fixture.ResetAndSeedAsync();
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Export/Holders?ticker=ZZZZ");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ExportHolders_NoHoldings_Returns404()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "EMPT",
+                    Name = "Empty Co.",
+                    Cik = "0000099001",
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Export/Holders?ticker=EMPT");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ExportHolders_HappyPath_ReturnsCsvWithHeaderAndHolderRow()
+    {
+        var stockId = Guid.NewGuid();
+        var holderId = Guid.NewGuid();
+        var reportDate = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "0001067983",
+                    Name = "Berkshire Hathaway",
+                }
+            );
+            db.Add(MakeHolding(stockId, holderId, reportDate, 1_500_000, 250_000_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/Holdings/Export/Holders?ticker=AAPL&date={reportDate:yyyy-MM-dd}"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/csv");
+        response
+            .Content.Headers.ContentDisposition!.FileName.Should()
+            .Be("AAPL-13F-2024-12-31.csv");
+        response.Headers.CacheControl!.NoStore.Should().BeTrue();
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should()
+            .Contain(
+                "Ticker,CompanyName,ReportDate,InstitutionalHolderName,InstitutionalHolderCik,"
+                    + "Shares,Value,ShareType,OptionType,AccessionNumber"
+            );
+        body.Should().Contain("AAPL,Apple Inc.,2024-12-31,Berkshire Hathaway,0001067983,");
+        body.Should().Contain("1500000,250000000");
+    }
+
+    [Fact]
+    public async Task ExportHolders_HolderNameWithComma_IsQuotedPerRfc4180()
+    {
+        var stockId = Guid.NewGuid();
+        var holderId = Guid.NewGuid();
+        var reportDate = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corp.",
+                    Cik = "0000789019",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "0009999999",
+                    // Name contains a comma — the writer must wrap in quotes.
+                    Name = "Apex, Capital LLC",
+                }
+            );
+            db.Add(MakeHolding(stockId, holderId, reportDate, 1, 1));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/Holdings/Export/Holders?ticker=MSFT&date={reportDate:yyyy-MM-dd}"
+        );
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().Contain("\"Apex, Capital LLC\"");
+    }
+
+    [Fact]
+    public async Task HoldingsTab_RendersDownloadCsvButton()
+    {
+        var stockId = Guid.NewGuid();
+        var holderId = Guid.NewGuid();
+        var reportDate = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "NVDA",
+                    Name = "NVIDIA Corp.",
+                    Cik = "0001045810",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "0001000099",
+                    Name = "Test Holder",
+                }
+            );
+            db.Add(MakeHolding(stockId, holderId, reportDate, 1, 1));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Stocks/NVDA/Holdings");
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        html.Should().Contain("data-testid=\"holdings-export-csv\"");
+        html.ToLowerInvariant().Should().Contain("/holdings/export/holders");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stockId:N}".Substring(0, 12) + $"-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

PR 2 of 4 for #1018. Intermediate slice — not the closing one.

Wires the `CsvExportService` (PR #1173) into the first export target. New `HoldingsExportController` hosts a `Holders` action at `~/Holdings/Export/Holders` that emits all institutional holders of a stock for the selected report date as `text/csv` with a filename matching the stock + date pair.

Refs #1018

## Code changes

- `Equibles.Web/Controllers/HoldingsExportController.cs` — `[HttpGet("~/Holdings/Export/Holders")]`. 404 for unknown ticker / no-holdings; otherwise emits ten columns through `CsvExportService.BuildCsv` with `Cache-Control: no-store`. Filename `<TICKER>-13F-<yyyy-MM-dd>.csv`.
- `Equibles.Web/Views/Stocks/_HoldingsTab.cshtml` — Download CSV button next to the date selector; carries the current ticker + report date.
- `tests/Equibles.IntegrationTests/Web/HoldingsExportHoldersTests.cs` — five cases: 404 for unknown ticker, 404 when no holdings exist, happy-path content-type / filename / header / row, RFC-4180 quoting for a holder name with a comma, and the button rendering on the Holdings tab.