### PR TITLE
refactor(fred-mcp): extract ParseDateOr helper for duplicated date-parsing fallback

### DIFF
--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -57,16 +57,11 @@ public class FredTools
                 if (series == null)
                     return $"Series '{seriesId}' not found. Use SearchEconomicIndicators to find available series.";
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var observations = await _observationRepository
                     .GetBySeries(series, start, end)
@@ -227,4 +222,7 @@ public class FredTools
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
+
+    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
+        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 }


### PR DESCRIPTION
## Summary

- \`GetEconomicIndicator\` had two near-identical 4-line date-parsing-fallback blocks for \`startDate\` and \`endDate\` — the same \`!IsNullOrEmpty(text) && DateOnly.TryParse(text, out var x) ? x : fallback\` ternary copied with different fallbacks.
- Extract a private static \`ParseDateOr(text, fallback)\` helper. Mirrors the existing pattern in \`Equibles.Cftc.Mcp.Tools.CftcTools\` (#1176) and \`Equibles.Finra.Mcp.Tools.ShortDataTools\` (#1108).
- Same null/empty check, same \`DateOnly.TryParse\`, same fallback when input is empty or unparseable. 24 Fred integration + 73 Fred unit tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.Fred.Mcp/Tools/FredTools.cs\` — collapse the two inline date-fallback ternaries into \`ParseDateOr(...)\` calls; add a one-line private static helper next to \`ReportError\`.