### PR TITLE
fix(sec-financial-facts): drop iXBRL facts whose scale would overflow decimal

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -290,8 +290,7 @@ public class InlineXbrlParser
             || format.EndsWith("fixedzero", StringComparison.OrdinalIgnoreCase)
         )
         {
-            value = ApplyScaleAndSign(0m, element);
-            return true;
+            return TryApplyScaleAndSign(0m, element, out value);
         }
 
         var parenthesised = raw.StartsWith('(') && raw.EndsWith(')');
@@ -317,8 +316,7 @@ public class InlineXbrlParser
         if (parenthesised)
             parsed = -parsed;
 
-        value = ApplyScaleAndSign(parsed, element);
-        return true;
+        return TryApplyScaleAndSign(parsed, element, out value);
     }
 
     private static string NormaliseDigits(string raw, bool commaDecimal)
@@ -358,15 +356,26 @@ public class InlineXbrlParser
         return stripped;
     }
 
-    private static decimal ApplyScaleAndSign(decimal parsed, IElement element)
+    private static bool TryApplyScaleAndSign(decimal parsed, IElement element, out decimal value)
     {
+        value = 0m;
         var scaleAttribute = element.GetAttribute("scale");
         if (!string.IsNullOrEmpty(scaleAttribute) && int.TryParse(scaleAttribute, out var scale))
         {
             // Positive scale shifts the value up; negative shifts down.
             // We use Pow over a literal multiplier so non-trivial scales
             // (e.g. 6 for "in millions") survive without precision loss.
-            parsed *= (decimal)Math.Pow(10, scale);
+            // A scale large enough to drive Math.Pow(10, scale) — or the
+            // subsequent multiply — past decimal.MaxValue (~7.92e28) is
+            // malformed input; drop the fact instead of aborting the parse.
+            try
+            {
+                parsed *= (decimal)Math.Pow(10, scale);
+            }
+            catch (OverflowException)
+            {
+                return false;
+            }
         }
 
         var signAttribute = element.GetAttribute("sign");
@@ -375,7 +384,8 @@ public class InlineXbrlParser
             parsed = -parsed;
         }
 
-        return parsed;
+        value = parsed;
+        return true;
     }
 
     private static int? ParseDecimals(string decimalsAttribute)

--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserScaleOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserScaleOverflowTests.cs
@@ -17,9 +17,7 @@ public class InlineXbrlParserScaleOverflowTests
     private const string ResourcesEnd = "</ix:resources></ix:header></div>";
     private const string DocClose = "</body></html>";
 
-    [Fact(
-        Skip = "GH-1215 — ApplyScaleAndSign casts Math.Pow(10, scale) to decimal; a scale >= 29 overflows decimal.MaxValue and aborts the whole filing parse."
-    )]
+    [Fact]
     public void Parse_ExtremeScaleAttribute_DoesNotThrowOnSingleBadFact()
     {
         // Contract: Parse extracts every well-formed ix:nonFraction fact from a filing.


### PR DESCRIPTION
## Summary

- `ApplyScaleAndSign` applied the `scale="N"` attribute as a 10^N decimal multiplier via `(decimal)Math.Pow(10, scale)`. For any `|scale| >= 29` the cast exceeds `decimal.MaxValue` (~7.92e28) and throws `OverflowException`; the exception escaped `TryDecodeValue` → `TryParseFact` → `Parse`, aborting the parse of the **entire filing** on a single malformed fact.
- Contract: `Parse` extracts every well-formed fact and skips bad ones (`TryDecodeValue` returns `false`). Convert the helper to a Try-pattern and wrap the cast/multiply in `try { ... } catch (OverflowException) { return false; }` so the call sites in `TryDecodeValue` drop the fact and continue, matching the existing skip-on-decode-failure shape.
- The wider `try` also covers the case where `parsed * 10^scale` overflows even when `|scale| <= 28`. `StandaloneXbrlParser` does not apply a `scale` multiplier, so it's unaffected.

Closes #1215

## Code changes

- `src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs` — rename `ApplyScaleAndSign` to `TryApplyScaleAndSign(decimal parsed, IElement element, out decimal value) : bool` and wrap the `(decimal)Math.Pow(10, scale)` cast / multiply in `try { ... } catch (OverflowException) { return false; }`. Both `TryDecodeValue` call sites now propagate the boolean.
- `tests/Equibles.UnitTests/Sec/InlineXbrlParserScaleOverflowTests.cs` — drop the `Skip = "GH-1215 …"` attribute so the regression test now runs (fails before, passes after).