### PR TITLE
fix(sec): gate IsRecentFtdFile year against DateOnly's >=1 requirement

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -355,6 +355,7 @@ public class FtdImportService
         if (
             fileName.Length >= 17
             && int.TryParse(fileName.AsSpan(8, 4), out var year)
+            && year is >= 1 and <= 9999
             && int.TryParse(fileName.AsSpan(12, 2), out var month)
             && month is >= 1 and <= 12
         )

--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceIsRecentFtdFileYearZeroTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceIsRecentFtdFileYearZeroTests.cs
@@ -14,7 +14,7 @@ public class FtdImportServiceIsRecentFtdFileYearZeroTests
     // zeros (a corrupted/zero-prefixed filename surfacing from SEC, a mirror, or
     // any caller that hands the helper an attacker-shaped or accidentally-empty
     // string) crashes the scrape cycle instead of being silently rejected.
-    [Fact(Skip = "GH-1350 — IsRecentFtdFile throws on year=0 instead of returning false")]
+    [Fact]
     public void IsRecentFtdFile_YearZero_ReturnsFalse()
     {
         var result = FtdImportService.IsRecentFtdFile("cnsfails000001a.zip");


### PR DESCRIPTION
## Summary

- Closes #1350. `IsRecentFtdFile`'s contract — return `false` for any malformed FTD filename, never throw — was violated when the YYYY slice parsed to `0`: the existing length + month-range gates passed and execution reached `new DateOnly(0, 1, 1)`, whose constructor requires `year >= 1` and threw `ArgumentOutOfRangeException`, aborting the scrape cycle on input the helper was meant to silently reject.
- Adds the missing `year is >= 1 and <= 9999` clause alongside the existing `month is >= 1 and <= 12` gate. Unskips the pre-existing regression test (`FtdImportServiceIsRecentFtdFileYearZeroTests`) added in the repro PR.

## Code changes

- `src/Equibles.Sec.HostedService/Services/FtdImportService.cs` — one extra clause in the validation chain inside `IsRecentFtdFile`: `&& year is >= 1 and <= 9999`. Pure gate; well-formed filenames are unaffected.
- `tests/Equibles.UnitTests/Sec/FtdImportServiceIsRecentFtdFileYearZeroTests.cs` — drops the `Skip = "GH-1350 …"` attribute so the regression test now runs.