### PR TITLE
test(web-messaging): pin AddMessaging doesn't register worker-only consumers

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/ProgramMessagingConfigurationTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProgramMessagingConfigurationTests.cs
@@ -1,3 +1,4 @@
+using Equibles.Holdings.HostedService.Consumers;
 using Equibles.IntegrationTests.Helpers;
 using MassTransit;
 using Microsoft.AspNetCore.Builder;
@@ -34,6 +35,32 @@ public class ProgramMessagingConfigurationTests
         app.Services.GetRequiredService<IOptions<SqlTransportOptions>>()
             .Value.ConnectionString.Should()
             .Be(transport, "AddMessaging binds the transport connection string");
+    }
+
+    [Fact]
+    public void ConfigureServices_DoesNotRegisterWorkerOnlyConsumer_EvenWhenWorkerAssemblyLoaded()
+    {
+        // AddMessaging's `consumerAssemblies` parameter exists so the web host
+        // scans only its own assembly — worker-only consumers like
+        // StockCusipChangedConsumer depend on services the web never wires
+        // (HoldingsRescanSignal, ProcessedDataSetRepository) and would crash
+        // service-provider validation. A regression that ignored the parameter
+        // and fell back to the default AppDomain scan would pick this consumer
+        // up once the holdings assembly is loaded — exactly the scenario this
+        // touch on `typeof(StockCusipChangedConsumer)` forces.
+        _ = typeof(StockCusipChangedConsumer);
+
+        using var app = BuildHost(
+            "Host=localhost;Database=equibles;Username=postgres;Password=postgres"
+        );
+
+        using var scope = app.Services.CreateScope();
+        var consumer = scope.ServiceProvider.GetService<StockCusipChangedConsumer>();
+        consumer
+            .Should()
+            .BeNull(
+                "the web host must only scan its own assembly for consumers, not every loaded assembly"
+            );
     }
 
     private WebApplication BuildHost(string transportConnection)


### PR DESCRIPTION
## Summary

- `AddMessaging` accepts a `consumerAssemblies` parameter so the web host can scan only its own assembly. Worker-only consumers like `StockCusipChangedConsumer` depend on services the web never wires (`HoldingsRescanSignal`, `ProcessedDataSetRepository`) and would crash service-provider validation if accidentally registered.
- The existing `ConfigureServices_RegistersMassTransitBusAndTransportOptions` pin checks `IBus`/`SqlTransportOptions` are wired — it would still pass if the consumer-scope filter regressed. A change that dropped the parameter, used the wrong assembly list, or fell back to the default AppDomain scan would register the worker's consumer once its assembly is loaded.
- Add `ConfigureServices_DoesNotRegisterWorkerOnlyConsumer_EvenWhenWorkerAssemblyLoaded`: touches `typeof(StockCusipChangedConsumer)` to force the holdings worker's assembly into the AppDomain, builds the web host via `Program.ConfigureServices`, and asserts the worker-only consumer is not in the service provider.

## Code changes

- `tests/Equibles.IntegrationTests/Web/ProgramMessagingConfigurationTests.cs` — add the consumer-scope pin alongside the existing IBus/transport-options pin; add the `Equibles.Holdings.HostedService.Consumers` using.