### PR TITLE
test(sec): pin FinancialConceptAliases.TryResolve resolves r&d via synonym hop

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveRdSynonymTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveRdSynonymTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialConceptAliasesTryResolveRdSynonymTests
+{
+    // The class-level WHY-comment enumerates "r&d" as one of three natural-
+    // phrasing examples callers must be able to use. `"r&d"` is not in Map —
+    // it only lives in Synonyms — so resolution depends on the Synonyms→Map
+    // hop firing AFTER Normalize lowercases the input. A refactor that drops
+    // the synonym pass, reorders to Map-first only, or changes Normalize to
+    // strip non-alphanumerics would silently break this exact phrasing with
+    // no surviving test net (no other FinancialConceptAliases test exists).
+    [Fact]
+    public void TryResolve_AmpersandRd_ResolvesToResearchAndDevelopmentConcept()
+    {
+        var resolved = FinancialConceptAliases.TryResolve("R&D", out var concepts);
+
+        resolved.Should().BeTrue();
+        concepts.Should().ContainSingle();
+        concepts[0].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
+        concepts[0].Tag.Should().Be("ResearchAndDevelopmentExpense");
+    }
+}


### PR DESCRIPTION
## Summary

- Lane A adversarial test for `FinancialConceptAliases.TryResolve`. The class-level WHY-comment enumerates `"r&d"` as one of three example synonyms that callers must be able to use. `"r&d"` is **not** in the canonical `Map` — it lives only in `Synonyms` — so resolution depends on the `Synonyms → Map` hop firing after `Normalize` lowercases.
- No existing test covered `FinancialConceptAliases` (`find tests -name 'FinancialConceptAliases*'` was empty); the synonym mechanism was unpinned. A refactor that drops the synonym pass, reorders to Map-first only, or changes `Normalize` to strip non-alphanumeric chars would silently break this exact phrasing.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveRdSynonymTests.cs` — one `[Fact]` calling `TryResolve("R&D", out var concepts)` and asserting it returns `true` with a single `(UsGaap, "ResearchAndDevelopmentExpense")` ref.