### PR TITLE
refactor(sec-normalizer): extract FindFirstMeaningfulSibling helper in PaginationRemovalStep

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs
@@ -16,47 +16,22 @@ internal class PaginationRemovalStep : IHtmlNormalizationStep
             var elementsToRemove = new List<INode> { hr };
 
             // Check element before HR for page number
-            var previousSibling = hr.PreviousSibling;
-            while (previousSibling != null)
+            var previousSibling = FindFirstMeaningfulSibling(hr, forward: false);
+            if (previousSibling != null && int.TryParse(previousSibling.TextContent.Trim(), out _))
             {
-                if (
-                    previousSibling.NodeType == NodeType.Comment
-                    || string.IsNullOrWhiteSpace(previousSibling.TextContent)
-                )
-                {
-                    previousSibling = previousSibling.PreviousSibling;
-                    continue;
-                }
-
-                var textContent = previousSibling.TextContent.Trim();
-                if (int.TryParse(textContent, out _))
-                {
-                    elementsToRemove.Add(previousSibling);
-                }
-
-                break;
+                elementsToRemove.Add(previousSibling);
             }
 
             // Check element after HR for Part header
-            var nextSibling = hr.NextSibling;
-            while (nextSibling != null)
+            var nextSibling = FindFirstMeaningfulSibling(hr, forward: true);
+            if (
+                nextSibling != null
+                && nextSibling
+                    .TextContent.Trim()
+                    .StartsWith("Part", StringComparison.OrdinalIgnoreCase)
+            )
             {
-                if (
-                    nextSibling.NodeType == NodeType.Comment
-                    || string.IsNullOrWhiteSpace(nextSibling.TextContent)
-                )
-                {
-                    nextSibling = nextSibling.NextSibling;
-                    continue;
-                }
-
-                var textContent = nextSibling.TextContent.Trim();
-                if (textContent.StartsWith("Part", StringComparison.OrdinalIgnoreCase))
-                {
-                    elementsToRemove.Add(nextSibling);
-                }
-
-                break;
+                elementsToRemove.Add(nextSibling);
             }
 
             foreach (var element in elementsToRemove)
@@ -64,5 +39,23 @@ internal class PaginationRemovalStep : IHtmlNormalizationStep
                 element.Parent?.RemoveChild(element);
             }
         }
+    }
+
+    private static INode FindFirstMeaningfulSibling(INode node, bool forward)
+    {
+        var current = forward ? node.NextSibling : node.PreviousSibling;
+        while (current != null)
+        {
+            if (
+                current.NodeType == NodeType.Comment
+                || string.IsNullOrWhiteSpace(current.TextContent)
+            )
+            {
+                current = forward ? current.NextSibling : current.PreviousSibling;
+                continue;
+            }
+            return current;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Summary

- \`PaginationRemovalStep.Execute\` had two sibling-walking loops (one walking \`PreviousSibling\`, one walking \`NextSibling\`) that duplicated the same "skip comments and whitespace-only text nodes, return the first meaningful sibling" traversal.
- Extract a private static \`FindFirstMeaningfulSibling(node, forward)\` helper parameterised by walk direction. Each call site collapses to a one-line lookup + the section-specific predicate (page-number \`int.TryParse\` vs Part-prefix \`StartsWith\`).
- Same nodes visited in the same order, same \`null\` returned when the chain runs out. 8 \`PaginationRemovalStep\` unit tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs\` — collapse the two inline sibling-walking \`while\` loops into single \`FindFirstMeaningfulSibling\` calls; add the helper next to the existing logic.