### PR TITLE
feat(worker): publish ScraperActivity from every scraper

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -37,7 +37,7 @@ Why the indirection through `ViewData` rather than a single `StockDetailViewMode
 | [`CftcController`](../../src/Equibles.Web/Controllers/CftcController.cs) | `~/Futures/...` | CFTC positioning per contract / category. |
 | [`MarketController`](../../src/Equibles.Web/Controllers/MarketController.cs) | `~/Market/...` | CBOE VIX + put/call ratios. |
 | [`SearchController`](../../src/Equibles.Web/Controllers/SearchController.cs) | `~/Search?q=…` | Aggregate search across registered `ISearchProvider`s. |
-| [`StatusController`](../../src/Equibles.Web/Controllers/StatusController.cs) | `~/Status` | Worker health, data counts, error log dashboard. |
+| [`StatusController`](../../src/Equibles.Web/Controllers/StatusController.cs) | `~/Status`, `~/Status/Activity`, `~/Status/Activity/Stream` | Worker health, data counts, error log dashboard + the live scraper activity page (SSE-driven). |
 | [`ChangelogController`](../../src/Equibles.Web/Controllers/ChangelogController.cs) | `~/Changelog` | Renders `CHANGELOG.md`. |
 | [`HomeController`](../../src/Equibles.Web/Controllers/HomeController.cs) | `~/` | Landing page. |
 | [`AuthController`](../../src/Equibles.Web/Controllers/AuthController.cs) | `~/Auth/...` | Login form used by the env-based auth scheme. |
@@ -89,6 +89,25 @@ Why the indirection through `ViewData` rather than a single `StockDetailViewMode
 - [`ChangelogService`](../../src/Equibles.Web/Services/ChangelogService.cs) — parses `CHANGELOG.md` for the version banner.
 
 The Status page is the operator's primary feedback loop — every new scraper that calls `ErrorReporter.Report(...)` shows up there automatically.
+
+## Live activity feed
+
+`~/Status/Activity` is the real-time companion to the Status dashboard. While the Status page shows persisted state (worker config, row counts, the error log), the Activity page tails what each scraper is doing **right now**.
+
+End-to-end shape:
+
+1. `BaseScraperWorker` (every scraper inherits it) and `ErrorReporter` publish `ScraperActivity` messages on the MassTransit bus — `Source`, `Severity` (`Info` / `Warn` / `Error`), `Message`, `Timestamp`, `CorrelationId`. Lifecycle events from the worker, error events from the reporter.
+2. The web host's `ScraperActivityConsumer` ([`Services/Activity/ScraperActivityConsumer.cs`](../../src/Equibles.Web/Services/Activity/ScraperActivityConsumer.cs)) receives each message and hands it to the in-process `ActivityFeedBroadcaster` (singleton, ring buffer of 500 events + per-subscriber bounded channel with `DropOldest`).
+3. `GET /Status/Activity/Stream` is an SSE endpoint that subscribes one bounded channel per browser tab, replays the small backlog, then forwards each new event as an `event: activity` SSE frame.
+4. The Razor page at `~/Status/Activity` opens an `EventSource` and renders rows live with DaisyUI styling — severity badge, stable-per-source colour badge, wall-clock timestamp; pause / resume / clear controls.
+
+Design notes:
+
+- **Not persisted.** A message with no listeners is dropped on the floor. Historical errors keep going through `ErrorReporter` to the database; the activity feed is purely a live view.
+- **Fire-and-forget.** Publishers call `IBus.Publish` directly so the activity event never goes through the EF outbox — a stuck DB transaction must not stall the scraper to push a status crumb.
+- **Best-effort.** Both `BaseScraperWorker` and `ErrorReporter` swallow publish failures (debug-level log only). A missing `IBus` (tests, hosts without messaging) makes activity publishing a no-op rather than a crash.
+- **Backpressure-safe.** Each browser gets its own 256-slot bounded channel with `BoundedChannelFullMode.DropOldest`. A paused tab cannot back up the bus.
+- **Cross-process.** Because the bus is Postgres SQL transport, events flow worker → DB → web → browser without any direct worker↔web connection. Multiple web replicas each get their own consumer endpoint (`AllowMultiple = true` on the consumer) and each forwards events to its own connected browsers.
 
 ## Conventions
 

