### PR TITLE
refactor(holdings-mcp): extract RenderTopBuyersSellers helper from GetTopBuyersSellers

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -399,62 +399,86 @@ public class InstitutionalHoldingsTools
                 if (topBuyers.Count == 0 && topSellers.Count == 0)
                     return $"No quarter-over-quarter movement found for {stock.Name} ({ticker}) as of {targetDate:yyyy-MM-dd}.";
 
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"Top buyers and sellers of {stock.Name} ({ticker}) as of {targetDate:yyyy-MM-dd}"
-                );
-                if (previousDate.HasValue)
-                    result.AppendLine($"vs prior quarter {previousDate.Value:yyyy-MM-dd}");
-                result.AppendLine();
-
-                AppendMoverSection(result, "## Top Buyers", "_No buyers this quarter._", topBuyers);
-                result.AppendLine();
-                AppendMoverSection(
-                    result,
-                    "## Top Sellers",
-                    "_No sellers this quarter._",
+                return RenderTopBuyersSellers(
+                    stock,
+                    ticker,
+                    targetDate,
+                    previousDate,
+                    topBuyers,
                     topSellers
                 );
-
-                return result.ToString();
-
-                static void AppendMoverSection(
-                    StringBuilder sb,
-                    string heading,
-                    string emptyMessage,
-                    IReadOnlyList<(
-                        string Name,
-                        long CurrentShares,
-                        long PreviousShares,
-                        long DeltaShares,
-                        long DeltaValue
-                    )> rows
-                )
-                {
-                    sb.AppendLine(heading);
-                    if (rows.Count == 0)
-                    {
-                        sb.AppendLine(emptyMessage);
-                        return;
-                    }
-                    sb.AppendLine(
-                        "| # | Institution | Δ Shares | Δ Value ($M) | Prior → New Shares |"
-                    );
-                    sb.AppendLine("|---|-------------|---------|-------------|------------------|");
-                    for (var i = 0; i < rows.Count; i++)
-                    {
-                        var m = rows[i];
-                        // `+` for positive deltas; N0 already emits `-` for negatives.
-                        var sign = m.DeltaShares > 0 ? "+" : "";
-                        sb.AppendLine(
-                            $"| {i + 1} | {m.Name} | {sign}{m.DeltaShares:N0} | {m.DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0} | {m.PreviousShares:N0} → {m.CurrentShares:N0} |"
-                        );
-                    }
-                }
             },
             "GetTopBuyersSellers",
             $"ticker: {ticker}"
         );
+    }
+
+    private static string RenderTopBuyersSellers(
+        CommonStock stock,
+        string ticker,
+        DateOnly targetDate,
+        DateOnly? previousDate,
+        IReadOnlyList<(
+            string Name,
+            long CurrentShares,
+            long PreviousShares,
+            long DeltaShares,
+            long DeltaValue
+        )> topBuyers,
+        IReadOnlyList<(
+            string Name,
+            long CurrentShares,
+            long PreviousShares,
+            long DeltaShares,
+            long DeltaValue
+        )> topSellers
+    )
+    {
+        var result = new StringBuilder();
+        result.AppendLine(
+            $"Top buyers and sellers of {stock.Name} ({ticker}) as of {targetDate:yyyy-MM-dd}"
+        );
+        if (previousDate.HasValue)
+            result.AppendLine($"vs prior quarter {previousDate.Value:yyyy-MM-dd}");
+        result.AppendLine();
+
+        AppendMoverSection(result, "## Top Buyers", "_No buyers this quarter._", topBuyers);
+        result.AppendLine();
+        AppendMoverSection(result, "## Top Sellers", "_No sellers this quarter._", topSellers);
+
+        return result.ToString();
+
+        static void AppendMoverSection(
+            StringBuilder sb,
+            string heading,
+            string emptyMessage,
+            IReadOnlyList<(
+                string Name,
+                long CurrentShares,
+                long PreviousShares,
+                long DeltaShares,
+                long DeltaValue
+            )> rows
+        )
+        {
+            sb.AppendLine(heading);
+            if (rows.Count == 0)
+            {
+                sb.AppendLine(emptyMessage);
+                return;
+            }
+            sb.AppendLine("| # | Institution | Δ Shares | Δ Value ($M) | Prior → New Shares |");
+            sb.AppendLine("|---|-------------|---------|-------------|------------------|");
+            for (var i = 0; i < rows.Count; i++)
+            {
+                var m = rows[i];
+                // `+` for positive deltas; N0 already emits `-` for negatives.
+                var sign = m.DeltaShares > 0 ? "+" : "";
+                sb.AppendLine(
+                    $"| {i + 1} | {m.Name} | {sign}{m.DeltaShares:N0} | {m.DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0} | {m.PreviousShares:N0} → {m.CurrentShares:N0} |"
+                );
+            }
+        }
     }
 
     [McpServerTool(Name = "GetMarketWide13FActivity")]


### PR DESCRIPTION
## Summary

- Extract the markdown rendering tail of `InstitutionalHoldingsTools.GetTopBuyersSellers` — heading + optional prior-quarter subtitle + two `AppendMoverSection` calls — plus the embedded `AppendMoverSection` local function, into a class-level `RenderTopBuyersSellers` helper. The Execute lambda's tail collapses to `return RenderTopBuyersSellers(stock, ticker, targetDate, previousDate, topBuyers, topSellers);` (the no-movement early return stays in the lambda).
- Behavior preserved: helper emits the same `Top buyers and sellers of {stock.Name} ({ticker}) as of {targetDate}` heading, the same `vs prior quarter {previousDate}` line when `previousDate.HasValue`, the same blank-line separator, the same two `## Top Buyers` / `## Top Sellers` sections with identical empty-message strings, the same 5-column header + alignment row, and the same per-row `±DeltaShares:N0` sign + `DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0` + `PreviousShares:N0 → CurrentShares:N0` formatting; pure relocation. WHY-comment on the `+` sign preserved.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — added `private static string RenderTopBuyersSellers(CommonStock stock, string ticker, DateOnly targetDate, DateOnly? previousDate, IReadOnlyList<(string Name, long CurrentShares, long PreviousShares, long DeltaShares, long DeltaValue)> topBuyers, IReadOnlyList<...> topSellers)` with the previously-inline `AppendMoverSection` static local function moved inside; `GetTopBuyersSellers`'s lambda now returns its result after the no-movement early return.