### PR TITLE
refactor(finra-shortinterest): drop narration comments in ShortInterestImportService

### DIFF
--- a/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
@@ -60,7 +60,6 @@ public class ShortInterestImportService
         var trackedStockIds = tickerMap.Values.ToHashSet();
         var reverseMap = tickerMap.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
 
-        // Get known settlement dates from DB
         HashSet<DateOnly> knownDates;
         using (var scope = _scopeFactory.CreateScope())
         {
@@ -69,7 +68,6 @@ public class ShortInterestImportService
             knownDates = dates.ToHashSet();
         }
 
-        // Discover new settlement dates from FINRA (bounded scan)
         var maxKnownDate = knownDates.Count > 0 ? knownDates.Max() : default;
         var minDate = SyncDateResolver.Resolve(default, _workerOptions);
 
@@ -93,7 +91,6 @@ public class ShortInterestImportService
             return;
         }
 
-        // Merge known + new dates
         var allDates = new HashSet<DateOnly>(knownDates);
         allDates.UnionWith(newDates);
 
@@ -121,7 +118,6 @@ public class ShortInterestImportService
 
             try
             {
-                // Determine which tracked stocks are missing data for this date
                 HashSet<Guid> existingStockIds;
                 using (var scope = _scopeFactory.CreateScope())
                 {
@@ -139,7 +135,6 @@ public class ShortInterestImportService
                     continue;
                 }
 
-                // Fetch from FINRA: bulk if all/many missing, filtered if few missing
                 List<ShortInterestRecord> records;
                 var useBulkFetch =
                     missingStockIds.Count == trackedStockIds.Count


### PR DESCRIPTION
## Summary

- Delete 5 narration comments in `ShortInterestImportService.Import` that just restated the immediately-following code (known-dates load, FINRA settlement-date discovery, dates merge, missing-stocks determination, bulk-vs-filtered branch).
- Same hygiene pass as #1134 / #1164 / #1185 / #1193 / #1206 / #1214 / #1228. WHY comments preserved — the bulk-fetch threshold rationale (line 47) and the multi-line concurrency race documentation around the batch re-validation (lines ~190-193).

## Code changes

- `src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs` — 5 narration comments removed; no code changes, no signature changes.