### PR TITLE
fix(sec): reject FTD lines with non-numeric quantity

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -299,7 +299,9 @@ public class FtdImportService
             return null;
         }
 
-        long.TryParse(parts[3], out var quantity);
+        if (!long.TryParse(parts[3], out var quantity))
+            return null;
+
         if (!decimal.TryParse(parts[5], CultureInfo.InvariantCulture, out var price))
             return null;
 

--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceParseLineNonNumericQuantityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceParseLineNonNumericQuantityTests.cs
@@ -15,7 +15,7 @@ public class FtdImportServiceParseLineNonNumericQuantityTests
     // Quantity = 0 record (which silently corrupts downstream FTD aggregates
     // — zero failed-to-deliver shares is itself a meaningful and distinct
     // value from "we couldn't parse this row").
-    [Fact(Skip = "GH-1438 — ParseLine emits record with Quantity=0 for non-numeric quantity")]
+    [Fact]
     public void ParseLine_NonNumericQuantity_ReturnsNull()
     {
         var method = typeof(FtdImportService).GetMethod(


### PR DESCRIPTION
## Summary

- Closes #1438. `FtdImportService.ParseLine` discarded `long.TryParse(parts[3], out var quantity)`'s return value, letting the `out` default leak through as `Quantity = 0` on any non-numeric `QUANTITY (FAILS)` token. Because `Quantity = 0` is itself a meaningful, observable value (a legitimate zero failed-to-deliver count), this silently corrupted downstream FTD aggregates by conflating "we couldn't parse this row" with a real zero. Same strict-null-on-malformed precedent as GH-1350 (`IsRecentFtdFile` year-zero gate).
- Adds the one-line gate `if (!long.TryParse(parts[3], out var quantity)) return null;`, mirroring the existing `SETTLEMENT DATE` reject path. Unskips the pre-existing regression test `FtdImportServiceParseLineNonNumericQuantityTests` shipped in the repro PR.
- Scope is exactly the `QUANTITY` field. The sibling defect on `PRICE` (`decimal.TryParse` with discarded return) is intentionally left for #1596 — that issue carries its own pinned skipped repro test.

## Code changes

- `src/Equibles.Sec.HostedService/Services/FtdImportService.cs` — added the `if (!long.TryParse(parts[3], out var quantity)) return null;` gate in `ParseLine`, immediately before the existing decimal price parse. Pure addition; well-formed lines are unaffected, malformed quantity lines now return `null`.
- `tests/Equibles.UnitTests/Sec/FtdImportServiceParseLineNonNumericQuantityTests.cs` — dropped the `Skip = "GH-1438 …"` attribute so the regression test now runs and locks the behavior.