### PR TITLE
fix(web): promote top-level stock-tab section headings from H3 to H2

### DIFF
--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -55,7 +55,7 @@
     @if (Model.Holdings.Count == 0) {
         <div class="card bg-base-100 shadow-sm">
             <div class="card-body text-center py-12">
-                <h3 class="text-base-content/60 mb-2">No Holdings History</h3>
+                <h2 class="text-base-content/60 mb-2">No Holdings History</h2>
                 <p class="text-base-content/40 text-sm">No holdings records found for this institution in @stock.Ticker.</p>
             </div>
         </div>

--- a/src/Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml
@@ -7,7 +7,7 @@
             <div class="text-base-content/30 mb-3">
                 <icon name="building-library" size="12" />
             </div>
-            <h3 class="text-base-content/60 mb-2">No Congressional Trades</h3>
+            <h2 class="text-base-content/60 mb-2">No Congressional Trades</h2>
             <p class="text-base-content/40 text-sm">No congressional trading data is available for this stock yet.</p>
         </div>
     </div>

--- a/src/Equibles.Web/Views/Stocks/_DocumentsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_DocumentsTab.cshtml
@@ -7,7 +7,7 @@
             <div class="text-base-content/30 mb-3">
                 <icon name="document-text" size="12" />
             </div>
-            <h3 class="text-base-content/60 mb-2">No Documents Available</h3>
+            <h2 class="text-base-content/60 mb-2">No Documents Available</h2>
             <p class="text-base-content/40 text-sm">No SEC filings or earnings transcripts are available for this stock yet.</p>
         </div>
     </div>

--- a/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
@@ -8,7 +8,7 @@
             <div class="text-base-content/30 mb-3">
                 <icon name="document-text" size="12" />
             </div>
-            <h3 class="text-base-content/60 mb-2">No Financial Data</h3>
+            <h2 class="text-base-content/60 mb-2">No Financial Data</h2>
             <p class="text-base-content/40 text-sm">No structured financial facts have been ingested for this stock yet.</p>
         </div>
     </div>

--- a/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
@@ -6,7 +6,7 @@
             <div class="text-base-content/30 mb-3">
                 <icon name="exclamation-triangle" size="12" />
             </div>
-            <h3 class="text-base-content/60 mb-2">No Fails to Deliver Data</h3>
+            <h2 class="text-base-content/60 mb-2">No Fails to Deliver Data</h2>
             <p class="text-base-content/40 text-sm">No fails-to-deliver data is available for this stock yet.</p>
         </div>
     </div>
@@ -14,7 +14,7 @@
     <!-- Chart -->
     <div class="card bg-base-100 shadow-sm mb-4">
         <div class="card-body p-4 lg:p-6">
-            <h3 class="font-semibold text-sm mb-3">Fails to Deliver History</h3>
+            <h2 class="font-semibold text-sm mb-3">Fails to Deliver History</h2>
             <div class="h-[200px]">
                 <canvas id="ftd-chart"></canvas>
             </div>

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -39,7 +39,7 @@
             <div class="text-base-content/30 mb-3">
                 <icon name="building-office" size="12" />
             </div>
-            <h3 class="text-base-content/60 mb-2">No Holdings Data</h3>
+            <h2 class="text-base-content/60 mb-2">No Holdings Data</h2>
             <p class="text-base-content/40 text-sm">No institutional holdings data is available for this stock yet.</p>
         </div>
     </div>
@@ -105,7 +105,7 @@
                     <div class="card-body p-4">
                         <div class="flex items-center justify-between mb-2">
                             <div class="flex items-center gap-2">
-                                <h3 class="text-base font-medium m-0">@card.Label</h3>
+                                <h2 class="text-base font-medium m-0">@card.Label</h2>
                                 <span class="badge @card.BadgeCss badge-sm">@card.Total.ToString("N0")</span>
                             </div>
                             @if (card.Total > card.Entries.Count) {

--- a/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
@@ -7,7 +7,7 @@
             <div class="text-base-content/30 mb-3">
                 <icon name="user" size="12" />
             </div>
-            <h3 class="text-base-content/60 mb-2">No Insider Trading Data</h3>
+            <h2 class="text-base-content/60 mb-2">No Insider Trading Data</h2>
             <p class="text-base-content/40 text-sm">No insider transactions are available for this stock yet.</p>
         </div>
     </div>

--- a/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
@@ -6,7 +6,7 @@
             <div class="text-base-content/30 mb-3">
                 <icon name="chart-bar" size="12" />
             </div>
-            <h3 class="text-base-content/60 mb-2">No Price Data</h3>
+            <h2 class="text-base-content/60 mb-2">No Price Data</h2>
             <p class="text-base-content/40 text-sm">No daily price data is available for this stock yet. Data syncs automatically from Yahoo Finance.</p>
         </div>
     </div>
@@ -24,7 +24,7 @@
     <!-- Price + SMA Chart -->
     <div class="card bg-base-100 shadow-sm mb-2">
         <div class="card-body p-4 lg:p-6 pb-2 lg:pb-2">
-            <h3 class="font-semibold text-sm mb-3">Price &amp; Moving Averages</h3>
+            <h2 class="font-semibold text-sm mb-3">Price &amp; Moving Averages</h2>
             <div class="h-[350px]">
                 <canvas id="price-chart"></canvas>
             </div>
@@ -43,7 +43,7 @@
     <!-- RSI Chart -->
     <div class="card bg-base-100 shadow-sm mb-2">
         <div class="card-body p-4 lg:p-6 pb-2 lg:pb-2">
-            <h3 class="font-semibold text-sm mb-3">RSI (14)</h3>
+            <h2 class="font-semibold text-sm mb-3">RSI (14)</h2>
             <div class="h-[120px]">
                 <canvas id="rsi-chart"></canvas>
             </div>
@@ -53,7 +53,7 @@
     <!-- MACD Chart -->
     <div class="card bg-base-100 shadow-sm mb-4">
         <div class="card-body p-4 lg:p-6 pb-2 lg:pb-2">
-            <h3 class="font-semibold text-sm mb-3">MACD (12, 26, 9)</h3>
+            <h2 class="font-semibold text-sm mb-3">MACD (12, 26, 9)</h2>
             <div class="h-[120px]">
                 <canvas id="macd-chart"></canvas>
             </div>

--- a/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
@@ -6,7 +6,7 @@
             <div class="text-base-content/30 mb-3">
                 <icon name="chart-bar" size="12" />
             </div>
-            <h3 class="text-base-content/60 mb-2">No Short Interest Data</h3>
+            <h2 class="text-base-content/60 mb-2">No Short Interest Data</h2>
             <p class="text-base-content/40 text-sm">No short interest data is available for this stock yet.</p>
         </div>
     </div>
@@ -14,7 +14,7 @@
     <!-- Chart -->
     <div class="card bg-base-100 shadow-sm mb-4">
         <div class="card-body p-4 lg:p-6">
-            <h3 class="font-semibold text-sm mb-3">Short Interest History</h3>
+            <h2 class="font-semibold text-sm mb-3">Short Interest History</h2>
             <div class="h-[200px]">
                 <canvas id="short-interest-chart"></canvas>
             </div>

--- a/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
@@ -6,7 +6,7 @@
             <div class="text-base-content/30 mb-3">
                 <icon name="arrow-trending-down" size="12" />
             </div>
-            <h3 class="text-base-content/60 mb-2">No Short Volume Data</h3>
+            <h2 class="text-base-content/60 mb-2">No Short Volume Data</h2>
             <p class="text-base-content/40 text-sm">No daily short volume data is available for this stock yet.</p>
         </div>
     </div>
@@ -14,7 +14,7 @@
     <!-- Chart -->
     <div class="card bg-base-100 shadow-sm mb-4">
         <div class="card-body p-4 lg:p-6">
-            <h3 class="font-semibold text-sm mb-3">Short Volume (Last 90 Days)</h3>
+            <h2 class="font-semibold text-sm mb-3">Short Volume (Last 90 Days)</h2>
             <div class="h-[200px]">
                 <canvas id="short-volume-chart"></canvas>
             </div>

--- a/tests/Equibles.FunctionalTests/Tests/StocksCongressionalTradesSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksCongressionalTradesSeededTests.cs
@@ -104,7 +104,7 @@ public class StocksCongressionalTradesSeededTests
 
         // Non-empty branch executed — the empty-state h3 must NOT be present.
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Congressional Trades" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Congressional Trades" }))
             .ToHaveCountAsync(0);
 
         var rows = page.Locator("table tbody tr");

