### PR TITLE
refactor(sec-mcp): extract RenderFactHistoryTable helper from GetFinancialFact

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -140,32 +140,7 @@ public class FinancialFactsTools
                 if (perPeriod.Count == 0)
                     return $"No '{concept}' data found for {stock.Ticker} with the given filters.";
 
-                var basis = asOriginallyReported ? "as originally reported" : "latest restated";
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"{concept} for {stock.Ticker} ({FactMarkdown.Cell(stock.Name)}) — {basis}:"
-                );
-                result.AppendLine();
-                result.AppendLine(
-                    "| Period End | FY | Period | Value | Unit | Form | Filed | Accession |"
-                );
-                result.AppendLine(
-                    "|-----------|---:|--------|------:|------|------|-------|-----------|"
-                );
-                foreach (var f in perPeriod)
-                {
-                    result.AppendLine(
-                        $"| {f.PeriodEnd:yyyy-MM-dd} | {f.FiscalYear} | "
-                            + $"{f.FiscalPeriod.NameForHumans()} | "
-                            + $"{FactMarkdown.Value(f.Value, f.Unit)} | "
-                            + $"{FactMarkdown.Cell(f.Unit)} | "
-                            + $"{FactMarkdown.Cell(f.Form?.DisplayName)} | "
-                            + $"{f.FiledDate:yyyy-MM-dd} | "
-                            + $"{FactMarkdown.Cell(f.AccessionNumber)} |"
-                    );
-                }
-
-                return result.ToString();
+                return RenderFactHistoryTable(concept, stock, asOriginallyReported, perPeriod);
             },
             "GetFinancialFact",
             $"ticker: {FactMarkdown.Clean(ticker)}, concept: {FactMarkdown.Clean(concept)}, "
@@ -278,6 +253,37 @@ public class FinancialFactsTools
             $"tickers: {FactMarkdown.Clean(tickers)}, concept: {FactMarkdown.Clean(concept)}, "
                 + $"year: {fiscalYear}, period: {FactMarkdown.Clean(fiscalPeriod)}"
         );
+    }
+
+    private static string RenderFactHistoryTable(
+        string concept,
+        CommonStock stock,
+        bool asOriginallyReported,
+        List<FinancialFact> perPeriod
+    )
+    {
+        var basis = asOriginallyReported ? "as originally reported" : "latest restated";
+        var result = new StringBuilder();
+        result.AppendLine(
+            $"{concept} for {stock.Ticker} ({FactMarkdown.Cell(stock.Name)}) — {basis}:"
+        );
+        result.AppendLine();
+        result.AppendLine("| Period End | FY | Period | Value | Unit | Form | Filed | Accession |");
+        result.AppendLine("|-----------|---:|--------|------:|------|------|-------|-----------|");
+        foreach (var f in perPeriod)
+        {
+            result.AppendLine(
+                $"| {f.PeriodEnd:yyyy-MM-dd} | {f.FiscalYear} | "
+                    + $"{f.FiscalPeriod.NameForHumans()} | "
+                    + $"{FactMarkdown.Value(f.Value, f.Unit)} | "
+                    + $"{FactMarkdown.Cell(f.Unit)} | "
+                    + $"{FactMarkdown.Cell(f.Form?.DisplayName)} | "
+                    + $"{f.FiledDate:yyyy-MM-dd} | "
+                    + $"{FactMarkdown.Cell(f.AccessionNumber)} |"
+            );
+        }
+
+        return result.ToString();
     }
 
     private static string RenderComparisonTable(


### PR DESCRIPTION
## Summary

- Extract the markdown rendering tail of `FinancialFactsTools.GetFinancialFact` (StringBuilder heading + 8-column header + alignment row + per-row markdown) into a `RenderFactHistoryTable` helper, so the Execute lambda ends with a single `return RenderFactHistoryTable(...)`. Mirrors `RenderComparisonTable` extracted in #1480.
- Behavior preserved: helper computes the same `basis` ternary, emits the same `{concept} for {Ticker} ({Name}) — {basis}:` heading, identical 8-column header and right-aligned separator, same per-row `FactMarkdown.Value` / `FactMarkdown.Cell` / `:yyyy-MM-dd` formatting in the same order, and same `ToString()` return — pure relocation.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — extracted `private static string RenderFactHistoryTable(string concept, CommonStock stock, bool asOriginallyReported, List<FinancialFact> perPeriod)`; `GetFinancialFact`'s lambda now calls it.