### PR TITLE
test(yahoo): pin TechnicalIndicatorService.ComputeObv stays at zero across constant closes

### DIFF
--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceObvTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceObvTests.cs
@@ -78,4 +78,18 @@ public class TechnicalIndicatorServiceObvTests
 
         obv.Should().BeEmpty();
     }
+
+    [Fact]
+    public void ComputeObv_ConstantCloses_RemainsAtZero_RegardlessOfVolumes()
+    {
+        // Every close equals the previous → per contract "leave unchanged on equality",
+        // so OBV stays at the seed 0 at every bar. Volumes vary to catch a bug that
+        // compares the wrong series, or that treats equality as an up-move (>=).
+        var closes = new List<decimal> { 10m, 10m, 10m, 10m };
+        var volumes = new List<long> { 100, 250, 500, 750 };
+
+        var obv = TechnicalIndicatorService.ComputeObv(closes, volumes);
+
+        obv.Should().Equal(0L, 0L, 0L, 0L);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a single adversarial unit test for the new On-Balance Volume indicator: when every close equals the previous one, OBV must stay at the seed value of 0 for every bar — varying volumes must be ignored. The existing six tests cover up/down/flat sequences and the strictly-rising/falling extremes but never feed constant closes alongside varying volumes, so a bug that compared the wrong series (volumes instead of closes) or treated equality as an up-move (`>=` instead of `>`) would still pass them.

## Code changes

- `tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceObvTests.cs` — adds `ComputeObv_ConstantCloses_RemainsAtZero_RegardlessOfVolumes`. Four flat closes with strictly-increasing volumes; asserts the entire OBV series is `[0, 0, 0, 0]`. No production code touched.