### PR TITLE
test(fred): add skipped repro for GH-1652 — ParseDate Hijri culture

### DIFF
--- a/tests/Equibles.UnitTests/Fred/FredImportServiceParseDateHijriCultureTests.cs
+++ b/tests/Equibles.UnitTests/Fred/FredImportServiceParseDateHijriCultureTests.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.Fred.HostedService.Services;
+
+namespace Equibles.UnitTests.Fred;
+
+public class FredImportServiceParseDateHijriCultureTests
+{
+    // ParseDate is the helper that hydrates FredSeries.ObservationStart and
+    // FredSeries.ObservationEnd from the FRED series-metadata payload. Per the
+    // strict-InvariantCulture precedent established for the sibling
+    // ParseObservationDates by GH-1501, an ISO `yyyy-MM-dd` date must round-trip
+    // to the expected DateOnly regardless of thread culture — every FRED date
+    // is emitted as ISO. The helper's signature has the right intent (returns
+    // DateOnly?) but the implementation calls `DateOnly.TryParse(value, out)`
+    // with no explicit InvariantCulture, so under ar-SA (Umm al-Qura) the parse
+    // fails and the helper returns null. ObservationStart / ObservationEnd are
+    // then persisted as null, silently corrupting every freshly-seeded
+    // FredSeries on Hijri-locale hosts.
+    [Fact(Skip = "GH-1652 — ParseDate returns null for ISO date under ar-SA culture")]
+    public void ParseDate_IsoDateUnderHijriCulture_DoesNotReturnNull()
+    {
+        var method = typeof(FredImportService).GetMethod(
+            "ParseDate",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+
+            var result = (DateOnly?)method.Invoke(null, ["2024-01-15"]);
+
+            result.Should().Be(new DateOnly(2024, 1, 15));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the strict-InvariantCulture contract for `FredImportService.ParseDate`, the helper that hydrates `FredSeries.ObservationStart` and `FredSeries.ObservationEnd` from the series-metadata payload. Same root-cause anti-pattern as the just-fixed GH-1501 (`ParseObservationDates`) — that fix tightened the per-record date parse to `InvariantCulture`, but the sibling metadata-date helper on the same class still uses the implicit overload. Under `ar-SA` (Umm al-Qura calendar), `DateOnly.TryParse("2024-01-15", out _)` fails and `ParseDate` returns null; `ObservationStart`/`ObservationEnd` then get persisted as null on every freshly-seeded `FredSeries` on Hijri-locale hosts.
- Ships as `[Fact(Skip = "GH-1652 — …")]` per the repro-first convention. See GH-1652; the skip drops as part of the fix PR.

## Code changes

- `tests/Equibles.UnitTests/Fred/FredImportServiceParseDateHijriCultureTests.cs` — new `[Fact(Skip = "GH-1652 — …")]`. Reflects into the private static `ParseDate`, pins `CultureInfo.CurrentCulture` to `ar-SA` inside a try/finally, and asserts `ParseDate("2024-01-15")` returns `new DateOnly(2024, 1, 15)`. Today the assertion fails because the unguarded `DateOnly.TryParse` returns `false` under the Hijri calendar — skipped — see GH-1652.