### PR TITLE
test(congress): pin DisclosureParsingHelper.IsValidDisclosureUrl rejects unparseable URL

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlUnparseableTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlUnparseableTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperIsValidUrlUnparseableTests
+{
+    [Fact]
+    public void IsValidDisclosureUrl_UnparseableAbsoluteUrl_ReturnsFalse()
+    {
+        // Contract: this is a security allowlist predicate — it must be total
+        // and return false on anything that can't be parsed as an absolute URI
+        // (no scheme/host), without NRE-ing on `parsed.Scheme`. A regression
+        // that dropped the Uri.TryCreate guard would crash the scraper on any
+        // junk href the upstream HTML happens to contain.
+        var result = DisclosureParsingHelper.IsValidDisclosureUrl(
+            "not a url",
+            "https://disclosures.house.gov"
+        );
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the unparseable-URL branch of the SSRF-guard predicate `DisclosureParsingHelper.IsValidDisclosureUrl`. Sibling to the existing null-url, scheme-downgrade, and attacker-prefix pins.
- Closes uncovered line 290 (the `return false` reached when `Uri.TryCreate` fails). A regression that dropped the `Uri.TryCreate` guard would NRE on `parsed.Scheme` for any junk href the scraped HTML happens to contain.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlUnparseableTests.cs` — new file. One `[Fact]` asserting `IsValidDisclosureUrl("not a url", "https://disclosures.house.gov")` returns `false`.