### PR TITLE
refactor(sec-normalizer): extract ClassifyHeadingTag helper from HeadingConversionStep.Execute

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -33,33 +33,37 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
             if (string.IsNullOrEmpty(combinedText))
                 continue;
 
-            string headingTag = null;
-            if (
-                IsPartHeading(combinedText)
-                && AllSiblingsMatch(siblingSpans, s => IsPartHeading(s.TextContent))
-            )
-                headingTag = "h1";
-            else if (
-                IsItemHeading(combinedText)
-                && AllSiblingsMatch(siblingSpans, s => IsItemHeading(s.TextContent))
-            )
-                headingTag = "h2";
-            else if (
-                AllSiblingsMatch(
-                    siblingSpans,
-                    s => !IsApart(s) && (IsBoldSpan(s) || IsAllUppercase(s) || IsCenterAligned(s))
-                )
-            )
-                headingTag = "h3";
-            else if (AllSiblingsMatch(siblingSpans, s => IsItalicSpan(s) && !IsApart(s)))
-                headingTag = "h4";
-
+            var headingTag = ClassifyHeadingTag(combinedText, siblingSpans);
             if (headingTag == null)
                 continue;
 
             ReplaceNodeWithHeading(parent, headingTag, doc);
             processedParents.Add(parent);
         }
+    }
+
+    private string ClassifyHeadingTag(string combinedText, List<IElement> siblingSpans)
+    {
+        if (
+            IsPartHeading(combinedText)
+            && AllSiblingsMatch(siblingSpans, s => IsPartHeading(s.TextContent))
+        )
+            return "h1";
+        if (
+            IsItemHeading(combinedText)
+            && AllSiblingsMatch(siblingSpans, s => IsItemHeading(s.TextContent))
+        )
+            return "h2";
+        if (
+            AllSiblingsMatch(
+                siblingSpans,
+                s => !IsApart(s) && (IsBoldSpan(s) || IsAllUppercase(s) || IsCenterAligned(s))
+            )
+        )
+            return "h3";
+        if (AllSiblingsMatch(siblingSpans, s => IsItalicSpan(s) && !IsApart(s)))
+            return "h4";
+        return null;
     }
 
     private bool AllSiblingsMatch(List<IElement> spans, Func<IElement, bool> condition)


### PR DESCRIPTION
## Summary

- `HeadingConversionStep.Execute` mixes the per-span loop (find candidate spans, replace classified ones with heading elements) with a four-branch if/else ladder that decides which heading tag (h1..h4) applies. Extract that ladder into a private `ClassifyHeadingTag` helper so the loop body reads as "compute the tag → if non-null, replace".
- Pure refactor — the helper evaluates the same predicates in the same short-circuit order; no side effects, no shared state; returns the same string (or null).

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs` — extracted `ClassifyHeadingTag(combinedText, siblingSpans) → string` as a private helper; `Execute` now calls it instead of inlining the four-branch ladder.