### PR TITLE
refactor(holdings-mcp): extract ResolveCommonReportDate helper from GetFundOverlap

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -971,21 +971,9 @@ public class InstitutionalHoldingsTools
                 if (holder2 == null)
                     return $"No institution found matching '{institutionName2}'.";
 
-                var dates1 = await _holdingRepository
-                    .GetHistoryByHolder(holder1)
-                    .Select(h => h.ReportDate)
-                    .Distinct()
-                    .ToListAsync();
-                var dates2 = await _holdingRepository
-                    .GetHistoryByHolder(holder2)
-                    .Select(h => h.ReportDate)
-                    .Distinct()
-                    .ToListAsync();
-                var common = dates1.Intersect(dates2).OrderByDescending(d => d).ToList();
-                if (common.Count == 0)
-                    return $"{holder1.Name} and {holder2.Name} share no common report dates.";
-
-                var selected = ResolveReportDate(reportDate, common);
+                var (selected, error) = await ResolveCommonReportDate(holder1, holder2, reportDate);
+                if (error != null)
+                    return error;
 
                 var holdings1 = await LoadHoldingsByHolderWithStock(holder1, selected);
                 var holdings2 = await LoadHoldingsByHolderWithStock(holder2, selected);
@@ -1002,6 +990,29 @@ public class InstitutionalHoldingsTools
             "GetFundOverlap",
             $"funds: {institutionName1}, {institutionName2}"
         );
+    }
+
+    private async Task<(DateOnly Selected, string Error)> ResolveCommonReportDate(
+        InstitutionalHolder holder1,
+        InstitutionalHolder holder2,
+        string reportDate
+    )
+    {
+        var dates1 = await _holdingRepository
+            .GetHistoryByHolder(holder1)
+            .Select(h => h.ReportDate)
+            .Distinct()
+            .ToListAsync();
+        var dates2 = await _holdingRepository
+            .GetHistoryByHolder(holder2)
+            .Select(h => h.ReportDate)
+            .Distinct()
+            .ToListAsync();
+        var common = dates1.Intersect(dates2).OrderByDescending(d => d).ToList();
+        if (common.Count == 0)
+            return (default, $"{holder1.Name} and {holder2.Name} share no common report dates.");
+
+        return (ResolveReportDate(reportDate, common), null);
     }
 
     private static string RenderOverlapTable(


### PR DESCRIPTION
## Summary

- Extract the common-report-date resolution (`GetHistoryByHolder` × 2 + `Intersect`/`OrderByDescending` + empty-intersection error + `ResolveReportDate` selection, ~14 lines) from `InstitutionalHoldingsTools.GetFundOverlap` into a `ResolveCommonReportDate(holder1, holder2, reportDate)` helper returning `(DateOnly Selected, string Error)`.
- Behavior preserved: helper performs the same two `_holdingRepository.GetHistoryByHolder(...).Select(h => h.ReportDate).Distinct().ToListAsync()` queries in the same order, the same `dates1.Intersect(dates2).OrderByDescending(d => d).ToList()` combination, the same `$"{holder1.Name} and {holder2.Name} share no common report dates."` error string on empty, and the same `ResolveReportDate(reportDate, common)` selection; pure relocation.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — added `private async Task<(DateOnly Selected, string Error)> ResolveCommonReportDate(InstitutionalHolder holder1, InstitutionalHolder holder2, string reportDate)`; `GetFundOverlap`'s lambda destructures its result and forwards the error string.