### PR TITLE
test(holdings): pin TryParseSubmissionRow includes period-of-report equal to min boundary

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseSubmissionRowBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseSubmissionRowBoundaryTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceTryParseSubmissionRowBoundaryTests
+{
+    private static readonly MethodInfo TryParseSubmissionRowMethod =
+        typeof(HoldingsImportService).GetMethod(
+            "TryParseSubmissionRow",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // TryParseSubmissionRow (extracted in #1527) filters submissions by report
+    // date with `reportDateCheck < context.MinReportDate` — strict less-than,
+    // so a PERIODOFREPORT exactly equal to MinReportDate is included. A
+    // single-character refactor to `<=` would compile cleanly, pass every
+    // existing integration test (none feed an exact-boundary date), and
+    // silently exclude every submission whose report date sits on the window
+    // boundary — the holdings backfill would lose a full reporting day at
+    // the leading edge of any tightened import window.
+    [Fact]
+    public void TryParseSubmissionRow_PeriodOfReportEqualsMinReportDate_IsIncluded()
+    {
+        var minReportDate = new DateOnly(2024, 9, 30);
+        var row = new Dictionary<string, string>
+        {
+            ["SUBMISSIONTYPE"] = "13F-HR",
+            ["ACCESSION_NUMBER"] = "0000950123-24-006477",
+            ["PERIODOFREPORT"] = "2024-09-30",
+            ["FILING_DATE"] = "2024-11-15",
+            ["CIK"] = "1067983",
+        };
+        var args = new object[] { row, minReportDate, null };
+
+        var resolved = (bool)TryParseSubmissionRowMethod.Invoke(null, args);
+
+        resolved.Should().BeTrue();
+        var submission = (SubmissionRow)args[2];
+        submission.Should().NotBeNull();
+        submission.AccessionNumber.Should().Be("0000950123-24-006477");
+        submission.PeriodOfReport.Should().Be("2024-09-30");
+    }
+}


### PR DESCRIPTION
## Summary

- `TryParseSubmissionRow` (extracted in #1527) filters submissions by report date with `reportDateCheck < context.MinReportDate` — strict less-than, so a `PERIODOFREPORT` exactly equal to `MinReportDate` is included (boundary belongs to the window).
- A single-character refactor to `<=` would compile cleanly, pass every existing integration test (none feed an exact-boundary date), and silently exclude every submission whose report date sits on the window boundary — the holdings backfill would lose a full reporting day at the leading edge of any tightened import window.
- New `[Fact]` invokes the private static helper via reflection on a row with `PERIODOFREPORT = "2024-09-30"` and `MinReportDate = 2024-09-30`; asserts the helper returns true and the out-param `SubmissionRow` is populated correctly.
- Passes 1/1 in 12 ms.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseSubmissionRowBoundaryTests.cs` — new reflection-based unit test sibling to the existing `Holdings/` unit tests. One `[Fact]`: `TryParseSubmissionRow_PeriodOfReportEqualsMinReportDate_IsIncluded`.