### PR TITLE
refactor(holdings-mcp): extract GetReportDatesByStock helper mirroring GetReportDatesByHolder

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
@@ -62,12 +63,7 @@ public class InstitutionalHoldingsTools
                 }
                 else
                 {
-                    var latestDate = await _holdingRepository
-                        .GetHistoryByStock(stock)
-                        .Select(h => h.ReportDate)
-                        .Distinct()
-                        .OrderByDescending(d => d)
-                        .FirstOrDefaultAsync();
+                    var latestDate = await GetReportDatesByStock(stock).FirstOrDefaultAsync();
 
                     if (latestDate == default)
                         return $"No institutional holdings data available for {ticker}.";
@@ -136,13 +132,7 @@ public class InstitutionalHoldingsTools
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
-                var reportDates = await _holdingRepository
-                    .GetHistoryByStock(stock)
-                    .Select(h => h.ReportDate)
-                    .Distinct()
-                    .OrderByDescending(d => d)
-                    .Take(maxPeriods)
-                    .ToListAsync();
+                var reportDates = await GetReportDatesByStock(stock).Take(maxPeriods).ToListAsync();
 
                 if (reportDates.Count == 0)
                     return $"No institutional holdings history available for {ticker}.";
@@ -320,12 +310,7 @@ public class InstitutionalHoldingsTools
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
-                var reportDates = await _holdingRepository
-                    .GetHistoryByStock(stock)
-                    .Select(h => h.ReportDate)
-                    .Distinct()
-                    .OrderByDescending(d => d)
-                    .ToListAsync();
+                var reportDates = await GetReportDatesByStock(stock).ToListAsync();
 
                 var targetDate = TryParseReportDate(reportDate, out var parsed)
                     ? parsed
@@ -1118,6 +1103,13 @@ public class InstitutionalHoldingsTools
     private IQueryable<DateOnly> GetReportDatesByHolder(InstitutionalHolder holder) =>
         _holdingRepository
             .GetHistoryByHolder(holder)
+            .Select(h => h.ReportDate)
+            .Distinct()
+            .OrderByDescending(d => d);
+
+    private IQueryable<DateOnly> GetReportDatesByStock(CommonStock stock) =>
+        _holdingRepository
+            .GetHistoryByStock(stock)
             .Select(h => h.ReportDate)
             .Distinct()
             .OrderByDescending(d => d);


### PR DESCRIPTION
## Summary

- The `_holdingRepository.GetHistoryByStock(stock).Select(h => h.ReportDate).Distinct().OrderByDescending(d => d)` pipeline was inlined in three places — `GetTopHolders`, `GetOwnershipHistory`, and `GetTopBuyersSellers`. Collapsed them into a private `GetReportDatesByStock(CommonStock stock)` helper that mirrors the existing `GetReportDatesByHolder(InstitutionalHolder holder)` so the two stock/holder paths are symmetric.
- Behavior-preserving by construction: literal expression-to-method substitution. The helper returns the same `IQueryable<DateOnly>`; each caller continues to chain its own `.FirstOrDefaultAsync()`, `.Take(N).ToListAsync()`, or `.ToListAsync()` after it. Identical expression tree, identical SQL.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs`
  - Added `using Equibles.CommonStocks.Data.Models;` so the new helper can reference `CommonStock` as a parameter type (transitively available; no new project reference).
  - Replaced the three inline pipelines with `GetReportDatesByStock(stock).<existing tail>`.
  - Added the helper next to `GetReportDatesByHolder` at the bottom of the file.

Local checks scoped to the change: Release build green; unit tests 1462/1462 (3 pre-existing skips); 206 Holdings-scoped integration tests pass; `csharpier check` clean on the touched file.