### PR TITLE
fix(web): set explicit dimensions on the Equibles logo + switch to 192px source

### DIFF
--- a/src/Equibles.Web/Views/Auth/Login.cshtml
+++ b/src/Equibles.Web/Views/Auth/Login.cshtml
@@ -7,7 +7,7 @@
 <div class="card bg-base-100 shadow-lg w-full max-w-sm">
     <div class="card-body">
         <div class="flex flex-col items-center gap-2 mb-4">
-            <img src="/favicon/favicon/android-chrome-512x512.png" alt="Equibles" class="h-12 w-auto" />
+            <img src="/favicon/favicon/android-chrome-192x192.png" alt="Equibles" width="48" height="48" class="h-12 w-auto" />
             <h1 class="card-title text-lg">Sign in to Equibles</h1>
         </div>
 

--- a/src/Equibles.Web/Views/Shared/_Footer.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Footer.cshtml
@@ -2,7 +2,7 @@
     <div class="max-w-6xl mx-auto px-6 py-8">
         <div class="flex flex-col md:flex-row justify-between items-center gap-4">
             <div class="flex items-center gap-2">
-                <img src="/favicon/favicon/android-chrome-512x512.png" alt="Equibles" class="h-5 w-auto" />
+                <img src="/favicon/favicon/android-chrome-192x192.png" alt="Equibles" width="20" height="20" class="h-5 w-auto" />
                 <span class="text-sm text-base-content/60 font-normal">&copy; @DateTime.UtcNow.Year Equibles</span>
             </div>
             <nav class="flex flex-wrap items-center gap-6 text-sm text-base-content/60 font-normal">

--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -23,7 +23,7 @@
         <div class="max-w-6xl mx-auto w-full px-6 flex items-center">
             <div class="flex-1 flex items-center gap-6">
                 <a asp-action="Index" asp-controller="Home" class="flex items-center gap-2">
-                    <img src="/favicon/favicon/android-chrome-512x512.png" alt="Equibles" class="h-7 w-auto" />
+                    <img src="/favicon/favicon/android-chrome-192x192.png" alt="Equibles" width="28" height="28" class="h-7 w-auto" />
                 </a>
                 <nav class="hidden lg:flex items-center gap-6 whitespace-nowrap" aria-label="Main navigation">
                     <a asp-action="Index" asp-controller="Home" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">Home</a>


### PR DESCRIPTION
## Summary

- Three \`<img>\` tags rendered the 512×512 PNG at 28 / 20 / 48 pixels with no \`width\` / \`height\` attributes. Two issues:
  1. Browser reserved zero space for the image until it loaded — navbar / footer / login card shifted on first paint (CLS).
  2. A 512×512 source for a 28-pixel render is wasteful; the 192×192 favicon variant covers up to 4× DPR for every usage.

## Code changes

- \`src/Equibles.Web/Views/Shared/_Layout.cshtml\` — navbar logo: src → 192×192, \`width=\"28\" height=\"28\"\`.
- \`src/Equibles.Web/Views/Shared/_Footer.cshtml\` — footer logo: src → 192×192, \`width=\"20\" height=\"20\"\`.
- \`src/Equibles.Web/Views/Auth/Login.cshtml\` — login logo: src → 192×192, \`width=\"48\" height=\"48\"\`.

OG / Twitter card meta images keep the 512×512 source — those are sized for social previews and shouldn't be downscaled. Visual size unchanged (Tailwind h-7 / h-5 / h-12 still drives the rendered dimensions).