### PR TITLE
test(fred-import): pin ParseObservationDates silently drops record with null Date

### DIFF
--- a/tests/Equibles.UnitTests/Fred/FredImportServiceParseObservationDatesNullDateTests.cs
+++ b/tests/Equibles.UnitTests/Fred/FredImportServiceParseObservationDatesNullDateTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Equibles.Fred.HostedService.Services;
+using Equibles.Integrations.Fred.Models;
+
+namespace Equibles.UnitTests.Fred;
+
+public class FredImportServiceParseObservationDatesNullDateTests
+{
+    private static readonly MethodInfo ParseObservationDatesMethod =
+        typeof(FredImportService).GetMethod(
+            "ParseObservationDates",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // ParseObservationDates' contract (extracted in #1488): records with
+    // unparseable Date strings are silently dropped. The implementation calls
+    // `DateOnly.TryParse(r.Date, out var date)` — and TryParse returns false
+    // (without throwing) when the input is null. A "defensive" refactor adding
+    // an explicit `r.Date != null` short-circuit would behave the same, but a
+    // regression that switched to `DateOnly.Parse` (or any throw-on-null
+    // shape) would crash ImportSeries on every FRED response that contains a
+    // sparse row. Pin the silent-drop contract with a record whose Date is
+    // null, mixed with a valid record to confirm the loop continues past it.
+    [Fact]
+    public void ParseObservationDates_RecordWithNullDate_IsSilentlyDroppedNotThrown()
+    {
+        var records = new List<FredObservationRecord>
+        {
+            new() { Date = null, Value = "5.33" },
+            new() { Date = "2024-01-15", Value = "5.40" },
+        };
+
+        var result = (System.Collections.IList)ParseObservationDatesMethod.Invoke(null, [records]);
+
+        result.Count.Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Summary

- `ParseObservationDates` (extracted in #1488) documents its contract via the WHY-comment on the helper: "Records with unparseable Date strings are dropped." The implementation calls `DateOnly.TryParse(r.Date, out var date)` — and `TryParse` returns false (without throwing) when the input is null.
- A regression switching to `DateOnly.Parse` (throw on null) or adding an explicit null-guard that throws/logs would crash `ImportSeries` on every sparse FRED row. Existing tests in `FredImportServiceTests` use happy-path observations with non-null dates; none feed a null-date row.
- New `[Fact]` invokes the private static helper via reflection with two records — one `Date = null`, one valid — and asserts the result contains exactly the valid one. Pins both "no throw" and "silent drop" at the unit level.
- Passes 1/1 in 8 ms.

## Code changes

- `tests/Equibles.UnitTests/Fred/FredImportServiceParseObservationDatesNullDateTests.cs` — new reflection-based unit test sibling to the existing `Fred/` unit tests. One `[Fact]`: `ParseObservationDates_RecordWithNullDate_IsSilentlyDroppedNotThrown`.