### PR TITLE
refactor(web): lowercase the literal segments of attribute route templates

### DIFF
--- a/src/Equibles.Web/Controllers/CftcController.cs
+++ b/src/Equibles.Web/Controllers/CftcController.cs
@@ -24,7 +24,7 @@ public class CftcController : BaseController
         _reportRepository = reportRepository;
     }
 
-    [HttpGet("~/Futures")]
+    [HttpGet("~/futures")]
     public async Task<IActionResult> Index()
     {
         var allContracts = await _contractRepository
@@ -62,7 +62,7 @@ public class CftcController : BaseController
         return View(new CftcIndexViewModel { Categories = categories });
     }
 
-    [HttpGet("~/Futures/{marketCode}")]
+    [HttpGet("~/futures/{marketCode}")]
     public async Task<IActionResult> Show(string marketCode)
     {
         if (string.IsNullOrWhiteSpace(marketCode))

--- a/src/Equibles.Web/Controllers/EconomicDataController.cs
+++ b/src/Equibles.Web/Controllers/EconomicDataController.cs
@@ -65,7 +65,7 @@ public class EconomicDataController : BaseController
         return View(new EconomyIndexViewModel { Categories = categories });
     }
 
-    [HttpGet("~/EconomicData/{seriesId}")]
+    [HttpGet("~/economicdata/{seriesId}")]
     public async Task<IActionResult> Show(string seriesId)
     {
         if (string.IsNullOrWhiteSpace(seriesId))

--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -23,7 +23,7 @@ public class HoldingsActivityController : BaseController
         _commonStockRepository = commonStockRepository;
     }
 
-    [HttpGet("~/Holdings/Activity")]
+    [HttpGet("~/holdings/activity")]
     public async Task<IActionResult> Activity(DateOnly? date)
     {
         var reportDates = await _holdingRepository

--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -27,7 +27,7 @@ public class HoldingsExportController : BaseController
         _holderRepository = holderRepository;
     }
 
-    [HttpGet("~/Holdings/Export/Holders")]
+    [HttpGet("~/holdings/export/holders")]
     public async Task<IActionResult> Holders(string ticker, DateOnly? date)
     {
         if (string.IsNullOrWhiteSpace(ticker))
@@ -98,7 +98,7 @@ public class HoldingsExportController : BaseController
         return CsvFile(csv, $"{stock.Ticker}-13F-{selectedDate:yyyy-MM-dd}.csv");
     }
 
-    [HttpGet("~/Holdings/Export/Institution")]
+    [HttpGet("~/holdings/export/institution")]
     public async Task<IActionResult> Institution(string cik, DateOnly? date)
     {
         if (string.IsNullOrWhiteSpace(cik))
@@ -169,7 +169,7 @@ public class HoldingsExportController : BaseController
         return CsvFile(csv, $"{Sanitize(holder.Cik)}-portfolio-{selectedDate:yyyy-MM-dd}.csv");
     }
 
-    [HttpGet("~/Holdings/Export/Activity")]
+    [HttpGet("~/holdings/export/activity")]
     public async Task<IActionResult> Activity(DateOnly? date)
     {
         var reportDates = await _holdingRepository

--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -29,7 +29,7 @@ public class HoldingsScreenerController : BaseController
         _industryRepository = industryRepository;
     }
 
-    [HttpGet("~/Holdings/Screener")]
+    [HttpGet("~/holdings/screener")]
     public async Task<IActionResult> Screener(
         [FromQuery] ScreenerCriteriaViewModel filters = null,
         [FromQuery(Name = "date")] DateOnly? date = null,
@@ -97,7 +97,7 @@ public class HoldingsScreenerController : BaseController
         return View(viewModel);
     }
 
-    [HttpGet("~/Holdings/Screener/Export.csv")]
+    [HttpGet("~/holdings/screener/export.csv")]
     public async Task<IActionResult> ExportCsv(
         [FromQuery] ScreenerCriteriaViewModel filters = null,
         [FromQuery(Name = "date")] DateOnly? date = null,

--- a/src/Equibles.Web/Controllers/HomeController.cs
+++ b/src/Equibles.Web/Controllers/HomeController.cs
@@ -13,7 +13,7 @@ public class HomeController : BaseController
         _configuration = configuration;
     }
 
-    [HttpGet("/Home/Error/{statusCode?}")]
+    [HttpGet("/home/error/{statusCode?}")]
     public IActionResult Error(int? statusCode = null)
     {
         var code = statusCode ?? 500;

--- a/src/Equibles.Web/Controllers/MarketController.cs
+++ b/src/Equibles.Web/Controllers/MarketController.cs
@@ -26,7 +26,7 @@ public class MarketController : BaseController
         _vixRepository = vixRepository;
     }
 
