### PR TITLE
docs(technical/web-portal): split Razor partial bullet

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -12,7 +12,8 @@ The trio:
 - Each action resolves the ticker, calls the matching `StockTabService.LoadXxxTab(stock, ...)`, stashes the result in `ViewData["TabViewModel"]`, and returns the shared `Show.cshtml` view.
 - **Service method** on [`StockTabService`](../../src/Equibles.Web/Services/StockTabService.cs) — `Task<XxxTabViewModel> LoadXxxTab(CommonStock stock, …)`.
 - The service is the only place that talks to repositories for tab data; all query composition lives here.
-- **Razor partial** under [`Views/Stocks/_XxxTab.cshtml`](../../src/Equibles.Web/Views/Stocks/) — typed `@model XxxTabViewModel`. Renders the tab body; the surrounding chrome (breadcrumb, stock header, tab strip) belongs to `Show.cshtml`.
+- **Razor partial** under [`Views/Stocks/_XxxTab.cshtml`](../../src/Equibles.Web/Views/Stocks/) — typed `@model XxxTabViewModel`, renders the tab body.
+- The surrounding chrome (breadcrumb, stock header, tab strip) belongs to `Show.cshtml`, not the partial.
 
 `Show.cshtml` dispatches by `Model.ActiveTab` and calls the right `Html.PartialAsync("_XxxTab", (XxxTabViewModel)ViewData["TabViewModel"])`. The tab-strip `<a asp-action="Xxx" asp-route-ticker="@stock.Ticker">` links route back to the controller's per-tab action.
 


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 240-char Razor partial bullet so the partial declaration and the chrome-ownership rule each stand alone.

## Code changes

- `docs/technical/web-portal.md` — split one bullet into two.