### PR TITLE
refactor(ftd-import): drop narration comments in FtdImportService

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -68,7 +68,6 @@ public class FtdImportService
             startDate
         );
 
-        // Build ticker map for matching
         var tickerMap = await BuildTickerMap(cancellationToken);
         var cusipsSeeded = 0;
 
@@ -82,10 +81,8 @@ public class FtdImportService
                 if (records.Count == 0)
                     continue;
 
-                // Seed CUSIPs from the FTD data (ticker → CUSIP mapping)
                 cusipsSeeded += await SeedCusips(records, tickerMap, cancellationToken);
 
-                // Import FTD data
                 var imported = await ImportRecords(records, tickerMap, cancellationToken);
 
                 _logger.LogInformation("FTD {File}: imported {Count} records", fileName, imported);
@@ -141,7 +138,6 @@ public class FtdImportService
         CancellationToken cancellationToken
     )
     {
-        // Collect unique ticker→CUSIP pairs where we have a matching stock
         var tickerToCusip = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var record in records)
         {
@@ -159,7 +155,6 @@ public class FtdImportService
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var stockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
 
-        // Load stocks that don't have CUSIPs yet
         var tickers = tickerToCusip.Keys.ToList();
         var stocks = await stockRepo
             .GetByTickers(tickers)
@@ -325,11 +320,9 @@ public class FtdImportService
         var fileNames = new List<string>();
         var now = DateOnly.FromDateTime(DateTime.UtcNow);
 
-        // Clamp to the oldest date the SEC provides FTD data for
         if (startDate < OldestAvailableDate)
             startDate = OldestAvailableDate;
 
-        // Start from the beginning of the start month
         var current = new DateOnly(startDate.Year, startDate.Month, 1);
 
         while (current <= now)


### PR DESCRIPTION
## Summary

- Delete 7 narration comments in `FtdImportService` that just restated the immediately-following code (the `BuildTickerMap` call, `SeedCusips`/`ImportRecords` calls, the ticker→CUSIP dict construction, the cusip-less stocks query, the start-date clamp, and the start-of-month rebase).
- Same hygiene pass as #1134 / #1164. WHY comments are preserved — including the discarded-`ReadLineAsync` "Skip header line" hint (line 271), the FTD column-layout reference (line 283), and the `OldestAvailableDate` rationale (line 315).

## Code changes

- `src/Equibles.Sec.HostedService/Services/FtdImportService.cs` — 7 narration comments removed; no code changes, no signature changes.