### PR TITLE
refactor(profiles-controller): collapse scan-for-index loop in BuildQuarterlyActivity to IndexOf+Max

### DIFF
--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -134,18 +134,9 @@ public class ProfilesController : BaseController
                 null
             );
 
-        var selectedIndex = 0;
-        if (requestedDate.HasValue)
-        {
-            for (var i = 0; i < distinctReportDates.Count; i++)
-            {
-                if (distinctReportDates[i] == requestedDate.Value)
-                {
-                    selectedIndex = i;
-                    break;
-                }
-            }
-        }
+        var selectedIndex = requestedDate.HasValue
+            ? Math.Max(0, distinctReportDates.ToList().IndexOf(requestedDate.Value))
+            : 0;
         var selected = distinctReportDates[selectedIndex];
         if (selectedIndex >= distinctReportDates.Count - 1)
             return (


### PR DESCRIPTION
## Summary

- `ProfilesController.BuildQuarterlyActivity` resolved `selectedIndex` via a 12-line manual `for`-loop scan-and-break gated on `requestedDate.HasValue`, defaulting to 0 when null or unfound.
- Collapse to a single ternary: `requestedDate.HasValue ? Math.Max(0, distinctReportDates.ToList().IndexOf(requestedDate.Value)) : 0`. `IndexOf` returns -1 on not-found, which `Math.Max(0, …)` clamps to 0 — exactly matching the original "selectedIndex stays at default 0" branch.
- Behavior-preserving across all three input shapes (null requested, requested found at index K, requested not found). The `.ToList()` materialization is needed because the parameter is `IReadOnlyList<DateOnly>` (no `IndexOf`); the actual runtime list is already a `List<DateOnly>` from the caller's `.ToListAsync()`, so the allocation is one cheap shallow copy of a short quarterly-date list.

## Code changes

- `src/Equibles.Web/Controllers/ProfilesController.cs` — replaced the 12-line for-loop in `BuildQuarterlyActivity` with a 3-line ternary using `IndexOf` + `Math.Max(0, …)`. No public-API change, no behavior change.