### PR TITLE
refactor(document-scraper): extract CollectFilingsAcrossCiks from ProcessDocumentTypeForCompany

### DIFF
--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -248,54 +248,12 @@ public class DocumentScraper : IDocumentScraper
 
         try
         {
-            // Subsidiary CIKs share the parent's public ticker (e.g. parent + co-registrant
-            // operating sub). Their filings belong on the parent's stock page, so we fetch
-            // each CIK separately and dedupe by AccessionNumber (globally unique in SEC).
-            var ciks = new List<string> { company.Cik };
-            ciks.AddRange(company.SecondaryCiks);
-
-            var fromDate =
-                _workerOptions.MinSyncDate != null
-                    ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
-                    : (DateOnly?)null;
-
-            var filings = new List<FilingData>();
-            var seenAccessions = new HashSet<string>();
-
-            foreach (var cik in ciks)
-            {
-                List<FilingData> cikFilings;
-                try
-                {
-                    cikFilings = await secEdgarClient.GetCompanyFilings(cik, secFilter, fromDate);
-                }
-                catch (HttpRequestException ex)
-                {
-                    // One CIK failing shouldn't drop the others — log and continue.
-                    _logger.LogWarning(
-                        ex,
-                        "HTTP error fetching {DocumentType} filings for CIK {Cik} ({Ticker})",
-                        documentType,
-                        cik,
-                        company.Ticker
-                    );
-                    RecordError(result, $"Company {company.Ticker} CIK {cik} - {documentType}", ex);
-                    continue;
-                }
-
-                foreach (var filing in cikFilings)
-                {
-                    if (seenAccessions.Add(filing.AccessionNumber))
-                        filings.Add(filing);
-                }
-            }
-
-            _logger.LogDebug(
-                "Found {FilingCount} {DocumentType} filings for {Ticker} across {CikCount} CIK(s)",
-                filings.Count,
+            var filings = await CollectFilingsAcrossCiks(
+                company,
                 documentType,
-                company.Ticker,
-                ciks.Count
+                secFilter,
+                result,
+                secEdgarClient
             );
 
             result.DocumentsFound += filings.Count;
@@ -320,6 +278,67 @@ public class DocumentScraper : IDocumentScraper
                 $"ticker: {company.Ticker}, type: {documentType}"
             );
         }
+    }
+
+    // Subsidiary CIKs share the parent's public ticker (e.g. parent + co-registrant
+    // operating sub). Their filings belong on the parent's stock page, so we fetch
+    // each CIK separately and dedupe by AccessionNumber (globally unique in SEC).
+    private async Task<List<FilingData>> CollectFilingsAcrossCiks(
+        CommonStock company,
+        DocumentType documentType,
+        DocumentTypeFilter secFilter,
+        ScrapingResult result,
+        ISecEdgarClient secEdgarClient
+    )
+    {
+        var ciks = new List<string> { company.Cik };
+        ciks.AddRange(company.SecondaryCiks);
+
+        var fromDate =
+            _workerOptions.MinSyncDate != null
+                ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
+                : (DateOnly?)null;
+
+        var filings = new List<FilingData>();
+        var seenAccessions = new HashSet<string>();
+
+        foreach (var cik in ciks)
+        {
+            List<FilingData> cikFilings;
+            try
+            {
+                cikFilings = await secEdgarClient.GetCompanyFilings(cik, secFilter, fromDate);
+            }
+            catch (HttpRequestException ex)
+            {
+                // One CIK failing shouldn't drop the others — log and continue.
+                _logger.LogWarning(
+                    ex,
+                    "HTTP error fetching {DocumentType} filings for CIK {Cik} ({Ticker})",
+                    documentType,
+                    cik,
+                    company.Ticker
+                );
+                RecordError(result, $"Company {company.Ticker} CIK {cik} - {documentType}", ex);
+                continue;
+            }
+
+            foreach (var filing in cikFilings)
+            {
+                if (seenAccessions.Add(filing.AccessionNumber))
+                    filings.Add(filing);
+            }
+        }
+
+        _logger.LogDebug(
+            "Found {FilingCount} {DocumentType} filings for {Ticker} across {CikCount} CIK(s)",
+            filings.Count,
+            documentType,
+            company.Ticker,
+            ciks.Count
+        );
+
+        return filings;
     }
 
     private async Task ProcessFiling(


### PR DESCRIPTION
## Summary

- Extract the inline ~50-line "build CIK list (primary + secondary) → derive `fromDate` from `MinSyncDate` → per-CIK `GetCompanyFilings` with HTTP-exception handling → cross-CIK accession dedupe → debug summary log" block out of `DocumentScraper.ProcessDocumentTypeForCompany` into a private async `CollectFilingsAcrossCiks(company, documentType, secFilter, result, secEdgarClient)` helper. The caller's body shrinks to a single call followed by `result.DocumentsFound += filings.Count;` and the per-filing `ProcessFiling` loop.
- Behaviour-preserving: same CIK list (`{Cik}` + `SecondaryCiks`), same `fromDate` ternary, same `GetCompanyFilings(cik, secFilter, fromDate)` call wrapped in the same `HttpRequestException` catch with the same warning + `RecordError("Company {ticker} CIK {cik} - {documentType}", ex)`, same `seenAccessions.Add` accession dedupe, same `LogDebug` "Found N filings across K CIK(s)" summary. The two WHY-comments ("Subsidiary CIKs share the parent's public ticker…" and "One CIK failing shouldn't drop the others…") follow their code into the helper. The outer `try/catch` in `ProcessDocumentTypeForCompany` still wraps non-HTTP exceptions.

## Code changes

- `src/Equibles.Sec.HostedService/DocumentScraper.cs` — add `private async Task<List<FilingData>> CollectFilingsAcrossCiks(CommonStock, DocumentType, DocumentTypeFilter, ScrapingResult, ISecEdgarClient)`. `ProcessDocumentTypeForCompany` now does `var filings = await CollectFilingsAcrossCiks(...);` and continues with the unchanged consumer loop. No public API change.