### PR TITLE
refactor(cftc-controller): use null-conditional for net calculations

### DIFF
--- a/src/Equibles.Web/Controllers/CftcController.cs
+++ b/src/Equibles.Web/Controllers/CftcController.cs
@@ -50,10 +50,8 @@ public class CftcController : BaseController
                         {
                             MarketCode = c.MarketCode,
                             MarketName = c.MarketName,
-                            CommercialNet =
-                                latest != null ? latest.CommLong - latest.CommShort : null,
-                            NonCommercialNet =
-                                latest != null ? latest.NonCommLong - latest.NonCommShort : null,
+                            CommercialNet = latest?.CommLong - latest?.CommShort,
+                            NonCommercialNet = latest?.NonCommLong - latest?.NonCommShort,
                             LatestDate = latest?.ReportDate,
                         };
                     })
@@ -102,9 +100,8 @@ public class CftcController : BaseController
             CategoryDisplayName = contract.Category.NameForHumans(),
             Reports = reports,
             LatestOpenInterest = latest?.OpenInterest,
-            LatestCommercialNet = latest != null ? latest.CommLong - latest.CommShort : null,
-            LatestNonCommercialNet =
-                latest != null ? latest.NonCommLong - latest.NonCommShort : null,
+            LatestCommercialNet = latest?.CommLong - latest?.CommShort,
+            LatestNonCommercialNet = latest?.NonCommLong - latest?.NonCommShort,
             LatestNonCommSpreads = latest?.NonCommSpreads,
         };
 


### PR DESCRIPTION
## Summary

- Replace four occurrences of `latest != null ? latest.X - latest.Y : null` ternaries (CommercialNet + NonCommercialNet, twice each across `Index` and `Show`) with the equivalent `latest?.X - latest?.Y` null-conditional form.
- Behavior is preserved: C# nullable arithmetic propagates null — `null - null` yields `null` (the ternary's null branch); two non-null operands return the same `long` (lifted to `long?` for the property type) as the ternary's true branch.

## Code changes

- ``src/Equibles.Web/Controllers/CftcController.cs`` — replace 4 ternaries with null-conditional subtractions (net -3 lines).