### PR TITLE
test(holdings): pin Filing13FXmlParser.ParseInformationTable tolerates null xml

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserNullInfoTableXmlTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserNullInfoTableXmlTests.cs
@@ -1,0 +1,26 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Filing13FXmlParserNullInfoTableXmlTests
+{
+    [Fact]
+    public void ParseInformationTable_NullXml_ReturnsEmptyListWithoutThrowing()
+    {
+        // Contract (method XML-doc on ParseInformationTable): "Tolerates a missing
+        // or empty table … by returning an empty list." The realtime ingestion
+        // sweep passes the artifact bytes through after a None/empty-string check
+        // upstream — but the unit contract is the safety net. A regression that
+        // dropped the IsNullOrWhiteSpace guard would NRE on XDocument.Parse(null)
+        // and crash the worker on the first amendment that ships without an info
+        // table. The existing empty-amendment pin covers the well-formed empty-root
+        // path; the null/whitespace branch is the unpinned half of the same
+        // promise.
+        var parser = new Filing13FXmlParser();
+
+        var act = () => parser.ParseInformationTable(null);
+
+        act.Should().NotThrow();
+        parser.ParseInformationTable(null).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the null/whitespace input branch of `Filing13FXmlParser.ParseInformationTable`. The method's doc-comment promises it "tolerates a missing or empty table … by returning an empty list," but only the well-formed empty-root case is currently pinned (`Filing13FXmlParserEmptyAmendmentTests`).
- A regression that dropped the `IsNullOrWhiteSpace` guard would NRE on `XDocument.Parse(null)` and crash the realtime worker on the first amendment that ships without an info table.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Filing13FXmlParserNullInfoTableXmlTests.cs` — new file. One `[Fact]` asserting `ParseInformationTable(null)` returns an empty list without throwing.