### PR TITLE
test(sec): pin FactMarkdown.Value renders bare USD with grouped whole and dollar prefix

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownValueBareUsdTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownValueBareUsdTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// FactMarkdown.Value's doc-comment guarantees that USD-denominated whole
+/// monetary values render as a "$"-prefixed grouped whole number — this is
+/// the dominant path for almost every fact in a 10-K (revenue, assets,
+/// cash). Existing tests pin "USD/shares" (cents precision) and bare
+/// non-USD codes (no prefix), but the plain "USD" path — where isPerShare
+/// is false yet isUsd is true — is unpinned. A refactor that only treats
+/// units starting with "USD/" as currency would drop the "$" and switch to
+/// fractional precision for every base-currency figure.
+/// </summary>
+public class FactMarkdownValueBareUsdTests
+{
+    [Fact]
+    public void Value_BareUsdUnit_RendersGroupedWholeWithDollarPrefix()
+    {
+        var result = FactMarkdown.Value(1234567m, "USD");
+
+        result.Should().Be("$1,234,567");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the "isUsd && !isPerShare" branch of `FactMarkdown.Value`. Existing tests cover the per-share USD branch (cents precision) and the bare non-USD branch (no \$ prefix), but the dominant case — plain whole-magnitude USD figures like revenue, assets, cash — was unpinned.
- A refactor that only treats units starting with `USD/` as currency would drop the `\$` prefix and switch to fractional precision for every base-currency value, silently rendering the LLM's reading of a 10-K as bare numbers.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownValueBareUsdTests.cs` — one `[Fact]` asserting `Value(1_234_567m, "USD")` returns `"\$1,234,567"`.