### PR TITLE
refactor(profiles-controller): extract ResolveSelectedDate helper for compare/combined

### DIFF
--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -247,9 +247,7 @@ public class ProfilesController : BaseController
         if (commonDates.Count == 0)
             return View(viewModel);
 
-        var selected = date ?? commonDates[0];
-        if (!commonDates.Contains(selected))
-            selected = commonDates[0];
+        var selected = ResolveSelectedDate(date, commonDates);
         viewModel.SelectedDate = selected;
 
         var perFund = await LoadPerFundHoldings(holders, selected);
@@ -284,9 +282,7 @@ public class ProfilesController : BaseController
         if (commonDates.Count == 0)
             return View(viewModel);
 
-        var selected = date ?? commonDates[0];
-        if (!commonDates.Contains(selected))
-            selected = commonDates[0];
+        var selected = ResolveSelectedDate(date, commonDates);
         viewModel.SelectedDate = selected;
 
         var perFund = await LoadPerFundHoldings(holders, selected);
@@ -431,6 +427,9 @@ public class ProfilesController : BaseController
         }
         return perFund;
     }
+
+    private static DateOnly ResolveSelectedDate(DateOnly? requested, List<DateOnly> available) =>
+        requested.HasValue && available.Contains(requested.Value) ? requested.Value : available[0];
 
     private static List<string> NormalizeCiks(string[] ciks) =>
         (ciks ?? [])


### PR DESCRIPTION
## Summary

- `CompareInstitutions` and `CombinedInstitutions` each ran the same 3-line "default-to-first / fallback-when-not-in-list" date resolution.
- Collapse both into a private static `ResolveSelectedDate(DateOnly?, List<DateOnly>)` helper.
- Behavior-preserving: helper returns `date.Value` when present and in the list, otherwise `commonDates[0]` — identical to the inlined `date ?? commonDates[0]; if (!Contains) → first` chain.

## Code changes

- `src/Equibles.Web/Controllers/ProfilesController.cs` — extract `ResolveSelectedDate` helper near the other private static helpers; replace both 3-line inlined chains with single-line calls.