### PR TITLE
refactor(holdings-recalc): extract IncrementRetryForUnresolved helper from Recalculate

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
@@ -72,17 +72,34 @@ public class HoldingsValueRecalculator
         );
 
         var resolvedPairKeys = prices.Keys.ToHashSet();
-        var totalGivenUp = 0;
 
         var totalUpdated = await ResolveHoldingsWithNewPrices(prices, cancellationToken);
 
-        // Increment retry count for unresolved pairs and give up after MaxRetries
         var unresolvedPairs = pendingPairs
             .Where(p => !resolvedPairKeys.Contains((p.CommonStockId, p.ReportDate)))
+            .Select(p => (p.CommonStockId, p.ReportDate))
             .ToList();
 
-        var now = DateTime.UtcNow;
+        var totalGivenUp = await IncrementRetryForUnresolved(
+            unresolvedPairs,
+            DateTime.UtcNow,
+            cancellationToken
+        );
 
+        _logger.LogInformation(
+            "Recalculated values for {Updated} holdings, gave up on {GivenUp}",
+            totalUpdated,
+            totalGivenUp
+        );
+    }
+
+    private async Task<int> IncrementRetryForUnresolved(
+        IReadOnlyList<(Guid CommonStockId, DateOnly ReportDate)> unresolvedPairs,
+        DateTime now,
+        CancellationToken cancellationToken
+    )
+    {
+        var totalGivenUp = 0;
         foreach (var pair in unresolvedPairs)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -90,7 +107,6 @@ public class HoldingsValueRecalculator
             using var scope = _scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
 
-            // Only load holdings that are due for retry based on their last retry time
             var holdings = await dbContext
                 .Set<InstitutionalHolding>()
                 .Where(h =>
@@ -127,12 +143,7 @@ public class HoldingsValueRecalculator
                 await dbContext.SaveChangesAsync(cancellationToken);
             }
         }
-
-        _logger.LogInformation(
-            "Recalculated values for {Updated} holdings, gave up on {GivenUp}",
-            totalUpdated,
-            totalGivenUp
-        );
+        return totalGivenUp;
     }
 
     private async Task<int> ResolveHoldingsWithNewPrices(


### PR DESCRIPTION
## Summary

- Sequel to #1461 which extracted phase A (`ResolveHoldingsWithNewPrices`). This iteration extracts phase B — the "increment retry count for unresolved pairs and give up after MaxRetries" foreach loop (~50 lines) — into a private async helper `IncrementRetryForUnresolved(unresolvedPairs, now, cancellationToken) → Task<int>` returning the given-up count.
- Top-level `Recalculate` now reads as a flat sequence: prologue → ResolveHoldingsWithNewPrices → compute unresolvedPairs → IncrementRetryForUnresolved → log. Both phases own their per-pair scope/query/save mechanics.
- Pure relocation: identical per-pair scope creation, EF query (filtered by `ValuePending && CommonStockId && ReportDate`), in-memory mutation order (delay → retry-increment → optional give-up flip), conditional `SaveChangesAsync` on `changed`, same cancellation handling; the given-up count flows back via return value. The `unresolvedPairs` projection is widened to an explicit `(Guid CommonStockId, DateOnly ReportDate)` tuple list so the helper can cross the method boundary cleanly (anonymous types can't be parameterised). Build + 8 integration + 4 unit recalculator tests + csharpier check all green locally. (One unrelated flaky timing test in `RateLimiterTests.ConcurrentCallers_ExceedingCapacity_HonorRatePerWindow` failed under parallel test load and passed in isolation — pre-existing, not introduced by this PR.)

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs` — added private `IncrementRetryForUnresolved`; replaced the inline phase-B loop in `Recalculate` with `var totalGivenUp = await IncrementRetryForUnresolved(unresolvedPairs, DateTime.UtcNow, cancellationToken);`; widened `unresolvedPairs` to an explicit tuple list. First-phase helper from #1461 and the final log unchanged.