### PR TITLE
test(holdings): add skipped repro for GH-1199 — HoldingsBacktestCalculator

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorCagrShortWindowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorCagrShortWindowTests.cs
@@ -1,0 +1,53 @@
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsBacktestCalculatorCagrShortWindowTests
+{
+    [Fact(
+        Skip = "GH-1199 — ComputeSummary casts Math.Pow(ratio, 365.25/days) to decimal; a short window with a large gain overflows decimal.MaxValue and throws."
+    )]
+    public void Calculate_OneDayWindowWithDoublingPortfolio_ReturnsSummaryWithoutOverflow()
+    {
+        // Contract: Calculate returns a populated BacktestResult — including a
+        // PortfolioSummary with TotalReturn / CAGR / MaxDrawdown — for any window
+        // where there's a rebalance + benchmark price. An extreme intraday move
+        // must not blow up the CAGR cast: Math.Pow(2.0, 365.25) ≈ 7.5e109, which
+        // exceeds decimal.MaxValue (≈7.92e28); the calculator must clamp / guard
+        // / round instead of throwing OverflowException.
+        var stockId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        var rebalanceDate = new DateOnly(2025, 1, 1);
+        var reportDate = rebalanceDate.AddDays(-HoldingsBacktestCalculator.RebalanceDelayDays);
+        var endDate = rebalanceDate.AddDays(1);
+
+        var snapshot = new BacktestQuarterSnapshot
+        {
+            ReportDate = reportDate,
+            Positions =
+            {
+                new BacktestPosition
+                {
+                    CommonStockId = stockId,
+                    Shares = 10_000,
+                    Value = 1_000_000,
+                    IsOption = false,
+                },
+            },
+        };
+
+        var act = () =>
+            HoldingsBacktestCalculator.Calculate(
+                [snapshot],
+                from: rebalanceDate,
+                to: endDate,
+                priceOf: (_, day) => day == rebalanceDate ? 100m : 200m,
+                benchmarkPriceOf: day => day == rebalanceDate ? 100m : 200m
+            );
+
+        act.Should().NotThrow();
+        var result = act();
+        result.Points.Should().HaveCount(2);
+        result.PortfolioSummary.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `HoldingsBacktestCalculator.Calculate` returns a finite summary on a short window with a large gain — currently throws `OverflowException` because `ComputeSummary` casts `Math.Pow(ratio, 365.25/days)` directly to `decimal`, and a 1-day doubling produces ~7.5e109 (well past `decimal.MaxValue` ≈ 7.92e28).
- Test is committed as `[Skip]` referencing GH-1199 — un-skip when the fix lands (clamp / cap / skip-sub-year CAGR before the decimal cast).

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorCagrShortWindowTests.cs` — new test pinning that a 1-day window where the held stock doubles still returns a populated `BacktestResult`. Skipped — see GH-1199.