### PR TITLE
refactor(yahoo): extract FlushPriceBatch helper from ImportTicker

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -134,20 +134,18 @@ public class YahooPriceImportService
         if (newPrices.Count == 0)
             return 0;
 
-        var inserted = await BatchPersister.Persist(
-            newPrices,
-            InsertBatchSize,
-            async batch =>
-            {
-                using var scope = _scopeFactory.CreateScope();
-                var repo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
-                repo.AddRange(batch);
-                await repo.SaveChanges();
-            }
-        );
+        var inserted = await BatchPersister.Persist(newPrices, InsertBatchSize, FlushPriceBatch);
 
         _logger.LogDebug("Inserted {Count} prices for {Ticker}", inserted, ticker);
         return inserted;
+    }
+
+    private async Task FlushPriceBatch(List<DailyStockPrice> batch)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
+        repo.AddRange(batch);
+        await repo.SaveChanges();
     }
 
     private async Task SyncKeyStatistics(


### PR DESCRIPTION
## Summary

- Replace the inline async `BatchPersister.Persist` flush lambda inside `YahooPriceImportService.ImportTicker` with a named `FlushPriceBatch` instance method. The persist call becomes the single-line `await BatchPersister.Persist(newPrices, InsertBatchSize, FlushPriceBatch);`.
- Behavior preserved: helper performs the identical `_scopeFactory.CreateScope()`, identical `GetRequiredService<DailyStockPriceRepository>()`, identical `repo.AddRange(batch)`, and identical `await repo.SaveChanges()` in the same order — pure relocation.

## Code changes

- `src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs` — added `private async Task FlushPriceBatch(List<DailyStockPrice> batch)`; `ImportTicker` now passes it as a method group to `BatchPersister.Persist`.