### PR TITLE
docs(readme): list Short Data under MCP Server tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The MCP server exposes financial data tools for AI assistants (Claude, ChatGPT, 
 - **Insider Trading** — Insider transactions, ownership summary, insider search
 - **Congressional Trading** — Trades for a ticker, trades by one member, member search
 - **SEC Documents** — Full-text search, semantic search, document browsing, keyword search within filings
+- **Short Data** — Daily short volume, bi-monthly short interest, and the latest short-interest snapshot across tickers
 - **Economic Indicators** — FRED data lookup, latest macro snapshot, indicator search across categories
 - **Stock Prices** — Daily OHLCV history with adjusted close, plus latest close across one or more tickers
 - **Futures Positioning** — COT positioning data, latest snapshot across all contracts, contract search


### PR DESCRIPTION
## Summary

- Lane: **README — drift fix**.
- The README's "What's Included" table lists Short Data as a supported domain and the MCP catalog exposes `GetShortVolume` / `GetShortInterest` / `GetShortInterestSnapshot`, but the MCP Server bullet list didn't mention them. Add the missing bullet.

## Code changes

- `README.md` — add a `**Short Data**` bullet between SEC Documents and Economic Indicators under the MCP Server section (daily short volume, bi-monthly short interest, latest snapshot across tickers).