### PR TITLE
refactor(holdings-import): extract ParseHoldingRow helper from StreamAndInsertHoldings

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -486,53 +486,26 @@ public class HoldingsImportService
             TryParseDateOnly(submission.FilingDate, out var filingDate);
             TryParseDateOnly(submission.PeriodOfReport, out var reportDate);
 
-            var shareType = ParseShareType(GetValue(row, "SSHPRNAMTTYPE"));
-            var optionType = ParseOptionType(GetValue(row, "PUTCALL"));
-            var uniqueKey = BuildHoldingKey(
+            var (holding, managerEntry, valuePending) = ParseHoldingRow(
+                row,
+                accession,
+                cusip,
                 commonStockId,
                 holderId,
+                filingDate,
                 reportDate,
-                shareType,
-                optionType
+                context
             );
-
-            var isAmendment =
-                context.CoverPages.TryGetValue(accession, out var cp)
-                && string.Equals(cp.IsAmendment, "Y", StringComparison.OrdinalIgnoreCase);
-
-            var shares = ParseLong(GetValue(row, "SSHPRNAMT"));
-            var votingAuthSole = ParseLong(GetValue(row, "VOTING_AUTH_SOLE"));
-            var votingAuthShared = ParseLong(GetValue(row, "VOTING_AUTH_SHARED"));
-            var votingAuthNone = ParseLong(GetValue(row, "VOTING_AUTH_NONE"));
-
-            // Calculate value from Yahoo stock price
-            var hasPrice = context.StockPrices.TryGetValue(
-                (commonStockId, reportDate),
-                out var closePrice
-            );
-            var value = hasPrice ? (long)(shares * closePrice) : 0L;
-            var valuePending = !hasPrice;
-
-            var otherManagerNumber = ParseNullableInt(GetValue(row, "OTHERMANAGER"));
-            var discretion = ParseInvestmentDiscretion(GetValue(row, "INVESTMENTDISCRETION"));
-
-            var managerEntry = new HoldingManagerEntry
-            {
-                ManagerNumber = otherManagerNumber,
-                ManagerName = ResolveManagerName(context, accession, otherManagerNumber),
-                Shares = shares,
-                Value = value,
-                InvestmentDiscretion = discretion,
-            };
+            var uniqueKey = BuildHoldingKey(holding);
 
             if (holdingsMap.TryGetValue(uniqueKey, out var existing))
             {
                 totalDuplicates++;
-                existing.Shares += shares;
-                existing.Value += value;
-                existing.VotingAuthSole += votingAuthSole;
-                existing.VotingAuthShared += votingAuthShared;
-                existing.VotingAuthNone += votingAuthNone;
+                existing.Shares += holding.Shares;
+                existing.Value += holding.Value;
+                existing.VotingAuthSole += holding.VotingAuthSole;
+                existing.VotingAuthShared += holding.VotingAuthShared;
+                existing.VotingAuthNone += holding.VotingAuthNone;
                 existing.ManagerEntries.Add(managerEntry);
             }
             else
@@ -540,26 +513,6 @@ public class HoldingsImportService
                 if (valuePending)
                     totalPending++;
 
-                var holding = new InstitutionalHolding
-                {
-                    InstitutionalHolderId = holderId,
-                    CommonStockId = commonStockId,
-                    FilingDate = filingDate,
-                    ReportDate = reportDate,
-                    Value = value,
-                    Shares = shares,
-                    ShareType = shareType,
-                    OptionType = optionType,
-                    InvestmentDiscretion = discretion,
-                    VotingAuthSole = votingAuthSole,
-                    VotingAuthShared = votingAuthShared,
-                    VotingAuthNone = votingAuthNone,
-                    TitleOfClass = GetValue(row, "TITLEOFCLASS"),
-                    Cusip = cusip,
-                    AccessionNumber = accession,
-                    IsAmendment = isAmendment,
-                    ValuePending = valuePending,
-                };
                 holding.ManagerEntries.Add(managerEntry);
                 holdingsMap[uniqueKey] = holding;
             }
@@ -603,6 +556,76 @@ public class HoldingsImportService
             totalDuplicates,
             totalPending
         );
