### PR TITLE
refactor(market-controller): extract ComputeStats helper for duplicated DescriptiveStatistics block

### DIFF
--- a/src/Equibles.Web/Controllers/MarketController.cs
+++ b/src/Equibles.Web/Controllers/MarketController.cs
@@ -111,12 +111,12 @@ public class MarketController : BaseController
             .ToArray();
         if (values.Length > 0)
         {
-            var stats = new DescriptiveStatistics(values);
-            viewModel.Mean = stats.Mean.SafeRound(4);
-            viewModel.Median = values.Median().SafeRound(4);
-            viewModel.Min = stats.Minimum.SafeRound(4);
-            viewModel.Max = stats.Maximum.SafeRound(4);
-            viewModel.StdDev = stats.StandardDeviation.SafeRound(4);
+            var s = ComputeStats(values, decimals: 4);
+            viewModel.Mean = s.Mean;
+            viewModel.Median = s.Median;
+            viewModel.Min = s.Min;
+            viewModel.Max = s.Max;
+            viewModel.StdDev = s.StdDev;
             viewModel.LatestRatio = records.FirstOrDefault()?.PutCallRatio;
             if (records.Count > 1)
                 viewModel.PreviousRatio = records[1].PutCallRatio;
@@ -149,12 +149,12 @@ public class MarketController : BaseController
         var values = records.Select(r => (double)r.Close).ToArray();
         if (values.Length > 0)
         {
-            var stats = new DescriptiveStatistics(values);
-            viewModel.Mean = stats.Mean.SafeRound(2);
-            viewModel.Median = values.Median().SafeRound(2);
-            viewModel.Min = stats.Minimum.SafeRound(2);
-            viewModel.Max = stats.Maximum.SafeRound(2);
-            viewModel.StdDev = stats.StandardDeviation.SafeRound(2);
+            var s = ComputeStats(values, decimals: 2);
+            viewModel.Mean = s.Mean;
+            viewModel.Median = s.Median;
+            viewModel.Min = s.Min;
+            viewModel.Max = s.Max;
+            viewModel.StdDev = s.StdDev;
             viewModel.LatestClose = records.FirstOrDefault()?.Close;
             if (records.Count > 1)
                 viewModel.PreviousClose = records[1].Close;
@@ -169,4 +169,24 @@ public class MarketController : BaseController
             "CBOE Volatility Index (VIX) daily history with chart and statistics.";
         return View(viewModel);
     }
+
+    private static StatsSummary ComputeStats(double[] values, int decimals)
+    {
+        var stats = new DescriptiveStatistics(values);
+        return new StatsSummary(
+            Mean: stats.Mean.SafeRound(decimals),
+            Median: values.Median().SafeRound(decimals),
+            Min: stats.Minimum.SafeRound(decimals),
+            Max: stats.Maximum.SafeRound(decimals),
+            StdDev: stats.StandardDeviation.SafeRound(decimals)
+        );
+    }
+
+    private readonly record struct StatsSummary(
+        decimal? Mean,
+        decimal? Median,
+        decimal? Min,
+        decimal? Max,
+        decimal? StdDev
+    );
 }


### PR DESCRIPTION
## Summary

- \`PutCallRatio\` and \`Vix\` actions both inlined the same 5-line \`DescriptiveStatistics\` + \`values.Median()\` + \`SafeRound\` block to populate Mean/Median/Min/Max/StdDev on their (different) viewmodels. The only difference was the rounding precision (4 vs 2 decimals).
- Lift into a private \`ComputeStats(values, decimals)\` static helper that returns a nested \`StatsSummary\` \`readonly record struct\`. Each call site reads the five fields onto its viewmodel one-for-one.
- Same \`DescriptiveStatistics\` instance, same \`Median()\` extension, same \`SafeRound(decimals)\` rounding. 5 MarketController integration tests pass locally; full csharpier check green.

## Code changes

- \`src/Equibles.Web/Controllers/MarketController.cs\` — extract \`ComputeStats(values, decimals)\` + \`StatsSummary\` record-struct; replace two inline 5-line stats blocks with field-by-field assignments from the returned summary.