### PR TITLE
refactor(company-sync): extract AttachAsSubsidiary helper from ResolveTickerCollision

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -440,23 +440,7 @@ public class CompanySyncService : ICompanySyncService
 
             if (incumbentWins)
             {
-                if (incumbent.SecondaryCiks.Contains(incoming.Cik))
-                    return;
-
-                incumbent.SecondaryCiks = [.. incumbent.SecondaryCiks, incoming.Cik];
-                // Save directly via the repository — manager.Update would re-run the full
-                // uniqueness validation against the incumbent's own Ticker/CIK, which is
-                // an unnecessary round-trip for a SecondaryCiks-only mutation.
-                await state.CommonStockRepository.SaveChanges();
-                state.SecondaryCikToParent[incoming.Cik] = incumbent;
-
-                _logger.LogInformation(
-                    "Attached subsidiary CIK {Cik} ({Name}) to parent {Ticker} (CIK: {ParentCik})",
-                    incoming.Cik,
-                    incoming.Name,
-                    ticker,
-                    incumbent.Cik
-                );
+                await AttachAsSubsidiary(incumbent, incoming, ticker, state);
             }
             else
             {
@@ -489,6 +473,32 @@ public class CompanySyncService : ICompanySyncService
                 $"ticker: {ticker}, incoming: {incoming.Cik}, incumbent: {incumbent.Cik}"
             );
         }
+    }
+
+    private async Task AttachAsSubsidiary(
+        CommonStock incumbent,
+        CompanyInfo incoming,
+        string ticker,
+        StockSyncState state
+    )
+    {
+        if (incumbent.SecondaryCiks.Contains(incoming.Cik))
+            return;
+
+        incumbent.SecondaryCiks = [.. incumbent.SecondaryCiks, incoming.Cik];
+        // Save directly via the repository — manager.Update would re-run the full
+        // uniqueness validation against the incumbent's own Ticker/CIK, which is
+        // an unnecessary round-trip for a SecondaryCiks-only mutation.
+        await state.CommonStockRepository.SaveChanges();
+        state.SecondaryCikToParent[incoming.Cik] = incumbent;
+
+        _logger.LogInformation(
+            "Attached subsidiary CIK {Cik} ({Name}) to parent {Ticker} (CIK: {ParentCik})",
+            incoming.Cik,
+            incoming.Name,
+            ticker,
+            incumbent.Cik
+        );
     }
 
     private async Task<bool> ShouldIncumbentWin(CompanyInfo incoming, CommonStock incumbent)


### PR DESCRIPTION
## Summary

- Extract the `if (incumbentWins) { … }` branch (~17 lines) out of `CompanySyncService.ResolveTickerCollision` into a private async `AttachAsSubsidiary(incumbent, incoming, ticker, state)` helper. The caller now reads `if (incumbentWins) await AttachAsSubsidiary(incumbent, incoming, ticker, state);` followed by the unchanged `else { LogWarning(...) }`.
- Behaviour-preserving: same `incumbent.SecondaryCiks.Contains(incoming.Cik) → return` short-circuit, same `[.. incumbent.SecondaryCiks, incoming.Cik]` spread-append, same `state.CommonStockRepository.SaveChanges()` (preserving the "Save directly via the repository…" WHY-comment), same `state.SecondaryCikToParent[incoming.Cik] = incumbent` map mutation, same `LogInformation` template + 4 args. The outer `try/catch` in `ResolveTickerCollision` still wraps any exception thrown by the helper, and the helper's early `return` (when the CIK is already attached) is observationally equivalent to the prior method-level `return`.

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — add `private async Task AttachAsSubsidiary(CommonStock, CompanyInfo, string, StockSyncState)`. The `incumbentWins` branch in `ResolveTickerCollision` collapses to a single helper call. No public API change.