### PR TITLE
refactor(fred-mcp): extract ParseDateOr helper for duplicated date-parsing fallback

### DIFF
--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -57,16 +57,11 @@ public class FredTools
                 if (series == null)
                     return $"Series '{seriesId}' not found. Use SearchEconomicIndicators to find available series.";
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var observations = await _observationRepository
                     .GetBySeries(series, start, end)
@@ -227,4 +222,7 @@ public class FredTools
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
+
+    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
+        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 }


### PR DESCRIPTION
## Summary

- Collapse two near-identical `!string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var x) ? x : fallback` blocks (for `start` and `end`) in `GetEconomicIndicator` into a single private static `ParseDateOr` helper.
- Mirrors the precedent in `Equibles.Finra.Mcp/Tools/ShortDataTools.cs` (#1108) and `Equibles.Cftc.Mcp/Tools/CftcTools.cs` (#1176).
- Behavior is preserved: the helper performs the same null/empty check and `DateOnly.TryParse` call, returning the caller-supplied fallback when the input is empty or unparseable.

## Code changes

- ``src/Equibles.Fred.Mcp/Tools/FredTools.cs`` — replace the two duplicated date-parse blocks in `GetEconomicIndicator` with `ParseDateOr` calls and add the helper alongside `ReportError` (net -2 lines).