### PR TITLE
fix(financial-facts): tighten TryBuildParsedFact Accn gate to IsNullOrWhiteSpace

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -201,7 +201,7 @@ public class FinancialFactsImportService
     {
         if (!TryMapFiscalPeriod(value.Fp, out var fiscalPeriod))
             return null;
-        if (string.IsNullOrEmpty(value.Accn))
+        if (string.IsNullOrWhiteSpace(value.Accn))
             return null;
 
         var isInstant = value.Start == null;

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactWhitespaceAccnTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactWhitespaceAccnTests.cs
@@ -24,7 +24,7 @@ public class FinancialFactsImportServiceTryBuildParsedFactWhitespaceAccnTests
     // a regression mode where a SEC payload with a blanked accession produces
     // a ParsedFact whose Accession is whitespace, silently corrupting downstream
     // dedup-by-accession and the (AccessionNumber, ...) unique index lookups.
-    [Fact(Skip = "GH-1514 — TryBuildParsedFact emits ParsedFact with whitespace-only Accn")]
+    [Fact]
     public void TryBuildParsedFact_WhitespaceOnlyAccn_ReturnsNull()
     {
         var value = new CompanyFactValue


### PR DESCRIPTION
## Summary

- Closes #1514. `FinancialFactsImportService.TryBuildParsedFact` guarded its `value.Accn` reject path with `string.IsNullOrEmpty`, which catches `null` and `""` but lets whitespace-only `"   "` through. A SEC company-facts payload with a blanked accession produced a `ParsedFact` whose `Accession = "   "`, silently corrupting downstream dedup-by-accession lookups and the `(AccessionNumber, …)` unique-index path used by ingestion.
- One-line tightening to `string.IsNullOrWhiteSpace`, matching the strict-null-on-malformed precedent established by GH-1350 (`IsRecentFtdFile`), GH-1438 (`ParseLine` quantity), GH-1544 (`TryParseOtherManagerRow`), GH-1563 (`TryParseSubmissionRow`) and GH-1583 (`DeduplicateSubmissions`). Unskips the pre-existing regression test.

## Code changes

- `src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs` — one-character predicate change in `TryBuildParsedFact`: `IsNullOrEmpty` → `IsNullOrWhiteSpace`. Pure tightening; `null` and `""` rejects unchanged.
- `tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactWhitespaceAccnTests.cs` — dropped the `Skip = "GH-1514 …"` attribute so the regression test now runs and locks the behaviour.