### PR TITLE
refactor(holdings-mcp): extract RenderOwnershipHistory helper from GetOwnershipHistory

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -149,44 +149,48 @@ public class InstitutionalHoldingsTools
                 if (reportDates.Count == 0)
                     return $"No institutional holdings history available for {ticker}.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"Institutional ownership history for {stock.Name} ({ticker}):");
-                result.AppendLine();
-                result.AppendLine(
-                    "| Report Date | Institutions | Total Shares | Total Value ($M) | Change |"
-                );
-                result.AppendLine(
-                    "|------------|-------------|-------------|-----------------|--------|"
-                );
-
-                long previousShares = 0;
-                foreach (var date in reportDates.OrderBy(d => d))
-                {
-                    var holdings = await _holdingRepository.GetByStock(stock, date).ToListAsync();
-                    var totalShares = holdings.Sum(h => h.Shares);
-                    var totalValue = holdings.Sum(h => h.Value);
-                    var institutionCount = holdings
-                        .Select(h => h.InstitutionalHolderId)
-                        .Distinct()
-                        .Count();
-
-                    var change =
-                        previousShares > 0
-                            ? $"{(double)(totalShares - previousShares) / previousShares * 100:+0.0;-0.0}%"
-                            : "—";
-
-                    result.AppendLine(
-                        $"| {date:yyyy-MM-dd} | {institutionCount:N0} | {totalShares:N0} | {totalValue / 1_000_000m:N1} | {change} |"
-                    );
-
-                    previousShares = totalShares;
-                }
-
-                return result.ToString();
+                return await RenderOwnershipHistory(stock, ticker, reportDates);
             },
             "GetOwnershipHistory",
             $"ticker: {ticker}"
         );
+    }
+
+    private async Task<string> RenderOwnershipHistory(
+        CommonStock stock,
+        string ticker,
+        List<DateOnly> reportDates
+    )
+    {
+        var result = new StringBuilder();
+        result.AppendLine($"Institutional ownership history for {stock.Name} ({ticker}):");
+        result.AppendLine();
+        result.AppendLine(
+            "| Report Date | Institutions | Total Shares | Total Value ($M) | Change |"
+        );
+        result.AppendLine("|------------|-------------|-------------|-----------------|--------|");
+
+        long previousShares = 0;
+        foreach (var date in reportDates.OrderBy(d => d))
+        {
+            var holdings = await _holdingRepository.GetByStock(stock, date).ToListAsync();
+            var totalShares = holdings.Sum(h => h.Shares);
+            var totalValue = holdings.Sum(h => h.Value);
+            var institutionCount = holdings.Select(h => h.InstitutionalHolderId).Distinct().Count();
+
+            var change =
+                previousShares > 0
+                    ? $"{(double)(totalShares - previousShares) / previousShares * 100:+0.0;-0.0}%"
+                    : "—";
+
+            result.AppendLine(
+                $"| {date:yyyy-MM-dd} | {institutionCount:N0} | {totalShares:N0} | {totalValue / 1_000_000m:N1} | {change} |"
+            );
+
+            previousShares = totalShares;
+        }
+
+        return result.ToString();
     }
 
     [McpServerTool(Name = "GetInstitutionPortfolio")]


### PR DESCRIPTION
## Summary

- Extract the ~34-line per-date fetch + markdown rendering tail of `InstitutionalHoldingsTools.GetOwnershipHistory` (StringBuilder heading + 5-column header + per-date `GetByStock(stock, date).ToListAsync()` → aggregate + change ratio + row append) into a `RenderOwnershipHistory` async helper. Lambda ends with `return await RenderOwnershipHistory(stock, ticker, reportDates);`.
- Behavior preserved: helper iterates `reportDates.OrderBy(d => d)` in the same order, performs the identical `_holdingRepository.GetByStock(stock, date).ToListAsync()` query, the same `Sum(h.Shares)` / `Sum(h.Value)` / `Select(h.InstitutionalHolderId).Distinct().Count()` aggregations, the same `previousShares > 0` change-ratio formatting with `:+0.0;-0.0%` or `"—"` fallback, the same 5-column per-row table, and threads `previousShares` identically between iterations; pure relocation.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — added `private async Task<string> RenderOwnershipHistory(CommonStock stock, string ticker, List<DateOnly> reportDates)`; `GetOwnershipHistory`'s lambda awaits it after the empty-dates early return.