### PR TITLE
refactor(insider-trading): extract SaveNoSecuritiesOwnedSentinel helper from Process

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -203,29 +203,13 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
         if (transactions.Count == 0)
         {
-            // Form 3 with noSecuritiesOwned — save a 0-shares record so the accession-number
-            // short-circuit at the top of Process() prevents re-fetching this filing every cycle.
-            _logger.LogDebug(
-                "No transactions found for {Ticker} - {AccessionNumber}, saving 0-shares holding",
-                companyTicker,
-                filing.AccessionNumber
+            await SaveNoSecuritiesOwnedSentinel(
+                transactionRepository,
+                owner,
+                companyId,
+                filing,
+                companyTicker
             );
-
-            transactionRepository.Add(
-                new InsiderTransaction
-                {
-                    InsiderOwnerId = owner.Id,
-                    CommonStockId = companyId,
-                    FilingDate = filing.FilingDate,
-                    TransactionDate = filing.ReportDate,
-                    TransactionCode = TransactionCode.Other,
-                    AccessionNumber = filing.AccessionNumber,
-                    SecurityTitle = "No Securities Owned",
-                    TransactionOrder = 0,
-                }
-            );
-            await transactionRepository.SaveChanges();
-
             return true;
         }
 
@@ -280,6 +264,38 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         ownerRepository.Add(owner);
         await ownerRepository.SaveChanges();
         return owner;
+    }
+
+    // Form 3 with noSecuritiesOwned — save a 0-shares record so the accession-number
+    // short-circuit at the top of Process() prevents re-fetching this filing every cycle.
+    private async Task SaveNoSecuritiesOwnedSentinel(
+        InsiderTransactionRepository transactionRepository,
+        InsiderOwner owner,
+        Guid companyId,
+        FilingData filing,
+        string companyTicker
+    )
+    {
+        _logger.LogDebug(
+            "No transactions found for {Ticker} - {AccessionNumber}, saving 0-shares holding",
+            companyTicker,
+            filing.AccessionNumber
+        );
+
+        transactionRepository.Add(
+            new InsiderTransaction
+            {
+                InsiderOwnerId = owner.Id,
+                CommonStockId = companyId,
+                FilingDate = filing.FilingDate,
+                TransactionDate = filing.ReportDate,
+                TransactionCode = TransactionCode.Other,
+                AccessionNumber = filing.AccessionNumber,
+                SecurityTitle = "No Securities Owned",
+                TransactionOrder = 0,
+            }
+        );
+        await transactionRepository.SaveChanges();
     }
 
     private InsiderTransaction ParseTransaction(


### PR DESCRIPTION
## Summary

- Extract the ~27-line "Form 3 noSecuritiesOwned sentinel" branch out of `InsiderTradingFilingProcessor.Process` into a private async `SaveNoSecuritiesOwnedSentinel(transactionRepository, owner, companyId, filing, companyTicker)` helper. Caller now reads `await SaveNoSecuritiesOwnedSentinel(...); return true;`.
- Behaviour-preserving: same `LogDebug` template + args, same `InsiderTransaction` initializer (`InsiderOwnerId = owner.Id`, `CommonStockId = companyId`, `FilingDate = filing.FilingDate`, `TransactionDate = filing.ReportDate`, `TransactionCode = TransactionCode.Other`, `AccessionNumber = filing.AccessionNumber`, `SecurityTitle = "No Securities Owned"`, `TransactionOrder = 0`), same `transactionRepository.Add(...)` + `SaveChanges()`. The WHY-comment ("Form 3 with noSecuritiesOwned — save a 0-shares record so the accession-number short-circuit…") moves with its code to the helper.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — add `private async Task SaveNoSecuritiesOwnedSentinel(InsiderTransactionRepository, InsiderOwner, Guid, FilingData, string)`. The `if (transactions.Count == 0)` branch in `Process` shrinks to a single helper call + `return true;`. No public API change.