### PR TITLE
test(web): pin HoldingsExportController.Sanitize strips slashes and dots from path-traversal CIK input

### DIFF
--- a/tests/Equibles.UnitTests/Web/HoldingsExportControllerSanitizePathTraversalTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsExportControllerSanitizePathTraversalTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using Equibles.Web.Controllers;
+
+namespace Equibles.UnitTests.Web;
+
+public class HoldingsExportControllerSanitizePathTraversalTests
+{
+    // Sanitize wraps the URL-supplied CIK before it lands inside the
+    // Content-Disposition filename of the institution-portfolio CSV download.
+    // Its source comment commits to "strip anything that's unsafe in a filename
+    // (slashes / quotes / control chars)"; the slash side is obvious, but the
+    // dot side is non-obvious — '../' is the canonical path-traversal payload
+    // and "." is also a header-significant character. A refactor that loosens
+    // the allowlist to admit '.' would still keep slashes out yet readmit a
+    // disguised traversal segment. Pin the dot+slash combo: only the
+    // [A-Za-z0-9_-] allowlist may survive.
+    [Fact]
+    public void Sanitize_PathTraversalPayload_StripsAllSlashesAndDots()
+    {
+        var method = typeof(HoldingsExportController).GetMethod(
+            "Sanitize",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (string)method.Invoke(null, ["123/../456"]);
+
+        result.Should().Be("123456");
+    }
+}


### PR DESCRIPTION
## Summary

- `HoldingsExportController.Sanitize` wraps a URL-supplied CIK before it lands inside the Content-Disposition filename of the institution-portfolio CSV download. The source comment commits to "strip anything that's unsafe in a filename (slashes / quotes / control chars)"; the slash side is obvious, but the dot side is non-obvious — `../` is the canonical path-traversal payload and `.` is also header-significant. A refactor that loosens the allowlist to admit `.` would still keep slashes out yet readmit a disguised traversal segment in a Content-Disposition `filename=` value.
- Pins the dot+slash combo on `123/../456` — both characters must be stripped, leaving only the `[A-Za-z0-9_-]` allowlist. Output must equal `123456`.

## Code changes

- `tests/Equibles.UnitTests/Web/HoldingsExportControllerSanitizePathTraversalTests.cs` — one `[Fact]` invoking the private static `Sanitize(string)` via reflection with `"123/../456"` and asserting the returned string equals `"123456"`.