### PR TITLE
refactor(holdings-mcp): extract RenderInstitutionSummary helper from GetInstitutionSummary

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -612,35 +612,39 @@ public class InstitutionalHoldingsTools
                     previousDate
                 );
 
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"Portfolio summary — **{holder.Name}** as of {targetDate:yyyy-MM-dd}"
-                );
-                if (previousDate.HasValue)
-                    result.AppendLine($"vs prior quarter {previousDate.Value:yyyy-MM-dd}");
-                result.AppendLine();
-                result.AppendLine("| Metric | Value |");
-                result.AppendLine("|--------|-------|");
-                result.AppendLine($"| Reported AUM | ${summary.ReportedAum:N0} |");
-                result.AppendLine($"| # Positions | {summary.PositionCount:N0} |");
-                result.AppendLine(
-                    $"| Top 10 concentration | {summary.Top10ConcentrationPercent:F1}% |"
-                );
-                result.AppendLine(
-                    $"| Top 25 concentration | {summary.Top25ConcentrationPercent:F1}% |"
-                );
-                result.AppendLine($"| QoQ turnover | {summary.QoQTurnoverPercent:F1}% |");
-                result.AppendLine($"| Quarters reported | {summary.QuartersReported} |");
-                result.AppendLine();
-                result.AppendLine(
-                    "_QoQ turnover = (Σ |Δ shares × current price proxy|) / (2 × AUM), where the per-share price proxy is the current quarter's Value / Shares._"
-                );
-
-                return result.ToString();
+                return RenderInstitutionSummary(holder, targetDate, previousDate, summary);
             },
             "GetInstitutionSummary",
             $"institution: {institutionName}"
         );
+    }
+
+    private static string RenderInstitutionSummary(
+        InstitutionalHolder holder,
+        DateOnly targetDate,
+        DateOnly? previousDate,
+        InstitutionPortfolioSummary summary
+    )
+    {
+        var result = new StringBuilder();
+        result.AppendLine($"Portfolio summary — **{holder.Name}** as of {targetDate:yyyy-MM-dd}");
+        if (previousDate.HasValue)
+            result.AppendLine($"vs prior quarter {previousDate.Value:yyyy-MM-dd}");
+        result.AppendLine();
+        result.AppendLine("| Metric | Value |");
+        result.AppendLine("|--------|-------|");
+        result.AppendLine($"| Reported AUM | ${summary.ReportedAum:N0} |");
+        result.AppendLine($"| # Positions | {summary.PositionCount:N0} |");
+        result.AppendLine($"| Top 10 concentration | {summary.Top10ConcentrationPercent:F1}% |");
+        result.AppendLine($"| Top 25 concentration | {summary.Top25ConcentrationPercent:F1}% |");
+        result.AppendLine($"| QoQ turnover | {summary.QoQTurnoverPercent:F1}% |");
+        result.AppendLine($"| Quarters reported | {summary.QuartersReported} |");
+        result.AppendLine();
+        result.AppendLine(
+            "_QoQ turnover = (Σ |Δ shares × current price proxy|) / (2 × AUM), where the per-share price proxy is the current quarter's Value / Shares._"
+        );
+
+        return result.ToString();
     }
 
     [McpServerTool(Name = "GetInstitutionSectorAllocation")]


### PR DESCRIPTION
## Summary

- Extract the markdown rendering tail of `InstitutionalHoldingsTools.GetInstitutionSummary` (StringBuilder heading + optional prior-quarter subtitle + 6-row metrics table + QoQ-turnover footnote) into a `RenderInstitutionSummary` helper, so the Execute lambda ends with a single `return RenderInstitutionSummary(holder, targetDate, previousDate, summary);`.
- Behavior preserved: helper emits the same `Portfolio summary — **{holder.Name}** as of {targetDate}` heading, the same `vs prior quarter {previousDate}` line only when `previousDate.HasValue`, the same `| Metric | Value |` header + separator, the same 6 rows (`ReportedAum:N0`, `PositionCount:N0`, `Top10/Top25ConcentrationPercent:F1%`, `QoQTurnoverPercent:F1%`, `QuartersReported`), and the same QoQ-turnover footnote — pure relocation.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — added `private static string RenderInstitutionSummary(InstitutionalHolder holder, DateOnly targetDate, DateOnly? previousDate, InstitutionPortfolioSummary summary)`; `GetInstitutionSummary`'s lambda returns its result.