### PR TITLE
refactor(cftc-mcp): collapse McpToolExecutor boilerplate behind private Execute helper

### DIFF
--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -50,7 +50,7 @@ public class CftcTools
             int maxResults = 52
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var contract = await _contractRepository
@@ -96,10 +96,8 @@ public class CftcTools
 
                 return result.ToString();
             },
-            _logger,
             "GetCftcPositioning",
-            $"marketCode: {marketCode}",
-            ReportError
+            $"marketCode: {marketCode}"
         );
     }
 
@@ -114,7 +112,7 @@ public class CftcTools
             string category = null
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 IQueryable<CftcContract> contractQuery;
@@ -177,10 +175,8 @@ public class CftcTools
 
                 return result.ToString();
             },
-            _logger,
             "GetLatestCftcData",
-            $"category: {category}",
-            ReportError
+            $"category: {category}"
         );
     }
 
@@ -196,7 +192,7 @@ public class CftcTools
         [Description("Maximum number of results to return (default: 20)")] int maxResults = 20
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var contracts = await _contractRepository
@@ -224,12 +220,13 @@ public class CftcTools
 
                 return result.ToString();
             },
-            _logger,
             "SearchCftcMarkets",
-            $"query: {query}",
-            ReportError
+            $"query: {query}"
         );
     }
+
+    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
+        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
 
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {


### PR DESCRIPTION
## Summary

- Same shape as the helper just landed in `Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` (PR #1367) and `Equibles.Congress.Mcp/Tools/CongressTools.cs` (PR #1376). `CftcTools` had three `McpToolExecutor.Execute(work, _logger, "ToolName", $"ctx", ReportError)` call sites where `_logger` and `ReportError` are class-instance state — pure boilerplate at every entry.
- Extracted a private `Execute(Func<Task<string>> work, string toolName, string context)` forwarder. Each tool call drops the two redundant arguments.
- Behavior-preserving: the helper calls the same `McpToolExecutor.Execute` with the same arguments in the same positional order; no logger swap, no delegate change. Build green, full unit + integration suite green (2908 passed + 1 pre-existing GH-1350 skip), `csharpier check` green.

## Code changes

- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs` — added a private `Execute` helper next to the existing `ReportError` / `ParseDateOr`, and threaded the three call sites in `GetCftcPositioning`, `GetLatestCftcData`, and `SearchCftcMarkets` through it. Net `-12 / +9`.