### PR TITLE
refactor(congress-mcp): extract ParseDateOr helper for duplicated date-parsing fallback

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -62,16 +62,11 @@ public class CongressTools
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var query = _tradeRepository.GetByStock(stock, start, end);
 
@@ -145,16 +140,11 @@ public class CongressTools
                 if (member == null)
                     return $"Member '{memberName}' not found. Use SearchCongressMembers to find the exact name.";
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var query = _tradeRepository
                     .GetByMember(member)
@@ -251,4 +241,7 @@ public class CongressTools
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
+
+    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
+        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 }


### PR DESCRIPTION
## Summary

- Collapse four occurrences of the `!string.IsNullOrEmpty(x) && DateOnly.TryParse(x, out var p) ? p : fallback` pattern in `CongressTools` (two each in `GetCongressionalTrades` and `GetMemberTrades`) into a single private static `ParseDateOr` helper.
- Matches the existing precedent across MCP tools (#1108 finra-mcp, #1181 fred-mcp, #1216 cboe-mcp). Same semantics: null-or-empty check, then `DateOnly.TryParse`, falling back to the supplied default.

## Code changes

- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — replace four inline ternaries with `ParseDateOr(text, fallback)` calls; add `private static DateOnly ParseDateOr(string text, DateOnly fallback)` at the bottom of the class. Output is byte-identical at every call site.