### PR TITLE
test(holdings-screener): pin EscapeCsvField quotes a field containing a newline

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/HoldingsScreenerExportCsvTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsScreenerExportCsvTests.cs
@@ -112,6 +112,45 @@ public class HoldingsScreenerExportCsvTests
     }
 
     [Fact]
+    public async Task ExportCsv_NameWithNewline_IsQuotedToPreserveRowStructure()
+    {
+        // RFC 4180 says: wrap a field in quotes when it contains a quote, comma, OR newline.
+        // The existing comma/quote pin would still pass if `\n` were dropped from the escape
+        // trigger; an unwrapped newline silently splits the row in two for downstream parsers.
+        var q1 = new DateOnly(2024, 9, 30);
+        var q2 = new DateOnly(2024, 12, 31);
+        var holderId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "0008000004",
+                    Name = "Newline Holder",
+                }
+            );
+            var stock = new CommonStock
+            {
+                Ticker = "NLN",
+                Name = "Acme\nNew Line Inc.",
+                Cik = "0000099995",
+            };
+            db.Add(stock);
+            db.Add(MakeHolding(stock.Id, holderId, q1, 1, 1));
+            db.Add(MakeHolding(stock.Id, holderId, q2, 1, 1));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/Screener/Export.csv");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().Contain("\"Acme\nNew Line Inc.\"");
+    }
+
+    [Fact]
     public async Task ExportCsv_FiltersApplyToDownloadSameAsForm()
     {
         var q1 = new DateOnly(2024, 9, 30);


### PR DESCRIPTION
## Summary

- `HoldingsScreenerController.EscapeCsvField` documents the RFC 4180 trigger as "a quote, comma, or newline". Existing tests cover the comma and quote arms; the newline arm is unpinned.
- A regression that dropped `\n` (or `\r`) from the `IndexOfAny` array would let an embedded newline through unwrapped, silently splitting one row into two for downstream parsers — and the comma/quote pin would still pass.
- Add an end-to-end test that seeds a stock whose `Name` contains `\n`, hits `/Holdings/Screener/Export.csv`, and asserts the response body wraps that name in quotes.

## Code changes

- `tests/Equibles.IntegrationTests/Web/HoldingsScreenerExportCsvTests.cs` — add `ExportCsv_NameWithNewline_IsQuotedToPreserveRowStructure` alongside the existing CSV-escape tests.