### PR TITLE
refactor(insider-trading): extract TryParseTransactionDate helper from ParseTransaction

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -338,18 +338,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             "postTransactionAmounts",
             "sharesOwnedFollowingTransaction"
         );
-        // Form 4 transactionDate is ISO yyyy-MM-dd (ownership XSD). Parse it
-        // culture-independently — under a non-Gregorian host culture (e.g.
-        // ar-SA Umm al-Qura) culture-sensitive TryParse fails and every
-        // insider transaction would be silently dropped.
-        if (
-            !DateOnly.TryParse(
-                transactionDateStr,
-                System.Globalization.CultureInfo.InvariantCulture,
-                System.Globalization.DateTimeStyles.None,
-                out var transactionDate
-            )
-        )
+        if (!TryParseTransactionDate(transactionDateStr, out var transactionDate))
             return null;
 
         return new InsiderTransaction
@@ -444,6 +433,21 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         // Fix unescaped ampersands in entity names
         return Regex.Replace(xml, @"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)", "&amp;");
     }
+
+    // Form 4 transactionDate is ISO yyyy-MM-dd (ownership XSD). Parse it
+    // culture-independently — under a non-Gregorian host culture (e.g.
+    // ar-SA Umm al-Qura) culture-sensitive TryParse fails and every insider
+    // transaction would be silently dropped.
+    private static bool TryParseTransactionDate(
+        string transactionDateStr,
+        out DateOnly transactionDate
+    ) =>
+        DateOnly.TryParse(
+            transactionDateStr,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None,
+            out transactionDate
+        );
 
     internal static TransactionCode ParseTransactionCode(string code)
     {


### PR DESCRIPTION
## Summary

- Extract the 12-line culture-invariant `DateOnly.TryParse` guard from `InsiderTradingFilingProcessor.ParseTransaction` into a `TryParseTransactionDate` helper, so the caller is `if (!TryParseTransactionDate(transactionDateStr, out var transactionDate)) return null;`. The Form 4 / Umm al-Qura WHY-comment moves to the helper next to the parse call it explains.
- Behavior preserved: helper calls `DateOnly.TryParse` with the identical `InvariantCulture` and `DateTimeStyles.None` arguments, returns the same bool, and emits the same `out DateOnly` — caller's null-return on false is unchanged.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — added `private static bool TryParseTransactionDate(string transactionDateStr, out DateOnly transactionDate)`; `ParseTransaction` now branches on its result.