### PR TITLE
test(holdings): pin Realtime13F OrderedInfoTableCandidates yields table-like names ahead of unrelated XMLs

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Realtime13FIngestionServiceOrderedInfoTableCandidatesTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13FIngestionServiceOrderedInfoTableCandidatesTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Realtime13FIngestionServiceOrderedInfoTableCandidatesTests
+{
+    // OrderedInfoTableCandidates documents: "Yield the table-looking names
+    // first, then the rest." The caller validates by content rather than
+    // trusting a single name guess, so the helper's ONLY job is to put info /
+    // table / 13f-bearing names ahead of unrelated XMLs. A flipped
+    // OrderByDescending → OrderBy on the bool keyname would silently emit
+    // rendering / schema XMLs first, sending the caller down the wrong
+    // artifact and triggering parse failures on every real-time ingestion.
+    [Fact]
+    public void OrderedInfoTableCandidates_TableLikeNameAfterUnrelated_TableLikeYieldedFirst()
+    {
+        List<string> artifacts = ["rendering.xml", "formInfo13f.xml"];
+
+        var method = typeof(Realtime13FIngestionService).GetMethod(
+            "OrderedInfoTableCandidates",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var result = ((IEnumerable<string>)method.Invoke(null, [artifacts])).ToList();
+
+        result.Should().Equal("formInfo13f.xml", "rendering.xml");
+    }
+}


### PR DESCRIPTION
## Summary

- `OrderedInfoTableCandidates` documents: "Yield the table-looking names first, then the rest." Its job is to bias `formInfo13f.xml` / `infotable.xml` / accession `13f` names ahead of `rendering.xml` / schema XMLs so the caller's content-validation loop hits the real information table first. A flipped `OrderByDescending → OrderBy` on the bool keyname would silently emit rendering / schema XMLs first — sending the caller down the wrong artifact and triggering parse failures on every real-time ingestion.
- Pins the contract on the hardest input: a non-table-looking artifact appearing BEFORE a table-looking one in the input list. Input `[rendering.xml, formInfo13f.xml]` must come out `[formInfo13f.xml, rendering.xml]` — distinguishably wrong if the predicate flips.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Realtime13FIngestionServiceOrderedInfoTableCandidatesTests.cs` — one `[Fact]` invoking the private static `OrderedInfoTableCandidates(List<string>)` via reflection and asserting the returned `IEnumerable<string>` materialises to `[formInfo13f.xml, rendering.xml]`.