### PR TITLE
refactor(economic-data-controller): drop redundant values array in Show

### DIFF
--- a/src/Equibles.Web/Controllers/EconomicDataController.cs
+++ b/src/Equibles.Web/Controllers/EconomicDataController.cs
@@ -96,13 +96,16 @@ public class EconomicDataController : BaseController
             Observations = observations,
         };
 
-        var values = observations
+        // Chronological order is needed for SMA; stats are order-invariant so the
+        // same array drives both.
+        var chronological = observations
             .Where(o => o.Value.HasValue)
+            .OrderBy(o => o.Date)
             .Select(o => (double)o.Value.Value)
             .ToArray();
-        if (values.Length > 0)
+        if (chronological.Length > 0)
         {
-            var s = ComputeStats(values, decimals: 4);
+            var s = ComputeStats(chronological, decimals: 4);
             viewModel.Mean = s.Mean;
             viewModel.Min = s.Min;
             viewModel.Max = s.Max;
@@ -111,13 +114,6 @@ public class EconomicDataController : BaseController
             viewModel.LatestValue = observations[0].Value; // observations are desc by date
             if (observations.Count > 1)
                 viewModel.PreviousValue = observations[1].Value;
-
-            // Moving averages (computed on chronological order)
-            var chronological = observations
-                .Where(o => o.Value.HasValue)
-                .OrderBy(o => o.Date)
-                .Select(o => (double)o.Value.Value)
-                .ToArray();
 
             viewModel.Sma20 = ComputeSma(chronological, 20);
             viewModel.Sma50 = ComputeSma(chronological, 50);


### PR DESCRIPTION
## Summary

- `EconomicDataController.Show` was building two arrays from the same observations: `values` (descending by date — observations are already sorted desc) used for stats, and `chronological` (ascending) used for SMA. Both filtered `o.Value.HasValue` and projected `(double)o.Value.Value` from the same source.
- Drop the `values` array; reuse `chronological` for both stats and SMA. Stats functions (`Mean`, `Min`, `Max`, `StdDev`, `Median`) are order-invariant — they depend on the multiset of values, not the iteration order — so the asc-ordered array produces identical Mean / Min / Max / Median / StdDev.
- Behavior-preserving: `MathNet.Numerics.DescriptiveStatistics` computes Mean/Min/Max/StdDev order-independently; `.Median()` extension sorts internally. Same gate (`Length > 0`), same downstream view-model values.

## Code changes

- `src/Equibles.Web/Controllers/EconomicDataController.cs` — removed the desc-ordered `values` projection; renamed the gating expression to use `chronological.Length`. Added one-line WHY-comment explaining why one array now serves both code paths.