### PR TITLE
refactor(finra-mcp): collapse McpToolExecutor boilerplate behind private Execute helper

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -49,7 +49,7 @@ public class ShortDataTools
             int maxResults = 90
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var stock = await _commonStockRepository.GetByTicker(
@@ -93,10 +93,8 @@ public class ShortDataTools
 
                 return result.ToString();
             },
-            _logger,
             "GetShortVolume",
-            $"ticker: {ticker}",
-            ReportError
+            $"ticker: {ticker}"
         );
     }
 
@@ -114,7 +112,7 @@ public class ShortDataTools
             int maxResults = 24
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var stock = await _commonStockRepository.GetByTicker(
@@ -166,10 +164,8 @@ public class ShortDataTools
 
                 return result.ToString();
             },
-            _logger,
             "GetShortInterest",
-            $"ticker: {ticker}",
-            ReportError
+            $"ticker: {ticker}"
         );
     }
 
@@ -182,7 +178,7 @@ public class ShortDataTools
         [Description("Maximum number of results to return (default: 50)")] int maxResults = 50
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var latestDate = await _shortInterestRepository
@@ -235,12 +231,13 @@ public class ShortDataTools
 
                 return result.ToString();
             },
-            _logger,
             "GetShortInterestSnapshot",
-            $"minDaysToCover: {minDaysToCover}",
-            ReportError
+            $"minDaysToCover: {minDaysToCover}"
         );
     }
+
+    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
+        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
 
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {


### PR DESCRIPTION
## Summary

- Same shape as the helper landed in `Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` (#1367), `Equibles.Congress.Mcp/Tools/CongressTools.cs` (#1376), and `Equibles.Cftc.Mcp/Tools/CftcTools.cs` (#1381). `ShortDataTools` had three `McpToolExecutor.Execute(work, _logger, "ToolName", $"ctx", ReportError)` call sites where `_logger` and `ReportError` are class-instance state — pure boilerplate at every entry.
- Extracted a private `Execute(Func<Task<string>> work, string toolName, string context)` forwarder. Each tool call drops the two redundant arguments.
- Behavior-preserving: the helper calls the same `McpToolExecutor.Execute` with the same arguments in the same positional order; no logger swap, no delegate change. Build green, full unit + integration suite green (2909 passed + 1 pre-existing GH-1350 skip), `csharpier check` green.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — added a private `Execute` helper next to the existing `ReportError` / `ParseDateOr`, and threaded the three call sites in `GetShortVolume`, `GetShortInterest`, and `GetShortInterestSnapshot` through it. Net `-12 / +9`.