### PR TITLE
docs(technical/migrations): split Worker-host migration bullet

### DIFF
--- a/docs/technical/migrations.md
+++ b/docs/technical/migrations.md
@@ -47,7 +47,8 @@ Hosts call `await dbContext.Database.MigrateAsync()` on startup.
 - The method creates a scope, resolves `EquiblesDbContext`, sets `Database.SetCommandTimeout(TimeSpan.FromHours(1))`, and runs `MigrateAsync()`.
 - The 1-hour command timeout absorbs index rebuilds on first run; BM25 + pgvector indexes on multi-million-row tables can take many minutes.
 - The MCP server does **not** run migrations. Its compose service `depends_on: web (condition: service_healthy)`, so by the time MCP starts the Web host has already finished migrating.
-- The Worker host doesn't call `MigrateAsync` on the EF model either, but it does run `MassTransit__RunMigration=true` so the MassTransit SQL transport tables apply on first boot. The EF tables are still owned by Web.
+- The Worker host doesn't call `MigrateAsync` on the EF model either; EF tables are still owned by Web.
+- The Worker does run `MassTransit__RunMigration=true` so the MassTransit SQL transport tables apply on first boot.
 - Migrations apply additively. There's no down-migration path in production — `Down` exists in the file but `MigrateAsync` only applies the unapplied `Up` set.
 
 ## Postgres extensions


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 217-char Worker-host bullet so the EF-tables ownership and the MassTransit transport migration each stand alone.

## Code changes

- `docs/technical/migrations.md` — split one bullet into two.