### PR TITLE
refactor(congress): extract ExtractTransactionsFromTable helper from ParseTransactionsFromHtml

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -27,24 +27,37 @@ public static partial class DisclosureParsingHelper
 
         foreach (var table in tables)
         {
-            var headerTexts = ExtractHeaderTexts(table);
-            if (headerTexts == null || !IsTransactionTable(headerTexts))
-                continue;
-
-            var cols = MapColumnIndices(headerTexts);
-            var rows = table.SelectNodes(".//tbody//tr");
-            if (rows == null)
-                continue;
-
-            foreach (var row in rows)
-            {
-                var tx = ParseTransactionRow(row, cols, memberName, position, filingDate, logger);
-                if (tx != null)
-                    transactions.Add(tx);
-            }
+            transactions.AddRange(
+                ExtractTransactionsFromTable(table, memberName, position, filingDate, logger)
+            );
         }
 
         return transactions;
+    }
+
+    private static IEnumerable<DisclosureTransaction> ExtractTransactionsFromTable(
+        HtmlNode table,
+        string memberName,
+        CongressPosition position,
+        DateOnly filingDate,
+        ILogger logger
+    )
+    {
+        var headerTexts = ExtractHeaderTexts(table);
+        if (headerTexts == null || !IsTransactionTable(headerTexts))
+            yield break;
+
+        var cols = MapColumnIndices(headerTexts);
+        var rows = table.SelectNodes(".//tbody//tr");
+        if (rows == null)
+            yield break;
+
+        foreach (var row in rows)
+        {
+            var tx = ParseTransactionRow(row, cols, memberName, position, filingDate, logger);
+            if (tx != null)
+                yield return tx;
+        }
     }
 
     private static List<string> ExtractHeaderTexts(HtmlNode table)


### PR DESCRIPTION
## Summary

- Flatten `DisclosureParsingHelper.ParseTransactionsFromHtml` by extracting the per-table extraction (header validate + col-map + row iterate + per-row parse) into an `IEnumerable<DisclosureTransaction>` helper, so the outer caller is `foreach (var table in tables) transactions.AddRange(ExtractTransactionsFromTable(...));`.
- Behavior preserved: helper performs the identical `ExtractHeaderTexts` → `IsTransactionTable` skip (now `yield break`), identical `MapColumnIndices` call, identical `tbody//tr` null-skip (now `yield break`), and identical inner `ParseTransactionRow` + null-filter (now `yield return`); same iteration order, same outputs.

## Code changes

- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — added `private static IEnumerable<DisclosureTransaction> ExtractTransactionsFromTable(HtmlNode table, string memberName, CongressPosition position, DateOnly filingDate, ILogger logger)`; `ParseTransactionsFromHtml`'s outer loop now `AddRange`s its output.