### PR TITLE
refactor(holdings-mcp): extract RenderInstitutionPortfolio helper from GetInstitutionPortfolio

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -226,27 +226,36 @@ public class InstitutionalHoldingsTools
                 if (holdings.Count == 0)
                     return $"No holdings found for {holder.Name} as of {targetDate:yyyy-MM-dd}.";
 
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"Portfolio of {holder.Name} (CIK: {holder.Cik}) as of {targetDate:yyyy-MM-dd}:"
-                );
-                result.AppendLine();
-                result.AppendLine("| # | Ticker | Company | Shares | Value ($M) |");
-                result.AppendLine("|---|--------|---------|--------|-----------|");
-
-                for (var i = 0; i < holdings.Count; i++)
-                {
-                    var h = holdings[i];
-                    result.AppendLine(
-                        $"| {i + 1} | {h.CommonStock.Ticker} | {h.CommonStock.Name} | {h.Shares:N0} | {h.Value / 1_000_000m:N1} |"
-                    );
-                }
-
-                return result.ToString();
+                return RenderInstitutionPortfolio(holder, targetDate, holdings);
             },
             "GetInstitutionPortfolio",
             $"institution: {institutionName}"
         );
+    }
+
+    private static string RenderInstitutionPortfolio(
+        InstitutionalHolder holder,
+        DateOnly targetDate,
+        List<InstitutionalHolding> holdings
+    )
+    {
+        var result = new StringBuilder();
+        result.AppendLine(
+            $"Portfolio of {holder.Name} (CIK: {holder.Cik}) as of {targetDate:yyyy-MM-dd}:"
+        );
+        result.AppendLine();
+        result.AppendLine("| # | Ticker | Company | Shares | Value ($M) |");
+        result.AppendLine("|---|--------|---------|--------|-----------|");
+
+        for (var i = 0; i < holdings.Count; i++)
+        {
+            var h = holdings[i];
+            result.AppendLine(
+                $"| {i + 1} | {h.CommonStock.Ticker} | {h.CommonStock.Name} | {h.Shares:N0} | {h.Value / 1_000_000m:N1} |"
+            );
+        }
+
+        return result.ToString();
     }
 
     [McpServerTool(Name = "SearchInstitutions")]


### PR DESCRIPTION
## Summary

- Extract the 17-line markdown rendering tail of `InstitutionalHoldingsTools.GetInstitutionPortfolio` (heading + 5-column header + per-row table) into a `RenderInstitutionPortfolio` helper, so the Execute lambda ends with `return RenderInstitutionPortfolio(holder, targetDate, holdings);`.
- Behavior preserved: helper emits the same `Portfolio of {holder.Name} (CIK: {holder.Cik}) as of {targetDate}:` heading, the same blank line, the same `| # | Ticker | Company | Shares | Value ($M) |` header + separator, and the same per-row `{h.CommonStock.Ticker}` / `{h.CommonStock.Name}` / `h.Shares:N0` / `h.Value / 1_000_000m:N1` formatting — pure relocation.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — added `private static string RenderInstitutionPortfolio(InstitutionalHolder holder, DateOnly targetDate, List<InstitutionalHolding> holdings)`; `GetInstitutionPortfolio`'s lambda returns its result after the empty-holdings early return.