### PR TITLE
fix(holdings-import): reject whitespace-only ACCESSION_NUMBER in TryParseSubmissionRow

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -128,7 +128,7 @@ public class HoldingsImportService
             return false;
 
         var accession = GetValue(row, "ACCESSION_NUMBER");
-        if (string.IsNullOrEmpty(accession))
+        if (string.IsNullOrWhiteSpace(accession))
             return false;
 
         var periodOfReport = GetValue(row, "PERIODOFREPORT");

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseSubmissionRowWhitespaceAccessionTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseSubmissionRowWhitespaceAccessionTests.cs
@@ -16,9 +16,7 @@ public class HoldingsImportServiceTryParseSubmissionRowWhitespaceAccessionTests
     // downstream where it lands in the Submissions dictionary keyed by a
     // whitespace string and propagates through every join (COVERPAGE, FILER
     // mapping, INFOTABLE).
-    [Fact(
-        Skip = "GH-1563 — TryParseSubmissionRow accepts whitespace-only ACCESSION_NUMBER instead of rejecting"
-    )]
+    [Fact]
     public void TryParseSubmissionRow_WhitespaceOnlyAccessionNumber_ReturnsFalse()
     {
         var minReportDate = new DateOnly(2024, 1, 1);


### PR DESCRIPTION
## Summary

- `HoldingsImportService.TryParseSubmissionRow` guarded `ACCESSION_NUMBER` with `string.IsNullOrEmpty`, which let whitespace-only values through and seeded `context.Submissions` with a malformed key that then propagated through every downstream join (COVERPAGE, FILER mapping, INFOTABLE).
- Tighten the guard to `IsNullOrWhiteSpace`, matching the strict-null-on-malformed precedent of the sibling parsers fixed under #1350, #1438, #1514, and #1544.
- Drops the `Skip` on the pinned repro test added in #1564, so the guard is now covered.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — `IsNullOrEmpty(accession)` → `IsNullOrWhiteSpace(accession)` in `TryParseSubmissionRow`.
- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseSubmissionRowWhitespaceAccessionTests.cs` — remove the `Skip` attribute now that the bug is fixed.

Closes #1563