### PR TITLE
refactor(fred-import): extract EnsureSeriesExists helper from ImportSeries

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/FredImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredImportService.cs
@@ -73,48 +73,9 @@ public class FredImportService
 
     private async Task ImportSeries(CuratedSeries curated, CancellationToken cancellationToken)
     {
-        FredSeries series;
-        using (var scope = _scopeFactory.CreateScope())
-        {
-            var seriesRepo = scope.ServiceProvider.GetRequiredService<FredSeriesRepository>();
-            series = await seriesRepo
-                .GetBySeriesId(curated.SeriesId)
-                .FirstOrDefaultAsync(cancellationToken);
-
-            if (series == null)
-            {
-                var metadata = await _fredClient.GetSeriesMetadata(curated.SeriesId);
-                if (metadata == null)
-                {
-                    _logger.LogWarning(
-                        "FRED series {SeriesId} not found in API, skipping",
-                        curated.SeriesId
-                    );
-                    return;
-                }
-
-                series = new FredSeries
-                {
-                    SeriesId = metadata.Id,
-                    Title = metadata.Title,
-                    Category = curated.Category,
-                    Frequency = metadata.FrequencyShort,
-                    Units = metadata.Units,
-                    SeasonalAdjustment = metadata.SeasonalAdjustmentShort,
-                    ObservationStart = ParseDate(metadata.ObservationStart),
-                    ObservationEnd = ParseDate(metadata.ObservationEnd),
-                };
-
-                seriesRepo.Add(series);
-                await seriesRepo.SaveChanges();
-
-                _logger.LogInformation(
-                    "Created FRED series {SeriesId} ({Title})",
-                    series.SeriesId,
-                    series.Title
-                );
-            }
-        }
+        var series = await EnsureSeriesExists(curated, cancellationToken);
+        if (series == null)
+            return;
 
         DateOnly startDate;
         using (var scope = _scopeFactory.CreateScope())
@@ -278,6 +239,54 @@ public class FredImportService
             totalInserted,
             curated.SeriesId
         );
+    }
+
+    private async Task<FredSeries> EnsureSeriesExists(
+        CuratedSeries curated,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var seriesRepo = scope.ServiceProvider.GetRequiredService<FredSeriesRepository>();
+        var series = await seriesRepo
+            .GetBySeriesId(curated.SeriesId)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (series != null)
+            return series;
+
+        var metadata = await _fredClient.GetSeriesMetadata(curated.SeriesId);
+        if (metadata == null)
+        {
+            _logger.LogWarning(
+                "FRED series {SeriesId} not found in API, skipping",
+                curated.SeriesId
+            );
+            return null;
+        }
+
+        series = new FredSeries
+        {
+            SeriesId = metadata.Id,
+            Title = metadata.Title,
+            Category = curated.Category,
+            Frequency = metadata.FrequencyShort,
+            Units = metadata.Units,
+            SeasonalAdjustment = metadata.SeasonalAdjustmentShort,
+            ObservationStart = ParseDate(metadata.ObservationStart),
+            ObservationEnd = ParseDate(metadata.ObservationEnd),
+        };
+
+        seriesRepo.Add(series);
+        await seriesRepo.SaveChanges();
+
+        _logger.LogInformation(
+            "Created FRED series {SeriesId} ({Title})",
+            series.SeriesId,
+            series.Title
+        );
+
+        return series;
     }
 
     private static DateOnly? ParseDate(string value)


### PR DESCRIPTION
## Summary

- Extract the 40-line "look up or create FredSeries" prologue from `FredImportService.ImportSeries` into a private `EnsureSeriesExists` helper, making the orchestration in `ImportSeries` linear.
- Behaviour-preserving: same scope lifecycle, same query, same fallback to `_fredClient.GetSeriesMetadata`, same null-check + warning log + skip, same `FredSeries` construction with identical field assignments, same `Add` + `SaveChanges`, same "Created FRED series" info log.

## Code changes

- `src/Equibles.Fred.HostedService/Services/FredImportService.cs` — extract `EnsureSeriesExists(curated, ct)` returning the resolved `FredSeries` (or `null` to signal "metadata unavailable, skip this series"). `ImportSeries` now starts with `var series = await EnsureSeriesExists(...); if (series == null) return;`. No public API change; helper is `private`.