### PR TITLE
refactor(holdings): extract TryParseOtherManagerRow helper from ParseOtherManagers

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -409,22 +409,15 @@ public class HoldingsImportService
         );
         await foreach (var row in context.TsvParser.ParseEntry(entry))
         {
-            var accession = GetValue(row, "ACCESSION_NUMBER");
-            if (string.IsNullOrEmpty(accession) || !context.Submissions.ContainsKey(accession))
-                continue;
-
-            var seqStr = GetValue(row, "SEQUENCENUMBER");
-            if (!int.TryParse(seqStr, out var seq))
-            {
-                _logger.LogDebug(
-                    "Failed to parse sequence number '{SeqStr}' in OTHERMANAGER2.tsv",
-                    seqStr
-                );
-                continue;
-            }
-
-            var name = GetValue(row, "NAME");
-            if (string.IsNullOrEmpty(name))
+            if (
+                !TryParseOtherManagerRow(
+                    row,
+                    context.Submissions,
+                    out var accession,
+                    out var seq,
+                    out var name
+                )
+            )
                 continue;
 
             if (!managers.TryGetValue(accession, out var seqMap))
@@ -438,6 +431,38 @@ public class HoldingsImportService
 
         context.OtherManagers = managers;
         _logger.LogInformation("Parsed other-manager mappings for {Count} filings", managers.Count);
+    }
+
+    private bool TryParseOtherManagerRow(
+        Dictionary<string, string> row,
+        Dictionary<string, SubmissionRow> submissions,
+        out string accession,
+        out int seq,
+        out string name
+    )
+    {
+        seq = 0;
+        name = null;
+
+        accession = GetValue(row, "ACCESSION_NUMBER");
+        if (string.IsNullOrEmpty(accession) || !submissions.ContainsKey(accession))
+            return false;
+
+        var seqStr = GetValue(row, "SEQUENCENUMBER");
+        if (!int.TryParse(seqStr, out seq))
+        {
+            _logger.LogDebug(
+                "Failed to parse sequence number '{SeqStr}' in OTHERMANAGER2.tsv",
+                seqStr
+            );
+            return false;
+        }
+
+        name = GetValue(row, "NAME");
+        if (string.IsNullOrEmpty(name))
+            return false;
+
+        return true;
     }
 
     private async Task HandleAmendments(ImportContext context, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

- Extract the 3-guard cascade (accession-empty/submissions-membership, `SEQUENCENUMBER int.TryParse` with parse-failure log, NAME-empty) from `HoldingsImportService.ParseOtherManagers` into a `TryParseOtherManagerRow(row, submissions, out accession, out seq, out name)` helper — completing the per-row extraction pattern already applied to `ParseSubmissions` (#1527) and `ParseCoverPages` (#1531). Loop body is now one guard + the existing dictionary upsert.
- Behavior preserved: helper runs the same `IsNullOrEmpty(accession) || !submissions.ContainsKey(accession)` guard, the same `int.TryParse(seqStr)` with the same `_logger.LogDebug` on failure, and the same `IsNullOrEmpty(name)` guard, in the same order; each former `continue` is now a `return false`.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — added `private bool TryParseOtherManagerRow(Dictionary<string, string> row, Dictionary<string, SubmissionRow> submissions, out string accession, out int seq, out string name)`; `ParseOtherManagers`'s loop branches on its result and runs the per-row dictionary upsert with the populated outputs.