### PR TITLE
test(yahoo-mcp): pin GetStochasticOscillator emits rows newest-first

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStochasticTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStochasticTests.cs
@@ -150,6 +150,48 @@ public class StockPriceToolsStochasticTests : ParadeDbMcpTestBase
         result.Should().Contain("dPeriod at least 1");
     }
 
+    [Fact]
+    public async Task GetStochasticOscillator_EmitsRowsNewestFirst()
+    {
+        // Tool description promises "(default: 60, newest first)". None of the other
+        // Stochastic tests pin the row order — a regression that flipped the loop
+        // direction (i = 0 → i < records.Count) would still pass them. Five
+        // increasing dates; first data row in the table must be the latest one.
+        var stock = MakeStock();
+        DbContext.Set<CommonStock>().Add(stock);
+        await DbContext.SaveChangesAsync();
+        var start = new DateOnly(2025, 1, 6);
+        for (var i = 0; i < 5; i++)
+        {
+            DbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = start.AddDays(i),
+                        Open = 100m,
+                        High = 101m,
+                        Low = 99m,
+                        Close = 100m,
+                        AdjustedClose = 100m,
+                        Volume = 1,
+                    }
+                );
+        }
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut()
+            .GetStochasticOscillator(
+                "AAPL",
+                startDate: start.ToString("yyyy-MM-dd"),
+                endDate: start.AddDays(5).ToString("yyyy-MM-dd")
+            );
+
+        var firstDataRow = result.Split('\n').First(line => line.StartsWith("| 2025-"));
+        firstDataRow.Should().StartWith($"| {start.AddDays(4):yyyy-MM-dd} |");
+    }
+
     private static CommonStock MakeStock() =>
         new()
         {


### PR DESCRIPTION
## Summary

- The `GetStochasticOscillator` MCP tool description promises "(default: 60, newest first)". None of the existing Stochastic tool tests pin the row order — a regression that flipped the loop direction (`i = 0; i < records.Count; i++`) would silently emit oldest-first and break the contract.
- Mirror the existing `GetOnBalanceVolume_EmitsRowsNewestFirst` and `GetAverageTrueRange_EmitsRowsNewestFirst` pattern so all three MCP indicator tools (OBV, ATR, Stochastic) have parity on the order pin.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsStochasticTests.cs` — add `GetStochasticOscillator_EmitsRowsNewestFirst`: seeds five increasing dates, calls the tool, asserts the first data row in the Markdown table is the latest date (`start + 4 days`).