### PR TITLE
docs(technical/web-portal): split FlashMessage bullet

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -43,7 +43,9 @@ Why the indirection through `ViewData` rather than a single `StockDetailViewMode
 
 - `_ViewStart.cshtml` pins every view to `_Layout.cshtml`. There is no per-area layout split — one shell for everything.
 - `_ViewImports.cshtml` declares the project-wide `@using`s + tag-helper imports + the `Equibles.Web` namespace.
-- [`FlashMessage`](../../src/Equibles.Web/FlashMessage) — one-shot session messages used across controllers. `services.AddFlashMessage()` registers the writer; the layout reads via injected `IFlashMessage`. Use for redirects after a write (Auth login success, etc.).
+- [`FlashMessage`](../../src/Equibles.Web/FlashMessage) — one-shot session messages used across controllers.
+- `services.AddFlashMessage()` registers the writer; the layout reads via injected `IFlashMessage`.
+- Use for redirects after a write (Auth login success, etc.).
 - [`StatusBadgeFilter`](../../src/Equibles.Web/Filters/StatusBadgeFilter.cs) counts recent errors and exposes a badge for the Status link in the layout.
 - [`VersionCheckFilter`](../../src/Equibles.Web/Filters/VersionCheckFilter.cs) compares `AssemblyInformationalVersion` against the latest GitHub release and surfaces an update banner.
 - Both filters register globally via `AddControllersWithViews(options => options.Filters.AddService<...>())`.


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `FlashMessage` bullet packed 268 chars: what it is (one-shot session messages), how to wire it (`services.AddFlashMessage()` + injected `IFlashMessage`), and when to use it (redirects after a write). Split into three single-fact bullets.

## Code changes

- `docs/technical/web-portal.md` — split the `FlashMessage` bullet into one stating what it is, one for the registration + injection wiring, and one for the redirect use case.