### PR TITLE
feat(holdings): add All Holders flat view + prevent prior→new wrap

### DIFF
--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -26,6 +26,11 @@
             _ => entries.OrderByDescending(e => e.CurrentValue),
         };
     }
+
+    static (string Label, string BadgeCss) StatusFor(PositionChangeType type) =>
+        Buckets.Where(b => b.Type == type)
+            .Select(b => (b.Label, b.BadgeCss))
+            .FirstOrDefault();
 }
 
 @if (Model.AvailableDates.Count == 0) {
@@ -130,7 +135,7 @@
                                                 <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
                                                 <td class="text-right font-mono @deltaSharesCss">@deltaSharesText</td>
                                                 <td class="text-right font-mono hidden md:table-cell @deltaValueCss">@deltaValueText</td>
-                                                <td class="text-right font-mono hidden lg:table-cell text-base-content/60">@e.PreviousShares.ToString("N0") → @e.CurrentShares.ToString("N0")</td>
+                                                <td class="text-right font-mono hidden lg:table-cell text-base-content/60 whitespace-nowrap">@e.PreviousShares.ToString("N0") → @e.CurrentShares.ToString("N0")</td>
                                             </tr>
                                         }
                                     </tbody>
@@ -140,6 +145,67 @@
                     </div>
                 </div>
             }
+        </div>
+    }
+
+    <!-- All Holders — flat view of every holder for the selected report date, default-collapsed.
+         Lets the user scan or sort the whole list without flipping between buckets. -->
+    var allHolders = Model.GroupedHolders
+        .SelectMany(kvp => kvp.Value.Select(h => new { Entry = h, Type = kvp.Key }))
+        .OrderByDescending(x => x.Entry.CurrentValue)
+        .ThenByDescending(x => x.Entry.PreviousValue)
+        .ToList();
+    if (allHolders.Count > 0) {
+        <div class="collapse collapse-arrow bg-base-100 shadow-sm mb-3" id="holdings-all" data-testid="holdings-all">
+            <input type="checkbox" />
+            <div class="collapse-title flex items-center gap-2 text-base font-medium">
+                <span>All Holders</span>
+                <span class="badge badge-neutral badge-sm">@allHolders.Count.ToString("N0")</span>
+            </div>
+            <div class="collapse-content p-0">
+                <div class="overflow-x-auto">
+                    <table class="table table-zebra table-sm">
+                        <thead>
+                            <tr>
+                                <th>Holder</th>
+                                <th>Status</th>
+                                <th class="text-right">Current Shares</th>
+                                <th class="text-right hidden md:table-cell">Previous Shares</th>
+                                <th class="text-right">Δ Shares</th>
+                                <th class="text-right hidden lg:table-cell">Current Value (USD)</th>
+                                <th class="text-right">Δ Value (USD)</th>
+                                <th class="text-right">Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var x in allHolders) {
+                                var e = x.Entry;
+                                var status = StatusFor(x.Type);
+                                var deltaSharesCss = e.DeltaShares > 0 ? "text-success" : e.DeltaShares < 0 ? "text-error" : "";
+                                var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
+                                var deltaSharesText = (e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "") + Math.Abs(e.DeltaShares).ToString("N0");
+                                var deltaValueText = (e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$") + Math.Abs(e.DeltaValue).ToString("N0");
+                                <tr>
+                                    <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
+                                    <td><span class="badge @status.BadgeCss badge-sm whitespace-nowrap">@status.Label</span></td>
+                                    <td class="text-right font-mono whitespace-nowrap">@e.CurrentShares.ToString("N0")</td>
+                                    <td class="text-right font-mono hidden md:table-cell whitespace-nowrap">@e.PreviousShares.ToString("N0")</td>
+                                    <td class="text-right font-mono whitespace-nowrap @deltaSharesCss">@deltaSharesText</td>
+                                    <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap">$@e.CurrentValue.ToString("N0")</td>
+                                    <td class="text-right font-mono whitespace-nowrap @deltaValueCss">@deltaValueText</td>
+                                    <td class="text-right">
+                                        @if (e.InstitutionalHolder?.Cik != null) {
+                                            <a asp-controller="Stocks" asp-action="ShowHolder"
+                                               asp-route-ticker="@Model.Ticker" asp-route-cik="@e.InstitutionalHolder.Cik"
+                                               class="btn btn-ghost btn-sm">View</a>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     }
 


### PR DESCRIPTION
## Summary

- Adds a default-collapsed **All Holders** section on `/stocks/{ticker}/holdings` that lists every holder for the selected report date in one flat table, with a Status badge per row derived from the position-change type. Lets users scan or sort the whole list without bouncing between buckets.
- Applies `whitespace-nowrap` to the **Prior → New** cells in the Top Buyers / Top Sellers cards (and to every numeric/status cell in the new flat table) so values like `100,000 → 150,000` never break onto two lines on narrower viewports.

Closes #1205.

## Code changes

- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml`
  - New `@functions` helper `StatusFor(type)` that maps a `PositionChangeType` back to the existing `Buckets` row (label + badge css) so the new table reuses the same badge palette as the bucket headers.
  - New "All Holders" `<div class="collapse collapse-arrow">` block (`data-testid="holdings-all"`) flattening `Model.GroupedHolders` ordered by current value desc, then previous value desc — sold-out rows naturally land last.
  - `whitespace-nowrap` added to the existing `Prior → New` cell and to every numeric/status cell in the new flat table.

## Test plan

- [x] `dotnet build Equibles.sln -c Release` — clean.
- [x] `dotnet test tests/Equibles.UnitTests/... --filter "FullyQualifiedName~HoldingsTopMovers|FullyQualifiedName~HoldingsPositionGrouper"` — 16/16 pass.
- [x] `dotnet test tests/Equibles.IntegrationTests/... --filter "FullyQualifiedName~StocksControllerHoldingsTab"` — 1/1 pass.
- [x] `dotnet csharpier check .` — clean.
- [x] Manual: rebuilt web container from this branch, `curl /stocks/aapl/holdings` confirms `data-testid="holdings-all"` is rendered with a Status badge column and `whitespace-nowrap` is on the `Prior → New` and numeric cells.