### PR TITLE
refactor(sec): extract TryExtractCompanyRow helper from ParseCompaniesFromResponse

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -649,14 +649,17 @@ public class SecEdgarClient : ISecEdgarClient
 
         foreach (var row in response.Data)
         {
-            if (row.Count <= Math.Max(Math.Max(cikIndex, nameIndex), tickerIndex))
-                continue;
-
-            var cik = row[cikIndex]?.ToString();
-            var name = row[nameIndex]?.ToString();
-            var ticker = row[tickerIndex]?.ToString();
-
-            if (string.IsNullOrEmpty(cik) || string.IsNullOrEmpty(ticker))
+            if (
+                !TryExtractCompanyRow(
+                    row,
+                    cikIndex,
+                    nameIndex,
+                    tickerIndex,
+                    out var cik,
+                    out var name,
+                    out var ticker
+                )
+            )
                 continue;
 
             if (companiesByCik.TryGetValue(cik, out var existing))
@@ -675,6 +678,33 @@ public class SecEdgarClient : ISecEdgarClient
         }
 
         return companiesByCik.Values.ToList();
+    }
+
+    private static bool TryExtractCompanyRow(
+        List<object> row,
+        int cikIndex,
+        int nameIndex,
+        int tickerIndex,
+        out string cik,
+        out string name,
+        out string ticker
+    )
+    {
+        cik = null;
+        name = null;
+        ticker = null;
+
+        if (row.Count <= Math.Max(Math.Max(cikIndex, nameIndex), tickerIndex))
+            return false;
+
+        cik = row[cikIndex]?.ToString();
+        name = row[nameIndex]?.ToString();
+        ticker = row[tickerIndex]?.ToString();
+
+        if (string.IsNullOrEmpty(cik) || string.IsNullOrEmpty(ticker))
+            return false;
+
+        return true;
     }
 
     private static List<FilingData> MapToFilingData(RecentFilings recent, string cik)


### PR DESCRIPTION
## Summary

- Extract the per-row count guard + 3-field extraction + empty-cik/ticker guard from `SecEdgarClient.ParseCompaniesFromResponse` into a `TryExtractCompanyRow(row, cikIndex, nameIndex, tickerIndex, out cik, out name, out ticker)` helper. Loop body is now a single guarded extract + the dictionary upsert.
- Behavior preserved: helper performs the same `row.Count <= Math.Max(Math.Max(cikIndex, nameIndex), tickerIndex)` guard returning false, the same three `row[i]?.ToString()` reads in the same order (cik, name, ticker), and the same `IsNullOrEmpty(cik) || IsNullOrEmpty(ticker)` guard returning false; each former `continue` is now matched by a false-return.

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — added `private static bool TryExtractCompanyRow(List<object> row, int cikIndex, int nameIndex, int tickerIndex, out string cik, out string name, out string ticker)`; `ParseCompaniesFromResponse`'s loop branches on its result before the dictionary upsert.