### PR TITLE
test(sec-financialfacts): pin FiscalPeriodResolver out-of-range fyeDay rejection

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverOutOfRangeFyeDayTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverOutOfRangeFyeDayTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FiscalPeriodResolverOutOfRangeFyeDayTests
+{
+    // Contract (doc-comment + validation gate at the top of Resolve):
+    // returns null when the FYE is unknown — and the gate explicitly rejects
+    // fyeDay outside 1..31 alongside fyeMonth outside 1..12. The existing
+    // `OutOfRangeFyeMonth` pin exercises only the fyeMonth arm; the OR is
+    // short-circuit, so the fyeDay > 31 arm is not reached by that test.
+    // A nonsensical fyeDay (e.g. a corrupted EntityType.fy field deserialising
+    // to 32) must return null so the caller falls back to filing-supplied
+    // identity, not throw inside the later DateOnly construction.
+    [Fact]
+    public void Resolve_OutOfRangeFyeDay_ReturnsNullSoCallerFallsBack()
+    {
+        var result = FiscalPeriodResolver.Resolve(
+            periodStart: new DateOnly(2023, 09, 30),
+            periodEnd: new DateOnly(2024, 09, 28),
+            fyeMonth: 9,
+            fyeDay: 32
+        );
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Sibling coverage test for `FiscalPeriodResolver.Resolve`. The validation gate at the top of the method rejects four out-of-range conditions in one short-circuit `||` chain — `fyeMonth < 1`, `fyeMonth > 12`, `fyeDay < 1`, `fyeDay > 31`. The existing `OutOfRangeFyeMonth_ReturnsNull` pin exercises only the `fyeMonth > 12` arm; the `fyeDay > 31` arm is never reached by any existing test because the OR short-circuits before it.
- Pins the documented "Returns null when the FYE is unknown" contract for a nonsensical fyeDay (e.g. a corrupted `EntityType.fy` field deserialising to 32) so a future refactor that drops the `fyeDay > 31` clause — leaving construction to `DateOnly` — would surface here instead of crashing the financial-facts import pipeline.

## Code changes

- `tests/Equibles.UnitTests/Sec/FiscalPeriodResolverOutOfRangeFyeDayTests.cs` — new file, one `[Fact]` calling `Resolve` with `fyeMonth: 9, fyeDay: 32` and asserting the result is `null`. The WHY-comment above the test explains why the `fyeDay` arm is worth a dedicated pin alongside the existing `fyeMonth=13` test.