### PR TITLE
refactor(holdings): hoist per-fund TotalValue in FundOverlapCalculator

### DIFF
--- a/src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs
@@ -39,7 +39,12 @@ public static class FundOverlapCalculator
                             Value = g.Sum(h => h.Value),
                         }
                     );
-                return new FundAggregate { Holder = f.Holder, PerStock = perStock };
+                return new FundAggregate
+                {
+                    Holder = f.Holder,
+                    PerStock = perStock,
+                    TotalValue = perStock.Values.Sum(s => s.Value),
+                };
             })
             .ToList();
 
@@ -52,7 +57,7 @@ public static class FundOverlapCalculator
                     HolderCik = fund.Holder.Cik,
                     HolderName = fund.Holder.Name,
                     PositionCount = fund.PerStock.Count,
-                    TotalValue = fund.PerStock.Values.Sum(s => s.Value),
+                    TotalValue = fund.TotalValue,
                 }
             );
         }
@@ -78,15 +83,14 @@ public static class FundOverlapCalculator
                 fund.PerStock.TryGetValue(stockId, out var perStock);
                 ticker ??= perStock?.Ticker;
                 name ??= perStock?.Name;
-                var fundTotal = fund.PerStock.Values.Sum(s => s.Value);
                 var slice = new FundOverlapRowSlice
                 {
                     HolderId = fund.Holder.Id,
                     Shares = perStock?.Shares ?? 0,
                     Value = perStock?.Value ?? 0,
                     PercentOfPortfolio =
-                        fundTotal > 0 && perStock != null
-                            ? (double)perStock.Value / fundTotal * 100.0
+                        fund.TotalValue > 0 && perStock != null
+                            ? (double)perStock.Value / fund.TotalValue * 100.0
                             : 0,
                 };
                 slices.Add(slice);
@@ -138,6 +142,7 @@ public static class FundOverlapCalculator
     {
         public InstitutionalHolder Holder { get; set; }
         public Dictionary<Guid, FundStockAggregate> PerStock { get; set; }
+        public long TotalValue { get; set; }
     }
 
     private class FundStockAggregate


### PR DESCRIPTION
## Summary

- `FundOverlapCalculator.Calculate` recomputed `fund.PerStock.Values.Sum(s => s.Value)` once when building `result.Funds[i].TotalValue` and then again on every iteration of the per-stock inner loop (used as the `fundTotal` divisor in `PercentOfPortfolio`). With S stocks and F funds that's S·F sum computations per call where one per fund suffices.
- Stored each fund's total on the private `FundAggregate` at projection time and reuse it everywhere. The dictionary is built once and never mutated, so the value is invariant for the lifetime of the call — moving the computation earlier changes nothing observable.
- No public-API change, no exception-behavior change, no iteration-order change. Build + 1521 unit + 1403 integration tests + csharpier check all green locally.

## Code changes

- `src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs` — added `TotalValue` to private `FundAggregate`; set it in the `Select` projection alongside `PerStock`; replaced the per-(fund,stock) `fund.PerStock.Values.Sum(...)` recomputation and the per-fund `result.Funds.Add(...)` Sum call with reads of `fund.TotalValue`.