### PR TITLE
test(holdings-backtest): pin ForwardFill returns last on-or-before-date price when date sits between entries

### DIFF
--- a/tests/Equibles.UnitTests/Web/HoldingsBacktestServiceForwardFillBetweenEntriesTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsBacktestServiceForwardFillBetweenEntriesTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+public class HoldingsBacktestServiceForwardFillBetweenEntriesTests
+{
+    // ForwardFill's inline contract is "binary search for the largest Date <= the requested
+    // date" — used by Execute() so a simulation day that falls on a weekend or holiday
+    // resolves to the LAST trading day's close, not the NEXT one. A flipped comparison
+    // (e.g. midDate < date instead of <=, or matchIdx/lo updates swapped) would silently
+    // return the wrong side: either null or the FUTURE price, both invalidating mark-to-
+    // market. Pick a date strictly between two entries so the LAST-trading-day invariant
+    // is observable — returning the next entry's price would distinguishably fail.
+    [Fact]
+    public void ForwardFill_DateStrictlyBetweenTwoEntries_ReturnsPriceOfLatestEntryOnOrBeforeDate()
+    {
+        var stockId = Guid.NewGuid();
+        var priceRowType = typeof(HoldingsBacktestService).GetNestedType(
+            "BacktestPriceRow",
+            BindingFlags.NonPublic
+        );
+        var priceRowCtor = priceRowType.GetConstructor([
+            typeof(Guid),
+            typeof(DateOnly),
+            typeof(decimal),
+        ]);
+        var series = Array.CreateInstance(priceRowType, 3);
+        series.SetValue(priceRowCtor.Invoke([stockId, new DateOnly(2025, 1, 1), 100m]), 0);
+        series.SetValue(priceRowCtor.Invoke([stockId, new DateOnly(2025, 1, 15), 200m]), 1);
+        series.SetValue(priceRowCtor.Invoke([stockId, new DateOnly(2025, 2, 1), 300m]), 2);
+
+        var forwardFill = typeof(HoldingsBacktestService)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(m =>
+                m.Name == "ForwardFill"
+                && m.GetParameters().Length == 2
+                && m.GetParameters()[0].ParameterType == priceRowType.MakeArrayType()
+            );
+
+        var result = (decimal?)forwardFill.Invoke(null, [series, new DateOnly(2025, 1, 20)]);
+
+        result.Should().Be(200m);
+    }
+}


### PR DESCRIPTION
## Summary

- `ForwardFill` is a private binary search that resolves a simulation day to the last trading day's close, including weekends/holidays. Its inline contract is "largest Date <= the requested date." A flipped comparison (e.g. `midDate < date` instead of `<=`) or swapped `matchIdx` / `lo` updates would silently return the next entry's price — invalidating mark-to-market.
- Pins the invariant on the hardest input: a date strictly between two entries. Series `[(2025-01-01, 100), (2025-01-15, 200), (2025-02-01, 300)]`, request `2025-01-20` → must return 200 (the Jan 15 entry, the largest Date ≤ Jan 20). Returning 300 (the Feb 1 entry) would be the next entry instead of the previous one — distinguishably wrong.

## Code changes

- `tests/Equibles.UnitTests/Web/HoldingsBacktestServiceForwardFillBetweenEntriesTests.cs` — one `[Fact]` building the `BacktestPriceRow[]` via reflection on the private nested record-struct, invoking the private static `ForwardFill(BacktestPriceRow[], DateOnly)` overload, asserting the returned `decimal?` equals 200m.