### PR TITLE
test(yahoo): pin SyncCompanyProfile early-returns on whitespace-only Industry

### DIFF
--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileTests.cs
@@ -155,6 +155,26 @@ public class YahooPriceImportServiceCompanyProfileTests : IDisposable
     }
 
     [Fact]
+    public async Task Import_WhitespaceIndustry_LeavesStockUntouchedAndCreatesNoRows()
+    {
+        // The guard is `IsNullOrWhiteSpace(profile.Industry)`, not `IsNullOrEmpty` — a
+        // regression that weakened it to the latter would let a whitespace-only industry
+        // through and create an Industry row with a blank name. The existing `null profile`
+        // pin doesn't cover this path.
+        var stock = SeedStock("WSI");
+        _yahooClient
+            .GetCompanyProfile("WSI")
+            .Returns(new CompanyProfile { Sector = "Technology", Industry = "   " });
+
+        await _service.Import(CancellationToken.None);
+
+        var refreshed = _stockRepo.GetAll().Single(s => s.Id == stock.Id);
+        refreshed.IndustryId.Should().BeNull();
+        _sectorRepo.GetAll().Should().BeEmpty();
+        _industryRepo.GetAll().Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task Import_IndustryAlreadyExistsWithoutSector_BackfillsTheSectorLink()
     {
         // Existing industry rows that pre-date the Sector taxonomy: the worker must


### PR DESCRIPTION
## Summary

- `SyncCompanyProfile` guards the upsert path with `string.IsNullOrWhiteSpace(profile.Industry)` (not `IsNullOrEmpty`). The existing `Import_NullProfile_LeavesStockIndustryUntouched` test pins only the `profile == null` half of that guard.
- A regression that downgraded the check to `IsNullOrEmpty` would let a whitespace-only industry through, creating an `Industry` row with a blank name and linking the stock to it — the existing pins would still pass.
- Add `Import_WhitespaceIndustry_LeavesStockUntouchedAndCreatesNoRows`: seeds a stock, returns a profile with `Industry = "   "`, asserts the stock's `IndustryId` stays null and no `Sector`/`Industry` rows are created.

## Code changes

- `tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceCompanyProfileTests.cs` — add the whitespace-industry fact alongside the existing five `SyncCompanyProfile` pins.