### PR TITLE
refactor(fred-import): extract UpdateSeriesMetadata helper from ImportSeries

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/FredImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredImportService.cs
@@ -192,17 +192,7 @@ public class FredImportService
             }
         );
 
-        using (var scope = _scopeFactory.CreateScope())
-        {
-            var seriesRepo = scope.ServiceProvider.GetRequiredService<FredSeriesRepository>();
-            var dbSeries = await seriesRepo.Get(series.Id);
-            dbSeries.LastUpdated = DateTime.UtcNow;
-            if (latestObservationDate != DateOnly.MinValue)
-            {
-                dbSeries.ObservationEnd = latestObservationDate;
-            }
-            await seriesRepo.SaveChanges();
-        }
+        await UpdateSeriesMetadata(series.Id, latestObservationDate);
 
         if (skipped > 0)
         {
@@ -218,6 +208,19 @@ public class FredImportService
             totalInserted,
             curated.SeriesId
         );
+    }
+
+    private async Task UpdateSeriesMetadata(Guid seriesId, DateOnly latestObservationDate)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var seriesRepo = scope.ServiceProvider.GetRequiredService<FredSeriesRepository>();
+        var dbSeries = await seriesRepo.Get(seriesId);
+        dbSeries.LastUpdated = DateTime.UtcNow;
+        if (latestObservationDate != DateOnly.MinValue)
+        {
+            dbSeries.ObservationEnd = latestObservationDate;
+        }
+        await seriesRepo.SaveChanges();
     }
 
     private async Task<FredSeries> EnsureSeriesExists(


### PR DESCRIPTION
## Summary

- `FredImportService.ImportSeries`' tail (after the batch-persist call) embedded a 10-line scope+lookup+mutate+save block updating `LastUpdated` and conditionally `ObservationEnd` on the `FredSeries` row. The block sat at the same indentation as the top-level import phases, hurting top-level readability of an already-long method.
- Extracted to a private async helper `UpdateSeriesMetadata(seriesId, latestObservationDate)`, sibling to the existing `EnsureSeriesExists`. ImportSeries' tail collapses to `await UpdateSeriesMetadata(series.Id, latestObservationDate);`. Sentinel preserved: the helper still uses `if (latestObservationDate != DateOnly.MinValue)` to gate the `ObservationEnd` update so callers don't need to convert to nullable.
- Pure relocation: same per-call scope creation, same `seriesRepo.Get(seriesId)` lookup, same `LastUpdated = DateTime.UtcNow` assignment, same conditional `ObservationEnd` write, same `SaveChanges`. The cancellationToken param was dropped from the helper signature because the original block never honored it (`Get`/`SaveChanges` don't accept one); preserving the existing non-honor-of-CT behavior is the equivalence story. Build + 1541 unit + 1404 integration tests + csharpier check all green locally.

## Code changes

- `src/Equibles.Fred.HostedService/Services/FredImportService.cs` — added private async `UpdateSeriesMetadata`; replaced the inline tail block in `ImportSeries` with a single `await UpdateSeriesMetadata(series.Id, latestObservationDate);` call.