### PR TITLE
fix(fred): parse observation dates with InvariantCulture

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/FredImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredImportService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
@@ -288,7 +289,14 @@ public class FredImportService
         var result = new List<(FredObservationRecord, DateOnly)>(records.Count);
         foreach (var r in records)
         {
-            if (DateOnly.TryParse(r.Date, out var date))
+            if (
+                DateOnly.TryParse(
+                    r.Date,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var date
+                )
+            )
                 result.Add((r, date));
         }
         return result;

--- a/tests/Equibles.UnitTests/Fred/FredImportServiceParseObservationDatesHijriCultureTests.cs
+++ b/tests/Equibles.UnitTests/Fred/FredImportServiceParseObservationDatesHijriCultureTests.cs
@@ -7,7 +7,7 @@ namespace Equibles.UnitTests.Fred;
 
 public class FredImportServiceParseObservationDatesHijriCultureTests
 {
-    [Fact(Skip = "GH-1501 — ParseObservationDates silently drops every observation under ar-SA")]
+    [Fact]
     public void ParseObservationDates_IsoDateUnderHijriCulture_DoesNotSilentlyDropRecord()
     {
         // FRED's observation feed always emits ISO `yyyy-MM-dd` dates. The


### PR DESCRIPTION
## Summary

- Closes #1501. `FredImportService.ParseObservationDates` called `DateOnly.TryParse(r.Date, out var date)` with no explicit culture, so the parse ran under the thread's `CurrentCulture`. Under `ar-SA` (Umm al-Qura calendar), the ISO `yyyy-MM-dd` strings FRED emits failed to parse, and every record was silently dropped by the per-record skip — any worker host whose locale defaulted to ar-SA imported zero FRED observations on every cycle.
- One-line hardening: pass `CultureInfo.InvariantCulture, DateTimeStyles.None`, mirroring the sister pattern already used in `InsiderTradingFilingProcessor.ParseTransaction`. Adds the `System.Globalization` using. Unskips the pre-existing regression test.

## Code changes

- `src/Equibles.Fred.HostedService/Services/FredImportService.cs` — added the explicit `InvariantCulture` / `DateTimeStyles.None` overload to the `DateOnly.TryParse` call inside `ParseObservationDates`; added `using System.Globalization;` since this project doesn't pull it in via a global using.
- `tests/Equibles.UnitTests/Fred/FredImportServiceParseObservationDatesHijriCultureTests.cs` — dropped the `Skip = "GH-1501 …"` attribute so the regression test now runs and locks the contract.