### PR TITLE
docs(technical/web-portal): split HeroIconTagHelper bullet

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -52,7 +52,8 @@ Why the indirection through `ViewData` rather than a single `StockDetailViewMode
 
 ## Tag helpers
 
-- [`HeroIconTagHelper`](../../src/Equibles.Web/TagHelpers/HeroIconTagHelper.cs) — `<icon name="..." size="6" />` renders inline SVG from the Heroicons set baked into [`HeroIcons.cs`](../../src/Equibles.Web/TagHelpers/HeroIcons.cs). No icon-font dependency.
+- [`HeroIconTagHelper`](../../src/Equibles.Web/TagHelpers/HeroIconTagHelper.cs) — `<icon name="..." size="6" />` renders inline SVG from the Heroicons set baked into [`HeroIcons.cs`](../../src/Equibles.Web/TagHelpers/HeroIcons.cs).
+- No icon-font dependency.
 
 ## Frontend build
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `HeroIconTagHelper` bullet packed 258 chars: the usage example (`<icon name="..." size="6" />` rendering inline SVG from `HeroIcons.cs`) and the "no icon-font dependency" consequence. Split into usage vs. dependency-footprint note.

## Code changes

- `docs/technical/web-portal.md` — split the bullet into one stating the tag-helper usage and inline-SVG source, and one stating the no-icon-font-dependency consequence.