### PR TITLE
docs(technical/mcp-tools): list GetStochasticOscillator and GetAverageTrueRange under Stock Prices

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -89,6 +89,8 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 
 - `GetStockPrices` — daily OHLCV + `AdjustedClose` for a ticker over a date range.
 - `GetLatestPrices` — latest close for one or more tickers.
+- `GetStochasticOscillator` — Stochastic Oscillator (%K and %D) for a ticker over a date range.
+- `GetAverageTrueRange` — Wilder's Average True Range (ATR) volatility measure for a ticker over a date range.
 
 ### `mcp.AddShortData()` — FINRA + SEC FTD
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- `GetStochasticOscillator` and `GetAverageTrueRange` are exposed on `StockPriceTools` (added with the technical-indicator extension landed in #1202 / #1197), but the `mcp.AddStockPrices()` section in `docs/technical/mcp-tools.md` still only listed `GetStockPrices` and `GetLatestPrices`. Tool inventory check: 42 `[McpServerTool]` methods in src vs. 40 catalog entries — these two were the gap.

## Code changes

- `docs/technical/mcp-tools.md` — append two bullets under `mcp.AddStockPrices()` → `StockPriceTools` describing `GetStochasticOscillator` (%K + %D over a date range) and `GetAverageTrueRange` (Wilder's ATR volatility measure over a date range).