### PR TITLE
test(sec-financial-facts): pin StandaloneXbrlParser skips divide unit missing measure

### DIFF
--- a/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserDivideUnitMissingMeasureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserDivideUnitMissingMeasureTests.cs
@@ -1,0 +1,41 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the divide-unit missing-measure branch of StandaloneXbrlParser.Parse
+/// (ResolveUnit's missing-numerator/denominator early return). A divide unit
+/// without both measures cannot be resolved to a "numerator/denominator" name;
+/// facts referencing it must be skipped, not emitted with Unit = null, since
+/// every downstream FinancialFacts tool keys off Unit ("USD", "shares/USD")
+/// to render the value column.
+/// </summary>
+public class StandaloneXbrlParserDivideUnitMissingMeasureTests
+{
+    [Fact]
+    public void Parse_DivideUnitWithMissingNumeratorMeasure_SkipsFactsReferencingThatUnit()
+    {
+        // The unit declares <xbrli:divide> but only ships a denominator measure;
+        // the numerator measure element is absent. ResolveUnit must return null
+        // (unit dropped from the units map), and the fact's unitRef lookup must
+        // therefore miss — yielding zero facts.
+        var xml =
+            "<xbrli:xbrl "
+            + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+            + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2018-01-31\">"
+            + "<xbrli:context id=\"C1\">"
+            + "<xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "<xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"bad\">"
+            + "<xbrli:divide>"
+            + "<xbrli:unitNumerator></xbrli:unitNumerator>"
+            + "<xbrli:unitDenominator><xbrli:measure>xbrli:shares</xbrli:measure></xbrli:unitDenominator>"
+            + "</xbrli:divide>"
+            + "</xbrli:unit>"
+            + "<us-gaap:EarningsPerShareBasic contextRef=\"C1\" unitRef=\"bad\">12.01</us-gaap:EarningsPerShareBasic>"
+            + "</xbrli:xbrl>";
+
+        new StandaloneXbrlParser().Parse(xml).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the divide-unit missing-measure branch of `StandaloneXbrlParser.ResolveUnit` (line 207, uncovered). A `<xbrli:unit>` declared with `<xbrli:divide>` but missing either the numerator or denominator `<xbrli:measure>` cannot be resolved to a `"numerator/denominator"` name.
- The fact referencing that unit must be skipped (the units map drops the entry, so the fact's `unitRef` lookup misses). Downstream FinancialFacts tools key off `Unit` to render the value column — emitting a fact with `Unit = null` would crash or render `""` and silently mislabel comparable peer facts.

## Code changes

- `tests/Equibles.UnitTests/Sec/StandaloneXbrlParserDivideUnitMissingMeasureTests.cs` — new file. One `[Fact]` building a standalone XBRL doc with a unit whose `<xbrli:unitNumerator>` is empty and asserting `Parse` returns an empty list.