### PR TITLE
test(sec): pin SecDocumentHtmlNormalizer allows decimal-suffixed EX-N.M exhibits

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerExhibitDecimalSuffixTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerExhibitDecimalSuffixTests.cs
@@ -1,0 +1,35 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentHtmlNormalizerExhibitDecimalSuffixTests
+{
+    private readonly SecDocumentHtmlNormalizer _sut = new();
+
+    [Fact]
+    public void Normalize_ExhibitTypeWithDecimalSubExhibitSuffix_IsAllowed()
+    {
+        // IsAllowedDocumentType's exhibit branch peels the decimal suffix via
+        //   var exNumberPartClean = exNumberPart.Split('.')[0];
+        // before int.TryParse. SEC exhibits routinely use the "EX-N.M" form
+        // (e.g. EX-10.1 for material contracts as sub-exhibits of Form 10),
+        // so the split is what lets the parser keep them. A "simplification"
+        // that drops the Split — e.g. int.TryParse(exNumberPart, ...) directly —
+        // would parse "10.1" as not-an-int, return false, and silently filter
+        // out every decimal-suffixed exhibit, dropping a large fraction of the
+        // attachments to material-contract filings. Pin EX-10.1 as allowed.
+        var sgml = """
+            <DOCUMENT>
+            <TYPE>EX-10.1
+            <FILENAME>contract.htm
+            <TEXT>
+            <html><body><p>Material contract body</p></body></html>
+            </TEXT>
+            </DOCUMENT>
+            """;
+
+        var result = _sut.Normalize(sgml);
+
+        result.Should().Contain("Material contract body");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `SecDocumentHtmlNormalizer` accepts decimal-suffixed exhibit types like `EX-10.1`. The implementation peels the suffix via `Split('.')[0]` before `int.TryParse`, so material-contract sub-exhibits keep being processed.
- Existing tests cover `EX-21` (allowed), `EX-foo` (filtered), and `EX-999` (filtered). The decimal-suffix path — the most common form in real SEC filings — was unpinned.
- A reader who "simplifies" the parsing to `int.TryParse(exNumberPart, …)` would silently filter every `EX-N.M` exhibit, dropping a large fraction of material-contract attachments.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerExhibitDecimalSuffixTests.cs` — one `[Fact]` feeding an SGML envelope with `<TYPE>EX-10.1` and asserting the exhibit body survives `Normalize`.