### PR TITLE
fix(web): label pagination links on the Stocks index for assistive tech

### DIFF
--- a/src/Equibles.Web/Views/Stocks/Index.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Index.cshtml
@@ -101,10 +101,11 @@
 
     <!-- Pagination -->
     @if (Model.TotalPages > 1) {
-        <div class="flex justify-center mt-6">
+        <nav class="flex justify-center mt-6" aria-label="Stocks pagination">
             <div class="join">
                 @if (Model.Page > 1) {
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page - 1)" class="join-item btn btn-sm">Previous</a>
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page - 1)"
+                       class="join-item btn btn-sm" aria-label="Go to previous page">Previous</a>
                 }
 
                 @{
@@ -113,29 +114,34 @@
                 }
 
                 @if (startPage > 1) {
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="1" class="join-item btn btn-sm">1</a>
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="1"
+                       class="join-item btn btn-sm" aria-label="Go to page 1">1</a>
                     @if (startPage > 2) {
-                        <span class="join-item btn btn-sm btn-disabled">...</span>
+                        <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
                     }
                 }
 
                 @for (var i = startPage; i <= endPage; i++) {
                     <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@i"
-                       class="join-item btn btn-sm @(i == Model.Page ? "btn-active" : "")">@i</a>
+                       class="join-item btn btn-sm @(i == Model.Page ? "btn-active" : "")"
+                       aria-label="Go to page @i"
+                       aria-current="@(i == Model.Page ? "page" : null)">@i</a>
                 }
 
                 @if (endPage < Model.TotalPages) {
                     @if (endPage < Model.TotalPages - 1) {
-                        <span class="join-item btn btn-sm btn-disabled">...</span>
+                        <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
                     }
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@Model.TotalPages" class="join-item btn btn-sm">@Model.TotalPages</a>
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@Model.TotalPages"
+                       class="join-item btn btn-sm" aria-label="Go to page @Model.TotalPages">@Model.TotalPages</a>
                 }
 
                 @if (Model.Page < Model.TotalPages) {
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page + 1)" class="join-item btn btn-sm">Next</a>
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page + 1)"
+                       class="join-item btn btn-sm" aria-label="Go to next page">Next</a>
                 }
             </div>
-        </div>
+        </nav>
     }
 </div>
 


### PR DESCRIPTION
## Summary

- Numeric page links on \`/Stocks\` rendered as bare \"1\" / \"2\" / \"3\" with no context — a screen reader announced them as \"link 1\" with no indication they were pagination. WCAG 2.4.4 (Link Purpose).

## Code changes

- \`src/Equibles.Web/Views/Stocks/Index.cshtml\` —
  - Wrap the pagination block in \`<nav aria-label=\"Stocks pagination\">\` so the region is identifiable as a landmark.
  - Add \`aria-label=\"Go to page N\"\` / \`Go to previous page\" / \"Go to next page\"\` to each link.
  - Mark the current page with \`aria-current=\"page\"\` so assistive tech knows which page you're on without needing to read the visual styling.
  - Mark the \"...\" ellipses \`aria-hidden=\"true\"\` so they aren't announced as content.