### PR TITLE
docs(technical/web-portal): split StocksController bullet

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -8,7 +8,8 @@ Most user-facing data lives under `~/Stocks/{ticker}/{tab}`. The tab pattern is 
 
 The trio:
 
-- **Controller action** in [`StocksController`](../../src/Equibles.Web/Controllers/StocksController.cs) — one action per tab (`Price`, `Holdings`, `ShortVolume`, `ShortInterest`, `Ftd`, `Documents`, `InsiderTrading`, `CongressionalTrades`, `Financials`). Resolves the ticker, calls the matching `StockTabService.LoadXxxTab(stock, ...)`, stashes the result in `ViewData["TabViewModel"]`, returns the shared `Show.cshtml` view.
+- **Controller action** in [`StocksController`](../../src/Equibles.Web/Controllers/StocksController.cs) — one action per tab: `Price`, `Holdings`, `ShortVolume`, `ShortInterest`, `Ftd`, `Documents`, `InsiderTrading`, `CongressionalTrades`, `Financials`.
+- Each action resolves the ticker, calls the matching `StockTabService.LoadXxxTab(stock, ...)`, stashes the result in `ViewData["TabViewModel"]`, and returns the shared `Show.cshtml` view.
 - **Service method** on [`StockTabService`](../../src/Equibles.Web/Services/StockTabService.cs) — `Task<XxxTabViewModel> LoadXxxTab(CommonStock stock, …)`. The only place that talks to repositories for tab data. All query composition lives here.
 - **Razor partial** under [`Views/Stocks/_XxxTab.cshtml`](../../src/Equibles.Web/Views/Stocks/) — typed `@model XxxTabViewModel`. Renders the tab body; the surrounding chrome (breadcrumb, stock header, tab strip) belongs to `Show.cshtml`.
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `StocksController` tab-pattern bullet packed 427 chars: the 9-action enumeration *and* the per-action mechanics (resolve ticker → call `StockTabService.LoadXxxTab` → stash in `ViewData["TabViewModel"]` → render shared `Show.cshtml`). Split into enumeration vs. mechanics.

## Code changes

- `docs/technical/web-portal.md` — split the `StocksController` bullet into one listing the 9 per-tab actions and one describing the shared action mechanics.