### PR TITLE
test(web): pin MarkdownExtensions neutralises vbscript: scheme in link destinations

### DIFF
--- a/tests/Equibles.UnitTests/Web/MarkdownExtensionsVbscriptUriTests.cs
+++ b/tests/Equibles.UnitTests/Web/MarkdownExtensionsVbscriptUriTests.cs
@@ -1,0 +1,38 @@
+using Equibles.Web.Extensions;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Web;
+
+public class MarkdownExtensionsVbscriptUriTests
+{
+    // Third and final sibling in the XSS-scheme family. The production WHY-comment
+    // on `IsSafeUrl` enumerates THREE schemes that `.DisableHtml()` does NOT
+    // defend against — javascript:, data:, and vbscript:. The javascript: arm
+    // is pinned by MarkdownExtensionsJavascriptUriTests, the data: arm by
+    // MarkdownExtensionsDataUriTests; vbscript: was the only one of the three
+    // not yet pinned.
+    //
+    // vbscript: is the historical IE-only XSS vector (active in Office/Outlook
+    // HTML rendering surfaces and in some old WebView2 contexts). Untrusted
+    // ingest from earnings transcripts / SEC filings can still carry payloads
+    // crafted for those environments — keep all three documented schemes
+    // locked down. A refactor that swaps `AllowedUriSchemes` to a different
+    // sanitiser path and forgets to deny vbscript: would leak past the
+    // existing two-scheme test net.
+    [Fact]
+    public void MarkdownToHtml_VbscriptUriInLink_DoesNotEmitActiveVbscriptHref()
+    {
+        string captured = null;
+        var htmlHelper = Substitute.For<IHtmlHelper>();
+        htmlHelper
+            .Raw(Arg.Do<string>(s => captured = s))
+            .Returns(callInfo => new HtmlString(callInfo.Arg<string>()));
+
+        htmlHelper.MarkdownToHtml("[click me](vbscript:MsgBox(\"xss\"))");
+
+        captured.Should().NotBeNull();
+        captured.Should().NotContain("href=\"vbscript:");
+    }
+}


### PR DESCRIPTION
## Summary

- Third and final sibling in the XSS-scheme family for `MarkdownExtensions.MarkdownToHtml`. The production WHY-comment on `IsSafeUrl` enumerates THREE schemes that `.DisableHtml()` does NOT defend against — `javascript:`, `data:`, and `vbscript:`. The first arm was pinned by `MarkdownExtensionsJavascriptUriTests`, the second by `MarkdownExtensionsDataUriTests` (#1391); `vbscript:` is the only one of the three not yet pinned.
- `vbscript:` is the historical IE-only XSS vector — still active in Office/Outlook HTML rendering surfaces and in some legacy WebView2 contexts. Untrusted ingest from earnings transcripts and SEC filings can carry payloads crafted for those environments. A refactor that swaps `AllowedUriSchemes` to a different sanitiser path and forgets to deny `vbscript:` would leak past the existing two-scheme test net.
- Test passes locally; closes the third arm so the regression class surfaces here rather than in a security incident.

## Code changes

- `tests/Equibles.UnitTests/Web/MarkdownExtensionsVbscriptUriTests.cs` — new file, one `[Fact]` feeding `[click me](vbscript:MsgBox("xss"))` through `htmlHelper.MarkdownToHtml(...)` and asserting the captured Raw payload does not contain `href="vbscript:`. Mirrors the structure of the two existing arms so all three remain maintainable side-by-side.