### PR TITLE
refactor(sec): extract TryBuildFilingDataAt helper from MapToFilingData

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -686,35 +686,47 @@ public class SecEdgarClient : ISecEdgarClient
 
         for (var i = 0; i < recent.AccessionNumber.Count; i++)
         {
-            // SEC can emit a ragged payload where a secondary array is shorter
-            // than AccessionNumber. Skip rows that cannot be fully mapped rather
-            // than throw, mirroring ParseCompaniesFromResponse's short-row guard.
-            if (
-                recent.FilingDate.Count <= i
-                || recent.ReportDate.Count <= i
-                || recent.Form.Count <= i
-                || recent.PrimaryDocument.Count <= i
-                || recent.PrimaryDocDescription.Count <= i
-            )
-                continue;
-
-            var accessionNumber = recent.AccessionNumber[i];
-            filings.Add(
-                new FilingData
-                {
-                    Cik = cik,
-                    AccessionNumber = accessionNumber,
-                    FilingDate = ParseInvariantDateOr(recent.FilingDate[i], DateOnly.MinValue),
-                    ReportDate = ParseInvariantDateOr(recent.ReportDate[i], DateOnly.MinValue),
-                    Form = recent.Form[i],
-                    PrimaryDocument = recent.PrimaryDocument[i],
-                    Description = recent.PrimaryDocDescription[i],
-                    DocumentUrl = GetDocumentUrl(cik, accessionNumber),
-                }
-            );
+            if (TryBuildFilingDataAt(recent, cik, i, out var filing))
+                filings.Add(filing);
         }
 
         return filings;
+    }
+
+    private static bool TryBuildFilingDataAt(
+        RecentFilings recent,
+        string cik,
+        int i,
+        out FilingData filing
+    )
+    {
+        filing = null;
+
+        // SEC can emit a ragged payload where a secondary array is shorter
+        // than AccessionNumber. Skip rows that cannot be fully mapped rather
+        // than throw, mirroring ParseCompaniesFromResponse's short-row guard.
+        if (
+            recent.FilingDate.Count <= i
+            || recent.ReportDate.Count <= i
+            || recent.Form.Count <= i
+            || recent.PrimaryDocument.Count <= i
+            || recent.PrimaryDocDescription.Count <= i
+        )
+            return false;
+
+        var accessionNumber = recent.AccessionNumber[i];
+        filing = new FilingData
+        {
+            Cik = cik,
+            AccessionNumber = accessionNumber,
+            FilingDate = ParseInvariantDateOr(recent.FilingDate[i], DateOnly.MinValue),
+            ReportDate = ParseInvariantDateOr(recent.ReportDate[i], DateOnly.MinValue),
+            Form = recent.Form[i],
+            PrimaryDocument = recent.PrimaryDocument[i],
+            Description = recent.PrimaryDocDescription[i],
+            DocumentUrl = GetDocumentUrl(cik, accessionNumber),
+        };
+        return true;
     }
 
     // SEC submissions feed dates are ISO yyyy-MM-dd. Parse them culture-independently —


### PR DESCRIPTION
## Summary

- Extract the per-row guard + `FilingData` construction in `SecEdgarClient.MapToFilingData` into a `TryBuildFilingDataAt` helper so the outer loop is a single-line append.
- Behavior preserved: helper checks the same five `Count <= i` guards in the same order, reads the same indexed fields, calls `ParseInvariantDateOr` / `GetDocumentUrl` identically; the previous `continue` becomes `return false`. The ragged-payload WHY-comment moved with its guard.

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — extracted `private static bool TryBuildFilingDataAt(RecentFilings recent, string cik, int i, out FilingData filing)`; `MapToFilingData` now iterates indices and appends the helper's output.