### PR TITLE
docs(technical): list SEC Financial Facts in the modules-section parenthetical

### DIFF
--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -6,7 +6,7 @@ Reference for developers working inside the Equibles codebase. Pairs with [`../g
 
 - [Architecture](architecture.md) — modular-monolith composition, the shared `EquiblesDbContext` module system, repo → manager → host data flow.
 - [Hosts](hosts.md) — the three host apps: `Equibles.Web` (MVC portal), `Equibles.Mcp.Server` (MCP transport), `Equibles.Worker.Host` (background scrapers).
-- [Modules](modules.md) — index of the financial-domain modules (SEC, Holdings, Insider, Congress, FRED, Yahoo, FINRA, CFTC, CBOE) with data source, key entities, and scraper entry point per row.
+- [Modules](modules.md) — index of the financial-domain modules (SEC, SEC Financial Facts, Holdings, Insider, Congress, FRED, Yahoo, FINRA, CFTC, CBOE) with data source, key entities, and scraper entry point per row.
 - [MCP tools](mcp-tools.md) — catalog of the tools exposed by each module's `*.Mcp` project and the wiring path through `Equibles.Mcp` → `Equibles.Mcp.Server`.
 - [Scrapers and integrations](scrapers.md) — `*.HostedService` worker pattern, `Equibles.Integrations.*` client pattern, rate limiting, retry, `ProcessedDataSet` / `ProcessedFiling` bookkeeping.
 - [Web portal](web-portal.md) — `StocksController` tab pattern, `StockTabService`, DaisyUI v5 + Tailwind v4 + Vite, Razor partial conventions.


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- The Modules bullet in `docs/technical/README.md` enumerated the financial-domain modules as "(SEC, Holdings, Insider, Congress, FRED, Yahoo, FINRA, CFTC, CBOE)" — 9 names — but `modules.md` actually has 10 rows: SEC Financial Facts is a distinct module with its own `.Mcp` + `.HostedService` + entities. Add it to the enumeration.

## Code changes

- `docs/technical/README.md` — add `SEC Financial Facts` between `SEC` and `Holdings` in the Modules bullet's parenthetical so the index agrees with `modules.md`.