### PR TITLE
fix(web): label all chart canvases with role=img + aria-label

### DIFF
--- a/src/Equibles.Web/Views/Cftc/Show.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Show.cshtml
@@ -75,7 +75,7 @@
             <div class="card-body p-4 lg:p-6">
                 <h2 class="font-semibold text-sm mb-3">Net Positioning</h2>
                 <div class="h-[320px]">
-                    <canvas id="cftc-chart"></canvas>
+                    <canvas id="cftc-chart" role="img" aria-label="CFTC net positioning over time"></canvas>
                 </div>
             </div>
         </div>

--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -126,7 +126,7 @@
             <div class="card-body p-4 lg:p-6">
                 <h2 class="font-semibold text-sm mb-3">@Model.Title (@Model.Units)</h2>
                 <div class="h-[320px]">
-                    <canvas id="economy-chart"></canvas>
+                    <canvas id="economy-chart" role="img" aria-label="Economic series history chart"></canvas>
                 </div>
             </div>
         </div>

--- a/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
+++ b/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
@@ -95,7 +95,7 @@
             <div class="card-body p-4 lg:p-6">
                 <h2 class="font-semibold text-sm mb-3">@Model.DisplayName P/C Ratio</h2>
                 <div class="h-[320px]">
-                    <canvas id="pcr-chart"></canvas>
+                    <canvas id="pcr-chart" role="img" aria-label="Put / call ratio history"></canvas>
                 </div>
             </div>
         </div>

--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -105,7 +105,7 @@
             <div class="card-body p-4 lg:p-6">
                 <h2 class="font-semibold text-sm mb-3">VIX Close</h2>
                 <div class="h-[320px]">
-                    <canvas id="vix-chart"></canvas>
+                    <canvas id="vix-chart" role="img" aria-label="VIX daily close history"></canvas>
                 </div>
             </div>
         </div>

--- a/src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml
@@ -92,7 +92,7 @@
                     <span class="text-xs text-base-content/60">@Model.Result.StartDate.ToString("yyyy-MM-dd") → @Model.Result.EndDate.ToString("yyyy-MM-dd") · @Model.Result.Points.Count.ToString("N0") days</span>
                 </div>
                 <div class="h-[360px]">
-                    <canvas id="backtest-chart" data-testid="backtest-chart"></canvas>
+                    <canvas id="backtest-chart" data-testid="backtest-chart" role="img" aria-label="Backtest cumulative return"></canvas>
                 </div>
             </div>
         </div>

--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -73,7 +73,7 @@
                 <div class="card-body p-4 lg:p-6">
                     <h3 class="font-semibold text-sm mb-3">Position Over Time</h3>
                     <div class="h-[200px]">
-                        <canvas id="holder-position-chart"></canvas>
+                        <canvas id="holder-position-chart" role="img" aria-label="Holder position over time"></canvas>
                     </div>
                 </div>
             </div>

--- a/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
@@ -16,7 +16,7 @@
         <div class="card-body p-4 lg:p-6">
             <h2 class="font-semibold text-sm mb-3">Fails to Deliver History</h2>
             <div class="h-[200px]">
-                <canvas id="ftd-chart"></canvas>
+                <canvas id="ftd-chart" role="img" aria-label="Fails-to-deliver history"></canvas>
             </div>
         </div>
     </div>

--- a/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
@@ -26,7 +26,7 @@
         <div class="card-body p-4 lg:p-6 pb-2 lg:pb-2">
             <h2 class="font-semibold text-sm mb-3">Price &amp; Moving Averages</h2>
             <div class="h-[350px]">
-                <canvas id="price-chart"></canvas>
+                <canvas id="price-chart" role="img" aria-label="Stock price with moving averages"></canvas>
             </div>
         </div>
     </div>
@@ -35,7 +35,7 @@
     <div class="card bg-base-100 shadow-sm mb-2">
         <div class="card-body p-4 lg:p-6 py-2 lg:py-2">
             <div class="h-[80px]">
-                <canvas id="volume-chart"></canvas>
+                <canvas id="volume-chart" role="img" aria-label="Trading volume"></canvas>
             </div>
         </div>
     </div>
@@ -45,7 +45,7 @@
         <div class="card-body p-4 lg:p-6 pb-2 lg:pb-2">
             <h2 class="font-semibold text-sm mb-3">RSI (14)</h2>
             <div class="h-[120px]">
-                <canvas id="rsi-chart"></canvas>
+                <canvas id="rsi-chart" role="img" aria-label="Relative strength index"></canvas>
             </div>
         </div>
     </div>
@@ -55,7 +55,7 @@
         <div class="card-body p-4 lg:p-6 pb-2 lg:pb-2">
             <h2 class="font-semibold text-sm mb-3">MACD (12, 26, 9)</h2>
             <div class="h-[120px]">
-                <canvas id="macd-chart"></canvas>
+                <canvas id="macd-chart" role="img" aria-label="MACD indicator"></canvas>
             </div>
         </div>
     </div>

--- a/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
@@ -16,7 +16,7 @@
         <div class="card-body p-4 lg:p-6">
             <h2 class="font-semibold text-sm mb-3">Short Interest History</h2>
             <div class="h-[200px]">
-                <canvas id="short-interest-chart"></canvas>
+                <canvas id="short-interest-chart" role="img" aria-label="Short interest history"></canvas>
             </div>
         </div>
     </div>

--- a/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
@@ -16,7 +16,7 @@
         <div class="card-body p-4 lg:p-6">
             <h2 class="font-semibold text-sm mb-3">Short Volume (Last 90 Days)</h2>
             <div class="h-[200px]">
-                <canvas id="short-volume-chart"></canvas>
+                <canvas id="short-volume-chart" role="img" aria-label="Daily short volume history"></canvas>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary

- Chart.js renders into bare \`<canvas>\` elements. Without \`role=\"img\"\` and \`aria-label\`, screen readers announce each chart as a generic \"graphic\" with no description — a blind user has no idea what data the chart visualises.

## Code changes

13 canvases gain \`role=\"img\"\` + a short \`aria-label\` describing what they show:

- Stock detail tabs (Price, ShortVolume, FTD, ShortInterest).
- \`Stocks/ShowHolder\` (Holder position over time).
- \`Market/Vix\`, \`Market/PutCallRatio\`.
- \`EconomicData/Show\`.
- \`Cftc/Show\` (CFTC net positioning over time).
- \`Profiles/BacktestInstitution\` (Backtest cumulative return).

Visual unchanged; only the AT-exposed name changes.