### PR TITLE
refactor(congress-parser): extract MatchesType helper in ParseTransactionType

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -231,24 +231,18 @@ public static partial class DisclosureParsingHelper
         // so accept the bare letter or the letter followed by a space/'(' in
         // addition to the Senate full words.
         var trimmed = type.Trim();
-        if (
-            trimmed.Contains("Sale", StringComparison.OrdinalIgnoreCase)
-            || trimmed.Contains("Sold", StringComparison.OrdinalIgnoreCase)
-            || trimmed.Equals("S", StringComparison.OrdinalIgnoreCase)
-            || trimmed.StartsWith("S ", StringComparison.OrdinalIgnoreCase)
-            || trimmed.StartsWith("S(", StringComparison.OrdinalIgnoreCase)
-        )
+        if (MatchesType(trimmed, ["Sale", "Sold"], "S"))
             return CongressTransactionType.Sale;
-        if (
-            trimmed.Contains("Purchase", StringComparison.OrdinalIgnoreCase)
-            || trimmed.Contains("Buy", StringComparison.OrdinalIgnoreCase)
-            || trimmed.Equals("P", StringComparison.OrdinalIgnoreCase)
-            || trimmed.StartsWith("P ", StringComparison.OrdinalIgnoreCase)
-            || trimmed.StartsWith("P(", StringComparison.OrdinalIgnoreCase)
-        )
+        if (MatchesType(trimmed, ["Purchase", "Buy"], "P"))
             return CongressTransactionType.Purchase;
         return null;
     }
+
+    private static bool MatchesType(string text, string[] words, string abbreviation) =>
+        words.Any(w => text.Contains(w, StringComparison.OrdinalIgnoreCase))
+        || text.Equals(abbreviation, StringComparison.OrdinalIgnoreCase)
+        || text.StartsWith(abbreviation + " ", StringComparison.OrdinalIgnoreCase)
+        || text.StartsWith(abbreviation + "(", StringComparison.OrdinalIgnoreCase);
 
     public static (long from, long to) ParseAmountRange(string amount)
     {


### PR DESCRIPTION
## Summary

- `ParseTransactionType` had two near-identical 5-condition OR-chains (one for Sale, one for Purchase) checking a free-text label against full-word variants plus a one-letter abbreviation and its space/'(' suffixes.
- Extract a private static `MatchesType(text, words, abbreviation)` helper that applies the same four predicates in the same order with the same short-circuit OR semantics.
- Behavior is preserved: identical comparisons, identical evaluation order, same `bool` result at each call site.

## Code changes

- ``src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs`` — replace the two 5-condition OR-chains in `ParseTransactionType` with `MatchesType` calls and add the helper alongside the method (net -6 lines).