### PR TITLE
refactor(congress-hostedservice): extract HonorificPrefixes constant and StripHonorificPrefixes helper from chained Replace calls

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -27,6 +27,8 @@ public partial class HouseDisclosureClient
     private const string ZipUrlTemplate = BaseUrl + "/public_disc/financial-pdfs/{0}FD.zip";
     private const string PtrPdfUrlTemplate = BaseUrl + "/public_disc/ptr-pdfs/{0}/{1}.pdf";
 
+    private static readonly string[] HonorificPrefixes = ["Hon. ", "Mr. ", "Mrs. ", "Ms. "];
+
     public HouseDisclosureClient(HttpClient httpClient, ILogger<HouseDisclosureClient> logger)
     {
         _httpClient = httpClient;
@@ -140,13 +142,7 @@ public partial class HouseDisclosureClient
                 var prefix = m.Element("Prefix")?.Value?.Trim() ?? "";
                 var first = m.Element("First")?.Value?.Trim() ?? "";
                 var last = m.Element("Last")?.Value?.Trim() ?? "";
-                var name = $"{prefix} {first} {last}"
-                    .Trim()
-                    .Replace("Hon. ", "")
-                    .Replace("Mr. ", "")
-                    .Replace("Mrs. ", "")
-                    .Replace("Ms. ", "")
-                    .Trim();
+                var name = StripHonorificPrefixes($"{prefix} {first} {last}".Trim()).Trim();
 
                 return new HouseFiling(
                     name,
@@ -369,4 +365,11 @@ public partial class HouseDisclosureClient
         DateOnly FilingDate,
         string StateDst
     );
+
+    private static string StripHonorificPrefixes(string name)
+    {
+        foreach (var prefix in HonorificPrefixes)
+            name = name.Replace(prefix, "");
+        return name;
+    }
 }


### PR DESCRIPTION
## Summary

- Collapse four chained `.Replace("X. ", "")` honorific-prefix strips in `HouseDisclosureClient.DownloadAndParseFilingIndex` into a `private static readonly string[] HonorificPrefixes` constant plus a `StripHonorificPrefixes(name)` helper. Names the intent and surfaces the prefix list at class scope.

## Code changes

- `src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs` — added `HonorificPrefixes` array `["Hon. ", "Mr. ", "Mrs. ", "Ms. "]` and `private static string StripHonorificPrefixes(string name)` helper. Helper applies the same `string.Replace(prefix, "")` calls in the same left-to-right order as the existing chain; .NET String.Replace semantics (all occurrences, ordinal, case-sensitive) preserved; outer `Trim()` bookends remain.