### PR TITLE
test(sec): pin ChunkingStrategy.CleanText strips style element CSS body

### DIFF
--- a/tests/Equibles.UnitTests/Sec/ChunkingStrategyCleanTextStyleTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ChunkingStrategyCleanTextStyleTests.cs
@@ -1,0 +1,31 @@
+using Equibles.Sec.BusinessLogic.Processing;
+using Equibles.Sec.BusinessLogic.Tokenization;
+
+namespace Equibles.UnitTests.Sec;
+
+public class ChunkingStrategyCleanTextStyleTests
+{
+    private readonly ChunkingStrategy _strategy = new(new TokenCounter());
+
+    // Sibling to CleanText_ScriptElement_DoesNotLeakScriptSourceIntoOutput.
+    // The production code removes script AND style nodes via a comma-separated
+    // CSS selector ("script, style") — but CSS selectors are split into two
+    // independent compound selectors and a single test only exercises one. The
+    // existing pin covers `<script>`; the `<style>` arm is unpinned. SEC EDGAR
+    // filings routinely embed inline CSS rule bodies, and AngleSharp's
+    // TextContent concatenates raw-text content from style elements just as it
+    // does for script — left in, the CSS rule text would pollute embeddings
+    // and RAG search results. A refactor that simplified the selector to just
+    // "script" (or that called QuerySelectorAll twice but missed updating the
+    // second arm) would silently leak every style block into RAG.
+    [Fact]
+    public void CleanText_StyleElement_DoesNotLeakCssRuleBodyIntoOutput()
+    {
+        var result = _strategy.CleanText(
+            "<style>.report-header { color: red; content: 'pollute-rag'; }</style>"
+                + "<p>Real annual report content.</p>"
+        );
+
+        result.Should().Be("Real annual report content.");
+    }
+}


### PR DESCRIPTION
## Summary

- Sibling coverage to the existing `CleanText_ScriptElement_DoesNotLeakScriptSourceIntoOutput` pin. The production code at `ChunkingStrategy.cs:93` removes `script` and `style` nodes via a comma-separated CSS selector — `"script, style"` — but a CSS selector list compiles into two independent compound selectors and a single test only ever exercises one of them. The `<script>` arm is pinned; the `<style>` arm is not.
- SEC EDGAR filings routinely embed inline CSS rule bodies for layout. AngleSharp's `TextContent` concatenates raw-text children of `<style>` (the CSS rule text) into the cleaned output just as it does for `<script>`. A refactor that simplified the selector to just `"script"` — or that switched to separate `QuerySelectorAll` calls and missed the second arm — would silently leak every CSS rule body into RAG embeddings + public search.
- Pins the contract documented in the production WHY-comment ("SEC EDGAR HTML routinely carries boilerplate inline JS/CSS; left in, its source pollutes embeddings and document search").

## Code changes

- `tests/Equibles.UnitTests/Sec/ChunkingStrategyCleanTextStyleTests.cs` — new file, one `[Fact]` feeding `<style>.report-header { content: 'pollute-rag'; }</style><p>Real annual report content.</p>` and asserting the cleaned output is just `"Real annual report content."`. Mirrors the existing script-element test exactly.