### PR TITLE
refactor(holdings-import): collapse duplicated BuildHoldingKey blocks in FlushBatch via entity overload

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -613,14 +613,7 @@ public class HoldingsImportService
         var entriesByKey = new Dictionary<string, List<HoldingManagerEntry>>();
         foreach (var h in holdings)
         {
-            var key = BuildHoldingKey(
-                h.CommonStockId,
-                h.InstitutionalHolderId,
-                h.ReportDate,
-                h.ShareType,
-                h.OptionType
-            );
-            entriesByKey[key] = h.ManagerEntries.ToList();
+            entriesByKey[BuildHoldingKey(h)] = h.ManagerEntries.ToList();
             h.ManagerEntries.Clear();
         }
 
@@ -664,14 +657,7 @@ public class HoldingsImportService
 
         foreach (var dbHolding in dbHoldings)
         {
-            var key = BuildHoldingKey(
-                dbHolding.CommonStockId,
-                dbHolding.InstitutionalHolderId,
-                dbHolding.ReportDate,
-                dbHolding.ShareType,
-                dbHolding.OptionType
-            );
-            if (entriesByKey.TryGetValue(key, out var entries))
+            if (entriesByKey.TryGetValue(BuildHoldingKey(dbHolding), out var entries))
             {
                 dbHolding.ManagerEntries.Clear();
                 dbHolding.ManagerEntries.AddRange(entries);
@@ -691,4 +677,13 @@ public class HoldingsImportService
         OptionType? optionType
     ) =>
         $"{commonStockId}|{institutionalHolderId}|{reportDate}|{(int)shareType}|{optionType?.ToString() ?? ""}";
+
+    private static string BuildHoldingKey(InstitutionalHolding h) =>
+        BuildHoldingKey(
+            h.CommonStockId,
+            h.InstitutionalHolderId,
+            h.ReportDate,
+            h.ShareType,
+            h.OptionType
+        );
 }


### PR DESCRIPTION
## Summary

- Collapse two near-identical 7-line `BuildHoldingKey(...)` call blocks in `HoldingsImportService.FlushBatch` into single-expression calls.
- Add a private static overload `BuildHoldingKey(InstitutionalHolding)` that delegates to the existing 5-parameter primitive overload — no behavior change.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — Add `BuildHoldingKey(InstitutionalHolding h)` overload (delegates to the existing primitive overload with the same 5 properties in the same order). Replace the two duplicated key-building blocks in `FlushBatch` (one in the `holdings` enumeration, one in the `dbHoldings` reconciliation loop) with single-line calls through the new overload. The third call site at line 491 still uses the primitive overload because the entity is not yet constructed there.