### PR TITLE
refactor(sec-mcp): extract ParseDateOr helper in FailToDeliverTools

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -55,16 +55,11 @@ public class FailToDeliverTools
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
-                var start =
-                    !string.IsNullOrEmpty(startDate)
-                    && DateOnly.TryParse(startDate, out var parsedStart)
-                        ? parsedStart
-                        : DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3));
-
-                var end =
-                    !string.IsNullOrEmpty(endDate) && DateOnly.TryParse(endDate, out var parsedEnd)
-                        ? parsedEnd
-                        : DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = ParseDateOr(
+                    startDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
+                );
+                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var records = await _ftdRepository
                     .GetByStock(stock)
@@ -103,4 +98,7 @@ public class FailToDeliverTools
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
+
+    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
+        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 }


### PR DESCRIPTION
## Summary

- \`GetFailsToDeliver\` had two near-identical 4-line \`!IsNullOrEmpty(text) && DateOnly.TryParse(text, ...) ? parsed : fallback\` blocks for \`startDate\`/\`endDate\`.
- Extract a private static \`ParseDateOr(text, fallback)\` helper. Sixth MCP tool file to adopt the same pattern after \`ShortDataTools\` (#1108), \`CftcTools\` (#1176), \`FredTools\` (#1179/#1181), and \`CboeTools\` (#1216).
- Same null/empty check, same \`DateOnly.TryParse\`, same fallback. 6 \`FailToDeliverTools\` integration tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs\` — collapse the two inline date-fallback ternaries into \`ParseDateOr(...)\` calls; add the one-line private static helper next to \`ReportError\`.