### PR TITLE
test(web): pin ProfileFormatting.JoinLocation omits whitespace-only parts

### DIFF
--- a/tests/Equibles.UnitTests/Web/ProfileFormattingJoinLocationWhitespaceTests.cs
+++ b/tests/Equibles.UnitTests/Web/ProfileFormattingJoinLocationWhitespaceTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class ProfileFormattingJoinLocationWhitespaceTests
+{
+    // Contract derived from class doc ("Small presentation helpers shared by
+    // the entity profile pages") and the method name `JoinLocation` — it joins
+    // location parts and must NOT emit a stray leading or trailing comma when
+    // one part is missing. Whitespace-only inputs (typically a database field
+    // that was set to " " or " " rather than NULL) are real in EDGAR /
+    // institutional-holder data — the implementation uses `IsNullOrWhiteSpace`
+    // to filter them out. A refactor that switches the predicate to
+    // `IsNullOrEmpty` would silently re-emit the trailing ", " in the rendered
+    // profile.
+    [Fact]
+    public void JoinLocation_WhitespaceOnlyStateOrCountry_IsOmittedFromOutput()
+    {
+        var result = ProfileFormatting.JoinLocation("San Francisco", "  ");
+
+        result.Should().Be("San Francisco");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial pin for `ProfileFormatting.JoinLocation(string city, string stateOrCountry)`. Untested member. Contract derived from the class doc ("Small presentation helpers shared by the entity profile pages") and the method name: joins location parts, omits empty parts so the rendered profile never carries a stray leading or trailing comma.
- Risk surface is null / empty / **whitespace** handling. Whitespace-only inputs (a DB field set to `" "` rather than `NULL`) are real in EDGAR / institutional-holder data; the implementation uses `IsNullOrWhiteSpace` to filter them. A refactor that swapped that to `IsNullOrEmpty` would silently re-emit the trailing `", "` on every "City" / "(city only)" profile.
- Test passes — pins the whitespace-rejection branch as a regression guard.

## Code changes

- `tests/Equibles.UnitTests/Web/ProfileFormattingJoinLocationWhitespaceTests.cs` — new file, one `[Fact]` calling `JoinLocation("San Francisco", "  ")` and asserting the result is `"San Francisco"` (no trailing `", "`). The WHY-comment above the test traces the contract source and the regression class the pin defends against.