### PR TITLE
test(insider-trading): pin TryParseTransactionDate parses ISO date under Hijri thread culture

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorTryParseTransactionDateHijriCultureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorTryParseTransactionDateHijriCultureTests.cs
@@ -1,0 +1,49 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InsiderTradingFilingProcessorTryParseTransactionDateHijriCultureTests
+{
+    // Sibling to GH-1501's pin on FredImportService.ParseObservationDates,
+    // which lacked the explicit-InvariantCulture hardening and silently dropped
+    // every ISO-formatted observation under ar-SA Umm al-Qura. This file's
+    // target — TryParseTransactionDate, extracted in #1507 — has the
+    // hardening (the WHY-comment documents it: "Parse it culture-independently
+    // — under a non-Gregorian host culture (e.g. ar-SA Umm al-Qura)
+    // culture-sensitive TryParse fails and every insider transaction would be
+    // silently dropped").
+    //
+    // Pin the documented contract: an ISO Form 4 `transactionDate` parses
+    // correctly under ar-SA. The test passes today because the helper passes
+    // `CultureInfo.InvariantCulture` explicitly; a "simplification" refactor
+    // dropping that argument (or switching to the no-culture
+    // `DateOnly.TryParse(string)` overload) would compile cleanly, pass every
+    // happy-path test (those all run under en-US), and silently drop every
+    // Form 4 transaction on any worker host whose locale defaults to ar-SA.
+    [Fact]
+    public void TryParseTransactionDate_IsoDateUnderHijriCulture_StillParsesViaInvariantCulture()
+    {
+        var method = typeof(InsiderTradingFilingProcessor).GetMethod(
+            "TryParseTransactionDate",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+
+            var args = new object[] { "2024-03-15", default(DateOnly) };
+            var parsed = (bool)method.Invoke(null, args);
+
+            parsed.Should().BeTrue();
+            ((DateOnly)args[1]).Should().Be(new DateOnly(2024, 3, 15));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `TryParseTransactionDate` (extracted in #1507) has its own WHY-comment documenting the hardening: "Form 4 transactionDate is ISO `yyyy-MM-dd` (ownership XSD). Parse it culture-independently — under a non-Gregorian host culture (e.g. ar-SA Umm al-Qura) culture-sensitive TryParse fails and every insider transaction would be silently dropped." The implementation passes `CultureInfo.InvariantCulture` and `DateTimeStyles.None` explicitly.
- Sibling to GH-1501's pin on `FredImportService.ParseObservationDates`, which lacked the same hardening and was confirmed broken under ar-SA (test skipped pending the fix). This test passes today because the InsiderTrading helper IS hardened — a "simplification" refactor dropping the explicit-culture arg (or switching to the no-culture `DateOnly.TryParse(string)` overload) would compile cleanly, pass every happy-path test (all run under en-US), and silently drop every Form 4 transaction on any worker host whose locale defaults to ar-SA.
- New `[Fact]` switches thread culture to `ar-SA`, invokes the private static helper via reflection on `"2024-03-15"`, asserts the bool result is true and the out param parses correctly. Try/finally restores the original culture.
- Passes 1/1 in 9 ms.

## Code changes

- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorTryParseTransactionDateHijriCultureTests.cs` — new reflection-based unit test sibling to the existing `FredImportServiceParseObservationDatesHijriCultureTests` (skipped per GH-1501). One `[Fact]`: `TryParseTransactionDate_IsoDateUnderHijriCulture_StillParsesViaInvariantCulture`.