### PR TITLE
refactor(market-controller): drop narration comments in MarketController

### DIFF
--- a/src/Equibles.Web/Controllers/MarketController.cs
+++ b/src/Equibles.Web/Controllers/MarketController.cs
@@ -47,7 +47,6 @@ public class MarketController : BaseController
             })
             .ToList();
 
-        // VIX summary
         var latestVix = await _vixRepository
             .GetAll()
             .OrderByDescending(v => v.Date)
@@ -106,7 +105,6 @@ public class MarketController : BaseController
             Records = records,
         };
 
-        // Compute statistics
         var values = records
             .Where(r => r.PutCallRatio.HasValue)
             .Select(r => (double)r.PutCallRatio.Value)
@@ -161,7 +159,6 @@ public class MarketController : BaseController
             if (records.Count > 1)
                 viewModel.PreviousClose = records[1].Close;
 
-            // Moving averages (chronological order)
             var chronological = records.OrderBy(r => r.Date).Select(r => (double)r.Close).ToArray();
             viewModel.Sma20 = chronological.ComputeSma(20, 2);
             viewModel.Sma50 = chronological.ComputeSma(50, 2);


### PR DESCRIPTION
## Summary

- Delete 3 narration comments in `MarketController` that just labeled the immediately-following code section (`// VIX summary`, `// Compute statistics`, `// Moving averages (chronological order)`). Variable names and method calls (`vixSummary`, `stats`, `chronological`, `ComputeSma`) already convey intent.
- Same hygiene pass as #1134 / #1164 / #1185 / #1193 / #1206 / #1214 / #1228 / #1245. The WHY comment at lines 80-82 explaining the `Enum.TryParse` + `Enum.IsDefined` defensive pair is preserved.

## Code changes

- `src/Equibles.Web/Controllers/MarketController.cs` — 3 narration comments removed; no code changes, no signature changes.