### PR TITLE
docs(technical/hosts): split RagManager wiring bullet

### DIFF
--- a/docs/technical/hosts.md
+++ b/docs/technical/hosts.md
@@ -25,7 +25,8 @@ The MCP transport exposing financial-domain tools to AI assistants.
 - Every module shipping a `.Mcp` project gets one of these `mcp.AddXxx()` calls.
 - `ConfigurePipeline` mounts the MCP transport at `/mcp` via `app.MapMcp("/mcp")` and wraps that path in `ApiKeyMiddleware` (under `UseWhen`, so the rest of the app stays open for health checks).
 - `IApiKeyValidator` resolves to `SimpleApiKeyValidator`, which reads `McpApiKey` from configuration. Empty / unset = auth disabled.
-- Wires `Equibles.Sec.BusinessLogic.Search.RagManager` via `AutoWireServicesFrom<T>` so MCP SEC tools can run semantic search. Requires the `Embedding` config section to be bound to `EmbeddingConfig`; without that, `EmbeddingConfig.Enabled` is false and semantic search no-ops.
+- Wires `Equibles.Sec.BusinessLogic.Search.RagManager` via `AutoWireServicesFrom<T>` so MCP SEC tools can run semantic search.
+- Requires the `Embedding` config section to be bound to `EmbeddingConfig`; without it, `EmbeddingConfig.Enabled` is false and semantic search no-ops.
 - Does **not** run migrations — the `mcp` compose service depends on `web` being healthy, and `web` owns migration application.
 
 ## Worker Host — [`src/Equibles.Worker.Host`](../../src/Equibles.Worker.Host)


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `RagManager` MCP-host wiring bullet packed 277 chars: the `AutoWireServicesFrom<T>` registration that lets MCP SEC tools run semantic search, *and* the `Embedding`/`EmbeddingConfig` binding requirement that gates `EmbeddingConfig.Enabled`. Split into registration vs. config requirement.

## Code changes

- `docs/technical/hosts.md` — split the bullet into one stating the `RagManager` registration via `AutoWireServicesFrom<T>` for semantic search, and one stating the `Embedding` → `EmbeddingConfig` binding requirement and the no-op fallback.