### PR TITLE
refactor(fred-import): extract ParseObservationDates helper from ImportSeries

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/FredImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredImportService.cs
@@ -5,6 +5,7 @@ using Equibles.Errors.Data.Models;
 using Equibles.Fred.Data.Models;
 using Equibles.Fred.Repositories;
 using Equibles.Integrations.Fred.Contracts;
+using Equibles.Integrations.Fred.Models;
 using Equibles.Worker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -119,15 +120,7 @@ public class FredImportService
             return;
         }
 
-        // Parse each record's date once and reuse the (record, date) pairs for
-        // both the range computation and the dedup/insert loop below.
-        var parsedRecords = records
-            .Select(r =>
-                (Record: r, ParsedDate: DateOnly.TryParse(r.Date, out var d) ? d : (DateOnly?)null)
-            )
-            .Where(p => p.ParsedDate.HasValue)
-            .Select(p => (p.Record, Date: p.ParsedDate.Value))
-            .ToList();
+        var parsedRecords = ParseObservationDates(records);
 
         if (parsedRecords.Count == 0)
         {
@@ -278,6 +271,22 @@ public class FredImportService
     private static DateOnly? ParseDate(string value)
     {
         return DateOnly.TryParse(value, out var date) ? date : null;
+    }
+
+    // Parse each FRED record's date once so callers can reuse the (record, date)
+    // pairs for both the range computation and the dedup/insert loop without
+    // re-parsing per use. Records with unparseable Date strings are dropped.
+    private static List<(FredObservationRecord Record, DateOnly Date)> ParseObservationDates(
+        List<FredObservationRecord> records
+    )
+    {
+        var result = new List<(FredObservationRecord, DateOnly)>(records.Count);
+        foreach (var r in records)
+        {
+            if (DateOnly.TryParse(r.Date, out var date))
+                result.Add((r, date));
+        }
+        return result;
     }
 
     // FRED uses the literal "." as its missing-observation sentinel.


### PR DESCRIPTION
## Summary

- `ImportSeries` built its `parsedRecords` list via a Select→Where→Select LINQ chain that used a `(DateOnly?)null` wrapper to smuggle `DateOnly.TryParse`'s `out` variable through a Select. The chain inverted itself twice — wrap-in-nullable, filter-on-HasValue, unwrap — purely to satisfy LINQ's no-out-arg restriction.
- Extracted to a private static `ParseObservationDates(records) → List<(FredObservationRecord, DateOnly)>` using a single-pass foreach. The WHY-comment ("parse each date once and reuse the pairs") moves onto the helper next to the existing `ParseFredValue` / `ParseDate` siblings.
- Pure transformation: same predicate (`DateOnly.TryParse` success), same iteration order over `records`, same `(Record, Date)` tuple shape, no exception change. Pre-sized list (`new(records.Count)`) is a minor incidental — same allocations under typical input. Build + 1534 unit + 1404 integration tests + csharpier check all green locally.

## Code changes

- `src/Equibles.Fred.HostedService/Services/FredImportService.cs` — added private static `ParseObservationDates`; replaced the inline LINQ chain in `ImportSeries` with `var parsedRecords = ParseObservationDates(records);`; imported `Equibles.Integrations.Fred.Models` so the helper signature can reference `FredObservationRecord`.