### PR TITLE
refactor(holdings-mcp): use ResolveReportDate in GetConsensusHoldings

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1017,12 +1017,7 @@ public class InstitutionalHoldingsTools
                 if (common.Count == 0)
                     return "The selected institutions share no common report dates.";
 
-                var selected =
-                    !string.IsNullOrEmpty(reportDate)
-                    && DateOnly.TryParse(reportDate, out var parsed)
-                    && common.Contains(parsed)
-                        ? parsed
-                        : common[0];
+                var selected = ResolveReportDate(reportDate, common);
 
                 var perFund =
                     new List<(


### PR DESCRIPTION
## Summary

- `GetConsensusHoldings` in `InstitutionalHoldingsTools` inlined the same parse-or-fall-back expression that the private `ResolveReportDate` helper already implements; this collapses the duplication.
- Behavior is identical: the inline expression `!string.IsNullOrEmpty(reportDate) && DateOnly.TryParse(reportDate, out var parsed) && common.Contains(parsed) ? parsed : common[0]` matches `ResolveReportDate`'s body line for line, and the temporary `parsed` was never referenced after the assignment.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — replace the inline expression in `GetConsensusHoldings` with `ResolveReportDate(reportDate, common)`.