### PR TITLE
refactor(insider-trading): extract TryParseOwnershipRoot helper from Process

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -70,69 +70,9 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             return false;
         }
 
-        var sanitized = SanitizeXml(xmlContent);
-
-        // Pre-XML-era ownership filings (Forms 3/4/5 before SEC mandated XML around
-        // mid-2003) are PEM/SGML text with no <ownershipDocument> root, so XML parsing
-        // always fails with "Data at the root level is invalid". They are unsupported
-        // by design — skip them quietly instead of reporting a guaranteed error per file.
-        if (!sanitized.Contains("<ownershipDocument", StringComparison.OrdinalIgnoreCase))
-        {
-            _logger.LogDebug(
-                "Skipping legacy non-XML ownership filing for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return false;
-        }
-
-        XDocument doc;
-        try
-        {
-            doc = XDocument.Parse(sanitized);
-        }
-        catch (System.Xml.XmlException ex)
-        {
-            // Many legacy ownership filings are technically <ownershipDocument> XML
-            // but malformed (broken <footnote>, unescaped entities, mismatched tags).
-            // These are expected, non-actionable, and historically numerous — skip
-            // quietly instead of flooding the Errors table with one row per filing.
-            _logger.LogDebug(
-                ex,
-                "Skipping malformed ownership XML for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return false;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to parse XML for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            await _errorReporter.Report(
-                ErrorSource.DocumentScraper,
-                "InsiderTrading.ParseXml",
-                ex.Message,
-                ex.StackTrace,
-                $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
-            );
-            return false;
-        }
-
-        var root = doc.Root;
+        var root = await TryParseOwnershipRoot(xmlContent, filing, companyTicker);
         if (root == null)
-        {
-            _logger.LogWarning(
-                "Parsed XML has no root element for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
             return false;
-        }
 
         var ownerElement = root.Element("reportingOwner");
         if (ownerElement == null)
@@ -233,6 +173,79 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         );
 
         return true;
+    }
+
+    private async Task<XElement> TryParseOwnershipRoot(
+        string xmlContent,
+        FilingData filing,
+        string companyTicker
+    )
+    {
+        var sanitized = SanitizeXml(xmlContent);
+
+        // Pre-XML-era ownership filings (Forms 3/4/5 before SEC mandated XML around
+        // mid-2003) are PEM/SGML text with no <ownershipDocument> root, so XML parsing
+        // always fails with "Data at the root level is invalid". They are unsupported
+        // by design — skip them quietly instead of reporting a guaranteed error per file.
+        if (!sanitized.Contains("<ownershipDocument", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug(
+                "Skipping legacy non-XML ownership filing for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return null;
+        }
+
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Parse(sanitized);
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            // Many legacy ownership filings are technically <ownershipDocument> XML
+            // but malformed (broken <footnote>, unescaped entities, mismatched tags).
+            // These are expected, non-actionable, and historically numerous — skip
+            // quietly instead of flooding the Errors table with one row per filing.
+            _logger.LogDebug(
+                ex,
+                "Skipping malformed ownership XML for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to parse XML for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            await _errorReporter.Report(
+                ErrorSource.DocumentScraper,
+                "InsiderTrading.ParseXml",
+                ex.Message,
+                ex.StackTrace,
+                $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
+            );
+            return null;
+        }
+
+        var root = doc.Root;
+        if (root == null)
+        {
+            _logger.LogWarning(
+                "Parsed XML has no root element for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return null;
+        }
+
+        return root;
     }
 
     private static async Task<InsiderOwner> EnsureInsiderOwnerExists(


### PR DESCRIPTION
## Summary

- Extract the XML sanitize + legacy-skip + parse-with-multi-catch + root-null block (~63 lines) of `InsiderTradingFilingProcessor.Process` into `TryParseOwnershipRoot(xmlContent, filing, companyTicker)` returning the root `XElement` or null on any failure. Caller now reads `var root = await TryParseOwnershipRoot(...); if (root == null) return false;`.
- Behavior preserved: helper runs `SanitizeXml`, the same `ownershipDocument` substring guard with the same debug log + null, `XDocument.Parse` in the same try, the same `XmlException` debug-log/null branch, the same generic `Exception` warning-log + `_errorReporter.Report` + null branch, and the same `root == null` warning-log + null guard, in the same order; every former `return false` now returns null from the helper, translated back to `return false` by the caller. All four WHY-comments (pre-XML-era PEM/SGML, legacy malformed XML noise, etc.) moved with their code.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — extracted `private async Task<XElement> TryParseOwnershipRoot(string xmlContent, FilingData filing, string companyTicker)`; `Process` now calls it for the root element.