### PR TITLE
refactor(holdings-13f-parser): extract WithLocalName helper for duplicated case-insensitive predicate

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
@@ -119,33 +119,25 @@ public class Filing13FXmlParser
         return holdings;
     }
 
+    private static IEnumerable<XElement> WithLocalName(
+        IEnumerable<XElement> source,
+        string localName
+    ) =>
+        source.Where(e =>
+            string.Equals(e.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)
+        );
+
     private static IEnumerable<XElement> Children(XElement parent, string localName) =>
-        parent
-            .Elements()
-            .Where(e =>
-                string.Equals(e.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)
-            );
+        WithLocalName(parent.Elements(), localName);
 
     private static XElement Descendant(XElement parent, string localName) =>
-        parent
-            ?.Descendants()
-            .FirstOrDefault(e =>
-                string.Equals(e.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)
-            );
+        parent == null ? null : WithLocalName(parent.Descendants(), localName).FirstOrDefault();
 
     private static IEnumerable<XElement> Descendants(XElement parent, string localName) =>
-        parent
-            .Descendants()
-            .Where(e =>
-                string.Equals(e.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)
-            );
+        WithLocalName(parent.Descendants(), localName);
 
     private static XElement Child(XElement parent, string localName) =>
-        parent
-            ?.Elements()
-            .FirstOrDefault(e =>
-                string.Equals(e.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)
-            );
+        parent == null ? null : WithLocalName(parent.Elements(), localName).FirstOrDefault();
 
     private static string Value(XElement element) => element?.Value.Trim();
 


### PR DESCRIPTION
## Summary

- `Filing13FXmlParser` had four `Child`/`Children`/`Descendant`/`Descendants` helpers, each repeating the same `e => string.Equals(e.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)` predicate.
- Extracted a private static `WithLocalName(IEnumerable<XElement> source, string localName)` helper. Each of the four wrappers now delegates to it; null-handling is preserved (the two `FirstOrDefault` helpers keep their `parent == null → null` short-circuit; the `Where` helpers continue to NRE when called with a null parent, exactly as before).

## Code changes

- `src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs` — added `WithLocalName`; rewrote `Child`, `Children`, `Descendant`, `Descendants` as thin one-liners over it.