### PR TITLE
refactor(finra-mcp): collapse McpToolExecutor.Execute boilerplate behind private Execute helper

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -49,7 +49,7 @@ public class ShortDataTools
             int maxResults = 90
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var stock = await _commonStockRepository.GetByTicker(
@@ -93,10 +93,8 @@ public class ShortDataTools
 
                 return result.ToString();
             },
-            _logger,
             "GetShortVolume",
-            $"ticker: {ticker}",
-            ReportError
+            $"ticker: {ticker}"
         );
     }
 
@@ -114,7 +112,7 @@ public class ShortDataTools
             int maxResults = 24
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var stock = await _commonStockRepository.GetByTicker(
@@ -166,10 +164,8 @@ public class ShortDataTools
 
                 return result.ToString();
             },
-            _logger,
             "GetShortInterest",
-            $"ticker: {ticker}",
-            ReportError
+            $"ticker: {ticker}"
         );
     }
 
@@ -182,7 +178,7 @@ public class ShortDataTools
         [Description("Maximum number of results to return (default: 50)")] int maxResults = 50
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var latestDate = await _shortInterestRepository
@@ -235,12 +231,13 @@ public class ShortDataTools
 
                 return result.ToString();
             },
-            _logger,
             "GetShortInterestSnapshot",
-            $"minDaysToCover: {minDaysToCover}",
-            ReportError
+            $"minDaysToCover: {minDaysToCover}"
         );
     }
+
+    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
+        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
 
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {


### PR DESCRIPTION
## Summary

- Extract a private instance helper `Execute(work, toolName, context)` on `ShortDataTools` that wraps `McpToolExecutor.Execute(work, _logger, toolName, context, ReportError)`, so each of the 3 tool methods stops repeating `_logger` and `ReportError` at every call site.
- Behavior-preserving: the helper is a pure delegating call passing the same five arguments in the same positions to the same static method; the `errorMessage` default remains null.
- Mirrors the same shape applied to `InstitutionalHoldingsTools` (#1360), `StockPriceTools` (#1367), `RagSearchTools` (#1373), `CongressTools` (#1377), and `FredTools` (#1383).

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — adds a private `Execute` helper and rewrites the 3 tool call sites to call it. Net 9 / -12 lines.