### PR TITLE
refactor(stock-tab): extract BuildStatementLines helper from LoadFinancialsTab

### DIFF
--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -280,6 +280,23 @@ public class StockTabService
         viewModel.SelectedYear = selected.FiscalYear;
         viewModel.SelectedPeriod = selected.FiscalPeriod;
 
+        viewModel.Lines = await BuildStatementLines(
+            stock,
+            statementType,
+            selected.FiscalYear,
+            selected.FiscalPeriod
+        );
+
+        return viewModel;
+    }
+
+    private async Task<List<FinancialsLineViewModel>> BuildStatementLines(
+        CommonStock stock,
+        FinancialStatementType statementType,
+        int fiscalYear,
+        SecFiscalPeriod fiscalPeriod
+    )
+    {
         var statementLines = FinancialStatementConcepts.For(statementType);
         var taxonomies = statementLines.Select(l => l.Taxonomy).Distinct().ToList();
         var tags = statementLines.Select(l => l.Tag).Distinct().ToList();
@@ -299,8 +316,8 @@ public class StockTabService
         var facts = await _financialFactRepository
             .GetByStock(stock)
             .Where(f =>
-                f.FiscalYear == selected.FiscalYear
-                && f.FiscalPeriod == selected.FiscalPeriod
+                f.FiscalYear == fiscalYear
+                && f.FiscalPeriod == fiscalPeriod
                 && conceptIds.Contains(f.FinancialConceptId)
             )
             .ToListAsync();
@@ -311,7 +328,7 @@ public class StockTabService
             .GroupBy(f => f.FinancialConceptId)
             .ToDictionary(g => g.Key, g => g.OrderByDescending(f => f.FiledDate).First());
 
-        viewModel.Lines = statementLines
+        return statementLines
             .Select(line =>
             {
                 var row = new FinancialsLineViewModel { Label = line.Label };
@@ -330,8 +347,6 @@ public class StockTabService
                 return row;
             })
             .ToList();
-
-        return viewModel;
     }
 
     // Chronological order within a fiscal year: Q1 < Q2 < Q3 < Q4 < FullYear.


### PR DESCRIPTION
## Summary

- Extract the inline ~50-line "load concept ids for the statement type → load facts for the selected period → group by concept (latest filed wins) → project to `FinancialsLineViewModel` rows" block out of `StockTabService.LoadFinancialsTab` into a private async `BuildStatementLines(stock, statementType, fiscalYear, fiscalPeriod)` helper returning `List<FinancialsLineViewModel>`. The caller now reads `viewModel.Lines = await BuildStatementLines(stock, statementType, selected.FiscalYear, selected.FiscalPeriod);`.
- Behaviour-preserving: same `FinancialStatementConcepts.For(statementType)` lookup, same `_financialConceptRepository.GetMatching(taxonomies, tags)` + `.ToDictionary/.ToHashSet` builds, same `_financialFactRepository.GetByStock(stock).Where(...)` filter against `fiscalYear`/`fiscalPeriod`/`conceptIds`, same `.GroupBy(f => f.FinancialConceptId).ToDictionary(g => g.Key, g => g.OrderByDescending(f => f.FiledDate).First())` latest-filed projection, same per-`statementLines` row construction with the same field assignments. The "SEC re-emits a concept across filings" WHY-comment moves with its code into the helper.

## Code changes

- `src/Equibles.Web/Services/StockTabService.cs` — add `private async Task<List<FinancialsLineViewModel>> BuildStatementLines(CommonStock, FinancialStatementType, int, SecFiscalPeriod)`. `LoadFinancialsTab` calls it after the period-selection logic and assigns the result to `viewModel.Lines`. No public API change.