### PR TITLE
fix(web): label the per-row View and Delete icon buttons on the Status page

### DIFF
--- a/src/Equibles.Web/Views/Status/Index.cshtml
+++ b/src/Equibles.Web/Views/Status/Index.cshtml
@@ -248,12 +248,12 @@
                                     <td class="whitespace-nowrap text-sm text-base-content/50">@error.CreationTime.ToString("yyyy-MM-dd HH:mm")</td>
                                     <td>
                                         <div class="flex items-center gap-1">
-                                            <a asp-action="Show" asp-route-id="@error.Id" class="btn btn-ghost btn-xs">
+                                            <a asp-action="Show" asp-route-id="@error.Id" class="btn btn-ghost btn-xs" aria-label="View error details" title="View">
                                                 <icon name="eye" size="4" />
                                             </a>
                                             <form asp-action="Delete" asp-route-id="@error.Id" class="form-confirm" data-message="Delete this error?">
                                                 @Html.AntiForgeryToken()
-                                                <button type="submit" class="btn btn-ghost btn-xs text-error">
+                                                <button type="submit" class="btn btn-ghost btn-xs text-error" aria-label="Delete this error" title="Delete">
                                                     <icon name="trash" size="4" />
                                                 </button>
                                             </form>


### PR DESCRIPTION
## Summary

- Each row in the Status page error table renders two icon-only controls — an eye link that opens the error detail, and a trash button inside a confirm form. Both lacked any accessible name, so screen readers announced them as generic \"link\" / \"button\" with no indication of what they do (WCAG 4.1.2 fail, repeated per error row).

## Code changes

- \`src/Equibles.Web/Views/Status/Index.cshtml\` — add \`aria-label=\"View error details\"\` + \`title=\"View\"\` to the eye link, and \`aria-label=\"Delete this error\"\` + \`title=\"Delete\"\` to the trash button. Visual unchanged.