### PR TITLE
test(sec-facts): add skipped repro for GH-1215 — InlineXbrlParser.Parse

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserScaleOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserScaleOverflowTests.cs
@@ -1,0 +1,44 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InlineXbrlParserScaleOverflowTests
+{
+    private const string DocOpen =
+        "<html "
+        + "xmlns=\"http://www.w3.org/1999/xhtml\" "
+        + "xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\" "
+        + "xmlns:ixt=\"http://www.xbrl.org/inlineXBRL/transformation/2015-02-26\" "
+        + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+        + "xmlns:xbrldi=\"http://xbrl.org/2006/xbrldi\" "
+        + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2018-01-31\""
+        + "><body><div style=\"display:none\"><ix:header><ix:resources>";
+
+    private const string ResourcesEnd = "</ix:resources></ix:header></div>";
+    private const string DocClose = "</body></html>";
+
+    [Fact(
+        Skip = "GH-1215 — ApplyScaleAndSign casts Math.Pow(10, scale) to decimal; a scale >= 29 overflows decimal.MaxValue and aborts the whole filing parse."
+    )]
+    public void Parse_ExtremeScaleAttribute_DoesNotThrowOnSingleBadFact()
+    {
+        // Contract: Parse extracts every well-formed ix:nonFraction fact from a filing.
+        // A single fact whose scale attribute (e.g. "29") drives the multiplier past
+        // decimal.MaxValue (~7.92e28) is malformed input; the parser must skip it and
+        // continue, not throw OverflowException and abort the whole filing parse.
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"us-gaap:Revenues\" contextRef=\"C1\" unitRef=\"u\" scale=\"29\">1</ix:nonFraction>"
+            + DocClose;
+
+        var act = () => new InlineXbrlParser().Parse(html);
+
+        act.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `InlineXbrlParser.Parse` skips a single `ix:nonFraction` whose `scale` attribute would overflow the decimal multiplier, instead of throwing `OverflowException` and aborting the entire filing parse — currently `ApplyScaleAndSign` does `(decimal)Math.Pow(10, scale)` unguarded, and `scale="29"` (well past `decimal.MaxValue` ≈ 7.92e28) escapes up through `TryDecodeValue` → `TryParseFact` → `Parse`.
- Test is committed as `[Skip]` referencing GH-1215 — un-skip when the fix lands (catch the overflow in `TryDecodeValue` and drop the fact, matching the existing skip-on-decode-failure pattern).

## Code changes

- `tests/Equibles.UnitTests/Sec/InlineXbrlParserScaleOverflowTests.cs` — new test pinning that an iXBRL document with one `scale="29"` fact does not throw. Skipped — see GH-1215.