### PR TITLE
fix(web): turn the date / period / statement selector spans into <label for>

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -20,7 +20,7 @@
     <div class="mb-4 text-sm">
         <div class="flex flex-wrap items-center gap-x-5 gap-y-2 mb-1">
             <div class="flex items-center gap-2 shrink-0">
-                <span class="text-base-content/60 whitespace-nowrap">Report Date:</span>
+                <label for="activity-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
                 <select id="activity-date" class="select select-bordered select-sm"
                     onchange="window.location.href='Activity?date=' + this.value">
                     @foreach (var date in Model.AvailableDates) {

--- a/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
@@ -22,7 +22,7 @@
     <div class="mb-4 text-sm">
         <div class="flex flex-wrap items-center gap-x-5 gap-y-2">
             <div class="flex items-center gap-2 shrink-0">
-                <span class="text-base-content/60 whitespace-nowrap">Statement:</span>
+                <label for="financials-statement" class="text-base-content/60 whitespace-nowrap">Statement:</label>
                 <select id="financials-statement" class="select select-bordered select-sm">
                     @foreach (var type in Enum.GetValues<FinancialStatementType>()) {
                         if (type == Model.StatementType) {
@@ -34,7 +34,7 @@
                 </select>
             </div>
             <div class="flex items-center gap-2 shrink-0">
-                <span class="text-base-content/60 whitespace-nowrap">Period:</span>
+                <label for="financials-period" class="text-base-content/60 whitespace-nowrap">Period:</label>
                 <select id="financials-period" class="select select-bordered select-sm">
                     @foreach (var p in Model.AvailablePeriods) {
                         if (p.Token == selectedToken) {

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -48,7 +48,7 @@
     <div class="mb-4 text-sm">
         <div class="flex flex-wrap lg:flex-nowrap items-center gap-x-5 gap-y-2 mb-1">
             <div class="flex items-center gap-2 shrink-0">
-                <span class="text-base-content/60 whitespace-nowrap">Report Date:</span>
+                <label for="holdings-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
                 <select id="holdings-date" class="select select-bordered select-sm"
                     onchange="window.location.href='Holdings?date=' + this.value">
                     @foreach (var date in Model.AvailableDates) {


### PR DESCRIPTION
## Summary

- Four selectors across \`/Holdings/Activity\`, \`/Stocks/{ticker}/Holdings\`, and \`/Stocks/{ticker}/Financials\` sat next to a \`<span>\` holding their label text but were never programmatically tied to it. Screen readers announced each select as a bare combobox with no context.

## Code changes

- Replace the adjacent \`<span>\` with \`<label for=\"<id>\">\` in each case (4 selectors):
  - \`src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml\` — \"Report Date:\".
  - \`src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml\` — \"Report Date:\".
  - \`src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml\` — \"Statement:\" and \"Period:\".

Visual unchanged (label inherits the same classes the span had).