+    }
+
+    private static (
+        InstitutionalHolding Holding,
+        HoldingManagerEntry ManagerEntry,
+        bool ValuePending
+    ) ParseHoldingRow(
+        Dictionary<string, string> row,
+        string accession,
+        string cusip,
+        Guid commonStockId,
+        Guid holderId,
+        DateOnly filingDate,
+        DateOnly reportDate,
+        ImportContext context
+    )
+    {
+        var shareType = ParseShareType(GetValue(row, "SSHPRNAMTTYPE"));
+        var optionType = ParseOptionType(GetValue(row, "PUTCALL"));
+
+        var isAmendment =
+            context.CoverPages.TryGetValue(accession, out var cp)
+            && string.Equals(cp.IsAmendment, "Y", StringComparison.OrdinalIgnoreCase);
+
+        var shares = ParseLong(GetValue(row, "SSHPRNAMT"));
+        var votingAuthSole = ParseLong(GetValue(row, "VOTING_AUTH_SOLE"));
+        var votingAuthShared = ParseLong(GetValue(row, "VOTING_AUTH_SHARED"));
+        var votingAuthNone = ParseLong(GetValue(row, "VOTING_AUTH_NONE"));
+
+        var hasPrice = context.StockPrices.TryGetValue(
+            (commonStockId, reportDate),
+            out var closePrice
+        );
+        var value = hasPrice ? (long)(shares * closePrice) : 0L;
+        var valuePending = !hasPrice;
+
+        var otherManagerNumber = ParseNullableInt(GetValue(row, "OTHERMANAGER"));
+        var discretion = ParseInvestmentDiscretion(GetValue(row, "INVESTMENTDISCRETION"));
+
+        var managerEntry = new HoldingManagerEntry
+        {
+            ManagerNumber = otherManagerNumber,
+            ManagerName = ResolveManagerName(context, accession, otherManagerNumber),
+            Shares = shares,
+            Value = value,
+            InvestmentDiscretion = discretion,
+        };
+
+        var holding = new InstitutionalHolding
+        {
+            InstitutionalHolderId = holderId,
+            CommonStockId = commonStockId,
+            FilingDate = filingDate,
+            ReportDate = reportDate,
+            Value = value,
+            Shares = shares,
+            ShareType = shareType,
+            OptionType = optionType,
+            InvestmentDiscretion = discretion,
+            VotingAuthSole = votingAuthSole,
+            VotingAuthShared = votingAuthShared,
+            VotingAuthNone = votingAuthNone,
+            TitleOfClass = GetValue(row, "TITLEOFCLASS"),
+            Cusip = cusip,
+            AccessionNumber = accession,
+            IsAmendment = isAmendment,
+            ValuePending = valuePending,
+        };
+
+        return (holding, managerEntry, valuePending);
     }
 
     private async Task<int> FlushBatch(


### PR DESCRIPTION
## Summary

- Extract the ~40-line "parse TSV row → compute shares/value/voting/discretion → build `InstitutionalHolding` + `HoldingManagerEntry`" inline block out of `HoldingsImportService.StreamAndInsertHoldings` into a private static `ParseHoldingRow` helper returning `(Holding, ManagerEntry, ValuePending)`. The loop body keeps the dedup/insert branching, batch-flush, and counter logic.
- Behaviour-preserving: same `ParseShareType/ParseOptionType/ParseLong/ParseNullableInt/ParseInvestmentDiscretion/ResolveManagerName/GetValue` calls in the same order, same `(stockId, reportDate)` price lookup, same field assignments on the constructed `InstitutionalHolding`. The dedup branch now reads `existing.Shares += holding.Shares` (etc.) — identical values via the returned holding's properties — and `BuildHoldingKey(holding)` uses the existing `BuildHoldingKey(InstitutionalHolding)` overload.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — add `private static (InstitutionalHolding, HoldingManagerEntry, bool) ParseHoldingRow(...)`. Replace the inline parse block inside `StreamAndInsertHoldings` with `var (holding, managerEntry, valuePending) = ParseHoldingRow(...);` followed by `var uniqueKey = BuildHoldingKey(holding);` and the same dedup-or-insert branches. No public API change; helper is `private static`.