### PR TITLE
docs(technical/hosts): split worker-registration bullet from cross-cutting plumbing

### DIFF
--- a/docs/technical/hosts.md
+++ b/docs/technical/hosts.md
@@ -35,7 +35,8 @@ The background-scraper host. Plain `Host.CreateApplicationBuilder` (not `WebAppl
 - Container: [`Dockerfile`](../../src/Equibles.Worker.Host/Dockerfile) — `dotnet/aspnet:10.0` (for shared runtime), `ENTRYPOINT ["dotnet", "Equibles.Worker.Host.dll"]`, no ports exposed.
 - `AddMessaging(builder.Configuration)` configures MassTransit on the Postgres SQL transport with the EF outbox sitting inside `EquiblesDbContext`. The transport connection comes from `ConnectionStrings__TransportConnection`; `MassTransit__RunMigration=true` makes the worker apply the transport schema on first run.
 - One scraper-options bind per source (`WorkerOptions`, `DocumentScraperOptions`, `FinraOptions` + `FinraScraperOptions`, `FredOptions` + `FredScraperOptions`, `FtdScraperOptions`, `FinancialFactsScraperOptions`, `YahooPriceScraperOptions`, `CftcScraperOptions`, `CboeScraperOptions`). Each scraper reads its own section so per-source tuning never leaks across modules.
-- `AddSecWorker()`, `AddSecFinancialFactsWorker()`, `AddFinraWorker()`, `AddFredWorker()`, `AddYahooWorker()`, `AddCftcWorker()`, `AddCboeWorker()`, `AddCongressWorker()`, `AddHoldingsWorker()` register the `BackgroundService` workers from each `.HostedService` project. `AddWorkerServices()` wires the cross-cutting worker plumbing (`SyncDateResolver`, etc.).
+- `AddSecWorker()`, `AddSecFinancialFactsWorker()`, `AddFinraWorker()`, `AddFredWorker()`, `AddYahooWorker()`, `AddCftcWorker()`, `AddCboeWorker()`, `AddCongressWorker()`, `AddHoldingsWorker()` register the `BackgroundService` workers from each `.HostedService` project.
+- `AddWorkerServices()` wires the cross-cutting worker plumbing (`SyncDateResolver`, etc.).
 - Per `Directory.Build.props`, every `.HostedService` project shares the global usings `Microsoft.Extensions.{DependencyInjection,Hosting,Logging,Options}` + `Equibles.Data` + `Equibles.Core`.
 
 ## Embedding profile


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The Worker-Host bullet that listed `AddSecWorker()` … `AddHoldingsWorker()` also tacked on the `AddWorkerServices()` cross-cutting plumbing in the same 360-char line — two unrelated facts. "One fact per bullet — a long bullet is a smell, split it."

## Code changes

- `docs/technical/hosts.md` — split the merged bullet into two: one for the `Add<Module>Worker()` enumeration that registers per-`.HostedService` `BackgroundService` workers, and one for `AddWorkerServices()` wiring cross-cutting worker plumbing (`SyncDateResolver`, etc.).