### PR TITLE
fix(web): add scope=col to remaining data-table headers across the app

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -74,12 +74,12 @@
                                 <table class="table table-sm">
                                     <thead>
                                         <tr>
-                                            <th>Ticker</th>
-                                            <th>Company</th>
-                                            <th class="text-right">Δ Shares</th>
-                                            <th class="text-right hidden md:table-cell">Δ Value (USD)</th>
-                                            <th class="text-right hidden lg:table-cell"># Filers</th>
-                                            <th class="text-right">Action</th>
+                                            <th scope="col">Ticker</th>
+                                            <th scope="col">Company</th>
+                                            <th scope="col" class="text-right">Δ Shares</th>
+                                            <th scope="col" class="text-right hidden md:table-cell">Δ Value (USD)</th>
+                                            <th scope="col" class="text-right hidden lg:table-cell"># Filers</th>
+                                            <th scope="col" class="text-right">Action</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -131,10 +131,10 @@
                                 <table class="table table-sm">
                                     <thead>
                                         <tr>
-                                            <th>Ticker</th>
-                                            <th>Company</th>
-                                            <th class="text-right">@board.FilerLabel</th>
-                                            <th class="text-right">Action</th>
+                                            <th scope="col">Ticker</th>
+                                            <th scope="col">Company</th>
+                                            <th scope="col" class="text-right">@board.FilerLabel</th>
+                                            <th scope="col" class="text-right">Action</th>
                                         </tr>
                                     </thead>
                                     <tbody>

--- a/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
+++ b/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
@@ -134,16 +134,16 @@
                         <table class="table table-zebra table-sm">
                             <thead>
                                 <tr>
-                                    <th>Ticker</th>
-                                    <th>Name</th>
-                                    <th>Industry</th>
-                                    <th class="text-right">Filers</th>
-                                    <th class="text-right">Δ Filers</th>
-                                    <th class="text-right">Total $ value</th>
-                                    <th class="text-right">Δ $ value</th>
-                                    <th class="text-right">New</th>
-                                    <th class="text-right">Sold out</th>
-                                    <th class="text-right">% float</th>
+                                    <th scope="col">Ticker</th>
+                                    <th scope="col">Name</th>
+                                    <th scope="col">Industry</th>
+                                    <th scope="col" class="text-right">Filers</th>
+                                    <th scope="col" class="text-right">Δ Filers</th>
+                                    <th scope="col" class="text-right">Total $ value</th>
+                                    <th scope="col" class="text-right">Δ $ value</th>
+                                    <th scope="col" class="text-right">New</th>
+                                    <th scope="col" class="text-right">Sold out</th>
+                                    <th scope="col" class="text-right">% float</th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
@@ -58,11 +58,11 @@
                 <table class="table table-zebra table-sm">
                     <thead>
                         <tr>
-                            <th>Ticker</th>
-                            <th>Company</th>
-                            <th class="text-right"># Funds</th>
-                            <th class="text-right">Combined Value (USD)</th>
-                            <th class="text-right hidden lg:table-cell">Avg % of portfolio</th>
+                            <th scope="col">Ticker</th>
+                            <th scope="col">Company</th>
+                            <th scope="col" class="text-right"># Funds</th>
+                            <th scope="col" class="text-right">Combined Value (USD)</th>
+                            <th scope="col" class="text-right hidden lg:table-cell">Avg % of portfolio</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/src/Equibles.Web/Views/Profiles/Insider.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Insider.cshtml
@@ -22,11 +22,11 @@
                 <table class="table table-zebra table-sm">
                     <thead>
                         <tr>
-                            <th>Ticker</th>
-                            <th class="hidden lg:table-cell">Date</th>
-                            <th class="hidden lg:table-cell">Security</th>
-                            <th class="text-right">Shares</th>
-                            <th class="text-right">Price</th>
+                            <th scope="col">Ticker</th>
+                            <th scope="col" class="hidden lg:table-cell">Date</th>
+                            <th scope="col" class="hidden lg:table-cell">Security</th>
+                            <th scope="col" class="text-right">Shares</th>
+                            <th scope="col" class="text-right">Price</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -82,10 +82,10 @@
                     <table class="table table-zebra table-sm">
                         <thead>
                             <tr>
