### PR TITLE
refactor(congress-mcp): extract ApplyTransactionTypeFilter helper for duplicated enum-filter block

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -69,18 +69,7 @@ public class CongressTools
                 var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
                 var query = _tradeRepository.GetByStock(stock, start, end);
-
-                if (
-                    !string.IsNullOrEmpty(transactionType)
-                    && Enum.TryParse<CongressTransactionType>(
-                        transactionType,
-                        true,
-                        out var parsedType
-                    )
-                )
-                {
-                    query = query.Where(t => t.TransactionType == parsedType);
-                }
+                query = ApplyTransactionTypeFilter(query, transactionType);
 
                 var trades = await query
                     .Include(t => t.CongressMember)
@@ -149,18 +138,7 @@ public class CongressTools
                 var query = _tradeRepository
                     .GetByMember(member)
                     .Where(t => t.TransactionDate >= start && t.TransactionDate <= end);
-
-                if (
-                    !string.IsNullOrEmpty(transactionType)
-                    && Enum.TryParse<CongressTransactionType>(
-                        transactionType,
-                        true,
-                        out var parsedType
-                    )
-                )
-                {
-                    query = query.Where(t => t.TransactionType == parsedType);
-                }
+                query = ApplyTransactionTypeFilter(query, transactionType);
 
                 var trades = await query
                     .Include(t => t.CommonStock)
@@ -240,6 +218,21 @@ public class CongressTools
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
+    }
+
+    private static IQueryable<CongressionalTrade> ApplyTransactionTypeFilter(
+        IQueryable<CongressionalTrade> query,
+        string transactionType
+    )
+    {
+        if (
+            string.IsNullOrEmpty(transactionType)
+            || !Enum.TryParse<CongressTransactionType>(transactionType, true, out var parsedType)
+        )
+        {
+            return query;
+        }
+        return query.Where(t => t.TransactionType == parsedType);
     }
 
     private static DateOnly ParseDateOr(string text, DateOnly fallback) =>


### PR DESCRIPTION
## Summary

- `CongressTools.GetCongressionalTrades` and `CongressTools.GetMemberTrades` both carried an identical 11-line block: `if (!string.IsNullOrEmpty(transactionType) && Enum.TryParse<CongressTransactionType>(...)) query = query.Where(...)`.
- Extract the chain into a private static `ApplyTransactionTypeFilter(IQueryable<CongressionalTrade>, string)` helper next to `ParseDateOr`. Both call sites become a one-liner: `query = ApplyTransactionTypeFilter(query, transactionType);`.
- Behavior-preserving: the helper performs the identical guards (`string.IsNullOrEmpty` short-circuits, then `Enum.TryParse` with `ignoreCase: true`) and returns the original query unchanged when the input is null/empty/unrecognized — same fall-through, same `Where(t => t.TransactionType == parsedType)` predicate when valid.

## Code changes

- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — replaced the two inline blocks with calls to the new private static helper; helper inverts the guard to an early-return for readability but is logically equivalent to the inline form.