### PR TITLE
docs(technical/scrapers): split realtime worker cold-start bullet

### DIFF
--- a/docs/technical/scrapers.md
+++ b/docs/technical/scrapers.md
@@ -109,7 +109,8 @@ The cursor pattern means re-running is cheap (a single query for `max(date)` per
 
 - Empty `CommonStock` table → most scrapers `RequestRetrySoon()` and wait `NotReadyRetryInterval` (2 min) instead of the full `SleepInterval` (24h).
 - The pattern handles the first ~30 min after a fresh deploy while `CompanySyncService` is still populating the universe.
-- Realtime workers depend on the bulk-data backfill having seeded history. Until then the realtime worker still runs but produces no rows; once `BackfillProcessedDataSets` has run, the realtime path takes over.
+- Realtime workers depend on the bulk-data backfill having seeded history; until then they still run but produce no rows.
+- Once `BackfillProcessedDataSets` has run, the realtime path takes over.
 
 ## Error reporting
 


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 210-char realtime cold-start bullet so the pre-backfill behavior and the post-backfill takeover each stand alone.

## Code changes

- `docs/technical/scrapers.md` — split one bullet into two.