### PR TITLE
feat(holdings): CSV download for institution portfolio

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -12,16 +12,19 @@ public class HoldingsExportController : BaseController
 {
     private readonly CommonStockRepository _stockRepository;
     private readonly InstitutionalHoldingRepository _holdingRepository;
+    private readonly InstitutionalHolderRepository _holderRepository;
 
     public HoldingsExportController(
         CommonStockRepository stockRepository,
         InstitutionalHoldingRepository holdingRepository,
+        InstitutionalHolderRepository holderRepository,
         ILogger<HoldingsExportController> logger
     )
         : base(logger)
     {
         _stockRepository = stockRepository;
         _holdingRepository = holdingRepository;
+        _holderRepository = holderRepository;
     }
 
     [HttpGet("~/Holdings/Export/Holders")]
@@ -96,5 +99,92 @@ public class HoldingsExportController : BaseController
         var filename = $"{stock.Ticker}-13F-{selectedDate:yyyy-MM-dd}.csv";
         Response.Headers.CacheControl = "no-store";
         return File(Encoding.UTF8.GetBytes(csv), "text/csv", filename);
+    }
+
+    [HttpGet("~/Holdings/Export/Institution")]
+    public async Task<IActionResult> Institution(string cik, DateOnly? date)
+    {
+        if (string.IsNullOrWhiteSpace(cik))
+            return NotFound();
+
+        var holder = await _holderRepository.GetByCik(cik);
+        if (holder == null)
+            return NotFound();
+
+        var reportDates = await _holdingRepository
+            .GetHistoryByHolder(holder)
+            .Select(h => h.ReportDate)
+            .Distinct()
+            .OrderByDescending(d => d)
+            .ToListAsync();
+        if (reportDates.Count == 0)
+            return NotFound();
+
+        var selectedDate =
+            date.HasValue && reportDates.Contains(date.Value) ? date.Value : reportDates[0];
+
+        var rowsRaw = await _holdingRepository
+            .GetByHolder(holder, selectedDate)
+            .Include(h => h.CommonStock)
+            .OrderByDescending(h => h.Value)
+            .Select(h => new
+            {
+                Ticker = h.CommonStock.Ticker,
+                Name = h.CommonStock.Name,
+                h.Shares,
+                h.Value,
+                h.ShareType,
+                h.OptionType,
+                h.AccessionNumber,
+            })
+            .ToListAsync();
+
+        string[] headers =
+        [
+            "InstitutionalHolderName",
+            "InstitutionalHolderCik",
+            "ReportDate",
+            "Ticker",
+            "CompanyName",
+            "Shares",
+            "Value",
+            "ShareType",
+            "OptionType",
+            "AccessionNumber",
+        ];
+
+        var rows = rowsRaw.Select(r =>
+            new[]
+            {
+                holder.Name,
+                holder.Cik,
+                CsvExportService.Format(selectedDate),
+                r.Ticker,
+                r.Name,
+                CsvExportService.Format(r.Shares),
+                CsvExportService.Format(r.Value),
+                r.ShareType.ToString(),
+                r.OptionType?.ToString() ?? string.Empty,
+                r.AccessionNumber,
+            }
+        );
+
+        var csv = CsvExportService.BuildCsv(headers, rows);
+        var filename = $"{Sanitize(holder.Cik)}-portfolio-{selectedDate:yyyy-MM-dd}.csv";
+        Response.Headers.CacheControl = "no-store";
+        return File(Encoding.UTF8.GetBytes(csv), "text/csv", filename);
+    }
+
+    // CIKs are numeric strings in production, but the URL could carry a hand-typed value.
+    // Strip anything that's unsafe in a filename (slashes / quotes / control chars) so the
+    // Content-Disposition header stays well-formed.
+    private static string Sanitize(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "institution";
+        var safe = new string(
+            value.Where(c => char.IsLetterOrDigit(c) || c is '-' or '_').ToArray()
+        );
+        return string.IsNullOrEmpty(safe) ? "institution" : safe;
     }
 }

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -12,14 +12,23 @@
                 Institutional holder@(string.IsNullOrWhiteSpace(Model.Location) ? "" : " · " + Model.Location) · CIK @Model.Cik
             </p>
         </div>
