### PR TITLE
fix(sec): reject FTD lines with non-numeric price

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -300,7 +300,8 @@ public class FtdImportService
         }
 
         long.TryParse(parts[3], out var quantity);
-        decimal.TryParse(parts[5], CultureInfo.InvariantCulture, out var price);
+        if (!decimal.TryParse(parts[5], CultureInfo.InvariantCulture, out var price))
+            return null;
 
         return new FtdRecord
         {

--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceParseLineNonNumericPriceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceParseLineNonNumericPriceTests.cs
@@ -13,7 +13,7 @@ public class FtdImportServiceParseLineNonNumericPriceTests
     // meaningful and observable value (delisted / no-bid securities), and
     // silently coercing "unparseable" into 0 corrupts downstream price-weighted
     // FTD aggregates with a value distinct from "we couldn't parse this row".
-    [Fact(Skip = "GH-1596 — ParseLine emits record with Price=0 for non-numeric price")]
+    [Fact]
     public void ParseLine_NonNumericPrice_ReturnsNull()
     {
         var method = typeof(FtdImportService).GetMethod(


### PR DESCRIPTION
## Summary

- Closes #1596. `FtdImportService.ParseLine` discarded `decimal.TryParse(parts[5], InvariantCulture, out var price)`'s return value, letting the `out` default leak through as `Price = 0M` on any non-numeric `PRICE` token. Because `Price = 0M` is itself a meaningful value (delisted / no-bid securities), this silently corrupted downstream price-weighted FTD aggregates by conflating "we couldn't parse this row" with a real zero. Same strict-null-on-malformed precedent as GH-1350 (`IsRecentFtdFile`) and GH-1438 (`ParseLine` quantity).
- One-line gate `if (!decimal.TryParse(parts[5], InvariantCulture, out var price)) return null;`, mirroring the existing `SETTLEMENT DATE` reject path. Unskips the pre-existing regression test `FtdImportServiceParseLineNonNumericPriceTests` shipped in the repro PR.
- Scope is exactly the `PRICE` field. The sibling defect on `QUANTITY` (`long.TryParse` with discarded return) remains tracked under #1438 / PR #1600.

## Code changes

- `src/Equibles.Sec.HostedService/Services/FtdImportService.cs` — added the `if (!decimal.TryParse(parts[5], InvariantCulture, out var price)) return null;` gate in `ParseLine`, immediately replacing the bare `decimal.TryParse` call that discarded its return. Pure addition; well-formed lines are unaffected, malformed price lines now return `null`.
- `tests/Equibles.UnitTests/Sec/FtdImportServiceParseLineNonNumericPriceTests.cs` — dropped the `Skip = "GH-1596 …"` attribute so the regression test now runs and locks the behaviour.