### PR TITLE
refactor(sec-normalizer): inline single-call Middle Man wrappers in TableNormalizationStep

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs
@@ -21,16 +21,11 @@ internal class TableNormalizationStep : IHtmlNormalizationStep
 
         foreach (var table in tables)
         {
-            FixColspanAndRowspan(table, doc);
-            CleanupTableRows(table);
+            FixColspan(table, doc);
+            FixRowspan(table, doc);
+            RemoveEmptyRows(table);
             RemoveEmptyColumns(table);
         }
-    }
-
-    private void FixColspanAndRowspan(IElement table, IHtmlDocument doc)
-    {
-        FixColspan(table, doc);
-        FixRowspan(table, doc);
     }
 
     private void FixColspan(IElement table, IHtmlDocument doc)
@@ -122,11 +117,6 @@ internal class TableNormalizationStep : IHtmlNormalizationStep
         {
             row.AppendChild(newCell);
         }
-    }
-
-    private void CleanupTableRows(IElement table)
-    {
-        RemoveEmptyRows(table);
     }
 
     private void RemoveEmptyRows(IElement table)


### PR DESCRIPTION
## Summary

- \`FixColspanAndRowspan(table, doc)\` and \`CleanupTableRows(table)\` in \`TableNormalizationStep\` were Middle Man pass-throughs — each called from exactly one place in \`Execute\` and forwarding straight to one or two inner methods (\`FixColspan\`/\`FixRowspan\`; \`RemoveEmptyRows\`).
- Inline both wrappers into the \`Execute\` per-table loop so the actual pipeline — \`FixColspan → FixRowspan → RemoveEmptyRows → RemoveEmptyColumns\` — is visible in one place.
- No external callers (grep confirms file-only references), so the change is purely internal. All 107 normalizer unit tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs\` — drop \`FixColspanAndRowspan\` and \`CleanupTableRows\` wrappers; their bodies move into the existing \`Execute\` foreach.