### PR TITLE
refactor(holdings-recalc): extract ResolveHoldingsWithNewPrices helper from Recalculate

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
@@ -72,39 +72,9 @@ public class HoldingsValueRecalculator
         );
 
         var resolvedPairKeys = prices.Keys.ToHashSet();
-        var totalUpdated = 0;
         var totalGivenUp = 0;
 
-        // Resolve holdings that now have a price
-        foreach (var ((stockId, reportDate), closePrice) in prices)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            using var scope = _scopeFactory.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
-
-            var pendingHoldings = await dbContext
-                .Set<InstitutionalHolding>()
-                .Include(h => h.ManagerEntries)
-                .Where(h =>
-                    h.ValuePending && h.CommonStockId == stockId && h.ReportDate == reportDate
-                )
-                .ToListAsync(cancellationToken);
-
-            foreach (var holding in pendingHoldings)
-            {
-                holding.Value = (long)(holding.Shares * closePrice);
-                holding.ValuePending = false;
-
-                foreach (var entry in holding.ManagerEntries)
-                {
-                    entry.Value = (long)(entry.Shares * closePrice);
-                }
-            }
-
-            await dbContext.SaveChangesAsync(cancellationToken);
-            totalUpdated += pendingHoldings.Count;
-        }
+        var totalUpdated = await ResolveHoldingsWithNewPrices(prices, cancellationToken);
 
         // Increment retry count for unresolved pairs and give up after MaxRetries
         var unresolvedPairs = pendingPairs
@@ -163,5 +133,43 @@ public class HoldingsValueRecalculator
             totalUpdated,
             totalGivenUp
         );
+    }
+
+    private async Task<int> ResolveHoldingsWithNewPrices(
+        Dictionary<(Guid CommonStockId, DateOnly Date), decimal> prices,
+        CancellationToken cancellationToken
+    )
+    {
+        var totalUpdated = 0;
+        foreach (var ((stockId, reportDate), closePrice) in prices)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var scope = _scopeFactory.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
+
+            var pendingHoldings = await dbContext
+                .Set<InstitutionalHolding>()
+                .Include(h => h.ManagerEntries)
+                .Where(h =>
+                    h.ValuePending && h.CommonStockId == stockId && h.ReportDate == reportDate
+                )
+                .ToListAsync(cancellationToken);
+
+            foreach (var holding in pendingHoldings)
+            {
+                holding.Value = (long)(holding.Shares * closePrice);
+                holding.ValuePending = false;
+
+                foreach (var entry in holding.ManagerEntries)
+                {
+                    entry.Value = (long)(entry.Shares * closePrice);
+                }
+            }
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+            totalUpdated += pendingHoldings.Count;
+        }
+        return totalUpdated;
     }
 }


### PR DESCRIPTION
## Summary

- `HoldingsValueRecalculator.Recalculate` (124-line method) had two clearly-comment-delimited phases: "Resolve holdings that now have a price" and "Increment retry count for unresolved pairs and give up after MaxRetries." Each phase opens its own per-pair scope and saves; they don't share state mid-loop. The method body is much harder to read than necessary because the two phases sit inline at the same indentation level as the prologue.
- Extracted the first phase (~30 lines) into a private async helper `ResolveHoldingsWithNewPrices(prices, cancellationToken) → Task<int>` that returns the updated count. Top-level `Recalculate` now reads as: prologue → resolve-phase call → retry-phase → log.
- Pure relocation: identical per-pair scope creation, EF query, in-memory mutation, and `SaveChangesAsync` in the same order; same cancellation handling; the updated count flows back via return value. Build + 1526 unit + 1404 integration tests + csharpier check all green locally.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs` — added private `ResolveHoldingsWithNewPrices`; replaced the inline first-phase loop in `Recalculate` with `var totalUpdated = await ResolveHoldingsWithNewPrices(prices, cancellationToken);`. Second phase and logging unchanged.