--- a/src/Equibles.Errors.BusinessLogic/Equibles.Errors.BusinessLogic.csproj
+++ b/src/Equibles.Errors.BusinessLogic/Equibles.Errors.BusinessLogic.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Equibles.Core.AutoWiring" />
+    <PackageReference Include="MassTransit" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Errors.Repositories\Equibles.Errors.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Errors.BusinessLogic/ErrorReporter.cs
+++ b/src/Equibles.Errors.BusinessLogic/ErrorReporter.cs
@@ -1,5 +1,7 @@
 using Equibles.Core.AutoWiring;
 using Equibles.Errors.Data.Models;
+using Equibles.Messaging.Contracts.Activity;
+using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -34,6 +36,36 @@ public class ErrorReporter
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Failed to report error for {Context}", context);
+        }
+
+        // Surface the error on the live activity feed so it shows up alongside
+        // normal scraper lifecycle events. Best-effort — a missing bus
+        // (tests, hosts without messaging) silently no-ops.
+        await PublishActivity(source, context, message);
+    }
+
+    private async Task PublishActivity(ErrorSource source, string context, string message)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var bus = scope.ServiceProvider.GetService<IBus>();
+            if (bus is null)
+                return;
+
+            await bus.Publish(
+                new ScraperActivity(
+                    Source: source.Value,
+                    Severity: ScraperActivitySeverity.Error,
+                    Message: $"{context}: {message}",
+                    Timestamp: DateTimeOffset.UtcNow,
+                    CorrelationId: Guid.NewGuid().ToString()
+                )
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to publish ScraperActivity for {Context}", context);
         }
     }
 }

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -1,5 +1,7 @@
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
+using Equibles.Messaging.Contracts.Activity;
+using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -17,6 +19,55 @@ public abstract class BaseScraperWorker : BackgroundService
     protected abstract string WorkerName { get; }
     protected abstract TimeSpan SleepInterval { get; }
     protected abstract ErrorSource ErrorSource { get; }
+
+    /// <summary>
+    /// Resolves the bus lazily — direct <see cref="IBus.Publish{T}"/> calls
+    /// don't go through the EF outbox, so activity events stay fire-and-forget
+    /// (a dropped event is fine; a stuck transaction would be worse). Returns
+    /// null if no bus is registered, so tests and any host that wires the
+    /// worker without messaging still run.
+    /// </summary>
+    private IBus TryGetBus()
+    {
+        using var scope = ScopeFactory.CreateScope();
+        return scope.ServiceProvider.GetService<IBus>();
+    }
+
+    private async Task PublishActivity(
+        ScraperActivitySeverity severity,
+        string message,
+        CancellationToken cancellationToken
+    )
+    {
+        var bus = TryGetBus();
+        if (bus is null)
+            return;
+
+        try
+        {
+            await bus.Publish(
+                new ScraperActivity(
+                    Source: WorkerName,
+                    Severity: severity,
+                    Message: message,
+                    Timestamp: DateTimeOffset.UtcNow,
+                    CorrelationId: Guid.NewGuid().ToString()
+                ),
+                cancellationToken
+            );
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Shutting down — swallow.
+        }
+        catch (Exception ex)
+        {
+            // The activity feed is best-effort. A failure here must never
+            // crash the scraper; log at Debug so it shows under verbose
+            // logging but doesn't pollute normal runs.
+            Logger.LogDebug(ex, "Failed to publish ScraperActivity for {Worker}", WorkerName);
+        }
+    }
 
     /// <summary>
     /// Wait used after a cycle that called <see cref="RequestRetrySoon"/> —
@@ -54,6 +105,8 @@ public abstract class BaseScraperWorker : BackgroundService
             Logger.LogInformation("{Worker} running at: {Time}", WorkerName, DateTimeOffset.Now);
             _retrySoonRequested = false;
 
+            await PublishActivity(ScraperActivitySeverity.Info, "cycle started", stoppingToken);
+
             try
             {
                 await DoWork(stoppingToken);
@@ -61,11 +114,19 @@ public abstract class BaseScraperWorker : BackgroundService
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
                 Logger.LogInformation("{Worker} cancelled", WorkerName);
+                await PublishActivity(
+                    ScraperActivitySeverity.Warn,
+                    "cancelled",
+                    CancellationToken.None
+                );
                 return;
             }
             catch (Exception ex)
             {
                 Logger.LogCritical(ex, "Critical error in {Worker}", WorkerName);
+                // ErrorReporter publishes its own ScraperActivity with the same
+                // source + the error message, so the activity feed gets a row
+                // without double-emitting here.
                 await ErrorReporter.Report(
                     ErrorSource,
                     $"{WorkerName}.DoWork",
@@ -82,8 +143,24 @@ public abstract class BaseScraperWorker : BackgroundService
                 WorkerName,
                 interval
             );
+            await PublishActivity(
+                _retrySoonRequested ? ScraperActivitySeverity.Warn : ScraperActivitySeverity.Info,
+                _retrySoonRequested
+                    ? $"not ready, retrying in {FormatInterval(interval)}"
+                    : $"cycle complete, sleeping {FormatInterval(interval)}",
+                stoppingToken
+            );
             await WaitForNextCycle(interval, stoppingToken);
         }
