### PR TITLE
refactor(profiles-controller): extract NormalizeCiks helper

### DIFF
--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -234,11 +234,7 @@ public class ProfilesController : BaseController
         [FromQuery(Name = "date")] DateOnly? date = null
     )
     {
-        ciks ??= [];
-        var distinctCiks = ciks.Where(c => !string.IsNullOrWhiteSpace(c))
-            .Select(c => c.Trim())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
+        var distinctCiks = NormalizeCiks(ciks);
         if (distinctCiks.Count > InstitutionCompareViewModel.MaxCiks)
             return BadRequest(
                 $"At most {InstitutionCompareViewModel.MaxCiks} CIKs may be compared."
@@ -275,11 +271,7 @@ public class ProfilesController : BaseController
         [FromQuery(Name = "date")] DateOnly? date = null
     )
     {
-        ciks ??= [];
-        var distinctCiks = ciks.Where(c => !string.IsNullOrWhiteSpace(c))
-            .Select(c => c.Trim())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
+        var distinctCiks = NormalizeCiks(ciks);
         if (distinctCiks.Count > InstitutionCombinedViewModel.MaxCiks)
             return BadRequest(
                 $"At most {InstitutionCombinedViewModel.MaxCiks} CIKs may be combined."
@@ -447,4 +439,11 @@ public class ProfilesController : BaseController
         }
         return perFund;
     }
+
+    private static List<string> NormalizeCiks(string[] ciks) =>
+        (ciks ?? [])
+            .Where(c => !string.IsNullOrWhiteSpace(c))
+            .Select(c => c.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
 }


### PR DESCRIPTION
## Summary

- Collapse two identical 5-line CIK normalization blocks (null-coalesce + whitespace filter + trim + OrdinalIgnoreCase distinct + ToList) in `ProfilesController.CompareInstitutions` and `ProfilesController.CombinedInstitutions` into a single private static `NormalizeCiks(string[] ciks)` helper.

## Code changes

- `src/Equibles.Web/Controllers/ProfilesController.cs` — replace two duplicated normalization blocks with `NormalizeCiks(ciks)` calls; add the helper at the bottom of the class. Helper preserves the exact pipeline: `(ciks ?? []).Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => c.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToList()`. Output identical at both sites.