### PR TITLE
test(financial-facts): add skipped repro for GH-1577 — TryMapTaxonomy

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapTaxonomyNullKeyTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapTaxonomyNullKeyTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactsImportServiceTryMapTaxonomyNullKeyTests
+{
+    // FinancialFactsImportService.TryMapTaxonomy follows the .NET Try* contract:
+    // map the wire key to a FactTaxonomy via the out parameter and return true,
+    // or return false on any input the helper does not recognize. The sibling
+    // TryMapFiscalPeriod (same file, same shape) already defends against null
+    // via `fp?.ToUpperInvariant()`; TryMapTaxonomy uses `key.ToLowerInvariant()`
+    // without the null-conditional, so a null key throws NullReferenceException
+    // instead of falling to the default arm. The Try* contract says "never
+    // throw on bad input — return false" — any future caller (refactor,
+    // parameterised matrix, defensive caller) that hands in null would crash.
+    [Fact(
+        Skip = "GH-1577 — TryMapTaxonomy throws NullReferenceException on null key instead of returning false"
+    )]
+    public void TryMapTaxonomy_NullKey_ReturnsFalseWithoutThrowing()
+    {
+        var method = typeof(FinancialFactsImportService).GetMethod(
+            "TryMapTaxonomy",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var args = new object[] { null, default(FactTaxonomy) };
+
+        // MethodInfo.Invoke wraps a thrown inner exception in
+        // TargetInvocationException, so `.NotThrow()` catches the NRE case.
+        bool resolved = false;
+        var act = () => resolved = (bool)method.Invoke(null, args);
+
+        act.Should().NotThrow();
+        resolved.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- `FinancialFactsImportService.TryMapTaxonomy` (private static helper, called from `ParseFacts` to map SEC company-facts taxonomy keys → `FactTaxonomy` enum) calls `key.ToLowerInvariant()` directly — no null-conditional — so a null key throws `NullReferenceException` instead of returning `false`.
- The sibling helper `TryMapFiscalPeriod` in the same file uses `fp?.ToUpperInvariant()` and correctly returns `false` on null. The asymmetry looks like a refactor oversight on `TryMapTaxonomy`. Per the .NET `Try*` convention, bad input is signalled via the `false` return value — never a thrown exception. Any defensive caller (or a future parameterised matrix, or a JSON path where the key is genuinely missing) that hands in null would crash instead of safely skipping the taxonomy.
- Adversarial test added as `[Fact(Skip = "GH-1577 — …")]` — verified failing on unfixed code (`Object reference not set to an instance of an object` at `FinancialFactsImportService.cs:438`). Drop the `Skip` attribute as part of the fix; the one-character fix is `switch (key?.ToLowerInvariant())`, matching the sibling helper.

closes — skipped — see GH-1577.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapTaxonomyNullKeyTests.cs` — new file. One `[Fact(Skip = "GH-1577 — …")]`: `TryMapTaxonomy_NullKey_ReturnsFalseWithoutThrowing`. Invokes the private static helper via reflection with a null key and asserts the call does not throw and the helper returns `false`. Skipped — see GH-1577.