### PR TITLE
test(insider-trading): pin DescribeRole all-null fallback returns null

### DIFF
--- a/tests/Equibles.UnitTests/Search/InsiderOwnerSearchProviderDescribeRoleNullFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Search/InsiderOwnerSearchProviderDescribeRoleNullFallbackTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using Equibles.InsiderTrading.Repositories.Search;
+
+namespace Equibles.UnitTests.Search;
+
+/// <summary>
+/// Pins the all-null fallback arm of InsiderOwnerSearchProvider.DescribeRole.
+/// Completes the 4-arm coverage alongside the officer-title-wins pin,
+/// the whitespace-Director pin (#1298), and the 10%-owner pin (#1299).
+/// When none of the three role indicators is set, the descriptor must be
+/// null — surfaced to the global search as "no subtitle", not as a literal
+/// "Unknown" or empty string. A regression that returned "Unknown" or "" would
+/// pollute every insider's "Insiders" group entry with a meaningless label.
+/// </summary>
+public class InsiderOwnerSearchProviderDescribeRoleNullFallbackTests
+{
+    [Fact]
+    public void DescribeRole_NoOfficerTitleNoDirectorNoTenPercent_ReturnsNull()
+    {
+        var describeRole = typeof(InsiderOwnerSearchProvider).GetMethod(
+            "DescribeRole",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+        var result = describeRole.Invoke(null, [null, false, false]);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the all-null fallback arm of `InsiderOwnerSearchProvider.DescribeRole`. Completes the 4-arm coverage alongside the existing officer-title-wins pin, the in-flight whitespace-Director pin (#1298), and the in-flight 10%-owner pin (#1299).
- A regression that returned `"Unknown"` or `""` instead of `null` when no role indicator is set would pollute every "Insiders" group entry with a meaningless role subtitle.

## Code changes

- `tests/Equibles.UnitTests/Search/InsiderOwnerSearchProviderDescribeRoleNullFallbackTests.cs` — new file. One `[Fact]` invoking the private static `DescribeRole` via reflection with `(null, isDirector: false, isTenPercentOwner: false)` and asserting the result is `null`.