### PR TITLE
refactor(yahoo-price-import): extract WarnAndCollectOverflowDates helper from ImportTicker

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -114,25 +114,7 @@ public class YahooPriceImportService
             cancellationToken
         );
 
-        var outOfRange = prices.Where(HasOverflowPrice).ToList();
-        if (outOfRange.Count > 0)
-        {
-            var sample = outOfRange[0];
-            _logger.LogWarning(
-                "Skipping {Count} prices for {Ticker} exceeding numeric(18,4) limit. "
-                    + "Sample: {Date} O={Open} H={High} L={Low} C={Close} AC={AdjClose}",
-                outOfRange.Count,
-                ticker,
-                sample.Date,
-                sample.Open,
-                sample.High,
-                sample.Low,
-                sample.Close,
-                sample.AdjustedClose
-            );
-        }
-
-        var overflowDates = outOfRange.Select(p => p.Date).ToHashSet();
+        var overflowDates = WarnAndCollectOverflowDates(prices, ticker);
 
         var newPrices = prices
             .Where(p => !existingDates.Contains(p.Date) && !overflowDates.Contains(p.Date))
@@ -329,6 +311,32 @@ public class YahooPriceImportService
             .FirstOrDefaultAsync(cancellationToken);
 
         return SyncDateResolver.Resolve(latestDate, _workerOptions);
+    }
+
+    private HashSet<DateOnly> WarnAndCollectOverflowDates(
+        List<HistoricalPrice> prices,
+        string ticker
+    )
+    {
+        var outOfRange = prices.Where(HasOverflowPrice).ToList();
+        if (outOfRange.Count > 0)
+        {
+            var sample = outOfRange[0];
+            _logger.LogWarning(
+                "Skipping {Count} prices for {Ticker} exceeding numeric(18,4) limit. "
+                    + "Sample: {Date} O={Open} H={High} L={Low} C={Close} AC={AdjClose}",
+                outOfRange.Count,
+                ticker,
+                sample.Date,
+                sample.Open,
+                sample.High,
+                sample.Low,
+                sample.Close,
+                sample.AdjustedClose
+            );
+        }
+
+        return outOfRange.Select(p => p.Date).ToHashSet();
     }
 
     private static bool HasOverflowPrice(HistoricalPrice p) =>


### PR DESCRIPTION
## Summary

- Extract the inline "filter prices over numeric(18,4) limit → log a single warning with the first sample → build a HashSet of overflow dates" block out of `YahooPriceImportService.ImportTicker` into a private `WarnAndCollectOverflowDates(prices, ticker)` helper that returns the overflow-date set (with the warning emitted as a side effect when any rows were filtered).
- Behaviour-preserving: same `prices.Where(HasOverflowPrice).ToList()` filter, same `outOfRange.Count > 0` guard, same `_logger.LogWarning(...)` with the same template and the same 8 args derived from `outOfRange[0]`, same `.Select(p => p.Date).ToHashSet()` projection.

## Code changes

- `src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs` — add `private HashSet<DateOnly> WarnAndCollectOverflowDates(List<HistoricalPrice>, string)`. `ImportTicker`'s overflow block shrinks to a single call: `var overflowDates = WarnAndCollectOverflowDates(prices, ticker);`. No public API change.