### PR TITLE
refactor(sec-companysync): extract AddAndTrack for duplicated stock-tracking adds

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -334,11 +334,7 @@ public class CompanySyncService : ICompanySyncService
                 }
             );
 
-            state.ExistingCiks.Add(secCompany.Cik);
-            state.ExistingPrimaryTickers.Add(primaryTicker);
-            foreach (var t in secondaryTickers)
-                state.ExistingSecondaryTickers.Add(t);
-            state.ExistingStocks.Add(newStock);
+            AddAndTrack(newStock, secCompany.Cik, primaryTicker, secondaryTickers, state);
 
             _logger.LogInformation(
                 "Replaced obsolete company {OldName} (CIK: {OldCik}) with {NewName} (CIK: {NewCik}) for ticker {Ticker}",
@@ -383,12 +379,7 @@ public class CompanySyncService : ICompanySyncService
                 }
             );
 
-            // Add to tracking sets to avoid duplicates in this run
-            state.ExistingCiks.Add(secCompany.Cik);
-            state.ExistingPrimaryTickers.Add(primaryTicker);
-            foreach (var t in secondaryTickers)
-                state.ExistingSecondaryTickers.Add(t);
-            state.ExistingStocks.Add(newStock);
+            AddAndTrack(newStock, secCompany.Cik, primaryTicker, secondaryTickers, state);
             _logger.LogDebug(
                 "Created new company: {Ticker} - {Name} (CIK: {Cik})",
                 primaryTicker,
@@ -587,6 +578,21 @@ public class CompanySyncService : ICompanySyncService
             }
         }
         return secondaryCikToParent;
+    }
+
+    private static void AddAndTrack(
+        CommonStock newStock,
+        string cik,
+        string primaryTicker,
+        List<string> secondaryTickers,
+        StockSyncState state
+    )
+    {
+        state.ExistingCiks.Add(cik);
+        state.ExistingPrimaryTickers.Add(primaryTicker);
+        foreach (var t in secondaryTickers)
+            state.ExistingSecondaryTickers.Add(t);
+        state.ExistingStocks.Add(newStock);
     }
 
     private static async Task DeleteAndUntrack(CommonStock stock, StockSyncState state)


### PR DESCRIPTION
## Summary

- `ReplaceObsoleteStock` and `CreateNewStock` both ended their happy path with the same 5-statement "register the new stock in all four tracking collections" block (Cik / primary ticker / each secondary ticker / stock entity).
- Extract that block into a private `AddAndTrack(...)` helper — the natural counterpart to the `DeleteAndUntrack` helper added recently. Two call sites now read as one line each, and the cleanup logic exists in one place.
- Behavior-preserving: the helper performs the exact same four `Add`/loop operations in the same order, with the same arguments the callers were passing (`secCompany.Cik`, `primaryTicker`, `secondaryTickers`, `newStock`).

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — replace two duplicated 5-statement tracking-add blocks with `AddAndTrack(newStock, secCompany.Cik, primaryTicker, secondaryTickers, state);` and add the private static helper.