### PR TITLE
refactor(sec-mcp): extract RenderComparisonTable helper from CompareFinancialFact

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -272,39 +272,48 @@ public class FinancialFactsTools
                     rows.Add((stock.Ticker, stock.Name, best));
                 }
 
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"{concept} — {fiscalYear} {period.NameForHumans()} peer comparison:"
-                );
-                result.AppendLine();
-                result.AppendLine("| Ticker | Company | Value | Unit | Form | Filed |");
-                result.AppendLine("|--------|---------|------:|------|------|-------|");
-                foreach (var (ticker, name, fact) in rows)
-                {
-                    result.AppendLine(
-                        $"| {FactMarkdown.Cell(ticker)} | {FactMarkdown.Cell(name)} | "
-                            + $"{FactMarkdown.Value(fact.Value, fact.Unit)} | "
-                            + $"{FactMarkdown.Cell(fact.Unit)} | "
-                            + $"{FactMarkdown.Cell(fact.Form?.DisplayName)} | "
-                            + $"{fact.FiledDate:yyyy-MM-dd} |"
-                    );
-                }
-
-                if (rows.Count == 0)
-                    result.AppendLine(
-                        $"\n_No company reported '{concept}' for {fiscalYear} "
-                            + $"{period.NameForHumans()}._"
-                    );
-
-                if (skipped.Count > 0)
-                    result.AppendLine($"\n_Skipped: {string.Join(", ", skipped)}._");
-
-                return result.ToString();
+                return RenderComparisonTable(concept, fiscalYear, period, rows, skipped);
             },
             "CompareFinancialFact",
             $"tickers: {FactMarkdown.Clean(tickers)}, concept: {FactMarkdown.Clean(concept)}, "
                 + $"year: {fiscalYear}, period: {FactMarkdown.Clean(fiscalPeriod)}"
         );
+    }
+
+    private static string RenderComparisonTable(
+        string concept,
+        int fiscalYear,
+        SecFiscalPeriod period,
+        List<(string Ticker, string Name, FinancialFact Fact)> rows,
+        List<string> skipped
+    )
+    {
+        var result = new StringBuilder();
+        result.AppendLine($"{concept} — {fiscalYear} {period.NameForHumans()} peer comparison:");
+        result.AppendLine();
+        result.AppendLine("| Ticker | Company | Value | Unit | Form | Filed |");
+        result.AppendLine("|--------|---------|------:|------|------|-------|");
+        foreach (var (ticker, name, fact) in rows)
+        {
+            result.AppendLine(
+                $"| {FactMarkdown.Cell(ticker)} | {FactMarkdown.Cell(name)} | "
+                    + $"{FactMarkdown.Value(fact.Value, fact.Unit)} | "
+                    + $"{FactMarkdown.Cell(fact.Unit)} | "
+                    + $"{FactMarkdown.Cell(fact.Form?.DisplayName)} | "
+                    + $"{fact.FiledDate:yyyy-MM-dd} |"
+            );
+        }
+
+        if (rows.Count == 0)
+            result.AppendLine(
+                $"\n_No company reported '{concept}' for {fiscalYear} "
+                    + $"{period.NameForHumans()}._"
+            );
+
+        if (skipped.Count > 0)
+            result.AppendLine($"\n_Skipped: {string.Join(", ", skipped)}._");
+
+        return result.ToString();
     }
 
     // AccessionNumber is the stable final tiebreak for same-day amendments


### PR DESCRIPTION
## Summary

- Extract the markdown table rendering tail of `FinancialFactsTools.CompareFinancialFact` (StringBuilder header line + blank + column header + separator + per-row markdown + empty-rows fallback + skipped-list footer) into a `RenderComparisonTable` helper, so the Execute lambda ends with a single `return RenderComparisonTable(...)`.
- Behavior preserved: helper emits the same `{concept} — {fiscalYear} {period.NameForHumans()} peer comparison:` heading, identical column header + alignment row, same per-row `FactMarkdown.Cell` / `FactMarkdown.Value` / `fact.FiledDate:yyyy-MM-dd` formatting, same `\n_No company reported..._` line when rows is empty, same `\n_Skipped:..._` line when skipped is non-empty, and same `ToString()` return — pure relocation.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — extracted `private static string RenderComparisonTable(string concept, int fiscalYear, SecFiscalPeriod period, List<(string Ticker, string Name, FinancialFact Fact)> rows, List<string> skipped)`; `CompareFinancialFact`'s lambda now calls it.