### PR TITLE
test(sec-financialfacts): pin InlineXbrlParser fixed-zero format hint emits zero

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserFixedZeroFormatTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserFixedZeroFormatTests.cs
@@ -1,0 +1,47 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InlineXbrlParserFixedZeroFormatTests
+{
+    private const string DocOpen =
+        "<html "
+        + "xmlns=\"http://www.w3.org/1999/xhtml\" "
+        + "xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\" "
+        + "xmlns:ixt=\"http://www.xbrl.org/inlineXBRL/transformation/2015-02-26\" "
+        + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+        + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+        + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2018-01-31\""
+        + "><body><div style=\"display:none\"><ix:header><ix:resources>";
+
+    private const string ResourcesEnd = "</ix:resources></ix:header></div>";
+
+    private const string DocClose = "</body></html>";
+
+    // Sibling to Parse_NumDashFormat_ReturnsZero. The WHY-comment on the zero-format
+    // branch enumerates THREE Inline XBRL Transformations format hints that mean
+    // "hard-coded zero" — `numdash`, `fixed-zero`, `fixedzero`. Only the first is
+    // pinned by the existing test; the `fixed-zero` arm (the standard spelling
+    // per the Inline XBRL 1.1 transformation registry) is short-circuited away by
+    // the leading `||`, so a refactor that drops the dash-spelled clause would
+    // silently parse the literal content of every `format="ixt:fixed-zero"` fact
+    // (often a placeholder dash or "0") instead of emitting 0.
+    [Fact]
+    public void Parse_FixedZeroFormat_ReturnsZero()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"us-gaap:Revenues\" contextRef=\"C1\" unitRef=\"u\" format=\"ixt:fixed-zero\">&#8212;</ix:nonFraction>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Value.Should().Be(0m);
+    }
+}


### PR DESCRIPTION
## Summary

- Sibling coverage to the existing `Parse_NumDashFormat_ReturnsZero` pin on `InlineXbrlParser`. The WHY-comment on the zero-format short-circuit lists three Inline XBRL Transformations format hints that mean "value is a hard-coded zero": `numdash`, `fixed-zero`, `fixedzero`. The existing test exercises `numdash`; the dash-spelled `fixed-zero` arm (the standard Inline XBRL 1.1 transformation registry spelling) is gated away by the leading `||` short-circuit and currently unpinned.
- A refactor that drops the dash-spelled clause (e.g. "normalising" the two `fixed-zero` spellings into a single `fixedzero` check) would silently leave every `format="ixt:fixed-zero"` fact carrying the literal content (often a placeholder em-dash or "0") instead of emitting 0 — and standard Inline XBRL filings use the dash form. Pin the arm.
- Test passes locally.

## Code changes

- `tests/Equibles.UnitTests/Sec/InlineXbrlParserFixedZeroFormatTests.cs` — new file, one `[Fact]` building a minimal Inline XBRL document with `format="ixt:fixed-zero"` on an `ix:nonFraction` element carrying a `—` (em-dash) placeholder and asserting the parsed fact's value is `0m`. Self-contained — copies the standard `DocOpen`/`ResourcesEnd`/`DocClose` const triplet locally so the test stays one file per `/add-test` rule.