### PR TITLE
docs(technical/web-portal): split src/css + src/js bullet

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -57,7 +57,8 @@ Why the indirection through `ViewData` rather than a single `StockDetailViewMode
 - [`package.json`](../../src/Equibles.Web/package.json) — Vite 6, Tailwind v4 (`@tailwindcss/postcss`), DaisyUI v5, plus `chart.js`, `aos`, `typed.js`.
 - [`vite.config.js`](../../src/Equibles.Web/vite.config.js) — single entry `src/index.js`, output to `wwwroot/dist/` as `bundle.js` + `main.css`. `emptyOutDir: true` cleans the bundle on each build.
 - [`src/css/main.css`](../../src/Equibles.Web/src/css/main.css) — Tailwind v4 CSS-first config: `@import "tailwindcss"`, `@plugin "daisyui"` + `@plugin "@tailwindcss/typography"`, `@source` directives for `Views/` + `TagHelpers/` + `src/js/`, and the custom `equibles` DaisyUI theme defined via `@plugin "daisyui/theme"`.
-- `src/Equibles.Web/src/css/` holds the entry CSS imported by `src/Equibles.Web/src/index.js`; `src/Equibles.Web/src/js/` holds chart wrappers and per-page JS modules. The bundle lazy-imports per-page modules so the Holdings tab doesn't pull Chart.js into the Documents tab.
+- `src/Equibles.Web/src/css/` holds the entry CSS imported by `src/Equibles.Web/src/index.js`; `src/Equibles.Web/src/js/` holds chart wrappers and per-page JS modules.
+- The bundle lazy-imports per-page modules so the Holdings tab doesn't pull Chart.js into the Documents tab.
 - Dev cycle: `npm run start` (Vite watch) alongside the .NET app — `AddRazorRuntimeCompilation()` (Web/Program.cs:105) makes Razor edits live without rebuild; Vite handles the bundle.
 - CI / Docker: `npm ci && npm run build` runs inside the multi-stage Dockerfile so `wwwroot/dist/` is pre-built into the image.
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `src/css/` + `src/js/` directory bullet packed 274 chars: the directory-layout enumeration (entry CSS vs. chart wrappers + per-page JS) *and* the lazy-import bundle behavior (Holdings tab doesn't pull Chart.js into the Documents tab). Split into layout vs. behavior.

## Code changes

- `docs/technical/web-portal.md` — split the bullet into one stating what each `src/Equibles.Web/src/` subdirectory holds and one stating the per-page lazy-import bundle behavior.