### PR TITLE
refactor(holdings-mcp): lift GetMarketWide13FActivity bucket validation behind ValidActivityBuckets array

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -17,6 +17,14 @@ namespace Equibles.Holdings.Mcp.Tools;
 [McpServerToolType]
 public class InstitutionalHoldingsTools
 {
+    private static readonly string[] ValidActivityBuckets =
+    [
+        "top-buys",
+        "top-sells",
+        "new-positions",
+        "sold-out-positions",
+    ];
+
     private readonly InstitutionalHoldingRepository _holdingRepository;
     private readonly InstitutionalHolderRepository _holderRepository;
     private readonly CommonStockRepository _commonStockRepository;
@@ -497,13 +505,8 @@ public class InstitutionalHoldingsTools
             async () =>
             {
                 var normalizedBucket = (bucket ?? string.Empty).Trim().ToLowerInvariant();
-                if (
-                    normalizedBucket != "top-buys"
-                    && normalizedBucket != "top-sells"
-                    && normalizedBucket != "new-positions"
-                    && normalizedBucket != "sold-out-positions"
-                )
-                    return "Unknown bucket. Use one of: top-buys, top-sells, new-positions, sold-out-positions.";
+                if (!ValidActivityBuckets.Contains(normalizedBucket))
+                    return $"Unknown bucket. Use one of: {string.Join(", ", ValidActivityBuckets)}.";
 
                 var (targetDate, previousDate, error) = await ResolveMarketActivityDates(
                     reportDate


### PR DESCRIPTION
## Summary

- `GetMarketWide13FActivity` validated its `bucket` argument with a four-way `!= "literal"` chain and emitted an error message containing those four literals again — five sites repeating the same vocabulary. Adding a fifth bucket would mean editing all five. Lift the four bucket strings into a single `static readonly string[] ValidActivityBuckets`; validation becomes `!Contains(normalizedBucket)`, the error message derives from `string.Join(", ", ValidActivityBuckets)`.
- Behavior preserved: same four literals, same order, `string[].Contains` uses Ordinal equality (same as `!=` on strings), and `string.Join(", ", arr)` produces byte-identical text to the existing comma-separated message.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — add a class-level `ValidActivityBuckets` array; replace the four-line `&&`-chained validation (and its duplicated error literal) with a single `Contains` check that emits the vocabulary via `string.Join`. The two existing dispatch arms (`is "top-buys" or "top-sells"` → movers vs churn) are untouched.