### PR TITLE
fix(holdings): guard TryResolveAmendmentTarget against null Cik

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -519,6 +519,8 @@ public class HoldingsImportService
             return false;
         if (!string.Equals(coverPage.IsAmendment, "Y", StringComparison.OrdinalIgnoreCase))
             return false;
+        if (string.IsNullOrWhiteSpace(submission.Cik))
+            return false;
         if (!context.CikToHolderId.TryGetValue(submission.Cik, out holderId))
             return false;
         if (!TryParseDateOnly(submission.PeriodOfReport, out reportDate))

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetNullCikTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetNullCikTests.cs
@@ -22,9 +22,7 @@ public class HoldingsImportServiceTryResolveAmendmentTargetNullCikTests
     // Dictionary<string, Guid> throws ArgumentNullException on a null key, so
     // an unguarded call aborts the entire amendment-reconciliation pass on the
     // first malformed row instead of skipping it.
-    [Fact(
-        Skip = "GH-1628 — TryResolveAmendmentTarget throws ArgumentNullException on null Cik instead of returning false"
-    )]
+    [Fact]
     public void TryResolveAmendmentTarget_NullCik_ReturnsFalseWithoutThrowing()
     {
         var accession = "0000950123-24-006477";


### PR DESCRIPTION
## Summary

- Closes #1628. `HoldingsImportService.TryResolveAmendmentTarget`'s third gate called `context.CikToHolderId.TryGetValue(submission.Cik, out _)` without a null check; `Dictionary<string, Guid>` throws `ArgumentNullException` on a null key, violating the `Try*` contract (return false, never throw on bad input). A null `Cik` is realistic: `TryParseSubmissionRow` does not validate `Cik` (intentional per the GH-1583 discussion — the parser is permissive, the consumer defends) and `HoldingsParsingHelper.GetValue` returns `null` for missing columns, so a SUBMISSION.tsv row without `"CIK"` flowed downstream as `SubmissionRow { Cik = null }`. The first such amendment-flagged row crashed the entire reconciliation pass instead of being skipped.
- One-line addition: `if (string.IsNullOrWhiteSpace(submission.Cik)) return false;` alongside the existing three early-return gates. `IsNullOrWhiteSpace` matches the strict-null-on-malformed precedent already used across the SUBMISSION.tsv ingest path (GH-1350 / GH-1438 / GH-1514 / GH-1544 / GH-1563 / GH-1583 / GH-1577) and folds the whitespace-only Cik case into the same reject path for free. Unskips the pre-existing regression test.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — added `if (string.IsNullOrWhiteSpace(submission.Cik)) return false;` between the existing `IsAmendment` gate and the `CikToHolderId.TryGetValue` lookup. Pure addition; valid Cik values are unaffected.
- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetNullCikTests.cs` — dropped the `Skip = "GH-1628 …"` attribute so the regression test now runs and locks the strict-Try* contract.