### PR TITLE
test(holdings): add skipped repro for GH-1628 — TryResolveAmendmentTarget null Cik

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetNullCikTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetNullCikTests.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceTryResolveAmendmentTargetNullCikTests
+{
+    private static readonly MethodInfo TryResolveAmendmentTargetMethod =
+        typeof(HoldingsImportService).GetMethod(
+            "TryResolveAmendmentTarget",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // TryParseSubmissionRow does not validate Cik (per the GH-1583 discussion),
+    // and HoldingsParsingHelper.GetValue returns null when a column is missing,
+    // so a SUBMISSION.tsv row without a "CIK" column produces a SubmissionRow
+    // whose Cik is null. Per the strict-Try*-never-throws-on-bad-input contract,
+    // TryResolveAmendmentTarget must return false on a null Cik (the amendment
+    // can't be reconciled), not throw. The body reaches
+    // `context.CikToHolderId.TryGetValue(submission.Cik, out holderId)`; a
+    // Dictionary<string, Guid> throws ArgumentNullException on a null key, so
+    // an unguarded call aborts the entire amendment-reconciliation pass on the
+    // first malformed row instead of skipping it.
+    [Fact(
+        Skip = "GH-1628 — TryResolveAmendmentTarget throws ArgumentNullException on null Cik instead of returning false"
+    )]
+    public void TryResolveAmendmentTarget_NullCik_ReturnsFalseWithoutThrowing()
+    {
+        var accession = "0000950123-24-006477";
+        var submission = new SubmissionRow
+        {
+            AccessionNumber = accession,
+            Cik = null,
+            PeriodOfReport = "2024-09-30",
+        };
+        var context = new ImportContext
+        {
+            CoverPages = new Dictionary<string, CoverPageRow>
+            {
+                [accession] = new() { AccessionNumber = accession, IsAmendment = "Y" },
+            },
+            CikToHolderId = new Dictionary<string, Guid>(),
+        };
+        var args = new object[] { accession, submission, context, null, null };
+
+        // MethodInfo.Invoke wraps a thrown inner exception in
+        // TargetInvocationException, so `.NotThrow()` catches the NRE case.
+        bool resolved = false;
+        var act = () => resolved = (bool)TryResolveAmendmentTargetMethod.Invoke(null, args);
+
+        act.Should().NotThrow();
+        resolved.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the strict `Try*` contract on `HoldingsImportService.TryResolveAmendmentTarget`: it must return `false` on a `null` `submission.Cik` rather than throwing. The third gate calls `context.CikToHolderId.TryGetValue(submission.Cik, out _)`; `Dictionary<string, Guid>` throws `ArgumentNullException` on a `null` key, so a single SUBMISSION.tsv row missing the `CIK` column crashes the entire amendment-reconciliation pass instead of being skipped.
- A null `Cik` is realistic on this path: `TryParseSubmissionRow` does not validate `Cik` (intentional per the GH-1583 discussion — the parser is permissive, the consumer defends) and `HoldingsParsingHelper.GetValue` returns `null` for missing columns, so a row without `"CIK"` flows downstream as `SubmissionRow { Cik = null }`.
- Ships as `[Fact(Skip = "GH-1628 — …")]` per the repro-first convention. See GH-1628; the skip drops as part of the fix PR.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetNullCikTests.cs` — new `[Fact(Skip = "GH-1628 — …")]`. Builds an `ImportContext` whose `CoverPages` carries the amendment flag and whose `CikToHolderId` is empty, invokes the private static `TryResolveAmendmentTarget` via reflection with a `SubmissionRow` whose `Cik` is `null`, and asserts the call does not throw and returns `false`. Today the assertion fails because the unguarded `Dictionary.TryGetValue` throws `ArgumentNullException` — skipped — see GH-1628.