### PR TITLE
docs(technical/scrapers): split RequestRetrySoon bullet

### DIFF
--- a/docs/technical/scrapers.md
+++ b/docs/technical/scrapers.md
@@ -25,7 +25,9 @@ Built-in behavior:
 
 - One try/catch per cycle. Unhandled exceptions go through `ErrorReporter.Report(ErrorSource, "<Worker>.DoWork", ...)` and the loop sleeps to the next cycle instead of crashing the host.
 - `OperationCanceledException` during shutdown logs and exits cleanly — never reported as an error.
-- `RequestRetrySoon()` — sets a flag mid-cycle that swaps the next wait from `SleepInterval` to `NotReadyRetryInterval` (default 2 minutes). Used when a dependency isn't ready yet (e.g. cold-start race where `CommonStock` hasn't been seeded). Flag resets at the start of every cycle.
+- `RequestRetrySoon()` — sets a flag mid-cycle that swaps the next wait from `SleepInterval` to `NotReadyRetryInterval` (default 2 minutes).
+- Used when a dependency isn't ready yet (e.g. cold-start race where `CommonStock` hasn't been seeded).
+- The flag resets at the start of every cycle.
 
 Subclass-specific extras (worth knowing because they show up in multiple workers):
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `RequestRetrySoon()` bullet packed 285 chars: the mechanism (flag → `NotReadyRetryInterval`), the use case (cold-start dependency races), and the lifecycle note (flag resets each cycle). Split into three single-fact bullets.

## Code changes

- `docs/technical/scrapers.md` — split `RequestRetrySoon()` into one bullet for the swap mechanism, one for the cold-start use case with the `CommonStock` example, and one for the per-cycle reset.