### PR TITLE
refactor(insider-trading): extract EnsureInsiderOwnerExists helper from Process

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -159,29 +159,12 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             return false;
         }
 
-        var owner = await ownerRepository.GetByOwnerCik(ownerCik);
-        if (owner == null)
-        {
-            var ownerAddress = ownerElement.Element("reportingOwnerAddress");
-            var ownerRelationship = ownerElement.Element("reportingOwnerRelationship");
-
-            owner = new InsiderOwner
-            {
-                OwnerCik = ownerCik,
-                Name = ownerName,
-                City = ownerAddress?.Element("rptOwnerCity")?.Value?.Trim(),
-                StateOrCountry = ownerAddress?.Element("rptOwnerStateOrCountry")?.Value?.Trim(),
-                IsDirector = ParseBool(ownerRelationship?.Element("isDirector")?.Value),
-                IsOfficer = ParseBool(ownerRelationship?.Element("isOfficer")?.Value),
-                OfficerTitle = ownerRelationship?.Element("officerTitle")?.Value?.Trim(),
-                IsTenPercentOwner = ParseBool(
-                    ownerRelationship?.Element("isTenPercentOwner")?.Value
-                ),
-            };
-
-            ownerRepository.Add(owner);
-            await ownerRepository.SaveChanges();
-        }
+        var owner = await EnsureInsiderOwnerExists(
+            ownerRepository,
+            ownerCik,
+            ownerName,
+            ownerElement
+        );
 
         var isAmendment = filing.Form.Contains("/A", StringComparison.OrdinalIgnoreCase);
 
@@ -266,6 +249,37 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         );
 
         return true;
+    }
+
+    private static async Task<InsiderOwner> EnsureInsiderOwnerExists(
+        InsiderOwnerRepository ownerRepository,
+        string ownerCik,
+        string ownerName,
+        XElement ownerElement
+    )
+    {
+        var owner = await ownerRepository.GetByOwnerCik(ownerCik);
+        if (owner != null)
+            return owner;
+
+        var ownerAddress = ownerElement.Element("reportingOwnerAddress");
+        var ownerRelationship = ownerElement.Element("reportingOwnerRelationship");
+
+        owner = new InsiderOwner
+        {
+            OwnerCik = ownerCik,
+            Name = ownerName,
+            City = ownerAddress?.Element("rptOwnerCity")?.Value?.Trim(),
+            StateOrCountry = ownerAddress?.Element("rptOwnerStateOrCountry")?.Value?.Trim(),
+            IsDirector = ParseBool(ownerRelationship?.Element("isDirector")?.Value),
+            IsOfficer = ParseBool(ownerRelationship?.Element("isOfficer")?.Value),
+            OfficerTitle = ownerRelationship?.Element("officerTitle")?.Value?.Trim(),
+            IsTenPercentOwner = ParseBool(ownerRelationship?.Element("isTenPercentOwner")?.Value),
+        };
+
+        ownerRepository.Add(owner);
+        await ownerRepository.SaveChanges();
+        return owner;
     }
 
     private InsiderTransaction ParseTransaction(


### PR DESCRIPTION
## Summary

- Extract the inline ~22-line "look up `InsiderOwner` by CIK → on miss extract `reportingOwnerAddress` / `reportingOwnerRelationship` fields → construct + Add + SaveChanges" block out of `InsiderTradingFilingProcessor.Process` into a private static `EnsureInsiderOwnerExists` helper.
- Behaviour-preserving: same `GetByOwnerCik` lookup, same XML element navigation on miss (`reportingOwnerAddress`, `reportingOwnerRelationship`), same field assignments on the constructed `InsiderOwner` (`OwnerCik`, `Name`, `City`, `StateOrCountry`, `IsDirector`, `IsOfficer`, `OfficerTitle`, `IsTenPercentOwner`) with the same `?.Value?.Trim()` chains and `ParseBool` calls, same `Add` + `SaveChanges`.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — add `private static async Task<InsiderOwner> EnsureInsiderOwnerExists(ownerRepository, ownerCik, ownerName, ownerElement)`. Caller now does `var owner = await EnsureInsiderOwnerExists(...)`. No public API change; helper is `private static`.