--- a/tests/Equibles.FunctionalTests/Tests/StocksCongressionalTradesTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksCongressionalTradesTests.cs
@@ -48,7 +48,7 @@ public class StocksCongressionalTradesTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Congressional Trades" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Congressional Trades" }))
             .ToHaveCountAsync(1);
     }
 }

--- a/tests/Equibles.FunctionalTests/Tests/StocksDocumentsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksDocumentsTests.cs
@@ -48,7 +48,7 @@ public class StocksDocumentsTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Documents Available" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Documents Available" }))
             .ToHaveCountAsync(1);
     }
 }

--- a/tests/Equibles.FunctionalTests/Tests/StocksFtdSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksFtdSeededTests.cs
@@ -76,10 +76,10 @@ public class StocksFtdSeededTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Fails to Deliver Data" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Fails to Deliver Data" }))
             .ToHaveCountAsync(0);
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "Fails to Deliver History" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "Fails to Deliver History" }))
             .ToHaveCountAsync(1);
 
         var rows = page.Locator("table tbody tr");

--- a/tests/Equibles.FunctionalTests/Tests/StocksFtdTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksFtdTests.cs
@@ -47,7 +47,7 @@ public class StocksFtdTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Fails to Deliver Data" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Fails to Deliver Data" }))
             .ToHaveCountAsync(1);
     }
 }