-    [HttpGet("~/Market")]
+    [HttpGet("~/market")]
     public async Task<IActionResult> Index()
     {
         var latestRatios = await _putCallRepository.GetLatestPerType().ToListAsync();
@@ -73,7 +73,7 @@ public class MarketController : BaseController
         );
     }
 
-    [HttpGet("~/Market/PutCallRatio/{type}")]
+    [HttpGet("~/market/putcallratio/{type}")]
     public async Task<IActionResult> PutCallRatio(string type)
     {
         // Enum.TryParse accepts any numeric string in range (e.g. "999" -> an
@@ -128,7 +128,7 @@ public class MarketController : BaseController
         return View(viewModel);
     }
 
-    [HttpGet("~/Market/Vix")]
+    [HttpGet("~/market/vix")]
     public async Task<IActionResult> Vix()
     {
         var records = await _vixRepository

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -47,7 +47,7 @@ public class ProfilesController : BaseController
         _holdingsBacktestService = holdingsBacktestService;
     }
 
-    [HttpGet("~/Institutions/{cik}")]
+    [HttpGet("~/institutions/{cik}")]
     public async Task<IActionResult> Institution(string cik, DateOnly? activityDate = null)
     {
         var holder = await _institutionalHolderRepository.GetByCik(cik);
@@ -101,7 +101,7 @@ public class ProfilesController : BaseController
         );
     }
 
-    [HttpGet("~/Institutions/{cik}/Backtest")]
+    [HttpGet("~/institutions/{cik}/backtest")]
     public async Task<IActionResult> BacktestInstitution(
         string cik,
         [FromQuery(Name = "from")] DateOnly? from = null,
@@ -211,7 +211,7 @@ public class ProfilesController : BaseController
         return (summary, allocation);
     }
 
-    [HttpGet("~/Institutions/Compare")]
+    [HttpGet("~/institutions/compare")]
     public async Task<IActionResult> CompareInstitutions(
         [FromQuery(Name = "ciks")] string[] ciks = null,
         [FromQuery(Name = "date")] DateOnly? date = null
@@ -246,7 +246,7 @@ public class ProfilesController : BaseController
         return View(viewModel);
     }
 
-    [HttpGet("~/Institutions/Combined")]
+    [HttpGet("~/institutions/combined")]
     public async Task<IActionResult> CombinedInstitutions(
         [FromQuery(Name = "ciks")] string[] ciks = null,
         [FromQuery(Name = "date")] DateOnly? date = null
@@ -296,7 +296,7 @@ public class ProfilesController : BaseController
         return View(viewModel);
     }
 
-    [HttpGet("~/Insiders/{ownerCik}")]
+    [HttpGet("~/insiders/{ownerCik}")]
     public async Task<IActionResult> Insider(string ownerCik)
     {
         var owner = await _insiderOwnerRepository.GetByOwnerCik(ownerCik);
@@ -334,7 +334,7 @@ public class ProfilesController : BaseController
         );
     }
 
-    [HttpGet("~/Congress/{id:guid}")]
+    [HttpGet("~/congress/{id:guid}")]
     public async Task<IActionResult> Member(Guid id)
     {
         var member = await _congressMemberRepository.Get(id);

--- a/src/Equibles.Web/Controllers/StatusController.cs
+++ b/src/Equibles.Web/Controllers/StatusController.cs
@@ -88,7 +88,7 @@ public class StatusController : BaseController
         return View(error);
     }
 
-    [HttpPost("{id:guid}/MarkAsSeen")]
+    [HttpPost("{id:guid}/markasseen")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> MarkAsSeen(Guid id)
     {
@@ -102,7 +102,7 @@ public class StatusController : BaseController
         return RedirectToAction(nameof(Show), new { id });
     }
 
-    [HttpPost("{id:guid}/Delete")]
+    [HttpPost("{id:guid}/delete")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Delete(Guid id)
     {
@@ -162,14 +162,14 @@ public class StatusController : BaseController
         );
     }
 
-    [HttpGet("~/Status/Activity")]
+    [HttpGet("~/status/activity")]
     public IActionResult Activity()
     {
         ViewData["Title"] = "Live activity";
         return View();
     }
 
-    [HttpGet("~/Status/Activity/Stream")]
+    [HttpGet("~/status/activity/stream")]
     public async Task ActivityStream(CancellationToken cancellationToken)
     {
         InitSseStream();
@@ -218,7 +218,7 @@ public class StatusController : BaseController
             }
         );
 
