### PR TITLE
docs(technical/mcp-tools): split AddEquiblesMcp bullet

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -5,7 +5,8 @@ Catalog of the MCP tools exposed by each `*.Mcp` project and the wiring path thr
 ## Wiring path
 
 - [`EquiblesMcpBuilder`](../../src/Equibles.Mcp/EquiblesMcpBuilder.cs) wraps the MCP server builder and tracks registered modules + middleware.
-- The MCP host calls [`services.AddEquiblesMcp(mcp => { ... })`](../../src/Equibles.Mcp/Extensions/ServiceCollectionExtensions.cs) once. That call invokes `services.AddMcpServer().WithHttpTransport()` and hands a fluent `EquiblesMcpBuilder` to the configuration lambda.
+- The MCP host calls [`services.AddEquiblesMcp(mcp => { ... })`](../../src/Equibles.Mcp/Extensions/ServiceCollectionExtensions.cs) once.
+- That call invokes `services.AddMcpServer().WithHttpTransport()` and hands a fluent `EquiblesMcpBuilder` to the configuration lambda.
 - Each module ships an `AddXxx(EquiblesMcpBuilder)` extension under `Equibles.<Module>.Mcp.Extensions.McpBuilderExtensions` that calls `builder.AddModule<AssemblyMcpModule<MarkerType>>()`.
 - [`AssemblyMcpModule<TMarker>`](../../src/Equibles.Mcp/AssemblyMcpModule.cs) calls `builder.WithToolsFromAssembly(typeof(TMarker).Assembly)` — discovers every `[McpServerToolType]` class in the module assembly and registers its `[McpServerTool]`-attributed methods.
 - The host pipeline mounts the transport at `/mcp` with `app.MapMcp("/mcp")` and gates it via [`ApiKeyMiddleware`](../../src/Equibles.Mcp/Middleware/ApiKeyMiddleware.cs) under `UseWhen(ctx.Request.Path.StartsWithSegments("/mcp"))`.


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `AddEquiblesMcp` registration bullet packed 269 chars: the host call ("calls `AddEquiblesMcp(mcp => {...})` once") *and* the underlying invocation that wires `AddMcpServer().WithHttpTransport()` plus the fluent `EquiblesMcpBuilder` handed to the lambda. Split into call vs. underlying invocation.

## Code changes

- `docs/technical/mcp-tools.md` — split the bullet into one stating the single-call rule at the host site and one describing the underlying `AddMcpServer().WithHttpTransport()` invocation plus the `EquiblesMcpBuilder` lambda parameter.