### PR TITLE
docs(technical/mcp-tools): broaden Stock Prices section heading to cover technical indicators

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -83,7 +83,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetLatestEconomicData` — latest snapshot across the curated macro indicators.
 - `SearchEconomicIndicators` — keyword search across series titles / categories.
 
-### `mcp.AddStockPrices()` — Yahoo OHLCV
+### `mcp.AddStockPrices()` — Yahoo OHLCV + technical indicators
 
 `StockPriceTools`:
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — stale code reference** (`docs/technical/`).
- The `mcp.AddStockPrices()` section heading still labelled the toolset as "Yahoo OHLCV", but the section now also lists three technical indicators (`GetStochasticOscillator`, `GetAverageTrueRange`, `GetOnBalanceVolume`). Broaden the heading.

## Code changes

- `docs/technical/mcp-tools.md` — change the `mcp.AddStockPrices()` H3 from "Yahoo OHLCV" to "Yahoo OHLCV + technical indicators" so the section label matches the bullets beneath it.