### PR TITLE
fix(fred): parse FredSeries observation dates with InvariantCulture

### DIFF
--- a/src/Equibles.Fred.HostedService/Services/FredImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredImportService.cs
@@ -276,7 +276,14 @@ public class FredImportService
 
     private static DateOnly? ParseDate(string value)
     {
-        return DateOnly.TryParse(value, out var date) ? date : null;
+        return DateOnly.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var date
+        )
+            ? date
+            : null;
     }
 
     // Parse each FRED record's date once so callers can reuse the (record, date)

--- a/tests/Equibles.UnitTests/Fred/FredImportServiceParseDateHijriCultureTests.cs
+++ b/tests/Equibles.UnitTests/Fred/FredImportServiceParseDateHijriCultureTests.cs
@@ -17,7 +17,7 @@ public class FredImportServiceParseDateHijriCultureTests
     // fails and the helper returns null. ObservationStart / ObservationEnd are
     // then persisted as null, silently corrupting every freshly-seeded
     // FredSeries on Hijri-locale hosts.
-    [Fact(Skip = "GH-1652 — ParseDate returns null for ISO date under ar-SA culture")]
+    [Fact]
     public void ParseDate_IsoDateUnderHijriCulture_DoesNotReturnNull()
     {
         var method = typeof(FredImportService).GetMethod(


### PR DESCRIPTION
## Summary

- Closes #1652. `FredImportService.ParseDate` (helper that hydrates `FredSeries.ObservationStart` / `ObservationEnd` from the series-metadata payload) called `DateOnly.TryParse(value, out var date)` under the thread's `CurrentCulture`, so an ISO `yyyy-MM-dd` failed to parse under `ar-SA` (Umm al-Qura) and the helper returned `null`. `ObservationStart` / `ObservationEnd` were then persisted as null on every freshly-seeded `FredSeries` on Hijri-locale hosts.
- One-line hardening: pass `CultureInfo.InvariantCulture, DateTimeStyles.None`, mirroring the sibling `ParseObservationDates` fix from #1501. Unskips the pre-existing regression test.

## Code changes

- `src/Equibles.Fred.HostedService/Services/FredImportService.cs` — `ParseDate` now calls the explicit `InvariantCulture` / `DateTimeStyles.None` overload of `DateOnly.TryParse`. Behavior unchanged for ISO inputs under the invariant or en-US cultures; ISO inputs no longer drop to `null` under ar-SA / other non-Gregorian locales.
- `tests/Equibles.UnitTests/Fred/FredImportServiceParseDateHijriCultureTests.cs` — dropped the `Skip = "GH-1652 …"` attribute so the regression test now runs and locks the contract.