### PR TITLE
refactor(insider-trading): collapse 6 GetWrappedValue(txElement, ...) calls in ParseTransaction behind a local Wrapped helper

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -319,25 +319,18 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         bool isAmendment
     )
     {
-        var securityTitle = GetWrappedValue(txElement, "securityTitle")?.Trim();
-        var transactionDateStr = GetWrappedValue(txElement, "transactionDate");
+        string Wrapped(params string[] path) => GetWrappedValue(txElement, path);
+
+        var securityTitle = Wrapped("securityTitle")?.Trim();
+        var transactionDateStr = Wrapped("transactionDate");
         var codeStr = txElement
             .Element("transactionCoding")
             ?.Element("transactionCode")
             ?.Value?.Trim();
-        var sharesStr = GetWrappedValue(txElement, "transactionAmounts", "transactionShares");
-        var priceStr = GetWrappedValue(txElement, "transactionAmounts", "transactionPricePerShare");
-        var adCode = GetWrappedValue(
-            txElement,
-            "transactionAmounts",
-            "transactionAcquiredDisposedCode"
-        )
-            ?.Trim();
-        var sharesAfterStr = GetWrappedValue(
-            txElement,
-            "postTransactionAmounts",
-            "sharesOwnedFollowingTransaction"
-        );
+        var sharesStr = Wrapped("transactionAmounts", "transactionShares");
+        var priceStr = Wrapped("transactionAmounts", "transactionPricePerShare");
+        var adCode = Wrapped("transactionAmounts", "transactionAcquiredDisposedCode")?.Trim();
+        var sharesAfterStr = Wrapped("postTransactionAmounts", "sharesOwnedFollowingTransaction");
         if (!TryParseTransactionDate(transactionDateStr, out var transactionDate))
             return null;
 


### PR DESCRIPTION
## Summary

- `ParseTransaction` reads six fields off the same `txElement` via `GetWrappedValue(txElement, …)`, repeating the element parameter at every site. A local function captures `txElement` once and keeps the call sites focused on the field path.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — added a local `Wrapped(params string[] path)` inside `ParseTransaction` that forwards to `GetWrappedValue(txElement, path)` and routed the six existing field reads through it. The helper passes the same arguments to the same call, so each site evaluates identically.