### PR TITLE
refactor(holdings): extract ComputeQoQTurnoverPercent helper from InstitutionPortfolioSummaryCalculator.Calculate

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionPortfolioSummaryCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionPortfolioSummaryCalculator.cs
@@ -45,43 +45,55 @@ public static class InstitutionPortfolioSummaryCalculator
 
         if (previousQuarterHoldings.Count > 0 && summary.ReportedAum > 0)
         {
-            // Current-quarter price proxy = Value / Shares per stock. For each stock that
-            // appears in either quarter, |Δ shares × current price proxy| is the absolute
-            // dollar movement; the canonical turnover formula then divides by 2 × AUM.
-            var currentByStock = currentQuarterHoldings
-                .GroupBy(h => h.CommonStockId)
-                .ToDictionary(
-                    g => g.Key,
-                    g => new { Shares = g.Sum(h => h.Shares), Value = g.Sum(h => h.Value) }
-                );
-            var previousByStock = previousQuarterHoldings
-                .GroupBy(h => h.CommonStockId)
-                .ToDictionary(g => g.Key, g => g.Sum(h => h.Shares));
-
-            var allStockIds = currentByStock.Keys.Union(previousByStock.Keys);
-            decimal turnoverDollars = 0m;
-            foreach (var stockId in allStockIds)
-            {
-                currentByStock.TryGetValue(stockId, out var current);
-                previousByStock.TryGetValue(stockId, out var priorShares);
-                var currentShares = current?.Shares ?? 0;
-                var deltaShares = Math.Abs(currentShares - priorShares);
-                if (deltaShares == 0)
-                    continue;
-
-                // Per-share proxy from the current quarter; fall back to 0 when the
-                // stock was sold out (no current Value to derive a proxy from). The
-                // sold-out side of the turnover for that stock is unavoidably missed
-                // without a price-history dependency, accepting that limitation.
-                var perShare = current is { Shares: > 0 }
-                    ? (decimal)current.Value / current.Shares
-                    : 0m;
-                turnoverDollars += deltaShares * perShare;
-            }
-            summary.QoQTurnoverPercent =
-                (double)(turnoverDollars / (2m * summary.ReportedAum)) * 100.0;
+            summary.QoQTurnoverPercent = ComputeQoQTurnoverPercent(
+                currentQuarterHoldings,
+                previousQuarterHoldings,
+                summary.ReportedAum
+            );
         }
 
         return summary;
+    }
+
+    private static double ComputeQoQTurnoverPercent(
+        IReadOnlyList<InstitutionalHolding> currentQuarterHoldings,
+        IReadOnlyList<InstitutionalHolding> previousQuarterHoldings,
+        long reportedAum
+    )
+    {
+        // Current-quarter price proxy = Value / Shares per stock. For each stock that
+        // appears in either quarter, |Δ shares × current price proxy| is the absolute
+        // dollar movement; the canonical turnover formula then divides by 2 × AUM.
+        var currentByStock = currentQuarterHoldings
+            .GroupBy(h => h.CommonStockId)
+            .ToDictionary(
+                g => g.Key,
+                g => new { Shares = g.Sum(h => h.Shares), Value = g.Sum(h => h.Value) }
+            );
+        var previousByStock = previousQuarterHoldings
+            .GroupBy(h => h.CommonStockId)
+            .ToDictionary(g => g.Key, g => g.Sum(h => h.Shares));
+
+        var allStockIds = currentByStock.Keys.Union(previousByStock.Keys);
+        decimal turnoverDollars = 0m;
+        foreach (var stockId in allStockIds)
+        {
+            currentByStock.TryGetValue(stockId, out var current);
+            previousByStock.TryGetValue(stockId, out var priorShares);
+            var currentShares = current?.Shares ?? 0;
+            var deltaShares = Math.Abs(currentShares - priorShares);
+            if (deltaShares == 0)
+                continue;
+
+            // Per-share proxy from the current quarter; fall back to 0 when the
+            // stock was sold out (no current Value to derive a proxy from). The
+            // sold-out side of the turnover for that stock is unavoidably missed
+            // without a price-history dependency, accepting that limitation.
+            var perShare = current is { Shares: > 0 }
+                ? (decimal)current.Value / current.Shares
+                : 0m;
+            turnoverDollars += deltaShares * perShare;
+        }
+        return (double)(turnoverDollars / (2m * reportedAum)) * 100.0;
     }
 }


### PR DESCRIPTION
## Summary

- `InstitutionPortfolioSummaryCalculator.Calculate` produces four distinct metrics (`ReportedAum`, `PositionCount`, `Top10/Top25Concentration`, `QoQTurnover`). The turnover computation alone is 37 lines, dominating the method. Extract it into a named `ComputeQoQTurnoverPercent` helper so `Calculate` reads as a sequence of named summary-metric computations.
- Pure refactor — helper preserves the exact data flow: same per-stock GroupBy aggregations for both quarters, same union of stock ids, same `|deltaShares| × perShare` arithmetic with the same per-share-proxy fallback to 0 for sold-out positions, same `turnoverDollars / (2 × reportedAum) × 100.0` formula.

## Code changes

- `src/Equibles.Holdings.Repositories/InstitutionPortfolioSummaryCalculator.cs` — extracted private static `ComputeQoQTurnoverPercent(current, previous, reportedAum) → double`; `Calculate` now calls it inside the existing `if (previousQuarterHoldings.Count > 0 && summary.ReportedAum > 0)` guard.