### PR TITLE
refactor(holdings): extract TryResolveAmendmentTarget helper from HandleAmendments

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -424,13 +424,15 @@ public class HoldingsImportService
 
         foreach (var (accession, submission) in context.Submissions)
         {
-            if (!context.CoverPages.TryGetValue(accession, out var coverPage))
-                continue;
-            if (!string.Equals(coverPage.IsAmendment, "Y", StringComparison.OrdinalIgnoreCase))
-                continue;
-            if (!context.CikToHolderId.TryGetValue(submission.Cik, out var holderId))
-                continue;
-            if (!TryParseDateOnly(submission.PeriodOfReport, out var reportDate))
+            if (
+                !TryResolveAmendmentTarget(
+                    accession,
+                    submission,
+                    context,
+                    out var holderId,
+                    out var reportDate
+                )
+            )
                 continue;
 
             var existingHoldings = await holdingRepo
@@ -450,6 +452,29 @@ public class HoldingsImportService
         }
 
         await holdingRepo.SaveChanges();
+    }
+
+    private static bool TryResolveAmendmentTarget(
+        string accession,
+        SubmissionRow submission,
+        ImportContext context,
+        out Guid holderId,
+        out DateOnly reportDate
+    )
+    {
+        holderId = default;
+        reportDate = default;
+
+        if (!context.CoverPages.TryGetValue(accession, out var coverPage))
+            return false;
+        if (!string.Equals(coverPage.IsAmendment, "Y", StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!context.CikToHolderId.TryGetValue(submission.Cik, out holderId))
+            return false;
+        if (!TryParseDateOnly(submission.PeriodOfReport, out reportDate))
+            return false;
+
+        return true;
     }
 
     private async Task StreamAndInsertHoldings(


### PR DESCRIPTION
## Summary

- Extract the 4-guard amendment-target resolution from `HoldingsImportService.HandleAmendments` (CoverPages lookup, IsAmendment=Y check, CikToHolderId lookup, TryParseDateOnly) into a `TryResolveAmendmentTarget(accession, submission, context, out holderId, out reportDate)` helper. The loop body now reads: resolve → load existing → delete + log.
- Behavior preserved: helper checks the same 4 conditions in the same order with identical comparisons (`StringComparison.OrdinalIgnoreCase`, same `TryParseDateOnly`); each false-return corresponds 1:1 to the original `continue`. No change to the existing-holdings query, delete call, or log.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — added `private static bool TryResolveAmendmentTarget(string accession, SubmissionRow submission, ImportContext context, out Guid holderId, out DateOnly reportDate)`; `HandleAmendments` now branches on its result.