### PR TITLE
fix(holdings): saturate CAGR on short-window overflow

### DIFF
--- a/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
@@ -184,7 +184,19 @@ public static class HoldingsBacktestCalculator
         {
             var years = (double)days / 365.25;
             var ratio = (double)(final / initial);
-            cagr = (decimal)(Math.Pow(ratio, 1.0 / years) - 1.0) * 100m;
+            var compounded = Math.Pow(ratio, 1.0 / years) - 1.0;
+            try
+            {
+                cagr = (decimal)compounded * 100m;
+            }
+            catch (OverflowException)
+            {
+                // Extreme single-window moves (e.g. an intraday double on a one-day
+                // window) drive the annualised compounding past decimal.MaxValue;
+                // saturate the CAGR cell rather than aborting the calculation —
+                // TotalReturn% / MaxDrawdown% are still meaningful.
+                cagr = decimal.MaxValue;
+            }
         }
 
         decimal peak = values[0];

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorCagrShortWindowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorCagrShortWindowTests.cs
@@ -5,9 +5,7 @@ namespace Equibles.UnitTests.Holdings;
 
 public class HoldingsBacktestCalculatorCagrShortWindowTests
 {
-    [Fact(
-        Skip = "GH-1199 — ComputeSummary casts Math.Pow(ratio, 365.25/days) to decimal; a short window with a large gain overflows decimal.MaxValue and throws."
-    )]
+    [Fact]
     public void Calculate_OneDayWindowWithDoublingPortfolio_ReturnsSummaryWithoutOverflow()
     {
         // Contract: Calculate returns a populated BacktestResult — including a


### PR DESCRIPTION
## Summary

- `HoldingsBacktestCalculator.ComputeSummary` annualised the period return as `(decimal)(Math.Pow(ratio, 1.0 / years) - 1.0) * 100m`. For a short window (e.g. one day, `years ≈ 0.00274`) the exponent is ~365.25, so a doubling drives `Math.Pow` to ~7.5e109 — well beyond `decimal.MaxValue` (~7.92e28). The explicit `(decimal)` cast then threw `OverflowException`, escaping `Calculate` and aborting the whole backtest run on a single extreme intraday move.
- Wrap the `(decimal)` cast and `* 100m` multiply in `try { ... } catch (OverflowException) { cagr = decimal.MaxValue; }` so the CAGR cell saturates instead of crashing the run. TotalReturn% and MaxDrawdown% — still meaningful for sub-year windows — are unaffected. Contract per the issue: "The CAGR cell may be saturated / clamped / `decimal.MaxValue`, but the call must not throw."

Closes #1199

## Code changes

- `src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs` — hoist the `Math.Pow` result into a local `compounded` double and wrap the `(decimal)compounded * 100m` cast in `try { ... } catch (OverflowException) { cagr = decimal.MaxValue; }`.
- `tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorCagrShortWindowTests.cs` — drop the `Skip = "GH-1199 …"` attribute so the regression test now runs (fails before, passes after).