### PR TITLE
test(sec): pin SecDocumentEnvelopeParser tolerates DOCUMENT block missing FILENAME tag

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserMissingFilenameTagTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserMissingFilenameTagTests.cs
@@ -1,0 +1,36 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentEnvelopeParserMissingFilenameTagTests
+{
+    // Contract: TryExtractPaperPdfFilename must tolerate a DOCUMENT block that
+    // has no <FILENAME> tag (TryExtractSgmlTagValue returns false → block
+    // skipped). A regression that dropped the IndexOf == -1 guard would throw
+    // ArgumentOutOfRangeException on the next `Substring(valueStart, …)` call
+    // and crash the document scraper for any filing whose first block omits
+    // FILENAME (e.g. some legacy <PAPER> envelopes with TYPE/SEQUENCE/TEXT but
+    // no explicit filename).
+    [Fact]
+    public void TryExtractPaperPdfFilename_DocumentBlockMissingFilenameTag_ReturnsFalse()
+    {
+        var envelope = """
+            <SEC-DOCUMENT>
+            <DOCUMENT>
+            <TYPE>6-K
+            <SEQUENCE>1
+            <TEXT>
+            </TEXT>
+            </DOCUMENT>
+            </SEC-DOCUMENT>
+            """;
+
+        var success = SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(
+            envelope,
+            out var filename
+        );
+
+        success.Should().BeFalse();
+        filename.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `TryExtractSgmlTagValue` "tag not found" path (line 92, uncovered). When a SEC envelope has a DOCUMENT block with no `<FILENAME>` entry, `TryExtractPaperPdfFilename` must skip that block cleanly and return `false`.
- Sibling to the existing leading-dot, encoded-traversal, whitespace, backslash, and missing-end-tag pins. A regression that dropped the `IndexOf == -1` guard would `ArgumentOutOfRangeException` on the next `Substring` and crash the document scraper on any legacy `<PAPER>` envelope that omits FILENAME.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserMissingFilenameTagTests.cs` — new file. One `[Fact]` building an envelope with a single `<DOCUMENT>` block containing TYPE/SEQUENCE/TEXT but no `<FILENAME>`, and asserting `TryExtractPaperPdfFilename` returns `false` with an empty out-parameter.