### PR TITLE
feat(web): add live activity page rendering the scraper SSE feed

### DIFF
--- a/src/Equibles.Web/Controllers/StatusController.cs
+++ b/src/Equibles.Web/Controllers/StatusController.cs
@@ -162,6 +162,13 @@ public class StatusController : BaseController
         );
     }
 
+    [HttpGet("~/Status/Activity")]
+    public IActionResult Activity()
+    {
+        ViewData["Title"] = "Live activity";
+        return View();
+    }
+
     [HttpGet("~/Status/Activity/Stream")]
     public async Task ActivityStream(CancellationToken cancellationToken)
     {

--- a/src/Equibles.Web/Views/Status/Activity.cshtml
+++ b/src/Equibles.Web/Views/Status/Activity.cshtml
@@ -1,0 +1,228 @@
+@{
+    ViewData["Title"] = "Live activity";
+}
+
+<div class="max-w-6xl mx-auto px-6 py-8 space-y-6">
+
+    <div class="flex flex-wrap items-center justify-between gap-3">
+        <div class="flex items-center gap-3">
+            <h1 class="text-2xl font-bold">Live activity</h1>
+            <span class="badge badge-ghost gap-1" data-activity-status>
+                <span class="loading loading-ring loading-xs" data-activity-spinner></span>
+                <span data-activity-status-text>Connecting…</span>
+            </span>
+        </div>
+
+        <div class="flex items-center gap-2">
+            <span class="text-xs text-base-content/50" data-activity-counter>0 events</span>
+            <button class="btn btn-ghost btn-sm" data-activity-clear title="Clear visible events">
+                <icon name="trash" size="4" /> Clear
+            </button>
+            <button class="btn btn-ghost btn-sm" data-activity-pause title="Pause live feed">
+                <icon name="pause" size="4" />
+                <span data-activity-pause-label>Pause</span>
+            </button>
+        </div>
+    </div>
+
+    <div class="card bg-base-100 shadow-sm">
+        <div class="card-body p-0">
+            <ul class="divide-y divide-base-200 max-h-[70vh] overflow-y-auto"
+                data-activity-list>
+                <li class="p-6 text-center text-base-content/50" data-activity-empty>
+                    <icon name="signal" size="8" class="mx-auto mb-2 opacity-50" />
+                    <p class="text-sm">No events yet. Scraper events will stream in as they happen.</p>
+                </li>
+            </ul>
+        </div>
+    </div>
+
+    <p class="text-xs text-base-content/50">
+        Live feed of what the background scrapers are doing right now. Nothing
+        is persisted — close the tab and the history goes with it. Historical
+        errors live on the
+        <a asp-action="Index" asp-controller="Status" class="link link-hover">Status</a>
+        page.
+    </p>
+</div>
+
+@section Scripts {
+    <script>
+        // Live activity feed: consumes the /Status/Activity/Stream SSE endpoint
+        // and renders each ScraperActivity as a row. Capped at 500 events in
+        // the DOM, oldest discarded — matches the broadcaster's server-side
+        // ring buffer. Pause stops appending without dropping the connection.
+        (function () {
+            const STREAM_URL = '@Url.Action("ActivityStream", "Status")';
+            const MAX_ROWS = 500;
+
+            const list = document.querySelector('[data-activity-list]');
+            const empty = list.querySelector('[data-activity-empty]');
+            const counter = document.querySelector('[data-activity-counter]');
+            const clearBtn = document.querySelector('[data-activity-clear]');
+            const pauseBtn = document.querySelector('[data-activity-pause]');
+            const pauseLabel = pauseBtn.querySelector('[data-activity-pause-label]');
+            const statusText = document.querySelector('[data-activity-status-text]');
+            const spinner = document.querySelector('[data-activity-spinner]');
+            const statusBadge = document.querySelector('[data-activity-status]');
+
+            let eventSource = null;
+            let paused = false;
+            let queueWhilePaused = [];
+            let rendered = 0;
+
+            // Tailwind can't see classes that only appear in JS strings — these
+            // names are referenced from main.css @@source inline so Tailwind keeps them.
+            const severityClasses = {
+                Info: 'badge badge-info',
+                Warn: 'badge badge-warning',
+                Error: 'badge badge-error',
+            };
+            const severityIcons = {
+                Info: 'information-circle',
+                Warn: 'exclamation-triangle',
+                Error: 'x-circle',
+            };
+
+            // Stable colour-per-module: deterministic hash so the same source
+            // always gets the same badge tint without a maintained map.
+            function moduleBadgeClass(source) {
+                const palette = [
+                    'badge badge-primary',
+                    'badge badge-secondary',
+                    'badge badge-accent',
+                    'badge badge-neutral',
+                    'badge badge-info',
+                ];
+                let h = 0;
+                for (let i = 0; i < source.length; i++) {
+                    h = (h * 31 + source.charCodeAt(i)) | 0;
+                }
+                return palette[Math.abs(h) % palette.length] + ' badge-sm';
+            }
+
+            // Escape a string for safe use as innerHTML text content
+            function esc(s) {
+                return String(s ?? '')
+                    .replaceAll('&', '&amp;')
+                    .replaceAll('<', '&lt;')
+                    .replaceAll('>', '&gt;')
+                    .replaceAll('"', '&quot;')
+                    .replaceAll("'", '&#39;');
+            }
+
+            // Format an ISO timestamp as HH:MM:SS local time
+            function fmtTime(ts) {
+                try {
+                    const d = new Date(ts);
+                    return d.toLocaleTimeString();
+                } catch {
+                    return ts;
+                }
+            }
+
+            // Render one activity row and append to the list
+            function appendRow(activity) {
+                if (empty && empty.parentNode === list) {
+                    list.removeChild(empty);
+                }
+
+                const row = document.createElement('li');
+                row.className = 'flex items-start gap-3 p-3';
+                const severityClass = severityClasses[activity.Severity] || 'badge badge-ghost';
+                const moduleClass = moduleBadgeClass(activity.Source);
+                row.innerHTML = `
+                    <span class="${severityClass} badge-sm shrink-0" title="${esc(activity.Severity)}">
+                        ${esc(activity.Severity)}
+                    </span>
+                    <span class="${moduleClass} shrink-0" title="${esc(activity.Source)}">
+                        ${esc(activity.Source)}
+                    </span>
+                    <span class="flex-1 text-sm break-words" data-activity-message>
+                        ${esc(activity.Message)}
+                    </span>
+                    <span class="text-xs text-base-content/50 whitespace-nowrap shrink-0">
+                        ${esc(fmtTime(activity.Timestamp))}
+                    </span>
+                `;
+                list.appendChild(row);
+                rendered++;
+
+                // Trim from the top so the visible buffer matches the server cap.
+                while (rendered > MAX_ROWS && list.firstElementChild) {
+                    list.removeChild(list.firstElementChild);
+                    rendered--;
+                }
+
+                counter.textContent = rendered + (rendered === 1 ? ' event' : ' events');
+
+                // Auto-scroll to bottom only if user was already near it — keeps
+                // someone reading older entries from being yanked away.
+                const nearBottom = list.scrollHeight - list.scrollTop - list.clientHeight < 60;
+                if (nearBottom) {
+                    list.scrollTop = list.scrollHeight;
+                }
+            }
+
+            // Set connection-status badge text
+            function setStatus(text, healthy) {
+                statusText.textContent = text;
+                statusBadge.className = 'badge gap-1 ' + (healthy ? 'badge-success' : 'badge-warning');
+                spinner.classList.toggle('hidden', healthy);
+            }
+
+            // Open the SSE connection (browser auto-reconnects on transient drops)
+            function connect() {
+                if (eventSource) eventSource.close();
+                eventSource = new EventSource(STREAM_URL);
+
+                eventSource.addEventListener('open', () => setStatus('Connected', true));
+                eventSource.addEventListener('error', () => setStatus('Reconnecting…', false));
+
+                // Server emits "activity" events; default "message" isn't used.
+                eventSource.addEventListener('activity', (ev) => {
+                    let activity;
+                    try {
+                        activity = JSON.parse(ev.data);
+                    } catch {
+                        return;
+                    }
+
+                    if (paused) {
+                        queueWhilePaused.push(activity);
+                        // Cap the off-screen queue too so a long pause can't
+                        // explode memory.
+                        if (queueWhilePaused.length > MAX_ROWS) {
+                            queueWhilePaused = queueWhilePaused.slice(-MAX_ROWS);
+                        }
+                        return;
+                    }
+                    appendRow(activity);
+                });
+            }
+
+            // Toggle pause / resume; on resume drain the off-screen queue.
+            pauseBtn.addEventListener('click', () => {
+                paused = !paused;
+                pauseLabel.textContent = paused ? 'Resume' : 'Pause';
+                if (!paused && queueWhilePaused.length > 0) {
+                    queueWhilePaused.forEach(appendRow);
+                    queueWhilePaused = [];
+                }
+            });
+
+            // Clear the visible list (and the off-screen queue) without
+            // disconnecting from the server.
+            clearBtn.addEventListener('click', () => {
+                while (list.firstChild) list.removeChild(list.firstChild);
+                if (empty) list.appendChild(empty);
+                rendered = 0;
+                queueWhilePaused = [];
+                counter.textContent = '0 events';
+            });
+
+            setStatus('Connecting…', false);
+            connect();
+        })();
+    </script>
+}

--- a/src/Equibles.Web/Views/Status/Index.cshtml
+++ b/src/Equibles.Web/Views/Status/Index.cshtml
@@ -11,18 +11,23 @@
 
 <div class="max-w-6xl mx-auto px-6 py-8 space-y-8">
 
-    <div class="flex items-center justify-between">
+    <div class="flex items-center justify-between gap-3 flex-wrap">
         <h1 class="text-2xl font-bold">System Status</h1>
-        <!-- Auto-refresh controls -->
-        <div class="flex items-center gap-2">
-            <span class="loading loading-ring loading-xs hidden" data-status-spinner></span>
-            <span class="text-sm text-base-content/50" data-status-countdown></span>
-            <div class="join">
-                <button class="btn btn-xs join-item" data-status-interval="1">1s</button>
-                <button class="btn btn-xs join-item btn-active" data-status-interval="5">5s</button>
-                <button class="btn btn-xs join-item" data-status-interval="30">30s</button>
+        <div class="flex items-center gap-3 flex-wrap">
+            <a asp-action="Activity" asp-controller="Status" class="btn btn-ghost btn-sm">
+                <icon name="signal" size="4" /> Live activity
+            </a>
+            <!-- Auto-refresh controls -->
+            <div class="flex items-center gap-2">
+                <span class="loading loading-ring loading-xs hidden" data-status-spinner></span>
+                <span class="text-sm text-base-content/50" data-status-countdown></span>
+                <div class="join">
+                    <button class="btn btn-xs join-item" data-status-interval="1">1s</button>
+                    <button class="btn btn-xs join-item btn-active" data-status-interval="5">5s</button>
+                    <button class="btn btn-xs join-item" data-status-interval="30">30s</button>
+                </div>
+                <input type="checkbox" class="toggle toggle-sm toggle-success" checked data-status-toggle title="Auto-refresh" />
             </div>
-            <input type="checkbox" class="toggle toggle-sm toggle-success" checked data-status-toggle title="Auto-refresh" />
         </div>
     </div>
 

--- a/tests/Equibles.FunctionalTests/Equibles.FunctionalTests.csproj
+++ b/tests/Equibles.FunctionalTests/Equibles.FunctionalTests.csproj
@@ -28,5 +28,6 @@
     <ProjectReference Include="..\..\src\Equibles.Web\Equibles.Web.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Migrations\Equibles.Migrations.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Mcp.Server\Equibles.Mcp.Server.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Equibles.FunctionalTests/Tests/StatusActivityTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StatusActivityTests.cs
@@ -1,0 +1,64 @@
+using Equibles.FunctionalTests.Fixtures;
+using Equibles.Messaging.Contracts.Activity;
+using Equibles.Web.Services.Activity;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class StatusActivityTests
+{
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public StatusActivityTests(WebAppFixture web, PlaywrightFixture playwright)
+    {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Activity_PublishedAfterOpen_AppearsInTheLiveList()
+    {
+        // Drive a real browser to /Status/Activity and confirm the page wires
+        // EventSource → SSE → DOM render. After the page opens, publish a
+        // ScraperActivity through the in-process broadcaster and assert the
+        // browser shows it. Without a Playwright check, the SSE plumbing only
+        // proves correct at the HTTP layer, not at the EventSource layer.
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/status/activity");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("h1")).ToHaveTextAsync("Live activity");
+
+        // Wait until the SSE connection is established before publishing — the
+        // server only forwards events that arrive AFTER a subscribe, and
+        // EventSource opens asynchronously.
+        await Assertions
+            .Expect(page.Locator("[data-activity-status-text]"))
+            .ToHaveTextAsync("Connected");
+
+        // Publish a unique-per-test message so a re-used browser context
+        // can't make the assertion pass on a stale row.
+        var unique = $"e2e-activity-{Guid.NewGuid():N}";
+        using var scope = _web.Services.CreateScope();
+        var broadcaster = scope.ServiceProvider.GetRequiredService<ActivityFeedBroadcaster>();
+        broadcaster.Publish(
+            new ScraperActivity(
+                Source: "SEC",
+                Severity: ScraperActivitySeverity.Info,
+                Message: unique,
+                Timestamp: DateTimeOffset.UtcNow,
+                CorrelationId: Guid.NewGuid().ToString()
+            )
+        );
+
+        await Assertions.Expect(page.GetByText(unique)).ToBeVisibleAsync(new() { Timeout = 5000 });
+    }
+}

--- a/tests/Equibles.IntegrationTests/Web/SeededViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/SeededViewRenderingTests.cs
@@ -128,5 +128,31 @@ public class SeededViewRenderingTests
                 "Seeded test error for view rendering",
                 "the seeded error must appear in the recent-errors table"
             );
+        // LowercaseUrls = true in Program.cs forces the rendered href to /status/activity.
+        html.Should()
+            .Contain(
+                "/status/activity",
+                "the Live activity link must point at the new page so users can navigate to it"
+            );
+    }
+
+    [Fact]
+    public async Task GetStatusActivity_RendersLiveActivityPageWithStreamUrl()
+    {
+        var response = await _fixture.Client.GetAsync("/Status/Activity");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Live activity", "the page heading must render");
+        html.Should()
+            .Contain(
+                "/status/activity/stream",
+                "the JS must point at the SSE endpoint resolved through Url.Action"
+            );
+        html.Should()
+            .Contain(
+                "data-activity-list",
+                "the live-tail list must be present for the script to fill in"
+            );
     }
 }


