### PR TITLE
refactor(sec-chunking): collapse running-max loop in FindLastSentenceEnd to LINQ Max

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Processing/ChunkingStrategy.cs
+++ b/src/Equibles.Sec.BusinessLogic/Processing/ChunkingStrategy.cs
@@ -124,15 +124,9 @@ public class ChunkingStrategy
         var searchText = text.Substring(start, end - start);
         var sentenceEndings = new[] { ".", "!", "?", "\n\n" };
 
-        var lastIndex = -1;
-        foreach (var ending in sentenceEndings)
-        {
-            var index = searchText.LastIndexOf(ending, StringComparison.Ordinal);
-            if (index > lastIndex)
-            {
-                lastIndex = index;
-            }
-        }
+        var lastIndex = sentenceEndings.Max(ending =>
+            searchText.LastIndexOf(ending, StringComparison.Ordinal)
+        );
 
         return lastIndex > -1 ? start + lastIndex + 1 : -1;
     }


### PR DESCRIPTION
## Summary

- Replace the explicit running-maximum `foreach`/`if (index > lastIndex)` loop in `ChunkingStrategy.FindLastSentenceEnd` with a single `sentenceEndings.Max(...)` expression.
- Behavior preserved: `LastIndexOf` returns -1 when not found, so `Max` over the four lookups yields the same value the loop accumulates, including the `-1` sentinel that drives the existing return branch.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Processing/ChunkingStrategy.cs` — In `FindLastSentenceEnd`, replace the 8-line running-max loop over the four sentence-ending strings (`.`, `!`, `?`, `\n\n`) with `sentenceEndings.Max(ending => searchText.LastIndexOf(ending, StringComparison.Ordinal))`. The `start`-clamp, the `Substring` window, the `StringComparison.Ordinal` comparer, and the final `lastIndex > -1 ? start + lastIndex + 1 : -1` return are unchanged.