### PR TITLE
refactor(holdings-import): collapse 4 ParseLong(GetValue(row, ...)) calls in ParseHoldingRow behind a local ParseLongField helper

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -605,10 +605,12 @@ public class HoldingsImportService
             context.CoverPages.TryGetValue(accession, out var cp)
             && string.Equals(cp.IsAmendment, "Y", StringComparison.OrdinalIgnoreCase);
 
-        var shares = ParseLong(GetValue(row, "SSHPRNAMT"));
-        var votingAuthSole = ParseLong(GetValue(row, "VOTING_AUTH_SOLE"));
-        var votingAuthShared = ParseLong(GetValue(row, "VOTING_AUTH_SHARED"));
-        var votingAuthNone = ParseLong(GetValue(row, "VOTING_AUTH_NONE"));
+        long ParseLongField(string field) => ParseLong(GetValue(row, field));
+
+        var shares = ParseLongField("SSHPRNAMT");
+        var votingAuthSole = ParseLongField("VOTING_AUTH_SOLE");
+        var votingAuthShared = ParseLongField("VOTING_AUTH_SHARED");
+        var votingAuthNone = ParseLongField("VOTING_AUTH_NONE");
 
         var hasPrice = context.StockPrices.TryGetValue(
             (commonStockId, reportDate),


### PR DESCRIPTION
## Summary

- Four field reads in `ParseHoldingRow` (`SSHPRNAMT`, `VOTING_AUTH_SOLE`, `VOTING_AUTH_SHARED`, `VOTING_AUTH_NONE`) each repeated the same `ParseLong(GetValue(row, "..."))` chain. A local function keeps the call sites focused on the column name and trims the boilerplate.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — added a local `ParseLongField(string field)` inside `ParseHoldingRow` and routed the four long-valued field reads through it. The local function forwards the same `GetValue(row, field)` and `ParseLong(...)` calls in the same order, so each site evaluates identically.