### PR TITLE
refactor(cftc-import): extract BuildPositionReport helper from ImportYear

### DIFF
--- a/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
+++ b/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
@@ -6,6 +6,7 @@ using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Cftc.Contracts;
+using Equibles.Integrations.Cftc.Models;
 using Equibles.Worker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -239,35 +240,7 @@ public class CftcImportService
                 if (existingKeys.Contains((contractId, date.Value)))
                     continue;
 
-                yield return new CftcPositionReport
-                {
-                    CftcContractId = contractId,
-                    ReportDate = date.Value,
-                    OpenInterest = record.OpenInterest ?? 0,
-                    NonCommLong = record.NonCommLong ?? 0,
-                    NonCommShort = record.NonCommShort ?? 0,
-                    NonCommSpreads = record.NonCommSpreads ?? 0,
-                    CommLong = record.CommLong ?? 0,
-                    CommShort = record.CommShort ?? 0,
-                    TotalRptLong = record.TotalRptLong ?? 0,
-                    TotalRptShort = record.TotalRptShort ?? 0,
-                    NonRptLong = record.NonRptLong ?? 0,
-                    NonRptShort = record.NonRptShort ?? 0,
-                    ChangeOpenInterest = record.ChangeOpenInterest,
-                    ChangeNonCommLong = record.ChangeNonCommLong,
-                    ChangeNonCommShort = record.ChangeNonCommShort,
-                    ChangeCommLong = record.ChangeCommLong,
-                    ChangeCommShort = record.ChangeCommShort,
-                    PctNonCommLong = record.PctNonCommLong,
-                    PctNonCommShort = record.PctNonCommShort,
-                    PctCommLong = record.PctCommLong,
-                    PctCommShort = record.PctCommShort,
-                    TradersTotal = record.TradersTotal,
-                    TradersNonCommLong = record.TradersNonCommLong,
-                    TradersNonCommShort = record.TradersNonCommShort,
-                    TradersCommLong = record.TradersCommLong,
-                    TradersCommShort = record.TradersCommShort,
-                };
+                yield return BuildPositionReport(record, contractId, date.Value);
             }
         }
 
@@ -314,6 +287,41 @@ public class CftcImportService
         repo.AddRange(items);
         await repo.SaveChanges();
     }
+
+    private static CftcPositionReport BuildPositionReport(
+        CftcReportRecord record,
+        Guid contractId,
+        DateOnly reportDate
+    ) =>
+        new()
+        {
+            CftcContractId = contractId,
+            ReportDate = reportDate,
+            OpenInterest = record.OpenInterest ?? 0,
+            NonCommLong = record.NonCommLong ?? 0,
+            NonCommShort = record.NonCommShort ?? 0,
+            NonCommSpreads = record.NonCommSpreads ?? 0,
+            CommLong = record.CommLong ?? 0,
+            CommShort = record.CommShort ?? 0,
+            TotalRptLong = record.TotalRptLong ?? 0,
+            TotalRptShort = record.TotalRptShort ?? 0,
+            NonRptLong = record.NonRptLong ?? 0,
+            NonRptShort = record.NonRptShort ?? 0,
+            ChangeOpenInterest = record.ChangeOpenInterest,
+            ChangeNonCommLong = record.ChangeNonCommLong,
+            ChangeNonCommShort = record.ChangeNonCommShort,
+            ChangeCommLong = record.ChangeCommLong,
+            ChangeCommShort = record.ChangeCommShort,
+            PctNonCommLong = record.PctNonCommLong,
+            PctNonCommShort = record.PctNonCommShort,
+            PctCommLong = record.PctCommLong,
+            PctCommShort = record.PctCommShort,
+            TradersTotal = record.TradersTotal,
+            TradersNonCommLong = record.TradersNonCommLong,
+            TradersNonCommShort = record.TradersNonCommShort,
+            TradersCommLong = record.TradersCommLong,
+            TradersCommShort = record.TradersCommShort,
+        };
 
     private static DateOnly? ParseDate(string value)
     {


### PR DESCRIPTION
## Summary

- Extract the 28-line `new CftcPositionReport { … }` initializer inside the `MapNewReports` local function's `yield return` (in `CftcImportService.ImportYear`) into a `private static CftcPositionReport BuildPositionReport(record, contractId, reportDate)` helper. The local function now reads as a tight guard-and-yield loop.
- Behaviour-preserving: the helper assembles `CftcPositionReport` with the exact same 25 field assignments and the exact same `?? 0` null-coalescing on the long-typed columns (`OpenInterest`, `NonCommLong`, … `NonRptShort`) — observable output unchanged.

## Code changes

- `src/Equibles.Cftc.HostedService/Services/CftcImportService.cs` — add `private static CftcPositionReport BuildPositionReport(CftcReportRecord, Guid, DateOnly)`. Collapse the inline `yield return new CftcPositionReport { … }` to `yield return BuildPositionReport(record, contractId, date.Value);`. Add `using Equibles.Integrations.Cftc.Models;` so the helper signature can name `CftcReportRecord`. No public API change.