### PR TITLE
refactor(cftc-import): drop narration comments in CftcImportService.ParseDate

### DIFF
--- a/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
+++ b/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
@@ -320,7 +320,6 @@ public class CftcImportService
         if (string.IsNullOrWhiteSpace(value))
             return null;
 
-        // Try YYYY-MM-DD first (standard format)
         if (
             DateOnly.TryParseExact(
                 value.Trim(),
@@ -332,7 +331,6 @@ public class CftcImportService
         )
             return date;
 
-        // Try YYMMDD (legacy format)
         if (
             DateOnly.TryParseExact(
                 value.Trim(),


### PR DESCRIPTION
## Summary

- Removes two narration comments inside `CftcImportService.ParseDate` (`// Try YYYY-MM-DD first (standard format)`, `// Try YYMMDD (legacy format)`) that just restate the format string passed to `DateOnly.TryParseExact` on the very next line.
- Matches the existing precedent in #1228 (CboeImportService) and #1245 (ShortInterestImportService).

## Code changes

- `src/Equibles.Cftc.HostedService/Services/CftcImportService.cs` — two single-line narration comments deleted from `ParseDate`. No executable code touched; runtime logic, exception flow, and public API are unchanged.