### PR TITLE
refactor(holdings-import): collapse 7 GetValue calls in TryParseCoverPageRow behind a local Get helper

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -215,20 +215,21 @@ public class HoldingsImportService
     )
     {
         coverPage = null;
+        string Get(string field) => GetValue(row, field);
 
-        var accession = GetValue(row, "ACCESSION_NUMBER");
+        var accession = Get("ACCESSION_NUMBER");
         if (string.IsNullOrEmpty(accession) || !submissions.ContainsKey(accession))
             return false;
 
         coverPage = new CoverPageRow
         {
             AccessionNumber = accession,
-            IsAmendment = GetValue(row, "ISAMENDMENT"),
-            CompanyName = GetValue(row, "FILINGMANAGER_NAME"),
-            City = GetValue(row, "FILINGMANAGER_CITY"),
-            StateOrCountry = GetValue(row, "FILINGMANAGER_STATEORCOUNTRY"),
-            Form13FFileNumber = GetValue(row, "FORM13FFILENUMBER"),
-            CrdNumber = GetValue(row, "CRDNUMBER"),
+            IsAmendment = Get("ISAMENDMENT"),
+            CompanyName = Get("FILINGMANAGER_NAME"),
+            City = Get("FILINGMANAGER_CITY"),
+            StateOrCountry = Get("FILINGMANAGER_STATEORCOUNTRY"),
+            Form13FFileNumber = Get("FORM13FFILENUMBER"),
+            CrdNumber = Get("CRDNUMBER"),
         };
         return true;
     }


### PR DESCRIPTION
## Summary

- `TryParseCoverPageRow` spelled `GetValue(row, "…")` 7 times in a row to project SUBMISSION.tsv columns into a `CoverPageRow`. The first argument is noise; only the column name varies per call.
- Introduce a local function `Get(string field) => GetValue(row, field)` inside the method so each call site reads as `Get("…")`. The reader sees the column-name → property mapping without 6 distractions.
- Mirrors the same shape already applied across this codebase: #1437 (CftcClient.ParseLine, 26 GetField calls), #1448 (CboeClient.ParseVixCsv, 4 TryParse guards), #1499 (HoldingsImportService.ParseHoldingRow, 4 ParseLong guards), #1508 (DisclosureParsingHelper.ParseTransactionRow, 7 GetCleanCell calls).
- Pure delegating wrapper; the closed-over `row` and the forwarded `field` are the same arguments each direct call previously received, so every site evaluates identically. Build + 187 Holdings unit tests + 212 Holdings integration tests + CSharpier check all green.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — add a local `Get` function inside `TryParseCoverPageRow` and rewrite all 7 call sites to call `Get(…)` instead of `GetValue(row, …)`. No other change.