### PR TITLE
fix(holdings-backtest): clamp pre-window padding to DateOnly.MinValue

### DIFF
--- a/src/Equibles.Web/Services/HoldingsBacktestService.cs
+++ b/src/Equibles.Web/Services/HoldingsBacktestService.cs
@@ -148,8 +148,12 @@ public class HoldingsBacktestService
             .ToList();
 
         // Forward-fill needs a few days of pre-window prices so day-zero of the simulation
-        // resolves to the last trading day's close even on a weekend or holiday.
-        var priceWindowFrom = resolvedFrom.AddDays(-14);
+        // resolves to the last trading day's close even on a weekend or holiday. Clamp the
+        // subtraction so a near-MinValue `from` (e.g. ?from=0001-01-01) doesn't underflow.
+        var priceWindowFrom =
+            resolvedFrom > DateOnly.MinValue.AddDays(14)
+                ? resolvedFrom.AddDays(-14)
+                : DateOnly.MinValue;
 
         var stockIds = holdings
             .Where(h => h.OptionType == null && h.Value > 0)

--- a/tests/Equibles.IntegrationTests/Web/ProfilesInstitutionBacktestExtremeFromDateTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesInstitutionBacktestExtremeFromDateTests.cs
@@ -14,9 +14,7 @@ public class ProfilesInstitutionBacktestExtremeFromDateTests
     public ProfilesInstitutionBacktestExtremeFromDateTests(WebHostFixture fixture) =>
         _fixture = fixture;
 
-    [Fact(
-        Skip = "GH-1271 — HoldingsBacktestService.Execute computes resolvedFrom.AddDays(-14) which throws on DateOnly underflow; ?from=0001-01-01 surfaces a 500 instead of an inline alert."
-    )]
+    [Fact]
     public async Task GetBacktest_FromAtDateOnlyMinValue_DoesNotReturn500()
     {
         // Contract (per the slice commit): "benchmark-not-found and no-rebalance-in-window


### PR DESCRIPTION
## Summary

- `HoldingsBacktestService.Execute` widened the price window with `resolvedFrom.AddDays(-14)`, which threw `ArgumentOutOfRangeException` when `from` was near `DateOnly.MinValue` (e.g. `?from=0001-01-01`). The exception escaped the controller as 500.
- Clamp the subtraction so dates within 14 days of `MinValue` collapse to `MinValue`; the existing inline-alert paths now handle the request.
- Un-skip the integration repro shipped with #1272.

Closes #1271

## Code changes

- `src/Equibles.Web/Services/HoldingsBacktestService.cs` — clamp `priceWindowFrom` to `DateOnly.MinValue` when `resolvedFrom` is within 14 days of it.
- `tests/Equibles.IntegrationTests/Web/ProfilesInstitutionBacktestExtremeFromDateTests.cs` — drop the `Skip` attribute so the repro now guards against regressions.