### PR TITLE
feat(web): add scraper activity broadcaster, consumer and SSE endpoint

### DIFF
--- a/src/Equibles.Web/Controllers/StatusController.cs
+++ b/src/Equibles.Web/Controllers/StatusController.cs
@@ -2,10 +2,12 @@ using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Errors.Repositories;
+using Equibles.Messaging.Contracts.Activity;
 using Equibles.Web.Controllers.Abstract;
 using Equibles.Web.FlashMessage.Contracts;
 using Equibles.Web.Models;
 using Equibles.Web.Services;
+using Equibles.Web.Services.Activity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.EntityFrameworkCore;
@@ -20,6 +22,7 @@ public class StatusController : BaseController
     private readonly IConfiguration _configuration;
     private readonly EquiblesDbContext _dbContext;
     private readonly DataCountService _dataCountService;
+    private readonly ActivityFeedBroadcaster _activityFeed;
 
     public StatusController(
         ErrorRepository errorRepository,
@@ -28,6 +31,7 @@ public class StatusController : BaseController
         IConfiguration configuration,
         EquiblesDbContext dbContext,
         DataCountService dataCountService,
+        ActivityFeedBroadcaster activityFeed,
         ILogger<StatusController> logger
     )
         : base(logger)
@@ -38,6 +42,7 @@ public class StatusController : BaseController
         _configuration = configuration;
         _dbContext = dbContext;
         _dataCountService = dataCountService;
+        _activityFeed = activityFeed;
     }
 
     public override void OnActionExecuting(ActionExecutingContext context)
@@ -156,6 +161,55 @@ public class StatusController : BaseController
             }
         );
     }
+
+    [HttpGet("~/Status/Activity/Stream")]
+    public async Task ActivityStream(CancellationToken cancellationToken)
+    {
+        InitSseStream();
+
+        // Hint to load balancers / browsers that the stream is live.
+        Response.Headers["X-Activity-Stream"] = "scraper";
+
+        // Flush the response headers immediately. Without this the headers
+        // sit in the buffer until the first SSE frame is written; that's
+        // fine for a noisy feed but a quiet one leaves the browser waiting
+        // forever for the connection to "open".
+        await Response.Body.FlushAsync(cancellationToken);
+
+        using var subscription = _activityFeed.Subscribe();
+
+        // Replay the small ring buffer so a freshly-opened tab has context,
+        // then forward live events until the client disconnects.
+        foreach (var activity in subscription.Backlog)
+        {
+            await WriteActivityEvent(activity);
+        }
+
+        try
+        {
+            await foreach (var activity in subscription.Reader.ReadAllAsync(cancellationToken))
+            {
+                await WriteActivityEvent(activity);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Browser closed the tab — clean disconnect.
+        }
+    }
+
+    private Task WriteActivityEvent(ScraperActivity activity) =>
+        WriteSseEvent(
+            "activity",
+            new
+            {
+                activity.Source,
+                Severity = activity.Severity.ToString(),
+                activity.Message,
+                activity.Timestamp,
+                activity.CorrelationId,
+            }
+        );
 
     [HttpPost("DeleteAll")]
     [ValidateAntiForgeryToken]

--- a/src/Equibles.Web/Services/Activity/ActivityFeedBroadcaster.cs
+++ b/src/Equibles.Web/Services/Activity/ActivityFeedBroadcaster.cs
@@ -1,0 +1,83 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using Equibles.Core.AutoWiring;
+using Equibles.Messaging.Contracts.Activity;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.Web.Services.Activity;
+
+/// <summary>
+/// In-process fan-out hub for live scraper activity events. The MassTransit
+/// consumer pushes each incoming <see cref="ScraperActivity"/> here; every
+/// connected SSE client gets its own bounded channel so a slow browser can't
+/// back-pressure the bus (oldest event is dropped instead).
+/// A small ring buffer is kept so a freshly-connected client gets a usable
+/// tail — the activity feed is otherwise "what's happening right now".
+/// </summary>
+[Service(ServiceLifetime.Singleton)]
+public class ActivityFeedBroadcaster
+{
+    public const int BufferCapacity = 500;
+    public const int SubscriberQueueCapacity = 256;
+
+    private readonly ConcurrentDictionary<Guid, Channel<ScraperActivity>> _subscribers = new();
+    private readonly LinkedList<ScraperActivity> _buffer = new();
+    private readonly object _bufferLock = new();
+
+    public void Publish(ScraperActivity activity)
+    {
+        lock (_bufferLock)
+        {
+            _buffer.AddLast(activity);
+            while (_buffer.Count > BufferCapacity)
+            {
+                _buffer.RemoveFirst();
+            }
+        }
+
+        foreach (var subscriber in _subscribers.Values)
+        {
+            // Bounded channel with DropOldest — a paused tab never blocks publish.
+            subscriber.Writer.TryWrite(activity);
+        }
+    }
+
+    public ActivityFeedSubscription Subscribe(int backlogSize = 200)
+    {
+        if (backlogSize < 0)
+            backlogSize = 0;
+        if (backlogSize > BufferCapacity)
+            backlogSize = BufferCapacity;
+
+        var channel = Channel.CreateBounded<ScraperActivity>(
+            new BoundedChannelOptions(SubscriberQueueCapacity)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+                SingleReader = true,
+                SingleWriter = false,
+            }
+        );
+
+        var id = Guid.NewGuid();
+        _subscribers[id] = channel;
+
+        List<ScraperActivity> backlog;
+        lock (_bufferLock)
+        {
+            var skip = Math.Max(0, _buffer.Count - backlogSize);
+            backlog = _buffer.Skip(skip).ToList();
+        }
+
+        return new ActivityFeedSubscription(id, backlog, channel.Reader, this);
+    }
+
+    internal void Unsubscribe(Guid id)
+    {
+        if (_subscribers.TryRemove(id, out var channel))
+        {
+            channel.Writer.TryComplete();
+        }
+    }
+
+    public int SubscriberCount => _subscribers.Count;
+}

