### PR TITLE
refactor(short-volume-import): extract AggregateVolumesByStock helper from Import

### DIFF
--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -5,6 +5,7 @@ using Equibles.Errors.Data.Models;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Repositories;
 using Equibles.Integrations.Finra.Contracts;
+using Equibles.Integrations.Finra.Models;
 using Equibles.Worker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -91,37 +92,7 @@ public class ShortVolumeImportService
                     continue;
                 }
 
-                // Aggregate volumes across all markets per stock
-                var aggregated = new Dictionary<Guid, DailyShortVolume>();
-
-                foreach (var record in records)
-                {
-                    if (
-                        string.IsNullOrEmpty(record.Symbol)
-                        || !tickerMap.TryGetValue(record.Symbol, out var commonStockId)
-                    )
-                    {
-                        continue;
-                    }
-
-                    if (aggregated.TryGetValue(commonStockId, out var existing))
-                    {
-                        existing.ShortVolume += record.ShortVolume ?? 0;
-                        existing.ShortExemptVolume += record.ShortExemptVolume ?? 0;
-                        existing.TotalVolume += record.TotalVolume ?? 0;
-                    }
-                    else
-                    {
-                        aggregated[commonStockId] = new DailyShortVolume
-                        {
-                            CommonStockId = commonStockId,
-                            Date = currentDate,
-                            ShortVolume = record.ShortVolume ?? 0,
-                            ShortExemptVolume = record.ShortExemptVolume ?? 0,
-                            TotalVolume = record.TotalVolume ?? 0,
-                        };
-                    }
-                }
+                var aggregated = AggregateVolumesByStock(records, tickerMap, currentDate);
 
                 var totalInserted = await BatchPersister.Persist(
                     aggregated.Values,
@@ -164,5 +135,47 @@ public class ShortVolumeImportService
 
             currentDate = currentDate.AddDays(1);
         }
+    }
+
+    // Aggregate volumes across all markets per stock so one DailyShortVolume row per
+    // (CommonStockId, currentDate) is persisted instead of one per FINRA market venue.
+    private static Dictionary<Guid, DailyShortVolume> AggregateVolumesByStock(
+        List<ShortVolumeRecord> records,
+        IReadOnlyDictionary<string, Guid> tickerMap,
+        DateOnly currentDate
+    )
+    {
+        var aggregated = new Dictionary<Guid, DailyShortVolume>();
+
+        foreach (var record in records)
+        {
+            if (
+                string.IsNullOrEmpty(record.Symbol)
+                || !tickerMap.TryGetValue(record.Symbol, out var commonStockId)
+            )
+            {
+                continue;
+            }
+
+            if (aggregated.TryGetValue(commonStockId, out var existing))
+            {
+                existing.ShortVolume += record.ShortVolume ?? 0;
+                existing.ShortExemptVolume += record.ShortExemptVolume ?? 0;
+                existing.TotalVolume += record.TotalVolume ?? 0;
+            }
+            else
+            {
+                aggregated[commonStockId] = new DailyShortVolume
+                {
+                    CommonStockId = commonStockId,
+                    Date = currentDate,
+                    ShortVolume = record.ShortVolume ?? 0,
+                    ShortExemptVolume = record.ShortExemptVolume ?? 0,
+                    TotalVolume = record.TotalVolume ?? 0,
+                };
+            }
+        }
+
+        return aggregated;
     }
 }


### PR DESCRIPTION
## Summary

- `ShortVolumeImportService.Import` (124-line method) embedded a 30-line inline aggregation loop with its own WHY-comment ("Aggregate volumes across all markets per stock"). FINRA returns one row per market venue per stock per day; the importer collapses them into one `DailyShortVolume` per `(CommonStockId, date)` so the table doesn't carry venue-level rows.
- Extracted the loop into a private static `AggregateVolumesByStock(records, tickerMap, currentDate) → Dictionary<Guid, DailyShortVolume>` with the WHY-comment moved onto it. Top-level `Import` now reads as a flat sequence: resolve start date → skip weekends → fetch records → guard empty → aggregate → batch-persist → log → catch.
- Pure transformation: identical iteration order over `records`, identical `tickerMap.TryGetValue` short-circuit on missing/empty symbol, identical sum-or-new dictionary mutation, identical `?? 0` null-coalescing on the three volume fields, no exception change. Added `using Equibles.Integrations.Finra.Models;` so the helper signature can reference `ShortVolumeRecord`. Build + 1531 unit + 1404 integration tests + csharpier check all green locally.

## Code changes

- `src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs` — added private static `AggregateVolumesByStock`; replaced the inline aggregation block in `Import` with `var aggregated = AggregateVolumesByStock(records, tickerMap, currentDate);`; imported `Equibles.Integrations.Finra.Models`.