### PR TITLE
test(web): pin CsvExportService.Format(double) culture-invariant decimal separator

### DIFF
--- a/tests/Equibles.UnitTests/Web/CsvExportServiceTests.cs
+++ b/tests/Equibles.UnitTests/Web/CsvExportServiceTests.cs
@@ -116,4 +116,23 @@ public class CsvExportServiceTests
             Thread.CurrentThread.CurrentCulture = prev;
         }
     }
+
+    [Fact]
+    public void Format_Double_CultureInvariant_UsesPeriodDecimalSeparator()
+    {
+        // The remaining Format overload not yet pinned for invariant culture. Same risk
+        // as the decimal overload: a regression that dropped InvariantCulture from the
+        // double overload would render 1.5 as "1,5" on de-DE and the comma would corrupt
+        // the surrounding CSV row.
+        var prev = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+            CsvExportService.Format(1.5).Should().Be("1.5");
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = prev;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- The CSV writer documents culture-invariant numeric output, but only `Format(long)` and `Format(decimal)` (the latter pinned by PR #1233) currently have culture tests. `Format(double)` is the only remaining `Format` overload unpinned — a regression that dropped `CultureInfo.InvariantCulture` from just the double branch would still pass the suite, and the resulting comma decimal separator under a comma-decimal locale would corrupt the surrounding CSV row.
- Adds one parallel test that pins `Format(double)` against `de-DE`.

## Code changes

- `tests/Equibles.UnitTests/Web/CsvExportServiceTests.cs` — adds `Format_Double_CultureInvariant_UsesPeriodDecimalSeparator`. Same try/finally culture-swap pattern as the existing `Format_LongCultureInvariant_NoThousandSeparator` and `Format_Decimal_CultureInvariant_UsesPeriodDecimalSeparator` tests. No production code touched.