### PR TITLE
test(holdings-import): add skipped repro for GH-1583 — DeduplicateSubmissions whitespace Cik

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceDeduplicateSubmissionsWhitespaceCikTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceDeduplicateSubmissionsWhitespaceCikTests.cs
@@ -1,0 +1,53 @@
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceDeduplicateSubmissionsWhitespaceCikTests
+{
+    // DeduplicateSubmissions filters out submissions that cannot be reliably
+    // grouped by (Cik, PeriodOfReport) — the existing
+    // DeduplicateSubmissions_MissingCikOrPeriod_SkippedFromGrouping test pins
+    // that null/empty Cik or PeriodOfReport short-circuit grouping so unrelated
+    // filings are not falsely collapsed onto one another. Per the project's
+    // strict-null-on-malformed precedent for the SUBMISSION.tsv ingest path
+    // (GH-1350 IsRecentFtdFile, GH-1438 FtdImportService.ParseLine, GH-1514
+    // TryBuildParsedFact, GH-1544 TryParseOtherManagerRow, GH-1563
+    // TryParseSubmissionRow), a whitespace-only Cik is malformed: SEC CIKs are
+    // numeric and can never legitimately be whitespace. The dedup filter must
+    // treat whitespace identically to null/empty — otherwise two submissions
+    // with Cik="   " and the same PeriodOfReport collapse into one and a
+    // legitimate filing disappears.
+    [Fact(
+        Skip = "GH-1583 — DeduplicateSubmissions groups submissions with whitespace-only Cik instead of skipping"
+    )]
+    public void DeduplicateSubmissions_WhitespaceOnlyCik_SkippedFromGrouping()
+    {
+        var context = new ImportContext
+        {
+            Submissions = new Dictionary<string, SubmissionRow>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ACC-001"] = new()
+                {
+                    AccessionNumber = "ACC-001",
+                    Cik = "   ",
+                    PeriodOfReport = "2024-09-30",
+                    FilingDate = "2024-11-15",
+                    FormType = "13F-HR",
+                },
+                ["ACC-002"] = new()
+                {
+                    AccessionNumber = "ACC-002",
+                    Cik = "   ",
+                    PeriodOfReport = "2024-09-30",
+                    FilingDate = "2024-11-20",
+                    FormType = "13F-HR",
+                },
+            },
+        };
+
+        HoldingsImportService.DeduplicateSubmissions(context);
+
+        context.Submissions.Should().HaveCount(2);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped repro pinning the strict-null-on-malformed contract for `DeduplicateSubmissions`: two submissions with `Cik = "   "` and the same `PeriodOfReport` must NOT collapse onto each other — current code uses `IsNullOrEmpty` and silently drops one as a "duplicate".
- Same shape as the parser-level guards already tightened under #1350, #1438, #1514, #1544, and #1563. The new test fails on `main`; the skip is removed as part of the fix for GH-1583.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceDeduplicateSubmissionsWhitespaceCikTests.cs` — new `[Fact(Skip = "GH-1583 — ...")]` covering whitespace-only `Cik` (skipped — see GH-1583).

Refs #1583