### PR TITLE
test(financial-facts): pin BuildFact returns null when concept missing

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceBuildFactMissingConceptTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceBuildFactMissingConceptTests.cs
@@ -1,0 +1,47 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactsImportServiceBuildFactMissingConceptTests
+{
+    // BuildFact's pre-pipeline fail-soft contract: if the (Taxonomy, Tag) of
+    // the parsed fact is not present in the resolved conceptIds dictionary the
+    // helper returns null instead of throwing, so the caller can quietly drop
+    // the orphan row. Concept resolution races a fresh DB (the FinancialConcept
+    // upsert and the subsequent fact insert use different scopes), so a missing
+    // entry is a real, transient possibility. A refactor that swapped TryGetValue
+    // for an indexer lookup would compile and start throwing KeyNotFoundException
+    // mid-import, aborting the entire batch instead of skipping the one row.
+    [Fact]
+    public void BuildFact_TaxonomyTagNotInConceptIds_ReturnsNull()
+    {
+        var serviceType = typeof(FinancialFactsImportService);
+        var parsedFactType = serviceType.GetNestedType("ParsedFact", BindingFlags.NonPublic);
+
+        var parsed = Activator.CreateInstance(parsedFactType);
+        parsedFactType.GetProperty("Taxonomy").SetValue(parsed, FactTaxonomy.UsGaap);
+        parsedFactType.GetProperty("Tag").SetValue(parsed, "UnknownTagNotInMap");
+        parsedFactType.GetProperty("Accession").SetValue(parsed, "0000320193-24-000123");
+        parsedFactType.GetProperty("Form").SetValue(parsed, "10-K");
+
+        var stock = new CommonStock { Id = Guid.NewGuid() };
+        var conceptIds = new Dictionary<(FactTaxonomy, string), Guid>
+        {
+            { (FactTaxonomy.UsGaap, "Revenues"), Guid.NewGuid() },
+        };
+        var documentIds = new Dictionary<string, Guid>();
+
+        var method = serviceType.GetMethod(
+            "BuildFact",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (FinancialFact)method.Invoke(null, [stock, parsed, conceptIds, documentIds]);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `FinancialFactsImportService.BuildFact`'s pre-pipeline fail-soft contract: if the `(Taxonomy, Tag)` of the parsed fact is not present in the resolved `conceptIds` dictionary, the helper returns `null` so the caller can quietly drop the orphan row.
- Concept resolution races a fresh DB — the `FinancialConcept` upsert and the subsequent fact insert run on different scopes — so a missing entry is a real, transient possibility. A refactor swapping `TryGetValue` for an indexer lookup would compile, ship a passing test suite, and start throwing `KeyNotFoundException` mid-import on the first such race, aborting the entire batch instead of dropping the one orphan row.
- Test reflects into the private `static FinancialFact BuildFact(CommonStock, ParsedFact, …)`, feeds a `ParsedFact` whose `(UsGaap, "UnknownTagNotInMap")` pair is intentionally absent from a one-entry `conceptIds` map, and asserts the result is `null` (no throw).

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceBuildFactMissingConceptTests.cs` — new `[Fact]` invoking the private static `BuildFact` via reflection, with a `ParsedFact` instantiated through the private nested `ParsedFact` type. Asserts the helper returns `null` (rather than throwing) when the parsed fact's `(Taxonomy, Tag)` is missing from the resolved `conceptIds` dictionary.