### PR TITLE
refactor(company-sync): extract BuildSyncState helper from SyncCompaniesFromSecApi

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -61,53 +61,7 @@ public class CompanySyncService : ICompanySyncService
             }
 
             using var scope = _serviceScopeFactory.CreateScope();
-            var commonStockRepository =
-                scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
-            var commonStockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
-            var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
-
-            var secCiks = secCompanies.Select(c => c.Cik).ToHashSet();
-
-            // Load every existing stock so we can detect subsidiaries already attached
-            // as SecondaryCiks on prior syncs. We can't filter by SEC CIKs alone because
-            // the subsidiary's CIK won't match any incoming primary CIK — it lives only
-            // inside another stock's SecondaryCiks list.
-            var allExistingStocks = await commonStockRepository.GetAll().ToListAsync();
-            var existingStocks = allExistingStocks.Where(cs => secCiks.Contains(cs.Cik)).ToList();
-            var existingCiks = existingStocks.Select(cs => cs.Cik).ToHashSet();
-
-            // Build the ticker → stock lookup over every row so ReplaceObsoleteStock can find
-            // a ticker holder whose own CIK dropped out of SEC's feed but who still owns the
-            // primary ticker our incoming company wants.
-            var primaryTickerToStock = allExistingStocks.ToDictionary(s => s.Ticker, s => s);
-
-            var secondaryCikToParent = BuildSecondaryCikToParent(allExistingStocks);
-
-            // Primary tickers are globally unique — collisions on primary mean the incoming
-            // company must replace or skip. Secondary tickers may legitimately overlap across
-            // related SEC filers (e.g. parent REIT + operating partnership sharing a
-            // preferred-share ticker), so they are tracked separately and never drive
-            // replace/skip routing decisions.
-            var existingPrimaryTickers = (
-                await commonStockRepository.GetAllTickers().ToListAsync()
-            ).ToHashSet(StringComparer.OrdinalIgnoreCase);
-            var existingSecondaryTickers = (
-                await commonStockRepository.GetAllSecondaryTickers().ToListAsync()
-            ).ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-            var state = new StockSyncState
-            {
-                SecCiks = secCiks,
-                ExistingStocks = existingStocks,
-                ExistingCiks = existingCiks,
-                ExistingPrimaryTickers = existingPrimaryTickers,
-                ExistingSecondaryTickers = existingSecondaryTickers,
-                PrimaryTickerToStock = primaryTickerToStock,
-                SecondaryCikToParent = secondaryCikToParent,
-                CommonStockRepository = commonStockRepository,
-                CommonStockManager = commonStockManager,
-                DbContext = dbContext,
-            };
+            var state = await BuildSyncState(secCompanies, scope);
 
             foreach (var secCompany in secCompanies)
             {
@@ -163,6 +117,60 @@ public class CompanySyncService : ICompanySyncService
             _logger.LogError(ex, "Error while syncing companies from SEC API");
             throw;
         }
+    }
+
+    private async Task<StockSyncState> BuildSyncState(
+        List<CompanyInfo> secCompanies,
+        IServiceScope scope
+    )
+    {
+        var commonStockRepository =
+            scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var commonStockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
+
+        var secCiks = secCompanies.Select(c => c.Cik).ToHashSet();
+
+        // Load every existing stock so we can detect subsidiaries already attached
+        // as SecondaryCiks on prior syncs. We can't filter by SEC CIKs alone because
+        // the subsidiary's CIK won't match any incoming primary CIK — it lives only
+        // inside another stock's SecondaryCiks list.
+        var allExistingStocks = await commonStockRepository.GetAll().ToListAsync();
+        var existingStocks = allExistingStocks.Where(cs => secCiks.Contains(cs.Cik)).ToList();
+        var existingCiks = existingStocks.Select(cs => cs.Cik).ToHashSet();
+
+        // Build the ticker → stock lookup over every row so ReplaceObsoleteStock can find
+        // a ticker holder whose own CIK dropped out of SEC's feed but who still owns the
+        // primary ticker our incoming company wants.
+        var primaryTickerToStock = allExistingStocks.ToDictionary(s => s.Ticker, s => s);
+
+        var secondaryCikToParent = BuildSecondaryCikToParent(allExistingStocks);
+
+        // Primary tickers are globally unique — collisions on primary mean the incoming
+        // company must replace or skip. Secondary tickers may legitimately overlap across
+        // related SEC filers (e.g. parent REIT + operating partnership sharing a
+        // preferred-share ticker), so they are tracked separately and never drive
+        // replace/skip routing decisions.
+        var existingPrimaryTickers = (
+            await commonStockRepository.GetAllTickers().ToListAsync()
+        ).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var existingSecondaryTickers = (
+            await commonStockRepository.GetAllSecondaryTickers().ToListAsync()
+        ).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return new StockSyncState
+        {
+            SecCiks = secCiks,
+            ExistingStocks = existingStocks,
+            ExistingCiks = existingCiks,
+            ExistingPrimaryTickers = existingPrimaryTickers,
+            ExistingSecondaryTickers = existingSecondaryTickers,
+            PrimaryTickerToStock = primaryTickerToStock,
+            SecondaryCikToParent = secondaryCikToParent,
+            CommonStockRepository = commonStockRepository,
+            CommonStockManager = commonStockManager,
+            DbContext = dbContext,
+        };
     }
 
     private async Task UpdateExistingStock(


### PR DESCRIPTION
## Summary

- Extract the inline ~45-line state-building block out of `CompanySyncService.SyncCompaniesFromSecApi` into a private `BuildSyncState(secCompanies, scope)` helper that returns the populated `StockSyncState`.
- The orchestration in `SyncCompaniesFromSecApi` shrinks to: load companies → filter by configured tickers → `using var scope = …` → `var state = await BuildSyncState(secCompanies, scope);` → per-company foreach. The caller keeps owning the scope so the captured scoped services stay alive for the foreach loop.
- Behaviour-preserving: same scope service resolves (`CommonStockRepository`, `CommonStockManager`, `EquiblesDbContext`), same `secCiks` HashSet, same `GetAll().ToListAsync()` + `Where` for existing-stocks, same `ToDictionary(s => s.Ticker)` for the ticker map, same `BuildSecondaryCikToParent` call, same case-insensitive `GetAllTickers` / `GetAllSecondaryTickers` HashSet builds; `StockSyncState` is assembled with the same field assignments and WHY-comments preserved.

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — add `private async Task<StockSyncState> BuildSyncState(List<CompanyInfo>, IServiceScope)`. Replace the inline state-building block inside `SyncCompaniesFromSecApi` with a single `await BuildSyncState(...)` call. No public API change.