### PR TITLE
test(yahoo-mcp): pin StockPriceTools.GetStochasticOscillator rejects dPeriod below one

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStochasticTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStochasticTests.cs
@@ -139,6 +139,17 @@ public class StockPriceToolsStochasticTests : ParadeDbMcpTestBase
         dataLines.Should().Be(5);
     }
 
+    [Fact]
+    public async Task GetStochasticOscillator_DPeriodBelowOne_ReturnsValidationMessage()
+    {
+        // Validation guards both periods: kPeriod < 2 || dPeriod < 1. The existing
+        // InvalidPeriods test only exercises the kPeriod side — a regression that dropped
+        // the dPeriod check (e.g. trimmed the `||` clause) would still pass it.
+        var result = await Sut().GetStochasticOscillator("AAPL", kPeriod: 14, dPeriod: 0);
+
+        result.Should().Contain("dPeriod at least 1");
+    }
+
     private static CommonStock MakeStock() =>
         new()
         {


### PR DESCRIPTION
## Summary

- The Stochastic validation guard is `kPeriod < 2 || dPeriod < 1`, but the existing `InvalidPeriods` test only feeds `kPeriod = 1` — it never exercises the `dPeriod` side. A regression that trimmed the `|| dPeriod < 1` clause would still pass the suite. Adds a single integration test that calls with `dPeriod: 0` and asserts the validation message mentions the `dPeriod` floor.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStochasticTests.cs` — adds `GetStochasticOscillator_DPeriodBelowOne_ReturnsValidationMessage`. No production code touched.