### PR TITLE
feat(holdings): CSV download for market-wide activity boards

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -175,6 +175,144 @@ public class HoldingsExportController : BaseController
         return File(Encoding.UTF8.GetBytes(csv), "text/csv", filename);
     }
 
+    [HttpGet("~/Holdings/Export/Activity")]
+    public async Task<IActionResult> Activity(DateOnly? date)
+    {
+        var reportDates = await _holdingRepository
+            .GetAvailableReportDates()
+            .OrderByDescending(d => d)
+            .ToListAsync();
+        if (reportDates.Count < 2)
+            return NotFound();
+
+        var selectedDate =
+            date.HasValue && reportDates.Contains(date.Value) ? date.Value : reportDates[0];
+        var selectedIndex = reportDates.IndexOf(selectedDate);
+        var previousDate =
+            selectedIndex < reportDates.Count - 1 ? reportDates[selectedIndex + 1] : reportDates[1];
+
+        // Per-stock buy/sell movers (CSV has no row cap — analysts expect the full set).
+        var activity = await _holdingRepository
+            .GetQuarterlyActivity(selectedDate, previousDate)
+            .Where(a => a.CurrentShares != a.PreviousShares)
+            .ToListAsync();
+        var topBuys = activity
+            .Where(a => a.CurrentShares > a.PreviousShares)
+            .OrderByDescending(a => a.CurrentValue - a.PreviousValue)
+            .ToList();
+        var topSells = activity
+            .Where(a => a.CurrentShares < a.PreviousShares)
+            .OrderBy(a => a.CurrentValue - a.PreviousValue)
+            .ToList();
+
+        var churn = await _holdingRepository
+            .GetQuarterlyNewSoldOutPositions(selectedDate, previousDate)
+            .Where(c => c.NewFilerCount > 0 || c.SoldOutFilerCount > 0)
+            .ToListAsync();
+        var newPositions = churn
+            .Where(c => c.NewFilerCount > 0)
+            .OrderByDescending(c => c.NewFilerCount)
+            .ToList();
+        var soldOut = churn
+            .Where(c => c.SoldOutFilerCount > 0)
+            .OrderByDescending(c => c.SoldOutFilerCount)
+            .ToList();
+
+        var stockIds = topBuys
+            .Concat(topSells)
+            .Select(a => a.CommonStockId)
+            .Concat(newPositions.Concat(soldOut).Select(c => c.CommonStockId))
+            .Distinct()
+            .ToList();
+        var stocks = await _stockRepository
+            .GetAll()
+            .Where(s => stockIds.Contains(s.Id))
+            .Select(s => new StockLabel(s.Id, s.Ticker, s.Name))
+            .ToDictionaryAsync(s => s.Id);
+
+        string[] headers =
+        [
+            "Board",
+            "ReportDate",
+            "ComparisonDate",
+            "Ticker",
+            "CompanyName",
+            "CurrentFilerCount",
+            "PreviousFilerCount",
+            "DeltaShares",
+            "DeltaValue",
+            "NewFilerCount",
+            "SoldOutFilerCount",
+        ];
+
+        var rows = new List<string[]>();
+        foreach (var row in topBuys)
+            rows.Add(ActivityRow("TopBuys", row, selectedDate, previousDate, stocks));
+        foreach (var row in topSells)
+            rows.Add(ActivityRow("TopSells", row, selectedDate, previousDate, stocks));
+        foreach (var row in newPositions)
+            rows.Add(ChurnRow("NewPositions", row, selectedDate, previousDate, stocks));
+        foreach (var row in soldOut)
+            rows.Add(ChurnRow("SoldOutPositions", row, selectedDate, previousDate, stocks));
+
+        var csv = CsvExportService.BuildCsv(headers, rows);
+        var filename = $"13F-activity-{selectedDate:yyyy-MM-dd}.csv";
+        Response.Headers.CacheControl = "no-store";
+        return File(Encoding.UTF8.GetBytes(csv), "text/csv", filename);
+    }
+
+    private static string[] ActivityRow(
+        string board,
+        Equibles.Holdings.Repositories.Models.MarketWideStockActivity row,
+        DateOnly current,
+        DateOnly previous,
+        IDictionary<Guid, StockLabel> stocks
+    )
+    {
+        stocks.TryGetValue(row.CommonStockId, out var stock);
+        return
+        [
+            board,
+            CsvExportService.Format(current),
+            CsvExportService.Format(previous),
+            stock?.Ticker ?? string.Empty,
+            stock?.Name ?? string.Empty,
+            CsvExportService.Format((long)row.CurrentFilerCount),
+            CsvExportService.Format((long)row.PreviousFilerCount),
+            CsvExportService.Format(row.CurrentShares - row.PreviousShares),
+            CsvExportService.Format(row.CurrentValue - row.PreviousValue),
+            string.Empty,
+            string.Empty,
+        ];
+    }
+
+    private static string[] ChurnRow(
+        string board,
+        Equibles.Holdings.Repositories.Models.MarketWideStockChurn row,
+        DateOnly current,
+        DateOnly previous,
+        IDictionary<Guid, StockLabel> stocks
+    )
+    {
+        stocks.TryGetValue(row.CommonStockId, out var stock);
+        return
+        [
+            board,
+            CsvExportService.Format(current),
+            CsvExportService.Format(previous),
+            stock?.Ticker ?? string.Empty,
+            stock?.Name ?? string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            CsvExportService.Format((long)row.NewFilerCount),
+            CsvExportService.Format((long)row.SoldOutFilerCount),
+        ];
+    }
+
+    private record StockLabel(Guid Id, string Ticker, string Name);
+
     // CIKs are numeric strings in production, but the URL could carry a hand-typed value.
     // Strip anything that's unsafe in a filename (slashes / quotes / control chars) so the
     // Content-Disposition header stays well-formed.

