### PR TITLE
refactor(holdings-scraper): extract RetryFailedDataSets helper from DoWork

### DIFF
--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -126,34 +126,7 @@ public class HoldingsScraperWorker : BaseScraperWorker
         }
 
         if (failedDataSets.Count > 0)
-        {
-            Logger.LogWarning(
-                "Retrying {Count} failed data sets at end of cycle: {FileNames}",
-                failedDataSets.Count,
-                string.Join(", ", failedDataSets)
-            );
-
-            foreach (var fileName in failedDataSets)
-            {
-                stoppingToken.ThrowIfCancellationRequested();
-
-                if (!await TryProcessDataSet(fileName, minReportDate, stoppingToken))
-                {
-                    Logger.LogError(
-                        "Data set {FileName} permanently failed after all retry attempts in this cycle",
-                        fileName
-                    );
-                    await ErrorReporter.Report(
-                        ErrorSource,
-                        "Holdings.ProcessDataSet",
-                        "Permanently failed after all retry attempts",
-                        null,
-                        $"file: {fileName}, permanently failed"
-                    );
-                    await Task.Delay(FailedDataSetCooldown, stoppingToken);
-                }
-            }
-        }
+            await RetryFailedDataSets(failedDataSets, minReportDate, stoppingToken);
 
         // Recalculate holdings that were imported without a Yahoo price available
         await RecalculatePendingValues(stoppingToken);
@@ -163,6 +136,40 @@ public class HoldingsScraperWorker : BaseScraperWorker
     /// On first run (empty ProcessedDataSet table), seeds all file names except the latest
     /// so only the most recent period gets downloaded and checked.
     /// </summary>
+    private async Task RetryFailedDataSets(
+        List<string> failedDataSets,
+        DateOnly minReportDate,
+        CancellationToken stoppingToken
+    )
+    {
+        Logger.LogWarning(
+            "Retrying {Count} failed data sets at end of cycle: {FileNames}",
+            failedDataSets.Count,
+            string.Join(", ", failedDataSets)
+        );
+
+        foreach (var fileName in failedDataSets)
+        {
+            stoppingToken.ThrowIfCancellationRequested();
+
+            if (!await TryProcessDataSet(fileName, minReportDate, stoppingToken))
+            {
+                Logger.LogError(
+                    "Data set {FileName} permanently failed after all retry attempts in this cycle",
+                    fileName
+                );
+                await ErrorReporter.Report(
+                    ErrorSource,
+                    "Holdings.ProcessDataSet",
+                    "Permanently failed after all retry attempts",
+                    null,
+                    $"file: {fileName}, permanently failed"
+                );
+                await Task.Delay(FailedDataSetCooldown, stoppingToken);
+            }
+        }
+    }
+
     private async Task BackfillProcessedDataSets(
         List<string> fileNames,
         CancellationToken cancellationToken


### PR DESCRIPTION
## Summary

- Move the inline "retry failed data sets at end of cycle" tail block out of `HoldingsScraperWorker.DoWork` into a private async `RetryFailedDataSets(failedDataSets, minReportDate, stoppingToken)` helper. `DoWork`'s tail collapses to `if (failedDataSets.Count > 0) await RetryFailedDataSets(failedDataSets, minReportDate, stoppingToken);` — matching the structural pattern landed for `DocumentScraper.RetryDeferredFilings` (#1413).
- Behaviour-preserving cosmetic extraction: same `LogWarning` header with the same template + args, same per-iteration `stoppingToken.ThrowIfCancellationRequested()`, same `await TryProcessDataSet(fileName, minReportDate, stoppingToken)` retry, same `LogError` + `ErrorReporter.Report(ErrorSource, "Holdings.ProcessDataSet", "Permanently failed after all retry attempts", null, $"file: {fileName}, permanently failed")` + `Task.Delay(FailedDataSetCooldown, stoppingToken)` on persistent failure.

## Code changes

- `src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs` — add `private async Task RetryFailedDataSets(List<string>, DateOnly, CancellationToken)`. `DoWork`'s post-loop tail is reduced to a single guarded helper call. No public API change.