### PR TITLE
refactor(sec-mcp): collapse 3 duplicated document-header interpolations in DocumentTextTools into FormatDocumentHeader helper

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -57,12 +57,12 @@ public class DocumentTextTools
 
                 if (matches.Count == 0)
                 {
-                    return $"No matches found for \"{keyword}\" in {document.CommonStock.Name} ({document.CommonStock.Ticker}) {document.DocumentType} filed {document.ReportingDate:yyyy-MM-dd}.";
+                    return $"No matches found for \"{keyword}\" in {FormatDocumentHeader(document)}.";
                 }
 
                 var result = new StringBuilder();
                 result.AppendLine(
-                    $"Keyword search for \"{keyword}\" in {document.CommonStock.Name} ({document.CommonStock.Ticker}) {document.DocumentType} filed {document.ReportingDate:yyyy-MM-dd} — {matches.Count} matches found:"
+                    $"Keyword search for \"{keyword}\" in {FormatDocumentHeader(document)} — {matches.Count} matches found:"
                 );
                 result.AppendLine();
 
@@ -124,7 +124,7 @@ public class DocumentTextTools
 
                 var result = new StringBuilder();
                 result.AppendLine(
-                    $"{document.CommonStock.Name} ({document.CommonStock.Ticker}) {document.DocumentType} filed {document.ReportingDate:yyyy-MM-dd} — lines {startLine:N0} to {endLine:N0} of {totalLines:N0}:"
+                    $"{FormatDocumentHeader(document)} — lines {startLine:N0} to {endLine:N0} of {totalLines:N0}:"
                 );
                 result.AppendLine();
 
@@ -195,6 +195,9 @@ public class DocumentTextTools
     {
         return $"{lineNumber, 6} │ {content}";
     }
+
+    private static string FormatDocumentHeader(Document document) =>
+        $"{document.CommonStock.Name} ({document.CommonStock.Ticker}) {document.DocumentType} filed {document.ReportingDate:yyyy-MM-dd}";
 
     private static string HighlightKeyword(string line, string keyword)
     {


### PR DESCRIPTION
## Summary

- `DocumentTextTools` spelled `\"{Name} ({Ticker}) {DocumentType} filed {ReportingDate:yyyy-MM-dd}\"` three times across `SearchDocumentKeyword` and `ReadDocumentLines` (the no-match string, the keyword-search header, and the read-lines header).
- Extract a `private static string FormatDocumentHeader(Document document)` and reuse it at all three sites.
- Same property accesses in the same order, same culture-independent date format, same lazy-load triggers — the resulting strings are byte-identical to the previous interpolations.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs` — add a `FormatDocumentHeader(Document)` helper next to `FormatLine`; rewrite the three call sites to use it.