### PR TITLE
docs(technical/scrapers): split IRateLimiter bullet

### DIFF
--- a/docs/technical/scrapers.md
+++ b/docs/technical/scrapers.md
@@ -53,7 +53,8 @@ Every client follows the same shape: one interface + one implementation register
 
 ### Rate limiting — [`RateLimiter`](../../src/Equibles.Integrations.Common/RateLimiter)
 
-- `IRateLimiter` with `WaitAsync()` + `PauseFor(TimeSpan)`. Each client owns a `static readonly IRateLimiter` configured for its upstream's published (or reverse-engineered) limit — e.g. Yahoo uses `40 requests / minute`.
+- `IRateLimiter` exposes `WaitAsync()` + `PauseFor(TimeSpan)`.
+- Each client owns a `static readonly IRateLimiter` configured for its upstream's published (or reverse-engineered) limit — e.g. Yahoo uses `40 requests / minute`.
 - `WaitAsync()` blocks until the sliding-window counter allows another request; calls itself recursively after the delay so a long pause never silently lets a request through.
 - `PauseFor(TimeSpan)` extends the no-go window — used when the upstream returns `429` to widen the cooldown beyond what the steady-state counter would impose.
 - The pause is monotonic: a later, shorter pause never shortens an already-set later deadline.


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 223-char IRateLimiter bullet so the interface methods and the per-client instance convention each stand alone.

## Code changes

- `docs/technical/scrapers.md` — split one bullet into two.