### PR TITLE
refactor(holdings): collapse double-parse to single-parse in BuildPriceMap reportDates

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -291,16 +291,12 @@ public class HoldingsImportService
     /// </summary>
     private async Task BuildPriceMap(ImportContext context, CancellationToken cancellationToken)
     {
-        var reportDates = context
-            .Submissions.Values.Select(s => s.PeriodOfReport)
-            .Where(p => TryParseDateOnly(p, out _))
-            .Select(p =>
-            {
-                TryParseDateOnly(p, out var d);
-                return d;
-            })
-            .Distinct()
-            .ToList();
+        var reportDates = new HashSet<DateOnly>();
+        foreach (var submission in context.Submissions.Values)
+        {
+            if (TryParseDateOnly(submission.PeriodOfReport, out var date))
+                reportDates.Add(date);
+        }
 
         var stockIds = context.CusipMapping.Values.Distinct().ToList();
 


### PR DESCRIPTION
## Summary

- Replace the two-pass LINQ chain (`.Where(p => TryParseDateOnly(p, out _)).Select(p => { TryParseDateOnly(p, out var d); return d; }).Distinct().ToList()`) with a single-pass `foreach` that parses each `PeriodOfReport` once and dedupes into a `HashSet<DateOnly>`.
- Pure efficiency / clarity refactor; same observable behavior — the resulting set of dates feeds `SelectMany` over `stockIds` and is consumed by `_stockPriceProvider.GetClosingPrices`, which returns an order-insensitive `Dictionary` keyed by `(stockId, date)`.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — `BuildPriceMap`: collapse the double `TryParseDateOnly` invocation into a single parse per submission, collecting distinct dates directly into a `HashSet<DateOnly>` instead of `.Where(...).Select(...).Distinct().ToList()`.