### PR TITLE
refactor(profiles): simplify selectedIndex lookup in BuildQuarterlyActivity

### DIFF
--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -134,27 +134,19 @@ public class ProfilesController : BaseController
                 null
             );
 
-        DateOnly selected;
-        var selectedIndex = -1;
+        var selectedIndex = 0;
         if (requestedDate.HasValue)
         {
             for (var i = 0; i < distinctReportDates.Count; i++)
             {
-                if (distinctReportDates[i] != requestedDate.Value)
-                    continue;
-                selectedIndex = i;
-                break;
+                if (distinctReportDates[i] == requestedDate.Value)
+                {
+                    selectedIndex = i;
+                    break;
+                }
             }
         }
-        if (selectedIndex < 0)
-        {
-            selected = distinctReportDates[0];
-            selectedIndex = 0;
-        }
-        else
-        {
-            selected = distinctReportDates[selectedIndex];
-        }
+        var selected = distinctReportDates[selectedIndex];
         if (selectedIndex >= distinctReportDates.Count - 1)
             return (
                 new Dictionary<StockPositionChangeType, List<StockPositionChange>>(),


### PR DESCRIPTION
## Summary

- `ProfilesController.BuildQuarterlyActivity` used a sentinel `selectedIndex = -1` plus a separate post-loop branch to handle "requested date not found" and "no requested date" as identical fallbacks to the first available date.
- Default `selectedIndex` to `0` and let the loop overwrite it only on a match, dropping the redundant post-loop branch and a separate `selected` declaration. Pure clarity refactor; same `(selected, selectedIndex)` produced for every input scenario.

## Code changes

- `src/Equibles.Web/Controllers/ProfilesController.cs` — `BuildQuarterlyActivity`: collapse the sentinel-based `selectedIndex` lookup into a single defaulted-index loop and inline the `selected` assignment.