### PR TITLE
refactor(financial-facts): extract TryBuildParsedFact helper from ParseFacts

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -174,48 +174,66 @@ public class FinancialFactsImportService
                 {
                     foreach (var value in values)
                     {
-                        if (!TryMapFiscalPeriod(value.Fp, out var fiscalPeriod))
-                            continue;
-                        if (string.IsNullOrEmpty(value.Accn))
-                            continue;
-
-                        var isInstant = value.Start == null;
-                        var periodStart = value.Start ?? value.End;
-                        // Derive (FiscalYear, FiscalPeriod) from the period the
-                        // fact actually measures — the filing's fy/fp identifies
-                        // the filing, not each comparable-year value inside it
-                        // (#982). Resolver returns null when FYE info is missing
-                        // or the duration shape is unrecognised; the original
-                        // SEC-supplied identity is the fallback.
-                        var resolved = FiscalPeriodResolver.Resolve(
-                            periodStart,
-                            value.End,
-                            stock.FiscalYearEndMonth,
-                            stock.FiscalYearEndDay
+                        var fact = TryBuildParsedFact(
+                            taxonomy,
+                            tag,
+                            concept.Label,
+                            unit,
+                            value,
+                            stock
                         );
-                        yield return new ParsedFact
-                        {
-                            Taxonomy = taxonomy,
-                            Tag = tag,
-                            Label = concept.Label,
-                            Unit = unit,
-                            PeriodType = isInstant
-                                ? FactPeriodType.Instant
-                                : FactPeriodType.Duration,
-                            PeriodStart = periodStart,
-                            PeriodEnd = value.End,
-                            Value = value.Val,
-                            FiscalYear = resolved?.Year ?? value.Fy ?? value.End.Year,
-                            FiscalPeriod = resolved?.Period ?? fiscalPeriod,
-                            Form = value.Form,
-                            Filed = value.Filed,
-                            Accession = value.Accn,
-                            Frame = value.Frame,
-                        };
+                        if (fact != null)
+                            yield return fact;
                     }
                 }
             }
         }
+    }
+
+    private static ParsedFact TryBuildParsedFact(
+        FactTaxonomy taxonomy,
+        string tag,
+        string label,
+        string unit,
+        CompanyFactValue value,
+        CommonStock stock
+    )
+    {
+        if (!TryMapFiscalPeriod(value.Fp, out var fiscalPeriod))
+            return null;
+        if (string.IsNullOrEmpty(value.Accn))
+            return null;
+
+        var isInstant = value.Start == null;
+        var periodStart = value.Start ?? value.End;
+        // Derive (FiscalYear, FiscalPeriod) from the period the fact actually
+        // measures — the filing's fy/fp identifies the filing, not each
+        // comparable-year value inside it (#982). Resolver returns null when
+        // FYE info is missing or the duration shape is unrecognised; the
+        // original SEC-supplied identity is the fallback.
+        var resolved = FiscalPeriodResolver.Resolve(
+            periodStart,
+            value.End,
+            stock.FiscalYearEndMonth,
+            stock.FiscalYearEndDay
+        );
+        return new ParsedFact
+        {
+            Taxonomy = taxonomy,
+            Tag = tag,
+            Label = label,
+            Unit = unit,
+            PeriodType = isInstant ? FactPeriodType.Instant : FactPeriodType.Duration,
+            PeriodStart = periodStart,
+            PeriodEnd = value.End,
+            Value = value.Val,
+            FiscalYear = resolved?.Year ?? value.Fy ?? value.End.Year,
+            FiscalPeriod = resolved?.Period ?? fiscalPeriod,
+            Form = value.Form,
+            Filed = value.Filed,
+            Accession = value.Accn,
+            Frame = value.Frame,
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Flatten the innermost 38-line body of `FinancialFactsImportService.ParseFacts` (4-level nested `foreach`) by extracting per-value guard + `ParsedFact` construction into a `TryBuildParsedFact` helper. The innermost loop is now 4 lines: build the candidate, yield-return if non-null.
- Behavior preserved: helper performs identical `TryMapFiscalPeriod(value.Fp, ...)` → return null, identical `string.IsNullOrEmpty(value.Accn)` → return null, identical `isInstant`/`periodStart` derivation, identical `FiscalPeriodResolver.Resolve(periodStart, value.End, stock.FiscalYearEndMonth, stock.FiscalYearEndDay)` call, and identical `ParsedFact` construction with the same `resolved?.Year ?? value.Fy ?? value.End.Year` and `resolved?.Period ?? fiscalPeriod` fallbacks. The `#982` WHY-comment about fiscal-period derivation moved with its code.

## Code changes

- `src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs` — added `private static ParsedFact TryBuildParsedFact(FactTaxonomy taxonomy, string tag, string label, string unit, CompanyFactValue value, CommonStock stock)`; the innermost foreach in `ParseFacts` now calls it and yields the result when non-null.