### PR TITLE
refactor(holdings-mcp): extract AppendActivitySection helper from GetInstitutionQuarterlyActivity

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -775,29 +775,8 @@ public class InstitutionalHoldingsTools
                         .OrderByDescending(r => Math.Abs(r.DeltaValue))
                         .Take(maxResults)
                         .ToList();
-                    result.AppendLine($"## {section.Label}");
-                    if (rows.Count == 0)
-                    {
-                        result.AppendLine("_No stocks in this bucket this quarter._");
-                        result.AppendLine();
-                        continue;
-                    }
-                    result.AppendLine(
-                        "| # | Ticker | Company | Prior | New | Δ Shares | Δ Value ($M) |"
-                    );
-                    result.AppendLine(
-                        "|---|--------|---------|-------|-----|---------|-------------|"
-                    );
-                    for (var i = 0; i < rows.Count; i++)
-                    {
-                        var r = rows[i];
-                        var sign = r.DeltaShares > 0 ? "+" : "";
-                        result.AppendLine(
-                            $"| {i + 1} | {r.Ticker} | {r.Name} | {r.PreviousShares:N0} | {r.CurrentShares:N0} | {sign}{r.DeltaShares:N0} | {r.DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0} |"
-                        );
-                    }
-                    result.AppendLine();
-                    rendered++;
+                    if (AppendActivitySection(result, section.Label, rows))
+                        rendered++;
                 }
 
                 if (rendered == 0)
@@ -807,6 +786,33 @@ public class InstitutionalHoldingsTools
             "GetInstitutionQuarterlyActivity",
             $"institution: {institutionName}"
         );
+    }
+
+    private static bool AppendActivitySection(
+        StringBuilder result,
+        string label,
+        List<StockPositionChange> rows
+    )
+    {
+        result.AppendLine($"## {label}");
+        if (rows.Count == 0)
+        {
+            result.AppendLine("_No stocks in this bucket this quarter._");
+            result.AppendLine();
+            return false;
+        }
+        result.AppendLine("| # | Ticker | Company | Prior | New | Δ Shares | Δ Value ($M) |");
+        result.AppendLine("|---|--------|---------|-------|-----|---------|-------------|");
+        for (var i = 0; i < rows.Count; i++)
+        {
+            var r = rows[i];
+            var sign = r.DeltaShares > 0 ? "+" : "";
+            result.AppendLine(
+                $"| {i + 1} | {r.Ticker} | {r.Name} | {r.PreviousShares:N0} | {r.CurrentShares:N0} | {sign}{r.DeltaShares:N0} | {r.DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0} |"
+            );
+        }
+        result.AppendLine();
+        return true;
     }
 
     [McpServerTool(Name = "GetFundOverlap")]


### PR DESCRIPTION
## Summary

- Extract the per-section markdown rendering (heading + empty fallback + 7-column header + per-row formatting + trailing blank line, 23 lines) of `GetInstitutionQuarterlyActivity` into a `AppendActivitySection(result, label, rows)` helper returning bool (rendered). The foreach body collapses to `if (AppendActivitySection(...)) rendered++;`.
- Behavior preserved: helper appends the identical `## {Label}` heading, the identical "_No stocks in this bucket this quarter._" + blank line on empty (returning false → no `rendered++`), the identical 7-column header + separator, the identical per-row interpolation (`{i + 1}`, `Ticker`, `Name`, `PreviousShares:N0`, `CurrentShares:N0`, `±DeltaShares:N0`, `DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0`), and the identical trailing blank line + true return — pure relocation; caller still increments `rendered` only on non-empty sections.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — added `private static bool AppendActivitySection(StringBuilder result, string label, List<StockPositionChange> rows)`; `GetInstitutionQuarterlyActivity`'s selectedSections loop now calls it.