### PR TITLE
test(web): pin VersionCheckService.IsNewer fails closed on unparseable version

### DIFF
--- a/tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerUnparseableTests.cs
+++ b/tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerUnparseableTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+/// <summary>
+/// Pins IsNewer's fail-closed contract on unparseable input. The method is the
+/// gate for the in-app update banner; if a garbage version string slips through
+/// (a corrupted GitHub Release tag, an InformationalVersion polluted by a
+/// build-tool quirk), the safe answer is "no update available" — never a
+/// thrown exception, never a spurious banner. A regression that returned true
+/// on parse failure would surface a false-positive banner; one that omitted
+/// the TryParse guard would throw FormatException up the request path.
+/// </summary>
+public class VersionCheckServiceIsNewerUnparseableTests
+{
+    [Fact]
+    public void IsNewer_UnparseableCurrentVersion_ReturnsFalseFailingClosed()
+    {
+        var method = typeof(VersionCheckService).GetMethod(
+            "IsNewer",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+        var result = (bool)method.Invoke(null, ["not a version", "1.2.3"])!;
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `IsNewer`'s fail-closed contract on unparseable input. The method gates the in-app update banner; if a corrupted release tag or polluted `InformationalVersion` slips through, the safe answer is "no update available" — never a thrown exception, never a spurious banner.
- Sibling to the existing two-segment-clamp pin. A regression that returned `true` on parse failure would surface false-positive banners; one that omitted the `TryParse` guard would `FormatException` up the request path.

## Code changes

- `tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerUnparseableTests.cs` — new file. One `[Fact]` invoking the private static `IsNewer` via reflection with `("not a version", "1.2.3")` and asserting the result is `false`.