### PR TITLE
docs(technical/hosts): split AddMessaging bullet

### DIFF
--- a/docs/technical/hosts.md
+++ b/docs/technical/hosts.md
@@ -33,7 +33,9 @@ The background-scraper host. Plain `Host.CreateApplicationBuilder` (not `WebAppl
 
 - Entry: [`Program.cs`](../../src/Equibles.Worker.Host/Program.cs) (top-level statements, not a partial class).
 - Container: [`Dockerfile`](../../src/Equibles.Worker.Host/Dockerfile) — `dotnet/aspnet:10.0` (for shared runtime), `ENTRYPOINT ["dotnet", "Equibles.Worker.Host.dll"]`, no ports exposed.
-- `AddMessaging(builder.Configuration)` configures MassTransit on the Postgres SQL transport with the EF outbox sitting inside `EquiblesDbContext`. The transport connection comes from `ConnectionStrings__TransportConnection`; `MassTransit__RunMigration=true` makes the worker apply the transport schema on first run.
+- `AddMessaging(builder.Configuration)` configures MassTransit on the Postgres SQL transport with the EF outbox sitting inside `EquiblesDbContext`.
+- The transport connection comes from `ConnectionStrings__TransportConnection`.
+- `MassTransit__RunMigration=true` makes the worker apply the transport schema on first run.
 - One scraper-options bind per source: `WorkerOptions`, `DocumentScraperOptions`, `FinraOptions` + `FinraScraperOptions`, `FredOptions` + `FredScraperOptions`, `FtdScraperOptions`, `FinancialFactsScraperOptions`, `YahooPriceScraperOptions`, `CftcScraperOptions`, `CboeScraperOptions`.
 - Each scraper reads its own section so per-source tuning never leaks across modules.
 - `AddSecWorker()`, `AddSecFinancialFactsWorker()`, `AddFinraWorker()`, `AddFredWorker()`, `AddYahooWorker()`, `AddCftcWorker()`, `AddCboeWorker()`, `AddCongressWorker()`, `AddHoldingsWorker()` register the `BackgroundService` workers from each `.HostedService` project.


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The Worker-Host `AddMessaging` bullet packed 316 chars: the MassTransit configuration (Postgres SQL transport with EF outbox in `EquiblesDbContext`), the transport connection string source, and the first-run transport-migration flag. "One fact per bullet — a long bullet is a smell, split it."

## Code changes

- `docs/technical/hosts.md` — split the bullet into three: one for the `AddMessaging` wiring, one for `ConnectionStrings__TransportConnection`, one for `MassTransit__RunMigration=true` first-run transport-schema migration.