--- a/tests/Equibles.FunctionalTests/Tests/StocksHoldingsSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksHoldingsSeededTests.cs
@@ -99,7 +99,7 @@ public class StocksHoldingsSeededTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Holdings Data" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Holdings Data" }))
             .ToHaveCountAsync(0);
 
         var dateSelect = page.Locator("select#holdings-date");

--- a/tests/Equibles.FunctionalTests/Tests/StocksHoldingsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksHoldingsTests.cs
@@ -47,7 +47,7 @@ public class StocksHoldingsTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Holdings Data" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Holdings Data" }))
             .ToHaveCountAsync(1);
     }
 }

--- a/tests/Equibles.FunctionalTests/Tests/StocksInsiderTradingSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksInsiderTradingSeededTests.cs
@@ -94,7 +94,7 @@ public class StocksInsiderTradingSeededTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Insider Trading Data" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Insider Trading Data" }))
             .ToHaveCountAsync(0);
 
         var rows = page.Locator("table tbody tr");

--- a/tests/Equibles.FunctionalTests/Tests/StocksInsiderTradingTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksInsiderTradingTests.cs
@@ -47,7 +47,7 @@ public class StocksInsiderTradingTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Insider Trading Data" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Insider Trading Data" }))
             .ToHaveCountAsync(1);
     }
 }

--- a/tests/Equibles.FunctionalTests/Tests/StocksPriceSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksPriceSeededTests.cs
@@ -89,10 +89,10 @@ public class StocksPriceSeededTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Price Data" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Price Data" }))
             .ToHaveCountAsync(0);
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "Price & Moving Averages" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "Price & Moving Averages" }))
             .ToHaveCountAsync(1);
 
         // Data Range text is rendered as `{first.Date} — {last.Date}` (em-dash). The text

--- a/tests/Equibles.FunctionalTests/Tests/StocksShortInterestTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksShortInterestTests.cs
@@ -74,7 +74,7 @@ public class StocksShortInterestTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Short Interest Data" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Short Interest Data" }))
             .ToHaveCountAsync(0);
         await Assertions.Expect(page.Locator("#short-interest-chart")).ToHaveCountAsync(1);
 
@@ -115,7 +115,7 @@ public class StocksShortInterestTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Short Interest Data" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Short Interest Data" }))
             .ToHaveCountAsync(1);
     }
 }

--- a/tests/Equibles.FunctionalTests/Tests/StocksShortVolumeTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksShortVolumeTests.cs
@@ -73,7 +73,7 @@ public class StocksShortVolumeTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Short Volume Data" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Short Volume Data" }))
             .ToHaveCountAsync(0);
         await Assertions.Expect(page.Locator("#short-volume-chart")).ToHaveCountAsync(1);
 
@@ -114,7 +114,7 @@ public class StocksShortVolumeTests
         response!.Status.Should().Be(200);
 
         await Assertions
-            .Expect(page.Locator("h3").Filter(new() { HasTextString = "No Short Volume Data" }))
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Short Volume Data" }))
             .ToHaveCountAsync(1);
     }
 }


### PR DESCRIPTION
## Summary

- Same shape as PR #1659 (Institution heading hierarchy). Every stock detail tab partial rendered its top-level section headers as H3 even though the page only carried H1 on the ticker — producing an H1>H3 skip on every tab. WCAG 1.3.1.

## Code changes

- 10 files in \`src/Equibles.Web/Views/Stocks/\`: \`_PriceTab\`, \`_HoldingsTab\`, \`_FtdTab\`, \`_FinancialsTab\`, \`_DocumentsTab\`, \`_CongressionalTradesTab\`, \`_ShortInterestTab\`, \`_InsiderTradingTab\`, \`_ShortVolumeTab\`, \`ShowHolder\`. Promote 19 top-level H3 section headings (chart titles, empty-state placeholders, mover-card labels) to H2.
- Sub-section H3s already correctly nested under an H2 (the \"Position Over Time\" chart inside the \"Holdings in TICKER\" section on ShowHolder) are left alone.
- Visual classes unchanged.