### PR TITLE
refactor(holdings-mcp): extract RenderOverlapTable helper from GetFundOverlap

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -869,50 +869,57 @@ public class InstitutionalHoldingsTools
                     selected
                 );
 
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"Portfolio overlap — **{holder1.Name}** vs **{holder2.Name}** as of {selected:yyyy-MM-dd}"
-                );
-                result.AppendLine();
-                result.AppendLine("| Metric | Value |");
-                result.AppendLine("|--------|-------|");
-                result.AppendLine($"| Union positions | {overlap.UnionPositionCount:N0} |");
-                result.AppendLine($"| Shared positions | {overlap.IntersectionPositionCount:N0} |");
-                result.AppendLine(
-                    $"| Jaccard similarity | {overlap.JaccardSimilarityPercent:F1}% |"
-                );
-                result.AppendLine(
-                    $"| $-weighted overlap | {overlap.DollarWeightedOverlapPercent:F1}% |"
-                );
-                result.AppendLine();
-
-                if (overlap.Rows.Count == 0)
-                {
-                    result.AppendLine("_Neither fund reports any positions for this date._");
-                    return result.ToString();
-                }
-
-                result.AppendLine(
-                    "| # | Ticker | Company | A Shares | A % | B Shares | B % | Combined ($M) |"
-                );
-                result.AppendLine(
-                    "|---|--------|---------|---------|-----|---------|-----|---------------|"
-                );
-                var rendered = overlap.Rows.Take(maxResults).ToList();
-                for (var i = 0; i < rendered.Count; i++)
-                {
-                    var row = rendered[i];
-                    var a = row.Slices[0];
-                    var b = row.Slices[1];
-                    result.AppendLine(
-                        $"| {i + 1} | {row.Ticker} | {row.Name} | {(a.Shares > 0 ? a.Shares.ToString("N0") : "—")} | {(a.Value > 0 ? a.PercentOfPortfolio.ToString("F1") + "%" : "—")} | {(b.Shares > 0 ? b.Shares.ToString("N0") : "—")} | {(b.Value > 0 ? b.PercentOfPortfolio.ToString("F1") + "%" : "—")} | {row.CombinedValue / 1_000_000m:N1} |"
-                    );
-                }
-                return result.ToString();
+                return RenderOverlapTable(holder1, holder2, selected, overlap, maxResults);
             },
             "GetFundOverlap",
             $"funds: {institutionName1}, {institutionName2}"
         );
+    }
+
+    private static string RenderOverlapTable(
+        InstitutionalHolder holder1,
+        InstitutionalHolder holder2,
+        DateOnly selected,
+        FundOverlapResult overlap,
+        int maxResults
+    )
+    {
+        var result = new StringBuilder();
+        result.AppendLine(
+            $"Portfolio overlap — **{holder1.Name}** vs **{holder2.Name}** as of {selected:yyyy-MM-dd}"
+        );
+        result.AppendLine();
+        result.AppendLine("| Metric | Value |");
+        result.AppendLine("|--------|-------|");
+        result.AppendLine($"| Union positions | {overlap.UnionPositionCount:N0} |");
+        result.AppendLine($"| Shared positions | {overlap.IntersectionPositionCount:N0} |");
+        result.AppendLine($"| Jaccard similarity | {overlap.JaccardSimilarityPercent:F1}% |");
+        result.AppendLine($"| $-weighted overlap | {overlap.DollarWeightedOverlapPercent:F1}% |");
+        result.AppendLine();
+
+        if (overlap.Rows.Count == 0)
+        {
+            result.AppendLine("_Neither fund reports any positions for this date._");
+            return result.ToString();
+        }
+
+        result.AppendLine(
+            "| # | Ticker | Company | A Shares | A % | B Shares | B % | Combined ($M) |"
+        );
+        result.AppendLine(
+            "|---|--------|---------|---------|-----|---------|-----|---------------|"
+        );
+        var rendered = overlap.Rows.Take(maxResults).ToList();
+        for (var i = 0; i < rendered.Count; i++)
+        {
+            var row = rendered[i];
+            var a = row.Slices[0];
+            var b = row.Slices[1];
+            result.AppendLine(
+                $"| {i + 1} | {row.Ticker} | {row.Name} | {(a.Shares > 0 ? a.Shares.ToString("N0") : "—")} | {(a.Value > 0 ? a.PercentOfPortfolio.ToString("F1") + "%" : "—")} | {(b.Shares > 0 ? b.Shares.ToString("N0") : "—")} | {(b.Value > 0 ? b.PercentOfPortfolio.ToString("F1") + "%" : "—")} | {row.CombinedValue / 1_000_000m:N1} |"
+            );
+        }
+        return result.ToString();
     }
 
     [McpServerTool(Name = "GetConsensusHoldings")]


### PR DESCRIPTION
## Summary

- Extract the 40-line markdown rendering tail of `InstitutionalHoldingsTools.GetFundOverlap` (StringBuilder heading + metrics table + empty-rows fallback + 8-column per-row overlap table) into a `RenderOverlapTable` helper, so the Execute lambda ends with `return RenderOverlapTable(holder1, holder2, selected, overlap, maxResults);`.
- Behavior preserved: helper emits the same `Portfolio overlap — **{holder1}** vs **{holder2}** as of {selected}` heading, the same `| Metric | Value |` table with `UnionPositionCount:N0` / `IntersectionPositionCount:N0` / `JaccardSimilarityPercent:F1%` / `DollarWeightedOverlapPercent:F1%`, the same empty-rows fallback that returns early, and the same 8-column overlap table with identical per-row `a.Shares > 0 ? "N0" : "—"` / `a.Value > 0 ? "F1%" : "—"` and `CombinedValue / 1_000_000m:N1` formatting; pure relocation.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — added `private static string RenderOverlapTable(InstitutionalHolder holder1, InstitutionalHolder holder2, DateOnly selected, FundOverlapResult overlap, int maxResults)`; `GetFundOverlap`'s lambda returns its result.