### PR TITLE
docs(technical/migrations): split vector extension bullet

### DIFF
--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -51,7 +51,8 @@ Hosts call `await dbContext.Database.MigrateAsync()` on startup.
 
 The initial migration declares two extensions, both required:
 
-- `vector` — pgvector. Stores SEC chunk embeddings on `Chunk.Embedding` (`vector` column). Disabled embedding (`EmbeddingConfig.Enabled=false`) just leaves the column null; the extension is still required because the column type references it.
+- `vector` — pgvector; stores SEC chunk embeddings on `Chunk.Embedding` (`vector` column).
+- Disabled embedding (`EmbeddingConfig.Enabled=false`) leaves the column null, but the extension is still required because the column type references it.
 - `pg_search` — ParadeDB BM25; powers full-text search over SEC chunk content via a BM25 index.
 - Declared via the EF annotation `Npgsql:PostgresExtension:pg_search` plus the index method override (`NpgsqlIndexBuilderExtensions.HasMethod(..., "bm25")`).
 


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 245-char vector extension bullet so identity + storage location sits separate from the disabled-embedding behavior.

## Code changes

- `docs/technical/migrations.md` — split one bullet into two.