### PR TITLE
refactor(holdings-backtest): extract BuildQuarterSnapshots helper from Execute

### DIFF
--- a/src/Equibles.Web/Services/HoldingsBacktestService.cs
+++ b/src/Equibles.Web/Services/HoldingsBacktestService.cs
@@ -116,22 +116,7 @@ public class HoldingsBacktestService
             ))
             .ToListAsync();
 
-        var snapshots = holdings
-            .GroupBy(h => h.ReportDate)
-            .OrderBy(g => g.Key)
-            .Select(g => new BacktestQuarterSnapshot
-            {
-                ReportDate = g.Key,
-                Positions = g.Select(h => new BacktestPosition
-                    {
-                        CommonStockId = h.CommonStockId,
-                        Shares = h.Shares,
-                        Value = h.Value,
-                        IsOption = h.OptionType != null,
-                    })
-                    .ToList(),
-            })
-            .ToList();
+        var snapshots = BuildQuarterSnapshots(holdings);
 
         // Forward-fill needs a few days of pre-window prices so day-zero of the simulation
         // resolves to the last trading day's close even on a weekend or holiday. Clamp the
@@ -181,6 +166,26 @@ public class HoldingsBacktestService
 
         return viewModel;
     }
+
+    private static List<BacktestQuarterSnapshot> BuildQuarterSnapshots(
+        IReadOnlyList<BacktestHoldingRow> holdings
+    ) =>
+        holdings
+            .GroupBy(h => h.ReportDate)
+            .OrderBy(g => g.Key)
+            .Select(g => new BacktestQuarterSnapshot
+            {
+                ReportDate = g.Key,
+                Positions = g.Select(h => new BacktestPosition
+                    {
+                        CommonStockId = h.CommonStockId,
+                        Shares = h.Shares,
+                        Value = h.Value,
+                        IsOption = h.OptionType != null,
+                    })
+                    .ToList(),
+            })
+            .ToList();
 
     private async Task<List<BacktestBenchmarkOption>> LoadBenchmarkOptions()
     {


### PR DESCRIPTION
## Summary

- `HoldingsBacktestService.Execute` reads a list of `BacktestHoldingRow` rows from the DB and projects them into per-quarter `BacktestQuarterSnapshot` records via an inline 16-line GroupBy / OrderBy / Select pyramid. Extract that block into a named private static helper `BuildQuarterSnapshots` so `Execute` reads as a linear data-flow narrative (load holdings → build snapshots → load prices → calculate).
- Pure refactor — the helper is the exact same expression with a name; same GroupBy keys, same iteration order, same `IsOption` mapping, no side effects, identical inputs and outputs.

## Code changes

- `src/Equibles.Web/Services/HoldingsBacktestService.cs` — extracted `BuildQuarterSnapshots(IReadOnlyList<BacktestHoldingRow>) → List<BacktestQuarterSnapshot>` as a private static helper; `Execute` now calls it instead of inlining the GroupBy/Select.