### PR TITLE
fix(holdings): tighten DeduplicateSubmissions filter to IsNullOrWhiteSpace

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -154,7 +154,7 @@ public class HoldingsImportService
         var superseded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var byCikAndPeriod = context
             .Submissions.Values.Where(s =>
-                !string.IsNullOrEmpty(s.Cik) && !string.IsNullOrEmpty(s.PeriodOfReport)
+                !string.IsNullOrWhiteSpace(s.Cik) && !string.IsNullOrWhiteSpace(s.PeriodOfReport)
             )
             .GroupBy(s => $"{s.Cik}|{s.PeriodOfReport}")
             .Where(g => g.Count() > 1);

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceDeduplicateSubmissionsWhitespaceCikTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceDeduplicateSubmissionsWhitespaceCikTests.cs
@@ -18,9 +18,7 @@ public class HoldingsImportServiceDeduplicateSubmissionsWhitespaceCikTests
     // treat whitespace identically to null/empty — otherwise two submissions
     // with Cik="   " and the same PeriodOfReport collapse into one and a
     // legitimate filing disappears.
-    [Fact(
-        Skip = "GH-1583 — DeduplicateSubmissions groups submissions with whitespace-only Cik instead of skipping"
-    )]
+    [Fact]
     public void DeduplicateSubmissions_WhitespaceOnlyCik_SkippedFromGrouping()
     {
         var context = new ImportContext


### PR DESCRIPTION
## Summary

- Closes #1583. `HoldingsImportService.DeduplicateSubmissions` guarded its `(Cik, PeriodOfReport)` grouping filter with `string.IsNullOrEmpty`, which caught `null` and `""` but let whitespace-only `"   "` through. Two submissions with whitespace-only `Cik` and the same `PeriodOfReport` collapsed into one group; the dedup loop then discarded every member except the latest by `FilingDate`, silently dropping a legitimate filing.
- Tightens **both** predicate clauses to `string.IsNullOrWhiteSpace`, matching the strict-null-on-malformed precedent already established on the SUBMISSION.tsv ingest path by GH-1350 (`IsRecentFtdFile`), GH-1438 (`FtdImportService.ParseLine`), GH-1514 (`TryBuildParsedFact`), GH-1544 (`TryParseOtherManagerRow`), and the recently-fixed GH-1563 (`TryParseSubmissionRow`). SEC CIKs are numeric and can never legitimately be whitespace, so whitespace-only `Cik` is malformed and must be skipped from grouping. Unskips the pre-existing regression test.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — one-line edit in `DeduplicateSubmissions`: `IsNullOrEmpty` → `IsNullOrWhiteSpace` on both predicate clauses. No new branch; the filter itself is unchanged in shape, just stricter.
- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceDeduplicateSubmissionsWhitespaceCikTests.cs` — dropped the `Skip = "GH-1583 …"` attribute so the regression test now runs and locks the behavior.