### PR TITLE
refactor(sec-scraper): drop narration comments in DocumentScraper

### DIFF
--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -61,10 +61,8 @@ public class DocumentScraper : IDocumentScraper
         {
             _logger.LogInformation("Starting document scraping process...");
 
-            // Step 1: Sync companies from SEC API to database
             await _companySyncService.SyncCompaniesFromSecApi();
 
-            // Step 2: Process SEC documents for each company
             var companiesUntracked = await GetAllCompaniesWithNoTracking();
             _logger.LogInformation(
                 "Found {CompanyCount} companies to process for documents",
@@ -81,7 +79,6 @@ public class DocumentScraper : IDocumentScraper
                 result.CompaniesProcessed++;
             }
 
-            // Step 3: Retry deferred filings (normalization failures) after all tickers
             if (result.DeferredFilings.Count > 0)
             {
                 _logger.LogInformation(
@@ -380,7 +377,6 @@ public class DocumentScraper : IDocumentScraper
     {
         try
         {
-            // Detect actual document type from SEC filing's form field
             var detectedType = DocumentTypeExtensions.FromFormName(filing.Form);
             if (detectedType == null)
             {
@@ -395,7 +391,6 @@ public class DocumentScraper : IDocumentScraper
 
             documentType = detectedType;
 
-            // Check if a specialized processor handles this document type
             var processor = _filingProcessors.FirstOrDefault(p => p.CanProcess(documentType));
             if (processor != null)
             {
@@ -407,7 +402,6 @@ public class DocumentScraper : IDocumentScraper
                 return;
             }
 
-            // Default flow: check if document already exists, then create as markdown
             if (
                 await persistenceService.Exists(
                     company,


### PR DESCRIPTION
## Summary

- Six comments in \`DocumentScraper\` just labelled the next line(s) of code: \`// Step 1: Sync companies from SEC API to database\`, \`// Step 2: Process SEC documents for each company\`, \`// Step 3: Retry deferred filings (normalization failures) after all tickers\`, \`// Detect actual document type from SEC filing's form field\`, \`// Check if a specialized processor handles this document type\`, and \`// Default flow: check if document already exists, then create as markdown\`.
- Drop them. Every WHY comment is preserved — metadata-cache priming rationale, subsidiary CIK dedupe, paper-filed PDF unwrap, image-only-scan handling, deferred-filing retry semantics, etc.
- Pure comment removal — every executable line unchanged. 23 \`DocumentScraper\` unit tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.Sec.HostedService/DocumentScraper.cs\` — delete six narration comment lines; no code changes.