### PR TITLE
refactor(short-interest-import): extract ValidateAndPersistBatch helper from Import

### DIFF
--- a/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
@@ -179,44 +179,7 @@ public class ShortInterestImportService
                 var inserted = await BatchPersister.Persist(
                     items,
                     InsertBatchSize,
-                    async batch =>
-                    {
-                        using var scope = _scopeFactory.CreateScope();
-                        var stockRepo =
-                            scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
-                        var repo =
-                            scope.ServiceProvider.GetRequiredService<ShortInterestRepository>();
-
-                        // tickerMap was built at the start of Import and goes stale if CompanySyncService
-                        // hard-deletes a stock in parallel (PR #5's ReplaceObsoleteStock path). Re-validate
-                        // each batch against the current set of CommonStockIds so dangling-FK inserts can't
-                        // poison the whole batch.
-                        var batchStockIds = batch.Select(b => b.CommonStockId).Distinct().ToList();
-                        var liveStockIds = await stockRepo
-                            .GetAll()
-                            .Where(s => batchStockIds.Contains(s.Id))
-                            .Select(s => s.Id)
-                            .ToHashSetAsync(cancellationToken);
-
-                        var validBatch = batch
-                            .Where(b => liveStockIds.Contains(b.CommonStockId))
-                            .ToList();
-                        var dropped = batch.Count - validBatch.Count;
-                        if (dropped > 0)
-                        {
-                            _logger.LogWarning(
-                                "Dropped {Dropped} short interest rows for {Date} referencing CommonStockIds no longer in the database",
-                                dropped,
-                                date
-                            );
-                        }
-
-                        if (validBatch.Count == 0)
-                            return;
-
-                        repo.AddRange(validBatch);
-                        await repo.SaveChanges();
-                    }
+                    batch => ValidateAndPersistBatch(batch, date, cancellationToken)
                 );
 
                 totalImported += inserted;
@@ -249,5 +212,44 @@ public class ShortInterestImportService
             totalImported,
             datesSkipped
         );
+    }
+
+    // tickerMap was built at the start of Import and goes stale if CompanySyncService
+    // hard-deletes a stock in parallel (PR #5's ReplaceObsoleteStock path). Re-validate
+    // each batch against the current set of CommonStockIds so dangling-FK inserts can't
+    // poison the whole batch.
+    private async Task ValidateAndPersistBatch(
+        List<ShortInterest> batch,
+        DateOnly date,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var repo = scope.ServiceProvider.GetRequiredService<ShortInterestRepository>();
+
+        var batchStockIds = batch.Select(b => b.CommonStockId).Distinct().ToList();
+        var liveStockIds = await stockRepo
+            .GetAll()
+            .Where(s => batchStockIds.Contains(s.Id))
+            .Select(s => s.Id)
+            .ToHashSetAsync(cancellationToken);
+
+        var validBatch = batch.Where(b => liveStockIds.Contains(b.CommonStockId)).ToList();
+        var dropped = batch.Count - validBatch.Count;
+        if (dropped > 0)
+        {
+            _logger.LogWarning(
+                "Dropped {Dropped} short interest rows for {Date} referencing CommonStockIds no longer in the database",
+                dropped,
+                date
+            );
+        }
+
+        if (validBatch.Count == 0)
+            return;
+
+        repo.AddRange(validBatch);
+        await repo.SaveChanges();
     }
 }


### PR DESCRIPTION
## Summary

- `ShortInterestImportService.Import` (207-line method) embedded a 37-line `BatchPersister.Persist` callback that opens its own scope, queries CommonStockRepository for live IDs, filters the batch against them, logs dropped rows, and persists the survivors. The whole block sat indented four levels deep inside `try` → `foreach date` → `Persist(items, …, async batch => { … })`, hurting top-level readability.
- Extracted to a private async helper `ValidateAndPersistBatch(batch, date, cancellationToken)`. The "tickerMap goes stale if CompanySyncService hard-deletes in parallel" WHY-comment moves onto the helper. The `BatchPersister.Persist` call collapses to a single-line `batch => ValidateAndPersistBatch(batch, date, cancellationToken)`.
- Pure relocation: same per-batch scope creation, same `GetByStock`/live-id EF query, same `Contains` filter, same conditional `LogWarning` on drop, same conditional `AddRange` + `SaveChanges`. The helper captures the same instance fields (`_scopeFactory`, `_logger`) and takes `date` + `cancellationToken` as parameters in place of the original closure. Build + 1537 unit + 1404 integration tests + csharpier check all green locally.

## Code changes

- `src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs` — added private async `ValidateAndPersistBatch`; replaced the inline `BatchPersister.Persist` callback with a one-line lambda calling the helper. WHY-comment moved onto the helper.