### PR TITLE
refactor(sec-facts): collapse 3 duplicated context tuples in StandaloneXbrlParser into ParsedContext record struct

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
@@ -87,15 +87,9 @@ public class StandaloneXbrlParser
         return facts;
     }
 
-    private static Dictionary<
-        string,
-        (bool IsInstant, DateOnly Start, DateOnly End, List<ParsedXbrlDimension> Dimensions)
-    > BuildContextMap(XElement root)
+    private static Dictionary<string, ParsedContext> BuildContextMap(XElement root)
     {
-        var contexts = new Dictionary<
-            string,
-            (bool, DateOnly, DateOnly, List<ParsedXbrlDimension>)
-        >(StringComparer.Ordinal);
+        var contexts = new Dictionary<string, ParsedContext>(StringComparer.Ordinal);
 
         foreach (var contextElement in root.Elements(ContextElement))
         {
@@ -111,7 +105,7 @@ public class StandaloneXbrlParser
                 continue;
 
             var dimensions = ExtractDimensions(contextElement);
-            contexts[id] = (isInstant, start, end, dimensions);
+            contexts[id] = new ParsedContext(isInstant, start, end, dimensions);
         }
 
         return contexts;
@@ -221,10 +215,7 @@ public class StandaloneXbrlParser
 
     private static bool TryParseFact(
         XElement element,
-        Dictionary<
-            string,
-            (bool IsInstant, DateOnly Start, DateOnly End, List<ParsedXbrlDimension> Dimensions)
-        > contexts,
+        Dictionary<string, ParsedContext> contexts,
         Dictionary<string, string> units,
         out ParsedXbrlFact fact
     )
@@ -286,4 +277,11 @@ public class StandaloneXbrlParser
             return int.MaxValue;
         return int.TryParse(decimalsAttribute, out var value) ? value : null;
     }
+
+    private record struct ParsedContext(
+        bool IsInstant,
+        DateOnly Start,
+        DateOnly End,
+        List<ParsedXbrlDimension> Dimensions
+    );
 }


### PR DESCRIPTION
## Summary

- `StandaloneXbrlParser` spelled the 4-element value tuple `(bool IsInstant, DateOnly Start, DateOnly End, List<ParsedXbrlDimension> Dimensions)` in three places: `BuildContextMap`'s return type, its local dictionary's type argument, and `TryParseFact`'s parameter type.
- Collapse all three into a `private record struct ParsedContext(bool IsInstant, DateOnly Start, DateOnly End, List<ParsedXbrlDimension> Dimensions)` — the same pattern already used by `InlineXbrlParser`.
- Field names match the existing tuple field names, so destructured reads at call sites (`context.IsInstant`, `context.Start`, `context.End`, `context.Dimensions`) continue to resolve identically. No public API touched: `BuildContextMap`, `BuildUnitMap`, and `TryParseFact` are all `private static`; the public `Parse` signature is unchanged.

## Code changes

- `src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs` — replace 3 tuple-type spellings with a `ParsedContext` record struct declared at file scope; swap the tuple-literal `contexts[id] = (...)` for `new ParsedContext(...)`.