### PR TITLE
refactor(fred-mcp): collapse McpToolExecutor.Execute boilerplate behind private Execute helper

### DIFF
--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -47,7 +47,7 @@ public class FredTools
             int maxResults = 100
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var series = await _seriesRepository
@@ -89,10 +89,8 @@ public class FredTools
 
                 return result.ToString();
             },
-            _logger,
             "GetEconomicIndicator",
-            $"seriesId: {seriesId}",
-            ReportError
+            $"seriesId: {seriesId}"
         );
     }
 
@@ -107,7 +105,7 @@ public class FredTools
             string category = null
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 IQueryable<FredSeries> seriesQuery;
@@ -164,10 +162,8 @@ public class FredTools
 
                 return result.ToString();
             },
-            _logger,
             "GetLatestEconomicData",
-            $"category: {category}",
-            ReportError
+            $"category: {category}"
         );
     }
 
@@ -183,7 +179,7 @@ public class FredTools
         [Description("Maximum number of results to return (default: 20)")] int maxResults = 20
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var series = await _seriesRepository
@@ -211,12 +207,13 @@ public class FredTools
 
                 return result.ToString();
             },
-            _logger,
             "SearchEconomicIndicators",
-            $"query: {query}",
-            ReportError
+            $"query: {query}"
         );
     }
+
+    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
+        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
 
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {


### PR DESCRIPTION
## Summary

- Extract a private instance helper `Execute(work, toolName, context)` on `FredTools` that wraps `McpToolExecutor.Execute(work, _logger, toolName, context, ReportError)`, so each of the 3 tool methods stops repeating `_logger` and `ReportError` at every call site.
- Behavior-preserving: the helper is a pure delegating call passing the same five arguments in the same positions to the same static method; the `errorMessage` default remains null.
- Mirrors the same shape applied to `InstitutionalHoldingsTools` (#1360), `StockPriceTools` (#1367), `RagSearchTools` (#1373), and `CongressTools` (#1377).

## Code changes

- `src/Equibles.Fred.Mcp/Tools/FredTools.cs` — adds a private `Execute` helper and rewrites the 3 tool call sites to call it. Net 9 / -12 lines.