### PR TITLE
refactor(flash-message): extract QueueOfType helper from Success/Error/Info/Warning

### DIFF
--- a/src/Equibles.Web/FlashMessage/FlashMessage.cs
+++ b/src/Equibles.Web/FlashMessage/FlashMessage.cs
@@ -62,55 +62,26 @@ public class FlashMessage : IFlashMessage
         TempData.Clear();
     }
 
-    public void Success(string message, string title = null, bool isHtml = false)
-    {
-        Queue(
-            new FlashMessageModel
-            {
-                Message = message,
-                Title = title,
-                IsHtml = isHtml,
-                Type = FlashMessageType.Success,
-            }
-        );
-    }
+    public void Success(string message, string title = null, bool isHtml = false) =>
+        QueueOfType(FlashMessageType.Success, message, title, isHtml);
 
-    public void Error(string message, string title = null, bool isHtml = false)
-    {
-        Queue(
-            new FlashMessageModel
-            {
-                Message = message,
-                Title = title,
-                IsHtml = isHtml,
-                Type = FlashMessageType.Error,
-            }
-        );
-    }
+    public void Error(string message, string title = null, bool isHtml = false) =>
+        QueueOfType(FlashMessageType.Error, message, title, isHtml);
 
-    public void Info(string message, string title = null, bool isHtml = false)
-    {
-        Queue(
-            new FlashMessageModel
-            {
-                Message = message,
-                Title = title,
-                IsHtml = isHtml,
-                Type = FlashMessageType.Info,
-            }
-        );
-    }
+    public void Info(string message, string title = null, bool isHtml = false) =>
+        QueueOfType(FlashMessageType.Info, message, title, isHtml);
 
-    public void Warning(string message, string title = null, bool isHtml = false)
-    {
+    public void Warning(string message, string title = null, bool isHtml = false) =>
+        QueueOfType(FlashMessageType.Warning, message, title, isHtml);
+
+    private void QueueOfType(FlashMessageType type, string message, string title, bool isHtml) =>
         Queue(
             new FlashMessageModel
             {
                 Message = message,
                 Title = title,
                 IsHtml = isHtml,
-                Type = FlashMessageType.Warning,
+                Type = type,
             }
         );
-    }
 }


### PR DESCRIPTION
## Summary

- \`FlashMessage.Success\`, \`.Error\`, \`.Info\`, and \`.Warning\` were four near-identical 11-line methods. Each constructed a \`FlashMessageModel\` with the same \`Message\` / \`Title\` / \`IsHtml\` fields and a hard-coded \`Type\`, then forwarded to \`Queue(IFlashMessageModel)\`.
- Lift the construction into a private \`QueueOfType(type, message, title, isHtml)\` helper. Each of the four public methods becomes a one-line expression-bodied delegation. Existing public \`Queue(IFlashMessageModel)\` is untouched.
- Same \`FlashMessageModel\` fields constructed, same \`Queue\` call invoked, identical observable behavior. Net 40 lines deleted, 11 added. 40 FlashMessage unit tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.Web/FlashMessage/FlashMessage.cs\` — collapse four 11-line type-specific queueing methods to one-line delegations; add the \`QueueOfType\` private helper.