-                                <th>Industry</th>
-                                <th class="text-right"># Positions</th>
-                                <th class="text-right">Value (USD)</th>
-                                <th class="text-right">% of portfolio</th>
+                                <th scope="col">Industry</th>
+                                <th scope="col" class="text-right"># Positions</th>
+                                <th scope="col" class="text-right">Value (USD)</th>
+                                <th scope="col" class="text-right">% of portfolio</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -184,13 +184,13 @@
                                     <table class="table table-xs">
                                         <thead>
                                             <tr>
-                                                <th>Ticker</th>
-                                                <th>Company</th>
-                                                <th class="text-right">Prior</th>
-                                                <th class="text-right">New</th>
-                                                <th class="text-right">Δ Shares</th>
-                                                <th class="text-right">Δ Value (USD)</th>
-                                                <th class="text-right">% Portfolio</th>
+                                                <th scope="col">Ticker</th>
+                                                <th scope="col">Company</th>
+                                                <th scope="col" class="text-right">Prior</th>
+                                                <th scope="col" class="text-right">New</th>
+                                                <th scope="col" class="text-right">Δ Shares</th>
+                                                <th scope="col" class="text-right">Δ Value (USD)</th>
+                                                <th scope="col" class="text-right">% Portfolio</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -227,11 +227,11 @@
                 <table class="table table-zebra table-sm">
                     <thead>
                         <tr>
-                            <th>Ticker</th>
-                            <th>Company</th>
-                            <th class="hidden lg:table-cell">Report date</th>
-                            <th class="text-right">Shares</th>
-                            <th class="text-right">Value (USD)</th>
+                            <th scope="col">Ticker</th>
+                            <th scope="col">Company</th>
+                            <th scope="col" class="hidden lg:table-cell">Report date</th>
+                            <th scope="col" class="text-right">Shares</th>
+                            <th scope="col" class="text-right">Value (USD)</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/src/Equibles.Web/Views/Profiles/Member.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Member.cshtml
@@ -19,11 +19,11 @@
                 <table class="table table-zebra table-sm">
                     <thead>
                         <tr>
-                            <th>Ticker</th>
-                            <th class="hidden lg:table-cell">Date</th>
-                            <th class="hidden lg:table-cell">Asset</th>
-                            <th class="hidden lg:table-cell">Owner</th>
-                            <th class="text-right">Amount (USD)</th>
+                            <th scope="col">Ticker</th>
+                            <th scope="col" class="hidden lg:table-cell">Date</th>
+                            <th scope="col" class="hidden lg:table-cell">Asset</th>
+                            <th scope="col" class="hidden lg:table-cell">Owner</th>
+                            <th scope="col" class="text-right">Amount (USD)</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -84,13 +84,13 @@
                 <table class="table table-zebra table-sm">
                     <thead>
                         <tr>
-                            <th>Report Date</th>
-                            <th class="text-right">Value (USD)</th>
-                            <th class="text-right">Shares</th>
-                            <th class="text-right hidden md:table-cell">Change</th>
-                            <th class="hidden lg:table-cell">Type</th>
-                            <th class="hidden lg:table-cell">Discretion</th>
-                            <th class="hidden lg:table-cell">Filed</th>
+                            <th scope="col">Report Date</th>
+                            <th scope="col" class="text-right">Value (USD)</th>
+                            <th scope="col" class="text-right">Shares</th>
+                            <th scope="col" class="text-right hidden md:table-cell">Change</th>
+                            <th scope="col" class="hidden lg:table-cell">Type</th>
+                            <th scope="col" class="hidden lg:table-cell">Discretion</th>
+                            <th scope="col" class="hidden lg:table-cell">Filed</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/src/Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml
@@ -17,13 +17,13 @@
             <table class="table table-zebra table-sm">
                 <thead>
                     <tr>
