### PR TITLE
feat(web): make the live activity feed a screen-reader live region

### DIFF
--- a/src/Equibles.Web/Views/Status/Activity.cshtml
+++ b/src/Equibles.Web/Views/Status/Activity.cshtml
@@ -28,7 +28,11 @@
     <div class="card bg-base-100 shadow-sm">
         <div class="card-body p-0">
             <ul class="divide-y divide-base-200 max-h-[70vh] overflow-y-auto"
-                data-activity-list>
+                data-activity-list
+                aria-label="Live scraper activity"
+                aria-live="polite"
+                aria-relevant="additions"
+                aria-atomic="false">
                 <li class="p-6 text-center text-base-content/50" data-activity-empty>
                     <icon name="signal" size="8" class="mx-auto mb-2 opacity-50" />
                     <p class="text-sm">No events yet. Scraper events will stream in as they happen.</p>


### PR DESCRIPTION
## Summary

- \`/Status/Activity\` streams rows in via SSE but had no \`aria-live\` on the list — screen-reader users had no way to follow new events without re-scanning the page manually.
- Found while sweeping the app post-#1162.

## Code changes

- \`src/Equibles.Web/Views/Status/Activity.cshtml\` — add \`aria-live=\"polite\"\` + \`aria-label=\"Live scraper activity\"\` + \`aria-relevant=\"additions\"\` + \`aria-atomic=\"false\"\` to the streaming \`<ul>\`. Screen readers now announce each newly-prepended row without interrupting other speech, only the new row is announced (not the whole list each time it grows), and the list has a name when navigating by landmarks.

Visual unchanged. The existing Pause button still works as the user-facing escape valve if the announcements are noisy — pausing stops new rows from entering the DOM, which stops the announcements too.