### PR TITLE
test(sec): pin ListConversionStep removes hyphen-bullet span

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepHyphenBulletTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepHyphenBulletTests.cs
@@ -1,0 +1,44 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class ListConversionStepHyphenBulletTests
+{
+    private readonly ListConversionStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    // Third sibling in the bullet-matcher family. ConvertItemToListItem's
+    // bullet glyph allowlist at line 95 is the three-arm pattern
+    //   `s.TextContent.Trim() is "•" or "·" or "-"`
+    // BulletSpans_AreRemovedFromListItems pins "•"; MiddleDotBulletSpans
+    // pins "·". The hyphen-minus arm is unpinned. SEC filings emitted by
+    // older ASCII-only pipelines (some 10-K exhibit indices, plain-text
+    // 10-D filings) use "-" as the bullet glyph; without this arm the
+    // hyphen survives into the rendered <li> and shows up as a stray "-"
+    // prefix in the public document viewer. A refactor that "rationalises"
+    // the three-arm pattern down to the dominant Unicode bullets would
+    // compile, pass the two existing bullet tests, and silently regress
+    // every hyphen-bullet filing.
+    [Fact]
+    public void HyphenBulletSpans_AreRemovedFromListItems()
+    {
+        var input = """
+            <div class="item-list-element-wrapper">
+              <span>-</span>
+              <div style="display:inline">Item with hyphen bullet</div>
+            </div>
+            """;
+
+        var html = $"<html><body>{input}</body></html>";
+        var doc = _parser.ParseDocument(html);
+        _step.Execute(doc);
+        var result = doc.Body!.InnerHtml;
+
+        result.Should().Contain("<ul>");
+        result.Should().Contain("<li>");
+        result.Should().Contain("Item with hyphen bullet");
+        // The hyphen-bullet span must not survive into the rendered li.
+        result.Should().NotContain("<span>-</span>");
+    }
+}


### PR DESCRIPTION
## Summary

- Third sibling in the bullet-matcher family for `ListConversionStep.ConvertItemToListItem`. The bullet glyph allowlist is the three-arm pattern `s.TextContent.Trim() is "•" or "·" or "-"`. The existing `BulletSpans_AreRemovedFromListItems` pins the `"•"` (U+2022) arm; `MiddleDotBulletSpans_AreRemovedFromListItems` pins `"·"` (U+00B7); the third arm — hyphen-minus — was unpinned.
- Hyphen bullets show up in SEC filings emitted by older ASCII-only pipelines (some 10-K exhibit indices, plain-text 10-D filings). Without the arm, the hyphen survives into the rendered `<li>` as a stray "-" prefix in the public document viewer and in stored RAG content.
- A refactor that "rationalises" the three-arm pattern down to the dominant Unicode bullets — say `is "•" or "·"` — would compile, pass the two existing bullet tests, and silently regress every hyphen-bullet filing. Pin closes that gap.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepHyphenBulletTests.cs` — new file, one `[Fact]` building a `<div class="item-list-element-wrapper"><span>-</span><div style="display:inline">…</div></div>` and asserting the rendered output contains the `<ul>` + `<li>` + the item content, with the `<span>-</span>` removed. Mirrors the structure of the two existing bullet pins.