### PR TITLE
refactor(congress): collapse 3 duplicated XML element reads in DownloadAndParseFilingIndex behind a local TrimmedField helper

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -137,11 +137,14 @@ public partial class HouseDisclosureClient
             .Where(m => m.Element("FilingType")?.Value == "P")
             .Select(m =>
             {
+                string TrimmedField(string elementName) =>
+                    m.Element(elementName)?.Value?.Trim() ?? "";
+
                 var filingDateStr = m.Element("FilingDate")?.Value;
                 DateOnly.TryParse(filingDateStr, out var filingDate);
-                var prefix = m.Element("Prefix")?.Value?.Trim() ?? "";
-                var first = m.Element("First")?.Value?.Trim() ?? "";
-                var last = m.Element("Last")?.Value?.Trim() ?? "";
+                var prefix = TrimmedField("Prefix");
+                var first = TrimmedField("First");
+                var last = TrimmedField("Last");
                 var name = StripHonorificPrefixes($"{prefix} {first} {last}".Trim()).Trim();
 
                 return new HouseFiling(


### PR DESCRIPTION
## Summary

- The Prefix / First / Last reads inside the Member-XML projection each repeated the same `m.Element("...")?.Value?.Trim() ?? ""` chain. A local function inside the projection lambda gives the pattern a name and shortens the call sites.

## Code changes

- `src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs` — added a local `TrimmedField(string elementName)` inside the `Select` lambda of `DownloadAndParseFilingIndex` and routed the three name-component reads through it. The helper performs the same `Element → Value → Trim → fallback` chain in the same order, so each site evaluates identically.