### PR TITLE
refactor(sec-mcp): extract LoadDocumentLines helper from DocumentTextTools

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -40,14 +40,10 @@ public class DocumentTextTools
     {
         try
         {
-            var document = await _documentRepository.GetWithContent(documentId);
-            if (document == null)
-                return $"Document {documentId} not found.";
-            if (document.Content?.FileContent?.Bytes == null)
-                return $"Document {documentId} has no content.";
+            var (document, lines, error) = await LoadDocumentLines(documentId);
+            if (error != null)
+                return error;
 
-            var text = Encoding.UTF8.GetString(document.Content.FileContent.Bytes);
-            var lines = text.Split('\n');
             var matches = new List<int>();
 
             for (var i = 0; i < lines.Length && matches.Count < maxResults; i++)
@@ -128,14 +124,10 @@ public class DocumentTextTools
     {
         try
         {
-            var document = await _documentRepository.GetWithContent(documentId);
-            if (document == null)
-                return $"Document {documentId} not found.";
-            if (document.Content?.FileContent?.Bytes == null)
-                return $"Document {documentId} has no content.";
+            var (document, lines, error) = await LoadDocumentLines(documentId);
+            if (error != null)
+                return error;
 
-            var text = Encoding.UTF8.GetString(document.Content.FileContent.Bytes);
-            var lines = text.Split('\n');
             var totalLines = lines.Length;
 
             // Clamp to valid range
@@ -176,6 +168,20 @@ public class DocumentTextTools
             catch { }
             return "An error occurred while reading document lines. Please try again.";
         }
+    }
+
+    private async Task<(Document Document, string[] Lines, string Error)> LoadDocumentLines(
+        Guid documentId
+    )
+    {
+        var document = await _documentRepository.GetWithContent(documentId);
+        if (document == null)
+            return (null, null, $"Document {documentId} not found.");
+        if (document.Content?.FileContent?.Bytes == null)
+            return (null, null, $"Document {documentId} has no content.");
+
+        var text = Encoding.UTF8.GetString(document.Content.FileContent.Bytes);
+        return (document, text.Split('\n'), null);
     }
 
     private static string FormatLine(int lineNumber, string content)


### PR DESCRIPTION
## Summary

- \`SearchDocumentKeyword\` and \`ReadDocumentLines\` in \`DocumentTextTools\` both opened with the same 5-line prologue: \`GetWithContent\` lookup, two null-shape guards that return \`"Document {id} not found."\` / \`"Document {id} has no content."\`, UTF-8 decode, and \`Split('\n')\`.
- Lift the prologue into a private async \`LoadDocumentLines(documentId)\` helper returning \`(Document Document, string[] Lines, string Error)\`. Each caller short-circuits on the error and keeps its method-specific logic + wrapping \`try/catch\` intact.
- Same loaded \`Document\` reference, same line array, same error strings. 22 \`DocumentTextTools\` integration + 2 unit tests pass locally (including the no-content / not-found pinning tests); full csharpier check green.

## Code changes

- \`src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs\` — drop the duplicated 5-line lookup prologue from both methods; add the \`LoadDocumentLines\` helper next to the existing private statics.