### PR TITLE
test(holdings-backtest): pin SelectRelevantSnapshotDates treats rebalance==resolvedFrom as in-window

### DIFF
--- a/tests/Equibles.UnitTests/Web/HoldingsBacktestServiceSelectRelevantSnapshotsBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsBacktestServiceSelectRelevantSnapshotsBoundaryTests.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+using Equibles.Holdings.Repositories;
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+public class HoldingsBacktestServiceSelectRelevantSnapshotsBoundaryTests
+{
+    private static readonly MethodInfo SelectRelevantSnapshotDatesMethod =
+        typeof(HoldingsBacktestService).GetMethod(
+            "SelectRelevantSnapshotDates",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // The newly-extracted SelectRelevantSnapshotDates helper (#1444) documents:
+    // "pick all snapshots whose rebalance date falls in [resolvedFrom,
+    // resolvedTo], plus the latest one whose rebalance date PRECEDES
+    // resolvedFrom so the simulation can open with an initial portfolio." The
+    // word "precedes" is strict-less; rebalance == resolvedFrom is therefore
+    // in-window, not the opening pre-window snapshot. A single-character
+    // refactor flipping the first arm from `rebalance < resolvedFrom` to
+    // `<= resolvedFrom` would silently send the equals-from snapshot down the
+    // `lastBeforeWindow` path, overwriting the genuine pre-window opener and
+    // collapsing two distinct snapshots into one — the simulation would lose
+    // a rebalance signal at the window's leading edge.
+    [Fact]
+    public void SelectRelevantSnapshotDates_RebalanceExactlyEqualsResolvedFrom_TreatedAsInWindowNotOpener()
+    {
+        // Construct so rebalance dates straddle the boundary: 45-day delay
+        // (HoldingsBacktestCalculator.RebalanceDelayDays) means a reportDate of
+        // resolvedFrom - 45 has rebalance == resolvedFrom (the equals-from
+        // case), while resolvedFrom - 46 sits one day inside the pre-window
+        // region — the genuine opener.
+        var resolvedFrom = new DateOnly(2024, 3, 15);
+        var resolvedTo = new DateOnly(2024, 12, 31);
+        var preWindowOpener = resolvedFrom.AddDays(-46);
+        var equalsFrom = resolvedFrom.AddDays(-HoldingsBacktestCalculator.RebalanceDelayDays);
+        IReadOnlyList<DateOnly> reportDates = [preWindowOpener, equalsFrom];
+
+        var result =
+            (List<DateOnly>)
+                SelectRelevantSnapshotDatesMethod.Invoke(
+                    null,
+                    [reportDates, resolvedFrom, resolvedTo]
+                );
+
+        result.Should().Equal(preWindowOpener, equalsFrom);
+    }
+}


### PR DESCRIPTION
## Summary

- `SelectRelevantSnapshotDates` (extracted in #1444) documents: "pick all snapshots whose rebalance date falls in `[resolvedFrom, resolvedTo]`, plus the latest one whose rebalance date **precedes** resolvedFrom so the simulation can open with an initial portfolio." "Precedes" is strict-less; `rebalance == resolvedFrom` is therefore in-window, not the opening pre-window snapshot.
- A single-character refactor flipping the first arm from `rebalance < resolvedFrom` to `<=` would silently send the equals-from snapshot down the `lastBeforeWindow` path, overwriting the genuine pre-window opener and collapsing two distinct snapshots into one — the simulation would lose a rebalance signal right at the window's leading edge. No CI signal, no exception, no log.
- New `[Fact]` constructs two reportDates straddling the 45-day rebalance boundary (`resolvedFrom - 46` = genuine opener, `resolvedFrom - 45` = equals-from in-window) and asserts the result is the two-element list in chronological order.
- Passes 1/1 in 12 ms.

## Code changes

- `tests/Equibles.UnitTests/Web/HoldingsBacktestServiceSelectRelevantSnapshotsBoundaryTests.cs` — new reflection-based unit test. One `[Fact]`: `SelectRelevantSnapshotDates_RebalanceExactlyEqualsResolvedFrom_TreatedAsInWindowNotOpener`.