### PR TITLE
refactor(holdings-backtest): extract LoadPriceRows helper for duplicated price-row projection

### DIFF
--- a/src/Equibles.Web/Services/HoldingsBacktestService.cs
+++ b/src/Equibles.Web/Services/HoldingsBacktestService.cs
@@ -3,6 +3,7 @@ using Equibles.Core.AutoWiring;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Models;
 using Equibles.Web.ViewModels.Profiles;
+using Equibles.Yahoo.Data.Models;
 using Equibles.Yahoo.Repositories;
 using Microsoft.EntityFrameworkCore;
 
@@ -156,26 +157,20 @@ public class HoldingsBacktestService
             .Distinct()
             .ToList();
 
-        // OrderBy() needs to precede the projection — EF can't translate an OrderBy keyed
-        // off the projected record's property because the constructor isn't translatable.
         var priceRows =
             stockIds.Count == 0
                 ? []
-                : await _priceRepository
-                    .GetByStocks(stockIds, priceWindowFrom, resolvedTo)
-                    .OrderBy(p => p.Date)
-                    .Select(p => new BacktestPriceRow(p.CommonStockId, p.Date, p.AdjustedClose))
-                    .ToListAsync();
+                : await LoadPriceRows(
+                    _priceRepository.GetByStocks(stockIds, priceWindowFrom, resolvedTo)
+                );
 
         var pricesByStock = priceRows
             .GroupBy(p => p.StockId)
             .ToDictionary(g => g.Key, g => g.ToArray());
 
-        var benchmarkPrices = await _priceRepository
-            .GetByStock(benchmarkStock, priceWindowFrom, resolvedTo)
-            .OrderBy(p => p.Date)
-            .Select(p => new BacktestPriceRow(p.CommonStockId, p.Date, p.AdjustedClose))
-            .ToListAsync();
+        var benchmarkPrices = await LoadPriceRows(
+            _priceRepository.GetByStock(benchmarkStock, priceWindowFrom, resolvedTo)
+        );
 
         if (benchmarkPrices.Count == 0)
         {
@@ -208,6 +203,14 @@ public class HoldingsBacktestService
         }
         return options;
     }
+
+    // OrderBy() must precede the projection — EF can't translate an OrderBy keyed off the
+    // projected record's property because the constructor isn't translatable.
+    private static Task<List<BacktestPriceRow>> LoadPriceRows(IQueryable<DailyStockPrice> query) =>
+        query
+            .OrderBy(p => p.Date)
+            .Select(p => new BacktestPriceRow(p.CommonStockId, p.Date, p.AdjustedClose))
+            .ToListAsync();
 
     private static decimal? ForwardFill(
         Dictionary<Guid, BacktestPriceRow[]> pricesByStock,


### PR DESCRIPTION
## Summary

- Two near-identical LINQ pipelines in `HoldingsBacktestService.Execute` (one for the held stocks' price history, one for the benchmark) both did `OrderBy(p => p.Date).Select(p => new BacktestPriceRow(...)).ToListAsync()` against `IQueryable<DailyStockPrice>`. Collapsed them into a single private static helper, `LoadPriceRows`, and moved the EF-translation comment onto the helper itself where it belongs.
- Behavior-preserving by construction: same expression tree, same source `IQueryable`, identical SQL, ordering, and materialization. The `stockIds.Count == 0 ? [] : ...` short-circuit stays at the call site so the empty-stocks case still skips the DB round-trip.

## Code changes

- `src/Equibles.Web/Services/HoldingsBacktestService.cs`
  - Added a `using Equibles.Yahoo.Data.Models;` for the `DailyStockPrice` parameter type (transitively referenced via `Equibles.Yahoo.Repositories`; no new project reference).
  - Replaced the two duplicated price-row LINQ pipelines with calls to a new private static `LoadPriceRows(IQueryable<DailyStockPrice>)`.
  - Moved the "OrderBy must precede the projection" why-comment onto the helper.

Local checks scoped to the change: Release build green; unit tests 1454/1454 (1 pre-existing skip); integration tests 482/482 incl. the 5 `ProfilesInstitutionBacktestTests`; `csharpier check` clean on the touched file.