### PR TITLE
fix(web): correct heading hierarchy on the remaining Profiles pages

### DIFF
--- a/src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml
@@ -61,7 +61,7 @@
             @foreach (var row in rows) {
                 <div class="card bg-base-100 shadow-sm" data-testid="@row.TestId">
                     <div class="card-body p-4">
-                        <h3 class="text-base font-medium mb-2">@row.Label</h3>
+                        <h2 class="text-base font-medium mb-2">@row.Label</h2>
                         <div class="stats stats-vertical sm:stats-horizontal shadow-sm bg-base-200 w-full">
                             <div class="stat">
                                 <div class="stat-title">Total return</div>
@@ -88,7 +88,7 @@
         <div class="card bg-base-100 shadow-sm mb-6" data-testid="backtest-chart-card">
             <div class="card-body p-4">
                 <div class="flex items-baseline justify-between mb-3">
-                    <h3 class="text-base font-medium m-0">Cumulative return (=100)</h3>
+                    <h2 class="text-base font-medium m-0">Cumulative return (=100)</h2>
                     <span class="text-xs text-base-content/60">@Model.Result.StartDate.ToString("yyyy-MM-dd") → @Model.Result.EndDate.ToString("yyyy-MM-dd") · @Model.Result.Points.Count.ToString("N0") days</span>
                 </div>
                 <div class="h-[360px]">

--- a/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
@@ -19,7 +19,7 @@
                 <div class="text-base-content/30 mb-3">
                     <icon name="user-group" size="12" />
                 </div>
-                <h3 class="text-base-content/60 mb-2">Pass at least two CIKs to combine</h3>
+                <h2 class="text-base-content/60 mb-2">Pass at least two CIKs to combine</h2>
                 <p class="text-base-content/40 text-sm">Example: <code>/Institutions/Combined?ciks=0001067983&amp;ciks=0001336528&amp;ciks=0001603466</code></p>
             </div>
         </div>

--- a/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
@@ -18,7 +18,7 @@
                 <div class="text-base-content/30 mb-3">
                     <icon name="user-group" size="12" />
                 </div>
-                <h3 class="text-base-content/60 mb-2">Pass at least two CIKs to compare</h3>
+                <h2 class="text-base-content/60 mb-2">Pass at least two CIKs to compare</h2>
                 <p class="text-base-content/40 text-sm">Example: <code>/Institutions/Compare?ciks=0001067983&amp;ciks=0001603466</code></p>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- Continues PRs #1659 (Institution) and #1660 (Stocks tabs). The three remaining Profiles views — CompareInstitutions, CombinedInstitutions, BacktestInstitution — jumped from H1 to H3 for their top-level section headings.

## Code changes

- \`src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml\` — empty-state \"Pass at least two CIKs to compare\" H3 → H2.
- \`src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml\` — empty-state \"Pass at least two CIKs to combine\" H3 → H2.
- \`src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml\` — backtest summary card \"@row.Label\" + chart heading \"Cumulative return (=100)\" H3 → H2.

\`Insider.cshtml\` and \`Member.cshtml\` already used H2 for their top-level sections; nothing to do there. Visual classes unchanged.