--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -35,6 +35,13 @@
             </div>
             @if (Model.PreviousDate.HasValue) {
                 <div class="text-xs text-base-content/50">vs prior quarter @Model.PreviousDate.Value.ToString("MMM dd, yyyy")</div>
+                <!-- CSV download covers all four boards for the selected ReportDate. -->
+                <a class="btn btn-outline btn-sm ml-auto"
+                   asp-controller="HoldingsExport" asp-action="Activity"
+                   asp-route-date="@Model.SelectedDate.ToString("yyyy-MM-dd")"
+                   data-testid="activity-export-csv">
+                    Download CSV
+                </a>
             } else {
                 <div class="text-xs text-base-content/50">No prior quarter available — buy/sell ranking needs two quarters.</div>
             }

--- a/tests/Equibles.IntegrationTests/Web/HoldingsExportActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsExportActivityTests.cs
@@ -1,0 +1,201 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins /Holdings/Export/Activity end-to-end and the Download CSV link on the
+/// Holdings/Activity page. The export bundles all four boards (TopBuys / TopSells /
+/// NewPositions / SoldOutPositions) into a single CSV keyed by the selected report date.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HoldingsExportActivityTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HoldingsExportActivityTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task ExportActivity_OnlyOneQuarter_Returns404()
+    {
+        var stockId = Guid.NewGuid();
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "ONE",
+                    Name = "One Quarter Co.",
+                    Cik = "0000700001",
+                }
+            );
+            var holder = new InstitutionalHolder { Cik = "0009000010", Name = "Solo" };
+            db.Add(holder);
+            db.Add(MakeHoldingById(stockId, holder.Id, new DateOnly(2024, 12, 31), 100, 100));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Export/Activity");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ExportActivity_HappyPath_BundlesAllFourBoardsIntoOneCsv()
+    {
+        var q1 = new DateOnly(2024, 9, 30);
+        var q2 = new DateOnly(2024, 12, 31);
+        var holderA = Guid.NewGuid();
+        var holderB = Guid.NewGuid();
+        var buyerStock = Guid.NewGuid();
+        var sellerStock = Guid.NewGuid();
+        var newStock = Guid.NewGuid();
+        var soldStock = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.AddRange(
+                new InstitutionalHolder
+                {
+                    Id = holderA,
+                    Cik = "0009000020",
+                    Name = "Holder A",
+                },
+                new InstitutionalHolder
+                {
+                    Id = holderB,
+                    Cik = "0009000021",
+                    Name = "Holder B",
+                }
+            );
+            db.AddRange(
+                new CommonStock
+                {
+                    Id = buyerStock,
+                    Ticker = "BUYR",
+                    Name = "Buyer Co.",
+                    Cik = "0007710001",
+                },
+                new CommonStock
+                {
+                    Id = sellerStock,
+                    Ticker = "SELL",
+                    Name = "Seller Co.",
+                    Cik = "0007710002",
+                },
+                new CommonStock
+                {
+                    Id = newStock,
+                    Ticker = "NEW1",
+                    Name = "Newcomer Co.",
+                    Cik = "0007710003",
+                },
+                new CommonStock
+                {
+                    Id = soldStock,
+                    Ticker = "OUT1",
+                    Name = "Exited Co.",
+                    Cik = "0007710004",
+                }
+            );
+
+            // Buyer: holder A holds 100, then 200 (Δ shares +100, Δ value +50).
+            db.Add(MakeHoldingById(buyerStock, holderA, q1, 100, 50));
+            db.Add(MakeHoldingById(buyerStock, holderA, q2, 200, 100));
+            // Seller: holder A holds 500 then 100 (Δ shares -400, Δ value -40).
+            db.Add(MakeHoldingById(sellerStock, holderA, q1, 500, 50));
+            db.Add(MakeHoldingById(sellerStock, holderA, q2, 100, 10));
+            // Newcomer: holder B first appears in Q2 only.
+            db.Add(MakeHoldingById(newStock, holderB, q2, 1, 1));
+            // Exited: holder B appears in Q1 only.
+            db.Add(MakeHoldingById(soldStock, holderB, q1, 1, 1));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/Holdings/Export/Activity?date={q2:yyyy-MM-dd}"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/csv");
+        response
+            .Content.Headers.ContentDisposition!.FileName.Should()
+            .Be("13F-activity-2024-12-31.csv");
+        response.Headers.CacheControl!.NoStore.Should().BeTrue();
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should()
+            .Contain(
+                "Board,ReportDate,ComparisonDate,Ticker,CompanyName,CurrentFilerCount,"
+                    + "PreviousFilerCount,DeltaShares,DeltaValue,NewFilerCount,SoldOutFilerCount"
+            );
+        body.Should().Contain("TopBuys,2024-12-31,2024-09-30,BUYR,Buyer Co.");
+        body.Should().Contain("TopSells,2024-12-31,2024-09-30,SELL,Seller Co.");
+        body.Should().Contain("NewPositions,2024-12-31,2024-09-30,NEW1,Newcomer Co.");
+        body.Should().Contain("SoldOutPositions,2024-12-31,2024-09-30,OUT1,Exited Co.");
+    }
+
+    [Fact]
+    public async Task ActivityPage_RendersDownloadCsvButton_WhenPriorQuarterExists()
+    {
+        var q1 = new DateOnly(2024, 9, 30);
+        var q2 = new DateOnly(2024, 12, 31);
+        var holderId = Guid.NewGuid();
+        var stockId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "0009000030",
+                    Name = "Test",
+                }
+            );
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "TKB",
+                    Name = "Button Co.",
+                    Cik = "0007777001",
+                }
+            );
+            db.Add(MakeHoldingById(stockId, holderId, q1, 1, 1));
+            db.Add(MakeHoldingById(stockId, holderId, q2, 2, 2));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Activity");
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        html.Should().Contain("data-testid=\"activity-export-csv\"");
+        html.ToLowerInvariant().Should().Contain("/holdings/export/activity");
+    }
+
+    private static InstitutionalHolding MakeHoldingById(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{stockId:N}".Substring(0, 12) + $"-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

PR 4 of 4 for #1018 — **closing slice**.

Adds an `Activity` action to `HoldingsExportController` at `~/Holdings/Export/Activity` that bundles all four boards (Top Buys, Top Sells, New Positions, Sold-out Positions) for the selected report date into a single CSV. Includes a Download CSV button on the Holdings Activity page when a prior quarter exists.

Closes #1018

## Code changes

- `Equibles.Web/Controllers/HoldingsExportController.cs` — `Activity(date)` action. Materialises both `GetQuarterlyActivity` and `GetQuarterlyNewSoldOutPositions`, splits the activity rows into Top Buys / Top Sells by Δ shares sign, ranks new / sold-out by their filer counts, joins with the stock label dictionary, and emits one row per board entry with a `Board` discriminator column. CSV bypasses the 20-row UI cap — analysts pulling into a spreadsheet expect the full set. Filename `13F-activity-<yyyy-MM-dd>.csv` with `Cache-Control: no-store`.
- `Equibles.Web/Views/HoldingsActivity/Activity.cshtml` — Download CSV button on the date-selector row, only when a prior quarter exists.
- `tests/Equibles.IntegrationTests/Web/HoldingsExportActivityTests.cs` — three cases: 404 with only one quarter on file, happy-path bundling of all four board kinds (TopBuys + TopSells + NewPositions + SoldOutPositions all appear), and the Download CSV button rendering on the page.