### PR TITLE
refactor(sec-mcp): drop narration comments in DocumentTextTools

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -69,17 +69,14 @@ public class DocumentTextTools
             {
                 var lineNumber = lineIndex + 1;
 
-                // Line before
                 if (lineIndex > 0)
                 {
                     result.AppendLine(FormatLine(lineIndex, lines[lineIndex - 1]));
                 }
 
-                // Matched line with bold markers
                 var highlightedLine = HighlightKeyword(lines[lineIndex], keyword);
                 result.AppendLine(FormatLine(lineNumber, highlightedLine));
 
-                // Line after
                 if (lineIndex < lines.Length - 1)
                 {
                     result.AppendLine(FormatLine(lineNumber + 1, lines[lineIndex + 1]));
@@ -130,7 +127,6 @@ public class DocumentTextTools
 
             var totalLines = lines.Length;
 
-            // Clamp to valid range
             startLine = Math.Max(1, startLine);
             endLine = Math.Min(totalLines, endLine);
 


### PR DESCRIPTION
## Summary

- Delete 4 narration comments in `DocumentTextTools` — three section labels (`// Line before`, `// Matched line with bold markers`, `// Line after`) inside `SearchDocumentKeyword`'s context loop, and `// Clamp to valid range` above the `Math.Max` / `Math.Min` clamp in `ReadDocumentLines`. Method names (`FormatLine`, `HighlightKeyword`, `Math.Max`, `Math.Min`) and index arithmetic (`lineIndex - 1`, `lineIndex + 1`) already convey the intent.
- Same hygiene pass as the recent narration deletions (#1134 / #1164 / #1185 / #1193 / #1206 / #1214 / #1228 / #1245 / #1253). The WHY comment at lines 194-196 explaining the empty-keyword DoS guard is preserved.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs` — 4 narration comments removed; no code changes, no signature changes.