### PR TITLE
refactor(finra-shortvolume): extract ImportSingleDay helper from Import loop

### DIFF
--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -81,59 +81,58 @@ public class ShortVolumeImportService
                 continue;
             }
 
-            try
-            {
-                var records = await _finraClient.GetDailyShortVolume(currentDate);
-
-                if (records.Count == 0)
-                {
-                    _logger.LogDebug("No short volume data for {Date}, skipping", currentDate);
-                    currentDate = currentDate.AddDays(1);
-                    continue;
-                }
-
-                var aggregated = AggregateVolumesByStock(records, tickerMap, currentDate);
-
-                var totalInserted = await BatchPersister.Persist(
-                    aggregated.Values,
-                    InsertBatchSize,
-                    async batch =>
-                    {
-                        using var scope = _scopeFactory.CreateScope();
-                        var repo =
-                            scope.ServiceProvider.GetRequiredService<DailyShortVolumeRepository>();
-                        repo.AddRange(batch);
-                        await repo.SaveChanges();
-                    }
-                );
-
-                _logger.LogInformation(
-                    "Imported {Count} short volume records for {Date}",
-                    totalInserted,
-                    currentDate
-                );
-            }
-            catch (HttpRequestException ex)
-            {
-                _logger.LogWarning(
-                    ex,
-                    "Failed to fetch short volume for {Date}, skipping",
-                    currentDate
-                );
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error importing short volume for {Date}", currentDate);
-                await _errorReporter.Report(
-                    ErrorSource.FinraScraper,
-                    "ShortVolume.ImportDate",
-                    ex.Message,
-                    ex.StackTrace,
-                    $"date: {currentDate}"
-                );
-            }
-
+            await ImportSingleDay(currentDate, tickerMap);
             currentDate = currentDate.AddDays(1);
+        }
+    }
+
+    private async Task ImportSingleDay(DateOnly date, IReadOnlyDictionary<string, Guid> tickerMap)
+    {
+        try
+        {
+            var records = await _finraClient.GetDailyShortVolume(date);
+
+            if (records.Count == 0)
+            {
+                _logger.LogDebug("No short volume data for {Date}, skipping", date);
+                return;
+            }
+
+            var aggregated = AggregateVolumesByStock(records, tickerMap, date);
+
+            var totalInserted = await BatchPersister.Persist(
+                aggregated.Values,
+                InsertBatchSize,
+                async batch =>
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var repo =
+                        scope.ServiceProvider.GetRequiredService<DailyShortVolumeRepository>();
+                    repo.AddRange(batch);
+                    await repo.SaveChanges();
+                }
+            );
+
+            _logger.LogInformation(
+                "Imported {Count} short volume records for {Date}",
+                totalInserted,
+                date
+            );
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch short volume for {Date}, skipping", date);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error importing short volume for {Date}", date);
+            await _errorReporter.Report(
+                ErrorSource.FinraScraper,
+                "ShortVolume.ImportDate",
+                ex.Message,
+                ex.StackTrace,
+                $"date: {date}"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- `ShortVolumeImportService.Import` mixed two distinct concerns inside one method: walking the date window (including weekend-skip) and the per-day fetch / aggregate / persist / try-catch body. Extract the per-day body into a private `ImportSingleDay(date, tickerMap)` so the outer loop reads as "for each weekday in the window, import its volumes".
- Pure refactor — helper keeps the same try / catch shape and log / report sequence; the empty-records "skip" becomes `return` from the helper, and the outer `currentDate.AddDays(1)` still fires after the helper returns (same net day-increment as the inline `continue` which also added 1 before continuing).

## Code changes

- `src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs` — extracted `ImportSingleDay(DateOnly date, IReadOnlyDictionary<string, Guid> tickerMap)` as a private helper; `Import` now calls it from the day-loop body.