### PR TITLE
test(sec-financial-facts-mcp): pin FactArgs.TryParsePeriod Q3 arm returns Q3

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodQ3Tests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodQ3Tests.cs
@@ -1,0 +1,22 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the Q3 switch arm of FactArgs.TryParsePeriod — sibling to the existing
+/// Q1 (#1270) and Q4 pins, one arm per PR. A copy-paste regression mapping
+/// "Q3" to Q2 or Q4 would compile cleanly and silently misalign every
+/// CompareFinancialFact invocation that names a third-quarter period.
+/// </summary>
+public class FactArgsTryParsePeriodQ3Tests
+{
+    [Fact]
+    public void TryParsePeriod_Q3_ReturnsTrueAndQ3()
+    {
+        var success = FactArgs.TryParsePeriod("Q3", out var period);
+
+        success.Should().BeTrue();
+        period.Should().Be(SecFiscalPeriod.Q3);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the Q3 switch arm of `FactArgs.TryParsePeriod`, the shared period parser every FinancialFacts MCP tool relies on. Sibling to the existing Q4 pin and the in-flight Q1 pin (#1270); one arm per PR per the convention noted in `FactArgsTryParsePeriodTests`.
- Closes the next uncovered arm. A copy-paste regression that mapped `"Q3"` to Q2 or Q4 would compile cleanly and silently misalign every `CompareFinancialFact` invocation that names a third-quarter period.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodQ3Tests.cs` — new file. One `[Fact]` asserting `FactArgs.TryParsePeriod("Q3", out var period)` returns `true` and sets `period` to `SecFiscalPeriod.Q3`.