### PR TITLE
feat(yahoo): expose Stochastic Oscillator via MCP

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -170,6 +170,95 @@ public class StockPriceTools
         );
     }
 
+    [McpServerTool(Name = "GetStochasticOscillator")]
+    [Description(
+        "Stochastic Oscillator (%K and %D) for a stock. %K measures the close relative to "
+            + "the high/low range over the lookback window; %D is the smoothed signal line "
+            + "(simple moving average of %K). Useful for spotting overbought (>80) and "
+            + "oversold (<20) conditions."
+    )]
+    public Task<string> GetStochasticOscillator(
+        [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Start date in YYYY-MM-DD format (defaults to 6 months ago)")]
+            string startDate = null,
+        [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
+            string endDate = null,
+        [Description("Lookback window for %K (default: 14)")] int kPeriod = 14,
+        [Description("Smoothing window for %D (default: 3)")] int dPeriod = 3,
+        [Description("Maximum number of records to return (default: 60, newest first)")]
+            int maxResults = 60
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                if (kPeriod < 2 || dPeriod < 1)
+                    return "kPeriod must be at least 2 and dPeriod at least 1.";
+
+                var stock = await _commonStockRepository.GetByTicker(
+                    ticker.Trim().ToUpperInvariant()
+                );
+                if (stock == null)
+                    return $"Stock '{ticker}' not found.";
+
+                var start =
+                    !string.IsNullOrEmpty(startDate)
+                    && DateOnly.TryParse(startDate, out var parsedStart)
+                        ? parsedStart
+                        : DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6));
+
+                var end =
+                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
+                        ? parsedEnd
+                        : DateOnly.FromDateTime(DateTime.UtcNow);
+
+                var records = await _priceRepository
+                    .GetByStock(stock, start, end)
+                    .OrderBy(p => p.Date)
+                    .ToListAsync();
+
+                if (records.Count == 0)
+                    return $"No price data found for {stock.Ticker} in the specified date range.";
+
+                var highs = records.Select(p => p.High).ToList();
+                var lows = records.Select(p => p.Low).ToList();
+                var closes = records.Select(p => p.Close).ToList();
+                var (k, d) = TechnicalIndicatorService.ComputeStochastic(
+                    highs,
+                    lows,
+                    closes,
+                    kPeriod,
+                    dPeriod
+                );
+
+                var result = new StringBuilder();
+                result.AppendLine(
+                    $"Stochastic Oscillator (%K={kPeriod}, %D={dPeriod}) for {stock.Ticker} ({stock.Name}):"
+                );
+                result.AppendLine();
+                result.AppendLine("| Date | Close | %K | %D |");
+                result.AppendLine("|------|-------|----|----|");
+
+                var emitted = 0;
+                for (var i = records.Count - 1; i >= 0 && emitted < maxResults; i--)
+                {
+                    var kCell = k[i].HasValue ? k[i].Value.ToString("F2") : "—";
+                    var dCell = d[i].HasValue ? d[i].Value.ToString("F2") : "—";
+                    result.AppendLine(
+                        $"| {records[i].Date:yyyy-MM-dd} | {records[i].Close:F2} | {kCell} | {dCell} |"
+                    );
+                    emitted++;
+                }
+
+                return result.ToString();
+            },
+            _logger,
+            "GetStochasticOscillator",
+            $"ticker: {ticker}",
+            ReportError
+        );
+    }
+
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);

--- a/src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs
+++ b/src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs
@@ -1,4 +1,4 @@
-namespace Equibles.Web.Services;
+namespace Equibles.Yahoo.Repositories;
 
 /// <summary>
 /// Computes common technical indicators from price series.

--- a/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceBenchmarks.cs
+++ b/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceBenchmarks.cs
@@ -1,5 +1,5 @@
 using BenchmarkDotNet.Attributes;
-using Equibles.Web.Services;
+using Equibles.Yahoo.Repositories;
 
 namespace Equibles.Benchmarks.Benchmarks;
 

--- a/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceEmaBenchmarks.cs
+++ b/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceEmaBenchmarks.cs
@@ -1,5 +1,5 @@
 using BenchmarkDotNet.Attributes;
-using Equibles.Web.Services;
+using Equibles.Yahoo.Repositories;
 
 namespace Equibles.Benchmarks.Benchmarks;
 

--- a/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceRsiBenchmarks.cs
+++ b/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceRsiBenchmarks.cs
@@ -1,5 +1,5 @@
 using BenchmarkDotNet.Attributes;
-using Equibles.Web.Services;
+using Equibles.Yahoo.Repositories;
 
 namespace Equibles.Benchmarks.Benchmarks;
 

--- a/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceSmaBenchmarks.cs
+++ b/tests/Equibles.Benchmarks/Benchmarks/TechnicalIndicatorServiceSmaBenchmarks.cs
@@ -1,5 +1,5 @@
 using BenchmarkDotNet.Attributes;
