### PR TITLE
test(holdings-export): pin Activity export TopBuys orders by delta-value descending

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/HoldingsExportActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsExportActivityTests.cs
@@ -179,6 +179,81 @@ public class HoldingsExportActivityTests
         html.ToLowerInvariant().Should().Contain("/holdings/export/activity");
     }
 
+    [Fact]
+    public async Task ExportActivity_TopBuys_OrdersByDeltaValueDescending()
+    {
+        // The TopBuys section sorts by `CurrentValue - PreviousValue` desc — not by
+        // share-count delta. None of the other Activity tests pin row order (they only
+        // assert via .Contain), so a regression that swapped the sort field would slip
+        // through. SmallShares has a much larger value jump than BigShares; it must lead.
+        var q1 = new DateOnly(2024, 9, 30);
+        var q2 = new DateOnly(2024, 12, 31);
+        var holderA = Guid.NewGuid();
+        var holderB = Guid.NewGuid();
+        var bigSharesStock = Guid.NewGuid();
+        var smallSharesStock = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.AddRange(
+                new InstitutionalHolder
+                {
+                    Id = holderA,
+                    Cik = "0009000040",
+                    Name = "Holder A",
+                },
+                new InstitutionalHolder
+                {
+                    Id = holderB,
+                    Cik = "0009000041",
+                    Name = "Holder B",
+                }
+            );
+            db.AddRange(
+                new CommonStock
+                {
+                    Id = bigSharesStock,
+                    Ticker = "BIGS",
+                    Name = "Big Share Move",
+                    Cik = "0007720001",
+                },
+                new CommonStock
+                {
+                    Id = smallSharesStock,
+                    Ticker = "BIGV",
+                    Name = "Big Value Move",
+                    Cik = "0007720002",
+                }
+            );
+            // BIGS: shares 100 → 200 (Δ +100), value 1000 → 1500 (Δ +500).
+            db.Add(MakeHoldingById(bigSharesStock, holderA, q1, 100, 1000));
+            db.Add(MakeHoldingById(bigSharesStock, holderA, q2, 200, 1500));
+            // BIGV: shares 100 → 110 (Δ +10), value 1000 → 3000 (Δ +2000).
+            db.Add(MakeHoldingById(smallSharesStock, holderB, q1, 100, 1000));
+            db.Add(MakeHoldingById(smallSharesStock, holderB, q2, 110, 3000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/Holdings/Export/Activity?date={q2:yyyy-MM-dd}"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        var topBuyRows = body.Split('\n').Where(line => line.StartsWith("TopBuys,")).ToList();
+        topBuyRows.Should().HaveCountGreaterThanOrEqualTo(2);
+        var bigvIndex = topBuyRows.FindIndex(line => line.Contains("BIGV"));
+        var bigsIndex = topBuyRows.FindIndex(line => line.Contains("BIGS"));
+        bigvIndex.Should().BeGreaterThanOrEqualTo(0);
+        bigsIndex.Should().BeGreaterThanOrEqualTo(0);
+        bigvIndex
+            .Should()
+            .BeLessThan(
+                bigsIndex,
+                "TopBuys orders by value delta descending; BIGV's +$2000 outranks BIGS's +$500"
+            );
+    }
+
     private static InstitutionalHolding MakeHoldingById(
         Guid stockId,
         Guid holderId,


### PR DESCRIPTION
## Summary

- The `/Holdings/Export/Activity` endpoint sorts the `TopBuys` board by `CurrentValue - PreviousValue` descending, not by share-count delta. None of the three existing Activity tests pin row order — they only check that each board contains the expected ticker via `.Contain`, so a regression that swapped the sort field (e.g. to `DeltaShares`) would slip through every assertion.
- Adds one integration test with two buyers where the rankings disagree: `BIGS` has a much larger share delta (+100) but `BIGV` has the larger value delta (+$2,000). The CSV's first `TopBuys` row must be `BIGV`.

## Code changes

- `tests/Equibles.IntegrationTests/Web/HoldingsExportActivityTests.cs` — adds `ExportActivity_TopBuys_OrdersByDeltaValueDescending`. Seeds two stocks across two quarters with intentionally crossed share-vs-value rankings, fetches the CSV, splits on newlines, and asserts the `BIGV` row's index in the `TopBuys` section is less than `BIGS`'s. No production code touched.