### PR TITLE
refactor(holdings-activity): collapse sentinel-style date resolution to index-first form

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -35,13 +35,9 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count == 0)
             return View(viewModel);
 
-        var selectedDate = date ?? reportDates[0];
-        var selectedIndex = reportDates.IndexOf(selectedDate);
-        if (selectedIndex < 0)
-        {
-            selectedDate = reportDates[0];
-            selectedIndex = 0;
-        }
+        var requestedIndex = date.HasValue ? reportDates.IndexOf(date.Value) : -1;
+        var selectedIndex = requestedIndex < 0 ? 0 : requestedIndex;
+        var selectedDate = reportDates[selectedIndex];
         viewModel.SelectedDate = selectedDate;
 
         var previousDate =


### PR DESCRIPTION
## Summary

- `HoldingsActivityController.Activity` carried a five-line sentinel-style selected-date resolver: `selectedDate = date ?? reportDates[0]` → `IndexOf(...)` → `if (selectedIndex < 0) { reassign both }`. Two reassignments and a redundant `IndexOf` lookup on the not-found branch.
- Collapse to three lines: compute the requested index once (gated on `date.HasValue`), normalize `-1` to `0`, read `selectedDate` from `reportDates[selectedIndex]`. Same observable result for every input shape; just one `IndexOf` call now.
- Note: `ProfilesController` and `HoldingsExportController` already have similar `ResolveSelectedDate` helpers but they're `private static`; cross-file extraction belongs to a separate follow-up.

## Code changes

- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — `Activity` action: replace the sentinel-style resolver with `requestedIndex / selectedIndex / selectedDate` triple; behavior unchanged.