### PR TITLE
docs(technical/hosts): split AddEquiblesMcp tool-set bullet

### DIFF
--- a/docs/technical/hosts.md
+++ b/docs/technical/hosts.md
@@ -21,7 +21,8 @@ The MCP transport exposing financial-domain tools to AI assistants.
 
 - Entry: [`Program.cs`](../../src/Equibles.Mcp.Server/Program.cs) (`public partial class Program`).
 - Container: [`Dockerfile`](../../src/Equibles.Mcp.Server/Dockerfile) — `dotnet/aspnet:10.0`, `EXPOSE 8080`. Compose maps `8081:8080` so the public endpoint is `http://localhost:8081/mcp`.
-- `AddEquiblesMcp(mcp => …)` registers per-module tool sets: `mcp.AddHoldings()`, `AddInsiderTrading()`, `AddFred()`, `AddSec()`, `AddFinancialFacts()`, `AddCftc()`, `AddCboe()`, `AddCongress()`, `AddShortData()`, `AddStockPrices()`.
+- `AddEquiblesMcp(mcp => …)` registers per-module tool sets.
+- Current set: `mcp.AddHoldings()`, `AddInsiderTrading()`, `AddFred()`, `AddSec()`, `AddFinancialFacts()`, `AddCftc()`, `AddCboe()`, `AddCongress()`, `AddShortData()`, `AddStockPrices()`.
 - Every module shipping a `.Mcp` project gets one of these `mcp.AddXxx()` calls.
 - `ConfigurePipeline` mounts the MCP transport at `/mcp` via `app.MapMcp("/mcp")` and wraps that path in `ApiKeyMiddleware` (under `UseWhen`, so the rest of the app stays open for health checks).
 - `IApiKeyValidator` resolves to `SimpleApiKeyValidator`, which reads `McpApiKey` from configuration. Empty / unset = auth disabled.


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 235-char `AddEquiblesMcp` bullet so the registration rule and the enumerated tool-set each stand alone.

## Code changes

- `docs/technical/hosts.md` — split one bullet into two.