### PR TITLE
refactor(holdings-mcp): collapse duplicated parse-or-fetch-latest report-date blocks into TryResolveLatestReportDate helper

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -56,19 +56,12 @@ public class InstitutionalHoldingsTools
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
-                DateOnly targetDate;
-                if (TryParseReportDate(reportDate, out var parsed))
-                {
-                    targetDate = parsed;
-                }
-                else
-                {
-                    var latestDate = await GetReportDatesByStock(stock).FirstOrDefaultAsync();
-
-                    if (latestDate == default)
-                        return $"No institutional holdings data available for {ticker}.";
-                    targetDate = latestDate;
-                }
+                var (targetDate, found) = await TryResolveLatestReportDate(
+                    reportDate,
+                    GetReportDatesByStock(stock)
+                );
+                if (!found)
+                    return $"No institutional holdings data available for {ticker}.";
 
                 var allHoldings = _holdingRepository.GetByStock(stock, targetDate);
                 var totalInstitutions = await allHoldings
@@ -200,19 +193,12 @@ public class InstitutionalHoldingsTools
 
                 var holder = holders.First();
 
-                DateOnly targetDate;
-                if (TryParseReportDate(reportDate, out var parsed))
-                {
-                    targetDate = parsed;
-                }
-                else
-                {
-                    var latestDate = await GetReportDatesByHolder(holder).FirstOrDefaultAsync();
-
-                    if (latestDate == default)
-                        return $"No holdings data for {holder.Name}.";
-                    targetDate = latestDate;
-                }
+                var (targetDate, found) = await TryResolveLatestReportDate(
+                    reportDate,
+                    GetReportDatesByHolder(holder)
+                );
+                if (!found)
+                    return $"No holdings data for {holder.Name}.";
 
                 var holdings = await _holdingRepository
                     .GetByHolder(holder, targetDate)
@@ -1107,6 +1093,18 @@ public class InstitutionalHoldingsTools
         TryParseReportDate(input, out var parsed) && validDates.Contains(parsed)
             ? parsed
             : validDates[0];
+
+    private static async Task<(DateOnly Date, bool Found)> TryResolveLatestReportDate(
+        string input,
+        IQueryable<DateOnly> dateSource
+    )
+    {
+        if (TryParseReportDate(input, out var parsed))
+            return (parsed, true);
+
+        var latest = await dateSource.FirstOrDefaultAsync();
+        return (latest, latest != default);
+    }
 
     private class HolderAggregate
     {


### PR DESCRIPTION
## Summary

- Two MCP tools (`GetTopHolders`, `GetInstitutionPortfolio`) repeated the same 13-line "parse the user-supplied `reportDate`, otherwise pull the latest from `IQueryable<DateOnly>` and bail out if nothing exists" block — only differing in the `IQueryable` source and the user-facing not-found message.
- Extracted that to a private `static async Task<(DateOnly Date, bool Found)> TryResolveLatestReportDate(string input, IQueryable<DateOnly> dateSource)` next to the existing `TryParseReportDate` / `ResolveReportDate` helpers. Call sites keep their own error strings, so external tool output is unchanged.
- Behavior-preserving: same `TryParseReportDate` then `FirstOrDefaultAsync` sequence; the `IQueryable` is still constructed by the same `GetReportDatesByStock(stock)` / `GetReportDatesByHolder(holder)` call and only enumerated in the parse-fails branch; the `latestDate == default` empty-check is preserved as `Found = latest != default`. Net `-26 / +24`.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — replaced the duplicated date-resolution `if/else` in `GetTopHolders` and `GetInstitutionPortfolio` with calls to the new `TryResolveLatestReportDate` helper; helper added in the same private-helpers block at the bottom of the class.