### PR TITLE
test(web): add skipped repro for GH-1186 — CsvExportService.Format(DateOnly)

### DIFF
--- a/tests/Equibles.UnitTests/Web/CsvExportServiceFormatDateOnlyCultureTests.cs
+++ b/tests/Equibles.UnitTests/Web/CsvExportServiceFormatDateOnlyCultureTests.cs
@@ -1,0 +1,28 @@
+using System.Globalization;
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+public class CsvExportServiceFormatDateOnlyCultureTests
+{
+    [Fact(
+        Skip = "GH-1186 — Format(DateOnly) doesn't pass InvariantCulture so the thread culture's calendar leaks through (th-TH shifts year by +543)."
+    )]
+    public void Format_DateOnly_ThaiBuddhistCulture_StillEmitsGregorianIsoDate()
+    {
+        // Contract (CsvExportService XML doc): "Numeric / DateOnly conversions use the
+        // invariant culture so the output is stable across hosts regardless of the
+        // request thread's culture." A th-TH host defaults to ThaiBuddhistCalendar,
+        // which would otherwise shift the year by +543 (e.g. 2024 -> 2567).
+        var prev = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("th-TH");
+            CsvExportService.Format(new DateOnly(2024, 6, 30)).Should().Be("2024-06-30");
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = prev;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the documented invariant-culture contract on `CsvExportService.Format(DateOnly)` — a `th-TH` thread (default `ThaiBuddhistCalendar`) currently shifts the year by +543, so an exported `2024-06-30` becomes `2567-06-30` in CSV filenames and date columns across the new institution-portfolio, per-stock-holders, and screener downloads.
- Test is committed as `[Skip]` referencing GH-1186 — un-skip when the fix lands (pass `CultureInfo.InvariantCulture` to `DateOnly.ToString`, same as the sibling `Format(long/double/decimal)` overloads).

## Code changes

- `tests/Equibles.UnitTests/Web/CsvExportServiceFormatDateOnlyCultureTests.cs` — new test pinning that `Format(new DateOnly(2024, 6, 30))` returns `"2024-06-30"` under `th-TH`. Skipped — see GH-1186.