### PR TITLE
test(holdings-mcp): pin RenderTopHoldersTable renders rows without NaN when totalSharesAll is 0

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableZeroDivisorTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableZeroDivisorTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class InstitutionalHoldingsToolsRenderTopHoldersTableZeroDivisorTests
+{
+    private static readonly MethodInfo RenderTopHoldersTableMethod =
+        typeof(InstitutionalHoldingsTools).GetMethod(
+            "RenderTopHoldersTable",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // RenderTopHoldersTable (extracted in #1561) computes per-row "% of Total"
+    // as shares / totalSharesAll. A holdings set composed entirely of option
+    // rows or other zero-share entries makes totalSharesAll == 0; without a
+    // divide-by-zero guard, double-arithmetic emits NaN and the format spec
+    // renders the literal "NaN" cell. The contract is that the table stays
+    // numeric — a refactor that dropped the `totalSharesAll > 0` guard would
+    // ship "NaN%" cells to the LLM consumer.
+    [Fact]
+    public void RenderTopHoldersTable_TotalSharesAllZero_RowsRenderWithoutNaN()
+    {
+        var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
+        var holder = new InstitutionalHolder { Name = "Test Fund" };
+        var holdings = new List<InstitutionalHolding>
+        {
+            new()
+            {
+                InstitutionalHolder = holder,
+                Shares = 0,
+                Value = 0,
+            },
+        };
+
+        var rendered = (string)
+            RenderTopHoldersTableMethod.Invoke(
+                null,
+                [stock, "AAPL", new DateOnly(2024, 9, 30), 1, 0L, 0L, holdings]
+            );
+
+        rendered.Should().NotContain("NaN");
+    }
+}


### PR DESCRIPTION
## Summary

- `RenderTopHoldersTable` (extracted in #1561) computes per-row "% of Total" as `(double)h.Shares / totalSharesAll * 100`. A holdings set composed entirely of zero-share rows (e.g. all-option positions) makes `totalSharesAll == 0`; without the `totalSharesAll > 0` guard, double-arithmetic emits NaN and the `:F2` format renders the literal "NaN" cell.
- Pins the divide-by-zero guard via reflection. A refactor that dropped the guard would ship "NaN%" cells to the LLM consumer for every all-option fund.

## Code changes

- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableZeroDivisorTests.cs` — one `[Fact]` invoking the private static `RenderTopHoldersTable` with `totalSharesAll = 0L` and a single zero-share holding, asserting the rendered output does NOT contain `"NaN"`.