### PR TITLE
test(sec): add skipped repro for GH-1596 — ParseLine non-numeric Price

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceParseLineNonNumericPriceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceParseLineNonNumericPriceTests.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Equibles.Sec.HostedService.Models;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FtdImportServiceParseLineNonNumericPriceTests
+{
+    // Same strict-null-on-malformed precedent as GH-1350 (IsRecentFtdFile) and
+    // GH-1438 (ParseLine non-numeric Quantity). PRICE is the sixth pipe-delimited
+    // field; a non-numeric value cannot be a real FTD price. The parser must
+    // reject the line, not fabricate Price = 0 — because Price = 0 is itself a
+    // meaningful and observable value (delisted / no-bid securities), and
+    // silently coercing "unparseable" into 0 corrupts downstream price-weighted
+    // FTD aggregates with a value distinct from "we couldn't parse this row".
+    [Fact(Skip = "GH-1596 — ParseLine emits record with Price=0 for non-numeric price")]
+    public void ParseLine_NonNumericPrice_ReturnsNull()
+    {
+        var method = typeof(FtdImportService).GetMethod(
+            "ParseLine",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var line = "20240315|037833100|AAPL|12345|APPLE INC.|notanumber";
+
+        var result = (FtdRecord)method.Invoke(null, [line]);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the strict-null-on-malformed contract for `FtdImportService.ParseLine`'s `PRICE` field — the parser does `decimal.TryParse(parts[5], InvariantCulture, out price)` and discards the return value, silently emitting `Price = 0M` on parse failure. `0M` is itself a meaningful price (delisted / no-bid securities), so the silent coercion corrupts any price-weighted FTD aggregate by conflating "we couldn't parse this row" with a legitimate zero. Same root-cause anti-pattern as GH-1438 (non-numeric `QUANTITY`); same strict-null-on-malformed precedent as GH-1350 (`IsRecentFtdFile`).
- Ships as `[Fact(Skip = "GH-1596 — ...")]` per the repro-first convention — see GH-1596. The skip drops as part of the fix PR.

## Code changes

- `tests/Equibles.UnitTests/Sec/FtdImportServiceParseLineNonNumericPriceTests.cs` — new `[Fact(Skip = "GH-1596 — ...")]`. Reflects into the `internal static FtdRecord ParseLine(string)` and asserts that `ParseLine("20240315|037833100|AAPL|12345|APPLE INC.|notanumber")` returns `null`. Today the assertion fails because the parser emits an `FtdRecord` with `Price = 0M` instead — skipped — see GH-1596.