### PR TITLE
fix(web): stop home-page title from duplicating the Equibles brand

### DIFF
--- a/src/Equibles.Web/Views/Home/Index.cshtml
+++ b/src/Equibles.Web/Views/Home/Index.cshtml
@@ -1,5 +1,5 @@
 @{
-    ViewData["Title"] = "Equibles — Open-Source Financial Data Platform";
+    ViewData["Title"] = "Open-source financial data platform";
 }
 
 <div class="max-w-4xl mx-auto px-6 py-16 text-center">

--- a/tests/Equibles.IntegrationTests/Web/HomeViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HomeViewRenderingTests.cs
@@ -31,6 +31,26 @@ public class HomeViewRenderingTests
     }
 
     [Fact]
+    public async Task GetIndex_TitleTagDoesNotDuplicateTheEquiblesBrand()
+    {
+        // _Head.cshtml appends " - Equibles" to ViewData["Title"]. If the view
+        // sets a Title that already starts with "Equibles", the rendered
+        // <title> doubles the brand — that's bad for OG / Twitter previews
+        // (they share the same value). Pin the contract: brand appears once.
+        var response = await _fixture.Client.GetAsync("/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        var match = System.Text.RegularExpressions.Regex.Match(html, "<title[^>]*>([^<]*)</title>");
+        match.Success.Should().BeTrue("the page must render a <title>");
+        var titleText = match.Groups[1].Value;
+        System
+            .Text.RegularExpressions.Regex.Matches(titleText, "Equibles")
+            .Count.Should()
+            .Be(1, $"brand should appear exactly once in <title>, got: {titleText!}");
+    }
+
+    [Fact]
     public async Task GetConnect_RendersConnectViewWithMcpUrl()
     {
         var response = await _fixture.Client.GetAsync("/Home/Connect");


### PR DESCRIPTION
## Summary

- Found while sweeping the app post-#1162. \`_Head.cshtml\` already appends \` - Equibles\` to whatever \`ViewData[\"Title\"]\` is set to, but \`Home/Index.cshtml\` was setting Title to a string that already started with \"Equibles\". The rendered \`<title>\` ended up as \`Equibles — Open-Source Financial Data Platform - Equibles\`. Same value flows into the OpenGraph and Twitter card meta tags, so social previews showed the brand twice too.

## Code changes

- \`src/Equibles.Web/Views/Home/Index.cshtml\` — set \`ViewData[\"Title\"]\` to \`Open-source financial data platform\` so the layout's brand suffix carries the brand exactly once.