### PR TITLE
refactor(insider-trading): extract TryResolveOwner helper from Process

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -74,37 +74,9 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         if (root == null)
             return false;
 
-        var ownerElement = root.Element("reportingOwner");
-        if (ownerElement == null)
-        {
-            _logger.LogWarning(
-                "Missing reportingOwner element for {Ticker} - {AccessionNumber}",
-                companyOutContext.Ticker,
-                filing.AccessionNumber
-            );
+        var owner = await TryResolveOwner(root, ownerRepository, filing, companyTicker);
+        if (owner == null)
             return false;
-        }
-
-        var ownerId = ownerElement.Element("reportingOwnerId");
-        var ownerCik = ownerId?.Element("rptOwnerCik")?.Value?.Trim();
-        var ownerName = ownerId?.Element("rptOwnerName")?.Value?.Trim();
-
-        if (string.IsNullOrEmpty(ownerCik) || string.IsNullOrEmpty(ownerName))
-        {
-            _logger.LogWarning(
-                "Missing owner CIK or name for {Ticker} - {AccessionNumber}",
-                companyOutContext.Ticker,
-                filing.AccessionNumber
-            );
-            return false;
-        }
-
-        var owner = await EnsureInsiderOwnerExists(
-            ownerRepository,
-            ownerCik,
-            ownerName,
-            ownerElement
-        );
 
         var isAmendment = filing.Form.Contains("/A", StringComparison.OrdinalIgnoreCase);
 
@@ -259,6 +231,41 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         }
 
         return root;
+    }
+
+    private async Task<InsiderOwner> TryResolveOwner(
+        XElement root,
+        InsiderOwnerRepository ownerRepository,
+        FilingData filing,
+        string companyTicker
+    )
+    {
+        var ownerElement = root.Element("reportingOwner");
+        if (ownerElement == null)
+        {
+            _logger.LogWarning(
+                "Missing reportingOwner element for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return null;
+        }
+
+        var ownerId = ownerElement.Element("reportingOwnerId");
+        var ownerCik = ownerId?.Element("rptOwnerCik")?.Value?.Trim();
+        var ownerName = ownerId?.Element("rptOwnerName")?.Value?.Trim();
+
+        if (string.IsNullOrEmpty(ownerCik) || string.IsNullOrEmpty(ownerName))
+        {
+            _logger.LogWarning(
+                "Missing owner CIK or name for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return null;
+        }
+
+        return await EnsureInsiderOwnerExists(ownerRepository, ownerCik, ownerName, ownerElement);
     }
 
     private static async Task<InsiderOwner> EnsureInsiderOwnerExists(


### PR DESCRIPTION
## Summary

- Extract the owner-resolution block (reportingOwner element lookup + CIK/Name validation + `EnsureInsiderOwnerExists` call, ~31 lines) from `InsiderTradingFilingProcessor.Process` into a `TryResolveOwner` helper. Caller is now `var owner = await TryResolveOwner(...); if (owner == null) return false;`.
- Behavior preserved: helper performs the identical `root.Element("reportingOwner")` lookup + warning-log + null return, the identical `reportingOwnerId/rptOwnerCik/rptOwnerName` reads with `.Trim()`, the identical `IsNullOrEmpty` empty-guard + warning-log + null return, and the identical `EnsureInsiderOwnerExists(ownerRepository, ownerCik, ownerName, ownerElement)` call. The two warning log calls switch from `companyOutContext.Ticker` to the `companyTicker` local — same source value (captured at the top of Process), no observable difference.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — added `private async Task<InsiderOwner> TryResolveOwner(XElement root, InsiderOwnerRepository ownerRepository, FilingData filing, string companyTicker)`; `Process` now branches on its null/non-null result.