### PR TITLE
docs(technical/hosts): split Add*Worker extensions bullet

### DIFF
--- a/docs/technical/hosts.md
+++ b/docs/technical/hosts.md
@@ -42,7 +42,8 @@ The background-scraper host. Plain `Host.CreateApplicationBuilder` (not `WebAppl
 - One scraper-options bind per source.
 - Current binds: `WorkerOptions`, `DocumentScraperOptions`, `FinraOptions` + `FinraScraperOptions`, `FredOptions` + `FredScraperOptions`, `FtdScraperOptions`, `FinancialFactsScraperOptions`, `YahooPriceScraperOptions`, `CftcScraperOptions`, `CboeScraperOptions`.
 - Each scraper reads its own section so per-source tuning never leaks across modules.
-- `AddSecWorker()`, `AddSecFinancialFactsWorker()`, `AddFinraWorker()`, `AddFredWorker()`, `AddYahooWorker()`, `AddCftcWorker()`, `AddCboeWorker()`, `AddCongressWorker()`, `AddHoldingsWorker()` register the `BackgroundService` workers from each `.HostedService` project.
+- Per-module `Add*Worker()` extensions register the `BackgroundService` workers from each `.HostedService` project.
+- Current set: `AddSecWorker()`, `AddSecFinancialFactsWorker()`, `AddFinraWorker()`, `AddFredWorker()`, `AddYahooWorker()`, `AddCftcWorker()`, `AddCboeWorker()`, `AddCongressWorker()`, `AddHoldingsWorker()`.
 - `AddWorkerServices()` wires the cross-cutting worker plumbing (`SyncDateResolver`, etc.).
 - Per `Directory.Build.props`, every `.HostedService` project shares the global usings `Microsoft.Extensions.{DependencyInjection,Hosting,Logging,Options}` + `Equibles.Data` + `Equibles.Core`.
 


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 270-char Add*Worker extensions bullet so the registration rule and the enumerated set each stand alone.

## Code changes

- `docs/technical/hosts.md` — split one bullet into two.