### PR TITLE
docs(technical/migrations): split ApplyMigrationsAsync bullet

### DIFF
--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -39,7 +39,8 @@ dotnet ef migrations add <Name> \
 
 Hosts call `await dbContext.Database.MigrateAsync()` on startup.
 
-- The Web host owns migration application via `ApplyMigrationsAsync` in [`src/Equibles.Web/Program.cs`](../../src/Equibles.Web/Program.cs) — it creates a scope, resolves `EquiblesDbContext`, sets `Database.SetCommandTimeout(TimeSpan.FromHours(1))`, and runs `MigrateAsync()`.
+- The Web host owns migration application via `ApplyMigrationsAsync` in [`src/Equibles.Web/Program.cs`](../../src/Equibles.Web/Program.cs).
+- The method creates a scope, resolves `EquiblesDbContext`, sets `Database.SetCommandTimeout(TimeSpan.FromHours(1))`, and runs `MigrateAsync()`.
 - The 1-hour command timeout absorbs index rebuilds on first run; BM25 + pgvector indexes on multi-million-row tables can take many minutes.
 - The MCP server does **not** run migrations. Its compose service `depends_on: web (condition: service_healthy)`, so by the time MCP starts the Web host has already finished migrating.
 - The Worker host doesn't call `MigrateAsync` on the EF model either, but it does run `MassTransit__RunMigration=true` so the MassTransit SQL transport tables apply on first boot. The EF tables are still owned by Web.


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `ApplyMigrationsAsync` bullet packed 277 chars: the owner (Web host, `Program.cs`) and the four method-body steps (scope, resolve `EquiblesDbContext`, set 1-hour command timeout, call `MigrateAsync()`). Split into owner vs. method-body steps.

## Code changes

- `docs/technical/migrations.md` — split the bullet into one naming the Web host owner with the `Program.cs` reference, and one listing the method-body steps.