### PR TITLE
fix(web): promote the Login card title from H2 to H1

### DIFF
--- a/src/Equibles.Web/Views/Auth/Login.cshtml
+++ b/src/Equibles.Web/Views/Auth/Login.cshtml
@@ -8,7 +8,7 @@
     <div class="card-body">
         <div class="flex flex-col items-center gap-2 mb-4">
             <img src="/favicon/favicon/android-chrome-512x512.png" alt="Equibles" class="h-12 w-auto" />
-            <h2 class="card-title text-lg">Sign in to Equibles</h2>
+            <h1 class="card-title text-lg">Sign in to Equibles</h1>
         </div>
 
         <form asp-action="Login" asp-controller="Auth">


### PR DESCRIPTION
## Summary

- The login page was the only view in the app with no \`<h1>\` — the only heading was an \`<h2 class=\"card-title\">Sign in to Equibles</h2>\`. Every other page now has exactly one H1 (heading-hierarchy sweep across PRs #1659 / #1660 / #1661 / #1662 / #1663); align Login with that contract.

## Code changes

- \`src/Equibles.Web/Views/Auth/Login.cshtml\` — promote the \"Sign in to Equibles\" \`<h2>\` to \`<h1>\`. Visual classes unchanged.