### PR TITLE
refactor(holdings-import): hoist duplicated voting-auth parses in StreamAndInsertHoldings

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -501,6 +501,9 @@ public class HoldingsImportService
                 && string.Equals(cp.IsAmendment, "Y", StringComparison.OrdinalIgnoreCase);
 
             var shares = ParseLong(GetValue(row, "SSHPRNAMT"));
+            var votingAuthSole = ParseLong(GetValue(row, "VOTING_AUTH_SOLE"));
+            var votingAuthShared = ParseLong(GetValue(row, "VOTING_AUTH_SHARED"));
+            var votingAuthNone = ParseLong(GetValue(row, "VOTING_AUTH_NONE"));
 
             // Calculate value from Yahoo stock price
             var hasPrice = context.StockPrices.TryGetValue(
@@ -527,9 +530,9 @@ public class HoldingsImportService
                 totalDuplicates++;
                 existing.Shares += shares;
                 existing.Value += value;
-                existing.VotingAuthSole += ParseLong(GetValue(row, "VOTING_AUTH_SOLE"));
-                existing.VotingAuthShared += ParseLong(GetValue(row, "VOTING_AUTH_SHARED"));
-                existing.VotingAuthNone += ParseLong(GetValue(row, "VOTING_AUTH_NONE"));
+                existing.VotingAuthSole += votingAuthSole;
+                existing.VotingAuthShared += votingAuthShared;
+                existing.VotingAuthNone += votingAuthNone;
                 existing.ManagerEntries.Add(managerEntry);
             }
             else
@@ -548,9 +551,9 @@ public class HoldingsImportService
                     ShareType = shareType,
                     OptionType = optionType,
                     InvestmentDiscretion = discretion,
-                    VotingAuthSole = ParseLong(GetValue(row, "VOTING_AUTH_SOLE")),
-                    VotingAuthShared = ParseLong(GetValue(row, "VOTING_AUTH_SHARED")),
-                    VotingAuthNone = ParseLong(GetValue(row, "VOTING_AUTH_NONE")),
+                    VotingAuthSole = votingAuthSole,
+                    VotingAuthShared = votingAuthShared,
+                    VotingAuthNone = votingAuthNone,
                     TitleOfClass = GetValue(row, "TITLEOFCLASS"),
                     Cusip = cusip,
                     AccessionNumber = accession,


### PR DESCRIPTION
## Summary

- Hoist three `ParseLong(GetValue(row, \"VOTING_AUTH_*\"))` calls (Sole, Shared, None) out of the if/else duplicate in `HoldingsImportService.StreamAndInsertHoldings` into locals computed once per row.
- Both branches — merge-into-existing and new-holding initializer — referenced the same three fields, so each row paid for the same three parses twice. Mirrors the merged `collapse double-parse to single-parse in BuildPriceMap reportDates` (#1257) pattern.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — In `StreamAndInsertHoldings`, compute `votingAuthSole`, `votingAuthShared`, `votingAuthNone` once next to the existing `shares` local. The merge-into-existing branch now adds the cached values into `existing.VotingAuth*`; the new-holding initializer assigns them directly. `GetValue` and `ParseLong` are pure `internal static` helpers in `HoldingsParsingHelper`, so single-evaluation is semantically identical to double-evaluation.