### PR TITLE
test(web): pin CsvExportService.Format(decimal) culture-invariant decimal separator

### DIFF
--- a/tests/Equibles.UnitTests/Web/CsvExportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Web/CsvExportServiceTests.cs
@@ -97,4 +97,23 @@ public class CsvExportServiceTests
 
         csv.Should().Be("Ticker\n");
     }
+
+    [Fact]
+    public void Format_Decimal_CultureInvariant_UsesPeriodDecimalSeparator()
+    {
+        // Format(long) is pinned for invariant culture but Format(decimal) is not. A
+        // regression that dropped CultureInfo.InvariantCulture from the decimal overload
+        // would render "123,45" on a comma-decimal locale like de-DE — that corrupts
+        // CSV (the comma becomes a column separator).
+        var prev = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+            CsvExportService.Format(123.45m).Should().Be("123.45");
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = prev;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- `CsvExportService.Format(long)` is already pinned for culture invariance, but `Format(decimal)` is not — none of the existing eleven tests in `CsvExportServiceTests` exercise it. A regression that dropped `CultureInfo.InvariantCulture` from the decimal overload would render `123.45m` as `"123,45"` on a comma-decimal locale like de-DE, and the comma would corrupt the CSV (it becomes a column separator).
- Adds one test that swaps `Thread.CurrentThread.CurrentCulture` to `de-DE` and asserts the output keeps the period decimal separator.

## Code changes

- `tests/Equibles.UnitTests/Web/CsvExportServiceTests.cs` — adds `Format_Decimal_CultureInvariant_UsesPeriodDecimalSeparator`. Pattern mirrors the existing `Format_LongCultureInvariant_NoThousandSeparator` test (try/finally culture swap). No production code touched.