### PR TITLE
refactor(holdings-screener): route CSV-field escaping through CsvExportService.EscapeField

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -4,6 +4,7 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Models;
 using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Services;
 using Equibles.Web.ViewModels.Holdings;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -134,9 +135,9 @@ public class HoldingsScreenerController : BaseController
         );
         foreach (var r in rows)
         {
-            sb.Append(EscapeCsvField(r.Ticker)).Append(',');
-            sb.Append(EscapeCsvField(r.Name)).Append(',');
-            sb.Append(EscapeCsvField(r.IndustryName)).Append(',');
+            sb.Append(CsvExportService.EscapeField(r.Ticker)).Append(',');
+            sb.Append(CsvExportService.EscapeField(r.Name)).Append(',');
+            sb.Append(CsvExportService.EscapeField(r.IndustryName)).Append(',');
             sb.Append(r.CurrentFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
             sb.Append(r.PreviousFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
             sb.Append(r.DeltaFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
@@ -153,18 +154,6 @@ public class HoldingsScreenerController : BaseController
             sb.AppendLine();
         }
         return sb.ToString();
-    }
-
-    // RFC 4180 escape: wrap a field in quotes when it contains a quote, comma, or newline;
-    // double any embedded quotes. Empty string passes through unwrapped.
-    private static string EscapeCsvField(string value)
-    {
-        if (string.IsNullOrEmpty(value))
-            return string.Empty;
-        var needsQuoting = value.IndexOfAny(['"', ',', '\n', '\r']) >= 0;
-        if (!needsQuoting)
-            return value;
-        return "\"" + value.Replace("\"", "\"\"") + "\"";
     }
 
     // Loads available report dates desc and resolves the selected/comparison dates from


### PR DESCRIPTION
## Summary

- `HoldingsScreenerController` carried a private `EscapeCsvField` helper that was byte-identical to the public `CsvExportService.EscapeField` already used by the rest of `Equibles.Web`: same null/empty handling, same `IndexOfAny(['"', ',', '\n', '\r'])` trigger, same quote-wrap + internal-quote-doubling output.
- Delete the duplicate and route the three call sites in `BuildCsv` through `CsvExportService.EscapeField`. Pure call-site swap; the existing newline-escape pin in `HoldingsScreenerExportCsvTests` continues to pass through the shared implementation.
- `BuildCsv` itself stays inline — switching to `CsvExportService.BuildCsv` would change `sb.AppendLine()` (`Environment.NewLine`, CRLF on Windows) to `'\n'`, a cross-platform behavior change that's out of scope here.

## Code changes

- `src/Equibles.Web/Controllers/HoldingsScreenerController.cs` — add `using Equibles.Web.Services;`, replace three `EscapeCsvField(...)` call sites with `CsvExportService.EscapeField(...)`, delete the private static `EscapeCsvField` helper.