### PR TITLE
refactor(sec-financialfacts): extract TryParseChildDate helper for three duplicated date-element parses in TryParsePeriod

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -115,8 +115,7 @@ public class InlineXbrlParser
         out DateOnly end
     )
     {
-        var instant = FindFirstChildByLocalName(period, InstantLocalName);
-        if (instant != null && DateOnly.TryParse(instant.TextContent.Trim(), out var instantDate))
+        if (TryParseChildDate(period, InstantLocalName, out var instantDate))
         {
             isInstant = true;
             start = instantDate;
@@ -124,13 +123,9 @@ public class InlineXbrlParser
             return true;
         }
 
-        var startElement = FindFirstChildByLocalName(period, StartDateLocalName);
-        var endElement = FindFirstChildByLocalName(period, EndDateLocalName);
         if (
-            startElement != null
-            && endElement != null
-            && DateOnly.TryParse(startElement.TextContent.Trim(), out var startDate)
-            && DateOnly.TryParse(endElement.TextContent.Trim(), out var endDate)
+            TryParseChildDate(period, StartDateLocalName, out var startDate)
+            && TryParseChildDate(period, EndDateLocalName, out var endDate)
         )
         {
             isInstant = false;
@@ -143,6 +138,13 @@ public class InlineXbrlParser
         start = default;
         end = default;
         return false;
+    }
+
+    private static bool TryParseChildDate(IElement parent, string localName, out DateOnly date)
+    {
+        date = default;
+        var child = FindFirstChildByLocalName(parent, localName);
+        return child != null && DateOnly.TryParse(child.TextContent.Trim(), out date);
     }
 
     private static List<ParsedXbrlDimension> ExtractDimensions(IElement contextElement)


### PR DESCRIPTION
## Summary

- `InlineXbrlParser.TryParsePeriod` had three near-identical sites (`instant`, `startDate`, `endDate`) each doing `FindFirstChildByLocalName` → null-check → `DateOnly.TryParse(child.TextContent.Trim(), ...)`. Extracted into a single `TryParseChildDate(parent, localName, out date)` helper.

## Code changes

- `src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs` — three duplicated date-element lookups in `TryParsePeriod` now route through `private static bool TryParseChildDate(IElement parent, string localName, out DateOnly date)`. Helper preserves the exact same `FindFirstChildByLocalName` lookup, null-check short-circuit, and `DateOnly.TryParse(child.TextContent.Trim(), out date)` semantics; same `out` parameter behavior on miss.