### PR TITLE
fix(web): add missing H1 to HoldingsActivity and promote H3s on Holdings pages

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -5,13 +5,15 @@
     ViewData["Menu"] = "Holdings";
 }
 
+<h1 class="text-2xl font-bold mb-4">13F Quarterly Activity</h1>
+
 @if (Model.AvailableDates.Count == 0) {
     <div class="card bg-base-100 shadow-sm">
         <div class="card-body items-center text-center py-12">
             <div class="text-base-content/30 mb-3">
                 <icon name="building-office" size="12" />
             </div>
-            <h3 class="text-base-content/60 mb-2">No 13F data yet</h3>
+            <h2 class="text-base-content/60 mb-2">No 13F data yet</h2>
             <p class="text-base-content/40 text-sm">Once at least one quarter of 13F filings has been ingested, the market-wide activity boards appear here.</p>
         </div>
     </div>
@@ -64,7 +66,7 @@
                 <div class="card bg-base-100 shadow-sm" data-testid="@board.TestId">
                     <div class="card-body p-4">
                         <div class="flex items-center gap-2 mb-2">
-                            <h3 class="text-base font-medium m-0">@board.Label</h3>
+                            <h2 class="text-base font-medium m-0">@board.Label</h2>
                             <span class="badge @board.BadgeCss badge-sm">@board.Rows.Count.ToString("N0")</span>
                         </div>
                         @if (board.Rows.Count == 0) {
@@ -121,7 +123,7 @@
                 <div class="card bg-base-100 shadow-sm" data-testid="@board.TestId">
                     <div class="card-body p-4">
                         <div class="flex items-center gap-2 mb-2">
-                            <h3 class="text-base font-medium m-0">@board.Label</h3>
+                            <h2 class="text-base font-medium m-0">@board.Label</h2>
                             <span class="badge @board.BadgeCss badge-sm">@board.Rows.Count.ToString("N0")</span>
                         </div>
                         @if (board.Rows.Count == 0) {

--- a/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
+++ b/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
@@ -122,7 +122,7 @@
         <div class="card bg-base-100 shadow-sm" data-testid="screener-results">
             <div class="card-body p-4">
                 <div class="flex items-baseline justify-between mb-2">
-                    <h3 class="text-base font-medium m-0">@Model.Rows.Count.ToString("N0") matching stocks</h3>
+                    <h2 class="text-base font-medium m-0">@Model.Rows.Count.ToString("N0") matching stocks</h2>
                     <span class="text-xs text-base-content/60">
                         @Model.SelectedDate.ToString("MMM dd, yyyy") vs @Model.ComparisonDate.ToString("MMM dd, yyyy")@(Model.TruncatedToCap ? " · truncated to first " + Equibles.Web.Controllers.HoldingsScreenerController.RowCap.ToString("N0") : "")
                     </span>


### PR DESCRIPTION
## Summary

- Continues the heading-hierarchy sweep (PRs #1659, #1660, #1661). Two findings on the Holdings views:
  1. \`/Holdings/Activity\` rendered ZERO \`<h1>\` elements — the page title only landed in \`<title>\` and the body started at H3. WCAG 2.4.6 + 1.3.1.
  2. \`/Holdings/Screener\` had \`H1 > H3\` (\"N matching stocks\" sub-heading skipped H2).

## Code changes

- \`src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml\` — add an explicit \`<h1>13F Quarterly Activity</h1>\` at the top of the body. Promote the four board labels (Top Buys / Top Sells / New Positions / Sold-Out Positions) and the empty-state heading from H3 to H2 so they nest cleanly under the new H1.
- \`src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml\` — promote the \"N matching stocks\" sub-heading from H3 to H2.

Visual classes unchanged.