### PR TITLE
test(insider-trading): pin DescribeRole whitespace officer title falls back to Director

### DIFF
--- a/tests/Equibles.UnitTests/Search/InsiderOwnerSearchProviderDescribeRoleDirectorTests.cs
+++ b/tests/Equibles.UnitTests/Search/InsiderOwnerSearchProviderDescribeRoleDirectorTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using Equibles.InsiderTrading.Repositories.Search;
+
+namespace Equibles.UnitTests.Search;
+
+/// <summary>
+/// Pins the whitespace-officer-title fallback of InsiderOwnerSearchProvider.DescribeRole.
+/// Form 4 ownership XML occasionally ships officerTitle as a blank-but-present value (a
+/// stray space, NBSP, etc.); the descriptor must not surface that whitespace as the
+/// role. A regression swapping `IsNullOrWhiteSpace` for `IsNullOrEmpty` would compile
+/// cleanly and silently mislabel every director whose officerTitle came through as
+/// whitespace, breaking the global search's "Insiders" group. DescribeRole is private
+/// static — reflection mirrors the repo pattern.
+/// </summary>
+public class InsiderOwnerSearchProviderDescribeRoleDirectorTests
+{
+    [Fact]
+    public void DescribeRole_WhitespaceOfficerTitleAndDirector_ReturnsDirectorNotWhitespace()
+    {
+        var describeRole = typeof(InsiderOwnerSearchProvider).GetMethod(
+            "DescribeRole",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+        var result = (string)describeRole.Invoke(null, [" ", true, false])!;
+
+        result.Should().Be("Director");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `InsiderOwnerSearchProvider.DescribeRole`'s whitespace-officer-title fallback. Sibling to the existing officer-title-wins pin; together they pin the "blank-or-present" semantics of the first branch.
- A regression swapping `IsNullOrWhiteSpace` for `IsNullOrEmpty` would compile cleanly and silently surface a whitespace string as the role for every director whose Form 4 `officerTitle` arrived as a blank-but-present value (stray space, NBSP, etc.) — breaking the global search's "Insiders" group label.

## Code changes

- `tests/Equibles.UnitTests/Search/InsiderOwnerSearchProviderDescribeRoleDirectorTests.cs` — new file. One `[Fact]` invoking the private static `DescribeRole` via reflection with `(" ", isDirector: true, isTenPercentOwner: false)` and asserting the result equals `"Director"`.