### PR TITLE
refactor(finra-mcp): extract FormatSignedChange helper for duplicated signed-N0 ternary

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -153,10 +153,7 @@ public class ShortDataTools
 
                 foreach (var r in records.OrderBy(r => r.SettlementDate))
                 {
-                    var changeStr =
-                        r.ChangeInShortPosition >= 0
-                            ? $"+{r.ChangeInShortPosition:N0}"
-                            : r.ChangeInShortPosition.ToString("N0");
+                    var changeStr = FormatSignedChange(r.ChangeInShortPosition);
                     var advStr = r.AverageDailyVolume?.ToString("N0") ?? "—";
                     var dtcStr = r.DaysToCover?.ToString("F1") ?? "—";
                     result.AppendLine(
@@ -223,10 +220,7 @@ public class ShortDataTools
 
                 foreach (var r in records)
                 {
-                    var changeStr =
-                        r.ChangeInShortPosition >= 0
-                            ? $"+{r.ChangeInShortPosition:N0}"
-                            : r.ChangeInShortPosition.ToString("N0");
+                    var changeStr = FormatSignedChange(r.ChangeInShortPosition);
                     var advStr = r.AverageDailyVolume?.ToString("N0") ?? "—";
                     result.AppendLine(
                         $"| {r.CommonStock.Ticker} | {r.CurrentShortPosition:N0} | {changeStr} | {advStr} | {r.DaysToCover:F1} |"
@@ -246,6 +240,9 @@ public class ShortDataTools
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
+
+    private static string FormatSignedChange(long change) =>
+        change >= 0 ? $"+{change:N0}" : change.ToString("N0");
 
     private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
         !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;


### PR DESCRIPTION
## Summary

- `ShortDataTools.GetShortInterest` and `ShortDataTools.GetShortInterestSnapshot` both rendered the `ChangeInShortPosition` cell with the identical 4-line ternary: `r.ChangeInShortPosition >= 0 ? $"+{r.ChangeInShortPosition:N0}" : r.ChangeInShortPosition.ToString("N0")`. Same `long` input, same `N0` format, same sign-prefixed branch.
- Extract into a private static `FormatSignedChange(long change)` next to `ParseDateOr`. Both call sites collapse to `var changeStr = FormatSignedChange(r.ChangeInShortPosition);`.
- Behavior-preserving: the helper performs the identical ternary on the same `long` input — same `N0` format string in both branches, same sign-prefixed positive branch, same culture handling.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — added `FormatSignedChange(long)` private static helper; replaced the two inline 4-line ternaries with calls to the helper. No public-API change, no behavior change.