### PR TITLE
fix(holdings-screener): default comparison to next-older relative to selected

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -184,11 +184,17 @@ public class HoldingsScreenerController : BaseController
             return (reportDates, null, null);
         var selected =
             date.HasValue && reportDates.Contains(date.Value) ? date.Value : reportDates[0];
-        var comparison =
-            compareDate.HasValue && reportDates.Contains(compareDate.Value)
-                ? compareDate.Value
-                : reportDates[1];
-        return (reportDates, selected, comparison);
+        // The default comparison must track the selected date — picking a fixed
+        // reportDates[1] collapses to selected==comparison when selected is the
+        // second-latest, and to a *newer* comparison when selected is older.
+        var selectedIndex = reportDates.IndexOf(selected);
+        DateOnly? comparison =
+            compareDate.HasValue && reportDates.Contains(compareDate.Value) ? compareDate.Value
+            : selectedIndex < reportDates.Count - 1 ? reportDates[selectedIndex + 1]
+            : null;
+        if (comparison is null)
+            return (reportDates, null, null);
+        return (reportDates, selected, comparison.Value);
     }
 
     internal static ScreenerCriteria ToCriteria(ScreenerCriteriaViewModel filters) =>

--- a/tests/Equibles.IntegrationTests/Web/HoldingsScreenerExportCsvComparisonDefaultTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsScreenerExportCsvComparisonDefaultTests.cs
@@ -12,9 +12,7 @@ public class HoldingsScreenerExportCsvComparisonDefaultTests
     public HoldingsScreenerExportCsvComparisonDefaultTests(WebHostFixture fixture) =>
         _fixture = fixture;
 
-    [Fact(
-        Skip = "GH-1252 — ResolveScreenerDates defaults comparison to reportDates[1] regardless of selected; collapses to selected==comparison when selected is second-latest."
-    )]
+    [Fact]
     public async Task ExportCsv_SelectedDateIsSecondLatest_DefaultComparisonIsNextOlderNotItself()
     {
         // Contract: the screener compares two quarters. When the user picks a


### PR DESCRIPTION
## Summary

- `HoldingsScreenerController.ResolveScreenerDates` defaulted the comparison to a fixed `reportDates[1]` (second-latest), ignoring the selected date. `reportDates` is descending, so the fallback was wrong in two distinct ways:
  - Selected = second-latest, no `compareDate` — comparison collapsed to selected itself; every Δ filer / Δ value / new-position / sold-out cell came back zero and the CSV filename was `screener-{selected}-vs-{selected}.csv`.
  - Selected = third-latest or older, no `compareDate` — comparison resolved to a date *newer* than selected, so the "delta" columns ran with `current` chronologically before `previous` — buys read as sells and vice versa.
- Compute the default comparison as the next-older quarter relative to the selected date (`reportDates[selectedIndex + 1]`). When the selected date is the oldest available (no temporally prior quarter), collapse to `(reportDates, null, null)` so existing callers fall into their existing "insufficient data" branch — the page action shows the "at least two distinct dates" message and the CSV export returns 404. Same family of bug as the merged GH-1243 / PR #1251 fix on `HoldingsExportController.Activity`.

Closes #1252

## Code changes

- `src/Equibles.Web/Controllers/HoldingsScreenerController.cs` — in `ResolveScreenerDates`, compute the default comparison as `reportDates[selectedIndex + 1]` and return `(reportDates, null, null)` when the selected date is the oldest available so existing null-selected branches in both the page and the export action handle it without changes elsewhere.
- `tests/Equibles.IntegrationTests/Web/HoldingsScreenerExportCsvComparisonDefaultTests.cs` — drop the `Skip = "GH-1252 …"` attribute so the regression test now runs (fails before, passes after).