### PR TITLE
docs(technical/web-portal): split StockTabService bullet

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -10,7 +10,8 @@ The trio:
 
 - **Controller action** in [`StocksController`](../../src/Equibles.Web/Controllers/StocksController.cs) — one action per tab: `Price`, `Holdings`, `ShortVolume`, `ShortInterest`, `Ftd`, `Documents`, `InsiderTrading`, `CongressionalTrades`, `Financials`.
 - Each action resolves the ticker, calls the matching `StockTabService.LoadXxxTab(stock, ...)`, stashes the result in `ViewData["TabViewModel"]`, and returns the shared `Show.cshtml` view.
-- **Service method** on [`StockTabService`](../../src/Equibles.Web/Services/StockTabService.cs) — `Task<XxxTabViewModel> LoadXxxTab(CommonStock stock, …)`. The only place that talks to repositories for tab data. All query composition lives here.
+- **Service method** on [`StockTabService`](../../src/Equibles.Web/Services/StockTabService.cs) — `Task<XxxTabViewModel> LoadXxxTab(CommonStock stock, …)`.
+- The service is the only place that talks to repositories for tab data; all query composition lives here.
 - **Razor partial** under [`Views/Stocks/_XxxTab.cshtml`](../../src/Equibles.Web/Views/Stocks/) — typed `@model XxxTabViewModel`. Renders the tab body; the surrounding chrome (breadcrumb, stock header, tab strip) belongs to `Show.cshtml`.
 
 `Show.cshtml` dispatches by `Model.ActiveTab` and calls the right `Html.PartialAsync("_XxxTab", (XxxTabViewModel)ViewData["TabViewModel"])`. The tab-strip `<a asp-action="Xxx" asp-route-ticker="@stock.Ticker">` links route back to the controller's per-tab action.


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 249-char Service method bullet so the signature and the centralization rule each stand alone.

## Code changes

- `docs/technical/web-portal.md` — split one bullet into two.