### PR TITLE
docs(technical/migrations): split csproj-references bullet

### DIFF
--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -4,7 +4,8 @@ Every entity in the codebase lives in one shared EF Core migrations history at [
 
 ## Project layout
 
-- [`Equibles.Migrations.csproj`](../../src/Equibles.Migrations/Equibles.Migrations.csproj) — references **every** `Equibles.*.Data` project plus `Equibles.Messaging`. The snapshot has to know about every module's entities, so the migrations assembly references them all.
+- [`Equibles.Migrations.csproj`](../../src/Equibles.Migrations/Equibles.Migrations.csproj) — references **every** `Equibles.*.Data` project plus `Equibles.Messaging`.
+- The snapshot has to know about every module's entities, so the migrations assembly references them all.
 - [`DesignTimeDbContextFactory.cs`](../../src/Equibles.Migrations/DesignTimeDbContextFactory.cs) — `IDesignTimeDbContextFactory<EquiblesDbContext>` that EF tooling invokes for `dotnet ef ...`.
 - [`designsettings.json`](../../src/Equibles.Migrations/designsettings.json) — connection string the design-time factory reads; defaults to `Host=localhost;Port=5432;Database=equibles;Username=equibles;Password=equibles`.
 - Override the default locally with `designsettings.Development.json` (gitignored).


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `Equibles.Migrations.csproj` bullet packed 272 chars: the reference rule (every `Equibles.*.Data` plus `Equibles.Messaging`) and the snapshot rationale ("the snapshot has to know about every module's entities"). Split into rule vs. rationale.

## Code changes

- `docs/technical/migrations.md` — split the bullet into one stating the reference rule and one stating the snapshot rationale.