### PR TITLE
test(yahoo-mcp): pin StockPriceTools.GetOnBalanceVolume emits rows newest first

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsObvTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsObvTests.cs
@@ -132,6 +132,48 @@ public class StockPriceToolsObvTests : ParadeDbMcpTestBase
         dataLines.Should().Be(5);
     }
 
+    [Fact]
+    public async Task GetOnBalanceVolume_EmitsRowsNewestFirst()
+    {
+        // Tool description promises "(default: 60, newest first)". None of the other
+        // tests pin the row order — a regression that flipped the loop direction would
+        // still pass them. Five increasing dates; first data row in the table must be
+        // the latest one.
+        var stock = MakeStock();
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+        var start = new DateOnly(2025, 1, 6);
+        for (var i = 0; i < 5; i++)
+        {
+            DbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = start.AddDays(i),
+                        Open = 100m,
+                        High = 101m,
+                        Low = 99m,
+                        Close = 100m + i,
+                        AdjustedClose = 100m,
+                        Volume = 1_000,
+                    }
+                );
+        }
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetOnBalanceVolume(
+                "AAPL",
+                startDate: start.ToString("yyyy-MM-dd"),
+                endDate: start.AddDays(5).ToString("yyyy-MM-dd")
+            );
+
+        var firstDataRow = result.Split('\n').First(line => line.StartsWith("| 2025-"));
+        firstDataRow.Should().StartWith($"| {start.AddDays(4):yyyy-MM-dd} |");
+    }
+
     private static CommonStock MakeStock() =>
         new()
         {


### PR DESCRIPTION
## Summary

- The `GetOnBalanceVolume` tool's `maxResults` description promises "(default: 60, newest first)", but none of the four existing tests pin the row order — a regression that flipped the emission loop direction would still pass them. Adds one integration test that seeds five increasing dates and asserts the first data row in the rendered table is the latest date.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsObvTests.cs` — adds `GetOnBalanceVolume_EmitsRowsNewestFirst`. Goes through the real ParadeDB-backed pipeline (repository → calculator → markdown formatting) like the other tests in this file. No production code touched.