### PR TITLE
test(sec-normalizer): pin ClassifyHeadingTag returns h2 not h3 for bold Item heading

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepClassifyHeadingTagCascadePrecedenceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepClassifyHeadingTagCascadePrecedenceTests.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class HeadingConversionStepClassifyHeadingTagCascadePrecedenceTests
+{
+    // ClassifyHeadingTag (extracted in #1573) walks a four-tier cascade:
+    // PART → h1, ITEM → h2, bold/uppercase/center-aligned → h3, italic → h4.
+    // A span can satisfy multiple tiers (an "Item 1." span is also bold), and
+    // the contract picks the higher-precedence tier (h2 over h3). A refactor
+    // that reordered the branches — for example to short-circuit the cheap
+    // bold check first — would silently demote ITEM headings to h3.
+    [Fact]
+    public void ClassifyHeadingTag_ItemHeadingThatIsAlsoBold_ReturnsH2NotH3()
+    {
+        var span = (IElement)
+            new HtmlParser()
+                .ParseDocument(
+                    "<html><body><span style=\"font-weight:bold\">Item 1. Business</span></body></html>"
+                )
+                .QuerySelector("span");
+
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "ClassifyHeadingTag",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var step = new HeadingConversionStep();
+
+        var result = (string)method.Invoke(step, ["Item 1. Business", new List<IElement> { span }]);
+
+        result.Should().Be("h2");
+    }
+}


### PR DESCRIPTION
## Summary

- `ClassifyHeadingTag` (extracted in #1573) walks a four-tier cascade: PART → h1, ITEM → h2, bold/uppercase/center-aligned → h3, italic → h4. A span often satisfies multiple tiers — an "Item 1." span rendered with `font-weight:bold` matches both h2 and h3 — and the contract requires the higher-precedence tier to win.
- Pins that cascade ordering. A refactor that reordered the branches (e.g. moving the cheaper bold predicate ahead of the ITEM check) would silently demote Item headings to h3.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepClassifyHeadingTagCascadePrecedenceTests.cs` — one `[Fact]` invoking the private `ClassifyHeadingTag` with a bold span whose text is "Item 1. Business" and asserting the returned tag is `"h2"`.