### PR TITLE
docs(technical/migrations): split first-run timeout bullet

### DIFF
--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -88,4 +88,6 @@ The snapshot is the source of truth for the entire EF model. New migrations shou
 - Most common cause: forgetting `AddMessaging()` in a host that calls `AddAllModules()`; see [Architecture → Host composition](architecture.md#host-composition) for the explicit-call requirement.
 - **"relation does not exist" after adding a new module** — the new module's `Equibles.<Module>.Data` was not added to `Equibles.Migrations.csproj` and `DesignTimeDbContextFactory`. Both edits, then `dotnet ef migrations add`.
 - **`CREATE EXTENSION "pg_search" does not exist`** — running against vanilla Postgres instead of ParadeDB. Use the `paradedb/paradedb` Docker image (see `docker-compose.yml`).
-- **Migration timeout on first run** — bumping `Database.SetCommandTimeout` higher is the lever. The default 1 hour covers the first-run BM25 index build; if you've split a heavy index migration across multiple files, the host applies them sequentially under the same command timeout.
+- **Migration timeout on first run** — bump `Database.SetCommandTimeout` higher.
+- The default 1 hour covers the first-run BM25 index build.
+- If you've split a heavy index migration across multiple files, the host applies them sequentially under the same command timeout.


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The "Migration timeout on first run" troubleshooting bullet packed 286 chars: the lever (`Database.SetCommandTimeout`), the default 1-hour rationale (BM25 index build), and the sequential-application caveat for split index migrations. Split into three single-fact bullets.

## Code changes

- `docs/technical/migrations.md` — split the bullet into one for the lever, one for the default 1-hour BM25 rationale, and one for the same-timeout behavior when a heavy index migration is split across files.