### PR TITLE
fix(web): give the Stocks index table headers and an accessible name

### DIFF
--- a/src/Equibles.Web/Views/Stocks/Index.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Index.cshtml
@@ -63,13 +63,13 @@
     <!-- Results Table -->
     <div class="card bg-base-100 shadow-sm">
         <div class="overflow-x-auto">
-            <table class="table table-zebra table-sm">
+            <table class="table table-zebra table-sm" aria-label="Stocks">
                 <thead>
                     <tr>
-                        <th>Ticker</th>
-                        <th>Name</th>
-                        <th class="hidden lg:table-cell">CUSIP</th>
-                        <th class="w-8"></th>
+                        <th scope="col">Ticker</th>
+                        <th scope="col">Name</th>
+                        <th scope="col" class="hidden lg:table-cell">CUSIP</th>
+                        <th scope="col" class="w-8"><span class="sr-only">Open</span></th>
                     </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
## Summary

- The data table on \`/Stocks\` had no \`aria-label\` / \`<caption>\` and none of its \`<th>\` elements declared \`scope\`. Screen readers landing on the table either via landmarks or by table-cell navigation had no context for what the table contained. WCAG 1.3.1 (Info & Relationships).

## Code changes

- \`src/Equibles.Web/Views/Stocks/Index.cshtml\` —
  - Add \`aria-label=\"Stocks\"\` on the \`<table>\`.
  - Add \`scope=\"col\"\` on every column header.
  - Add a \`sr-only\` \"Open\" label inside the empty chevron-column \`<th>\` so that header is no longer nameless.

Visual unchanged.