### PR TITLE
docs(technical/mcp-tools): split McpToolExecutor bullet — instrumentation vs. error return

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -118,7 +118,8 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 
 ## Tool implementation conventions
 
-- Every tool method runs through [`McpToolExecutor.Execute`](../../src/Equibles.Mcp/McpToolExecutor.cs). It wraps the body in a try/catch, logs failures, reports them via the injected `ErrorManager` (so they show on the Status dashboard), and returns a safe `"An error occurred while executing <ToolName>..."` string instead of throwing across the MCP boundary.
+- Every tool method runs through [`McpToolExecutor.Execute`](../../src/Equibles.Mcp/McpToolExecutor.cs); it wraps the body in a try/catch, logs failures, and reports them via the injected `ErrorManager` so they show on the Status dashboard.
+- On failure, `McpToolExecutor.Execute` returns a safe `"An error occurred while executing <ToolName>..."` string instead of throwing across the MCP boundary.
 - Tool classes carry `[McpServerToolType]`; tool methods carry `[McpServerTool(Name = "...")]` + a `[Description]` so the MCP client gets a usable schema.
 - Tools return Markdown-formatted strings (tables for tabular data, headings for grouped output). The MCP transport ferries strings; no binary payloads.
 - Tools call repositories directly for reads. Writes are not exposed through MCP — the surface is intentionally read-only.


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `McpToolExecutor.Execute` bullet under "Tool implementation conventions" packed five facts into 361 chars: where every tool runs, try/catch, log, `ErrorManager` reporting, *and* the safe-string return on failure. "One fact per bullet — a long bullet is a smell, split it."

## Code changes

- `docs/technical/mcp-tools.md` — split the bullet into two: one for instrumentation (`McpToolExecutor.Execute` wraps the body in try/catch, logs, reports through `ErrorManager` so failures show on the Status dashboard) and one for the error-return contract (returns a safe `"An error occurred while executing <ToolName>..."` string instead of throwing across the MCP boundary).