-                        <th>Date</th>
-                        <th>Member</th>
-                        <th class="hidden md:table-cell">Position</th>
-                        <th>Type</th>
-                        <th class="hidden md:table-cell">Owner</th>
-                        <th class="text-right">Amount</th>
-                        <th class="hidden lg:table-cell">Filed</th>
+                        <th scope="col">Date</th>
+                        <th scope="col">Member</th>
+                        <th scope="col" class="hidden md:table-cell">Position</th>
+                        <th scope="col">Type</th>
+                        <th scope="col" class="hidden md:table-cell">Owner</th>
+                        <th scope="col" class="text-right">Amount</th>
+                        <th scope="col" class="hidden lg:table-cell">Filed</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/Equibles.Web/Views/Stocks/_DocumentsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_DocumentsTab.cshtml
@@ -17,10 +17,10 @@
             <table class="table table-zebra table-sm">
                 <thead>
                     <tr>
-                        <th>Type</th>
-                        <th>Filing Date</th>
-                        <th>Period</th>
-                        <th class="text-right">Action</th>
+                        <th scope="col">Type</th>
+                        <th scope="col">Filing Date</th>
+                        <th scope="col">Period</th>
+                        <th scope="col" class="text-right">Action</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
@@ -53,12 +53,12 @@
             <table class="table table-zebra table-sm">
                 <thead>
                     <tr>
-                        <th>Line Item</th>
-                        <th class="text-right">Value</th>
-                        <th class="hidden md:table-cell">Unit</th>
-                        <th class="hidden md:table-cell">Period End</th>
-                        <th class="hidden lg:table-cell">Form</th>
-                        <th class="hidden lg:table-cell">Filed</th>
+                        <th scope="col">Line Item</th>
+                        <th scope="col" class="text-right">Value</th>
+                        <th scope="col" class="hidden md:table-cell">Unit</th>
+                        <th scope="col" class="hidden md:table-cell">Period End</th>
+                        <th scope="col" class="hidden lg:table-cell">Form</th>
+                        <th scope="col" class="hidden lg:table-cell">Filed</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
@@ -27,10 +27,10 @@
             <table class="table table-zebra table-sm">
                 <thead>
                     <tr>
-                        <th>Settlement Date</th>
-                        <th class="text-right">Quantity</th>
-                        <th class="text-right">Price</th>
-                        <th class="text-right">Value</th>
+                        <th scope="col">Settlement Date</th>
+                        <th scope="col" class="text-right">Quantity</th>
+                        <th scope="col" class="text-right">Price</th>
+                        <th scope="col" class="text-right">Value</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -119,10 +119,10 @@
                                 <table class="table table-sm">
                                     <thead>
                                         <tr>
-                                            <th>Institution</th>
-                                            <th class="text-right">Δ Shares</th>
-                                            <th class="text-right hidden md:table-cell">Δ Value (USD)</th>
-                                            <th class="text-right hidden lg:table-cell">Prior → New</th>
+                                            <th scope="col">Institution</th>
+                                            <th scope="col" class="text-right">Δ Shares</th>
+                                            <th scope="col" class="text-right hidden md:table-cell">Δ Value (USD)</th>
+                                            <th scope="col" class="text-right hidden lg:table-cell">Prior → New</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -167,14 +167,14 @@
                     <table class="table table-zebra table-sm">
                         <thead>
                             <tr>
-                                <th>Holder</th>
-                                <th>Status</th>
-                                <th class="text-right">Current Shares</th>
-                                <th class="text-right hidden md:table-cell">Previous Shares</th>
-                                <th class="text-right">Δ Shares</th>
-                                <th class="text-right hidden lg:table-cell">Current Value (USD)</th>
-                                <th class="text-right">Δ Value (USD)</th>
-                                <th class="text-right">Action</th>
+                                <th scope="col">Holder</th>
+                                <th scope="col">Status</th>
+                                <th scope="col" class="text-right">Current Shares</th>
+                                <th scope="col" class="text-right hidden md:table-cell">Previous Shares</th>
+                                <th scope="col" class="text-right">Δ Shares</th>
+                                <th scope="col" class="text-right hidden lg:table-cell">Current Value (USD)</th>
+                                <th scope="col" class="text-right">Δ Value (USD)</th>
+                                <th scope="col" class="text-right">Action</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -230,13 +230,13 @@
                         <table class="table table-zebra table-sm">
                             <thead>
                                 <tr>
