### PR TITLE
feat(yahoo): expose On-Balance Volume via MCP

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -340,6 +340,79 @@ public class StockPriceTools
         );
     }
 
+    [McpServerTool(Name = "GetOnBalanceVolume")]
+    [Description(
+        "On-Balance Volume (OBV) for a stock. Running cumulative volume that adds the "
+            + "bar's volume on up-closes, subtracts on down-closes, and stays flat on "
+            + "equal closes. Useful for confirming or diverging from price trends with "
+            + "volume flow."
+    )]
+    public Task<string> GetOnBalanceVolume(
+        [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Start date in YYYY-MM-DD format (defaults to 6 months ago)")]
+            string startDate = null,
+        [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
+            string endDate = null,
+        [Description("Maximum number of records to return (default: 60, newest first)")]
+            int maxResults = 60
+    )
+    {
+        return McpToolExecutor.Execute(
+            async () =>
+            {
+                var stock = await _commonStockRepository.GetByTicker(
+                    ticker.Trim().ToUpperInvariant()
+                );
+                if (stock == null)
+                    return $"Stock '{ticker}' not found.";
+
+                var start =
+                    !string.IsNullOrEmpty(startDate)
+                    && DateOnly.TryParse(startDate, out var parsedStart)
+                        ? parsedStart
+                        : DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6));
+
+                var end =
+                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
+                        ? parsedEnd
+                        : DateOnly.FromDateTime(DateTime.UtcNow);
+
+                var records = await _priceRepository
+                    .GetByStock(stock, start, end)
+                    .OrderBy(p => p.Date)
+                    .ToListAsync();
+
+                if (records.Count == 0)
+                    return $"No price data found for {stock.Ticker} in the specified date range.";
+
+                var closes = records.Select(p => p.Close).ToList();
+                var volumes = records.Select(p => p.Volume).ToList();
+                var obv = TechnicalIndicatorService.ComputeObv(closes, volumes);
+
+                var result = new StringBuilder();
+                result.AppendLine($"On-Balance Volume for {stock.Ticker} ({stock.Name}):");
+                result.AppendLine();
+                result.AppendLine("| Date | Close | Volume | OBV |");
+                result.AppendLine("|------|-------|--------|-----|");
+
+                var emitted = 0;
+                for (var i = records.Count - 1; i >= 0 && emitted < maxResults; i--)
+                {
+                    result.AppendLine(
+                        $"| {records[i].Date:yyyy-MM-dd} | {records[i].Close:F2} | {records[i].Volume:N0} | {obv[i]:N0} |"
+                    );
+                    emitted++;
+                }
+
+                return result.ToString();
+            },
+            _logger,
+            "GetOnBalanceVolume",
+            $"ticker: {ticker}",
+            ReportError
+        );
+    }
+
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsObvTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsObvTests.cs
@@ -1,0 +1,142 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Mcp.Tools;
+using Equibles.Yahoo.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins the GetOnBalanceVolume MCP tool end-to-end against ParadeDB so repository +
+/// projection + calculator + Markdown formatting all run through the real pipeline.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class StockPriceToolsObvTests : ParadeDbMcpTestBase
+{
+    public StockPriceToolsObvTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private StockPriceTools Sut() =>
+        new(
+            new DailyStockPriceRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<StockPriceTools>()
+        );
+
+    [Fact]
+    public async Task GetOnBalanceVolume_UnknownTicker_ReturnsNotFoundMessage()
+    {
+        var result = await Sut().GetOnBalanceVolume("ZZZZ");
+
+        result.Should().Be("Stock 'ZZZZ' not found.");
+    }
+
+    [Fact]
+    public async Task GetOnBalanceVolume_NoPrices_ReturnsEmptyRangeMessage()
+    {
+        DbContext.Set<CommonStock>().Add(MakeStock());
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetOnBalanceVolume("AAPL", startDate: "2026-04-01", endDate: "2026-04-30");
+
+        result.Should().Contain("No price data found for AAPL");
+    }
+
+    [Fact]
+    public async Task GetOnBalanceVolume_StrictlyRising_AccumulatesAllVolumes()
+    {
+        var stock = MakeStock();
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+
+        // Bars 0..4 with closes 10,11,12,13,14 and volumes 100,200,300,400,500.
+        // OBV at bar 4 = 0 + 200 + 300 + 400 + 500 = 1,400.
+        var start = new DateOnly(2025, 1, 6);
+        var closes = new[] { 10m, 11m, 12m, 13m, 14m };
+        var volumes = new long[] { 100, 200, 300, 400, 500 };
+        for (var i = 0; i < closes.Length; i++)
+        {
+            DbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = start.AddDays(i),
+                        Open = closes[i],
+                        High = closes[i],
+                        Low = closes[i],
+                        Close = closes[i],
+                        AdjustedClose = closes[i],
+                        Volume = volumes[i],
+                    }
+                );
+        }
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetOnBalanceVolume(
+                "AAPL",
+                startDate: start.ToString("yyyy-MM-dd"),
+                endDate: start.AddDays(5).ToString("yyyy-MM-dd")
+            );
+
+        result.Should().Contain("On-Balance Volume");
+        result.Should().Contain("| Date | Close | Volume | OBV |");
+        // Culture-tolerant: thousand separator may be `,` (US/UK), `.` (DE),
+        // ` ` (FR), or NBSP. Anchor on the digits.
+        var digitsOnly = new string(result.Where(char.IsDigit).ToArray());
+        digitsOnly.Should().Contain("1400");
+    }
+
+    [Fact]
+    public async Task GetOnBalanceVolume_MaxResults_LimitsRowCount()
+    {
+        var stock = MakeStock();
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+        var start = new DateOnly(2025, 1, 6);
+        for (var i = 0; i < 30; i++)
+        {
+            DbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = start.AddDays(i),
+                        Open = 100m,
+                        High = 101m,
+                        Low = 99m,
+                        Close = 100m + i,
+                        AdjustedClose = 100m,
+                        Volume = 1_000,
+                    }
+                );
+        }
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetOnBalanceVolume(
+                "AAPL",
+                startDate: start.ToString("yyyy-MM-dd"),
+                endDate: start.AddDays(30).ToString("yyyy-MM-dd"),
+                maxResults: 5
+            );
+
+        var dataLines = result.Split('\n').Count(line => line.StartsWith("| 2025-"));
+        dataLines.Should().Be(5);
+    }
+
+    private static CommonStock MakeStock() =>
+        new()
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+        };
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -409,6 +409,7 @@ public class McpModuleToolDiscoveryTests
                     "GetLatestPrices",
                     "GetStochasticOscillator",
                     "GetAverageTrueRange",
+                    "GetOnBalanceVolume",
                 }
             },
         };


### PR DESCRIPTION
## Summary

PR 2 of 2 for #689 — **closing slice**.

Adds `GetOnBalanceVolume` to the Yahoo MCP tool surface. Mirrors the shape of `GetStochasticOscillator` / `GetAverageTrueRange`: loads close + volume for a range, calls `TechnicalIndicatorService.ComputeObv` (PR #1204), and emits a Markdown table newest-first.

Closes #689

## Code changes

- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — new `GetOnBalanceVolume(ticker, startDate, endDate, maxResults=60)` tool. Default start date is six months ago for readable trend direction (no warm-up needed since OBV is well-defined from bar 0).
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — adds `GetOnBalanceVolume` to the `StockPriceTools` expected-tool array; the cross-module uniqueness check naturally covers the new name.
- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsObvTests.cs` — four cases: unknown ticker, no-prices-in-range, a strictly-rising series whose terminal OBV equals the sum of trailing volumes (culture-tolerant digit assertion), and the `maxResults` row-count trim.