### PR TITLE
docs(technical/web-portal): split Tailwind main.css bullet

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -61,7 +61,11 @@ Why the indirection through `ViewData` rather than a single `StockDetailViewMode
 
 - [`package.json`](../../src/Equibles.Web/package.json) — Vite 6, Tailwind v4 (`@tailwindcss/postcss`), DaisyUI v5, plus `chart.js`, `aos`, `typed.js`.
 - [`vite.config.js`](../../src/Equibles.Web/vite.config.js) — single entry `src/index.js`, output to `wwwroot/dist/` as `bundle.js` + `main.css`. `emptyOutDir: true` cleans the bundle on each build.
-- [`src/css/main.css`](../../src/Equibles.Web/src/css/main.css) — Tailwind v4 CSS-first config: `@import "tailwindcss"`, `@plugin "daisyui"` + `@plugin "@tailwindcss/typography"`, `@source` directives for `Views/` + `TagHelpers/` + `src/js/`, and the custom `equibles` DaisyUI theme defined via `@plugin "daisyui/theme"`.
+- [`src/css/main.css`](../../src/Equibles.Web/src/css/main.css) — Tailwind v4 CSS-first config.
+  - `@import "tailwindcss"`.
+  - `@plugin "daisyui"` + `@plugin "@tailwindcss/typography"`.
+  - `@source` directives for `Views/` + `TagHelpers/` + `src/js/`.
+  - Custom `equibles` DaisyUI theme via `@plugin "daisyui/theme"`.
 - `src/Equibles.Web/src/css/` holds the entry CSS imported by `src/Equibles.Web/src/index.js`; `src/Equibles.Web/src/js/` holds chart wrappers and per-page JS modules.
 - The bundle lazy-imports per-page modules so the Holdings tab doesn't pull Chart.js into the Documents tab.
 - Dev cycle: `npm run start` (Vite watch) alongside the .NET app — `AddRazorRuntimeCompilation()` (Web/Program.cs:105) makes Razor edits live without rebuild; Vite handles the bundle.


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 323-char `main.css` bullet into a parent identifier + nested sub-bullets so each @-rule / theme entry carries one fact.

## Code changes

- `docs/technical/web-portal.md` — flatten one bullet into a parent + four sub-bullets.