### PR TITLE
test(web): pin TechnicalIndicatorService.ComputeStochastic %K lower bound at zero

### DIFF
--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceStochasticTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceStochasticTests.cs
@@ -100,4 +100,20 @@ public class TechnicalIndicatorServiceStochasticTests
         k.Should().BeEmpty();
         d.Should().BeEmpty();
     }
+
+    [Fact]
+    public void ComputeStochastic_CloseEqualsLookbackLowestLow_PercentKIsZero()
+    {
+        // Pins the lower bound of the [0, 100] %K band: by definition
+        // 100 * (close - lowestLow) / range, so close == lowestLow ⇒ %K = 0.
+        // The upper bound (100) is already exercised by the strictly-increasing
+        // default-periods test.
+        var highs = new List<decimal> { 10m, 11m, 12m };
+        var lows = new List<decimal> { 5m, 6m, 4m };
+        var closes = new List<decimal> { 7m, 8m, 4m };
+
+        var (k, _) = TechnicalIndicatorService.ComputeStochastic(highs, lows, closes, 3, 3);
+
+        k[2].Should().Be(0m);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a single adversarial unit test that pins the lower bound of the Stochastic Oscillator's %K — when the current close equals the lookback's lowest low, %K must be exactly 0. The upper bound (100) is already exercised by the existing strictly-increasing default-periods test; this closes the symmetric gap.

## Code changes

- `tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceStochasticTests.cs` — adds `ComputeStochastic_CloseEqualsLookbackLowestLow_PercentKIsZero`. Hand-built 3-bar fixture with `closes[2] == lowestLow == 4` over a `kPeriod=3` window; asserts `k[2] == 0m`. No production code touched.