### PR TITLE
docs(technical/operations): split Status dashboard bullet

### DIFF
--- a/docs/technical/operations.md
+++ b/docs/technical/operations.md
@@ -146,7 +146,8 @@ A `docker compose down` keeps these volumes. `docker compose down -v` deletes th
 
 ## Monitoring
 
-- **Status dashboard** at `~/Status` on the Web host — recent worker errors, per-domain row counts, version banner. The dashboard reads from the `Error` table that every scraper writes to via `ErrorReporter` (see [Scrapers → Error reporting](scrapers.md#error-reporting)).
+- **Status dashboard** at `~/Status` on the Web host — recent worker errors, per-domain row counts, version banner.
+- The dashboard reads from the `Error` table that every scraper writes to via `ErrorReporter` (see [Scrapers → Error reporting](scrapers.md#error-reporting)).
 - **Health check** at `~/healthz` on the Web host — anonymous; Compose uses it as `web`'s health probe.
 - **Container logs** — `docker compose logs -f <service>`. Logs honor `MINIMUM_LOG_LEVEL`.
 - **Postgres metrics** — standard Postgres tooling (`pg_stat_*` views) against the `db` service.


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The Status-dashboard bullet packed 276 chars: the page route (`~/Status`) with its three contents (recent errors, row counts, version banner), *and* the data-source mechanics (`Error` table, written via `ErrorReporter`, with cross-ref to Scrapers → Error reporting). Split into page-contents vs. data-source.

## Code changes

- `docs/technical/operations.md` — split the Status-dashboard bullet into one stating the page route and its three sections, and one describing the `Error`-table + `ErrorReporter` data source with the cross-reference.