### PR TITLE
test(holdings-import): add skipped repro for GH-1563 — TryParseSubmissionRow

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseSubmissionRowWhitespaceAccessionTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseSubmissionRowWhitespaceAccessionTests.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceTryParseSubmissionRowWhitespaceAccessionTests
+{
+    // TryParseSubmissionRow gates the ACCESSION_NUMBER field with
+    // `string.IsNullOrEmpty(accession)` — catching null and "" but letting
+    // whitespace-only "   " through. Per the strict-null-on-malformed
+    // precedent for sibling parse helpers (GH-1350 IsRecentFtdFile, GH-1438
+    // FtdImportService.ParseLine, GH-1514 TryBuildParsedFact, GH-1544
+    // TryParseOtherManagerRow), a SEC SUBMISSION.tsv row carrying a blanked
+    // ACCESSION_NUMBER is malformed and should be rejected — not surfaced
+    // downstream where it lands in the Submissions dictionary keyed by a
+    // whitespace string and propagates through every join (COVERPAGE, FILER
+    // mapping, INFOTABLE).
+    [Fact(
+        Skip = "GH-1563 — TryParseSubmissionRow accepts whitespace-only ACCESSION_NUMBER instead of rejecting"
+    )]
+    public void TryParseSubmissionRow_WhitespaceOnlyAccessionNumber_ReturnsFalse()
+    {
+        var minReportDate = new DateOnly(2024, 1, 1);
+        var row = new Dictionary<string, string>
+        {
+            ["SUBMISSIONTYPE"] = "13F-HR",
+            ["ACCESSION_NUMBER"] = "   ",
+            ["PERIODOFREPORT"] = "2024-09-30",
+            ["FILING_DATE"] = "2024-11-15",
+            ["CIK"] = "1067983",
+        };
+
+        var method = typeof(HoldingsImportService).GetMethod(
+            "TryParseSubmissionRow",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var args = new object[] { row, minReportDate, null };
+
+        var resolved = (bool)method.Invoke(null, args);
+
+        resolved.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- `HoldingsImportService.TryParseSubmissionRow` gates the `ACCESSION_NUMBER` field with `string.IsNullOrEmpty(accession)` — catching `null` and `""` but letting whitespace-only `"   "` through. The whitespace accession then lands in `context.Submissions` keyed by a blank string and propagates through every downstream join (COVERPAGE, OTHERMANAGER2, INFOTABLE).
- Same shape as GH-1350 (`IsRecentFtdFile`), GH-1438 (`FtdImportService.ParseLine`), GH-1514 (`TryBuildParsedFact`), and the just-fixed GH-1544 (`TryParseOtherManagerRow`) — the helper's intent is "ACCESSION_NUMBER required", but the guard uses the weaker `IsNullOrEmpty` rather than `IsNullOrWhiteSpace`.
- Adversarial test added as `[Fact(Skip = "GH-1563 — …")]` — verified failing on unfixed code with `Expected resolved to be False, but found True`. Drop the `Skip` attribute as part of the fix (one-character change at `HoldingsImportService.cs:131`).

closes — skipped — see GH-1563.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseSubmissionRowWhitespaceAccessionTests.cs` — new file. One `[Fact(Skip = "GH-1563 — …")]`: `TryParseSubmissionRow_WhitespaceOnlyAccessionNumber_ReturnsFalse`. Invokes the private static helper via reflection with a whitespace-only `ACCESSION_NUMBER` and asserts the helper returns `false`. Skipped — see GH-1563.