### PR TITLE
test(web): pin MarkdownExtensions neutralises data: scheme in link destinations

### DIFF
--- a/tests/Equibles.UnitTests/Web/MarkdownExtensionsDataUriTests.cs
+++ b/tests/Equibles.UnitTests/Web/MarkdownExtensionsDataUriTests.cs
@@ -1,0 +1,36 @@
+using Equibles.Web.Extensions;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Web;
+
+public class MarkdownExtensionsDataUriTests
+{
+    // Sibling to MarkdownExtensionsJavascriptUriTests. The production WHY-comment
+    // on `IsSafeUrl` enumerates THREE XSS-prone schemes — javascript:, data:, and
+    // vbscript: — that .DisableHtml() does NOT defend against because Markdig
+    // treats link destinations as opaque text. Only `javascript:` is pinned.
+    // `data:text/html,<script>alert('xss')</script>` is a modern stored-XSS
+    // vector that bypasses CSPs missing `data:` in their `default-src` and is
+    // exactly the kind of payload a SEC filing / transcript ingest could carry.
+    // A refactor that "ergonomically" adds `data` to AllowedUriSchemes (e.g. to
+    // enable inline base64 images) would silently let active data: hrefs into
+    // the rendered DOM.
+    [Fact]
+    public void MarkdownToHtml_DataUriInLink_DoesNotEmitActiveDataHref()
+    {
+        string captured = null;
+        var htmlHelper = Substitute.For<IHtmlHelper>();
+        htmlHelper
+            .Raw(Arg.Do<string>(s => captured = s))
+            .Returns(callInfo => new HtmlString(callInfo.Arg<string>()));
+
+        htmlHelper.MarkdownToHtml(
+            "[click me](data:text/html,<script>alert(document.cookie)</script>)"
+        );
+
+        captured.Should().NotBeNull();
+        captured.Should().NotContain("href=\"data:");
+    }
+}


### PR DESCRIPTION
## Summary

- Sibling to the existing `MarkdownExtensionsJavascriptUriTests.MarkdownToHtml_JavascriptUriInLink_DoesNotEmitActiveJavascriptHref` pin. The production WHY-comment on `IsSafeUrl` enumerates THREE XSS-prone schemes that `.DisableHtml()` does not defend against because Markdig treats link destinations as opaque text — `javascript:`, `data:`, and `vbscript:`. Only `javascript:` is pinned.
- `data:text/html,<script>...</script>` is a modern stored-XSS vector that bypasses CSPs missing `data:` in their `default-src` and is exactly the kind of payload a SEC filing / earnings transcript ingest could carry. A refactor that "ergonomically" adds `data` to `AllowedUriSchemes` — for example to enable inline base64 images — would silently let an active `data:` href into the rendered DOM and through `htmlHelper.Raw()` into the page.
- Pin passes locally; locks down the rejection arm so the regression class surfaces here, not in a security incident.

## Code changes

- `tests/Equibles.UnitTests/Web/MarkdownExtensionsDataUriTests.cs` — new file, one `[Fact]` feeding `[click me](data:text/html,<script>alert(document.cookie)</script>)` through `htmlHelper.MarkdownToHtml(...)` and asserting the captured Raw payload does not contain `href="data:`. Mirrors the existing javascript: pin exactly so the two stay maintainable side-by-side.