### PR TITLE
docs(technical/architecture): split migrations assembly bullet

### DIFF
--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -61,7 +61,8 @@ Data (entities) → Repositories (IQueryable) → Managers (write paths) → Con
 
 ## EF and database
 
-- Single migrations assembly: [`src/Equibles.Migrations`](../../src/Equibles.Migrations). Every host passes `migrationsAssembly: typeof(Equibles.Migrations.DesignTimeDbContextFactory).Assembly` when calling `AddEquiblesDbContext`.
+- Single migrations assembly: [`src/Equibles.Migrations`](../../src/Equibles.Migrations).
+- Every host passes `migrationsAssembly: typeof(Equibles.Migrations.DesignTimeDbContextFactory).Assembly` when calling `AddEquiblesDbContext`.
 - Migrations apply on host startup via `await dbContext.Database.MigrateAsync()` with a 1-hour command timeout for index rebuilds.
 - The Npgsql provider is configured with `UseVector()` (pgvector), `UseParadeDb()` (BM25 / `pg_search`), `UseQuerySplittingBehavior(SplitQuery)`, and lazy-loading proxies.
 


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 230-char migrations-assembly bullet so the assembly location and the per-host wiring rule each stand alone.

## Code changes

- `docs/technical/architecture.md` — split one bullet into two.