### PR TITLE
docs(readme): list Financial Statements under MCP Server tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The MCP server exposes financial data tools for AI assistants (Claude, ChatGPT, 
 - **Insider Trading** — Insider transactions, ownership summary, insider search
 - **Congressional Trading** — Trades for a ticker, trades by one member, member search
 - **SEC Documents** — Full-text search, semantic search, document browsing, keyword search within filings
+- **Financial Statements** — XBRL fact time series per ticker, cross-ticker fact comparison, full income statement / balance sheet / cash flow per fiscal period
 - **Short Data** — Daily short volume, bi-monthly short interest, and the latest short-interest snapshot across tickers
 - **Economic Indicators** — FRED data lookup, latest macro snapshot, indicator search across categories
 - **Stock Prices** — Daily OHLCV history with adjusted close, plus latest close across one or more tickers


### PR DESCRIPTION
## Summary

- Lane: **README — drift fix**.
- The MCP catalog exposes `GetFinancialFact`, `CompareFinancialFact`, and `GetFinancialStatement` from `Equibles.Sec.FinancialFacts.Mcp`, but the README's MCP Server bullet list didn't mention them. Add the missing category.

## Code changes

- `README.md` — add a `**Financial Statements**` bullet between SEC Documents and Short Data under the MCP Server section (XBRL fact time series, cross-ticker comparison, full income statement / balance sheet / cash flow per fiscal period).