### PR TITLE
docs(technical/scrapers): split HoldingsRescanSignal bullet

### DIFF
--- a/docs/technical/scrapers.md
+++ b/docs/technical/scrapers.md
@@ -112,7 +112,9 @@ The cursor pattern means re-running is cheap (a single query for `max(date)` per
 
 In-process pub/sub between modules:
 
-- [`HoldingsRescanSignal`](../../src/Equibles.Holdings.HostedService/HoldingsRescanSignal.cs) — singleton with an internal `TaskCompletionSource` queue. `StockCusipChangedConsumer` (MassTransit) calls `Signal()` after invalidating processed data; `HoldingsScraperWorker.WaitForNextCycle` races the signal against its 24h timer and wakes on whichever fires first.
+- [`HoldingsRescanSignal`](../../src/Equibles.Holdings.HostedService/HoldingsRescanSignal.cs) — singleton with an internal `TaskCompletionSource` queue.
+- `StockCusipChangedConsumer` (MassTransit) calls `HoldingsRescanSignal.Signal()` after invalidating processed data.
+- `HoldingsScraperWorker.WaitForNextCycle` races the signal against its 24h timer and wakes on whichever fires first.
 - Pattern is reusable. Add a singleton with the same async-signal shape (`WaitAsync` / `Signal`) when one module's events should wake another module's worker.
 
 ## Adding a new scraper


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `HoldingsRescanSignal` bullet under "Rescan signals" packed three facts into a 364-char run-on (what the signal is, who calls `Signal()`, who races it in `WaitForNextCycle`). "One fact per bullet — a long bullet is a smell, split it."

## Code changes

- `docs/technical/scrapers.md` — split the single bullet into three: one stating what `HoldingsRescanSignal` is, one for the `StockCusipChangedConsumer` publisher, one for the `HoldingsScraperWorker.WaitForNextCycle` consumer.