### PR TITLE
test(sec): add skipped repro for GH-1350 — FtdImportService.IsRecentFtdFile year-zero throws

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceIsRecentFtdFileYearZeroTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceIsRecentFtdFileYearZeroTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FtdImportServiceIsRecentFtdFileYearZeroTests
+{
+    // Contract (doc-comment + explicit validation gates): IsRecentFtdFile returns
+    // true iff the embedded YYYYMM is within the last 2 months, returns false for
+    // any malformed input, and never throws. The body validates length and gates
+    // `month is >= 1 and <= 12`, but does not gate year >= 1. `int.TryParse("0000",
+    // out year)` succeeds with year=0, both span parses pass, and execution falls
+    // through to `new DateOnly(0, 1, 1)` — whose constructor requires year >= 1
+    // and throws ArgumentOutOfRangeException. A filename whose YYYY slice is all
+    // zeros (a corrupted/zero-prefixed filename surfacing from SEC, a mirror, or
+    // any caller that hands the helper an attacker-shaped or accidentally-empty
+    // string) crashes the scrape cycle instead of being silently rejected.
+    [Fact(Skip = "GH-1350 — IsRecentFtdFile throws on year=0 instead of returning false")]
+    public void IsRecentFtdFile_YearZero_ReturnsFalse()
+    {
+        var result = FtdImportService.IsRecentFtdFile("cnsfails000001a.zip");
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `FtdImportService.IsRecentFtdFile(string)`. Contract (per doc-comment + the body's explicit validation gates): returns `true` iff the filename's embedded YYYYMM is within the last 2 months, returns `false` for any malformed input, never throws.
- Input `"cnsfails000001a.zip"` exposes a gap: `int.TryParse("0000", out year)` succeeds with `year = 0`; every existing gate (`length >= 17`, two `TryParse`s, `month is 1..12`) passes; execution falls through to `new DateOnly(0, 1, 1)` which throws `ArgumentOutOfRangeException` because `DateOnly` requires `year >= 1`. A zero-prefixed YYYY filename crashes the scrape cycle instead of being silently rejected.
- Bug filed as **#1350**. Test ships as `[Fact(Skip = "GH-1350 — ...")]` — un-skip as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Sec/FtdImportServiceIsRecentFtdFileYearZeroTests.cs` — new file, one `[Fact(Skip = "GH-1350 — ...")]` pinning the contract. The comment above the test states the contract derived from the doc-comment plus the validation-gate intent (so future readers see why this is a bug and not a "we just don't support year 0" choice).