### PR TITLE
test(holdings): pin BuildFundAggregate sums Shares and Value across multiple discretion rows for same stock

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/FundOverlapCalculatorBuildFundAggregateMultiDiscretionSumTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundOverlapCalculatorBuildFundAggregateMultiDiscretionSumTests.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class FundOverlapCalculatorBuildFundAggregateMultiDiscretionSumTests
+{
+    // BuildFundAggregate (extracted in #1610) collapses multiple discretion
+    // rows for the same CommonStockId into one FundStockAggregate per
+    // doc-comment. The contract: Shares and Value across the rows MUST be
+    // summed, while Ticker/Name come from the first row's CommonStock
+    // navigation. A refactor that swapped g.Sum for g.First on Shares (or
+    // dropped the GroupBy entirely) would silently lose half a fund's
+    // position when a holder reports the same stock under two managers.
+    [Fact]
+    public void BuildFundAggregate_SameStockReportedTwiceUnderDifferentDiscretion_PerStockSumsSharesAndValue()
+    {
+        var stockId = Guid.NewGuid();
+        var stock = new CommonStock
+        {
+            Id = stockId,
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+        };
+        var holdings = new List<InstitutionalHolding>
+        {
+            new()
+            {
+                CommonStockId = stockId,
+                CommonStock = stock,
+                Shares = 100,
+                Value = 1_000,
+            },
+            new()
+            {
+                CommonStockId = stockId,
+                CommonStock = stock,
+                Shares = 200,
+                Value = 2_000,
+            },
+        };
+        var holder = new InstitutionalHolder { Name = "Test Fund" };
+        var fundType = typeof(FundOverlapCalculator);
+        var method = fundType.GetMethod(
+            "BuildFundAggregate",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        // The method takes a ValueTuple, build it via reflection on parameter type.
+        var paramType = method.GetParameters()[0].ParameterType;
+        var fund = Activator.CreateInstance(
+            paramType,
+            holder,
+            (IReadOnlyList<InstitutionalHolding>)holdings
+        );
+
+        var result = method.Invoke(null, [fund]);
+
+        var perStock = result.GetType().GetProperty("PerStock").GetValue(result);
+        // PerStock is Dictionary<Guid, FundStockAggregate>; index in via reflection.
+        var indexer = perStock.GetType().GetProperty("Item");
+        var aggregate = indexer.GetValue(perStock, [stockId]);
+        var shares = (long)aggregate.GetType().GetProperty("Shares").GetValue(aggregate);
+        var value = (long)aggregate.GetType().GetProperty("Value").GetValue(aggregate);
+
+        shares.Should().Be(300);
+        value.Should().Be(3_000);
+    }
+}


### PR DESCRIPTION
## Summary

- `BuildFundAggregate` (extracted in #1610) collapses multiple discretion rows for the same `CommonStockId` into one `FundStockAggregate` per the doc-comment. The contract: Shares and Value across the rows MUST be **summed**, while Ticker / Name come from the first row's CommonStock navigation.
- Pins the multi-discretion sum via reflection. A refactor that swapped `g.Sum` for `g.First` on Shares (or dropped the GroupBy entirely) would silently lose half a fund's position whenever a holder reports the same stock under two managers.

## Code changes

- `tests/Equibles.UnitTests/Holdings/FundOverlapCalculatorBuildFundAggregateMultiDiscretionSumTests.cs` — one `[Fact]` invoking the private static `BuildFundAggregate` with two holdings rows for the same stock (Shares 100/Value 1000 + Shares 200/Value 2000) and asserting `PerStock[stockId].Shares == 300` and `Value == 3000`. Uses reflection on the private nested `FundAggregate` / `FundStockAggregate` types.