### PR TITLE
refactor(sec-edgar-client): reuse FilesBaseUrl const in GetDocumentUrl

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -745,7 +745,7 @@ public class SecEdgarClient : ISecEdgarClient
         var formattedCik = FormatCik(cik);
 
         // Official SEC pattern for raw text files
-        return $"https://www.sec.gov/Archives/edgar/data/{formattedCik}/{accessionNumber}.txt";
+        return $"{FilesBaseUrl}/Archives/edgar/data/{formattedCik}/{accessionNumber}.txt";
     }
 
     private static string FormatCik(string cik)


### PR DESCRIPTION
## Summary

- `GetDocumentUrl` hardcoded the literal `https://www.sec.gov/Archives/edgar/data/...` even though the class already declares the const `FilesBaseUrl = "https://www.sec.gov"` (line 33) and uses it in `BuildArchiveUrl` and the company-tickers endpoint. Two places had the same base URL spelled out two different ways — a refactor that moves SEC requests to a different host (e.g. a mirror) would have to remember to update both.
- Behavior-preserving: `FilesBaseUrl` is exactly `"https://www.sec.gov"`, so `$"{FilesBaseUrl}/Archives/edgar/data/…"` produces the same string the literal did. All existing `GetDocumentUrl` unit tests (which assert the full URL including the literal `https://www.sec.gov/...`) and the `MapToFilingData` integration assertion still pass locally.
- Build green, full unit + integration suite green (2903 passed, 1 pre-existing skip for GH-1350), `csharpier check` green.

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — `GetDocumentUrl` now interpolates `FilesBaseUrl` instead of duplicating the literal `https://www.sec.gov` host. One-line diff; the existing WHY-comment ("Official SEC pattern for raw text files") is preserved.