### PR TITLE
refactor(insider-trading): drop narration comments in InsiderTradingFilingProcessor

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -52,14 +52,12 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         var transactionRepository =
             scope.ServiceProvider.GetRequiredService<InsiderTransactionRepository>();
 
-        // Check if already imported by accession number
         var existing = await transactionRepository
             .GetByAccessionNumber(filing.AccessionNumber)
             .AnyAsync();
         if (existing)
             return false;
 
-        // Fetch the XML document from SEC
         var xmlContent = await secEdgarClient.GetDocumentContent(filing);
         if (string.IsNullOrWhiteSpace(xmlContent))
         {
@@ -88,7 +86,6 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             return false;
         }
 
-        // Parse XML
         XDocument doc;
         try
         {
@@ -137,7 +134,6 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             return false;
         }
 
-        // Extract reporting owner
         var ownerElement = root.Element("reportingOwner");
         if (ownerElement == null)
         {
@@ -163,7 +159,6 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             return false;
         }
 
-        // Upsert insider owner
         var owner = await ownerRepository.GetByOwnerCik(ownerCik);
         if (owner == null)
         {


### PR DESCRIPTION
## Summary

- Removes five narration comments inside `InsiderTradingFilingProcessor.Process` that just restate the next 1-3 lines (`// Check if already imported by accession number`, `// Fetch the XML document from SEC`, `// Parse XML`, `// Extract reporting owner`, `// Upsert insider owner`).
- Matches the existing precedent in #1228 (CboeImportService) and #1245 (ShortInterestImportService). All WHY-comments that explain non-obvious behaviour are preserved.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — five single-line narration comments deleted from `Process`. No executable code touched; runtime logic, exception flow, log messages, and public API are unchanged.