### PR TITLE
refactor(holdings-backtest): extract SelectRelevantSnapshotDates helper from Execute

### DIFF
--- a/src/Equibles.Web/Services/HoldingsBacktestService.cs
+++ b/src/Equibles.Web/Services/HoldingsBacktestService.cs
@@ -95,21 +95,7 @@ public class HoldingsBacktestService
         var firstRebalance = reportDates[0].AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
         var resolvedFrom = from ?? firstRebalance;
 
-        // Determine which snapshots feed the simulation: all whose rebalance date falls in
-        // [resolvedFrom, resolvedTo], plus the latest one whose rebalance date precedes
-        // resolvedFrom so the simulation can open with an initial portfolio.
-        var relevant = new List<DateOnly>();
-        DateOnly? lastBeforeWindow = null;
-        foreach (var date in reportDates)
-        {
-            var rebalance = date.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
-            if (rebalance < resolvedFrom)
-                lastBeforeWindow = date;
-            else if (rebalance <= resolvedTo)
-                relevant.Add(date);
-        }
-        if (lastBeforeWindow.HasValue && !relevant.Contains(lastBeforeWindow.Value))
-            relevant.Insert(0, lastBeforeWindow.Value);
+        var relevant = SelectRelevantSnapshotDates(reportDates, resolvedFrom, resolvedTo);
 
         if (relevant.Count == 0)
         {
@@ -206,6 +192,30 @@ public class HoldingsBacktestService
                 options.Add(new BacktestBenchmarkOption { Ticker = ticker, Name = stock.Name });
         }
         return options;
+    }
+
+    // Select all snapshots whose rebalance date falls in [resolvedFrom, resolvedTo], plus the
+    // latest one whose rebalance date precedes resolvedFrom so the simulation can open with an
+    // initial portfolio.
+    private static List<DateOnly> SelectRelevantSnapshotDates(
+        IReadOnlyList<DateOnly> reportDates,
+        DateOnly resolvedFrom,
+        DateOnly resolvedTo
+    )
+    {
+        var relevant = new List<DateOnly>();
+        DateOnly? lastBeforeWindow = null;
+        foreach (var date in reportDates)
+        {
+            var rebalance = date.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
+            if (rebalance < resolvedFrom)
+                lastBeforeWindow = date;
+            else if (rebalance <= resolvedTo)
+                relevant.Add(date);
+        }
+        if (lastBeforeWindow.HasValue && !relevant.Contains(lastBeforeWindow.Value))
+            relevant.Insert(0, lastBeforeWindow.Value);
+        return relevant;
     }
 
     // OrderBy() must precede the projection — EF can't translate an OrderBy keyed off the


### PR DESCRIPTION
## Summary

- `HoldingsBacktestService.Execute` (150-line method) embedded a 16-line block — with its own `WHY` comment — that picks the relevant 13F snapshot dates for the requested window: all snapshots whose rebalance date falls in `[resolvedFrom, resolvedTo]`, plus the latest one whose rebalance date precedes `resolvedFrom` so the simulation can open with an initial portfolio.
- Extracted to a private static helper `SelectRelevantSnapshotDates(reportDates, resolvedFrom, resolvedTo) → List<DateOnly>`. The `Execute` body now reads as a flat sequence of view-model setup → guard → snapshot selection → price load → calculate; the helper carries the explanatory comment with it.
- Pure transformation: identical iteration order, same `<` / `<=` comparisons against `rebalance`, same `lastBeforeWindow` tracking, same `Insert(0, …)` fallback; inputs are values, output is a fresh list. Build + 1523 unit + 1403 integration tests + csharpier check all green locally.

## Code changes

- `src/Equibles.Web/Services/HoldingsBacktestService.cs` — added private static `SelectRelevantSnapshotDates`; replaced the inline loop+fallback in `Execute` with a single call; moved the WHY comment onto the helper.