### PR TITLE
fix(web): give the EconomicData and Cftc tables headers and accessible names

### DIFF
--- a/src/Equibles.Web/Views/Cftc/Index.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Index.cshtml
@@ -22,15 +22,15 @@
                 <div class="card-body p-4 lg:p-6">
                     <h2 class="card-title text-lg mb-3">@category.DisplayName</h2>
                     <div class="overflow-x-auto">
-                        <table class="table table-zebra table-sm">
+                        <table class="table table-zebra table-sm" aria-label="@(category.DisplayName) futures markets">
                             <thead>
                                 <tr>
-                                    <th>Code</th>
-                                    <th>Market Name</th>
-                                    <th class="text-right hidden sm:table-cell">Comm Net</th>
-                                    <th class="text-right hidden sm:table-cell">Non-Comm Net</th>
-                                    <th class="text-right hidden md:table-cell">Date</th>
-                                    <th class="w-8"></th>
+                                    <th scope="col">Code</th>
+                                    <th scope="col">Market Name</th>
+                                    <th scope="col" class="text-right hidden sm:table-cell">Comm Net</th>
+                                    <th scope="col" class="text-right hidden sm:table-cell">Non-Comm Net</th>
+                                    <th scope="col" class="text-right hidden md:table-cell">Date</th>
+                                    <th scope="col" class="w-8"><span class="sr-only">Open</span></th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/src/Equibles.Web/Views/Cftc/Show.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Show.cshtml
@@ -95,17 +95,17 @@
                 </div>
             } else {
                 <div class="overflow-x-auto max-h-[400px] overflow-y-auto">
-                    <table class="table table-zebra table-sm">
+                    <table class="table table-zebra table-sm" aria-label="Position history">
                         <thead class="sticky top-0 bg-base-100 z-10">
                             <tr>
-                                <th>Date</th>
-                                <th class="text-right">Open Interest</th>
-                                <th class="text-right hidden sm:table-cell">Comm Long</th>
-                                <th class="text-right hidden sm:table-cell">Comm Short</th>
-                                <th class="text-right hidden md:table-cell">Non-Comm Long</th>
-                                <th class="text-right hidden md:table-cell">Non-Comm Short</th>
-                                <th class="text-right hidden lg:table-cell">Spreads</th>
-                                <th class="text-right hidden lg:table-cell">Change OI</th>
+                                <th scope="col">Date</th>
+                                <th scope="col" class="text-right">Open Interest</th>
+                                <th scope="col" class="text-right hidden sm:table-cell">Comm Long</th>
+                                <th scope="col" class="text-right hidden sm:table-cell">Comm Short</th>
+                                <th scope="col" class="text-right hidden md:table-cell">Non-Comm Long</th>
+                                <th scope="col" class="text-right hidden md:table-cell">Non-Comm Short</th>
+                                <th scope="col" class="text-right hidden lg:table-cell">Spreads</th>
+                                <th scope="col" class="text-right hidden lg:table-cell">Change OI</th>
                             </tr>
                         </thead>
                         <tbody>

--- a/src/Equibles.Web/Views/EconomicData/Index.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Index.cshtml
@@ -22,15 +22,15 @@
                 <div class="card-body p-4 lg:p-6">
                     <h2 class="card-title text-lg mb-3">@category.DisplayName</h2>
                     <div class="overflow-x-auto">
-                        <table class="table table-zebra table-sm">
+                        <table class="table table-zebra table-sm" aria-label="@(category.DisplayName) series">
                             <thead>
                                 <tr>
-                                    <th>Series</th>
-                                    <th>Name</th>
-                                    <th class="hidden md:table-cell">Frequency</th>
-                                    <th class="text-right">Latest Value</th>
-                                    <th class="text-right hidden sm:table-cell">Date</th>
-                                    <th class="w-8"></th>
+                                    <th scope="col">Series</th>
+                                    <th scope="col">Name</th>
+                                    <th scope="col" class="hidden md:table-cell">Frequency</th>
+                                    <th scope="col" class="text-right">Latest Value</th>
+                                    <th scope="col" class="text-right hidden sm:table-cell">Date</th>
+                                    <th scope="col" class="w-8"><span class="sr-only">Open</span></th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -146,12 +146,12 @@
                 </div>
             } else {
                 <div class="overflow-x-auto max-h-[400px] overflow-y-auto">
-                    <table class="table table-zebra table-sm">
+                    <table class="table table-zebra table-sm" aria-label="Series observations">
                         <thead class="sticky top-0 bg-base-100 z-10">
                             <tr>
-                                <th>Date</th>
-                                <th class="text-right">Value</th>
-                                <th class="text-right hidden sm:table-cell">Change %</th>
+                                <th scope="col">Date</th>
+                                <th scope="col" class="text-right">Value</th>
+                                <th scope="col" class="text-right hidden sm:table-cell">Change %</th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
## Summary

- Continues the table-a11y sweep (PRs #1634 / #1637 / #1644). Four more data tables across \`/economicdata\` and \`/futures\` got the same fix.

## Code changes

- \`src/Equibles.Web/Views/EconomicData/Index.cshtml\` — \`aria-label=\"{category} series\"\` + \`scope=\"col\"\` + sr-only \"Open\" on the chevron header.
- \`src/Equibles.Web/Views/EconomicData/Show.cshtml\` — \`aria-label=\"Series observations\"\` + scopes.
- \`src/Equibles.Web/Views/Cftc/Index.cshtml\` — \`aria-label=\"{category} futures markets\"\` + scopes + sr-only \"Open\" on chevron.
- \`src/Equibles.Web/Views/Cftc/Show.cshtml\` — \`aria-label=\"Position history\"\` + scopes.

Visual unchanged.