### PR TITLE
fix(rate-limiter): replace tail recursion in WaitAsync with a while loop

### DIFF
--- a/src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs
+++ b/src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs
@@ -17,29 +17,29 @@ public class RateLimiter : IRateLimiter
 
     public async Task WaitAsync()
     {
-        TimeSpan waitTime;
-
-        lock (_lock)
+        while (true)
         {
-            waitTime = CalculateWaitTime();
+            TimeSpan waitTime;
 
-            // If a 429 triggered a pause, wait for the longer of the two
-            var pauseRemaining = _pauseUntil - DateTime.UtcNow;
-            if (pauseRemaining > waitTime)
+            lock (_lock)
             {
-                waitTime = pauseRemaining;
+                waitTime = CalculateWaitTime();
+
+                // If a 429 triggered a pause, wait for the longer of the two
+                var pauseRemaining = _pauseUntil - DateTime.UtcNow;
+                if (pauseRemaining > waitTime)
+                {
+                    waitTime = pauseRemaining;
+                }
+
+                if (waitTime <= TimeSpan.Zero)
+                {
+                    _requestTimes.Enqueue(DateTime.UtcNow);
+                    return;
+                }
             }
 
-            if (waitTime <= TimeSpan.Zero)
-            {
-                _requestTimes.Enqueue(DateTime.UtcNow);
-            }
-        }
-
-        if (waitTime > TimeSpan.Zero)
-        {
             await Task.Delay(waitTime);
-            await WaitAsync();
         }
     }
 

--- a/tests/Equibles.UnitTests/Integrations/RateLimiterTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/RateLimiterTests.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using Equibles.Integrations.Common.RateLimiter;
 
 namespace Equibles.UnitTests.Integrations;
@@ -161,5 +163,72 @@ public class RateLimiterTests
         // Assert
         limiter.Should().NotBeNull();
         limiter.Should().BeAssignableTo<IRateLimiter>();
+    }
+
+    [Fact]
+    public void WaitAsync_StateMachine_DoesNotCallWaitAsyncRecursively()
+    {
+        // Bug #1273: WaitAsync was written as `await Task.Delay(waitTime); await WaitAsync();`.
+        // Each saturated iteration boxed a fresh state machine and registered an inline
+        // continuation onto the cascade. When the leaf iteration finally completed, the
+        // chain of continuations unwound synchronously on a single stack — one MoveNext
+        // frame per iteration — and under sustained saturation (reproducible by the full
+        // integration test suite) the cascade overflowed the stack and crashed the host.
+        //
+        // A direct stress-test cannot pin this contract: StackOverflowException is
+        // uncatchable and would terminate the test host, polluting unrelated tests.
+        // Instead the test inspects the compiler-generated state machine for WaitAsync
+        // and asserts the structural property that makes the cascade impossible — its
+        // MoveNext must not contain a call back into WaitAsync. Replacing the recursion
+        // with a `while` loop removes that call and is the canonical fix; a future PR
+        // re-introducing `await WaitAsync()` (or any other self-call within the body)
+        // re-introduces the same unbounded cascade and trips this regression.
+        var waitAsync = typeof(RateLimiter).GetMethod(nameof(RateLimiter.WaitAsync));
+        waitAsync.Should().NotBeNull();
+
+        var stateMachineAttr = waitAsync.GetCustomAttribute<AsyncStateMachineAttribute>();
+        stateMachineAttr
+            .Should()
+            .NotBeNull(
+                "WaitAsync should be an async method with a compiler-generated state machine"
+            );
+
+        var moveNext = stateMachineAttr.StateMachineType.GetMethod(
+            "MoveNext",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public
+        );
+        moveNext.Should().NotBeNull();
+
+        var body = moveNext.GetMethodBody();
+        body.Should().NotBeNull();
+        var il = body.GetILAsByteArray();
+        il.Should().NotBeNull();
+
+        // The compiler emits a `call`/`callvirt` to WaitAsync using its MethodDef token
+        // (same module). Scanning the IL for the 4-byte token detects the self-call
+        // without depending on full IL-disassembly machinery; tokens are 4-byte aligned
+        // operand values, so false positives in well-formed IL are negligible.
+        var token = waitAsync.MetadataToken;
+        var tokenBytes = BitConverter.GetBytes(token);
+        var selfCallFound = false;
+        for (var i = 0; i <= il.Length - 4; i++)
+        {
+            if (
+                il[i] == tokenBytes[0]
+                && il[i + 1] == tokenBytes[1]
+                && il[i + 2] == tokenBytes[2]
+                && il[i + 3] == tokenBytes[3]
+            )
+            {
+                selfCallFound = true;
+                break;
+            }
+        }
+
+        selfCallFound
+            .Should()
+            .BeFalse(
+                "WaitAsync's state machine must not call WaitAsync — recursion grows the inline completion cascade by one frame per iteration and overflowed the stack under sustained saturation (bug #1273)"
+            );
     }
 }


### PR DESCRIPTION
## Summary

- `RateLimiter.WaitAsync` looped via `await Task.Delay(waitTime); await WaitAsync();`. Each saturated iteration boxed a fresh state machine and registered an inline continuation; when the leaf finally completed, the cascade unwound on one stack with one `MoveNext` per iteration. Under sustained saturation (reproducible by the full integration test suite, observed at 416–1071 tests in) it overran the stack and crashed the test host.
- Replaces the recursion with a `while` loop that re-enters the lock and recomputes the wait between delays — same well-behaved-path behavior, no unbounded cascade.
- Adds a regression unit test that inspects the compiler-generated state machine and asserts `WaitAsync`'s `MoveNext` does not call `WaitAsync` — fails on the old body, passes on the new one, and trips on any future PR that re-introduces the self-call.

closes #1273

## Code changes

- `src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs` — convert tail recursion to a `while (true)` loop. On `waitTime <= TimeSpan.Zero` the lock body enqueues and returns; otherwise the method drops the lock, awaits `Task.Delay(waitTime)`, and loops to recompute. Identical observable behavior to the previous body on the well-behaved path.
- `tests/Equibles.UnitTests/Integrations/RateLimiterTests.cs` — add `WaitAsync_StateMachine_DoesNotCallWaitAsyncRecursively`. Resolves the `[AsyncStateMachine]` attribute, walks the IL of its `MoveNext`, and asserts the `WaitAsync` method-token does not appear — pins the structural invariant that prevents the bug from re-emerging. A direct stress test is unsafe here: `StackOverflowException` is uncatchable and would crash the test host, polluting unrelated tests.