### PR TITLE
refactor(sec-normalizer): extract IsMeaningfulText helper for cell-emptiness check

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs
@@ -151,7 +151,7 @@ internal class TableNormalizationStep : IHtmlNormalizationStep
             var cellText = cell.TextContent.Trim();
             var cellHtml = cell.InnerHtml.Trim();
 
-            if (!string.IsNullOrWhiteSpace(cellText) && cellText != "\u00A0" && cellText != " ")
+            if (IsMeaningfulText(cellText) && cellText != " ")
             {
                 return false;
             }
@@ -184,7 +184,7 @@ internal class TableNormalizationStep : IHtmlNormalizationStep
         foreach (var span in spans)
         {
             var spanText = span.TextContent.Trim();
-            if (!string.IsNullOrWhiteSpace(spanText) && spanText != "\u00A0")
+            if (IsMeaningfulText(spanText))
             {
                 return false;
             }
@@ -221,7 +221,7 @@ internal class TableNormalizationStep : IHtmlNormalizationStep
             if (colIndex < cells.Count)
             {
                 var cellText = cells[colIndex].TextContent.Trim();
-                if (!string.IsNullOrWhiteSpace(cellText) && cellText != "\u00A0")
+                if (IsMeaningfulText(cellText))
                 {
                     return false;
                 }
@@ -245,4 +245,7 @@ internal class TableNormalizationStep : IHtmlNormalizationStep
             }
         }
     }
+
+    private static bool IsMeaningfulText(string text) =>
+        !string.IsNullOrWhiteSpace(text) && text != " ";
 }


### PR DESCRIPTION
## Summary

- Collapse three near-identical `!string.IsNullOrWhiteSpace(text) && text != \"\\u00A0\"` checks in `IsRowEmpty`, `IsOnlyWhitespaceSpan`, and `IsColumnEmpty` into a single private static `IsMeaningfulText` helper.
- `IsRowEmpty`'s trailing `&& cellText != \" \"` (a literal regular-space check) is preserved inline so its semantics are byte-identical to the original.
- Behavior-preserving: the helper evaluates the exact same boolean expression at each site; no input/output changes.

## Code changes

- ``src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs`` — extract `IsMeaningfulText(string)` helper and apply at three call sites (net +3 lines including the helper).