### PR TITLE
docs(technical/migrations): split new-module registration bullet

### DIFF
--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -33,7 +33,8 @@ dotnet ef migrations add <Name> \
 
 - `--startup-project` points at `Equibles.Migrations` itself (not one of the host apps) — the design-time factory has everything EF needs and avoids dragging host-specific DI in.
 - Name format: `PascalCase` describing the change, e.g. `AddProcessedFiling`, `WidenInsiderTransactionUniqueIndexForMultiTxPerFiling`.
-- A new `Equibles.<Module>.Data` project doesn't appear in migrations until it's added to both `Equibles.Migrations.csproj` (`<ProjectReference>`) and `DesignTimeDbContextFactory.modules`. Both edits land in the same PR as the new module.
+- A new `Equibles.<Module>.Data` project doesn't appear in migrations until it's added to both `Equibles.Migrations.csproj` (`<ProjectReference>`) and `DesignTimeDbContextFactory.modules`.
+- Both edits land in the same PR as the new module.
 - Inspect the generated `.cs` before committing. `Up`/`Down` are inferred from the snapshot diff and occasionally produce noisier changes than intended (column reorders, index rebuilds) — rewrite if needed before committing.
 
 ## Applying migrations


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 238-char new-module-registration bullet so the two-file edit and the same-PR landing rule each stand alone.

## Code changes

- `docs/technical/migrations.md` — split one bullet into two.