### PR TITLE
docs(technical/operations): split regenerable volumes bullet

### DIFF
--- a/docs/technical/operations.md
+++ b/docs/technical/operations.md
@@ -143,7 +143,9 @@ A `docker compose down` keeps these volumes. `docker compose down -v` deletes th
 
 - Snapshot the `db-data` volume with your usual Postgres tooling: `docker compose exec db pg_dump -U postgres equibles | gzip > equibles-$(date +%F).sql.gz`.
 - Restoring is the reverse: `gunzip -c equibles-….sql.gz | docker compose exec -T db psql -U postgres equibles`.
-- The other volumes (`web-keys`, `ollama-data`) are regenerable. Losing `web-keys` invalidates outstanding auth cookies (users have to log in again); losing `ollama-data` means re-downloading the embedding model.
+- The other volumes (`web-keys`, `ollama-data`) are regenerable.
+  - Losing `web-keys` invalidates outstanding auth cookies (users have to log in again).
+  - Losing `ollama-data` means re-downloading the embedding model.
 
 ## Monitoring
 


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 212-char regenerable-volumes bullet so the rule and the per-volume consequences each stand alone.

## Code changes

- `docs/technical/operations.md` — flatten one bullet into a parent + two sub-bullets.