### PR TITLE
test(holdings-mcp): pin AppendActivitySection emits rank/Ticker/Name in that column order

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsAppendActivitySectionRowColumnOrderTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsAppendActivitySectionRowColumnOrderTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using System.Text;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class InstitutionalHoldingsToolsAppendActivitySectionRowColumnOrderTests
+{
+    private static readonly MethodInfo AppendActivitySectionMethod =
+        typeof(InstitutionalHoldingsTools).GetMethod(
+            "AppendActivitySection",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // AppendActivitySection (extracted in #1542) emits a row in the order
+    // "| {rank} | {Ticker} | {Name} | {Prior} | {New} | {Δ Shares} | {Δ Value} |"
+    // — the same column sequence its header line declares. The LLM consumer
+    // reads the header to bind columns by position; a refactor that swapped
+    // the Ticker/Name order in the row template without updating the header
+    // (or vice versa) would silently misattribute every stock's data to the
+    // wrong field. Pin both the rank-as-first-cell and the
+    // Ticker-before-Name ordering on a single-row input.
+    [Fact]
+    public void AppendActivitySection_SingleRow_EmitsRankThenTickerThenNameInOrder()
+    {
+        var result = new StringBuilder();
+        var rows = new List<StockPositionChange>
+        {
+            new()
+            {
+                Ticker = "TICK",
+                Name = "NAME",
+                CurrentShares = 0,
+                PreviousShares = 0,
+                CurrentValue = 0,
+                PreviousValue = 0,
+            },
+        };
+
+        var returned = (bool)AppendActivitySectionMethod.Invoke(null, [result, "Initiated", rows]);
+
+        returned.Should().BeTrue();
+        result.ToString().Should().Contain("| 1 | TICK | NAME |");
+    }
+}


### PR DESCRIPTION
## Summary

- `AppendActivitySection` (extracted in #1542) emits each row as `"| {rank} | {Ticker} | {Name} | {Prior} | {New} | {Δ Shares} | {Δ Value} |"` — the same column sequence its header line declares. The LLM consumer reads the header to bind columns by position; a refactor that swapped the Ticker / Name order in the row template without updating the header (or vice versa) would silently misattribute every stock's data to the wrong field.
- Pins the rank-as-first-cell, Ticker-second, Name-third ordering via reflection on a single-row input. A refactor that broke any of those positions would change the substring this test asserts on.

## Code changes

- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsAppendActivitySectionRowColumnOrderTests.cs` — one `[Fact]` invoking the private static `AppendActivitySection` with a single `StockPositionChange` (Ticker="TICK", Name="NAME"), asserting the rendered StringBuilder contains the exact substring `"| 1 | TICK | NAME |"` and that the function reports the section as rendered (`true`).