### PR TITLE
test(yahoo): pin HasOverflowPrice AdjustedClose-only overflow returns true

### DIFF
--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceAdjustedCloseOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceAdjustedCloseOverflowTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using Equibles.Integrations.Yahoo.Models;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+public class YahooPriceImportServiceAdjustedCloseOverflowTests
+{
+    private static readonly MethodInfo HasOverflowPriceMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "HasOverflowPrice",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // Sibling to HasOverflowPrice_AbsValueExceedsNumeric18_4Ceiling_ReturnsTrue
+    // (covers `Open`) and …_AllFieldsWithinNumericCeiling_ReturnsFalse. The
+    // overflow check is a 5-arm OR chain (Open || High || Low || Close ||
+    // AdjustedClose); only the first and the all-normal cases are pinned.
+    // AdjustedClose is the last arm — the easiest to silently drop during a
+    // refactor — and the most volatile field in practice (Yahoo's split /
+    // dividend back-adjustments can fabricate extreme values long after the
+    // raw OHLC has stabilised). A regression that dropped the AdjustedClose
+    // clause would silently re-enable the numeric(18,4) overflow path for
+    // every adjusted-close outlier in the entire daily batch.
+    [Fact]
+    public void HasOverflowPrice_OnlyAdjustedCloseExceedsCeiling_ReturnsTrue()
+    {
+        var price = new HistoricalPrice
+        {
+            Open = 150.25m,
+            High = 152.80m,
+            Low = 149.10m,
+            Close = 151.45m,
+            AdjustedClose = 200_000_000_000_000m,
+        };
+
+        var result = (bool)HasOverflowPriceMethod.Invoke(null, [price]);
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Third pin for `YahooPriceImportService.HasOverflowPrice`. The existing siblings cover `Open` (negative side, returns true) and the all-normal path (returns false). The OR chain has five arms — `Open || High || Low || Close || AdjustedClose` — and only one is individually pinned. AdjustedClose is the last clause and the most volatile field in practice (Yahoo's back-applied split / dividend adjustments can fabricate extreme values long after the raw OHLC has stabilised).
- A regression that dropped the AdjustedClose clause during an OR-chain refactor would silently re-enable the numeric(18,4) overflow path for every adjusted-close outlier in the daily batch; the existing two pins both pass under that regression. This test isolates the AdjustedClose arm with realistic OHLC alongside a single overflowing adjusted close.
- Test passes 1/1 in 6 ms.

## Code changes

- `tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceAdjustedCloseOverflowTests.cs` — new reflection-based unit test, sibling to the existing `YahooPriceImportServiceTests`. One `[Fact]`: `HasOverflowPrice_OnlyAdjustedCloseExceedsCeiling_ReturnsTrue`.