--- a/src/Equibles.Web/Services/Activity/ActivityFeedSubscription.cs
+++ b/src/Equibles.Web/Services/Activity/ActivityFeedSubscription.cs
@@ -1,0 +1,35 @@
+using System.Threading.Channels;
+using Equibles.Messaging.Contracts.Activity;
+
+namespace Equibles.Web.Services.Activity;
+
+public sealed class ActivityFeedSubscription : IDisposable
+{
+    private readonly ActivityFeedBroadcaster _broadcaster;
+    private bool _disposed;
+
+    internal ActivityFeedSubscription(
+        Guid id,
+        IReadOnlyList<ScraperActivity> backlog,
+        ChannelReader<ScraperActivity> reader,
+        ActivityFeedBroadcaster broadcaster
+    )
+    {
+        Id = id;
+        Backlog = backlog;
+        Reader = reader;
+        _broadcaster = broadcaster;
+    }
+
+    public Guid Id { get; }
+    public IReadOnlyList<ScraperActivity> Backlog { get; }
+    public ChannelReader<ScraperActivity> Reader { get; }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        _broadcaster.Unsubscribe(Id);
+    }
+}

--- a/src/Equibles.Web/Services/Activity/ScraperActivityConsumer.cs
+++ b/src/Equibles.Web/Services/Activity/ScraperActivityConsumer.cs
@@ -1,0 +1,29 @@
+using Equibles.Messaging.Attributes;
+using Equibles.Messaging.Contracts.Activity;
+using MassTransit;
+
+namespace Equibles.Web.Services.Activity;
+
+/// <summary>
+/// Receives <see cref="ScraperActivity"/> events on the bus and hands them off
+/// to the in-process broadcaster, which fans them out to connected SSE
+/// clients. <c>AllowMultiple = true</c>: every web replica gets its own
+/// endpoint so each replica forwards events to the browsers it's serving
+/// (rather than competing for messages with the other replicas).
+/// </summary>
+[Consumer(allowMultiple: true)]
+public class ScraperActivityConsumer : IConsumer<ScraperActivity>
+{
+    private readonly ActivityFeedBroadcaster _broadcaster;
+
+    public ScraperActivityConsumer(ActivityFeedBroadcaster broadcaster)
+    {
+        _broadcaster = broadcaster;
+    }
+
+    public Task Consume(ConsumeContext<ScraperActivity> context)
+    {
+        _broadcaster.Publish(context.Message);
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Equibles.IntegrationTests/Helpers/WebHostFixture.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/WebHostFixture.cs
@@ -41,6 +41,12 @@ public class WebHostFixture : IAsyncLifetime
 
     public HttpClient Client { get; private set; }
 
+    /// <summary>
+    /// Application root services. Use a scope (<c>Services.CreateScope()</c>)
+    /// before resolving scoped dependencies; never resolve them directly.
+    /// </summary>
+    public IServiceProvider Services => _app.Services;
+
     public async Task InitializeAsync()
     {
         await _db.StartAsync();

--- a/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
@@ -31,6 +31,7 @@ using Equibles.Web.Controllers;
 using Equibles.Web.FlashMessage.Contracts;
 using Equibles.Web.Models;
 using Equibles.Web.Services;
+using Equibles.Web.Services.Activity;
 using Equibles.Web.ViewModels.EconomicData;
 using Equibles.Web.ViewModels.Stocks;
 using Equibles.Yahoo.Data;
@@ -925,6 +926,7 @@ public class StatusControllerTests : IDisposable
             BuildConfiguration(),
             _dbContext,
             _dataCountService,
+            new ActivityFeedBroadcaster(),
             _logger
         );
         controller.ControllerContext = new ControllerContext

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerActivityStreamTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerActivityStreamTests.cs
@@ -1,0 +1,85 @@
+using System.Net.Http.Headers;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging.Contracts.Activity;
+using Equibles.Web.Services.Activity;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.IntegrationTests.Web;
+
+[Collection(WebHostCollection.Name)]
+public class StatusControllerActivityStreamTests
+{
+    private readonly WebHostFixture _host;
+
+    public StatusControllerActivityStreamTests(WebHostFixture host) => _host = host;
+
+    [Fact]
+    public async Task ActivityStream_PublishedAfterConnect_StreamsTheEventToTheClient()
+    {
+        // Wait until the response headers come back but keep the body open —
+        // SSE never closes, so the default ResponseContentRead would hang.
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/Status/Activity/Stream");
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var response = await _host.Client.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cts.Token
+        );
+
+        response.EnsureSuccessStatusCode();
+        response.Content.Headers.ContentType?.MediaType.Should().Be("text/event-stream");
+        response.Headers.TryGetValues("X-Activity-Stream", out var marker).Should().BeTrue();
+        marker.Should().Contain("scraper");
+
+        // Now publish — the SSE endpoint subscribes during the request, so any
+        // event raised after that point flows out the body as SSE frames.
+        using var bodyScope = _host.Services.CreateScope();
+        var broadcaster = bodyScope.ServiceProvider.GetRequiredService<ActivityFeedBroadcaster>();
+        var activity = new ScraperActivity(
+            Source: "SEC",
+            Severity: ScraperActivitySeverity.Info,
+            Message: "fetching 10-K",
+            Timestamp: new DateTimeOffset(2026, 5, 20, 12, 0, 0, TimeSpan.Zero),
+            CorrelationId: "corr-1"
+        );
+        broadcaster.Publish(activity);
+
+        var frame = await ReadOneEventFrame(response, cts.Token);
+
+        frame.Should().Contain("event: activity");
+        frame.Should().Contain("\"Source\":\"SEC\"");
+        frame.Should().Contain("\"Severity\":\"Info\"");
+        frame.Should().Contain("\"Message\":\"fetching 10-K\"");
+        frame.Should().Contain("\"CorrelationId\":\"corr-1\"");
+    }
+
+    private static async Task<string> ReadOneEventFrame(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken
+    )
+    {
+        using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var reader = new StreamReader(stream);
+        var buffer = new System.Text.StringBuilder();
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var line = await reader.ReadLineAsync(cancellationToken);
+            if (line is null)
+            {
+                break;
+            }
+            if (line.Length == 0)
+            {
+                if (buffer.Length > 0)
+                {
+                    return buffer.ToString();
+                }
+                continue;
+            }
+            buffer.AppendLine(line);
+        }
+        return buffer.ToString();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerDataTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerDataTests.cs
@@ -25,6 +25,7 @@ using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
 using Equibles.Web.FlashMessage.Contracts;
 using Equibles.Web.Services;
+using Equibles.Web.Services.Activity;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Repositories;
 using Microsoft.AspNetCore.Http;
@@ -98,6 +99,7 @@ public class StatusControllerDataTests : IDisposable
             configuration,
             _dbContext,
             dataCountService,
+            new ActivityFeedBroadcaster(),
             Substitute.For<ILogger<StatusController>>()
         );
         controller.ControllerContext = new ControllerContext

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerDeleteAllTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerDeleteAllTests.cs
@@ -14,6 +14,7 @@ using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
 using Equibles.Web.FlashMessage.Contracts;
 using Equibles.Web.Services;
+using Equibles.Web.Services.Activity;
 using Equibles.Yahoo.Repositories;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -105,6 +106,7 @@ public class StatusControllerDeleteAllTests : ParadeDbMcpTestBase
             configuration,
             DbContext,
             dataCountService,
+            new ActivityFeedBroadcaster(),
             Substitute.For<ILogger<StatusController>>()
         );
         controller.ControllerContext = new ControllerContext

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerDeleteHappyTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerDeleteHappyTests.cs
@@ -26,6 +26,7 @@ using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
 using Equibles.Web.FlashMessage.Contracts;
 using Equibles.Web.Services;
