### PR TITLE
refactor(sec-financialfacts-mcp): collapse McpToolExecutor.Execute boilerplate behind private Execute helper

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -72,7 +72,7 @@ public class FinancialFactsTools
             bool asOriginallyReported = false
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 if (string.IsNullOrWhiteSpace(ticker))
@@ -167,11 +167,9 @@ public class FinancialFactsTools
 
                 return result.ToString();
             },
-            _logger,
             "GetFinancialFact",
             $"ticker: {FactMarkdown.Clean(ticker)}, concept: {FactMarkdown.Clean(concept)}, "
-                + $"form: {FactMarkdown.Clean(form)}",
-            ReportError
+                + $"form: {FactMarkdown.Clean(form)}"
         );
     }
 
@@ -193,7 +191,7 @@ public class FinancialFactsTools
         [Description("Fiscal period: 'FY' (default) or 'Q1'..'Q4'")] string fiscalPeriod = "FY"
     )
     {
-        return McpToolExecutor.Execute(
+        return Execute(
             async () =>
             {
                 if (string.IsNullOrWhiteSpace(concept))
@@ -303,11 +301,9 @@ public class FinancialFactsTools
 
                 return result.ToString();
             },
-            _logger,
             "CompareFinancialFact",
             $"tickers: {FactMarkdown.Clean(tickers)}, concept: {FactMarkdown.Clean(concept)}, "
-                + $"year: {fiscalYear}, period: {FactMarkdown.Clean(fiscalPeriod)}",
-            ReportError
+                + $"year: {fiscalYear}, period: {FactMarkdown.Clean(fiscalPeriod)}"
         );
     }
 
@@ -392,6 +388,9 @@ public class FinancialFactsTools
             + $"{string.Join(", ", FinancialConceptAliases.SupportedAliases)} "
             + "(common synonyms like 'sales', 'r&d', 'ocf' also work).";
     }
+
+    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
+        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
 
     private Task ReportError(string toolName, string message, string stackTrace, string context)
     {


### PR DESCRIPTION
## Summary

- Apply the same `Execute` helper pattern that was rolled across the other MCP-tool classes (cboe-mcp #1399, finra-mcp #1388, sec-mcp #1373, congress-mcp #1376, cftc-mcp #1381, holdings-mcp #1360, …) to `FinancialFactsTools.cs`.
- Both `GetFinancialFact` and `CompareFinancialFact` now read `return Execute(work, toolName, context)` instead of the verbose 5-arg `McpToolExecutor.Execute(work, _logger, toolName, context, ReportError)`.
- Behaviour-preserving: the new private helper is `private Task<string> Execute(Func<Task<string>> work, string toolName, string context) => McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);` — identical forwarded call.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — add the `Execute` helper just above `ReportError`; switch both tool methods (`GetFinancialFact`, `CompareFinancialFact`) to call `Execute(...)` instead of `McpToolExecutor.Execute(...)`. No public API change; helper is `private`.