### PR TITLE
fix(yahoo): preserve existing Industry.SectorId in SyncCompanyProfile

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -294,8 +294,9 @@ public class YahooPriceImportService
         if (existing != null)
         {
             // Backfill the sector link if it was missing — newly-imported industries that
-            // pre-dated the Sector taxonomy would otherwise stay unlinked.
-            if (sectorId.HasValue && existing.SectorId != sectorId)
+            // pre-dated the Sector taxonomy would otherwise stay unlinked. An already-linked
+            // industry keeps its existing sector even when Yahoo classifies it differently.
+            if (sectorId.HasValue && !existing.SectorId.HasValue)
             {
                 existing.SectorId = sectorId;
                 await industryRepo.SaveChanges();

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfilePreservesSectorTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfilePreservesSectorTests.cs
@@ -69,9 +69,7 @@ public class YahooPriceImportServiceCompanyProfilePreservesSectorTests : IDispos
 
     public void Dispose() => _dbContext.Dispose();
 
-    [Fact(
-        Skip = "GH-1235 — SyncCompanyProfile overwrites Industry.SectorId whenever Yahoo's sector differs, contradicting the in-source 'backfill if missing' comment."
-    )]
+    [Fact]
     public async Task Import_ExistingIndustryAlreadyLinkedToSector_DoesNotOverwriteWithDifferentYahooSector()
     {
         // Contract (per the SyncCompanyProfile code comment):


### PR DESCRIPTION
## Summary

- `UpsertIndustry`'s in-source comment promised "Backfill the sector link if it was missing", but the condition was `existing.SectorId != sectorId` — which also fires when the new sector merely *differs*, silently rewriting a confirmed FK every time Yahoo reclassifies the same industry under a different sector.
- Yahoo's `assetProfile` is not always self-consistent across tickers and the daily worker iterates every ticker, so this turned every classification drift into a write — exactly the case the existing five integration tests did not cover.
- Tighten the condition to `!existing.SectorId.HasValue` so the implementation matches the documented narrower contract: backfill only, never overwrite.

Closes #1235

## Code changes

- `src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs` — narrow the `UpsertIndustry` backfill branch from `existing.SectorId != sectorId` to `!existing.SectorId.HasValue`, and extend the comment to make the preserve-existing case explicit.
- `tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfilePreservesSectorTests.cs` — drop the `Skip = "GH-1235 …"` attribute so the regression test now runs (fails before, passes after).