### PR TITLE
refactor(congress-mcp): collapse McpToolExecutor boilerplate behind private Execute helper

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -53,7 +53,7 @@ public class CongressTools
             int maxResults = 50
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var stock = await _commonStockRepository.GetByTicker(
@@ -109,10 +109,8 @@ public class CongressTools
 
                 return result.ToString();
             },
-            _logger,
             "GetCongressionalTrades",
-            $"ticker: {ticker}",
-            ReportError
+            $"ticker: {ticker}"
         );
     }
 
@@ -133,7 +131,7 @@ public class CongressTools
             int maxResults = 50
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var member = await _memberRepository.GetByName(memberName.Trim());
@@ -188,10 +186,8 @@ public class CongressTools
 
                 return result.ToString();
             },
-            _logger,
             "GetMemberTrades",
-            $"memberName: {memberName}",
-            ReportError
+            $"memberName: {memberName}"
         );
     }
 
@@ -205,7 +201,7 @@ public class CongressTools
         [Description("Maximum number of results to return (default: 20)")] int maxResults = 20
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var members = await _memberRepository
@@ -230,12 +226,13 @@ public class CongressTools
 
                 return result.ToString();
             },
-            _logger,
             "SearchCongressMembers",
-            $"query: {query}",
-            ReportError
+            $"query: {query}"
         );
     }
+
+    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
+        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
 
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {


### PR DESCRIPTION
## Summary

- Mirrors the helper that just landed in `Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs:402` (PR #1367). `CongressTools` had three `McpToolExecutor.Execute(work, _logger, "ToolName", $"ctx", ReportError)` call sites where `_logger` and `ReportError` are class-instance state — pure boilerplate at every tool entry.
- Extracted a private `Execute(Func<Task<string>> work, string toolName, string context)` forwarder. Each tool call drops the two redundant arguments.
- Behavior-preserving: the helper calls the same `McpToolExecutor.Execute` with the same arguments in the same positional order; no logger swap, no delegate change. Build green, full unit + integration suite green (the pre-existing `RateLimiterTests.ConcurrentCallers_ExceedingCapacity_HonorRatePerWindow` flake passes when run alone — unrelated to this PR's changes, which don't touch `RateLimiter`). `csharpier check` green.

## Code changes

- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — added a private `Execute` helper next to the existing `ReportError` / `ParseDateOr`, and threaded the three call sites in `GetCongressionalTrades`, `GetMemberTrades`, and `SearchCongressMembers` through it. Net `-12 / +9`.