### PR TITLE
refactor(holdings-mcp): extract ResolveHolderAndTargetDate helper for duplicated find-holder-and-resolve-quarter prologue

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -611,15 +611,13 @@ public class InstitutionalHoldingsTools
         return McpToolExecutor.Execute(
             async () =>
             {
-                var holder = await FindHolderByName(institutionName);
-                if (holder == null)
-                    return $"No institution found matching '{institutionName}'.";
+                var (holder, reportDates, targetDate, error) = await ResolveHolderAndTargetDate(
+                    institutionName,
+                    reportDate
+                );
+                if (error != null)
+                    return error;
 
-                var reportDates = await GetReportDatesByHolder(holder).ToListAsync();
-                if (reportDates.Count == 0)
-                    return $"No 13F holdings reported by {holder.Name}.";
-
-                var targetDate = ResolveReportDate(reportDate, reportDates);
                 var targetIndex = reportDates.IndexOf(targetDate);
                 var previousDate =
                     targetIndex < reportDates.Count - 1
@@ -687,15 +685,12 @@ public class InstitutionalHoldingsTools
         return McpToolExecutor.Execute(
             async () =>
             {
-                var holder = await FindHolderByName(institutionName);
-                if (holder == null)
-                    return $"No institution found matching '{institutionName}'.";
-
-                var reportDates = await GetReportDatesByHolder(holder).ToListAsync();
-                if (reportDates.Count == 0)
-                    return $"No 13F holdings reported by {holder.Name}.";
-
-                var targetDate = ResolveReportDate(reportDate, reportDates);
+                var (holder, _, targetDate, error) = await ResolveHolderAndTargetDate(
+                    institutionName,
+                    reportDate
+                );
+                if (error != null)
+                    return error;
 
                 var holdings = await _holdingRepository
                     .GetByHolder(holder, targetDate)
@@ -1082,6 +1077,24 @@ public class InstitutionalHoldingsTools
 
     private Task<InstitutionalHolder> FindHolderByName(string name) =>
         _holderRepository.Search(name ?? string.Empty).OrderBy(h => h.Name).FirstOrDefaultAsync();
+
+    private async Task<(
+        InstitutionalHolder Holder,
+        List<DateOnly> ReportDates,
+        DateOnly TargetDate,
+        string Error
+    )> ResolveHolderAndTargetDate(string institutionName, string reportDate)
+    {
+        var holder = await FindHolderByName(institutionName);
+        if (holder == null)
+            return (null, null, default, $"No institution found matching '{institutionName}'.");
+
+        var reportDates = await GetReportDatesByHolder(holder).ToListAsync();
+        if (reportDates.Count == 0)
+            return (holder, null, default, $"No 13F holdings reported by {holder.Name}.");
+
+        return (holder, reportDates, ResolveReportDate(reportDate, reportDates), null);
+    }
 
     private IQueryable<DateOnly> GetReportDatesByHolder(InstitutionalHolder holder) =>
         _holdingRepository


### PR DESCRIPTION
## Summary

- Collapse two identical 8-line "find holder + load report dates + resolve target date" blocks in `InstitutionalHoldingsTools` into a single `ResolveHolderAndTargetDate` private helper.
- Behaviour-preserving: same calls, same call order, same error messages (`"No institution found matching '{name}'."` and `"No 13F holdings reported by {holder.Name}."`), same `holder` / `reportDates` / `targetDate` propagated to callers.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — extract `ResolveHolderAndTargetDate(institutionName, reportDate)` returning `(holder, reportDates, targetDate, error)`. Call it from `GetInstitutionSummary` and `GetInstitutionSectorAllocation`, replacing the duplicated prologue with a single helper call plus an `if (error != null) return error;` guard. `GetInstitutionSectorAllocation` discards the unused `reportDates` slot. No public API change; no other call sites touched. `GetInstitutionQuarterlyActivity` is intentionally left alone because its threshold (`reportDates.Count < 2`) and error message differ.