### PR TITLE
fix(web): add accessible label to the Status alert badges

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Footer.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Footer.cshtml
@@ -15,7 +15,7 @@
                 <a asp-controller="Status" asp-action="Index" class="hover:text-base-content flex items-center gap-1">
                     Status
                     @if (ViewData["StatusBadgeCount"] is int footerBadge && footerBadge > 0) {
-                        <span class="badge badge-warning badge-xs">@footerBadge</span>
+                        <span class="badge badge-warning badge-xs" aria-label="@footerBadge status alerts">@footerBadge</span>
                     }
                 </a>
                 <a href="https://github.com/daniel3303/Equibles" target="_blank" rel="noopener" aria-label="Equibles on GitHub" title="GitHub" class="hover:text-base-content">

--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -27,7 +27,7 @@
                     <a asp-action="Index" asp-controller="Status" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors flex items-center gap-1">
                         Status
                         @if (ViewData["StatusBadgeCount"] is int badgeCount && badgeCount > 0) {
-                            <span class="badge badge-warning badge-xs">@badgeCount</span>
+                            <span class="badge badge-warning badge-xs" aria-label="@badgeCount status alerts">@badgeCount</span>
                         }
                     </a>
                 </nav>
@@ -107,7 +107,7 @@
                             <a asp-action="Index" asp-controller="Status" class="flex items-center gap-2">
                                 <icon name="signal" size="4" /> Status
                                 @if (ViewData["StatusBadgeCount"] is int mobileBadge && mobileBadge > 0) {
-                                    <span class="badge badge-warning badge-xs">@mobileBadge</span>
+                                    <span class="badge badge-warning badge-xs" aria-label="@mobileBadge status alerts">@mobileBadge</span>
                                 }
                             </a>
                         </li>


### PR DESCRIPTION
## Summary

- Found while sweeping the app post-#1162. The Status link's numeric alert badge (rendered in the navbar, mobile menu, and footer) was a bare DaisyUI badge with no \`aria-label\`, so screen readers announced it as just \"Status 155\" with no context for what 155 referred to.

## Code changes

- \`src/Equibles.Web/Views/Shared/_Layout.cshtml\` — set \`aria-label=\"<count> status alerts\"\` on the navbar and mobile-menu badges.
- \`src/Equibles.Web/Views/Shared/_Footer.cshtml\` — same on the footer badge.

The visual stays compact; assistive tech now reads the full meaning. Source of the count is \`StatusBadgeFilter\` (unseen errors + configuration warnings).