### PR TITLE
refactor(financial-facts-mcp): extract BuildComparisonRows helper from CompareFinancialFact

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -230,22 +230,7 @@ public class FinancialFactsTools
                     .GroupBy(f => f.CommonStockId)
                     .ToDictionary(g => g.Key, g => PickBestFact(g, conceptPriority));
 
-                var rows = new List<(string Ticker, string Name, FinancialFact Fact)>();
-                var skipped = new List<string>();
-                foreach (var ticker in requested)
-                {
-                    if (!stockByTicker.TryGetValue(ticker, out var stock))
-                    {
-                        skipped.Add($"{FactMarkdown.Cell(ticker)} (not found)");
-                        continue;
-                    }
-                    if (!bestByStock.TryGetValue(stock.Id, out var best))
-                    {
-                        skipped.Add($"{FactMarkdown.Cell(ticker)} (no data)");
-                        continue;
-                    }
-                    rows.Add((stock.Ticker, stock.Name, best));
-                }
+                var (rows, skipped) = BuildComparisonRows(requested, stockByTicker, bestByStock);
 
                 return RenderComparisonTable(concept, fiscalYear, period, rows, skipped);
             },
@@ -284,6 +269,34 @@ public class FinancialFactsTools
         }
 
         return result.ToString();
+    }
+
+    private static (
+        List<(string Ticker, string Name, FinancialFact Fact)> Rows,
+        List<string> Skipped
+    ) BuildComparisonRows(
+        IReadOnlyList<string> requested,
+        IReadOnlyDictionary<string, CommonStock> stockByTicker,
+        IReadOnlyDictionary<Guid, FinancialFact> bestByStock
+    )
+    {
+        var rows = new List<(string Ticker, string Name, FinancialFact Fact)>();
+        var skipped = new List<string>();
+        foreach (var ticker in requested)
+        {
+            if (!stockByTicker.TryGetValue(ticker, out var stock))
+            {
+                skipped.Add($"{FactMarkdown.Cell(ticker)} (not found)");
+                continue;
+            }
+            if (!bestByStock.TryGetValue(stock.Id, out var best))
+            {
+                skipped.Add($"{FactMarkdown.Cell(ticker)} (no data)");
+                continue;
+            }
+            rows.Add((stock.Ticker, stock.Name, best));
+        }
+        return (rows, skipped);
     }
 
     private static string RenderComparisonTable(


### PR DESCRIPTION
## Summary

- `CompareFinancialFact` walks the user-supplied tickers list and partitions each into either a rendered row (stock + best fact) or a skipped-list message ("(not found)" / "(no data)"). Extract that per-ticker projection into a `BuildComparisonRows` helper so the main method reads as "validate → load → build rows → render".
- Pure refactor — same iteration order over `requested`, same TryGetValue lookups, same skipped messages, same `(ticker, name, fact)` tuple shape; no side effects, no shared state.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — extracted `BuildComparisonRows(requested, stockByTicker, bestByStock) → (rows, skipped)` as a private static helper; `CompareFinancialFact` now calls it instead of inlining the projection loop.