### PR TITLE
refactor(house-disclosure): convert ParseTransactionLines for-loop to foreach

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -225,10 +225,8 @@ public partial class HouseDisclosureClient
     {
         var transactions = new List<DisclosureTransaction>();
 
-        for (var i = 0; i < lines.Length; i++)
+        foreach (var line in lines)
         {
-            var line = lines[i];
-
             // Look for lines with owner codes (SP, JT, DC, Self) followed by asset description
             // Transaction lines typically start with an owner code and contain a date pattern
             var ownerMatch = OwnerCodeRegex().Match(line);


### PR DESCRIPTION
## Summary

- `ParseTransactionLines` used `for (var i = 0; i < lines.Length; i++) { var line = lines[i]; ... }` but the index `i` was never read outside the array access. Convert to `foreach (var line in lines)`.
- The C# compiler lowers `foreach` over an array to an indexed loop, so the JIT-generated code is equivalent — same iteration order, no allocations, no behavior change.

## Code changes

- `src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs` — In `ParseTransactionLines`, replace the explicit indexed `for` with `foreach (var line in lines)` and drop the now-redundant `var line = lines[i];`. The 32 unit tests + integration tests covering this method (`HouseDisclosureClientParseTransactionLines*`, `HouseDisclosureClient*`) all continue to pass.