### PR TITLE
refactor(stock-price-mcp): extract ParseDateOr helper for duplicated date-parsing fallback

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -394,7 +394,9 @@ public class StockPriceTools
     }
 
     private static DateOnly ParseDateOr(string value, DateOnly fallback) =>
-        !string.IsNullOrEmpty(value) && DateOnly.TryParse(value, out var parsed) ? parsed : fallback;
+        !string.IsNullOrEmpty(value) && DateOnly.TryParse(value, out var parsed)
+            ? parsed
+            : fallback;
 
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -55,16 +55,11 @@ public class StockPriceTools
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var records = await _priceRepository
                     .GetByStock(stock, start, end)
@@ -201,16 +196,11 @@ public class StockPriceTools
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var records = await _priceRepository
                     .GetByStock(stock, start, end)
@@ -289,16 +279,11 @@ public class StockPriceTools
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var records = await _priceRepository
                     .GetByStock(stock, start, end)
@@ -366,16 +351,11 @@ public class StockPriceTools
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var records = await _priceRepository
                     .GetByStock(stock, start, end)
@@ -412,6 +392,9 @@ public class StockPriceTools
             ReportError
         );
     }
+
+    private static DateOnly ParseDateOr(string value, DateOnly fallback) =>
+        !string.IsNullOrEmpty(value) && DateOnly.TryParse(value, out var parsed) ? parsed : fallback;
 
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {


### PR DESCRIPTION
## Summary

- `StockPriceTools.GetStockPrices` and `.GetStochasticOscillator` each parsed `startDate` and `endDate` arguments with the same `!string.IsNullOrEmpty(x) && DateOnly.TryParse(x, out var parsed) ? parsed : fallback` expression — four occurrences across the two tools.
- Extracted a private static `ParseDateOr(string value, DateOnly fallback)` helper (same shape as the existing helpers in `FredTools` / `CftcTools`). Each call site is byte-for-byte equivalent — same null/empty short-circuit, same `DateOnly.TryParse` (no culture/style arguments), same fallback in the same branch order.

## Code changes

- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — added a private static `ParseDateOr` helper; replaced the four inline `start`/`end` date-parsing expressions in `GetStockPrices` and `GetStochasticOscillator` with calls to it.