### PR TITLE
docs(readme): include technical indicators in Stock Prices MCP bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The MCP server exposes financial data tools for AI assistants (Claude, ChatGPT, 
 - **Financial Statements** — XBRL fact time series per ticker, cross-ticker fact comparison, full income statement / balance sheet / cash flow per fiscal period
 - **Short Data** — Daily short volume, bi-monthly short interest, and the latest short-interest snapshot across tickers
 - **Economic Indicators** — FRED data lookup, latest macro snapshot, indicator search across categories
-- **Stock Prices** — Daily OHLCV history with adjusted close, plus latest close across one or more tickers
+- **Stock Prices** — Daily OHLCV history with adjusted close, latest close across one or more tickers, and on-demand technical indicators (Stochastic Oscillator, Average True Range, On-Balance Volume)
 - **Futures Positioning** — COT positioning data, latest snapshot across all contracts, contract search
 - **Market Indicators** — VIX historical data, put/call ratios by type (equity, index, total, VIX, ETP)
 


### PR DESCRIPTION
## Summary

- Lane: **README — drift fix**.
- The README's MCP Server "Stock Prices" bullet only mentioned OHLCV + latest close, but `StockPriceTools` also exposes three technical-indicator tools (`GetStochasticOscillator`, `GetAverageTrueRange`, `GetOnBalanceVolume`). Update the bullet so the front-door summary matches the MCP catalog.

## Code changes

- `README.md` — extend the `**Stock Prices**` bullet under MCP Server with "on-demand technical indicators (Stochastic Oscillator, Average True Range, On-Balance Volume)" so the README summary agrees with the technical catalog in `docs/technical/mcp-tools.md`.