-                                    <th>Holder</th>
-                                    <th class="text-right">Current Shares</th>
-                                    <th class="text-right hidden md:table-cell">Previous Shares</th>
-                                    <th class="text-right">Δ Shares</th>
-                                    <th class="text-right hidden lg:table-cell">Current Value (USD)</th>
-                                    <th class="text-right">Δ Value (USD)</th>
-                                    <th class="text-right">Action</th>
+                                    <th scope="col">Holder</th>
+                                    <th scope="col" class="text-right">Current Shares</th>
+                                    <th scope="col" class="text-right hidden md:table-cell">Previous Shares</th>
+                                    <th scope="col" class="text-right">Δ Shares</th>
+                                    <th scope="col" class="text-right hidden lg:table-cell">Current Value (USD)</th>
+                                    <th scope="col" class="text-right">Δ Value (USD)</th>
+                                    <th scope="col" class="text-right">Action</th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
@@ -17,14 +17,14 @@
             <table class="table table-zebra table-sm">
                 <thead>
                     <tr>
-                        <th>Date</th>
-                        <th>Insider</th>
-                        <th class="hidden md:table-cell">Role</th>
-                        <th>Type</th>
-                        <th class="text-right">Shares</th>
-                        <th class="text-right hidden md:table-cell">Price</th>
-                        <th class="text-right hidden lg:table-cell">Value</th>
-                        <th class="text-right hidden lg:table-cell"><span class="tooltip tooltip-left cursor-help" data-tip="Total shares owned by the insider after this transaction">After</span></th>
+                        <th scope="col">Date</th>
+                        <th scope="col">Insider</th>
+                        <th scope="col" class="hidden md:table-cell">Role</th>
+                        <th scope="col">Type</th>
+                        <th scope="col" class="text-right">Shares</th>
+                        <th scope="col" class="text-right hidden md:table-cell">Price</th>
+                        <th scope="col" class="text-right hidden lg:table-cell">Value</th>
+                        <th scope="col" class="text-right hidden lg:table-cell"><span class="tooltip tooltip-left cursor-help" data-tip="Total shares owned by the insider after this transaction">After</span></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
@@ -27,12 +27,12 @@
             <table class="table table-zebra table-sm">
                 <thead>
                     <tr>
-                        <th>Settlement Date</th>
-                        <th class="text-right">Current Position</th>
-                        <th class="text-right">Previous Position</th>
-                        <th class="text-right">Change</th>
-                        <th class="text-right hidden md:table-cell">Avg Daily Volume</th>
-                        <th class="text-right">Days to Cover</th>
+                        <th scope="col">Settlement Date</th>
+                        <th scope="col" class="text-right">Current Position</th>
+                        <th scope="col" class="text-right">Previous Position</th>
+                        <th scope="col" class="text-right">Change</th>
+                        <th scope="col" class="text-right hidden md:table-cell">Avg Daily Volume</th>
+                        <th scope="col" class="text-right">Days to Cover</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
@@ -27,11 +27,11 @@
             <table class="table table-zebra table-sm">
                 <thead>
                     <tr>
-                        <th>Date</th>
-                        <th class="text-right">Short Volume</th>
-                        <th class="text-right">Short Exempt</th>
-                        <th class="text-right">Total Volume</th>
-                        <th class="text-right">Short %</th>
+                        <th scope="col">Date</th>
+                        <th scope="col" class="text-right">Short Volume</th>
+                        <th scope="col" class="text-right">Short Exempt</th>
+                        <th scope="col" class="text-right">Total Volume</th>
+                        <th scope="col" class="text-right">Short %</th>
                     </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
## Summary

- Continues the table-a11y sweep (PRs #1634 / #1637 / #1644 / #1647). The 8 Stocks tab partials, the per-holder detail page, the holdings screener / activity dashboards, and the four Profiles pages all rendered \`<th>\` elements without \`scope=\"col\"\` — 117 headers across 15 files.

## Code changes

- Mechanical: \`scope=\"col\"\` added on every \`<th>\` that lacked it. Verified no \`<th>\` lives inside \`<tbody>\` in any of these files, so col scope is correct (no row-headers misclassed).
- \`aria-label\` additions are intentionally out of scope here — those need per-table judgment and will follow up.