### PR TITLE
docs(technical/web-portal): split layout-filters bullet into one fact per bullet

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -43,7 +43,9 @@ Why the indirection through `ViewData` rather than a single `StockDetailViewMode
 - `_ViewStart.cshtml` pins every view to `_Layout.cshtml`. There is no per-area layout split — one shell for everything.
 - `_ViewImports.cshtml` declares the project-wide `@using`s + tag-helper imports + the `Equibles.Web` namespace.
 - [`FlashMessage`](../../src/Equibles.Web/FlashMessage) — one-shot session messages used across controllers. `services.AddFlashMessage()` registers the writer; the layout reads via injected `IFlashMessage`. Use for redirects after a write (Auth login success, etc.).
-- Layout includes [`StatusBadgeFilter`](../../src/Equibles.Web/Filters/StatusBadgeFilter.cs) (counts recent errors and exposes a badge for the Status link) and [`VersionCheckFilter`](../../src/Equibles.Web/Filters/VersionCheckFilter.cs) (compares `AssemblyInformationalVersion` against the latest GitHub release and surfaces an update banner). Both filters are registered globally on `AddControllersWithViews(options => options.Filters.AddService<...>())`.
+- [`StatusBadgeFilter`](../../src/Equibles.Web/Filters/StatusBadgeFilter.cs) counts recent errors and exposes a badge for the Status link in the layout.
+- [`VersionCheckFilter`](../../src/Equibles.Web/Filters/VersionCheckFilter.cs) compares `AssemblyInformationalVersion` against the latest GitHub release and surfaces an update banner.
+- Both filters register globally via `AddControllersWithViews(options => options.Filters.AddService<...>())`.
 
 ## Tag helpers
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The "Shared shell" layout-filters bullet packed three facts into a 456-char run-on (StatusBadgeFilter, VersionCheckFilter, registration mechanics). Technical-docs writing rule: "One fact per bullet — A long bullet is a smell, split it."

## Code changes

- `docs/technical/web-portal.md` — replace the single layout-filters bullet with three: one for `StatusBadgeFilter`, one for `VersionCheckFilter`, one for the global `AddControllersWithViews(...Filters.AddService<...>())` registration.