### PR TITLE
refactor(document-scraper): extract TryExtractPdfFallback helper from CreateDocument

### DIFF
--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -495,56 +495,17 @@ public class DocumentScraper : IDocumentScraper
 
                 if (string.IsNullOrWhiteSpace(markdownDocument))
                 {
-                    // Paper-filed submissions (typically older 6-K/20-F) wrap a uuencoded PDF
-                    // and have no HTML for the normalizer to consume. Fetch the standalone PDF
-                    // artifact and extract its text instead.
-                    if (
-                        !SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(
-                            content,
-                            out var pdfFilename
-                        )
-                    )
-                    {
-                        _logger.LogWarning(
-                            "Skipping document for {Ticker} - {DocumentType} - {FilingDate}: no content after conversion. URL: {Url}",
-                            companyOutContext.Ticker,
-                            documentType,
-                            filing.FilingDate,
-                            filing.DocumentUrl
-                        );
-                        return;
-                    }
-
-                    var pdfBytes = await secEdgarClient.GetDocumentFileBytes(
-                        filing.Cik,
-                        filing.AccessionNumber,
-                        pdfFilename,
+                    markdownDocument = await TryExtractPdfFallback(
+                        secEdgarClient,
+                        pdfTextExtractor,
+                        content,
+                        companyOutContext,
+                        filing,
+                        documentType,
                         cancellationToken
                     );
-                    markdownDocument = pdfTextExtractor.Extract(pdfBytes);
-
-                    if (string.IsNullOrWhiteSpace(markdownDocument))
-                    {
-                        // PDF was located but yielded no extractable text — either the artifact was
-                        // missing (404, logged by the client), or it's an image-only scan needing OCR.
-                        _logger.LogWarning(
-                            "Skipping document for {Ticker} - {DocumentType} - {FilingDate}: PDF {Filename} produced no text. URL: {Url}",
-                            companyOutContext.Ticker,
-                            documentType,
-                            filing.FilingDate,
-                            pdfFilename,
-                            filing.DocumentUrl
-                        );
+                    if (markdownDocument == null)
                         return;
-                    }
-
-                    _logger.LogInformation(
-                        "Extracted PDF text for {Ticker} - {DocumentType} - {FilingDate} from paper filing artifact {Filename}",
-                        companyOutContext.Ticker,
-                        documentType,
-                        filing.FilingDate,
-                        pdfFilename
-                    );
                 }
 
                 await persistenceService.Save(
@@ -567,6 +528,66 @@ public class DocumentScraper : IDocumentScraper
                 );
             }
         );
+    }
+
+    // Paper-filed submissions (typically older 6-K/20-F) wrap a uuencoded PDF
+    // and have no HTML for the normalizer to consume. Fetch the standalone PDF
+    // artifact and extract its text instead. Returns null to signal "skip this
+    // filing" — the caller short-circuits without persisting.
+    private async Task<string> TryExtractPdfFallback(
+        ISecEdgarClient secEdgarClient,
+        IPdfTextExtractor pdfTextExtractor,
+        string content,
+        CommonStock companyOutContext,
+        FilingData filing,
+        DocumentType documentType,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(content, out var pdfFilename))
+        {
+            _logger.LogWarning(
+                "Skipping document for {Ticker} - {DocumentType} - {FilingDate}: no content after conversion. URL: {Url}",
+                companyOutContext.Ticker,
+                documentType,
+                filing.FilingDate,
+                filing.DocumentUrl
+            );
+            return null;
+        }
+
+        var pdfBytes = await secEdgarClient.GetDocumentFileBytes(
+            filing.Cik,
+            filing.AccessionNumber,
+            pdfFilename,
+            cancellationToken
+        );
+        var markdown = pdfTextExtractor.Extract(pdfBytes);
+
+        if (string.IsNullOrWhiteSpace(markdown))
+        {
+            // PDF was located but yielded no extractable text — either the artifact was
+            // missing (404, logged by the client), or it's an image-only scan needing OCR.
+            _logger.LogWarning(
+                "Skipping document for {Ticker} - {DocumentType} - {FilingDate}: PDF {Filename} produced no text. URL: {Url}",
+                companyOutContext.Ticker,
+                documentType,
+                filing.FilingDate,
+                pdfFilename,
+                filing.DocumentUrl
+            );
+            return null;
+        }
+
+        _logger.LogInformation(
+            "Extracted PDF text for {Ticker} - {DocumentType} - {FilingDate} from paper filing artifact {Filename}",
+            companyOutContext.Ticker,
+            documentType,
+            filing.FilingDate,
+            pdfFilename
+        );
+
+        return markdown;
     }
 
     private static void RecordError(ScrapingResult result, string label, Exception ex)


### PR DESCRIPTION
## Summary

- Move the inline "paper-PDF fallback for empty HTML" block (~52 lines) out of the `_retryPipeline.ExecuteAsync` lambda body inside `DocumentScraper.CreateDocument` into a private async `TryExtractPdfFallback(...)` helper that returns the extracted markdown or `null` to signal "skip this filing".
- Caller now does `markdownDocument = await TryExtractPdfFallback(...); if (markdownDocument == null) return;` instead of nesting two `if (string.IsNullOrWhiteSpace(...)) return;` branches.
- Behaviour-preserving: same `SecDocumentEnvelopeParser.TryExtractPaperPdfFilename` call (same "no content after conversion" warning + null on miss), same `secEdgarClient.GetDocumentFileBytes`, same `pdfTextExtractor.Extract`, same "PDF produced no text" warning + null when extracted text is blank, same "Extracted PDF text" info log on success. The two WHY-comments ("Paper-filed submissions wrap a uuencoded PDF…" and "PDF was located but yielded no extractable text…") follow their code into the helper.

## Code changes

- `src/Equibles.Sec.HostedService/DocumentScraper.cs` — add `private async Task<string> TryExtractPdfFallback(ISecEdgarClient, IPdfTextExtractor, string, CommonStock, FilingData, DocumentType, CancellationToken)`. The retry-lambda body in `CreateDocument` shrinks the empty-HTML branch to a guarded helper call. No public API change.