### PR TITLE
refactor(sec-companysync): extract CreateCommonStock helper for duplicated Create blocks

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -321,17 +321,11 @@ public class CompanySyncService : ICompanySyncService
         {
             await DeleteAndUntrack(obsoleteStock, state);
 
-            var newStock = await state.CommonStockManager.Create(
-                new CommonStock
-                {
-                    Ticker = primaryTicker,
-                    Name = NormalizeCompanyName(secCompany.Name),
-                    Cik = secCompany.Cik,
-                    SecondaryTickers = secondaryTickers,
-                    Description = $"Company with tickers: {string.Join(", ", secCompany.Tickers)}",
-                    MarketCapitalization = 0,
-                    SharesOutStanding = 0,
-                }
+            var newStock = await CreateCommonStock(
+                secCompany,
+                primaryTicker,
+                secondaryTickers,
+                state
             );
 
             AddAndTrack(newStock, secCompany.Cik, primaryTicker, secondaryTickers, state);
@@ -366,18 +360,7 @@ public class CompanySyncService : ICompanySyncService
         CommonStock newStock = null;
         try
         {
-            newStock = await state.CommonStockManager.Create(
-                new CommonStock
-                {
-                    Ticker = primaryTicker,
-                    Name = NormalizeCompanyName(secCompany.Name),
-                    Cik = secCompany.Cik,
-                    SecondaryTickers = secondaryTickers,
-                    Description = $"Company with tickers: {string.Join(", ", secCompany.Tickers)}",
-                    MarketCapitalization = 0,
-                    SharesOutStanding = 0,
-                }
-            );
+            newStock = await CreateCommonStock(secCompany, primaryTicker, secondaryTickers, state);
 
             AddAndTrack(newStock, secCompany.Cik, primaryTicker, secondaryTickers, state);
             _logger.LogDebug(
@@ -579,6 +562,25 @@ public class CompanySyncService : ICompanySyncService
         }
         return secondaryCikToParent;
     }
+
+    private static Task<CommonStock> CreateCommonStock(
+        CompanyInfo secCompany,
+        string primaryTicker,
+        List<string> secondaryTickers,
+        StockSyncState state
+    ) =>
+        state.CommonStockManager.Create(
+            new CommonStock
+            {
+                Ticker = primaryTicker,
+                Name = NormalizeCompanyName(secCompany.Name),
+                Cik = secCompany.Cik,
+                SecondaryTickers = secondaryTickers,
+                Description = $"Company with tickers: {string.Join(", ", secCompany.Tickers)}",
+                MarketCapitalization = 0,
+                SharesOutStanding = 0,
+            }
+        );
 
     private static void AddAndTrack(
         CommonStock newStock,


### PR DESCRIPTION
## Summary

- `ReplaceObsoleteStock` and `CreateNewStock` each ran an identical 11-line `state.CommonStockManager.Create(new CommonStock { Ticker, Name, Cik, SecondaryTickers, Description, MarketCapitalization, SharesOutStanding })` block.
- Hoist that block into a private static `CreateCommonStock(CompanyInfo, primaryTicker, secondaryTickers, state)` helper that returns `Task<CommonStock>`.
- Behavior-preserving: identical field values flow into the same `CommonStockManager.Create` call; exception types propagate unchanged.

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — extract `CreateCommonStock` helper; replace both 11-line `new CommonStock { … }` literals at the call sites with delegations.