### PR TITLE
docs(technical/migrations): split relation-does-not-exist bullet

### DIFF
--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -91,7 +91,8 @@ The snapshot is the source of truth for the entire EF model. New migrations shou
 
 - **`PendingModelChanges` at host startup** — a module's `IModuleConfiguration` is in the runtime model but not in the migration snapshot.
 - Most common cause: forgetting `AddMessaging()` in a host that calls `AddAllModules()`; see [Architecture → Host composition](architecture.md#host-composition) for the explicit-call requirement.
-- **"relation does not exist" after adding a new module** — the new module's `Equibles.<Module>.Data` was not added to `Equibles.Migrations.csproj` and `DesignTimeDbContextFactory`. Both edits, then `dotnet ef migrations add`.
+- **"relation does not exist" after adding a new module** — the new module's `Equibles.<Module>.Data` was not added to `Equibles.Migrations.csproj` and `DesignTimeDbContextFactory`.
+- Fix: make both edits, then run `dotnet ef migrations add`.
 - **`CREATE EXTENSION "pg_search" does not exist`** — running against vanilla Postgres instead of ParadeDB. Use the `paradedb/paradedb` Docker image (see `docker-compose.yml`).
 - **Migration timeout on first run** — bump `Database.SetCommandTimeout` higher.
 - The default 1 hour covers the first-run BM25 index build.


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 228-char troubleshooting bullet so the diagnosis and the fix each stand alone.

## Code changes

- `docs/technical/migrations.md` — split one bullet into two.