### PR TITLE
docs(technical/migrations): split ApplyMigrationsAsync bullet — separate what from why

### DIFF
--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -38,7 +38,8 @@ dotnet ef migrations add <Name> \
 
 Hosts call `await dbContext.Database.MigrateAsync()` on startup.
 
-- The Web host owns migration application. `ApplyMigrationsAsync` in [`src/Equibles.Web/Program.cs`](../../src/Equibles.Web/Program.cs) creates a scope, resolves `EquiblesDbContext`, sets `Database.SetCommandTimeout(TimeSpan.FromHours(1))`, and runs `MigrateAsync()`. The 1-hour timeout absorbs index rebuilds on first run (BM25 + pgvector indexes on multi-million-row tables can take many minutes).
+- The Web host owns migration application via `ApplyMigrationsAsync` in [`src/Equibles.Web/Program.cs`](../../src/Equibles.Web/Program.cs) — it creates a scope, resolves `EquiblesDbContext`, sets `Database.SetCommandTimeout(TimeSpan.FromHours(1))`, and runs `MigrateAsync()`.
+- The 1-hour command timeout absorbs index rebuilds on first run; BM25 + pgvector indexes on multi-million-row tables can take many minutes.
 - The MCP server does **not** run migrations. Its compose service `depends_on: web (condition: service_healthy)`, so by the time MCP starts the Web host has already finished migrating.
 - The Worker host doesn't call `MigrateAsync` on the EF model either, but it does run `MassTransit__RunMigration=true` so the MassTransit SQL transport tables apply on first boot. The EF tables are still owned by Web.
 - Migrations apply additively. There's no down-migration path in production — `Down` exists in the file but `MigrateAsync` only applies the unapplied `Up` set.


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `ApplyMigrationsAsync` bullet under "Applying migrations" packed two facts into a 399-char run-on: what the method does (create scope → resolve context → set 1-hour timeout → run `MigrateAsync`) and why the 1-hour timeout exists (BM25 + pgvector first-run index rebuilds). Split.

## Code changes

- `docs/technical/migrations.md` — replace the single bullet with two: one stating the Web host's `ApplyMigrationsAsync` mechanics, one stating the rationale for the 1-hour command timeout.