### PR TITLE
refactor(holdings-mcp): extract RenderBuyersSellersTable helper from GetTopBuyersSellers

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -365,62 +365,86 @@ public class InstitutionalHoldingsTools
                 if (topBuyers.Count == 0 && topSellers.Count == 0)
                     return $"No quarter-over-quarter movement found for {stock.Name} ({ticker}) as of {targetDate:yyyy-MM-dd}.";
 
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"Top buyers and sellers of {stock.Name} ({ticker}) as of {targetDate:yyyy-MM-dd}"
-                );
-                if (previousDate.HasValue)
-                    result.AppendLine($"vs prior quarter {previousDate.Value:yyyy-MM-dd}");
-                result.AppendLine();
-
-                AppendMoverSection(result, "## Top Buyers", "_No buyers this quarter._", topBuyers);
-                result.AppendLine();
-                AppendMoverSection(
-                    result,
-                    "## Top Sellers",
-                    "_No sellers this quarter._",
+                return RenderBuyersSellersTable(
+                    stock,
+                    ticker,
+                    targetDate,
+                    previousDate,
+                    topBuyers,
                     topSellers
                 );
-
-                return result.ToString();
-
-                static void AppendMoverSection(
-                    StringBuilder sb,
-                    string heading,
-                    string emptyMessage,
-                    IReadOnlyList<(
-                        string Name,
-                        long CurrentShares,
-                        long PreviousShares,
-                        long DeltaShares,
-                        long DeltaValue
-                    )> rows
-                )
-                {
-                    sb.AppendLine(heading);
-                    if (rows.Count == 0)
-                    {
-                        sb.AppendLine(emptyMessage);
-                        return;
-                    }
-                    sb.AppendLine(
-                        "| # | Institution | Δ Shares | Δ Value ($M) | Prior → New Shares |"
-                    );
-                    sb.AppendLine("|---|-------------|---------|-------------|------------------|");
-                    for (var i = 0; i < rows.Count; i++)
-                    {
-                        var m = rows[i];
-                        // `+` for positive deltas; N0 already emits `-` for negatives.
-                        var sign = m.DeltaShares > 0 ? "+" : "";
-                        sb.AppendLine(
-                            $"| {i + 1} | {m.Name} | {sign}{m.DeltaShares:N0} | {m.DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0} | {m.PreviousShares:N0} → {m.CurrentShares:N0} |"
-                        );
-                    }
-                }
             },
             "GetTopBuyersSellers",
             $"ticker: {ticker}"
         );
+    }
+
+    private static string RenderBuyersSellersTable(
+        CommonStock stock,
+        string ticker,
+        DateOnly targetDate,
+        DateOnly? previousDate,
+        IReadOnlyList<(
+            string Name,
+            long CurrentShares,
+            long PreviousShares,
+            long DeltaShares,
+            long DeltaValue
+        )> topBuyers,
+        IReadOnlyList<(
+            string Name,
+            long CurrentShares,
+            long PreviousShares,
+            long DeltaShares,
+            long DeltaValue
+        )> topSellers
+    )
+    {
+        var result = new StringBuilder();
+        result.AppendLine(
+            $"Top buyers and sellers of {stock.Name} ({ticker}) as of {targetDate:yyyy-MM-dd}"
+        );
+        if (previousDate.HasValue)
+            result.AppendLine($"vs prior quarter {previousDate.Value:yyyy-MM-dd}");
+        result.AppendLine();
+
+        AppendMoverSection(result, "## Top Buyers", "_No buyers this quarter._", topBuyers);
+        result.AppendLine();
+        AppendMoverSection(result, "## Top Sellers", "_No sellers this quarter._", topSellers);
+
+        return result.ToString();
+
+        static void AppendMoverSection(
+            StringBuilder sb,
+            string heading,
+            string emptyMessage,
+            IReadOnlyList<(
+                string Name,
+                long CurrentShares,
+                long PreviousShares,
+                long DeltaShares,
+                long DeltaValue
+            )> rows
+        )
+        {
+            sb.AppendLine(heading);
+            if (rows.Count == 0)
+            {
+                sb.AppendLine(emptyMessage);
+                return;
+            }
+            sb.AppendLine("| # | Institution | Δ Shares | Δ Value ($M) | Prior → New Shares |");
+            sb.AppendLine("|---|-------------|---------|-------------|------------------|");
+            for (var i = 0; i < rows.Count; i++)
+            {
+                var m = rows[i];
+                // `+` for positive deltas; N0 already emits `-` for negatives.
+                var sign = m.DeltaShares > 0 ? "+" : "";
+                sb.AppendLine(
+                    $"| {i + 1} | {m.Name} | {sign}{m.DeltaShares:N0} | {m.DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0} | {m.PreviousShares:N0} → {m.CurrentShares:N0} |"
+                );
+            }
+        }
     }
 
     [McpServerTool(Name = "GetMarketWide13FActivity")]


### PR DESCRIPTION
## Summary

- Move the markdown-rendering tail of `GetTopBuyersSellers` (header + two `AppendMoverSection` calls + the nested `AppendMoverSection` static local function) into a new `private static RenderBuyersSellersTable(...)` helper, mirroring `RenderInstitutionSummary` (#1547), `RenderOverlapTable` (#1548), and `RenderSectorAllocationTable` (#1549).
- Shrinks the tool method body to just data loading + aggregation + delegation.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — extract `RenderBuyersSellersTable` from `GetTopBuyersSellers`; the nested `AppendMoverSection` static local function moves inside the new helper unchanged.