### PR TITLE
feat(yahoo): add On-Balance Volume (OBV) calculator

### DIFF
--- a/src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs
+++ b/src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs
@@ -114,6 +114,35 @@ public static class TechnicalIndicatorService
     }
 
     /// <summary>
+    /// On-Balance Volume. Running cumulative sum seeded at 0: add the bar's volume when
+    /// close > prev_close, subtract when close < prev_close, leave unchanged on equality.
+    /// Bar 0 emits the seed (0) since there is no prior close to compare against.
+    /// Returns a list aligned to input length.
+    /// </summary>
+    public static List<long> ComputeObv(List<decimal> closes, List<long> volumes)
+    {
+        if (closes.Count != volumes.Count)
+            throw new ArgumentException("closes and volumes must have the same length");
+
+        var count = closes.Count;
+        var result = new List<long>(count);
+        if (count == 0)
+            return result;
+
+        long obv = 0;
+        result.Add(obv);
+        for (var i = 1; i < count; i++)
+        {
+            if (closes[i] > closes[i - 1])
+                obv += volumes[i];
+            else if (closes[i] < closes[i - 1])
+                obv -= volumes[i];
+            result.Add(obv);
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Average True Range (Wilder, J. Welles). TR = max(high − low, |high − prev_close|,
     /// |low − prev_close|); ATR is seeded with the simple average of the first
     /// <paramref name="period"/> TRs and then smoothed via Wilder's recursive average:

--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceObvTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceObvTests.cs
@@ -1,0 +1,81 @@
+using Equibles.Yahoo.Repositories;
+
+namespace Equibles.UnitTests.Web;
+
+public class TechnicalIndicatorServiceObvTests
+{
+    [Fact]
+    public void ComputeObv_FirstBarIsSeedZero()
+    {
+        var closes = new List<decimal> { 100m };
+        var volumes = new List<long> { 1_000_000 };
+
+        var obv = TechnicalIndicatorService.ComputeObv(closes, volumes);
+
+        obv.Should().ContainSingle().Which.Should().Be(0L);
+    }
+
+    [Fact]
+    public void ComputeObv_UpDownFlatSequence_AccumulatesAccordingToDirection()
+    {
+        // i=0: seed 0
+        // i=1: close 102 > 100 → +500 → 500
+        // i=2: close 101 < 102 → -200 → 300
+        // i=3: close 101 == 101 → unchanged → 300
+        // i=4: close 105 > 101 → +1000 → 1300
+        var closes = new List<decimal> { 100m, 102m, 101m, 101m, 105m };
+        var volumes = new List<long> { 999, 500, 200, 700, 1000 };
+
+        var obv = TechnicalIndicatorService.ComputeObv(closes, volumes);
+
+        obv.Should().HaveCount(5);
+        obv[0].Should().Be(0L);
+        obv[1].Should().Be(500L);
+        obv[2].Should().Be(300L);
+        obv[3].Should().Be(300L);
+        obv[4].Should().Be(1300L);
+    }
+
+    [Fact]
+    public void ComputeObv_StrictlyRising_AccumulatesAllVolumes()
+    {
+        // Every bar's close is higher than the previous, so OBV at end equals the sum of
+        // volumes from index 1 onward (the seed at index 0 is 0).
+        var closes = new List<decimal> { 10, 11, 12, 13, 14 };
+        var volumes = new List<long> { 100, 200, 300, 400, 500 };
+
+        var obv = TechnicalIndicatorService.ComputeObv(closes, volumes);
+
+        obv[^1].Should().Be(200 + 300 + 400 + 500);
+    }
+
+    [Fact]
+    public void ComputeObv_StrictlyFalling_SubtractsAllVolumes()
+    {
+        var closes = new List<decimal> { 14, 13, 12, 11, 10 };
+        var volumes = new List<long> { 100, 200, 300, 400, 500 };
+
+        var obv = TechnicalIndicatorService.ComputeObv(closes, volumes);
+
+        obv[^1].Should().Be(-(200 + 300 + 400 + 500));
+    }
+
+    [Fact]
+    public void ComputeObv_MismatchedSeriesLengths_Throws()
+    {
+        var closes = new List<decimal> { 1, 2, 3 };
+        var volumes = new List<long> { 100, 200 };
+
+        var act = () => TechnicalIndicatorService.ComputeObv(closes, volumes);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void ComputeObv_EmptyInput_ReturnsEmptyList()
+    {
+        var obv = TechnicalIndicatorService.ComputeObv([], []);
+
+        obv.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

PR 1 of 2 for #689. Intermediate slice — not the closing one.

Adds `ComputeObv(closes, volumes)` to the technical-indicator service. OBV is a running cumulative volume sum: add the bar's volume on up-closes (close > prev_close), subtract on down-closes (close < prev_close), leave unchanged on equality. Bar 0 emits the seed `0`. Slice 2 exposes this through the Yahoo MCP server.

Refs #689

## Code changes

- `src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs` — `ComputeObv` static method. Returns `List<long>` (no warm-up padding — OBV is well-defined from bar 0). Throws `ArgumentException` on mismatched series lengths.
- `tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceObvTests.cs` — six cases: single-bar seed, hand-computed up/down/flat sequence, strictly-rising series accumulating all subsequent volumes, strictly-falling series subtracting them, mismatched series lengths, and the empty-input edge.