### PR TITLE
refactor(fred-import): extract ParseFredValue helper from ImportSeries

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/FredImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredImportService.cs
@@ -177,26 +177,12 @@ public class FredImportService
                 continue;
             }
 
-            // FRED returns "." for missing values
-            decimal? value = null;
-            if (
-                record.Value != "."
-                && decimal.TryParse(
-                    record.Value,
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    out var parsed
-                )
-            )
-            {
-                value = parsed;
-            }
-
             observations.Add(
                 new FredObservation
                 {
                     FredSeriesId = series.Id,
                     Date = date,
-                    Value = value,
+                    Value = ParseFredValue(record.Value),
                 }
             );
         }
@@ -292,5 +278,19 @@ public class FredImportService
     private static DateOnly? ParseDate(string value)
     {
         return DateOnly.TryParse(value, out var date) ? date : null;
+    }
+
+    // FRED uses the literal "." as its missing-observation sentinel.
+    private static decimal? ParseFredValue(string raw)
+    {
+        if (raw == ".")
+            return null;
+        return decimal.TryParse(
+            raw,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out var parsed
+        )
+            ? parsed
+            : null;
     }
 }


### PR DESCRIPTION
## Summary

- `FredImportService.ImportSeries` had a 13-line inline block parsing the FRED API's `Value` string into `decimal?`. The block carries a real domain rule (FRED uses the literal `"."` as its missing-observation sentinel; treat it as null instead of fabricating zero) that's worth naming.
- Extracted to a private static `ParseFredValue(string raw) → decimal?` helper. The dot-sentinel WHY-comment moves onto the helper. Call site collapses to a single expression inside the `FredObservation` initializer, which is now uniformly one line of code per field.
- Pure transformation: same `== "."` short-circuit, same `decimal.TryParse(..., InvariantCulture)`, same null-on-fail semantics, no exception change. Build + 1524 unit + 1404 integration tests + csharpier check all green locally. The integration test `FredImportServiceMissingValueTests.ImportSeries_ObservationWithDotSentinel_PersistedAsNullValueNotDropped` continues to pin the end-to-end behavior.

## Code changes

- `src/Equibles.Fred.HostedService/Services/FredImportService.cs` — added private static `ParseFredValue` next to the existing `ParseDate` helper; replaced the inline parse block in `ImportSeries` with `Value = ParseFredValue(record.Value)`.