### PR TITLE
test(web): pin VersionCheckService.NormalizeVersion strips uppercase V prefix

### DIFF
--- a/tests/Equibles.UnitTests/Web/VersionCheckServiceNormalizeVersionUppercaseVPrefixTests.cs
+++ b/tests/Equibles.UnitTests/Web/VersionCheckServiceNormalizeVersionUppercaseVPrefixTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Equibles.Web.Services;
+using Xunit;
+
+namespace Equibles.UnitTests.Web;
+
+/// <summary>
+/// NormalizeVersion's docstring only mentions stripping a leading "v", but the
+/// implementation accepts both "v" and "V". A release tagged "V1.2.3" must
+/// normalize the same as "v1.2.3", otherwise IsNewer fails to parse it and the
+/// update banner silently never appears.
+/// </summary>
+public class VersionCheckServiceNormalizeVersionUppercaseVPrefixTests
+{
+    [Fact]
+    public void NormalizeVersion_UppercaseVPrefix_StripsPrefixSoVersionParses()
+    {
+        var method = typeof(VersionCheckService).GetMethod(
+            "NormalizeVersion",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var normalized = (string)method.Invoke(null, ["V1.2.3"]);
+
+        Version.TryParse(normalized, out var parsed).Should().BeTrue();
+        parsed.Should().Be(new Version(1, 2, 3));
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `NormalizeVersion("V1.2.3")` strips the uppercase `V` so the result parses with `System.Version`.
- The implementation accepts both `v` and `V` prefixes, but the docstring only mentions `v` and the existing test coverage only feeds lowercase. A future reader could "fix" the implementation to match the docstring and silently break the update banner for any release tagged `V<version>`.

## Code changes

- `tests/Equibles.UnitTests/Web/VersionCheckServiceNormalizeVersionUppercaseVPrefixTests.cs` — one `[Fact]` asserting `NormalizeVersion("V1.2.3")` yields a value that `Version.TryParse` reads as `1.2.3`.