### PR TITLE
docs(technical/scrapers): split BackfillGuardFileName sentinel bullet

### DIFF
--- a/docs/technical/scrapers.md
+++ b/docs/technical/scrapers.md
@@ -74,7 +74,8 @@ Workers that fetch from a paginated / batched feed maintain a dedup ledger so re
 - Keyed by SEC quarterly bulk-data-set file name (`form13fhr_2024q3_01.zip`).
 - Marks a file as fully ingested so the next `HoldingsScraperWorker` cycle skips it.
 - Stores a `SubmissionCount` for observability.
-- Contains a sentinel row `BackfillGuardFileName = "__backfill-guard__"` — a name that never matches a real file. Its purpose is to keep the table non-empty after `StockCusipChangedConsumer` clears real rows for a backfill, so `BackfillProcessedDataSets` doesn't re-seed history as "processed" before the backfill actually runs.
+- Contains a sentinel row `BackfillGuardFileName = "__backfill-guard__"` — a name that never matches a real file.
+- The sentinel keeps the table non-empty after `StockCusipChangedConsumer` clears real rows for a backfill, so `BackfillProcessedDataSets` doesn't re-seed history as "processed" before the backfill actually runs.
 
 [`ProcessedFiling`](../../src/Equibles.Holdings.Data/Models/ProcessedFiling.cs):
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `ProcessedDataSet` sentinel bullet packed three facts into a 330-char run-on: what the sentinel row is, why the table must stay non-empty after `StockCusipChangedConsumer` clears rows, and how `BackfillProcessedDataSets` would otherwise misbehave. Split into what / why for one fact per bullet.

## Code changes

- `docs/technical/scrapers.md` — split the `BackfillGuardFileName` sentinel bullet into two: one stating the sentinel exists with a never-matching name, and one stating the rationale (keep the table non-empty so `BackfillProcessedDataSets` doesn't re-seed history as "processed" before the backfill actually runs).