### PR TITLE
refactor(ftd-import): extract ParseLine helper from DownloadAndParse

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -268,43 +268,48 @@ public class FtdImportService
 
         while (await reader.ReadLineAsync(cancellationToken) is { } line)
         {
-            if (string.IsNullOrWhiteSpace(line))
-                continue;
-
-            var parts = line.Split('|');
-            if (parts.Length < 6)
-                continue;
-
-            // Fields: SETTLEMENT DATE|CUSIP|SYMBOL|QUANTITY (FAILS)|DESCRIPTION|PRICE
-            if (
-                !DateOnly.TryParseExact(
-                    parts[0],
-                    "yyyyMMdd",
-                    CultureInfo.InvariantCulture,
-                    DateTimeStyles.None,
-                    out var date
-                )
-            )
-            {
-                continue;
-            }
-
-            long.TryParse(parts[3], out var quantity);
-            decimal.TryParse(parts[5], CultureInfo.InvariantCulture, out var price);
-
-            records.Add(
-                new FtdRecord
-                {
-                    SettlementDate = date,
-                    Cusip = parts[1].Trim(),
-                    Symbol = parts[2].Trim(),
-                    Quantity = quantity,
-                    Price = price,
-                }
-            );
+            var record = ParseLine(line);
+            if (record != null)
+                records.Add(record);
         }
 
         return records;
+    }
+
+    // Fields: SETTLEMENT DATE|CUSIP|SYMBOL|QUANTITY (FAILS)|DESCRIPTION|PRICE
+    private static FtdRecord ParseLine(string line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+            return null;
+
+        var parts = line.Split('|');
+        if (parts.Length < 6)
+            return null;
+
+        if (
+            !DateOnly.TryParseExact(
+                parts[0],
+                "yyyyMMdd",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var date
+            )
+        )
+        {
+            return null;
+        }
+
+        long.TryParse(parts[3], out var quantity);
+        decimal.TryParse(parts[5], CultureInfo.InvariantCulture, out var price);
+
+        return new FtdRecord
+        {
+            SettlementDate = date,
+            Cusip = parts[1].Trim(),
+            Symbol = parts[2].Trim(),
+            Quantity = quantity,
+            Price = price,
+        };
     }
 
     // Oldest FTD file available on SEC EDGAR is cnsfails201706b.zip (second half of June 2017).


### PR DESCRIPTION
## Summary

- Extract the inline ~20-line "skip blank/short line → parse settlement date as yyyyMMdd InvariantCulture → parse quantity / price → build `FtdRecord`" loop body out of `FtdImportService.DownloadAndParse` into a private static `ParseLine(line)` helper returning the record or `null`.
- The `while (await reader.ReadLineAsync(...) is { } line)` loop body shrinks to two lines: `var record = ParseLine(line); if (record != null) records.Add(record);`. The "Fields: SETTLEMENT DATE|CUSIP|SYMBOL|…" WHY-comment now sits on the helper instead of inside the loop.
- Behaviour-preserving: same `string.IsNullOrWhiteSpace` skip, same `Split('|')` + length-6 check, same `DateOnly.TryParseExact("yyyyMMdd", InvariantCulture, None)`, same `long.TryParse` / `decimal.TryParse(InvariantCulture)`, same `parts[1].Trim()` / `parts[2].Trim()` for CUSIP/Symbol — identical observable output and ordering.

## Code changes

- `src/Equibles.Sec.HostedService/Services/FtdImportService.cs` — add `private static FtdRecord ParseLine(string line)`; collapse the loop body in `DownloadAndParse` to call it and append only non-null returns. No public API change; helper is `private static`.