### PR TITLE
refactor(cboe-client): collapse 4 duplicated decimal.TryParse guards in ParseVixCsv behind a local TryDec helper

### DIFF
--- a/src/Equibles.Integrations.Cboe/CboeClient.cs
+++ b/src/Equibles.Integrations.Cboe/CboeClient.cs
@@ -131,6 +131,9 @@ public class CboeClient : ICboeClient
         var records = new List<CboeVixRecord>();
         foreach (var fields in EnumerateCsvRows(content, minFields: 5))
         {
+            bool TryDec(int index, out decimal value) =>
+                decimal.TryParse(fields[index].Trim(), CultureInfo.InvariantCulture, out value);
+
             if (
                 !DateOnly.TryParseExact(
                     fields[0].Trim(),
@@ -142,13 +145,13 @@ public class CboeClient : ICboeClient
             )
                 continue;
 
-            if (!decimal.TryParse(fields[1].Trim(), CultureInfo.InvariantCulture, out var open))
+            if (!TryDec(1, out var open))
                 continue;
-            if (!decimal.TryParse(fields[2].Trim(), CultureInfo.InvariantCulture, out var high))
+            if (!TryDec(2, out var high))
                 continue;
-            if (!decimal.TryParse(fields[3].Trim(), CultureInfo.InvariantCulture, out var low))
+            if (!TryDec(3, out var low))
                 continue;
-            if (!decimal.TryParse(fields[4].Trim(), CultureInfo.InvariantCulture, out var close))
+            if (!TryDec(4, out var close))
                 continue;
 
             records.Add(


### PR DESCRIPTION
## Summary

- `ParseVixCsv` spelled out `decimal.TryParse(fields[i].Trim(), CultureInfo.InvariantCulture, out var x)` four times in a row for Open / High / Low / Close.
- Introduce a local function `bool TryDec(int index, out decimal value)` closing over the loop's `fields` so each guard collapses to `if (!TryDec(i, out var x)) continue;`.
- Same predicate, same `Trim()`, same culture argument — every call site retains its own `continue`, so short-circuit and iteration order are unchanged.

## Code changes

- `src/Equibles.Integrations.Cboe/CboeClient.cs` — inside `ParseVixCsv`'s `foreach`, declare a local `TryDec(int, out decimal)` and rewrite the four OHLC parse guards to call it. `DateOnly.TryParseExact` is left as-is (different signature, single occurrence).