### PR DESCRIPTION
## Summary

- Slice 3/4 of the live scraper activity feed (#1162). Adds the `/Status/Activity` Razor page that consumes the SSE endpoint from slice 2 and renders incoming events in a live-tailing list with DaisyUI styling.
- No producers yet — that's slice 4, which closes the issue.

Refs #1162

## Code changes

- `src/Equibles.Web/Views/Status/Activity.cshtml` — new page. Severity badge per row, stable hash-derived module badge, wall-clock timestamp, pause / resume (queues while paused, drains on resume), clear, connection-status badge that flips to "Reconnecting…" on transient drops. 500-row cap with auto-scroll only when the user is already near the bottom.
- `src/Equibles.Web/Controllers/StatusController.cs` — `GET /Status/Activity` returns the view.
- `src/Equibles.Web/Views/Status/Index.cshtml` — adds a "Live activity" link in the header so the new page is discoverable from where users already look.
- `tests/Equibles.IntegrationTests/Web/SeededViewRenderingTests.cs` — view-rendering tests for the new page (heading + SSE URL + DOM hooks) and a cross-link assertion from the existing Status page.
- `tests/Equibles.FunctionalTests/Tests/StatusActivityTests.cs` — Playwright e2e: open the page, wait for SSE "Connected", publish via the in-process broadcaster, assert the row is visible.
- `tests/Equibles.FunctionalTests/Equibles.FunctionalTests.csproj` — references Equibles.Messaging so the test can construct a `ScraperActivity`.