### PR TITLE
docs(technical/web-portal): split StocksController tabs bullet

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -8,7 +8,8 @@ Most user-facing data lives under `~/Stocks/{ticker}/{tab}`. The tab pattern is 
 
 The trio:
 
-- **Controller action** in [`StocksController`](../../src/Equibles.Web/Controllers/StocksController.cs) — one action per tab: `Price`, `Holdings`, `ShortVolume`, `ShortInterest`, `Ftd`, `Documents`, `InsiderTrading`, `CongressionalTrades`, `Financials`.
+- **Controller action** in [`StocksController`](../../src/Equibles.Web/Controllers/StocksController.cs) — one action per tab.
+- Current tabs: `Price`, `Holdings`, `ShortVolume`, `ShortInterest`, `Ftd`, `Documents`, `InsiderTrading`, `CongressionalTrades`, `Financials`.
 - Each action resolves the ticker, calls the matching `StockTabService.LoadXxxTab(stock, ...)`, stashes the result in `ViewData["TabViewModel"]`, and returns the shared `Show.cshtml` view.
 - **Service method** on [`StockTabService`](../../src/Equibles.Web/Services/StockTabService.cs) — `Task<XxxTabViewModel> LoadXxxTab(CommonStock stock, …)`.
 - The service is the only place that talks to repositories for tab data; all query composition lives here.


### PR DESCRIPTION
## Summary

- Lane: Maintain (sentence) → technical.
- Split the 255-char StocksController bullet so the action-per-tab rule and the enumerated tab list each stand alone.

## Code changes

- `docs/technical/web-portal.md` — split one bullet into two.