### PR TITLE
refactor(insider-trading-processor): extract XML envelope tags as named consts in SanitizeXml

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -385,14 +385,17 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         return element?.Element("value")?.Value;
     }
 
+    private const string XmlEnvelopeStart = "<XML>";
+    private const string XmlEnvelopeEnd = "</XML>";
+
     internal static string SanitizeXml(string xml)
     {
         // SEC filings wrap the actual XML inside an SGML envelope.
-        var xmlStart = xml.IndexOf("<XML>", StringComparison.OrdinalIgnoreCase);
-        var xmlEnd = xml.IndexOf("</XML>", StringComparison.OrdinalIgnoreCase);
+        var xmlStart = xml.IndexOf(XmlEnvelopeStart, StringComparison.OrdinalIgnoreCase);
+        var xmlEnd = xml.IndexOf(XmlEnvelopeEnd, StringComparison.OrdinalIgnoreCase);
         if (xmlStart >= 0 && xmlEnd > xmlStart)
         {
-            xml = xml[(xmlStart + 5)..xmlEnd].Trim();
+            xml = xml[(xmlStart + XmlEnvelopeStart.Length)..xmlEnd].Trim();
         }
 
         // Fix unescaped ampersands in entity names


### PR DESCRIPTION
## Summary

- `SanitizeXml` hardcoded the SGML envelope tags `<XML>` and `</XML>` as inline string literals AND a magic offset of `5` (the hand-counted length of `<XML>`). The string and the offset were two coupled facts living in three places: the tag string in `IndexOf` for both ends, and the offset in the substring slice. Changing the envelope tag would silently desynchronize the offset.
- Promoted the two tag literals to private const fields (`XmlEnvelopeStart`, `XmlEnvelopeEnd`) right above the method, and replaced the magic offset with `XmlEnvelopeStart.Length`. Single source of truth.
- Behavior-preserving: `"<XML>".Length == 5`; both `IndexOf` calls feed the same string via the const with the same `OrdinalIgnoreCase` comparison; the substring slice resolves to byte-identical character positions. Build green, full unit + integration suite green (2906 passed, 1 pre-existing skip for GH-1350), `csharpier check` green.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — added `private const string XmlEnvelopeStart = "<XML>"` and `XmlEnvelopeEnd = "</XML>"`, threaded both through the two `IndexOf` calls and the substring offset (`xmlStart + XmlEnvelopeStart.Length` instead of `xmlStart + 5`). The existing WHY-comment ("SEC filings wrap the actual XML inside an SGML envelope.") is preserved.