### PR TITLE
refactor(document-scraper): extract RetryDeferredFilings helper from ScrapeDocuments

### DIFF
--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -80,46 +80,7 @@ public class DocumentScraper : IDocumentScraper
             }
 
             if (result.DeferredFilings.Count > 0)
-            {
-                _logger.LogInformation(
-                    "Retrying {Count} deferred filings after all tickers processed",
-                    result.DeferredFilings.Count
-                );
-
-                var deferred = result.DeferredFilings.ToList();
-                result.DeferredFilings.Clear();
-
-                foreach (var filing in deferred)
-                {
-                    if (cancellationToken.IsCancellationRequested)
-                        break;
-
-                    try
-                    {
-                        await CreateDocument(filing.Company, filing.Filing, filing.DocumentType);
-                        result.DocumentsAdded++;
-
-                        _logger.LogInformation(
-                            "Deferred document succeeded for {Ticker} - {DocumentType} - {FilingDate}",
-                            filing.Company.Ticker,
-                            filing.DocumentType,
-                            filing.Filing.FilingDate
-                        );
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning(
-                            ex,
-                            "Skipping document for {Ticker} - {DocumentType} - {FilingDate} after retry: {Message}",
-                            filing.Company.Ticker,
-                            filing.DocumentType,
-                            filing.Filing.FilingDate,
-                            ex.Message
-                        );
-                        result.DocumentsSkipped++;
-                    }
-                }
-            }
+                await RetryDeferredFilings(result, cancellationToken);
 
             result.Duration = DateTime.UtcNow - startTime;
 
@@ -456,6 +417,51 @@ public class DocumentScraper : IDocumentScraper
                 ex,
                 $"ticker: {company.Ticker}, accession: {filing.AccessionNumber}"
             );
+        }
+    }
+
+    private async Task RetryDeferredFilings(
+        ScrapingResult result,
+        CancellationToken cancellationToken
+    )
+    {
+        _logger.LogInformation(
+            "Retrying {Count} deferred filings after all tickers processed",
+            result.DeferredFilings.Count
+        );
+
+        var deferred = result.DeferredFilings.ToList();
+        result.DeferredFilings.Clear();
+
+        foreach (var filing in deferred)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                break;
+
+            try
+            {
+                await CreateDocument(filing.Company, filing.Filing, filing.DocumentType);
+                result.DocumentsAdded++;
+
+                _logger.LogInformation(
+                    "Deferred document succeeded for {Ticker} - {DocumentType} - {FilingDate}",
+                    filing.Company.Ticker,
+                    filing.DocumentType,
+                    filing.Filing.FilingDate
+                );
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Skipping document for {Ticker} - {DocumentType} - {FilingDate} after retry: {Message}",
+                    filing.Company.Ticker,
+                    filing.DocumentType,
+                    filing.Filing.FilingDate,
+                    ex.Message
+                );
+                result.DocumentsSkipped++;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Extract the ~40-line "retry deferred filings" tail block out of `DocumentScraper.ScrapeDocuments` into a private async `RetryDeferredFilings(result, cancellationToken)` helper. The caller's tail now reads `if (result.DeferredFilings.Count > 0) await RetryDeferredFilings(result, cancellationToken);`.
- Behaviour-preserving: same `LogInformation` header + arg, same `.ToList()` snapshot followed by `result.DeferredFilings.Clear()`, same per-filing try/catch around `CreateDocument(filing.Company, filing.Filing, filing.DocumentType)` + `result.DocumentsAdded++` on success / `result.DocumentsSkipped++` on failure, same info / warning logs with the same template args, same `IsCancellationRequested` short-circuit. `result` is the same reference, so mutations remain visible to the caller.

## Code changes

- `src/Equibles.Sec.HostedService/DocumentScraper.cs` — add `private async Task RetryDeferredFilings(ScrapingResult, CancellationToken)`; collapse the inline tail block in `ScrapeDocuments` to a single guarded call. No public API change.