### PR TITLE
fix(web): give the Status errors table headers and an accessible name

### DIFF
--- a/src/Equibles.Web/Views/Status/Index.cshtml
+++ b/src/Equibles.Web/Views/Status/Index.cshtml
@@ -221,15 +221,15 @@
                 </div>
             } else {
                 <div class="overflow-x-auto">
-                    <table class="table table-sm">
+                    <table class="table table-sm" aria-label="Recent errors">
                         <thead>
                             <tr>
-                                <th>Source</th>
-                                <th>Context</th>
-                                <th>Message</th>
-                                <th>Status</th>
-                                <th>Created</th>
-                                <th class="w-1"></th>
+                                <th scope="col">Source</th>
+                                <th scope="col">Context</th>
+                                <th scope="col">Message</th>
+                                <th scope="col">Status</th>
+                                <th scope="col">Created</th>
+                                <th scope="col" class="w-1"><span class="sr-only">Actions</span></th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
## Summary

- Same shape as PR #1634 but for the recent-errors table on \`/Status\`: no \`aria-label\`, no \`scope=\"col\"\` on the \`<th>\` elements, and an empty header on the icons column.

## Code changes

- \`src/Equibles.Web/Views/Status/Index.cshtml\` — add \`aria-label=\"Recent errors\"\` on the table, \`scope=\"col\"\` on every column header, and a \`sr-only\` \"Actions\" label on the trailing icon column.