### PR TITLE
feat(messaging): add ScraperActivity contract and wire web to the bus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - "8080:8080"
     environment:
       ConnectionStrings__DefaultConnection: "Host=db;Database=equibles;Username=postgres;Password=postgres"
+      ConnectionStrings__TransportConnection: "Host=db;Database=equibles;Username=postgres;Password=postgres"
       Auth__Username: ${AUTH_USERNAME:-}
       Auth__Password: ${AUTH_PASSWORD:-}
       McpApiKey: ${MCP_API_KEY:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,11 @@ services:
     environment:
       ConnectionStrings__DefaultConnection: "Host=db;Database=equibles;Username=postgres;Password=postgres"
       ConnectionStrings__TransportConnection: "Host=db;Database=equibles;Username=postgres;Password=postgres"
+      # Web boots before worker (worker depends on web). Without this flag the
+      # bus has no schema to connect to, fails its health check, and /healthz
+      # never goes ready — leaving worker stuck on `web: service_healthy`.
+      # Schema creation is idempotent, so it's safe that worker may also run it.
+      MassTransit__RunMigration: "true"
       Auth__Username: ${AUTH_USERNAME:-}
       Auth__Password: ${AUTH_PASSWORD:-}
       McpApiKey: ${MCP_API_KEY:-}

--- a/src/Equibles.Messaging/Contracts/Activity/ScraperActivity.cs
+++ b/src/Equibles.Messaging/Contracts/Activity/ScraperActivity.cs
@@ -1,0 +1,14 @@
+namespace Equibles.Messaging.Contracts.Activity;
+
+// Human-readable "what is this scraper doing right now" event. Carried over the
+// shared MassTransit transport so the web portal can fan it out to connected
+// browsers (live activity feed). Not persisted — messages with no listeners are
+// dropped. Use Severity.Info for normal lifecycle events, Warn for skips /
+// throttling / backoff, Error for failures.
+public record ScraperActivity(
+    string Source,
+    ScraperActivitySeverity Severity,
+    string Message,
+    DateTimeOffset Timestamp,
+    string CorrelationId
+);

--- a/src/Equibles.Messaging/Contracts/Activity/ScraperActivitySeverity.cs
+++ b/src/Equibles.Messaging/Contracts/Activity/ScraperActivitySeverity.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Messaging.Contracts.Activity;
+
+public enum ScraperActivitySeverity
+{
+    [Display(Name = "Info")]
+    Info = 0,
+
+    [Display(Name = "Warning")]
+    Warn = 1,
+
+    [Display(Name = "Error")]
+    Error = 2,
+}

--- a/src/Equibles.Messaging/Extensions/MessagingServiceCollectionExtensions.cs
+++ b/src/Equibles.Messaging/Extensions/MessagingServiceCollectionExtensions.cs
@@ -9,7 +9,21 @@ namespace Equibles.Messaging.Extensions;
 
 public static class MessagingServiceCollectionExtensions
 {
-    public static void AddMessaging(this IServiceCollection services, IConfiguration configuration)
+    /// <summary>
+    /// Wires MassTransit (Postgres SQL transport + EF outbox) and auto-registers
+    /// every [Consumer] in matching loaded assemblies. When
+    /// <paramref name="consumerAssemblies"/> is null, every non-system assembly
+    /// in the current AppDomain is scanned — the default used by the worker host
+    /// so a new HostedService's consumer is picked up automatically. Pass a
+    /// specific set when the calling host should only own a subset of consumers
+    /// (the web host scans just its own assembly so it doesn't try to
+    /// instantiate worker-only consumers whose dependencies it never wires).
+    /// </summary>
+    public static void AddMessaging(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IEnumerable<Assembly> consumerAssemblies = null
+    )
     {
         // Only the host that owns the DB should create the transport schema /
         // infrastructure (idempotent, but gated to avoid every host racing it).
@@ -41,10 +55,15 @@ public static class MessagingServiceCollectionExtensions
                 ?? throw new InvalidOperationException("Could not determine main assembly name.");
             x.SetEndpointNameFormatter(new KebabCaseEndpointNameFormatter(mainAssemblyName, true));
 
-            // Auto-register every [Consumer] IConsumer<T> across loaded assemblies.
-            var consumerTypes = AppDomain
-                .CurrentDomain.GetAssemblies()
-                .Where(a => !IsSystemAssembly(a))
+            // Auto-register every [Consumer] IConsumer<T> across the chosen
+            // assemblies. Default scope: every non-system assembly currently
+            // loaded (worker behavior); explicit scope: only the assemblies the
+            // caller actually owns (web behavior).
+            var scannedAssemblies =
+                consumerAssemblies
+                ?? AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsSystemAssembly(a));
+
+            var consumerTypes = scannedAssemblies
                 .SelectMany(a =>
                 {
                     try

--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -59,6 +59,18 @@ public partial class Program
         // AddAllRepositories) so new modules join global search with no host change.
         builder.Services.AddEquiblesSearch();
 
+        // MassTransit (Postgres SQL transport + EF outbox in EquiblesDbContext).
+        // Web subscribes to events published by other hosts — e.g. the live
+        // ScraperActivity feed from the worker. The consumer scan is restricted
+        // to Equibles.Web's own assembly: worker-only consumers (e.g. the
+        // Holdings rescan signal handler) require services the web host never
+        // registers, so picking them up here would crash service-provider
+        // validation as soon as a referenced HostedService assembly loads.
+        builder.Services.AddMessaging(
+            builder.Configuration,
+            consumerAssemblies: [typeof(Program).Assembly]
+        );
+
         builder.Services.AutoWireServicesFrom<Equibles.Errors.BusinessLogic.ErrorManager>();
         builder.Services.AutoWireServicesFrom<Equibles.Web.Services.StockTabService>();
 

--- a/tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs
@@ -77,6 +77,10 @@ public class WebAppFixture : IAsyncLifetime
         // container as the app DB to mirror docker-compose, where web and worker
         // share Postgres.
         builder.Configuration["ConnectionStrings:TransportConnection"] = _db.GetConnectionString();
+        // No worker in functional tests, so the web host has to create the
+        // transport schema itself. Otherwise the bus fails its health check on
+        // first start and /healthz returns 503.
+        builder.Configuration["MassTransit:RunMigration"] = "true";
         builder.Configuration["DataProtection:KeysDirectory"] = _keysDirectory;
 
         Program.ConfigureServices(builder);

--- a/tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs
@@ -73,6 +73,10 @@ public class WebAppFixture : IAsyncLifetime
         );
 
         builder.Configuration["ConnectionStrings:DefaultConnection"] = _db.GetConnectionString();
+        // AddMessaging binds MassTransit's SQL transport from this string. Same
+        // container as the app DB to mirror docker-compose, where web and worker
+        // share Postgres.
+        builder.Configuration["ConnectionStrings:TransportConnection"] = _db.GetConnectionString();
         builder.Configuration["DataProtection:KeysDirectory"] = _keysDirectory;
 
         Program.ConfigureServices(builder);

--- a/tests/Equibles.IntegrationTests/Helpers/WebHostFixture.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/WebHostFixture.cs
@@ -63,6 +63,10 @@ public class WebHostFixture : IAsyncLifetime
         );
 
         builder.Configuration["ConnectionStrings:DefaultConnection"] = _db.GetConnectionString();
+        // AddMessaging binds MassTransit's SQL transport from this string. Same
+        // container as the app DB to mirror docker-compose, where web and worker
+        // share Postgres.
+        builder.Configuration["ConnectionStrings:TransportConnection"] = _db.GetConnectionString();
         builder.Configuration["DataProtection:KeysDirectory"] = _keysDirectory;
 
         Program.ConfigureServices(builder);

--- a/tests/Equibles.IntegrationTests/Helpers/WebHostFixture.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/WebHostFixture.cs
@@ -67,6 +67,10 @@ public class WebHostFixture : IAsyncLifetime
         // container as the app DB to mirror docker-compose, where web and worker
         // share Postgres.
         builder.Configuration["ConnectionStrings:TransportConnection"] = _db.GetConnectionString();
+        // No worker in integration tests, so the web host creates the transport
+        // schema itself. Without this the bus fails its health check on first
+        // start and any test that exercises /healthz returns 503.
+        builder.Configuration["MassTransit:RunMigration"] = "true";
         builder.Configuration["DataProtection:KeysDirectory"] = _keysDirectory;
 
         Program.ConfigureServices(builder);

--- a/tests/Equibles.IntegrationTests/Web/ProgramConfigurationTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProgramConfigurationTests.cs
@@ -100,6 +100,9 @@ public class ProgramConfigurationTests
             }
         );
         builder.Configuration["ConnectionStrings:DefaultConnection"] = _db.ConnectionString;
