### PR TITLE
refactor(cboe-mcp): collapse McpToolExecutor boilerplate behind private Execute helper

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -48,7 +48,7 @@ public class CboeTools
             int maxResults = 60
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 if (!Enum.TryParse<CboePutCallRatioType>(type, true, out var ratioType))
@@ -88,10 +88,8 @@ public class CboeTools
 
                 return result.ToString();
             },
-            _logger,
             "GetPutCallRatios",
-            $"type: {type}",
-            ReportError
+            $"type: {type}"
         );
     }
 
@@ -108,7 +106,7 @@ public class CboeTools
             int maxResults = 60
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 var start = ParseDateOr(
@@ -141,12 +139,13 @@ public class CboeTools
 
                 return result.ToString();
             },
-            _logger,
             "GetVixHistory",
-            $"startDate: {startDate}",
-            ReportError
+            $"startDate: {startDate}"
         );
     }
+
+    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
+        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
 
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {


### PR DESCRIPTION
## Summary

- Last of the MCP tool classes to receive the same `Execute` helper. Joins yahoo-mcp #1367, congress-mcp #1376, cftc-mcp #1381, finra-mcp #1388, sec-mcp #1373, and insidertrading-mcp #1392. `CboeTools` had two `McpToolExecutor.Execute(work, _logger, "ToolName", $"ctx", ReportError)` call sites; `_logger` and `ReportError` are class-instance state — boilerplate at every entry.
- Extracted a private `Execute(Func<Task<string>> work, string toolName, string context)` forwarder. Each tool call drops the two redundant arguments.
- Behavior-preserving: the helper calls the same `McpToolExecutor.Execute` with the same arguments in the same positional order; no logger swap, no delegate change. Build green, full unit + integration suite green (2911 passed + 1 pre-existing GH-1350 skip), `csharpier check` green.

## Code changes

- `src/Equibles.Cboe.Mcp/Tools/CboeTools.cs` — added a private `Execute` helper next to the existing `ReportError`, and threaded the two call sites in `GetPutCallRatios` and `GetVixHistory` through it. Net `-8 / +7`.