### PR TITLE
test(sec-financial-facts-mcp): pin FactArgs.TryParsePeriod unknown input returns false

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodDefaultTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodDefaultTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the default-arm contract of FactArgs.TryParsePeriod: per the .NET
+/// Try-pattern convention, any unrecognized fiscal-period string must return
+/// false rather than silently succeed with a default SecFiscalPeriod.
+/// Without this pin, a regression that "simplified" the switch into an
+/// always-FullYear fallback would compile cleanly and silently misclassify
+/// every typo'd period (e.g. "Q5", "first quarter") as the annual figure.
+/// </summary>
+public class FactArgsTryParsePeriodDefaultTests
+{
+    [Fact]
+    public void TryParsePeriod_UnrecognizedValue_ReturnsFalse()
+    {
+        var success = FactArgs.TryParsePeriod("Q5", out _);
+
+        success.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the default arm of `FactArgs.TryParsePeriod` (the shared period parser every FinancialFacts MCP tool relies on). Per the .NET Try-pattern convention, any unrecognized fiscal-period string must return `false` rather than silently succeed with a default `SecFiscalPeriod`.
- Completes the switch-arm coverage alongside the existing Q4 pin and in-flight Q1 (#1270) / Q3 (#1276) pins. A regression that simplified the switch into an always-FullYear fallback would compile cleanly and silently misclassify every typo'd period (e.g. `"Q5"`, `"first quarter"`) as the annual figure.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodDefaultTests.cs` — new file. One `[Fact]` asserting `FactArgs.TryParsePeriod("Q5", out _)` returns `false`.