### PR TITLE
test(sec): pin FactMarkdown.Cell replaces bare carriage return with space

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownCellCarriageReturnTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownCellCarriageReturnTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// FactMarkdown.Cell has three sanitization Replace calls — for '|', '\r' and
+/// '\n'. The existing pin covers '|' and '\n' together; the '\r' arm is a
+/// separate code path that fires when source data carries a bare CR (legacy
+/// Mac line endings, half-stripped CRLF after some pipelines, or values
+/// pasted from spreadsheets). A refactor that drops the '\r' Replace would
+/// pass the existing pin and silently let CR through unsanitized — a bare CR
+/// inside a Markdown table cell breaks the table the LLM reads downstream.
+/// </summary>
+public class FactMarkdownCellCarriageReturnTests
+{
+    [Fact]
+    public void Cell_BareCarriageReturn_IsReplacedWithSpace()
+    {
+        var result = FactMarkdown.Cell("foo\rbar");
+
+        result.Should().Be("foo bar");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `\r` arm of `FactMarkdown.Cell`. The existing test covers the `|` and `\n` arms together; the bare-CR arm is a separate code path fired by legacy Mac line endings, half-stripped CRLF, and spreadsheet-pasted values.
- A refactor that drops the `Replace("\r", " ")` step would pass the existing pin yet let CR through unsanitized — a bare CR inside a Markdown table cell can break the table the LLM consumes.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownCellCarriageReturnTests.cs` — one `[Fact]` asserting `Cell("foo\rbar")` returns `"foo bar"`.