### PR TITLE
test(web): pin MarkdownExtensions neutralises javascript: scheme in image destinations

### DIFF
--- a/tests/Equibles.UnitTests/Web/MarkdownExtensionsImageJavascriptUriTests.cs
+++ b/tests/Equibles.UnitTests/Web/MarkdownExtensionsImageJavascriptUriTests.cs
@@ -1,0 +1,33 @@
+using Equibles.Web.Extensions;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Web;
+
+public class MarkdownExtensionsImageJavascriptUriTests
+{
+    // The IsSafeUrl WHY-comment explicitly enumerates "a markdown link/image
+    // with a javascript:/data:/vbscript: scheme" as the risk. All three
+    // existing sibling tests cover the LINK form ([text](url) → href=);
+    // the IMAGE form (![alt](url) → src=) is unpinned. The implementation
+    // covers both today because Markdig represents inline images as
+    // LinkInline with IsImage=true, so a single Descendants<LinkInline>()
+    // walk neutralises them — but a refactor that filters that walk to
+    // `!link.IsImage`, or splits image rendering into a separate pass, would
+    // silently leak javascript: through <img src> with no test catching it.
+    [Fact]
+    public void MarkdownToHtml_JavascriptUriInImage_DoesNotEmitActiveJavascriptSrc()
+    {
+        string captured = null;
+        var htmlHelper = Substitute.For<IHtmlHelper>();
+        htmlHelper
+            .Raw(Arg.Do<string>(s => captured = s))
+            .Returns(callInfo => new HtmlString(callInfo.Arg<string>()));
+
+        htmlHelper.MarkdownToHtml("![logo](javascript:alert(\"xss\"))");
+
+        captured.Should().NotBeNull();
+        captured.Should().NotContain("src=\"javascript:");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial sibling test pinning the **image form** (`![alt](url)` → `<img src=...>`) of the XSS-scheme family. The existing three sibling tests (`MarkdownExtensionsJavascriptUriTests`, `DataUriTests`, `VbscriptUriTests`) all cover the link form (`[text](url)` → `<a href=...>`); image rendering was unpinned.
- `IsSafeUrl`'s WHY-comment explicitly enumerates "a markdown link/image with a javascript:/data:/vbscript: scheme" as the threat. Today the protection is shared because Markdig represents both as `LinkInline`, but a future refactor that splits image rendering or filters out `IsImage=true` from the sanitisation walk would silently leak `javascript:` through `<img src>` with no test net to catch it.

## Code changes

- `tests/Equibles.UnitTests/Web/MarkdownExtensionsImageJavascriptUriTests.cs` — one `[Fact]` rendering `![logo](javascript:alert("xss"))` and asserting the captured HTML does not contain `src="javascript:`.