### PR TITLE
docs(technical/scrapers): split empty-CommonStock retry bullet

### DIFF
--- a/docs/technical/scrapers.md
+++ b/docs/technical/scrapers.md
@@ -103,7 +103,8 @@ The cursor pattern means re-running is cheap (a single query for `max(date)` per
 
 ## Cold-start patterns
 
-- Empty `CommonStock` table → most scrapers `RequestRetrySoon()` and wait `NotReadyRetryInterval` (2 min) instead of the full `SleepInterval` (24h). Pattern handles the first ~30 min after a fresh deploy where `CompanySyncService` is still populating the universe.
+- Empty `CommonStock` table → most scrapers `RequestRetrySoon()` and wait `NotReadyRetryInterval` (2 min) instead of the full `SleepInterval` (24h).
+- The pattern handles the first ~30 min after a fresh deploy while `CompanySyncService` is still populating the universe.
 - Realtime workers depend on the bulk-data backfill having seeded history. Until then the realtime worker still runs but produces no rows; once `BackfillProcessedDataSets` has run, the realtime path takes over.
 
 ## Error reporting


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The empty-`CommonStock` retry pattern bullet packed 266 chars: the retry mechanic (`RequestRetrySoon()` → 2-min `NotReadyRetryInterval` instead of the 24h `SleepInterval`) and the cold-start window rationale (first ~30 min while `CompanySyncService` populates). Split into mechanic vs. cold-start window.

## Code changes

- `docs/technical/scrapers.md` — split the bullet into one stating the trigger and retry-interval swap and one stating the cold-start window the pattern covers.