### PR TITLE
refactor(common-stocks): use ArgumentNullException.ThrowIfNull in FiscalCalendar

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/FiscalCalendar.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/FiscalCalendar.cs
@@ -103,10 +103,7 @@ public static class FiscalCalendar
     /// </summary>
     public static FiscalPeriod? GetPeriod(DateOnly date, CommonStock commonStock)
     {
-        if (commonStock == null)
-        {
-            throw new ArgumentNullException(nameof(commonStock));
-        }
+        ArgumentNullException.ThrowIfNull(commonStock);
 
         return commonStock.FiscalYearEndMonth is { } month ? GetPeriod(date, month) : null;
     }
@@ -123,10 +120,7 @@ public static class FiscalCalendar
         CommonStock commonStock
     )
     {
-        if (commonStock == null)
-        {
-            throw new ArgumentNullException(nameof(commonStock));
-        }
+        ArgumentNullException.ThrowIfNull(commonStock);
 
         return commonStock.FiscalYearEndMonth is { } month
             ? GetQuarterEndDate(fiscalYear, fiscalQuarter, month)


### PR DESCRIPTION
## Summary

- \`FiscalCalendar.GetPeriod\` and \`GetQuarterEndDate\` each wrapped a manual \`if (commonStock == null) throw new ArgumentNullException(nameof(commonStock));\` guard.
- Collapse both to \`ArgumentNullException.ThrowIfNull(commonStock)\` — same exception type, same parameter name, same throw-on-null / pass-on-non-null behavior. Mirrors the convention adopted in \`CommonStockManager\` (#1269).
- 43 \`FiscalCalendar\` unit tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.CommonStocks.BusinessLogic/FiscalCalendar.cs\` — replace two five-line manual null-guard blocks with single-line \`ArgumentNullException.ThrowIfNull(commonStock)\` calls.