-        <!-- Action bar — Backtest link only renders when the holder has at least one 13F
-             snapshot, since the route's first useful response needs a rebalance date. -->
+        <!-- Action bar — links only render when the holder has at least one 13F
+             snapshot, since the routes' first useful response needs a rebalance date. -->
         @if (Model.AvailableReportDates.Count > 0) {
-            <a asp-action="BacktestInstitution" asp-route-cik="@Model.Cik"
-               class="btn btn-outline btn-sm"
-               data-testid="institution-backtest-link">
-                Backtest
-            </a>
+            <div class="flex flex-wrap gap-2">
+                <a asp-action="BacktestInstitution" asp-route-cik="@Model.Cik"
+                   class="btn btn-outline btn-sm"
+                   data-testid="institution-backtest-link">
+                    Backtest
+                </a>
+                <a asp-controller="HoldingsExport" asp-action="Institution"
+                   asp-route-cik="@Model.Cik"
+                   asp-route-date="@Model.AvailableReportDates[0].ToString("yyyy-MM-dd")"
+                   class="btn btn-outline btn-sm"
+                   data-testid="institution-export-csv">
+                    Download CSV
+                </a>
+            </div>
         }
     </div>
 

--- a/tests/Equibles.IntegrationTests/Web/HoldingsExportInstitutionTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsExportInstitutionTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins /Holdings/Export/Institution end-to-end and the Download CSV link on the
+/// Institution profile. The export reflects the same selected report date as the
+/// profile page's latest snapshot.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HoldingsExportInstitutionTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HoldingsExportInstitutionTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task ExportInstitution_UnknownCik_Returns404()
+    {
+        await _fixture.ResetAndSeedAsync();
+
+        var response = await _fixture.Client.GetAsync(
+            "/Holdings/Export/Institution?cik=0000000000"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ExportInstitution_HappyPath_ReturnsCsvWithHoldings()
+    {
+        var holderId = Guid.NewGuid();
+        var aaplId = Guid.NewGuid();
+        var msftId = Guid.NewGuid();
+        var reportDate = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "0008900001",
+                    Name = "Portfolio Holder",
+                }
+            );
+            db.AddRange(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                },
+                new CommonStock
+                {
+                    Id = msftId,
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corp.",
+                    Cik = "0000789019",
+                }
+            );
+            db.Add(MakeHolding(aaplId, holderId, reportDate, 100_000, 25_000_000));
+            db.Add(MakeHolding(msftId, holderId, reportDate, 50_000, 10_000_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/Holdings/Export/Institution?cik=0008900001&date={reportDate:yyyy-MM-dd}"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/csv");
+        response
+            .Content.Headers.ContentDisposition!.FileName.Should()
+            .Be("0008900001-portfolio-2024-12-31.csv");
+        response.Headers.CacheControl!.NoStore.Should().BeTrue();
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should()
+            .Contain(
+                "InstitutionalHolderName,InstitutionalHolderCik,ReportDate,Ticker,"
+                    + "CompanyName,Shares,Value,ShareType,OptionType,AccessionNumber"
+            );
+        // AAPL comes first because it has the higher Value.
+        body.Should().Contain("Portfolio Holder,0008900001,2024-12-31,AAPL,Apple Inc.,100000");
+        body.Should().Contain("Microsoft Corp.,50000");
+    }
+
+    [Fact]
+    public async Task InstitutionProfile_RendersDownloadCsvButton()
+    {
+        var holderId = Guid.NewGuid();
+        var stockId = Guid.NewGuid();
+        var cik = "0008900002";
+        var reportDate = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = cik,
+                    Name = "Buttoned Holder",
+                }
+            );
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "TKR",
+                    Name = "Test Inc.",
+                    Cik = "0000099500",
+                }
+            );
+            db.Add(MakeHolding(stockId, holderId, reportDate, 1, 1));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync($"/Institutions/{cik}");
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        html.Should().Contain("data-testid=\"institution-export-csv\"");
+        html.ToLowerInvariant().Should().Contain("/holdings/export/institution");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stockId:N}".Substring(0, 12) + $"-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

PR 3 of 4 for #1018. Intermediate slice — not the closing one.

Adds an `Institution` action to `HoldingsExportController` at `~/Holdings/Export/Institution` that emits a holder's full reported portfolio for the selected report date as `text/csv`. Row order matches the institution profile's value-desc default. Slice 4 adds the market-wide activity export and closes the issue.

Refs #1018

## Code changes

- `Equibles.Web/Controllers/HoldingsExportController.cs` — `Institution(cik, date)` action returning `text/csv` with `Cache-Control: no-store`. Filename `<cik>-portfolio-<yyyy-MM-dd>.csv`; CIK is sanitized to alphanumeric / dash / underscore so any URL input produces a well-formed `Content-Disposition`. Columns: `InstitutionalHolderName`, `InstitutionalHolderCik`, `ReportDate`, `Ticker`, `CompanyName`, `Shares`, `Value`, `ShareType`, `OptionType`, `AccessionNumber`.
- `Equibles.Web/Views/Profiles/Institution.cshtml` — Download CSV button added next to the existing Backtest link, defaulting to the holder's latest report date.
- `tests/Equibles.IntegrationTests/Web/HoldingsExportInstitutionTests.cs` — three cases: 404 for an unknown CIK, happy-path CSV body / filename / content-type, and the button rendering on the Institution profile.