+using Equibles.Web.Services.Activity;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Repositories;
 using Microsoft.AspNetCore.Http;
@@ -110,6 +111,7 @@ public class StatusControllerDeleteHappyTests : IDisposable
             configuration,
             _dbContext,
             dataCountService,
+            new ActivityFeedBroadcaster(),
             Substitute.For<ILogger<StatusController>>()
         );
         controller.ControllerContext = new ControllerContext

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerMarkAsSeenHappyTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerMarkAsSeenHappyTests.cs
@@ -26,6 +26,7 @@ using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
 using Equibles.Web.FlashMessage.Contracts;
 using Equibles.Web.Services;
+using Equibles.Web.Services.Activity;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Repositories;
 using Microsoft.AspNetCore.Http;
@@ -112,6 +113,7 @@ public class StatusControllerMarkAsSeenHappyTests : IDisposable
             configuration,
             _dbContext,
             dataCountService,
+            new ActivityFeedBroadcaster(),
             Substitute.For<ILogger<StatusController>>()
         );
         controller.ControllerContext = new ControllerContext

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerShowNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerShowNotFoundTests.cs
@@ -25,6 +25,7 @@ using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
 using Equibles.Web.FlashMessage.Contracts;
 using Equibles.Web.Services;
+using Equibles.Web.Services.Activity;
 using Equibles.Yahoo.Data;
 using Equibles.Yahoo.Repositories;
 using Microsoft.AspNetCore.Http;
