### PR TITLE
test(sec-financial-facts-mcp): pin FactMarkdown.Value preserves precision for dimensionless units

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownValuePureDimensionlessTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownValuePureDimensionlessTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// FactMarkdown.Value's doc-comment promises that dimensionless / ratio units
+/// (e.g. "pure") "keep their fractional precision rather than being rounded to
+/// an integer." A regression that routed unknown / ratio units through the
+/// grouped-whole-number "N0" arm would silently round every reported ratio
+/// fact (P/E, margins, EPS-pure variants) to "0" in the MCP table output —
+/// the exact failure mode the doc-comment names.
+/// </summary>
+public class FactMarkdownValuePureDimensionlessTests
+{
+    [Fact]
+    public void Value_PureDimensionlessUnit_PreservesFractionalPrecision()
+    {
+        var result = FactMarkdown.Value(0.1234m, "pure");
+
+        result.Should().Be("0.1234");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `FactMarkdown.Value`'s ratio / dimensionless arm: per the doc-comment ("dimensionless or ratio units (e.g. `pure`) keep their fractional precision rather than being rounded to an integer"), a value with unit `"pure"` must render with its fraction intact.
- Closes the only uncovered line in `FactMarkdown` (the `0.############` format arm). Sibling to the existing per-share-USD and bare-currency `Value` pins. A regression that routed unknown units through the `N0` arm would silently render every reported ratio fact (P/E, margins) as `"0"` in the MCP table output — the exact failure mode the doc-comment names.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownValuePureDimensionlessTests.cs` — new file. One `[Fact]` asserting `FactMarkdown.Value(0.1234m, "pure")` returns `"0.1234"`.