### PR TITLE
refactor(holdings): extract TryParseCoverPageRow helper from ParseCoverPages

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -199,24 +199,37 @@ public class HoldingsImportService
         var coverPages = new Dictionary<string, CoverPageRow>(StringComparer.OrdinalIgnoreCase);
         await foreach (var row in context.TsvParser.ParseEntry(coverPageEntry))
         {
-            var accession = GetValue(row, "ACCESSION_NUMBER");
-            if (string.IsNullOrEmpty(accession) || !context.Submissions.ContainsKey(accession))
-                continue;
-
-            coverPages[accession] = new CoverPageRow
-            {
-                AccessionNumber = accession,
-                IsAmendment = GetValue(row, "ISAMENDMENT"),
-                CompanyName = GetValue(row, "FILINGMANAGER_NAME"),
-                City = GetValue(row, "FILINGMANAGER_CITY"),
-                StateOrCountry = GetValue(row, "FILINGMANAGER_STATEORCOUNTRY"),
-                Form13FFileNumber = GetValue(row, "FORM13FFILENUMBER"),
-                CrdNumber = GetValue(row, "CRDNUMBER"),
-            };
+            if (TryParseCoverPageRow(row, context.Submissions, out var coverPage))
+                coverPages[coverPage.AccessionNumber] = coverPage;
         }
 
         _logger.LogInformation("Parsed {Count} cover pages", coverPages.Count);
         context.CoverPages = coverPages;
+        return true;
+    }
+
+    private static bool TryParseCoverPageRow(
+        Dictionary<string, string> row,
+        Dictionary<string, SubmissionRow> submissions,
+        out CoverPageRow coverPage
+    )
+    {
+        coverPage = null;
+
+        var accession = GetValue(row, "ACCESSION_NUMBER");
+        if (string.IsNullOrEmpty(accession) || !submissions.ContainsKey(accession))
+            return false;
+
+        coverPage = new CoverPageRow
+        {
+            AccessionNumber = accession,
+            IsAmendment = GetValue(row, "ISAMENDMENT"),
+            CompanyName = GetValue(row, "FILINGMANAGER_NAME"),
+            City = GetValue(row, "FILINGMANAGER_CITY"),
+            StateOrCountry = GetValue(row, "FILINGMANAGER_STATEORCOUNTRY"),
+            Form13FFileNumber = GetValue(row, "FORM13FFILENUMBER"),
+            CrdNumber = GetValue(row, "CRDNUMBER"),
+        };
         return true;
     }
 


### PR DESCRIPTION
## Summary

- Extract the per-row accession guard + submissions-membership check + 7-field `CoverPageRow` construction from `HoldingsImportService.ParseCoverPages` into a `TryParseCoverPageRow(row, submissions, out var coverPage)` helper. The async-foreach body collapses to `if (TryParseCoverPageRow(...)) coverPages[coverPage.AccessionNumber] = coverPage;` — mirroring `TryParseSubmissionRow` extracted in #1527.
- Behavior preserved: helper performs the identical `IsNullOrEmpty(accession) || !submissions.ContainsKey(accession)` guard returning false, and the identical 7-field `CoverPageRow` construction with the same `GetValue` keys in the same order; pure relocation.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — added `private static bool TryParseCoverPageRow(Dictionary<string, string> row, Dictionary<string, SubmissionRow> submissions, out CoverPageRow coverPage)`; `ParseCoverPages`'s loop branches on its result.