### PR TITLE
docs(technical/scrapers): split WaitForNextCycle hook from HoldingsScraperWorker usage

### DIFF
--- a/docs/technical/scrapers.md
+++ b/docs/technical/scrapers.md
@@ -29,7 +29,8 @@ Built-in behavior:
 
 Subclass-specific extras (worth knowing because they show up in multiple workers):
 
-- `WaitForNextCycle(interval, stoppingToken)` — override hook to interrupt the sleep on an external signal. [`HoldingsScraperWorker`](../../src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs) uses it to wake immediately when `HoldingsRescanSignal` fires after a `StockCusipChanged` event.
+- `WaitForNextCycle(interval, stoppingToken)` — override hook to interrupt the sleep on an external signal.
+- [`HoldingsScraperWorker`](../../src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs) uses `WaitForNextCycle` to wake immediately when `HoldingsRescanSignal` fires after a `StockCusipChanged` event.
 - Per-attempt retry delays exposed as `protected virtual` properties (e.g. `RetryDelays = [30s, 2m, 10m]`) so tests can collapse them without changing production.
 
 ## Integration clients — [`Equibles.Integrations.*`](../../src/Equibles.Integrations.Common)


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `WaitForNextCycle` bullet packed two facts into 300 chars: what the override hook does *and* how `HoldingsScraperWorker` uses it with `HoldingsRescanSignal`. "One fact per bullet — split it."

## Code changes

- `docs/technical/scrapers.md` — split the bullet into one stating the `WaitForNextCycle(interval, stoppingToken)` hook contract, and one showing `HoldingsScraperWorker` using it to wake on `HoldingsRescanSignal` after a `StockCusipChanged` event.