+        // AddMessaging binds the SQL transport host from this connection; without
+        // it MassTransit throws "Host cannot be empty" when the SP is built.
+        builder.Configuration["ConnectionStrings:TransportConnection"] = _db.ConnectionString;
         if (!omitKeysDirectoryConfig)
         {
             builder.Configuration["DataProtection:KeysDirectory"] = Path.Combine(

--- a/tests/Equibles.IntegrationTests/Web/ProgramMessagingConfigurationTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProgramMessagingConfigurationTests.cs
@@ -1,0 +1,75 @@
+using Equibles.IntegrationTests.Helpers;
+using MassTransit;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the line that adds MassTransit to the web host. The web subscribes to
+/// events published by the worker (live ScraperActivity feed and any future
+/// cross-host event), so omitting <c>AddMessaging</c> silently breaks every
+/// consumer the web tries to wire — a regression we want a test to catch.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class ProgramMessagingConfigurationTests
+{
+    private readonly ParadeDbFixture _db;
+
+    public ProgramMessagingConfigurationTests(ParadeDbFixture db) => _db = db;
+
+    [Fact]
+    public async Task ConfigureServices_RegistersMassTransitBusAndTransportOptions()
+    {
+        const string transport =
+            "Host=localhost;Database=equibles;Username=postgres;Password=postgres";
+
+        await using var app = BuildHost(transport);
+
+        app.Services.GetService<IBus>()
+            .Should()
+            .NotBeNull("AddMessaging is what brings the bus into the container");
+        app.Services.GetRequiredService<IOptions<SqlTransportOptions>>()
+            .Value.ConnectionString.Should()
+            .Be(transport, "AddMessaging binds the transport connection string");
+    }
+
+    private WebApplication BuildHost(string transportConnection)
+    {
+        var builder = WebApplication.CreateBuilder(
+            new WebApplicationOptions
+            {
+                ApplicationName = "Equibles.Web",
+                EnvironmentName = "Development",
+                ContentRootPath = ResolveWebContentRoot(),
+            }
+        );
+        builder.Configuration["ConnectionStrings:DefaultConnection"] = _db.ConnectionString;
+        builder.Configuration["ConnectionStrings:TransportConnection"] = transportConnection;
+        builder.Configuration["DataProtection:KeysDirectory"] = Path.Combine(
+            Path.GetTempPath(),
+            $"equibles-msg-keys-{Guid.NewGuid():N}"
+        );
+
+        Equibles.Web.Program.ConfigureServices(builder);
+        return builder.Build();
+    }
+
+    private static string ResolveWebContentRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Equibles.sln")))
+        {
+            dir = dir.Parent;
+        }
+        if (dir is null)
+        {
+            throw new InvalidOperationException(
+                "Could not locate Equibles.sln from test bin directory — cannot resolve ContentRootPath."
+            );
+        }
+        return Path.Combine(dir.FullName, "src", "Equibles.Web");
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 1/4 of the live scraper activity feed (#1162). Introduces the `ScraperActivity` message and brings the MassTransit bus into the web host so later slices can subscribe to events from the worker.
- Web's `[Consumer]` scan is scoped to its own assembly via a new optional parameter on `AddMessaging`. Worker-only consumers depend on services the web never registers — the previous "scan every loaded non-system assembly" default would break service-provider validation as soon as any HostedService assembly loads.
- This PR does not close the issue.

Refs #1162

## Code changes

- `src/Equibles.Messaging/Contracts/Activity/ScraperActivity.cs` — new message record (`Source`, `Severity`, `Message`, `Timestamp`, `CorrelationId`).
- `src/Equibles.Messaging/Contracts/Activity/ScraperActivitySeverity.cs` — `Info / Warn / Error` with `[Display]` labels.
- `src/Equibles.Messaging/Extensions/MessagingServiceCollectionExtensions.cs` — `AddMessaging` accepts an optional `consumerAssemblies` set; default still scans every non-system assembly (worker behavior).
- `src/Equibles.Web/Program.cs` — calls `AddMessaging` with `[typeof(Program).Assembly]` so only consumers defined in the web host are picked up.
- `docker-compose.yml` — adds `ConnectionStrings__TransportConnection` to the web service, pointing at the same Postgres instance the worker uses for transport.
- `tests/Equibles.IntegrationTests/Web/ProgramMessagingConfigurationTests.cs` — new test pinning that `IBus` and `SqlTransportOptions` are registered by `Program.ConfigureServices`.
- `tests/Equibles.IntegrationTests/Web/ProgramConfigurationTests.cs`, `tests/Equibles.IntegrationTests/Helpers/WebHostFixture.cs`, `tests/Equibles.FunctionalTests/Fixtures/WebAppFixture.cs` — set `TransportConnection` on the test container so MassTransit can bind its SQL host during integration / functional / view-rendering tests.