### PR TITLE
refactor(holdings-mcp): extract RenderQuarterlyActivity helper from GetInstitutionQuarterlyActivity

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -840,43 +840,59 @@ public class InstitutionalHoldingsTools
                     previousHoldings
                 );
 
-                var sections = new (StockPositionChangeType Type, string Label)[]
-                {
-                    (StockPositionChangeType.Initiated, "Initiated"),
-                    (StockPositionChangeType.Increased, "Increased"),
-                    (StockPositionChangeType.Reduced, "Reduced"),
-                    (StockPositionChangeType.Exited, "Exited"),
-                };
-
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"Quarterly activity — **{holder.Name}** as of {targetDate:yyyy-MM-dd}"
+                return RenderQuarterlyActivity(
+                    holder,
+                    targetDate,
+                    priorDate,
+                    grouped,
+                    normalizedBucket,
+                    maxResults
                 );
-                result.AppendLine($"vs prior quarter {priorDate:yyyy-MM-dd}");
-                result.AppendLine();
-
-                var rendered = 0;
-                var selectedSections = sections.Where(s =>
-                    string.IsNullOrEmpty(normalizedBucket)
-                    || s.Label.ToLowerInvariant() == normalizedBucket
-                );
-                foreach (var section in selectedSections)
-                {
-                    var rows = grouped[section.Type]
-                        .OrderByDescending(r => Math.Abs(r.DeltaValue))
-                        .Take(maxResults)
-                        .ToList();
-                    if (AppendActivitySection(result, section.Label, rows))
-                        rendered++;
-                }
-
-                if (rendered == 0)
-                    result.AppendLine("_No matching buckets._");
-                return result.ToString();
             },
             "GetInstitutionQuarterlyActivity",
             $"institution: {institutionName}"
         );
+    }
+
+    private static string RenderQuarterlyActivity(
+        InstitutionalHolder holder,
+        DateOnly targetDate,
+        DateOnly priorDate,
+        Dictionary<StockPositionChangeType, List<StockPositionChange>> grouped,
+        string normalizedBucket,
+        int maxResults
+    )
+    {
+        var sections = new (StockPositionChangeType Type, string Label)[]
+        {
+            (StockPositionChangeType.Initiated, "Initiated"),
+            (StockPositionChangeType.Increased, "Increased"),
+            (StockPositionChangeType.Reduced, "Reduced"),
+            (StockPositionChangeType.Exited, "Exited"),
+        };
+
+        var result = new StringBuilder();
+        result.AppendLine($"Quarterly activity — **{holder.Name}** as of {targetDate:yyyy-MM-dd}");
+        result.AppendLine($"vs prior quarter {priorDate:yyyy-MM-dd}");
+        result.AppendLine();
+
+        var rendered = 0;
+        var selectedSections = sections.Where(s =>
+            string.IsNullOrEmpty(normalizedBucket) || s.Label.ToLowerInvariant() == normalizedBucket
+        );
+        foreach (var section in selectedSections)
+        {
+            var rows = grouped[section.Type]
+                .OrderByDescending(r => Math.Abs(r.DeltaValue))
+                .Take(maxResults)
+                .ToList();
+            if (AppendActivitySection(result, section.Label, rows))
+                rendered++;
+        }
+
+        if (rendered == 0)
+            result.AppendLine("_No matching buckets._");
+        return result.ToString();
     }
 
     private static bool AppendActivitySection(


### PR DESCRIPTION
## Summary

- Extract the rendering tail of `InstitutionalHoldingsTools.GetInstitutionQuarterlyActivity` (sections array + StringBuilder heading + `selectedSections` filter + foreach with `AppendActivitySection` calls + rendered counter + `_No matching buckets._` fallback, ~33 lines) into a `RenderQuarterlyActivity` helper. Lambda ends with `return RenderQuarterlyActivity(holder, targetDate, priorDate, grouped, normalizedBucket, maxResults);`.
- Behavior preserved: helper builds the same 4-entry sections array in the same `Initiated/Increased/Reduced/Exited` order, emits the same `Quarterly activity — **{holder.Name}** as of {targetDate}` heading + `vs prior quarter {priorDate}` line, runs the same `selectedSections` filter (string-empty bucket OR case-insensitive label match), the same per-section `OrderByDescending(r => Math.Abs(r.DeltaValue)).Take(maxResults)` ranking, the same `AppendActivitySection` call + `rendered++` accounting, and the same `_No matching buckets._` fallback when nothing rendered — pure relocation.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — added `private static string RenderQuarterlyActivity(InstitutionalHolder holder, DateOnly targetDate, DateOnly priorDate, Dictionary<StockPositionChangeType, List<StockPositionChange>> grouped, string normalizedBucket, int maxResults)`; `GetInstitutionQuarterlyActivity`'s lambda returns its result after `HolderQuarterlyActivityCalculator.Group(...)`.