### PR TITLE
refactor(common-stocks): replace three null-guards with ArgumentNullException.ThrowIfNull

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -31,10 +31,7 @@ public class CommonStockManager
     /// </summary>
     public async Task SetCusip(CommonStock commonStock, string cusip)
     {
-        if (commonStock == null)
-        {
-            throw new ArgumentNullException(nameof(commonStock));
-        }
+        ArgumentNullException.ThrowIfNull(commonStock);
 
         if (string.Equals(commonStock.Cusip, cusip, StringComparison.OrdinalIgnoreCase))
         {
@@ -60,10 +57,7 @@ public class CommonStockManager
     /// </summary>
     public async Task SetFiscalYearEnd(CommonStock commonStock, int month, int? day)
     {
-        if (commonStock == null)
-        {
-            throw new ArgumentNullException(nameof(commonStock));
-        }
+        ArgumentNullException.ThrowIfNull(commonStock);
 
         if (month is < 1 or > 12)
         {
@@ -106,10 +100,7 @@ public class CommonStockManager
 
     private async Task ValidateCommonStock(CommonStock commonStock, bool isInsert)
     {
-        if (commonStock == null)
-        {
-            throw new ArgumentNullException(nameof(commonStock));
-        }
+        ArgumentNullException.ThrowIfNull(commonStock);
 
         // Required fields: a whitespace-only value is not a provided value.
         // Ticker is the globally-unique key and the lookup key, so accepting


### PR DESCRIPTION
## Summary

- `CommonStockManager.SetCusip`, `SetFiscalYearEnd`, and `ValidateCommonStock` each opened with the same 4-line `if (commonStock == null) throw new ArgumentNullException(nameof(commonStock));` guard.
- Replaced all three with `ArgumentNullException.ThrowIfNull(commonStock);`. Same exception type, same parameter name (captured via `[CallerArgumentExpression]` instead of `nameof`) — identical observable behavior.

## Code changes

- `src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs` — collapsed three 4-line null-guards to one-liners using the .NET 6+ built-in.