-using Equibles.Web.Services;
+using Equibles.Yahoo.Repositories;
 
 namespace Equibles.Benchmarks.Benchmarks;
 

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStochasticTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStochasticTests.cs
@@ -1,0 +1,149 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Mcp.Tools;
+using Equibles.Yahoo.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins the GetStochasticOscillator MCP tool end-to-end against ParadeDB so
+/// repository + projection + calculator + Markdown formatting all run through the
+/// real pipeline.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class StockPriceToolsStochasticTests : ParadeDbMcpTestBase
+{
+    public StockPriceToolsStochasticTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private StockPriceTools Sut() =>
+        new(
+            new DailyStockPriceRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<StockPriceTools>()
+        );
+
+    [Fact]
+    public async Task GetStochasticOscillator_UnknownTicker_ReturnsNotFoundMessage()
+    {
+        var result = await Sut().GetStochasticOscillator("ZZZZ");
+
+        result.Should().Be("Stock 'ZZZZ' not found.");
+    }
+
+    [Fact]
+    public async Task GetStochasticOscillator_NoPrices_ReturnsEmptyRangeMessage()
+    {
+        DbContext.Set<CommonStock>().Add(MakeStock());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetStochasticOscillator("AAPL", startDate: "2026-04-01", endDate: "2026-04-30");
+
+        result.Should().Contain("No price data found for AAPL");
+    }
+
+    [Fact]
+    public async Task GetStochasticOscillator_InvalidPeriods_ReturnsValidationMessage()
+    {
+        var result = await Sut().GetStochasticOscillator("AAPL", kPeriod: 1);
+
+        result.Should().Contain("kPeriod must be at least 2");
+    }
+
+    [Fact]
+    public async Task GetStochasticOscillator_RisingPrices_ReturnsTableWithKAndDValues()
+    {
+        var stock = MakeStock();
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+
+        // 20 strictly-increasing daily bars; the 14/3 default lookback fills around
+        // index 15 and %K trends toward 100 as the close stays at the lookback high.
+        var start = new DateOnly(2025, 1, 6); // a Monday so the date range covers ~4 weeks
+        for (var i = 0; i < 20; i++)
+        {
+            DbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = start.AddDays(i),
+                        Open = 100m + i,
+                        High = 100.5m + i,
+                        Low = 99.5m + i,
+                        Close = 100m + i,
+                        AdjustedClose = 100m + i,
+                        Volume = 1_000_000,
+                    }
+                );
+        }
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetStochasticOscillator(
+                "AAPL",
+                startDate: start.ToString("yyyy-MM-dd"),
+                endDate: start.AddDays(20).ToString("yyyy-MM-dd")
+            );
+
+        result.Should().Contain("Stochastic Oscillator");
+        result.Should().Contain("| Date | Close | %K | %D |");
+        // Latest bar's %K should be at or near 100 since price is the lookback high.
+        // Allow culture-invariant formatting (always F2 → "100.00").
+        result.Should().Contain("100.00");
+    }
+
+    [Fact]
+    public async Task GetStochasticOscillator_MaxResults_LimitsRowCount()
+    {
+        var stock = MakeStock();
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+        var start = new DateOnly(2025, 1, 6);
+        for (var i = 0; i < 30; i++)
+        {
+            DbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = start.AddDays(i),
+                        Open = 100m,
+                        High = 101m,
+                        Low = 99m,
+                        Close = 100m,
+                        AdjustedClose = 100m,
+                        Volume = 1,
+                    }
+                );
+        }
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetStochasticOscillator(
+                "AAPL",
+                startDate: start.ToString("yyyy-MM-dd"),
+                endDate: start.AddDays(30).ToString("yyyy-MM-dd"),
+                maxResults: 5
+            );
+
+        // Header row + separator + 5 data rows = at most 5 lines starting with "| 2025-"
+        var dataLines = result.Split('\n').Count(line => line.StartsWith("| 2025-"));
+        dataLines.Should().Be(5);
+    }
+
+    private static CommonStock MakeStock() =>
+        new()
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+        };
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -401,7 +401,10 @@ public class McpModuleToolDiscoveryTests
                 typeof(ShortDataTools),
                 new[] { "GetShortVolume", "GetShortInterest", "GetShortInterestSnapshot" }
             },
-            { typeof(StockPriceTools), new[] { "GetStockPrices", "GetLatestPrices" } },
+            {
+                typeof(StockPriceTools),
+                new[] { "GetStockPrices", "GetLatestPrices", "GetStochasticOscillator" }
+            },
         };
 
     public static TheoryData<Type> AllToolMarkerTypes =>

--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceComputeRsiZeroLossTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceComputeRsiZeroLossTests.cs
@@ -1,4 +1,4 @@
-using Equibles.Web.Services;
+using Equibles.Yahoo.Repositories;
 
 namespace Equibles.UnitTests.Web;
 

--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceStochasticTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceStochasticTests.cs
@@ -1,4 +1,4 @@
-using Equibles.Web.Services;
+using Equibles.Yahoo.Repositories;
 
 namespace Equibles.UnitTests.Web;
 

--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceTests.cs
@@ -1,4 +1,4 @@
-using Equibles.Web.Services;
+using Equibles.Yahoo.Repositories;
 
 namespace Equibles.UnitTests.Web;
 


### PR DESCRIPTION
## Summary

PR 2 of 2 for #686 — **closing slice**.

Adds `GetStochasticOscillator` to the Yahoo MCP tool surface. Moves `TechnicalIndicatorService` from `Equibles.Web.Services` to `Equibles.Yahoo.Repositories` so MCP tools can reach it without a wide cross-cut (the existing web caller and benchmarks follow the move; the file is moved with `git mv` to preserve history).

Closes #686

## Code changes

- `src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs` (moved from `src/Equibles.Web/Services/`) — namespace updated; logic unchanged.
- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — new `GetStochasticOscillator(ticker, startDate, endDate, kPeriod=14, dPeriod=3, maxResults=60)` tool. Loads OHLC for the range, hands it to the calculator, emits a Markdown table sorted newest-first. Validates `kPeriod >= 2` and `dPeriod >= 1` with a friendly inline message rather than throwing.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — adds `GetStochasticOscillator` to the StockPriceTools expected-tool array; the cross-module uniqueness check naturally covers the new name.
- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStochasticTests.cs` — five cases: unknown ticker, no-prices-in-range, period validation, happy-path table on rising prices, and `maxResults` trimming.
- `using` updates in the existing TechnicalIndicatorService unit tests + benchmark suite (no behavior change).