### PR TITLE
docs(technical/migrations): split pg_search bullet

### DIFF
--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -52,7 +52,8 @@ Hosts call `await dbContext.Database.MigrateAsync()` on startup.
 The initial migration declares two extensions, both required:
 
 - `vector` — pgvector. Stores SEC chunk embeddings on `Chunk.Embedding` (`vector` column). Disabled embedding (`EmbeddingConfig.Enabled=false`) just leaves the column null; the extension is still required because the column type references it.
-- `pg_search` — ParadeDB BM25. Powers full-text search over SEC chunk content via a BM25 index. Declared via the EF annotation `Npgsql:PostgresExtension:pg_search` plus the index method override (`NpgsqlIndexBuilderExtensions.HasMethod(..., "bm25")`).
+- `pg_search` — ParadeDB BM25; powers full-text search over SEC chunk content via a BM25 index.
+- Declared via the EF annotation `Npgsql:PostgresExtension:pg_search` plus the index method override (`NpgsqlIndexBuilderExtensions.HasMethod(..., "bm25")`).
 
 Both extensions ship out-of-the-box in the `paradedb/paradedb:latest` Docker image used by `db` in `docker-compose.yml`. On a non-ParadeDB Postgres install, `MigrateAsync` will fail at `CREATE EXTENSION pg_search` with a clear error.
 


### PR DESCRIPTION
## Summary

- Lane: **Maintain — unclear sentence** (`docs/technical/`).
- The `pg_search` extension bullet packed 253 chars: the identity + purpose (ParadeDB BM25 full-text search over SEC chunk content) and the EF declaration mechanism (`Npgsql:PostgresExtension:pg_search` annotation + `HasMethod(..., "bm25")` index override). Split into identity+purpose vs. declaration.

## Code changes

- `docs/technical/migrations.md` — split the `pg_search` bullet into one stating what it is and what it powers, and one describing the EF annotation + index-method declaration.