### PR TITLE
refactor(yahoo-mcp): extract FindStockByTicker helper in StockPriceTools

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
@@ -49,9 +50,7 @@ public class StockPriceTools
         return McpToolExecutor.Execute(
             async () =>
             {
-                var stock = await _commonStockRepository.GetByTicker(
-                    ticker.Trim().ToUpperInvariant()
-                );
+                var stock = await FindStockByTicker(ticker);
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
@@ -190,9 +189,7 @@ public class StockPriceTools
                 if (kPeriod < 2 || dPeriod < 1)
                     return "kPeriod must be at least 2 and dPeriod at least 1.";
 
-                var stock = await _commonStockRepository.GetByTicker(
-                    ticker.Trim().ToUpperInvariant()
-                );
+                var stock = await FindStockByTicker(ticker);
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
@@ -273,9 +270,7 @@ public class StockPriceTools
                 if (period < 2)
                     return "period must be at least 2.";
 
-                var stock = await _commonStockRepository.GetByTicker(
-                    ticker.Trim().ToUpperInvariant()
-                );
+                var stock = await FindStockByTicker(ticker);
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
@@ -345,9 +340,7 @@ public class StockPriceTools
         return McpToolExecutor.Execute(
             async () =>
             {
-                var stock = await _commonStockRepository.GetByTicker(
-                    ticker.Trim().ToUpperInvariant()
-                );
+                var stock = await FindStockByTicker(ticker);
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
@@ -397,6 +390,9 @@ public class StockPriceTools
         !string.IsNullOrEmpty(value) && DateOnly.TryParse(value, out var parsed)
             ? parsed
             : fallback;
+
+    private Task<CommonStock> FindStockByTicker(string ticker) =>
+        _commonStockRepository.GetByTicker(ticker.Trim().ToUpperInvariant());
 
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {


### PR DESCRIPTION
## Summary

- `GetStockPrices`, `GetStochasticOscillator`, `GetAverageTrueRange`, and `GetOnBalanceVolume` each inlined the same `_commonStockRepository.GetByTicker(ticker.Trim().ToUpperInvariant())` expression before their null-check.
- Extract a private `FindStockByTicker` helper so each call site reads as a single lookup, matching the existing `FindHolderByName` pattern in `InstitutionalHoldingsTools`.
- Behavior is identical — the helper body is the exact expression callers used to inline, and the not-found message still references the original `ticker` parameter from the caller's scope.

## Code changes

- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — add private `FindStockByTicker(string ticker)` helper; replace four inline `GetByTicker(ticker.Trim().ToUpperInvariant())` blocks with `await FindStockByTicker(ticker)`. `GetLatestPrices`' per-ticker loop (which already iterates pre-normalized tickers) is intentionally left untouched.