### PR TITLE
test(sec): pin SecDocumentEnvelopeParser.TryExtractPaperPdfFilename uppercase .PDF case-insensitive match

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserUppercaseExtensionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserUppercaseExtensionTests.cs
@@ -1,0 +1,41 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentEnvelopeParserUppercaseExtensionTests
+{
+    // Contract: TryExtractPaperPdfFilename matches the .pdf suffix with
+    // StringComparison.OrdinalIgnoreCase, so a legacy SEC paper-filing envelope
+    // emitting an uppercase ".PDF" filename must still be extracted. Every
+    // existing happy-path pin uses lowercase ".pdf"; the case-insensitivity
+    // arm is unpinned. A refactor that swaps the comparison to ordinal /
+    // case-sensitive would silently drop every uppercase paper filing on the
+    // floor, leaving callers with no PDF artifact to fetch.
+    [Fact]
+    public void TryExtractPaperPdfFilename_UppercasePdfExtension_MatchesCaseInsensitively()
+    {
+        var envelope = """
+            <SEC-DOCUMENT>
+            <DOCUMENT>
+            <TYPE>6-K
+            <SEQUENCE>1
+            <FILENAME>FORM6K.PDF
+            <DESCRIPTION>Form 6-K
+            <TEXT>
+            begin 644 FORM6K.PDF
+            (uuencoded body)
+            end
+            </TEXT>
+            </DOCUMENT>
+            </SEC-DOCUMENT>
+            """;
+
+        var found = SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(
+            envelope,
+            out var filename
+        );
+
+        found.Should().BeTrue();
+        filename.Should().Be("FORM6K.PDF");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `SecDocumentEnvelopeParser.TryExtractPaperPdfFilename`. Contract: the `.pdf` suffix check uses `StringComparison.OrdinalIgnoreCase`, so a legacy SEC paper-filing envelope emitting an uppercase `.PDF` filename must still be extracted.
- Every existing happy-path pin (`EnvelopeWrappingPdfDocument_ReturnsFilename`, etc.) feeds a lowercase `.pdf`; the case-insensitivity arm of the suffix check is unpinned. A refactor that swaps `OrdinalIgnoreCase` to ordinal / case-sensitive would silently drop every uppercase paper filing on the floor (caller would never get a PDF artifact to fetch from `/Archives/edgar/data/...`).
- Test passes — pins the case-insensitive behavior as a regression guard.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserUppercaseExtensionTests.cs` — new file, one `[Fact]` feeding an envelope whose `<FILENAME>` is `FORM6K.PDF` (uppercase extension) and asserting the parser returns `true` with `filename == "FORM6K.PDF"`. The WHY-comment above the test explains why the case-insensitive arm is worth a dedicated pin alongside the existing lowercase happy-path test.