### PR TITLE
refactor(fred-import): extract FlushObservationBatch helper from ImportSeries

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/FredImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredImportService.cs
@@ -183,13 +183,7 @@ public class FredImportService
         var totalInserted = await BatchPersister.Persist(
             observations,
             InsertBatchSize,
-            async batch =>
-            {
-                using var scope = _scopeFactory.CreateScope();
-                var repo = scope.ServiceProvider.GetRequiredService<FredObservationRepository>();
-                repo.AddRange(batch);
-                await repo.SaveChanges();
-            }
+            FlushObservationBatch
         );
 
         await UpdateSeriesMetadata(series.Id, latestObservationDate);
@@ -208,6 +202,14 @@ public class FredImportService
             totalInserted,
             curated.SeriesId
         );
+    }
+
+    private async Task FlushObservationBatch(List<FredObservation> batch)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<FredObservationRepository>();
+        repo.AddRange(batch);
+        await repo.SaveChanges();
     }
 
     private async Task UpdateSeriesMetadata(Guid seriesId, DateOnly latestObservationDate)


### PR DESCRIPTION
## Summary

- `FredImportService.ImportSeries`' `BatchPersister.Persist` callback embedded a 6-line "open scope, get FredObservationRepository, AddRange + SaveChanges" lambda. Sibling pattern to `YahooPriceImportService.FlushPriceBatch` extracted in #1518 — same shape, same surrounding context.
- Extracted to a private async `FlushObservationBatch(batch)` method. The `BatchPersister.Persist` call collapses to a single-line method-group reference. Brings the FredImportService BatchPersister call shape in line with the YahooPriceImportService precedent.
- Pure relocation: identical scope creation, identical repository resolution, identical `AddRange` + `SaveChanges` order, no exception change. Build + 1545 unit + 1404 integration tests + csharpier check all green locally.

## Code changes

- `src/Equibles.Fred.HostedService/Services/FredImportService.cs` — added private async `FlushObservationBatch(List<FredObservation>)`; replaced the inline callback in `ImportSeries` with a method-group reference (`FlushObservationBatch`).