### PR TITLE
fix(web): pin CsvExportService.Format(DateOnly) to invariant culture

### DIFF
--- a/src/Equibles.Web/Services/CsvExportService.cs
+++ b/src/Equibles.Web/Services/CsvExportService.cs
@@ -40,7 +40,8 @@ public static class CsvExportService
 
     public static string Format(decimal value) => value.ToString(CultureInfo.InvariantCulture);
 
-    public static string Format(DateOnly date) => date.ToString("yyyy-MM-dd");
+    public static string Format(DateOnly date) =>
+        date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
     private static void AppendRow(StringBuilder sb, IReadOnlyList<string> fields)
     {

--- a/tests/Equibles.UnitTests/Web/CsvExportServiceFormatDateOnlyCultureTests.cs
+++ b/tests/Equibles.UnitTests/Web/CsvExportServiceFormatDateOnlyCultureTests.cs
@@ -5,9 +5,7 @@ namespace Equibles.UnitTests.Web;
 
 public class CsvExportServiceFormatDateOnlyCultureTests
 {
-    [Fact(
-        Skip = "GH-1186 — Format(DateOnly) doesn't pass InvariantCulture so the thread culture's calendar leaks through (th-TH shifts year by +543)."
-    )]
+    [Fact]
     public void Format_DateOnly_ThaiBuddhistCulture_StillEmitsGregorianIsoDate()
     {
         // Contract (CsvExportService XML doc): "Numeric / DateOnly conversions use the


### PR DESCRIPTION
## Summary

- `CsvExportService.Format(DateOnly)` was the lone overload that didn't pass `CultureInfo.InvariantCulture` to `ToString`, so on a host whose thread culture used a non-Gregorian calendar (e.g. `th-TH` with `ThaiBuddhistCalendar`) CSV downloads emitted years shifted by +543 — breaking the documented "invariant culture so the output is stable across hosts" contract and diverging from the sibling `Format(long|double|decimal)` overloads.
- Pass `CultureInfo.InvariantCulture` to `DateOnly.ToString`, matching the rest of the file.
- Un-skip the `[Skip]` regression test added in #1187 / GH-1186; it now fails before the fix and passes after.

Closes #1186

## Code changes

- `src/Equibles.Web/Services/CsvExportService.cs` — pass `CultureInfo.InvariantCulture` to `DateOnly.ToString("yyyy-MM-dd", …)` so the formatter is no longer driven by the thread's calendar.
- `tests/Equibles.UnitTests/Web/CsvExportServiceFormatDateOnlyCultureTests.cs` — drop the `Skip = "GH-1186 …"` attribute so the regression test now runs.