### PR TITLE
docs(technical/modules): split SEC three-scrapers bullet

### DIFF
--- a/docs/technical/modules.md
+++ b/docs/technical/modules.md
@@ -36,7 +36,10 @@ These do not own a financial-domain dataset; they support every other module.
 - [`InsiderTradingFilingProcessor`](../../src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs) runs inside `DocumentProcessorWorker`, parses the form, and writes through the Insider Trading repositories.
 - **Holdings has two scrapers.** `HoldingsScraperWorker` does the periodic bulk pull; `Holdings13FRealtimeWorker` watches EDGAR for new 13F-HR submissions and ingests them as they post.
 - Both scrapers share the same `ProcessedDataSet` / `ProcessedFiling` deduplication bookkeeping.
-- **SEC ships three scrapers.** `SecScraperWorker` pulls filings; `DocumentProcessorWorker` normalises them and routes them to per-document-type processors; `FtdScraperWorker` pulls fails-to-deliver data.
+- **SEC ships three scrapers.**
+- `SecScraperWorker` pulls filings.
+- `DocumentProcessorWorker` normalises filings and routes them to per-document-type processors.
+- `FtdScraperWorker` pulls fails-to-deliver data.
 - `Equibles.Sec.FinancialFacts.HostedService` is a separate worker that pulls the XBRL fact stream from the same EDGAR root.
 - **SEC Financial Facts ships two XBRL extractors in `Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/`.** `StandaloneXbrlParser` consumes older filings' dedicated `.xml` instance documents; `InlineXbrlParser` consumes the embedded iXBRL of modern `.htm` filings. Both emit the same `ParsedXbrlFact` shape (concept + period + unit + `xbrldi:explicitMember` dimensions) that maps onto `FinancialFact` + `FinancialFactDimension`. **The parsers are not wired into the worker pipeline** — running them at scale requires persisting the raw XBRL artifacts at ingest time (today they live only in transient envelopes; `XbrlStripStep` deletes the inline header before downstream consumers see it). That prerequisite is tracked in [#1118](https://github.com/daniel3303/Equibles/issues/1118); once it lands the import service can call these parsers and start populating dimensional rows.
 - **The `*.Mcp` project is optional.** A module without AI-assistant-facing tools (currently: `Errors`, `Media`, `CommonStocks` — internal infrastructure) ships only `.Data` + `.Repositories` (+ `.BusinessLogic` when needed).


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 204-char SEC three-scrapers bullet into a heading + one bullet per scraper so each scraper carries one fact.

## Code changes

- `docs/technical/modules.md` — split one bullet into four.