### PR TITLE
refactor(sec-mcp): extract ToDateOnly helper in RagSearchTools

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -56,8 +56,8 @@ public class RagSearchTools
                     query,
                     maxResults,
                     parsedType,
-                    startDate.HasValue ? DateOnly.FromDateTime(startDate.Value) : null,
-                    endDate.HasValue ? DateOnly.FromDateTime(endDate.Value) : null
+                    ToDateOnly(startDate),
+                    ToDateOnly(endDate)
                 );
                 return await _ragManager.BuildContext(chunks);
             },
@@ -90,8 +90,8 @@ public class RagSearchTools
                     ticker,
                     maxResults,
                     parsedType,
-                    startDate.HasValue ? DateOnly.FromDateTime(startDate.Value) : null,
-                    endDate.HasValue ? DateOnly.FromDateTime(endDate.Value) : null
+                    ToDateOnly(startDate),
+                    ToDateOnly(endDate)
                 );
                 return await _ragManager.BuildContext(chunks);
             },
@@ -205,4 +205,7 @@ public class RagSearchTools
 
         return DocumentType.FromDisplayName(documentType) ?? DocumentType.FromValue(documentType);
     }
+
+    private static DateOnly? ToDateOnly(DateTime? value) =>
+        value.HasValue ? DateOnly.FromDateTime(value.Value) : null;
 }


### PR DESCRIPTION
## Summary

- \`SearchDocuments\` and \`SearchCompanyDocuments\` each forwarded \`startDate\` / \`endDate\` to the rag manager via the same \`value.HasValue ? DateOnly.FromDateTime(value.Value) : null\` ternary (four occurrences total — start + end in each method).
- Lift the conversion into a private static \`ToDateOnly(DateTime?)\` helper. Each call site becomes a one-liner that reads as a typed conversion rather than a \`HasValue\` dance.
- Same \`HasValue\` check, same \`FromDateTime\` call, same nullable \`DateOnly\` returned. 13 RagSearchTools integration tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs\` — replace four inline \`DateTime?\` → \`DateOnly?\` ternaries with \`ToDateOnly(...)\` calls; add the one-line private static helper next to \`ParseDocumentType\`.