### PR TITLE
test(sec): pin SecDocumentEnvelopeParser rejects filename starting with dot

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserLeadingDotFilenameTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserLeadingDotFilenameTests.cs
@@ -1,0 +1,38 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentEnvelopeParserLeadingDotFilenameTests
+{
+    // Contract (IsSafeFilename, SecDocumentEnvelopeParser.cs:64-68): a candidate
+    // whose first character is '.' must be rejected. Dot is the leading
+    // character of "../" traversal sequences and of Unix hidden-file conventions;
+    // the bare-name allowlist alone permits dots anywhere, so the explicit
+    // leading-dot rejection is the defense in depth. Sibling to the encoded-
+    // traversal, whitespace, and backslash pins. A regression that dropped this
+    // single line would let "..pdf" / ".hidden.pdf" through and flow into the
+    // /Archives/edgar/data/{cik}/{accession}/{filename} URL.
+    [Fact]
+    public void TryExtractPaperPdfFilename_FilenameStartingWithDot_RejectsAndReturnsFalse()
+    {
+        var envelope = """
+            <SEC-DOCUMENT>
+            <DOCUMENT>
+            <TYPE>6-K
+            <SEQUENCE>1
+            <FILENAME>.hidden.pdf
+            <TEXT>
+            </TEXT>
+            </DOCUMENT>
+            </SEC-DOCUMENT>
+            """;
+
+        var success = SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(
+            envelope,
+            out var filename
+        );
+
+        success.Should().BeFalse();
+        filename.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `SecDocumentEnvelopeParser.IsSafeFilename`'s leading-dot rejection (line 67, uncovered). The check is the defense-in-depth complement to the bare-name allowlist: dot is the leading character of `../` traversal sequences and Unix hidden-file conventions, so any filename whose first character is `.` must be rejected before it can flow into `/Archives/edgar/data/{cik}/{accession}/{filename}`.
- Sibling to the existing encoded-traversal, whitespace-only, backslash, and missing-end-tag pins. A regression that dropped this single line would let `.hidden.pdf` / `..pdf` through the allowlist.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserLeadingDotFilenameTests.cs` — new file. One `[Fact]` building an envelope with `<FILENAME>.hidden.pdf` and asserting `TryExtractPaperPdfFilename` returns `false` with an empty out-parameter.