### PR TITLE
refactor(cboe-import): drop narration comments in CboeImportService

### DIFF
--- a/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
+++ b/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
@@ -98,7 +98,6 @@ public class CboeImportService
         if (records.Count == 0)
             return;
 
-        // Get latest stored date for this type
         DateOnly latestStoredDate;
         using (var scope = _scopeFactory.CreateScope())
         {
@@ -107,7 +106,6 @@ public class CboeImportService
                 .FirstOrDefaultAsync(cancellationToken);
         }
 
-        // Filter to only new records
         var newRecords =
             latestStoredDate != default
                 ? records.Where(r => r.Date > latestStoredDate).ToList()
@@ -150,7 +148,6 @@ public class CboeImportService
             if (records.Count == 0)
                 return;
 
-            // Get latest stored date
             DateOnly latestStoredDate;
             using (var scope = _scopeFactory.CreateScope())
             {
@@ -159,7 +156,6 @@ public class CboeImportService
                     .FirstOrDefaultAsync(cancellationToken);
             }
 
-            // Filter to only new records
             var newRecords =
                 latestStoredDate != default
                     ? records.Where(r => r.Date > latestStoredDate).ToList()


### PR DESCRIPTION
## Summary

- Delete 4 narration comments in `CboeImportService` (two each in `ImportPutCallRatio` and `ImportVixHistory`) that just restated the immediately-following get-latest-date / filter-new-records blocks.
- Same hygiene pass as #1134 / #1164 / #1185 / #1193 / #1206 / #1214. Code intent is clear from the variable names (`latestStoredDate`, `newRecords`) and the LINQ shape.

## Code changes

- `src/Equibles.Cboe.HostedService/Services/CboeImportService.cs` — 4 narration comments removed; no code changes, no signature changes.