### PR TITLE
refactor(holdings-export): extract ResolveSelectedDate helper for duplicated requested-vs-fallback expression

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -46,8 +46,7 @@ public class HoldingsExportController : BaseController
         if (reportDates.Count == 0)
             return NotFound();
 
-        var selectedDate =
-            date.HasValue && reportDates.Contains(date.Value) ? date.Value : reportDates[0];
+        var selectedDate = ResolveSelectedDate(date, reportDates);
 
         var holdings = await _holdingRepository
             .GetByStock(stock, selectedDate)
@@ -118,8 +117,7 @@ public class HoldingsExportController : BaseController
         if (reportDates.Count == 0)
             return NotFound();
 
-        var selectedDate =
-            date.HasValue && reportDates.Contains(date.Value) ? date.Value : reportDates[0];
+        var selectedDate = ResolveSelectedDate(date, reportDates);
 
         var rowsRaw = await _holdingRepository
             .GetByHolder(holder, selectedDate)
@@ -181,8 +179,7 @@ public class HoldingsExportController : BaseController
         if (reportDates.Count < 2)
             return NotFound();
 
-        var selectedDate =
-            date.HasValue && reportDates.Contains(date.Value) ? date.Value : reportDates[0];
+        var selectedDate = ResolveSelectedDate(date, reportDates);
         var selectedIndex = reportDates.IndexOf(selectedDate);
         var previousDate =
             selectedIndex < reportDates.Count - 1 ? reportDates[selectedIndex + 1] : reportDates[1];
@@ -260,6 +257,9 @@ public class HoldingsExportController : BaseController
         Response.Headers.CacheControl = "no-store";
         return File(Encoding.UTF8.GetBytes(csv), "text/csv", filename);
     }
+
+    private static DateOnly ResolveSelectedDate(DateOnly? requested, List<DateOnly> available) =>
+        requested.HasValue && available.Contains(requested.Value) ? requested.Value : available[0];
 
     private static string[] ActivityRow(
         string board,


### PR DESCRIPTION
## Summary

- `HoldingsExportController` had three identical copies of `date.HasValue && reportDates.Contains(date.Value) ? date.Value : reportDates[0]` — one each in `Holders`, `Institution`, and `Activity`. Collapsed them into a single private static helper, `ResolveSelectedDate`, so the requested-vs-fallback rule lives in one place.
- Behavior-preserving by construction: literal expression-to-method substitution. Same null check, same `Contains` lookup against the same list, same fallback to `reportDates[0]`, same `DateOnly` returned. No control-flow or allocation changes.

## Code changes

- `src/Equibles.Web/Controllers/HoldingsExportController.cs`
  - Replaced the three duplicated `selectedDate = …` expressions with `ResolveSelectedDate(date, reportDates)`.
  - Added the helper alongside the existing private static helpers in the file (`Sanitize`, `ActivityRow`, `ChurnRow`).

Local checks scoped to the change: Release build green; unit tests 1442/1442 (2 pre-existing skips); integration tests 1379/1379; `csharpier check` clean on the touched file.