### PR TITLE
refactor(media): drop narration comments in ImageManager.SaveImage

### DIFF
--- a/src/Equibles.Media.BusinessLogic/ImageManager.cs
+++ b/src/Equibles.Media.BusinessLogic/ImageManager.cs
@@ -36,10 +36,8 @@ public class ImageManager : IImageManager
         int? maxHeight
     )
     {
-        // Gets the file extension from the file name
         var fileExtension = Path.GetExtension(fileName)?.TrimStart('.');
 
-        // Gets the file name without extension
         var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
 
         if (string.IsNullOrEmpty(fileExtension))
@@ -47,7 +45,6 @@ public class ImageManager : IImageManager
             throw new ArgumentException("The file extension cannot be null or empty.");
         }
 
-        // Get the content type from the file extension
         var contentType = MimeTypeMap.GetMimeType(fileExtension);
         if (string.IsNullOrEmpty(contentType))
         {


### PR DESCRIPTION
## Summary

- Delete 3 narration comments in `ImageManager.SaveImage` that just restated the immediately-following `Path.GetExtension` / `Path.GetFileNameWithoutExtension` / `MimeTypeMap.GetMimeType` calls.
- Same hygiene pass as #1134 (`FileManager.SaveFile`). The WHY comment at lines 56-58 explaining the "only resize down, never enlarge" policy is preserved.

## Code changes

- `src/Equibles.Media.BusinessLogic/ImageManager.cs` — 3 narration comments removed; no code changes, no signature changes.