-    [HttpPost("DeleteAll")]
+    [HttpPost("deleteall")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteAll()
     {

--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -101,17 +101,17 @@ public class StocksController : BaseController
     }
 
     // Default stock page — redirects to Price tab
-    [HttpGet("~/Stocks/{ticker}")]
+    [HttpGet("~/stocks/{ticker}")]
     public IActionResult Show(string ticker)
     {
         return RedirectToAction(nameof(Price), new { ticker });
     }
 
-    [HttpGet("~/Stocks/{ticker}/Price")]
+    [HttpGet("~/stocks/{ticker}/price")]
     public Task<IActionResult> Price(string ticker) =>
         ShowStockTab(ticker, "price", async s => await _stockTabService.LoadPriceTab(s));
 
-    [HttpGet("~/Stocks/{ticker}/Holdings")]
+    [HttpGet("~/stocks/{ticker}/holdings")]
     public Task<IActionResult> Holdings(string ticker, DateOnly? date) =>
         ShowStockTab(
             ticker,
@@ -119,7 +119,7 @@ public class StocksController : BaseController
             async s => await _stockTabService.LoadHoldingsTab(s, date)
         );
 
-    [HttpGet("~/Stocks/{ticker}/ShortVolume")]
+    [HttpGet("~/stocks/{ticker}/shortvolume")]
     public Task<IActionResult> ShortVolume(string ticker) =>
         ShowStockTab(
             ticker,
@@ -127,7 +127,7 @@ public class StocksController : BaseController
             async s => await _stockTabService.LoadShortVolumeTab(s)
         );
 
-    [HttpGet("~/Stocks/{ticker}/ShortInterest")]
+    [HttpGet("~/stocks/{ticker}/shortinterest")]
     public Task<IActionResult> ShortInterest(string ticker) =>
         ShowStockTab(
             ticker,
@@ -135,11 +135,11 @@ public class StocksController : BaseController
             async s => await _stockTabService.LoadShortInterestTab(s)
         );
 
-    [HttpGet("~/Stocks/{ticker}/Ftd")]
+    [HttpGet("~/stocks/{ticker}/ftd")]
     public Task<IActionResult> Ftd(string ticker) =>
         ShowStockTab(ticker, "ftd", async s => await _stockTabService.LoadFtdTab(s));
 
-    [HttpGet("~/Stocks/{ticker}/Financials")]
+    [HttpGet("~/stocks/{ticker}/financials")]
     public Task<IActionResult> Financials(
         string ticker,
         FinancialStatementType statement = FinancialStatementType.IncomeStatement,
@@ -152,11 +152,11 @@ public class StocksController : BaseController
             async s => await _stockTabService.LoadFinancialsTab(s, statement, year, period)
         );
 
-    [HttpGet("~/Stocks/{ticker}/Documents")]
+    [HttpGet("~/stocks/{ticker}/documents")]
     public Task<IActionResult> Documents(string ticker) =>
         ShowStockTab(ticker, "documents", async s => await _stockTabService.LoadDocumentsTab(s));
 
-    [HttpGet("~/Stocks/{ticker}/InsiderTrading")]
+    [HttpGet("~/stocks/{ticker}/insidertrading")]
     public Task<IActionResult> InsiderTrading(string ticker) =>
         ShowStockTab(
             ticker,
@@ -164,7 +164,7 @@ public class StocksController : BaseController
             async s => await _stockTabService.LoadInsiderTradingTab(s)
         );
 
-    [HttpGet("~/Stocks/{ticker}/CongressionalTrades")]
+    [HttpGet("~/stocks/{ticker}/congressionaltrades")]
     public Task<IActionResult> CongressionalTrades(string ticker) =>
         ShowStockTab(
             ticker,
@@ -206,7 +206,7 @@ public class StocksController : BaseController
         return viewModel;
     }
 
-    [HttpGet("~/Stocks/{ticker}/Documents/{id:guid}")]
+    [HttpGet("~/stocks/{ticker}/documents/{id:guid}")]
     public async Task<IActionResult> ShowDocument(string ticker, Guid id)
     {
         var document = await _documentRepository.GetWithContent(id);
@@ -234,7 +234,7 @@ public class StocksController : BaseController
         return View(viewModel);
     }
 
-    [HttpGet("~/Stocks/{ticker}/Holders/{cik}")]
+    [HttpGet("~/stocks/{ticker}/holders/{cik}")]
     public async Task<IActionResult> ShowHolder(string ticker, string cik)
     {
         var stock = await _commonStockRepository.GetByTicker(ticker.ToUpper());


### PR DESCRIPTION
## Summary

- \`RouteOptions.LowercaseUrls = true\` is set in \`Program.cs\`, so every rendered URL is already lowercase regardless of attribute case. Aligning the attribute templates with that convention makes the source match what users see in the address bar and what \`asp-action\` / \`Url.Action\` emits.
- No behavior change: ASP.NET routing matches case-insensitively.

## Code changes

- 10 controllers in \`src/Equibles.Web/Controllers/\` — lowercase the literal path segments in \`[HttpGet("~/...")]\` / \`[HttpPost("...")]\` / \`[HttpGet("/...")]\` attributes.
- Placeholder names inside \`{}\` are left untouched (\`{seriesId}\`, \`{marketCode}\`, \`{id:guid}\`, etc.) so the bind from template token to action parameter stays exact.