### PR TITLE
refactor(fred-import): collapse double-parse of record dates to single-parse in ImportSeries

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/FredImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredImportService.cs
@@ -158,14 +158,17 @@ public class FredImportService
             return;
         }
 
-        // Parse all dates from API response to determine the range we need to check
-        var apiDates = records
-            .Select(r => DateOnly.TryParse(r.Date, out var d) ? d : (DateOnly?)null)
-            .Where(d => d.HasValue)
-            .Select(d => d.Value)
+        // Parse each record's date once and reuse the (record, date) pairs for
+        // both the range computation and the dedup/insert loop below.
+        var parsedRecords = records
+            .Select(r =>
+                (Record: r, ParsedDate: DateOnly.TryParse(r.Date, out var d) ? d : (DateOnly?)null)
+            )
+            .Where(p => p.ParsedDate.HasValue)
+            .Select(p => (p.Record, Date: p.ParsedDate.Value))
             .ToList();
 
-        if (apiDates.Count == 0)
+        if (parsedRecords.Count == 0)
         {
             _logger.LogDebug(
                 "No parseable dates in FRED API response for {SeriesId}",
@@ -174,8 +177,8 @@ public class FredImportService
             return;
         }
 
-        var minApiDate = apiDates.Min();
-        var maxApiDate = apiDates.Max();
+        var minApiDate = parsedRecords.Min(p => p.Date);
+        var maxApiDate = parsedRecords.Max(p => p.Date);
 
         HashSet<DateOnly> existingDates;
         using (var scope = _scopeFactory.CreateScope())
@@ -202,10 +205,8 @@ public class FredImportService
         var skipped = 0;
         var latestObservationDate = DateOnly.MinValue;
 
-        foreach (var record in records)
+        foreach (var (record, date) in parsedRecords)
         {
-            if (!DateOnly.TryParse(record.Date, out var date))
-                continue;
             if (date > latestObservationDate)
                 latestObservationDate = date;
 


### PR DESCRIPTION
## Summary

- Collapse the double-parse of `record.Date` in `FredImportService.ImportSeries` — once to compute the API date range, once again inside the dedup/insert `foreach` — into a single materialization of `(record, date)` tuples reused by both phases.
- Mirrors the merged `collapse double-parse to single-parse in BuildPriceMap reportDates` (#1257) pattern.

## Code changes

- `src/Equibles.Fred.HostedService/Services/FredImportService.cs` — In `ImportSeries`, replace the `apiDates` projection (which discarded the corresponding `FredObservationRecord`) with a `parsedRecords` list of `(record, date)` tuples. `minApiDate`/`maxApiDate` now project off the tuples, and the observation-building `foreach` deconstructs each tuple so the inner `DateOnly.TryParse` and `continue` guard go away. `DateOnly.TryParse` is pure, both phases already drop records with unparseable dates, and `Select.Where.ToList` preserves iteration order — `observations`, `skipped`, and `latestObservationDate` are unchanged.