### PR TITLE
docs(technical/migrations): split designsettings.json bullet — default vs. local override

### DIFF
--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -6,7 +6,8 @@ Every entity in the codebase lives in one shared EF Core migrations history at [
 
 - [`Equibles.Migrations.csproj`](../../src/Equibles.Migrations/Equibles.Migrations.csproj) — references **every** `Equibles.*.Data` project plus `Equibles.Messaging`. The snapshot has to know about every module's entities, so the migrations assembly references them all.
 - [`DesignTimeDbContextFactory.cs`](../../src/Equibles.Migrations/DesignTimeDbContextFactory.cs) — `IDesignTimeDbContextFactory<EquiblesDbContext>` that EF tooling invokes for `dotnet ef ...`.
-- [`designsettings.json`](../../src/Equibles.Migrations/designsettings.json) — connection string the design-time factory reads. Defaults to `Host=localhost;Port=5432;Database=equibles;Username=equibles;Password=equibles`. Override locally with `designsettings.Development.json` (gitignored).
+- [`designsettings.json`](../../src/Equibles.Migrations/designsettings.json) — connection string the design-time factory reads; defaults to `Host=localhost;Port=5432;Database=equibles;Username=equibles;Password=equibles`.
+- Override the default locally with `designsettings.Development.json` (gitignored).
 - [`Migrations/`](../../src/Equibles.Migrations/Migrations) — generated `<timestamp>_<Name>.cs` files plus the `EquiblesDbContextModelSnapshot.cs`.
 
 ## Design-time factory


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `designsettings.json` bullet packed 293 chars: what the file is, the long default connection string, *and* the local-override mechanism (`designsettings.Development.json`). Split so each fact gets its own bullet.

## Code changes

- `docs/technical/migrations.md` — split the `designsettings.json` bullet into one stating purpose + default connection string and one for the gitignored `designsettings.Development.json` override.