### PR TITLE
test(sec): add skipped repro for GH-1438 — FtdImportService.ParseLine

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceParseLineNonNumericQuantityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceParseLineNonNumericQuantityTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Equibles.Sec.HostedService.Models;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FtdImportServiceParseLineNonNumericQuantityTests
+{
+    // Contract (newly extracted ParseLine helper, #1386): three explicit reject
+    // paths — whitespace, fewer than 6 pipe-delimited fields, unparseable
+    // SETTLEMENT DATE — all return null. Per the strict-null-on-malformed
+    // precedent set by GH-1350 ("IsRecentFtdFile returns false for any
+    // malformed input"), a non-numeric QUANTITY field is also malformed: a
+    // careful caller of an FTD parser would not expect a fabricated
+    // Quantity = 0 record (which silently corrupts downstream FTD aggregates
+    // — zero failed-to-deliver shares is itself a meaningful and distinct
+    // value from "we couldn't parse this row").
+    [Fact(Skip = "GH-1438 — ParseLine emits record with Quantity=0 for non-numeric quantity")]
+    public void ParseLine_NonNumericQuantity_ReturnsNull()
+    {
+        var method = typeof(FtdImportService).GetMethod(
+            "ParseLine",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var line = "20240315|037833100|AAPL|notanumber|APPLE INC.|175.50";
+
+        var result = (FtdRecord)method.Invoke(null, [line]);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test against `FtdImportService.ParseLine` (extracted in #1386). Contract derived per the GH-1350 precedent: "malformed input should be rejected (return null), not silently defaulted." The helper has three explicit reject paths (whitespace, fewer than 6 pipe-delimited fields, unparseable date) but `long.TryParse(parts[3], …)` for QUANTITY has no such gate — when parsing fails, `quantity` silently defaults to `0` and the record is emitted as if the row were valid.
- Test executed once: failed with `Expected result to be <null>, but found FtdRecord { Cusip = "037833100", Price = 175.50, Quantity = 0L, SettlementDate = 2024-03-15, Symbol = "AAPL" }`. Bug reproduced — silent data corruption of downstream FTD aggregates, which cannot distinguish "row failed to parse" from "legitimate zero failed-to-deliver shares."
- Filed GH-1438 capturing the defect; test committed with `[Fact(Skip = "GH-1438 — …")]` per add-test's discovered-bug flow.

## Code changes

- `tests/Equibles.UnitTests/Sec/FtdImportServiceParseLineNonNumericQuantityTests.cs` — new reflection-based unit test (skipped — see GH-1438). One `[Fact]`: `ParseLine_NonNumericQuantity_ReturnsNull` asserting the strict-null contract on a line with `notanumber` in the quantity column.