### PR TITLE
test(web): pin ProfilesController.ResolveSelectedDate falls back to first available when requested date is unknown

### DIFF
--- a/tests/Equibles.UnitTests/Web/ProfilesControllerResolveSelectedDateFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Web/ProfilesControllerResolveSelectedDateFallbackTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Equibles.Web.Controllers;
+
+namespace Equibles.UnitTests.Web;
+
+public class ProfilesControllerResolveSelectedDateFallbackTests
+{
+    // ResolveSelectedDate accepts a user-controlled `date=` query parameter and
+    // maps it against the available report-date list before the caller issues
+    // a holdings lookup. The contract its name promises is fallback semantics:
+    // an unknown requested date must NOT pass through unchecked, because the
+    // downstream WHERE ReportDate = @date silently returns zero rows on an
+    // unrecognised input and the page would render as "no data" instead of
+    // showing the latest snapshot. A refactor that drops the `.Contains(...)`
+    // guard (e.g. `requested.HasValue ? requested.Value : available[0]`)
+    // compiles and passes any test that only exercises clean inputs — pin the
+    // fallback explicitly so the guard cannot regress.
+    [Fact]
+    public void ResolveSelectedDate_RequestedDateNotInAvailable_FallsBackToFirstAvailable()
+    {
+        var available = new List<DateOnly>
+        {
+            new(2024, 12, 31),
+            new(2024, 9, 30),
+            new(2024, 6, 30),
+        };
+        DateOnly? requested = new(1999, 1, 1);
+
+        var method = typeof(ProfilesController).GetMethod(
+            "ResolveSelectedDate",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var result = (DateOnly)method.Invoke(null, [requested, available]);
+
+        result.Should().Be(new DateOnly(2024, 12, 31));
+    }
+}


### PR DESCRIPTION
## Summary

- `ResolveSelectedDate` is the private static guard between a user-controlled `date=` query parameter and the downstream `WHERE ReportDate = @date` lookup that drives the institutional Compare / Combined views. Its contract is "use the requested date IF it is in the available list; otherwise fall back to a known-good date." A refactor that drops the `.Contains(...)` guard (e.g. `requested.HasValue ? requested.Value : available[0]`) would compile, pass any test feeding only clean inputs, and silently render the page as "no data" on any stale-bookmark URL whose date no longer exists.
- Pins the fallback semantics on an unrecognised requested date (`1999-01-01`) against a three-element descending available list. Helper is private — invoked via reflection per the established `ProfilesControllerNormalizeCiksTests` pattern.

## Code changes

- `tests/Equibles.UnitTests/Web/ProfilesControllerResolveSelectedDateFallbackTests.cs` — one `[Fact]` invoking the private static `ResolveSelectedDate(DateOnly?, List<DateOnly>)` via reflection with a requested date that is not in the available list and asserting the returned `DateOnly` equals the first available date.