### PR TITLE
refactor(cboe-mcp): extract ParseDateOr helper for duplicated date-parsing fallback

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -54,16 +54,11 @@ public class CboeTools
                 if (!Enum.TryParse<CboePutCallRatioType>(type, true, out var ratioType))
                     return $"Invalid type '{type}'. Valid types: Total, Equity, Index, Vix, Etp";
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var records = await _putCallRepository
                     .GetByType(ratioType, start, end)
@@ -116,16 +111,11 @@ public class CboeTools
         return McpToolExecutor.Execute(
             async () =>
             {
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var records = await _vixRepository
                     .GetByDateRange(start, end)
@@ -162,4 +152,7 @@ public class CboeTools
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
+
+    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
+        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 }


### PR DESCRIPTION
## Summary

- \`GetPutCallRatios\` and \`GetVixHistory\` each had two near-identical 4-line \`!IsNullOrEmpty(text) && DateOnly.TryParse(text, ...) ? parsed : fallback\` blocks for \`startDate\`/\`endDate\` — four total.
- Extract a private static \`ParseDateOr(text, fallback)\` helper. Mirrors the existing pattern in \`Equibles.Cftc.Mcp.Tools.CftcTools\` (#1176), \`Equibles.Finra.Mcp.Tools.ShortDataTools\` (#1108), and \`Equibles.Fred.Mcp.Tools.FredTools\` (#1179/#1181).
- Same null/empty check, same \`DateOnly.TryParse\`, same fallback when input is empty or unparseable. 8 CboeTools integration tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.Cboe.Mcp/Tools/CboeTools.cs\` — collapse four inline date-fallback ternaries into \`ParseDateOr(...)\` calls; add a one-line private static helper next to \`ReportError\`.