### PR TITLE
refactor(holdings-mcp): extract ResolveMarketActivityDates helper from GetMarketWide13FActivity

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -505,34 +505,18 @@ public class InstitutionalHoldingsTools
                 )
                     return "Unknown bucket. Use one of: top-buys, top-sells, new-positions, sold-out-positions.";
 
-                var reportDates = await _holdingRepository
-                    .GetAvailableReportDates()
-                    .Distinct()
-                    .OrderByDescending(d => d)
-                    .ToListAsync();
-                if (reportDates.Count == 0)
-                    return "No 13F holdings data available.";
-
-                var targetDate = TryParseReportDate(reportDate, out var parsed)
-                    ? parsed
-                    : reportDates[0];
-                var targetIndex = reportDates.IndexOf(targetDate);
-                if (targetIndex < 0)
-                    return $"Report date {targetDate:yyyy-MM-dd} not found. Available dates: {string.Join(", ", reportDates.Take(5).Select(d => d.ToString("yyyy-MM-dd")))}{(reportDates.Count > 5 ? "…" : "")}.";
-
-                var previousDate =
-                    targetIndex < reportDates.Count - 1
-                        ? reportDates[targetIndex + 1]
-                        : (DateOnly?)null;
-                if (!previousDate.HasValue)
-                    return $"No prior quarter to compare against for {targetDate:yyyy-MM-dd}.";
+                var (targetDate, previousDate, error) = await ResolveMarketActivityDates(
+                    reportDate
+                );
+                if (error != null)
+                    return error;
 
                 // Headline + comparison subtitle.
                 var result = new StringBuilder();
                 result.AppendLine(
                     $"Market-wide 13F **{normalizedBucket}** for {targetDate:yyyy-MM-dd}"
                 );
-                result.AppendLine($"vs prior quarter {previousDate.Value:yyyy-MM-dd}");
+                result.AppendLine($"vs prior quarter {previousDate:yyyy-MM-dd}");
                 result.AppendLine();
 
                 if (normalizedBucket is "top-buys" or "top-sells")
@@ -540,7 +524,7 @@ public class InstitutionalHoldingsTools
                     return await RenderMarketActivityMovers(
                         normalizedBucket,
                         targetDate,
-                        previousDate.Value,
+                        previousDate,
                         maxResults,
                         result
                     );
@@ -550,7 +534,7 @@ public class InstitutionalHoldingsTools
                     return await RenderMarketActivityChurn(
                         normalizedBucket,
                         targetDate,
-                        previousDate.Value,
+                        previousDate,
                         maxResults,
                         result
                     );
@@ -559,6 +543,39 @@ public class InstitutionalHoldingsTools
             "GetMarketWide13FActivity",
             $"bucket: {bucket}"
         );
+    }
+
+    private async Task<(
+        DateOnly Target,
+        DateOnly Previous,
+        string Error
+    )> ResolveMarketActivityDates(string reportDate)
+    {
+        var reportDates = await _holdingRepository
+            .GetAvailableReportDates()
+            .Distinct()
+            .OrderByDescending(d => d)
+            .ToListAsync();
+        if (reportDates.Count == 0)
+            return (default, default, "No 13F holdings data available.");
+
+        var targetDate = TryParseReportDate(reportDate, out var parsed) ? parsed : reportDates[0];
+        var targetIndex = reportDates.IndexOf(targetDate);
+        if (targetIndex < 0)
+            return (
+                default,
+                default,
+                $"Report date {targetDate:yyyy-MM-dd} not found. Available dates: {string.Join(", ", reportDates.Take(5).Select(d => d.ToString("yyyy-MM-dd")))}{(reportDates.Count > 5 ? "…" : "")}."
+            );
+
+        if (targetIndex >= reportDates.Count - 1)
+            return (
+                default,
+                default,
+                $"No prior quarter to compare against for {targetDate:yyyy-MM-dd}."
+            );
+
+        return (targetDate, reportDates[targetIndex + 1], null);
     }
 
     private async Task<string> RenderMarketActivityMovers(


### PR DESCRIPTION
## Summary

- Extract the date-resolution prologue (~21 lines) of `InstitutionalHoldingsTools.GetMarketWide13FActivity` (`GetAvailableReportDates` query + empty-data error + `TryParseReportDate`-or-latest target resolution + index-not-found error with first-5-dates hint + previousDate computation + no-prior-quarter error) into a `ResolveMarketActivityDates` async helper returning `(DateOnly Target, DateOnly Previous, string Error)`. Caller is `var (targetDate, previousDate, error) = await ResolveMarketActivityDates(reportDate); if (error != null) return error;`.
- Behavior preserved: helper performs the identical `GetAvailableReportDates().Distinct().OrderByDescending(d => d).ToListAsync()` query, the same `"No 13F holdings data available."` early-empty error, the same `TryParseReportDate(...) ? parsed : reportDates[0]` resolution, the same `targetIndex < 0` not-found error with the same first-5-date hint + ellipsis, the same `targetIndex >= reportDates.Count - 1` no-prior check, and returns the same `(targetDate, previousDate)` tuple — pure relocation. Caller no longer needs `previousDate.Value` since the helper returns a non-nullable.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — added `private async Task<(DateOnly Target, DateOnly Previous, string Error)> ResolveMarketActivityDates(string reportDate)`; `GetMarketWide13FActivity`'s lambda destructures its result and forwards the error string or branches into the existing movers/churn renderers.