### PR TITLE
test(web): pin StatisticsExtensions.SafeRound negative-overflow arm returns null

### DIFF
--- a/tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundNegativeOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundNegativeOverflowTests.cs
@@ -1,0 +1,36 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class StatisticsExtensionsSafeRoundNegativeOverflowTests
+{
+    [Fact]
+    public void SafeRound_NegativeFiniteValueBelowDecimalRange_ReturnsNullInsteadOfThrowing()
+    {
+        // Sibling pin to StatisticsExtensionsSafeRoundOverflowTests, which covers
+        // only the positive-overflow arm (1e29 > decimal.MaxValue). The production
+        // guard is bi-directional:
+        //   if (!double.IsFinite(value)
+        //       || value > (double)decimal.MaxValue
+        //       || value < (double)decimal.MinValue)
+        //       return null;
+        // The third condition — `value < (double)decimal.MinValue` — is the
+        // symmetric negative-overflow arm. Without an isolated pin, a refactor
+        // that "tidies" the guard to just `value > (double)decimal.MaxValue`
+        // (under the false intuition that "overflow only goes one way") would
+        // compile, pass the existing +1e29 pin, and throw OverflowException
+        // on the (decimal) cast for any large negative finite — for example a
+        // runaway variance calculation in DescriptiveStatistics or a
+        // pathological FRED observation whose unit conversion produced
+        // -1e30. The Show action's `ComputeStats` path calls SafeRound on
+        // every Min/Max/Mean/Median/StdDev, and any one of them crashing
+        // the view render is the failure mode the "Safe" prefix exists to
+        // prevent.
+        //
+        // Pin -1e29 (just past decimal.MinValue ≈ -7.9e28). Both the +1e29
+        // sibling and this one together prove the bi-directional guard fires.
+        var result = (-1e29).SafeRound(2);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Sibling pin to `StatisticsExtensionsSafeRoundOverflowTests`. The existing pin only exercises the positive-overflow arm (`1e29 > decimal.MaxValue`); the symmetric `value < (double)decimal.MinValue` arm is unpinned.
- A refactor that "tidies" the guard to a single positive comparison would compile, pass the existing pin, and on the first large-negative finite (a runaway variance, a pathological FRED observation, a unit conversion blowup) throw `OverflowException` out of the `(decimal)` cast — the precise crash the "Safe" prefix exists to prevent on the EconomicData/Show view render.

## Code changes

- `tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundNegativeOverflowTests.cs` — new file. Calls `(-1e29).SafeRound(2)` and asserts the result is `null`.