### PR TITLE
fix(holdings-import): reject whitespace-only NAME in TryParseOtherManagerRow

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -459,7 +459,7 @@ public class HoldingsImportService
         }
 
         name = GetValue(row, "NAME");
-        if (string.IsNullOrEmpty(name))
+        if (string.IsNullOrWhiteSpace(name))
             return false;
 
         return true;

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseOtherManagerRowWhitespaceNameTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseOtherManagerRowWhitespaceNameTests.cs
@@ -20,9 +20,7 @@ public class HoldingsImportServiceTryParseOtherManagerRowWhitespaceNameTests
     // blanked NAME is malformed and should be rejected — not surfaced
     // downstream where it lands in the (Accession → SequenceNumber → Name)
     // map and gets attached to filings as a "valid manager named '   '".
-    [Fact(
-        Skip = "GH-1544 — TryParseOtherManagerRow accepts whitespace-only NAME instead of rejecting"
-    )]
+    [Fact]
     public void TryParseOtherManagerRow_WhitespaceOnlyName_ReturnsFalse()
     {
         var sut = new HoldingsImportService(


### PR DESCRIPTION
## Summary

- `HoldingsImportService.TryParseOtherManagerRow` gated the NAME field with `string.IsNullOrEmpty(name)` — catching null and `""` but letting whitespace-only `"   "` through. A SEC `OTHERMANAGER2.tsv` row with a blanked NAME slipped past the guard and landed in the `(Accession → SequenceNumber → Name)` map as a "valid manager named '   '", later attached to filings as a manager-entry row with a whitespace-only `ManagerName`.
- Tightens the gate to `string.IsNullOrWhiteSpace(name)`, matching the strict-null-on-malformed precedent in `IsRecentFtdFile` (GH-1350), `FtdImportService.ParseLine` (GH-1438), and `TryBuildParsedFact` (GH-1514).
- Unskips the GH-1544 repro test added in #1545 — verified failing on unfixed code, passing on the fix.

closes #1544

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — change the NAME guard in `TryParseOtherManagerRow` from `IsNullOrEmpty` to `IsNullOrWhiteSpace`.
- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseOtherManagerRowWhitespaceNameTests.cs` — drop the `Skip` attribute so the regression test runs.