### PR TITLE
feat(yahoo): expose Average True Range via MCP

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -259,6 +259,87 @@ public class StockPriceTools
         );
     }
 
+    [McpServerTool(Name = "GetAverageTrueRange")]
+    [Description(
+        "Average True Range (ATR) for a stock. Wilder's volatility measure built from "
+            + "the True Range (max of high-low, |high-prev_close|, |low-prev_close|) and "
+            + "smoothed recursively. Higher ATR means wider daily moves; commonly used "
+            + "for position sizing and stop placement."
+    )]
+    public Task<string> GetAverageTrueRange(
+        [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Start date in YYYY-MM-DD format (defaults to 6 months ago)")]
+            string startDate = null,
+        [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
+            string endDate = null,
+        [Description("Smoothing window (default: 14)")] int period = 14,
+        [Description("Maximum number of records to return (default: 60, newest first)")]
+            int maxResults = 60
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                if (period < 2)
+                    return "period must be at least 2.";
+
+                var stock = await _commonStockRepository.GetByTicker(
+                    ticker.Trim().ToUpperInvariant()
+                );
+                if (stock == null)
+                    return $"Stock '{ticker}' not found.";
+
+                var start =
+                    !string.IsNullOrEmpty(startDate)
+                    && DateOnly.TryParse(startDate, out var parsedStart)
+                        ? parsedStart
+                        : DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6));
+
+                var end =
+                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
+                        ? parsedEnd
+                        : DateOnly.FromDateTime(DateTime.UtcNow);
+
+                var records = await _priceRepository
+                    .GetByStock(stock, start, end)
+                    .OrderBy(p => p.Date)
+                    .ToListAsync();
+
+                if (records.Count == 0)
+                    return $"No price data found for {stock.Ticker} in the specified date range.";
+
+                var highs = records.Select(p => p.High).ToList();
+                var lows = records.Select(p => p.Low).ToList();
+                var closes = records.Select(p => p.Close).ToList();
+                var atr = TechnicalIndicatorService.ComputeAtr(highs, lows, closes, period);
+
+                var result = new StringBuilder();
+                result.AppendLine(
+                    $"Average True Range (period={period}) for {stock.Ticker} ({stock.Name}):"
+                );
+                result.AppendLine();
+                result.AppendLine("| Date | Close | ATR |");
+                result.AppendLine("|------|-------|-----|");
+
+                var emitted = 0;
+                for (var i = records.Count - 1; i >= 0 && emitted < maxResults; i--)
+                {
+                    var atrCell = atr[i].HasValue ? atr[i].Value.ToString("F4") : "—";
+                    result.AppendLine(
+                        $"| {records[i].Date:yyyy-MM-dd} | {records[i].Close:F2} | {atrCell} |"
+                    );
+                    emitted++;
+                }
+
+                return result.ToString();
+            },
+            _logger,
+            "GetAverageTrueRange",
+            $"ticker: {ticker}",
+            ReportError
+        );
+    }
+
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsAtrTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsAtrTests.cs
@@ -1,0 +1,145 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Mcp.Tools;
+using Equibles.Yahoo.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins the GetAverageTrueRange MCP tool end-to-end against ParadeDB so repository +
+/// projection + calculator + Markdown formatting all run through the real pipeline.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class StockPriceToolsAtrTests : ParadeDbMcpTestBase
+{
+    public StockPriceToolsAtrTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private StockPriceTools Sut() =>
+        new(
+            new DailyStockPriceRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<StockPriceTools>()
+        );
+
+    [Fact]
+    public async Task GetAverageTrueRange_UnknownTicker_ReturnsNotFoundMessage()
+    {
+        var result = await Sut().GetAverageTrueRange("ZZZZ");
+
+        result.Should().Be("Stock 'ZZZZ' not found.");
+    }
+
+    [Fact]
+    public async Task GetAverageTrueRange_NoPrices_ReturnsEmptyRangeMessage()
+    {
+        DbContext.Set<CommonStock>().Add(MakeStock());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetAverageTrueRange("AAPL", startDate: "2026-04-01", endDate: "2026-04-30");
+
+        result.Should().Contain("No price data found for AAPL");
+    }
+
+    [Fact]
+    public async Task GetAverageTrueRange_InvalidPeriod_ReturnsValidationMessage()
+    {
+        var result = await Sut().GetAverageTrueRange("AAPL", period: 1);
+
+        result.Should().Contain("period must be at least 2");
+    }
+
+    [Fact]
+    public async Task GetAverageTrueRange_FlatOhlc_ReturnsZeroAtrAfterWarmUp()
+    {
+        var stock = MakeStock();
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+
+        // 20 identical bars → TR is 0 throughout → ATR is 0 after the seed lands.
+        var start = new DateOnly(2025, 1, 6);
+        for (var i = 0; i < 20; i++)
+        {
+            DbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = start.AddDays(i),
+                        Open = 100m,
+                        High = 100m,
+                        Low = 100m,
+                        Close = 100m,
+                        AdjustedClose = 100m,
+                        Volume = 1,
+                    }
+                );
+        }
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetAverageTrueRange(
+                "AAPL",
+                startDate: start.ToString("yyyy-MM-dd"),
+                endDate: start.AddDays(20).ToString("yyyy-MM-dd")
+            );
+
+        result.Should().Contain("Average True Range");
+        result.Should().Contain("| Date | Close | ATR |");
+        // The latest bar is index 19 (well past the period=14 seed at index 13) → ATR = 0.
+        result.Should().Contain("0.0000");
+    }
+
+    [Fact]
+    public async Task GetAverageTrueRange_MaxResults_LimitsRowCount()
+    {
+        var stock = MakeStock();
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+        var start = new DateOnly(2025, 1, 6);
+        for (var i = 0; i < 30; i++)
+        {
+            DbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = start.AddDays(i),
+                        Open = 100m,
+                        High = 101m,
+                        Low = 99m,
+                        Close = 100m,
+                        AdjustedClose = 100m,
+                        Volume = 1,
+                    }
+                );
+        }
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetAverageTrueRange(
+                "AAPL",
+                startDate: start.ToString("yyyy-MM-dd"),
+                endDate: start.AddDays(30).ToString("yyyy-MM-dd"),
+                maxResults: 5
+            );
+
+        var dataLines = result.Split('\n').Count(line => line.StartsWith("| 2025-"));
+        dataLines.Should().Be(5);
+    }
+
+    private static CommonStock MakeStock() =>
+        new()
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+        };
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -403,7 +403,13 @@ public class McpModuleToolDiscoveryTests
             },
             {
                 typeof(StockPriceTools),
-                new[] { "GetStockPrices", "GetLatestPrices", "GetStochasticOscillator" }
+                new[]
+                {
+                    "GetStockPrices",
+                    "GetLatestPrices",
+                    "GetStochasticOscillator",
+                    "GetAverageTrueRange",
+                }
             },
         };
 


### PR DESCRIPTION
## Summary

PR 2 of 2 for #688 — **closing slice**.

Adds `GetAverageTrueRange` to the Yahoo MCP tool surface. Mirrors the shape of `GetStochasticOscillator` (PR #1192): loads OHLC for a range, calls `TechnicalIndicatorService.ComputeAtr` (PR #1197), and emits a Markdown table newest-first.

Closes #688

## Code changes

- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — new `GetAverageTrueRange(ticker, startDate, endDate, period=14, maxResults=60)` tool. Validates `period >= 2` with a friendly inline message rather than throwing. Default start date is six months ago — plenty of warm-up plus current-state visibility for the 14-period default.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — adds `GetAverageTrueRange` to the `StockPriceTools` expected-tool array; the cross-module uniqueness check naturally covers the new name.
- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsAtrTests.cs` — five cases: unknown ticker, no-prices-in-range, period validation, the flat-OHLC zero-volatility happy-path showing `0.0000` after the seed lands, and the `maxResults` row-count trim.