### PR TITLE
test(holdings): pin HoldingsPositionGrouper CurrentHolding is latest-FilingDate when holder files multiple times

### DIFF
--- a/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperMultipleFilingsLatestHoldingTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperMultipleFilingsLatestHoldingTests.cs
@@ -1,0 +1,46 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Web.Services;
+using Equibles.Web.ViewModels.Stocks;
+
+namespace Equibles.UnitTests.Web;
+
+public class HoldingsPositionGrouperMultipleFilingsLatestHoldingTests
+{
+    // Group aggregates same-holder filings via AggregateByHolder, which picks
+    // LatestHolding = g.OrderByDescending(h => h.FilingDate).First() to surface
+    // one representative filing per holder. A swap to OrderBy (ascending) would
+    // silently expose the EARLIEST filing — invalidating any UI / downstream
+    // logic that reads CurrentHolding for filing-specific metadata.
+    [Fact]
+    public void Group_MultipleFilingsForSameHolder_CurrentHoldingIsLatestByFilingDate()
+    {
+        var holderId = Guid.NewGuid();
+        var holder = new InstitutionalHolder { Id = holderId, Name = "Holder" };
+        var earlier = new InstitutionalHolding
+        {
+            Id = Guid.NewGuid(),
+            InstitutionalHolderId = holderId,
+            InstitutionalHolder = holder,
+            Shares = 40,
+            Value = 400,
+            FilingDate = new DateOnly(2025, 1, 1),
+            ReportDate = new DateOnly(2024, 12, 31),
+        };
+        var later = new InstitutionalHolding
+        {
+            Id = Guid.NewGuid(),
+            InstitutionalHolderId = holderId,
+            InstitutionalHolder = holder,
+            Shares = 60,
+            Value = 600,
+            FilingDate = new DateOnly(2025, 2, 1),
+            ReportDate = new DateOnly(2024, 12, 31),
+        };
+
+        var result = HoldingsPositionGrouper.Group([earlier, later], []);
+
+        var entry = result[PositionChangeType.New].Should().ContainSingle().Subject;
+        entry.CurrentHolding.Id.Should().Be(later.Id);
+        entry.CurrentHolding.FilingDate.Should().Be(new DateOnly(2025, 2, 1));
+    }
+}


### PR DESCRIPTION
## Summary

- `HoldingsPositionGrouper.AggregateByHolder` picks `LatestHolding = g.OrderByDescending(h => h.FilingDate).First()` to surface one representative filing per holder, which `Group` then exposes as `HolderPositionChange.CurrentHolding`. A swap to `OrderBy` (ascending) would silently expose the earliest filing — invalidating any downstream reader of `CurrentHolding` for filing-specific metadata.
- The existing 8 grouper tests don't exercise multiple filings with different `FilingDate` values, so this contract is currently unverified. Pin it: two filings for the same holder dated 2025-01-01 and 2025-02-01 — the `New`-bucket entry's `CurrentHolding` must be the 2025-02-01 row.

## Code changes

- `tests/Equibles.UnitTests/Web/HoldingsPositionGrouperMultipleFilingsLatestHoldingTests.cs` — one `[Fact]` that constructs two `InstitutionalHolding` rows for the same holder with distinct `FilingDate`s, runs `Group([earlier, later], [])`, and asserts the single `PositionChangeType.New` entry's `CurrentHolding.Id` and `CurrentHolding.FilingDate` match the later filing.