+    }
+
+    private static string FormatInterval(TimeSpan interval)
+    {
+        if (interval.TotalHours >= 1)
+            return $"{interval.TotalHours:0.#}h";
+        if (interval.TotalMinutes >= 1)
+            return $"{interval.TotalMinutes:0.#}m";
+        return $"{interval.TotalSeconds:0}s";
     }
 
     /// <summary>

--- a/src/Equibles.Worker/Equibles.Worker.csproj
+++ b/src/Equibles.Worker/Equibles.Worker.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Equibles.Core.AutoWiring" />
+    <PackageReference Include="MassTransit" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
@@ -8,5 +9,6 @@
     <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
+    <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Equibles.UnitTests/Errors/ErrorReporterTests.cs
+++ b/tests/Equibles.UnitTests/Errors/ErrorReporterTests.cs
@@ -1,13 +1,70 @@
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
+using Equibles.Messaging.Contracts.Activity;
+using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.Core;
 
 namespace Equibles.UnitTests.Errors;
 
 public class ErrorReporterTests
 {
+    [Fact]
+    public async Task Report_PublishesScraperActivityWithErrorSeverity()
+    {
+        // Error rows on the database power the static Status page; the activity
+        // feed needs the same signal in real time. Pin the IBus.Publish call so
+        // a future refactor that drops the publish (or downgrades severity)
+        // breaks this test instead of silently disabling the live feed.
+        var bus = Substitute.For<IBus>();
+        var scope = Substitute.For<IServiceScope>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IBus)).Returns(bus);
+        scope.ServiceProvider.Returns(serviceProvider);
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+
+        var sut = new ErrorReporter(scopeFactory, Substitute.For<ILogger<ErrorReporter>>());
+
+        await sut.Report(
+            ErrorSource.YahooPriceScraper,
+            context: "Yahoo.Fetch",
+            message: "rate limited",
+            stackTrace: null
+        );
+
+        var captured = bus.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(IBus.Publish))
+            .Select(c => (ScraperActivity)c.GetArguments()[0]!)
+            .ToList();
+
+        captured.Should().HaveCount(1);
+        captured[0].Source.Should().Be(ErrorSource.YahooPriceScraper.Value);
+        captured[0].Severity.Should().Be(ScraperActivitySeverity.Error);
+        captured[0].Message.Should().Contain("Yahoo.Fetch").And.Contain("rate limited");
+    }
+
+    [Fact]
+    public async Task Report_NoBusRegistered_DoesNotThrow()
+    {
+        // The activity feed is opportunistic — a host without IBus
+        // (tests, future micro-host slices) must still let ErrorReporter run.
+        var scope = Substitute.For<IServiceScope>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IBus)).Returns((object?)null);
+        scope.ServiceProvider.Returns(serviceProvider);
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+
+        var sut = new ErrorReporter(scopeFactory, Substitute.For<ILogger<ErrorReporter>>());
+
+        var act = () => sut.Report(ErrorSource.Other, "Ctx", "msg", stackTrace: null);
+
+        await act.Should().NotThrowAsync();
+    }
+
     [Fact]
     public async Task Report_ScopeFactoryThrows_DoesNotPropagate()
     {

--- a/tests/Equibles.UnitTests/Errors/ErrorReporterTests.cs
+++ b/tests/Equibles.UnitTests/Errors/ErrorReporterTests.cs
@@ -47,6 +47,30 @@ public class ErrorReporterTests
     }
 
     [Fact]
