### PR TITLE
refactor(sec-mcp): extract RenderStatementTable helper from GetFinancialStatement

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -7,6 +7,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Statements;
 using Equibles.Sec.FinancialFacts.Mcp.Helpers;
 using Equibles.Sec.FinancialFacts.Repositories;
@@ -128,45 +129,15 @@ public class FinancialStatementTools
                     .GroupBy(f => f.FinancialConceptId)
                     .ToDictionary(g => g.Key, g => g.OrderByDescending(f => f.FiledDate).First());
 
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"{statementType.NameForHumans()} for {stock.Ticker} "
-                        + $"({FactMarkdown.Cell(stock.Name)}) — "
-                        + $"FY{selectedYear} {selectedPeriod.NameForHumans()}:"
+                return RenderStatementTable(
+                    stock,
+                    statementType,
+                    selectedYear,
+                    selectedPeriod,
+                    statementLines,
+                    conceptIdByKey,
+                    latestByConcept
                 );
-                result.AppendLine();
-                result.AppendLine("| Line Item | Value | Unit | Period End | Form | Filed |");
-                result.AppendLine("|-----------|------:|------|-----------|------|-------|");
-
-                var rendered = 0;
-                foreach (var line in statementLines)
-                {
-                    if (
-                        !conceptIdByKey.TryGetValue((line.Taxonomy, line.Tag), out var conceptId)
-                        || !latestByConcept.TryGetValue(conceptId, out var fact)
-                    )
-                    {
-                        result.AppendLine($"| {FactMarkdown.Cell(line.Label)} | — | | | | |");
-                        continue;
-                    }
-
-                    result.AppendLine(
-                        $"| {FactMarkdown.Cell(line.Label)} | "
-                            + $"{FactMarkdown.Value(fact.Value, fact.Unit)} | "
-                            + $"{FactMarkdown.Cell(fact.Unit)} | "
-                            + $"{fact.PeriodEnd:yyyy-MM-dd} | "
-                            + $"{FactMarkdown.Cell(fact.Form?.DisplayName)} | "
-                            + $"{fact.FiledDate:yyyy-MM-dd} |"
-                    );
-                    rendered++;
-                }
-
-                if (rendered == 0)
-                    result.AppendLine(
-                        $"\n_No line items of this statement were reported for the period._"
-                    );
-
-                return result.ToString();
             },
             _logger,
             "GetFinancialStatement",
@@ -174,6 +145,55 @@ public class FinancialStatementTools
                 + $"year: {year}, period: {FactMarkdown.Clean(period)}",
             ReportError
         );
+    }
+
+    private static string RenderStatementTable(
+        CommonStock stock,
+        FinancialStatementType statementType,
+        int selectedYear,
+        SecFiscalPeriod selectedPeriod,
+        IReadOnlyList<StatementLine> statementLines,
+        Dictionary<(FactTaxonomy Taxonomy, string Tag), Guid> conceptIdByKey,
+        Dictionary<Guid, FinancialFact> latestByConcept
+    )
+    {
+        var result = new StringBuilder();
+        result.AppendLine(
+            $"{statementType.NameForHumans()} for {stock.Ticker} "
+                + $"({FactMarkdown.Cell(stock.Name)}) — "
+                + $"FY{selectedYear} {selectedPeriod.NameForHumans()}:"
+        );
+        result.AppendLine();
+        result.AppendLine("| Line Item | Value | Unit | Period End | Form | Filed |");
+        result.AppendLine("|-----------|------:|------|-----------|------|-------|");
+
+        var rendered = 0;
+        foreach (var line in statementLines)
+        {
+            if (
+                !conceptIdByKey.TryGetValue((line.Taxonomy, line.Tag), out var conceptId)
+                || !latestByConcept.TryGetValue(conceptId, out var fact)
+            )
+            {
+                result.AppendLine($"| {FactMarkdown.Cell(line.Label)} | — | | | | |");
+                continue;
+            }
+
+            result.AppendLine(
+                $"| {FactMarkdown.Cell(line.Label)} | "
+                    + $"{FactMarkdown.Value(fact.Value, fact.Unit)} | "
+                    + $"{FactMarkdown.Cell(fact.Unit)} | "
+                    + $"{fact.PeriodEnd:yyyy-MM-dd} | "
+                    + $"{FactMarkdown.Cell(fact.Form?.DisplayName)} | "
+                    + $"{fact.FiledDate:yyyy-MM-dd} |"
+            );
+            rendered++;
+        }
+
+        if (rendered == 0)
+            result.AppendLine($"\n_No line items of this statement were reported for the period._");
+
+        return result.ToString();
     }
 
     private async Task<(


### PR DESCRIPTION
## Summary

- `FinancialStatementTools.GetFinancialStatement` (126-line method) embedded a 37-line markdown-table rendering block — title, header row, foreach over `statementLines` with two-arm branch (missing fact → "—" placeholder, present fact → full row), and `_No line items..._` fallback. The block sat at the same indentation level as the prologue, query, and grouping logic, hurting top-level readability.
- Extracted to a private static `RenderStatementTable(stock, statementType, selectedYear, selectedPeriod, statementLines, conceptIdByKey, latestByConcept) → string`. Sibling to `FinancialFactsTools.RenderFactHistoryTable` / `RenderComparisonTable` extracted in #1485 / #1480. The public method's tail collapses to a single `return RenderStatementTable(...)`.
- Pure string-building transformation: identical iteration order over `statementLines`, identical two-arm conditional, identical `FactMarkdown.Cell`/`Value` escaping, identical "—" placeholder formatting, identical empty-set fallback. Added `using Equibles.Sec.FinancialFacts.Data.Models;` so the helper signature can reference `FinancialFact`. Build + 1539 unit + 1404 integration tests + csharpier check all green locally.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs` — added private static `RenderStatementTable`; replaced the inline rendering block with `return RenderStatementTable(...)`; imported `Equibles.Sec.FinancialFacts.Data.Models`.