### PR TITLE
test(sec-financial-facts-mcp): pin FactArgs.TryParsePeriod Q1 arm returns Q1

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodQ1Tests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodQ1Tests.cs
@@ -1,0 +1,23 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the Q1 switch arm of FactArgs.TryParsePeriod — one arm per PR, sibling
+/// to TryParsePeriod_Q4_ReturnsTrueAndQ4 and the lowercase-annual-alias test.
+/// A copy-paste regression that mapped "Q1" to Q2 (or to default/FullYear)
+/// would compile cleanly and silently misalign every CompareFinancialFact
+/// invocation that names a first-quarter period.
+/// </summary>
+public class FactArgsTryParsePeriodQ1Tests
+{
+    [Fact]
+    public void TryParsePeriod_Q1_ReturnsTrueAndQ1()
+    {
+        var success = FactArgs.TryParsePeriod("Q1", out var period);
+
+        success.Should().BeTrue();
+        period.Should().Be(SecFiscalPeriod.Q1);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the Q1 switch arm of `FactArgs.TryParsePeriod`, the shared period parser every FinancialFacts MCP tool relies on. Sibling to the existing Q4 and lowercase-`annual` arm pins; one arm per PR per the convention noted in `FactArgsTryParsePeriodTests`.
- Closes one of the three uncovered switch arms (Q1 / Q3 / default). A copy-paste regression that mapped `"Q1"` to Q2 or routed it through the default-false arm would compile cleanly and silently misalign every `CompareFinancialFact` invocation that names a first-quarter period.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodQ1Tests.cs` — new file. One `[Fact]` asserting `FactArgs.TryParsePeriod("Q1", out var period)` returns `true` and sets `period` to `SecFiscalPeriod.Q1`.