### PR TITLE
refactor(holdings-mcp): extract RenderMarketActivityChurn helper from GetMarketWide13FActivity

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -520,55 +520,63 @@ public class InstitutionalHoldingsTools
                 }
                 else
                 {
-                    var churn = _holdingRepository.GetQuarterlyNewSoldOutPositions(
+                    return await RenderMarketActivityChurn(
+                        normalizedBucket,
                         targetDate,
-                        previousDate.Value
+                        previousDate.Value,
+                        maxResults,
+                        result
                     );
-                    var rows =
-                        normalizedBucket == "new-positions"
-                            ? await churn
-                                .Where(c => c.NewFilerCount > 0)
-                                .OrderByDescending(c => c.NewFilerCount)
-                                .Take(maxResults)
-                                .ToListAsync()
-                            : await churn
-                                .Where(c => c.SoldOutFilerCount > 0)
-                                .OrderByDescending(c => c.SoldOutFilerCount)
-                                .Take(maxResults)
-                                .ToListAsync();
-                    if (rows.Count == 0)
-                        return result + "_No stocks in this bucket this quarter._";
-
-                    var stockIds = rows.Select(r => r.CommonStockId).ToList();
-                    var stocks = await _commonStockRepository
-                        .GetAll()
-                        .Where(s => stockIds.Contains(s.Id))
-                        .ToDictionaryAsync(s => s.Id);
-
-                    var label =
-                        normalizedBucket == "new-positions"
-                            ? "# Filers Initiated"
-                            : "# Filers Exited";
-                    result.AppendLine($"| # | Ticker | Company | {label} |");
-                    result.AppendLine("|---|--------|---------|-------------|");
-                    for (var i = 0; i < rows.Count; i++)
-                    {
-                        var r = rows[i];
-                        stocks.TryGetValue(r.CommonStockId, out var s);
-                        var count =
-                            normalizedBucket == "new-positions"
-                                ? r.NewFilerCount
-                                : r.SoldOutFilerCount;
-                        result.AppendLine(
-                            $"| {i + 1} | {s?.Ticker ?? "—"} | {s?.Name ?? "Unknown"} | {count:N0} |"
-                        );
-                    }
-                    return result.ToString();
                 }
             },
             "GetMarketWide13FActivity",
             $"bucket: {bucket}"
         );
+    }
+
+    private async Task<string> RenderMarketActivityChurn(
+        string normalizedBucket,
+        DateOnly targetDate,
+        DateOnly previousDate,
+        int maxResults,
+        StringBuilder result
+    )
+    {
+        var churn = _holdingRepository.GetQuarterlyNewSoldOutPositions(targetDate, previousDate);
+        var rows =
+            normalizedBucket == "new-positions"
+                ? await churn
+                    .Where(c => c.NewFilerCount > 0)
+                    .OrderByDescending(c => c.NewFilerCount)
+                    .Take(maxResults)
+                    .ToListAsync()
+                : await churn
+                    .Where(c => c.SoldOutFilerCount > 0)
+                    .OrderByDescending(c => c.SoldOutFilerCount)
+                    .Take(maxResults)
+                    .ToListAsync();
+        if (rows.Count == 0)
+            return result + "_No stocks in this bucket this quarter._";
+
+        var stockIds = rows.Select(r => r.CommonStockId).ToList();
+        var stocks = await _commonStockRepository
+            .GetAll()
+            .Where(s => stockIds.Contains(s.Id))
+            .ToDictionaryAsync(s => s.Id);
+
+        var label = normalizedBucket == "new-positions" ? "# Filers Initiated" : "# Filers Exited";
+        result.AppendLine($"| # | Ticker | Company | {label} |");
+        result.AppendLine("|---|--------|---------|-------------|");
+        for (var i = 0; i < rows.Count; i++)
+        {
+            var r = rows[i];
+            stocks.TryGetValue(r.CommonStockId, out var s);
+            var count = normalizedBucket == "new-positions" ? r.NewFilerCount : r.SoldOutFilerCount;
+            result.AppendLine(
+                $"| {i + 1} | {s?.Ticker ?? "—"} | {s?.Name ?? "Unknown"} | {count:N0} |"
+            );
+        }
+        return result.ToString();
     }
 
     [McpServerTool(Name = "GetInstitutionSummary")]


### PR DESCRIPTION
## Summary

- Extract the `new-positions` / `sold-out-positions` else-branch (~46 lines) of `InstitutionalHoldingsTools.GetMarketWide13FActivity` into a `RenderMarketActivityChurn` instance helper, so the lambda's else-arm collapses to `return await RenderMarketActivityChurn(...);`.
- Behavior preserved: helper performs the identical `_holdingRepository.GetQuarterlyNewSoldOutPositions(targetDate, previousDate)` query, the same `NewFilerCount > 0` / `SoldOutFilerCount > 0` filter and ordering, the same empty-rows `_No stocks in this bucket this quarter._` fallback, the same `_commonStockRepository` stocks-by-id `ToDictionaryAsync` lookup, the same `# Filers Initiated` / `# Filers Exited` label selection, and the same 4-column per-row table with `Ticker ?? "—"` / `Name ?? "Unknown"` / `count:N0`; pure relocation.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — added `private async Task<string> RenderMarketActivityChurn(string normalizedBucket, DateOnly targetDate, DateOnly previousDate, int maxResults, StringBuilder result)`; `GetMarketWide13FActivity`'s else-branch awaits it and returns its result.