### PR TITLE
test(financial-facts): pin TryBuildParsedFact FiscalYear falls back to End.Year

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactFiscalYearFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactFiscalYearFallbackTests.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Integrations.Sec.Models.Responses;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactsImportServiceTryBuildParsedFactFiscalYearFallbackTests
+{
+    // TryBuildParsedFact's three-step FiscalYear chain is
+    // `resolved?.Year ?? value.Fy ?? value.End.Year`. The last fallback fires
+    // when neither FiscalPeriodResolver (no FYE on the stock) nor the wire
+    // payload supplies a year — a common shape for small / foreign filers
+    // whose CommonStock row hasn't been seeded with FiscalYearEndMonth/Day yet
+    // and whose Company Facts entry omits `fy`. Without the `?? value.End.Year`
+    // tail, FiscalYear would land at 0 for every such fact (int default),
+    // which silently corrupts both the (CommonStockId, FiscalYear,
+    // FiscalPeriod) index lookup and any year-keyed downstream aggregate. A
+    // refactor that dropped the final coalesce would compile, pass every test
+    // with a populated Fy, and only surface as zero-year FinancialFact rows
+    // in production.
+    [Fact]
+    public void TryBuildParsedFact_NoResolverAndNullWireFy_FiscalYearFallsBackToEndYear()
+    {
+        var serviceType = typeof(FinancialFactsImportService);
+        var parsedFactType = serviceType.GetNestedType("ParsedFact", BindingFlags.NonPublic);
+
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "FOO",
+            FiscalYearEndMonth = null,
+            FiscalYearEndDay = null,
+        };
+        var value = new CompanyFactValue
+        {
+            Start = null,
+            End = new DateOnly(2024, 12, 31),
+            Val = 100m,
+            Accn = "0000320193-24-000123",
+            Fy = null,
+            Fp = "FY",
+            Form = "10-K",
+            Filed = new DateOnly(2025, 1, 15),
+        };
+
+        var method = serviceType.GetMethod(
+            "TryBuildParsedFact",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var parsed = method.Invoke(
+            null,
+            [FactTaxonomy.UsGaap, "Assets", "Assets", "USD", value, stock]
+        );
+
+        parsed.Should().NotBeNull();
+        var fiscalYear = (int)parsedFactType.GetProperty("FiscalYear").GetValue(parsed);
+        fiscalYear.Should().Be(2024);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the third leg of `FinancialFactsImportService.TryBuildParsedFact`'s `FiscalYear` coalesce chain: `resolved?.Year ?? value.Fy ?? value.End.Year`. The `?? value.End.Year` tail fires when neither `FiscalPeriodResolver` (returns null when the stock has no `FiscalYearEndMonth`/`Day`) nor the wire payload's `fy` supplies a year — a common shape for small / foreign filers whose `CommonStock` row isn't seeded with FYE info yet and whose `Company Facts` entry omits `fy`.
- Without that final coalesce, `FiscalYear` would land at `0` (int default) on every such fact, silently corrupting the `(CommonStockId, FiscalYear, FiscalPeriod)` index lookups and every year-keyed downstream aggregate. A refactor dropping `?? value.End.Year` would compile, pass every existing test (all of which supply a populated `fy`), and only surface as zero-year `FinancialFact` rows in production.
- Test feeds an instant fact with `End = 2024-12-31`, `Start = null`, `Fy = null` against a stock with `FiscalYearEndMonth = null` / `FiscalYearEndDay = null`, and asserts the resulting `ParsedFact.FiscalYear == 2024`.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryBuildParsedFactFiscalYearFallbackTests.cs` — new `[Fact]` invoking the private static `TryBuildParsedFact` via reflection with a stock missing FYE info and a `CompanyFactValue` whose `Fy` is null; reflects into the private nested `ParsedFact` to assert `FiscalYear == End.Year`.