### PR TITLE
refactor(holdings-13f-parser): route Child/Descendant through their plural primitives

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
@@ -131,13 +131,13 @@ public class Filing13FXmlParser
         WithLocalName(parent.Elements(), localName);
 
     private static XElement Descendant(XElement parent, string localName) =>
-        parent == null ? null : WithLocalName(parent.Descendants(), localName).FirstOrDefault();
+        parent == null ? null : Descendants(parent, localName).FirstOrDefault();
 
     private static IEnumerable<XElement> Descendants(XElement parent, string localName) =>
         WithLocalName(parent.Descendants(), localName);
 
     private static XElement Child(XElement parent, string localName) =>
-        parent == null ? null : WithLocalName(parent.Elements(), localName).FirstOrDefault();
+        parent == null ? null : Children(parent, localName).FirstOrDefault();
 
     private static string Value(XElement element) => element?.Value.Trim();
 


### PR DESCRIPTION
## Summary

- `Filing13FXmlParser` exposed four traversal helpers — `Children` / `Child` and `Descendants` / `Descendant` — but the singular variants reached into `WithLocalName(parent.Elements(), …)` / `WithLocalName(parent.Descendants(), …)` directly instead of using the plural helpers that already wrap exactly that. Four `WithLocalName` call sites where there should be two.
- Route `Child` through `Children` and `Descendant` through `Descendants`, leaving the `parent == null ? null : ….FirstOrDefault()` shape on the singulars intact. Now there's one primitive per traversal kind, and the singulars read as "the plural, restricted to the first match".
- Behavior-preserving: by definition `Children(p, n) ≡ WithLocalName(p.Elements(), n)` and `Descendants(p, n) ≡ WithLocalName(p.Descendants(), n)`, and the singulars' null guard + `.FirstOrDefault()` semantics are unchanged.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs` — `Child` now calls `Children(parent, localName).FirstOrDefault()`; `Descendant` now calls `Descendants(parent, localName).FirstOrDefault()`.