### PR TITLE
fix(web): give the Market tables headers and accessible names

### DIFF
--- a/src/Equibles.Web/Views/Market/Index.cshtml
+++ b/src/Equibles.Web/Views/Market/Index.cshtml
@@ -21,15 +21,15 @@
             <div class="card-body p-4 lg:p-6">
                 <h2 class="card-title text-lg mb-3">Put/Call Ratios</h2>
                 <div class="overflow-x-auto">
-                    <table class="table table-zebra table-sm">
+                    <table class="table table-zebra table-sm" aria-label="Put / call ratios by type">
                         <thead>
                             <tr>
-                                <th>Type</th>
-                                <th class="text-right">P/C Ratio</th>
-                                <th class="text-right hidden sm:table-cell">Call Volume</th>
-                                <th class="text-right hidden sm:table-cell">Put Volume</th>
-                                <th class="text-right hidden md:table-cell">Date</th>
-                                <th class="w-8"></th>
+                                <th scope="col">Type</th>
+                                <th scope="col" class="text-right">P/C Ratio</th>
+                                <th scope="col" class="text-right hidden sm:table-cell">Call Volume</th>
+                                <th scope="col" class="text-right hidden sm:table-cell">Put Volume</th>
+                                <th scope="col" class="text-right hidden md:table-cell">Date</th>
+                                <th scope="col" class="w-8"><span class="sr-only">Open</span></th>
                             </tr>
                         </thead>
                         <tbody>

--- a/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
+++ b/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
@@ -115,14 +115,14 @@
                 </div>
             } else {
                 <div class="overflow-x-auto max-h-[400px] overflow-y-auto">
-                    <table class="table table-zebra table-sm">
+                    <table class="table table-zebra table-sm" aria-label="Put / call ratio history">
                         <thead class="sticky top-0 bg-base-100 z-10">
                             <tr>
-                                <th>Date</th>
-                                <th class="text-right">Call Vol</th>
-                                <th class="text-right">Put Vol</th>
-                                <th class="text-right hidden sm:table-cell">Total Vol</th>
-                                <th class="text-right">P/C Ratio</th>
+                                <th scope="col">Date</th>
+                                <th scope="col" class="text-right">Call Vol</th>
+                                <th scope="col" class="text-right">Put Vol</th>
+                                <th scope="col" class="text-right hidden sm:table-cell">Total Vol</th>
+                                <th scope="col" class="text-right">P/C Ratio</th>
                             </tr>
                         </thead>
                         <tbody>

--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -125,14 +125,14 @@
                 </div>
             } else {
                 <div class="overflow-x-auto max-h-[400px] overflow-y-auto">
-                    <table class="table table-zebra table-sm">
+                    <table class="table table-zebra table-sm" aria-label="VIX daily values">
                         <thead class="sticky top-0 bg-base-100 z-10">
                             <tr>
-                                <th>Date</th>
-                                <th class="text-right hidden sm:table-cell">Open</th>
-                                <th class="text-right hidden sm:table-cell">High</th>
-                                <th class="text-right hidden sm:table-cell">Low</th>
-                                <th class="text-right">Close</th>
+                                <th scope="col">Date</th>
+                                <th scope="col" class="text-right hidden sm:table-cell">Open</th>
+                                <th scope="col" class="text-right hidden sm:table-cell">High</th>
+                                <th scope="col" class="text-right hidden sm:table-cell">Low</th>
+                                <th scope="col" class="text-right">Close</th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
## Summary

- Same shape as PR #1634 (Stocks table) and #1637 (Status errors table): the three data tables on the Market pages (Index P/C ratios, Vix history, PutCallRatio history) had no \`aria-label\` and no \`scope=\"col\"\` on their \`<th>\` elements.

## Code changes

- \`src/Equibles.Web/Views/Market/Index.cshtml\` — add \`aria-label=\"Put / call ratios by type\"\`, \`scope=\"col\"\` on every header, sr-only \"Open\" label on the chevron column.
- \`src/Equibles.Web/Views/Market/Vix.cshtml\` — \`aria-label=\"VIX daily values\"\` + scopes.
- \`src/Equibles.Web/Views/Market/PutCallRatio.cshtml\` — \`aria-label=\"Put / call ratio history\"\` + scopes.

Visual unchanged.