### PR TITLE
fix(financial-facts): null-safe TryMapTaxonomy switch key

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -435,7 +435,7 @@ public class FinancialFactsImportService
 
     private static bool TryMapTaxonomy(string key, out FactTaxonomy taxonomy)
     {
-        switch (key.ToLowerInvariant())
+        switch (key?.ToLowerInvariant())
         {
             case "us-gaap":
                 taxonomy = FactTaxonomy.UsGaap;

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapTaxonomyNullKeyTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapTaxonomyNullKeyTests.cs
@@ -15,9 +15,7 @@ public class FinancialFactsImportServiceTryMapTaxonomyNullKeyTests
     // instead of falling to the default arm. The Try* contract says "never
     // throw on bad input — return false" — any future caller (refactor,
     // parameterised matrix, defensive caller) that hands in null would crash.
-    [Fact(
-        Skip = "GH-1577 — TryMapTaxonomy throws NullReferenceException on null key instead of returning false"
-    )]
+    [Fact]
     public void TryMapTaxonomy_NullKey_ReturnsFalseWithoutThrowing()
     {
         var method = typeof(FinancialFactsImportService).GetMethod(


### PR DESCRIPTION
## Summary

- Closes #1577. `FinancialFactsImportService.TryMapTaxonomy` called `key.ToLowerInvariant()` directly inside the switch expression, throwing `NullReferenceException` on a null key. This violates the `Try*` contract (never throw on bad input — signal failure via the `false` return) and is asymmetric with the sibling helper `TryMapFiscalPeriod` in the same file, which already uses `fp?.ToUpperInvariant()`.
- One-character fix: add the null-conditional `?.` so a null key short-circuits to the switch's `default` arm and returns `false` with `taxonomy = default(FactTaxonomy)`. Unskips the pre-existing regression test `FinancialFactsImportServiceTryMapTaxonomyNullKeyTests`.

## Code changes

- `src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs` — `switch (key.ToLowerInvariant())` → `switch (key?.ToLowerInvariant())` on the `TryMapTaxonomy` helper. Pure null-safety addition; non-null behavior is unchanged.
- `tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapTaxonomyNullKeyTests.cs` — dropped the `Skip = "GH-1577 …"` attribute so the regression test now runs and locks the contract.