### PR TITLE
docs(technical/mcp-tools): list GetOnBalanceVolume under Stock Prices

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -91,6 +91,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetLatestPrices` — latest close for one or more tickers.
 - `GetStochasticOscillator` — Stochastic Oscillator (%K and %D) for a ticker over a date range.
 - `GetAverageTrueRange` — Wilder's Average True Range (ATR) volatility measure for a ticker over a date range.
+- `GetOnBalanceVolume` — On-Balance Volume (OBV) cumulative-flow indicator for a ticker over a date range.
 
 ### `mcp.AddShortData()` — FINRA + SEC FTD
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- `StockPriceTools` exposes `GetOnBalanceVolume` (added in #1204 alongside the OBV addition to `TechnicalIndicatorService`), but `docs/technical/mcp-tools.md` under `mcp.AddStockPrices()` didn't list it. Inventory check: 43 `[McpServerTool]` methods in src vs. 42 catalog entries.

## Code changes

- `docs/technical/mcp-tools.md` — append one bullet under `mcp.AddStockPrices()` → `StockPriceTools` describing `GetOnBalanceVolume` (OBV cumulative-flow indicator over a date range).