### PR TITLE
docs(technical/migrations): split designsettings.json bullet

### DIFF
--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -7,7 +7,8 @@ Every entity in the codebase lives in one shared EF Core migrations history at [
 - [`Equibles.Migrations.csproj`](../../src/Equibles.Migrations/Equibles.Migrations.csproj) — references **every** `Equibles.*.Data` project plus `Equibles.Messaging`.
 - The snapshot has to know about every module's entities, so the migrations assembly references them all.
 - [`DesignTimeDbContextFactory.cs`](../../src/Equibles.Migrations/DesignTimeDbContextFactory.cs) — `IDesignTimeDbContextFactory<EquiblesDbContext>` that EF tooling invokes for `dotnet ef ...`.
-- [`designsettings.json`](../../src/Equibles.Migrations/designsettings.json) — connection string the design-time factory reads; defaults to `Host=localhost;Port=5432;Database=equibles;Username=equibles;Password=equibles`.
+- [`designsettings.json`](../../src/Equibles.Migrations/designsettings.json) — connection string the design-time factory reads.
+- Default: `Host=localhost;Port=5432;Database=equibles;Username=equibles;Password=equibles`.
 - Override the default locally with `designsettings.Development.json` (gitignored).
 - [`Migrations/`](../../src/Equibles.Migrations/Migrations) — generated `<timestamp>_<Name>.cs` files plus the `EquiblesDbContextModelSnapshot.cs`.
 


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 223-char designsettings.json bullet so the file identifier and the default connection string each stand alone.

## Code changes

- `docs/technical/migrations.md` — split one bullet into two.