### PR TITLE
refactor(holdings-mcp): extract RenderSectorAllocationTable helper from GetInstitutionSectorAllocation

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -647,6 +647,33 @@ public class InstitutionalHoldingsTools
         return result.ToString();
     }
 
+    private static string RenderSectorAllocationTable(
+        InstitutionalHolder holder,
+        DateOnly targetDate,
+        List<IndustryAllocationSlice> slices
+    )
+    {
+        var result = new StringBuilder();
+        result.AppendLine($"Sector allocation — **{holder.Name}** as of {targetDate:yyyy-MM-dd}");
+        result.AppendLine();
+        if (slices.Count == 0)
+        {
+            result.AppendLine("_No holdings reported for the selected quarter._");
+            return result.ToString();
+        }
+
+        result.AppendLine("| # | Industry | # Positions | Value ($M) | % of Portfolio |");
+        result.AppendLine("|---|----------|-------------|------------|----------------|");
+        for (var i = 0; i < slices.Count; i++)
+        {
+            var s = slices[i];
+            result.AppendLine(
+                $"| {i + 1} | {s.IndustryName} | {s.PositionCount:N0} | {s.TotalValue / 1_000_000m:N1} | {s.PercentOfPortfolio:F1}% |"
+            );
+        }
+        return result.ToString();
+    }
+
     [McpServerTool(Name = "GetInstitutionSectorAllocation")]
     [Description(
         "Get an institution's portfolio allocation grouped by industry / sector for its latest 13F report. Returns a markdown table sorted by % of portfolio descending, with stocks lacking an industry classification collapsed into a single 'Unclassified' row at the end. Use this to answer 'is this fund concentrated in tech / energy / generalist?'"
@@ -675,27 +702,7 @@ public class InstitutionalHoldingsTools
                     .ToListAsync();
                 var slices = IndustryAllocationCalculator.Calculate(holdings);
 
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"Sector allocation — **{holder.Name}** as of {targetDate:yyyy-MM-dd}"
-                );
-                result.AppendLine();
-                if (slices.Count == 0)
-                {
-                    result.AppendLine("_No holdings reported for the selected quarter._");
-                    return result.ToString();
-                }
-
-                result.AppendLine("| # | Industry | # Positions | Value ($M) | % of Portfolio |");
-                result.AppendLine("|---|----------|-------------|------------|----------------|");
-                for (var i = 0; i < slices.Count; i++)
-                {
-                    var s = slices[i];
-                    result.AppendLine(
-                        $"| {i + 1} | {s.IndustryName} | {s.PositionCount:N0} | {s.TotalValue / 1_000_000m:N1} | {s.PercentOfPortfolio:F1}% |"
-                    );
-                }
-                return result.ToString();
+                return RenderSectorAllocationTable(holder, targetDate, slices);
             },
             "GetInstitutionSectorAllocation",
             $"institution: {institutionName}"


### PR DESCRIPTION
## Summary

- `InstitutionalHoldingsTools.GetInstitutionSectorAllocation` embedded a 20-line markdown-rendering block — title, blank line, empty-slice fallback, header rows, foreach loop — at the same indentation level as the prologue and EF query. Sibling pattern to `RenderInstitutionSummary` (extracted in #1547) and `AppendActivitySection` (#1542); same file, same shape.
- Extracted to a private static `RenderSectorAllocationTable(holder, targetDate, slices) → string`. The public method's tail collapses to a single `return RenderSectorAllocationTable(holder, targetDate, slices);`.
- Pure string-building: identical title format, identical empty-slice early return, identical column headers, identical per-row formatting (1-indexed, N0 / N1 / F1% specifiers), no exception change. Build + 4 unit + 57 integration Holdings-scoped tests + csharpier check all green locally. (Pre-existing flaky `RateLimiterTests.ConcurrentCallers_ExceedingCapacity_HonorRatePerWindow` failed under parallel test load and passed in isolation — same timing flake observed in earlier loop iterations, unrelated to this PR which only touches `Holdings.Mcp`.)

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — added private static `RenderSectorAllocationTable`; replaced the inline rendering block in `GetInstitutionSectorAllocation` with `return RenderSectorAllocationTable(holder, targetDate, slices);`.