### PR TITLE
refactor(insidertrading-mcp): collapse McpToolExecutor boilerplate behind private Execute helper

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -45,7 +45,7 @@ public class InsiderTradingTools
         [Description("Maximum number of transactions to return (default: 50)")] int maxResults = 50
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var stock = await _commonStockRepository.GetByTicker(ticker);
@@ -92,10 +92,8 @@ public class InsiderTradingTools
 
                 return result.ToString();
             },
-            _logger,
             "GetInsiderTransactions",
-            $"ticker: {ticker}",
-            ReportError
+            $"ticker: {ticker}"
         );
     }
 
@@ -107,7 +105,7 @@ public class InsiderTradingTools
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var stock = await _commonStockRepository.GetByTicker(ticker);
@@ -156,10 +154,8 @@ public class InsiderTradingTools
 
                 return result.ToString();
             },
-            _logger,
             "GetInsiderOwnership",
-            $"ticker: {ticker}",
-            ReportError
+            $"ticker: {ticker}"
         );
     }
 
@@ -172,7 +168,7 @@ public class InsiderTradingTools
         [Description("Maximum number of results (default: 10)")] int maxResults = 10
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var insiders = await _ownerRepository.Search(query).Take(maxResults).ToListAsync();
@@ -202,12 +198,13 @@ public class InsiderTradingTools
 
                 return result.ToString();
             },
-            _logger,
             "SearchInsiders",
-            $"query: {query}",
-            ReportError
+            $"query: {query}"
         );
     }
+
+    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
+        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
 
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {


### PR DESCRIPTION
## Summary

- Same shape as the helper landed in `Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` (#1367), `Equibles.Congress.Mcp/Tools/CongressTools.cs` (#1376), `Equibles.Cftc.Mcp/Tools/CftcTools.cs` (#1381), and `Equibles.Finra.Mcp/Tools/ShortDataTools.cs` (#1388). `InsiderTradingTools` had three `McpToolExecutor.Execute(work, _logger, "ToolName", $"ctx", ReportError)` call sites where `_logger` and `ReportError` are class-instance state — pure boilerplate at every entry.
- Extracted a private `Execute(Func<Task<string>> work, string toolName, string context)` forwarder. Each tool call drops the two redundant arguments.
- Behavior-preserving: the helper calls the same `McpToolExecutor.Execute` with the same arguments in the same positional order; no logger swap, no delegate change. Build green, full unit + integration suite green (2910 passed + 1 pre-existing GH-1350 skip), `csharpier check` green.

## Code changes

- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — added a private `Execute` helper next to the existing `ReportError` / `GetRole`, and threaded the three call sites in `GetInsiderTransactions`, `GetInsiderOwnership`, and `SearchInsiders` through it. Net `-12 / +9`.