### PR TITLE
feat(web): add skip-to-main-content link in the shared layout

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -10,6 +10,14 @@
     @await RenderSectionAsync("Styles", false)
 </head>
 <body class="bg-base-200 min-h-screen flex flex-col">
+    <!-- Skip link: first focusable element so keyboard users can jump past the
+         navbar into the page's main content (WCAG 2.4.1 Bypass Blocks). The
+         link is visually hidden by default and reveals itself on focus. -->
+    <a href="#main-content"
+       class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:rounded focus:bg-primary focus:text-primary-content focus:outline-2 focus:outline-primary-content">
+        Skip to main content
+    </a>
+
     <!-- Navbar -->
     <div class="navbar bg-base-100 border-b border-base-200 min-h-0 h-14 sticky top-0 z-40">
         <div class="max-w-6xl mx-auto w-full px-6 flex items-center">
@@ -120,7 +128,7 @@
     <partial name="_VersionBanner" />
 
     <!-- Main Content -->
-    <main class="flex-1 relative">
+    <main id="main-content" tabindex="-1" class="flex-1 relative">
         @body
     </main>
 


### PR DESCRIPTION
## Summary

- Keyboard and screen-reader users had to tab through every navbar link on every page before reaching the page's main content. WCAG 2.4.1 (Bypass Blocks) calls for a mechanism to skip repeated content; the cheapest and most universal is a visually-hidden skip link that becomes visible when focused.
- Found while sweeping the app post-#1162.

## Code changes

- \`src/Equibles.Web/Views/Shared/_Layout.cshtml\` — add a \"Skip to main content\" anchor as the first focusable element in the body. \`sr-only\` by default, \`focus:not-sr-only\` + fixed-position pill on focus. Targets \`#main-content\` which is the existing \`<main>\` element (now carrying \`id=\"main-content\"\` and \`tabindex=\"-1\"\` so the focus jump lands inside the region).