### PR TITLE
test(sec): pin InlineXbrlParser.ParseDecimals accepts lowercase inf case-insensitively

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserDecimalsInfLowercaseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserDecimalsInfLowercaseTests.cs
@@ -1,0 +1,37 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InlineXbrlParserDecimalsInfLowercaseTests
+{
+    // Sibling of Parse_DecimalsInf_MapsToIntMaxValue (which only pins "INF").
+    // ParseDecimals uses OrdinalIgnoreCase to accept any case of "INF" — older
+    // filings occasionally emit non-spec-strict lowercase. A refactor that
+    // tightens the comparer to Ordinal (or replaces string.Equals with ==)
+    // would silently route "inf" to int.TryParse, which fails, returning null
+    // and losing the precision hint without the existing test catching it.
+    [Fact]
+    public void Parse_DecimalsLowercaseInf_MapsToIntMaxValue()
+    {
+        var html =
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\" "
+            + "xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\" "
+            + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+            + "xmlns:dei=\"http://xbrl.sec.gov/dei/2018-01-31\""
+            + "><body><div style=\"display:none\"><ix:header><ix:resources>"
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>xbrli:shares</xbrli:measure></xbrli:unit>"
+            + "</ix:resources></ix:header></div>"
+            + "<ix:nonFraction name=\"dei:EntityCommonStockSharesOutstanding\" "
+            + "contextRef=\"C1\" unitRef=\"u\" decimals=\"inf\">1000</ix:nonFraction>"
+            + "</body></html>";
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Decimals.Should().Be(int.MaxValue);
+    }
+}


### PR DESCRIPTION
## Summary

- Lane A sibling pinning case-insensitive handling of `decimals="inf"` (lowercase). The existing `Parse_DecimalsInf_MapsToIntMaxValue` only exercises uppercase `"INF"`.
- `ParseDecimals` uses `string.Equals(..., "INF", StringComparison.OrdinalIgnoreCase)` — a defensive choice for non-spec-strict filings that emit lowercase. A refactor tightening the comparer to `Ordinal` (or replacing `string.Equals` with `==`) would silently route `"inf"` through `int.TryParse`, which fails, returning `null` and losing the precision hint.

## Code changes

- `tests/Equibles.UnitTests/Sec/InlineXbrlParserDecimalsInfLowercaseTests.cs` — one `[Fact]` parsing an iXBRL fragment with `decimals="inf"` and asserting `fact.Decimals == int.MaxValue`.