+    public async Task Report_BusPublishThrows_SwallowsAndContinues()
+    {
+        // A broker hiccup must never propagate through ErrorReporter — it's
+        // called from every scraper's catch block, and rethrowing would
+        // replace the original error in the activity feed with a Publish
+        // failure that's not what the operator needs to see.
+        var bus = Substitute.For<IBus>();
+        bus.Publish(Arg.Any<ScraperActivity>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException(new InvalidOperationException("broker down")));
+        var scope = Substitute.For<IServiceScope>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IBus)).Returns(bus);
+        scope.ServiceProvider.Returns(serviceProvider);
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+
+        var sut = new ErrorReporter(scopeFactory, Substitute.For<ILogger<ErrorReporter>>());
+
+        var act = () => sut.Report(ErrorSource.Other, "Ctx", "msg", stackTrace: null);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
     public async Task Report_NoBusRegistered_DoesNotThrow()
     {
         // The activity feed is opportunistic — a host without IBus

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerActivityTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerActivityTests.cs
@@ -76,6 +76,56 @@ public class BaseScraperWorkerActivityTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_NoBusRegistered_CycleStillRunsToCompletion()
+    {
+        // Hosts that wire BaseScraperWorker without messaging (legacy code paths,
+        // future micro-host slices) must keep working — publish lookups fall
+        // back to no-op, so DoWork still runs and the cycle still loops.
+        var scope = Substitute.For<IServiceScope>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IBus)).Returns((object?)null);
+        scope.ServiceProvider.Returns(serviceProvider);
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+
+        var reporter = new ErrorReporter(scopeFactory, Substitute.For<ILogger<ErrorReporter>>());
+        using var worker = new ActivityTestWorker(
+            _logger,
+            scopeFactory,
+            reporter,
+            sleepInterval: TimeSpan.FromSeconds(30)
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitUntil(() => worker.DoWorkCalls >= 1);
+        await worker.StopAsync(CancellationToken.None);
+
+        worker.DoWorkCalls.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BusPublishThrows_CycleStillCompletes()
+    {
+        // Broker errors must never crash the scraper. If Publish throws, the
+        // worker should still progress through DoWork and the sleep block.
+        _bus.Publish(Arg.Any<ScraperActivity>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException(new InvalidOperationException("broker down")));
+
+        using var worker = new ActivityTestWorker(
+            _logger,
+            _scopeFactory,
+            _errorReporter,
+            sleepInterval: TimeSpan.FromSeconds(30)
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitUntil(() => worker.DoWorkCalls >= 1);
+        await worker.StopAsync(CancellationToken.None);
+
+        worker.DoWorkCalls.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_DoWorkThrows_ErrorReporterPublishesErrorSeverityActivity()
     {
         var failure = new InvalidOperationException("boom");

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerActivityTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerActivityTests.cs
@@ -1,0 +1,154 @@
+#nullable enable
+
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Messaging.Contracts.Activity;
+using Equibles.Worker;
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.Core;
+
+namespace Equibles.UnitTests.Worker;
+
+public class BaseScraperWorkerActivityTests
+{
+    private readonly ILogger _logger = Substitute.For<ILogger>();
+    private readonly IBus _bus = Substitute.For<IBus>();
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ErrorReporter _errorReporter;
+
+    public BaseScraperWorkerActivityTests()
+    {
+        // Wire a scope factory that hands back an IBus, so BaseScraperWorker's
+        // lazy resolution finds the substitute. Each scope gets the SAME bus
+        // mock so a single .Received() on the bus covers calls from any scope.
+        var scope = Substitute.For<IServiceScope>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IBus)).Returns(_bus);
+        scope.ServiceProvider.Returns(serviceProvider);
+        _scopeFactory = Substitute.For<IServiceScopeFactory>();
+        _scopeFactory.CreateScope().Returns(scope);
+
+        _errorReporter = new ErrorReporter(_scopeFactory, Substitute.For<ILogger<ErrorReporter>>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NormalCycle_PublishesStartAndCompleteActivities()
+    {
+        using var worker = new ActivityTestWorker(
+            _logger,
+            _scopeFactory,
+            _errorReporter,
+            sleepInterval: TimeSpan.FromSeconds(30)
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitUntil(() => worker.DoWorkCalls >= 1);
+        // Wait for the post-cycle publish too — DoWorkCalls flips inside DoWork
+        // but the "cycle complete" publish happens after DoWork returns.
+        await WaitUntil(() =>
+            _bus.ReceivedCalls()
+                .Any(c => Captured(c).Message.Contains("cycle complete", StringComparison.Ordinal))
+        );
+        await worker.StopAsync(CancellationToken.None);
+
+        var published = _bus.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(IBus.Publish))
+            .Select(Captured)
+            .ToList();
+
+        published
+            .Should()
+            .Contain(a =>
+                a.Source == "TestWorker"
+                && a.Severity == ScraperActivitySeverity.Info
+                && a.Message == "cycle started"
+            );
+        published
+            .Should()
+            .Contain(a =>
+                a.Source == "TestWorker"
+                && a.Severity == ScraperActivitySeverity.Info
+                && a.Message.StartsWith("cycle complete", StringComparison.Ordinal)
+            );
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoWorkThrows_ErrorReporterPublishesErrorSeverityActivity()
+    {
+        var failure = new InvalidOperationException("boom");
+        using var worker = new ActivityTestWorker(
+            _logger,
+            _scopeFactory,
+            _errorReporter,
+            sleepInterval: TimeSpan.FromSeconds(30),
+            doWorkOverride: _ => throw failure
+        );
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitUntil(() =>
+            _bus.ReceivedCalls().Any(c => Captured(c).Severity == ScraperActivitySeverity.Error)
+        );
+        await worker.StopAsync(CancellationToken.None);
+
+        var errors = _bus.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(IBus.Publish))
+            .Select(Captured)
+            .Where(a => a.Severity == ScraperActivitySeverity.Error)
+            .ToList();
+
+        errors
+            .Should()
+            .Contain(a => a.Source == ErrorSource.Other.Value && a.Message.Contains("boom"));
+    }
+
+    private static ScraperActivity Captured(ICall call)
+    {
+        var args = call.GetArguments();
+        return (ScraperActivity)args[0]!;
+    }
+
+    private static async Task WaitUntil(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+                return;
+            await Task.Delay(10);
+        }
+    }
+
+    private sealed class ActivityTestWorker : BaseScraperWorker
+    {
+        private readonly Func<CancellationToken, Task>? _doWorkOverride;
+
+        protected override string WorkerName => "TestWorker";
+        protected override TimeSpan SleepInterval { get; }
+        protected override ErrorSource ErrorSource => ErrorSource.Other;
+
+        public int DoWorkCalls;
+
+        public ActivityTestWorker(
+            ILogger logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            TimeSpan sleepInterval,
+            Func<CancellationToken, Task>? doWorkOverride = null
+        )
+            : base(logger, scopeFactory, errorReporter)
+        {
+            SleepInterval = sleepInterval;
+            _doWorkOverride = doWorkOverride;
+        }
+
+        protected override async Task DoWork(CancellationToken stoppingToken)
+        {
+            Interlocked.Increment(ref DoWorkCalls);
+            if (_doWorkOverride is not null)
+                await _doWorkOverride(stoppingToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 4/4 of the live scraper activity feed. Closes #1162.
- Publishes `ScraperActivity` events from the two chokepoints every scraper already goes through, so every existing scraper participates in the feed with no per-scraper code change.

Closes #1162

## Code changes

- `src/Equibles.Worker/BaseScraperWorker.cs` — publishes Info "cycle started", Info "cycle complete, sleeping <interval>", Warn "not ready, retrying in <interval>" (cold-start path), and Warn "cancelled" on graceful shutdown. Lazy `IBus` resolution so hosts without messaging keep working.
- `src/Equibles.Errors.BusinessLogic/ErrorReporter.cs` — publishes an Error-severity activity alongside the existing database write, so per-call failures across any scraper surface on the feed with the same context that goes to the error log.
- Both publishers use `IBus.Publish` directly (not `IPublishEndpoint`), so events bypass the EF outbox — activity is fire-and-forget by design, and a stuck DB transaction must never block status crumbs.
- Publish failures are swallowed and logged at Debug; a missing `IBus` is a no-op (tests and hosts without messaging continue to work).
- `tests/Equibles.UnitTests/Worker/BaseScraperWorkerActivityTests.cs` — pins the lifecycle publishes (start / complete) and the error-cycle path through `ErrorReporter`.
- `tests/Equibles.UnitTests/Errors/ErrorReporterTests.cs` — pins that `Report` publishes Error-severity activity with the source + context-merged message, and that a host without `IBus` doesn't throw.
- `docs/technical/web-portal.md` — adds a "Live activity feed" section walking through the end-to-end shape (publisher → consumer → broadcaster → SSE → browser).
- csproj refs for `MassTransit` + `Equibles.Messaging` from `Equibles.Worker` and `Equibles.Errors.BusinessLogic`.