### PR TITLE
fix(holdings-export): 404 Activity when selected date has no prior quarter

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -181,8 +181,9 @@ public class HoldingsExportController : BaseController
 
         var selectedDate = ResolveSelectedDate(date, reportDates);
         var selectedIndex = reportDates.IndexOf(selectedDate);
-        var previousDate =
-            selectedIndex < reportDates.Count - 1 ? reportDates[selectedIndex + 1] : reportDates[1];
+        if (selectedIndex >= reportDates.Count - 1)
+            return NotFound();
+        var previousDate = reportDates[selectedIndex + 1];
 
         // Per-stock buy/sell movers (CSV has no row cap — analysts expect the full set).
         var activity = await _holdingRepository

--- a/tests/Equibles.IntegrationTests/Web/HoldingsExportActivityOldestSelectedTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsExportActivityOldestSelectedTests.cs
@@ -12,9 +12,7 @@ public class HoldingsExportActivityOldestSelectedTests
 
     public HoldingsExportActivityOldestSelectedTests(WebHostFixture fixture) => _fixture = fixture;
 
-    [Fact(
-        Skip = "GH-1243 — HoldingsExportController.Activity fallback `previousDate = reportDates[1]` returns 200 with a degenerate same-date or backwards-time comparison when the oldest date is selected; expected 404."
-    )]
+    [Fact]
     public async Task ExportActivity_SelectedDateIsOldestAvailable_ReturnsNotFoundBecauseNoPriorQuarter()
     {
         // Contract: the action compares the selected report date against the


### PR DESCRIPTION
## Summary

- `HoldingsExportController.Activity` resolved the comparison date with `selectedIndex < reportDates.Count - 1 ? reportDates[selectedIndex + 1] : reportDates[1]`. `reportDates` is sorted descending, so the conditional branch correctly picks the next-older snapshot, but the fallback `reportDates[1]` (taken when the user picks the oldest available date) was broken:
  - With exactly two reports — the minimum count, since the endpoint 404s on `Count < 2` — picking the older one resolved `previousDate` to the selected date itself; `GetQuarterlyActivity(selectedDate, selectedDate)` collapsed every Δ to zero and the CSV was bundled with a misleading filename.
  - With three or more reports, picking the oldest resolved `previousDate` to the second-newest — temporally *newer* than the selected date — so Top Buys (ranked by `CurrentValue - PreviousValue`) labelled genuine sells as buys and vice-versa.
- Replace the fallback with the same 404 the controller already returns when `reportDates.Count < 2` — there is no comparable prior quarter, so the only safe response is the existing "not enough data" one.

Closes #1243

## Code changes

- `src/Equibles.Web/Controllers/HoldingsExportController.cs` — when the selected date is the oldest available (`selectedIndex >= reportDates.Count - 1`), `Activity` returns `NotFound()` instead of falling back to `reportDates[1]`. The non-oldest branch is unchanged: `previousDate = reportDates[selectedIndex + 1]`.
- `tests/Equibles.IntegrationTests/Web/HoldingsExportActivityOldestSelectedTests.cs` — drop the `Skip = "GH-1243 …"` attribute so the regression test now runs (fails before, passes after).