### PR TITLE
feat(yahoo): add Average True Range (ATR) calculator

### DIFF
--- a/src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs
+++ b/src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs
@@ -114,6 +114,70 @@ public static class TechnicalIndicatorService
     }
 
     /// <summary>
+    /// Average True Range (Wilder, J. Welles). TR = max(high − low, |high − prev_close|,
+    /// |low − prev_close|); ATR is seeded with the simple average of the first
+    /// <paramref name="period"/> TRs and then smoothed via Wilder's recursive average:
+    /// <c>atr_i = (atr_{i-1} × (period − 1) + tr_i) / period</c>. Returns a list aligned
+    /// to input length, null-padded while the window fills.
+    /// </summary>
+    public static List<decimal?> ComputeAtr(
+        List<decimal> highs,
+        List<decimal> lows,
+        List<decimal> closes,
+        int period = 14
+    )
+    {
+        if (highs.Count != lows.Count || lows.Count != closes.Count)
+            throw new ArgumentException("highs, lows, and closes must all have the same length");
+
+        var count = closes.Count;
+        var result = new List<decimal?>(count);
+        if (count == 0)
+            return result;
+
+        // True Range per bar. Bar 0 has no previous close — TR_0 collapses to high − low,
+        // which is the standard convention.
+        var trueRanges = new decimal[count];
+        trueRanges[0] = highs[0] - lows[0];
+        for (var i = 1; i < count; i++)
+        {
+            var prevClose = closes[i - 1];
+            var range = highs[i] - lows[i];
+            var upGap = Math.Abs(highs[i] - prevClose);
+            var downGap = Math.Abs(lows[i] - prevClose);
+            trueRanges[i] = Math.Max(range, Math.Max(upGap, downGap));
+        }
+
+        // Need at least `period` TR values before emitting an ATR — short series stays null.
+        if (count < period)
+        {
+            for (var i = 0; i < count; i++)
+                result.Add(null);
+            return result;
+        }
+
+        // First (period - 1) bars are warm-up; the seed lands at index (period - 1).
+        for (var i = 0; i < period - 1; i++)
+            result.Add(null);
+
+        decimal seed = 0m;
+        for (var i = 0; i < period; i++)
+            seed += trueRanges[i];
+        seed /= period;
+        result.Add(Math.Round(seed, 4));
+
+        // Wilder smoothing: combine the running ATR with the next TR.
+        var atr = seed;
+        for (var i = period; i < count; i++)
+        {
+            atr = (atr * (period - 1) + trueRanges[i]) / period;
+            result.Add(Math.Round(atr, 4));
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Stochastic Oscillator. %K = 100 × (close - lowestLow) / (highestHigh - lowestLow)
     /// over a <paramref name="kPeriod"/> lookback; %D is the simple moving average of %K
     /// over <paramref name="dPeriod"/> bars. Returns lists matching the input length,

--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceAtrTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceAtrTests.cs
@@ -1,0 +1,111 @@
+using Equibles.Yahoo.Repositories;
+
+namespace Equibles.UnitTests.Web;
+
+public class TechnicalIndicatorServiceAtrTests
+{
+    [Fact]
+    public void ComputeAtr_FirstPeriodMinusOneBars_AreNull()
+    {
+        // 3-period ATR over 5 bars: indices 0..1 are warm-up, index 2 carries the seed.
+        var highs = new List<decimal> { 11, 12, 13, 14, 15 };
+        var lows = new List<decimal> { 9, 10, 11, 12, 13 };
+        var closes = new List<decimal> { 10, 11, 12, 13, 14 };
+
+        var atr = TechnicalIndicatorService.ComputeAtr(highs, lows, closes, 3);
+
+        atr.Should().HaveCount(5);
+        atr[0].Should().BeNull();
+        atr[1].Should().BeNull();
+        atr[2].Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ComputeAtr_HappyPath_SeedIsAverageOfFirstPeriodTrueRanges()
+    {
+        // Bars chosen so TR is non-trivial at every step.
+        // i=0: H=10 L=8  C=9   → TR_0 = H-L = 2
+        // i=1: H=12 L=9  C=11  → prev_close=9 → TR_1 = max(12-9, |12-9|, |9-9|) = 3
+        // i=2: H=14 L=10 C=13  → prev_close=11 → TR_2 = max(14-10, |14-11|, |10-11|) = 4
+        // seed at i=2 = mean(2,3,4) = 3
+        // i=3: H=13 L=8  C=9   → prev_close=13 → TR_3 = max(13-8, |13-13|, |8-13|) = 5
+        // ATR_3 = (3 * 2 + 5) / 3 = 11/3 ≈ 3.6667
+        // i=4: H=11 L=7  C=10  → prev_close=9 → TR_4 = max(11-7, |11-9|, |7-9|) = 4
+        // ATR_4 = (3.6667 * 2 + 4) / 3 ≈ 3.7778
+        var highs = new List<decimal> { 10, 12, 14, 13, 11 };
+        var lows = new List<decimal> { 8, 9, 10, 8, 7 };
+        var closes = new List<decimal> { 9, 11, 13, 9, 10 };
+
+        var atr = TechnicalIndicatorService.ComputeAtr(highs, lows, closes, 3);
+
+        atr[2].Should().Be(3m);
+        atr[3].Should().BeApproximately(3.6667m, 0.001m);
+        atr[4].Should().BeApproximately(3.7778m, 0.001m);
+    }
+
+    [Fact]
+    public void ComputeAtr_FlatOhlc_ReturnsZeroVolatility()
+    {
+        // Identical bars → TR is always 0 → ATR is 0 throughout (post warm-up).
+        var highs = new List<decimal> { 10, 10, 10, 10, 10 };
+        var lows = new List<decimal> { 10, 10, 10, 10, 10 };
+        var closes = new List<decimal> { 10, 10, 10, 10, 10 };
+
+        var atr = TechnicalIndicatorService.ComputeAtr(highs, lows, closes, 3);
+
+        atr[2].Should().Be(0m);
+        atr[3].Should().Be(0m);
+        atr[4].Should().Be(0m);
+    }
+
+    [Fact]
+    public void ComputeAtr_ShorterThanPeriod_AllNulls()
+    {
+        // Only 5 bars but period 14 — the seed never lands, so every value stays null.
+        var highs = Enumerable.Range(1, 5).Select(i => (decimal)(i + 1)).ToList();
+        var lows = Enumerable.Range(1, 5).Select(i => (decimal)i).ToList();
+        var closes = Enumerable.Range(1, 5).Select(i => (decimal)i).ToList();
+
+        var atr = TechnicalIndicatorService.ComputeAtr(highs, lows, closes);
+
+        atr.Should().HaveCount(5);
+        atr.Should().OnlyContain(v => v == null);
+    }
+
+    [Fact]
+    public void ComputeAtr_DefaultPeriodIsFourteen_SeedAtIndexThirteen()
+    {
+        // 20 bars with identical H/L/C across the series → TR is 0 every bar, ATR is 0
+        // throughout. The point of this test is the default-period warm-up boundary:
+        // index 12 must still be null, index 13 carries the first ATR value.
+        var highs = Enumerable.Repeat(10m, 20).ToList();
+        var lows = Enumerable.Repeat(10m, 20).ToList();
+        var closes = Enumerable.Repeat(10m, 20).ToList();
+
+        var atr = TechnicalIndicatorService.ComputeAtr(highs, lows, closes);
+
+        atr[12].Should().BeNull();
+        atr[13].Should().NotBeNull();
+        atr[19].Should().Be(0m);
+    }
+
+    [Fact]
+    public void ComputeAtr_MismatchedSeriesLengths_Throws()
+    {
+        var highs = new List<decimal> { 1, 2, 3 };
+        var lows = new List<decimal> { 1, 2 };
+        var closes = new List<decimal> { 1, 2, 3 };
+
+        var act = () => TechnicalIndicatorService.ComputeAtr(highs, lows, closes);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void ComputeAtr_EmptyInput_ReturnsEmptyList()
+    {
+        var atr = TechnicalIndicatorService.ComputeAtr([], [], []);
+
+        atr.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

PR 1 of 2 for #688. Intermediate slice — not the closing one.

Adds `ComputeAtr(highs, lows, closes, period=14)` to the technical-indicator service. True Range per bar is `max(H - L, |H - prev_close|, |L - prev_close|)`; ATR is seeded with the simple average of the first `period` TRs and then Wilder-smoothed. Slice 2 exposes this through the Yahoo MCP server.

Refs #688

## Code changes

- `src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs` — `ComputeAtr` static method. Bar 0's TR collapses to `H - L` (no prior close). Throws `ArgumentException` on mismatched series lengths. Series shorter than `period` returns all nulls (the seed never lands).
- `tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceAtrTests.cs` — seven cases: warm-up nulls, a hand-computed 3-period happy-path verifying both the seed and two subsequent Wilder-smoothed bars, the flat-OHLC zero-volatility case, the shorter-than-period short-circuit, default-period seed boundary at index 13, mismatched series lengths, and the empty-input edge.