### PR TITLE
test(rate-limiter): pin WaitAsync uses queue wait when pause is shorter

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/RateLimiterTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/RateLimiterTests.cs
@@ -290,4 +290,36 @@ public class RateLimiterTests
                 );
         }
     }
+
+    [Fact]
+    public async Task WaitAsync_PauseShorterThanQueueWait_UsesQueueWait()
+    {
+        // WaitAsync's wait is `max(queue saturation wait, pause remaining)` — implemented
+        // by the `if (pauseRemaining > waitTime) waitTime = pauseRemaining;` guard. Two
+        // halves of that contract are already pinned: PauseFor_DelaysSubsequentWaitAsyncCalls
+        // (queue=0, pause>0 → use pause) and WaitAsync_FillsCapacity_NextRequestWaitsForOldestToAgeOut
+        // (queue>0, pause<0 → use queue). The remaining cell — both positive, pause < queue
+        // — is unpinned, and is exactly the case a "simplification" PR could regress by
+        // dropping the if-guard and writing `waitTime = pauseRemaining;` unconditionally.
+        // That refactor would replace the ~400ms queue wait below with a ~50ms pause wait,
+        // releasing the scraper before the upstream window allows it and triggering bans.
+        //
+        // Construction: maxRequests=1 saturates after the first call so the second WaitAsync
+        // sees a positive queue-driven wait of ~400ms. A short PauseFor of 50ms sits BELOW
+        // that — the longer (queue) wait must dominate, so total time is ~400ms, never ~50ms.
+        var limiter = new RateLimiter(maxRequests: 1, timeWindow: TimeSpan.FromMilliseconds(400));
+        await limiter.WaitAsync();
+
+        limiter.PauseFor(TimeSpan.FromMilliseconds(50));
+
+        var sw = Stopwatch.StartNew();
+        await limiter.WaitAsync();
+        sw.Stop();
+
+        sw.ElapsedMilliseconds.Should()
+            .BeGreaterThanOrEqualTo(
+                350,
+                "queue saturation wait (~400ms) must dominate the shorter pause (50ms) — if the if-guard were dropped the wait would collapse to ~50ms"
+            );
+    }
 }


### PR DESCRIPTION
## Summary

- `WaitAsync`'s wait is `max(queue saturation, pause remaining)`. Two halves of that contract were pinned already — queue=0 with pause>0 (`PauseFor_DelaysSubsequentWaitAsyncCalls`) and queue>0 with pause<0 (`WaitAsync_FillsCapacity_NextRequestWaitsForOldestToAgeOut`). The remaining cell, both positive with pause < queue, was unpinned.
- That cell is the one a "simplification" PR could regress by dropping the `if (pauseRemaining > waitTime)` guard and writing `waitTime = pauseRemaining;` unconditionally. The wait would collapse from the queue's ~400ms to the pause's ~50ms, the scraper would burst before its upstream window allowed, and bans would follow. No existing test catches it.

## Code changes

- `tests/Equibles.UnitTests/Integrations/RateLimiterTests.cs` — add `WaitAsync_PauseShorterThanQueueWait_UsesQueueWait`. Saturates `maxRequests=1` with a single prior call so the second `WaitAsync` sees a ~400ms queue-driven wait; issues a 50ms `PauseFor` that sits below that; asserts the wait stays ≥ 350ms.