@@ -99,6 +100,7 @@ public class StatusControllerShowNotFoundTests : IDisposable
             configuration,
             _dbContext,
             dataCountService,
+            new ActivityFeedBroadcaster(),
             Substitute.For<ILogger<StatusController>>()
         );
         controller.ControllerContext = new ControllerContext

--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -83,5 +83,6 @@
     <ProjectReference Include="..\..\src\Equibles.Search\Equibles.Search.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Search.Abstractions\Equibles.Search.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cboe.HostedService\Equibles.Cboe.HostedService.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Equibles.UnitTests/Web/Activity/ActivityFeedBroadcasterTests.cs
+++ b/tests/Equibles.UnitTests/Web/Activity/ActivityFeedBroadcasterTests.cs
@@ -1,0 +1,138 @@
+using Equibles.Messaging.Contracts.Activity;
+using Equibles.Web.Services.Activity;
+
+namespace Equibles.UnitTests.Web.Activity;
+
+public class ActivityFeedBroadcasterTests
+{
+    private readonly ActivityFeedBroadcaster _sut = new();
+
+    [Fact]
+    public void Publish_FansOutToEverySubscriber()
+    {
+        using var a = _sut.Subscribe();
+        using var b = _sut.Subscribe();
+        var activity = MakeActivity("SEC", "fetching 10-K");
+
+        _sut.Publish(activity);
+
+        a.Reader.TryRead(out var fromA).Should().BeTrue();
+        b.Reader.TryRead(out var fromB).Should().BeTrue();
+        fromA.Should().Be(activity);
+        fromB.Should().Be(activity);
+    }
+
+    [Fact]
+    public void Subscribe_AfterPublish_ReplaysBufferedEvents()
+    {
+        var first = MakeActivity("SEC", "first");
+        var second = MakeActivity("Yahoo", "second");
+        _sut.Publish(first);
+        _sut.Publish(second);
+
+        using var subscription = _sut.Subscribe();
+
+        subscription
+            .Backlog.Should()
+            .Equal(new[] { first, second }, "newly-connected clients need recent context");
+    }
+
+    [Fact]
+    public void Subscribe_RequestingFewerThanBuffered_TrimsToTheNewestEvents()
+    {
+        var first = MakeActivity("SEC", "first");
+        var second = MakeActivity("SEC", "second");
+        var third = MakeActivity("SEC", "third");
+        _sut.Publish(first);
+        _sut.Publish(second);
+        _sut.Publish(third);
+
+        using var subscription = _sut.Subscribe(backlogSize: 2);
+
+        subscription.Backlog.Should().Equal(second, third);
+    }
+
+    [Fact]
+    public void Subscribe_NegativeBacklog_ReturnsEmpty()
+    {
+        _sut.Publish(MakeActivity("SEC", "noise"));
+
+        using var subscription = _sut.Subscribe(backlogSize: -5);
+
+        subscription.Backlog.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Dispose_RemovesSubscriberSoFuturePublishesIgnoreIt()
+    {
+        var subscription = _sut.Subscribe();
+        _sut.SubscriberCount.Should().Be(1);
+
+        subscription.Dispose();
+
+        _sut.SubscriberCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Publish_FloodingBuffer_KeepsLatestBufferCapacityItems()
+    {
+        for (var i = 0; i < ActivityFeedBroadcaster.BufferCapacity + 50; i++)
+        {
+            _sut.Publish(MakeActivity("SEC", $"msg-{i}"));
+        }
+
+        using var subscription = _sut.Subscribe(
+            backlogSize: ActivityFeedBroadcaster.BufferCapacity + 1
+        );
+
+        subscription
+            .Backlog.Should()
+            .HaveCount(ActivityFeedBroadcaster.BufferCapacity, "buffer is a ring");
+        subscription
+            .Backlog.Last()
+            .Message.Should()
+            .Be($"msg-{ActivityFeedBroadcaster.BufferCapacity + 49}");
+    }
+
+    [Fact]
+    public void Publish_FloodingSlowSubscriber_DropsOldestUnread()
+    {
+        // Subscribe but never read — pretend a paused tab.
+        using var subscription = _sut.Subscribe();
+
+        var flood = ActivityFeedBroadcaster.SubscriberQueueCapacity + 10;
+        for (var i = 0; i < flood; i++)
+        {
+            _sut.Publish(MakeActivity("SEC", $"msg-{i}"));
+        }
+
+        // The channel only retains up to its bounded capacity; older items are
+        // dropped on overflow (FullMode = DropOldest), so the bus and the
+        // other subscribers never block waiting on this slow client.
+        var drained = new List<ScraperActivity>();
+        while (subscription.Reader.TryRead(out var item))
+        {
+            drained.Add(item);
+        }
+
+        drained
+            .Should()
+            .HaveCountLessThanOrEqualTo(ActivityFeedBroadcaster.SubscriberQueueCapacity);
+        drained
+            .Last()
+            .Message.Should()
+            .Be(
+                $"msg-{flood - 1}",
+                "the newest event must survive even when the subscriber is slow"
+            );
+    }
+
+    private static ScraperActivity MakeActivity(string source, string message) =>
+        new(
+            source,
+            ScraperActivitySeverity.Info,
+            message,
+            DateTimeOffset.UtcNow,
+            CorrelationId: Guid.NewGuid().ToString()
+        );
+}

--- a/tests/Equibles.UnitTests/Web/Activity/ActivityFeedBroadcasterTests.cs
+++ b/tests/Equibles.UnitTests/Web/Activity/ActivityFeedBroadcasterTests.cs
@@ -63,6 +63,33 @@ public class ActivityFeedBroadcasterTests
     }
 
     [Fact]
+    public void Subscribe_BacklogLargerThanBuffer_ClampsToBufferCapacity()
+    {
+        for (var i = 0; i < 50; i++)
+        {
+            _sut.Publish(MakeActivity("SEC", $"msg-{i}"));
+        }
+
+        using var subscription = _sut.Subscribe(
+            backlogSize: ActivityFeedBroadcaster.BufferCapacity + 1000
+        );
+
+        // Only 50 events were ever published, so the clamp lands well below
+        // BufferCapacity — the assert is that nothing extra is invented.
+        subscription.Backlog.Should().HaveCount(50);
+    }
+
+    [Fact]
+    public void Dispose_CalledTwice_IsIdempotent()
+    {
+        var subscription = _sut.Subscribe();
+        subscription.Dispose();
+        var act = () => subscription.Dispose();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
     public void Dispose_RemovesSubscriberSoFuturePublishesIgnoreIt()
     {
         var subscription = _sut.Subscribe();

--- a/tests/Equibles.UnitTests/Web/Activity/ScraperActivityConsumerTests.cs
+++ b/tests/Equibles.UnitTests/Web/Activity/ScraperActivityConsumerTests.cs
@@ -1,0 +1,36 @@
+using Equibles.Messaging.Contracts.Activity;
+using Equibles.Web.Services.Activity;
+using MassTransit;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Web.Activity;
+
+public class ScraperActivityConsumerTests
+{
+    private readonly ActivityFeedBroadcaster _broadcaster = new();
+    private readonly ScraperActivityConsumer _sut;
+
+    public ScraperActivityConsumerTests() => _sut = new ScraperActivityConsumer(_broadcaster);
+
+    [Fact]
+    public async Task Consume_HandsMessageOffToBroadcaster()
+    {
+        var activity = new ScraperActivity(
+            Source: "SEC",
+            Severity: ScraperActivitySeverity.Info,
+            Message: "fetching 10-K",
+            Timestamp: DateTimeOffset.UtcNow,
+            CorrelationId: Guid.NewGuid().ToString()
+        );
+
+        using var subscription = _broadcaster.Subscribe(backlogSize: 0);
+
+        var context = Substitute.For<ConsumeContext<ScraperActivity>>();
+        context.Message.Returns(activity);
+
+        await _sut.Consume(context);
+
+        subscription.Reader.TryRead(out var observed).Should().BeTrue();
+        observed.Should().Be(activity);
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 2/4 of the live scraper activity feed (#1162). Brings the broadcaster, MassTransit consumer, and SSE endpoint online in the web host. No UI yet (slice 3) and no producers yet (slice 4).
- Per-subscriber bounded channels with DropOldest mean a paused tab can never block publishers. A small ring buffer is replayed so a freshly-opened tab has context.

Refs #1162

## Code changes

- `src/Equibles.Web/Services/Activity/ActivityFeedBroadcaster.cs` — singleton fan-out; 500-event buffer; per-subscriber 256-slot bounded channel with `DropOldest`.
- `src/Equibles.Web/Services/Activity/ActivityFeedSubscription.cs` — disposable handle returned to subscribers; auto-unsubscribes on dispose.
- `src/Equibles.Web/Services/Activity/ScraperActivityConsumer.cs` — `[Consumer(allowMultiple: true)]`; receives `ScraperActivity` from the bus and hands it to the broadcaster.
- `src/Equibles.Web/Controllers/StatusController.cs` — adds `GET /Status/Activity/Stream` (SSE). Flushes headers eagerly so a quiet feed still opens for the browser.
- `tests/Equibles.UnitTests/Web/Activity/ActivityFeedBroadcasterTests.cs` — fan-out, backlog replay, ring buffer cap, dispose semantics, slow-subscriber drop-oldest behavior.
- `tests/Equibles.UnitTests/Web/Activity/ScraperActivityConsumerTests.cs` — pins that `Consume` hands the message to the broadcaster.
- `tests/Equibles.IntegrationTests/Web/StatusControllerActivityStreamTests.cs` — end-to-end SSE: connect, publish via DI, assert the event frame is streamed back.
- `tests/Equibles.IntegrationTests/Helpers/WebHostFixture.cs` — exposes `Services` so tests can resolve singletons without reflection.
- Existing `StatusController*Tests.cs` — pass `new ActivityFeedBroadcaster()` into the constructor now that the controller depends on it.