### PR TITLE
refactor(insider-trading): drop narration comments in InsiderTradingFilingProcessor

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -52,14 +52,12 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         var transactionRepository =
             scope.ServiceProvider.GetRequiredService<InsiderTransactionRepository>();
 
-        // Check if already imported by accession number
         var existing = await transactionRepository
             .GetByAccessionNumber(filing.AccessionNumber)
             .AnyAsync();
         if (existing)
             return false;
 
-        // Fetch the XML document from SEC
         var xmlContent = await secEdgarClient.GetDocumentContent(filing);
         if (string.IsNullOrWhiteSpace(xmlContent))
         {
@@ -88,7 +86,6 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             return false;
         }
 
-        // Parse XML
         XDocument doc;
         try
         {
@@ -137,7 +134,6 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             return false;
         }
 
-        // Extract reporting owner
         var ownerElement = root.Element("reportingOwner");
         if (ownerElement == null)
         {
@@ -393,7 +389,6 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
     internal static string SanitizeXml(string xml)
     {
         // SEC filings wrap the actual XML inside an SGML envelope.
-        // Extract the XML content from within <XML>...</XML> tags.
         var xmlStart = xml.IndexOf("<XML>", StringComparison.OrdinalIgnoreCase);
         var xmlEnd = xml.IndexOf("</XML>", StringComparison.OrdinalIgnoreCase);
         if (xmlStart >= 0 && xmlEnd > xmlStart)


### PR DESCRIPTION
## Summary

- Five comments in \`InsiderTradingFilingProcessor\` just labelled the next line(s) of code — \`// Check if already imported by accession number\`, \`// Fetch the XML document from SEC\`, \`// Parse XML\`, \`// Extract reporting owner\`, and the redundant second line \`// Extract the XML content from within <XML>...</XML> tags.\` in the \`SanitizeXml\` comment block.
- Drop them. Every WHY comment is kept — legacy XML envelope, malformed-ownership-XML rationale, \`ar-SA\`/Umm al-Qura culture-invariant date parsing, ownership XSD notes, the TransactionOrder uniqueness invariant, the no-in-memory-dedup explanation, and the SGML-envelope first line of \`SanitizeXml\`'s comment.
- Pure comment removal — every executable line unchanged. 24 \`InsiderTradingFilingProcessor\` unit tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs\` — delete five narration comment lines; no code changes.