### PR TITLE
test(financial-facts): pin TryBuildParsedFact sets PeriodStart=End for instant facts

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactInstantPeriodStartTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactInstantPeriodStartTests.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Integrations.Sec.Models.Responses;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactsImportServiceTryBuildParsedFactInstantPeriodStartTests
+{
+    // Load-bearing contract spelled out on FinancialFact.PeriodStart: for
+    // instant facts (balance-sheet line items — Start = null on the wire), the
+    // parser must set PeriodStart EQUAL to PeriodEnd so the unique index
+    // (CommonStockId, FinancialConceptId, Unit, PeriodStart, PeriodEnd,
+    // AccessionNumber) stays NULL-free — Postgres treats NULLs as distinct in
+    // unique indexes, so a NULL PeriodStart would silently let restatements
+    // re-insert duplicate rows instead of upserting in place. A refactor
+    // dropping the `value.Start ?? value.End` fallback to just `value.Start`
+    // would compile, pass any duration-fact test, and break the entire
+    // restatement-collapse invariant on the next instant fact imported.
+    [Fact]
+    public void TryBuildParsedFact_InstantFact_PeriodStartEqualsPeriodEndAndPeriodTypeIsInstant()
+    {
+        var serviceType = typeof(FinancialFactsImportService);
+        var parsedFactType = serviceType.GetNestedType("ParsedFact", BindingFlags.NonPublic);
+
+        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "AAPL" };
+        var instantEnd = new DateOnly(2024, 12, 31);
+        var value = new CompanyFactValue
+        {
+            Start = null,
+            End = instantEnd,
+            Val = 100m,
+            Accn = "0000320193-24-000123",
+            Fy = 2024,
+            Fp = "FY",
+            Form = "10-K",
+            Filed = new DateOnly(2024, 11, 1),
+        };
+
+        var method = serviceType.GetMethod(
+            "TryBuildParsedFact",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var parsed = method.Invoke(
+            null,
+            [FactTaxonomy.UsGaap, "Assets", "Assets", "USD", value, stock]
+        );
+
+        parsed.Should().NotBeNull();
+        var periodType = (FactPeriodType)parsedFactType.GetProperty("PeriodType").GetValue(parsed);
+        var periodStart = (DateOnly)parsedFactType.GetProperty("PeriodStart").GetValue(parsed);
+        var periodEnd = (DateOnly)parsedFactType.GetProperty("PeriodEnd").GetValue(parsed);
+
+        periodType.Should().Be(FactPeriodType.Instant);
+        periodStart.Should().Be(instantEnd);
+        periodEnd.Should().Be(instantEnd);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the load-bearing invariant spelled out on `FinancialFact.PeriodStart`: for instant facts (balance-sheet items, where the wire payload has `start = null`), the parser must set `PeriodStart == PeriodEnd` so the unique index `(CommonStockId, FinancialConceptId, Unit, PeriodStart, PeriodEnd, AccessionNumber)` stays NULL-free. Postgres treats NULLs as distinct in unique indexes — a NULL `PeriodStart` would silently let restatements re-insert duplicate rows instead of upserting in place, quietly corrupting the deduplication invariant.
- The current code expresses this via `periodStart = value.Start ?? value.End`. A refactor dropping the fallback to just `value.Start` would compile, pass every duration-fact test, and break the entire restatement-collapse contract on the next instant fact imported.
- Test feeds a `CompanyFactValue { Start = null, End = 2024-12-31, … }` through `TryBuildParsedFact` and asserts `PeriodType = Instant`, `PeriodStart = 2024-12-31`, and `PeriodEnd = 2024-12-31`.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactInstantPeriodStartTests.cs` — new `[Fact]` invoking the private static `TryBuildParsedFact` via reflection with an instant-fact `CompanyFactValue`; reads the resulting private nested `ParsedFact` via reflection too, asserting `PeriodType = Instant` and `PeriodStart = PeriodEnd = wire End date`.