### PR TITLE
fix(web): label the ajax modal title and close controls for assistive tech

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Modals.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Modals.cshtml
@@ -1,11 +1,13 @@
 <!-- Reusable ajax modal container -->
-<dialog id="ajax-modal" class="modal">
+<dialog id="ajax-modal" class="modal" aria-labelledby="ajax-modal-title">
     <div class="modal-box w-11/12 max-w-lg max-h-[90vh] flex flex-col relative">
-        <button type="button" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2 modal-close">✕</button>
-        <h3 class="modal-title text-lg font-medium mb-4 title-text"></h3>
+        <button type="button" aria-label="Close" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2 modal-close">
+            <span aria-hidden="true">✕</span>
+        </button>
+        <h3 id="ajax-modal-title" class="modal-title text-lg font-medium mb-4 title-text"></h3>
         <div class="modal-body flex-1 overflow-y-auto"></div>
     </div>
     <form method="dialog" class="modal-backdrop">
-        <button>close</button>
+        <button aria-label="Close modal">close</button>
     </form>
 </dialog>


### PR DESCRIPTION
## Summary

- Three small accessibility gaps in the shared ajax modal scaffold (\`_Modals.cshtml\` — instantiated on every page).

## Code changes

- \`src/Equibles.Web/Views/Shared/_Modals.cshtml\`:
  - \`<dialog>\` gains \`aria-labelledby=\"ajax-modal-title\"\`; the modal-title \`<h3>\` gains that id so screen readers announce the modal's purpose when it opens.
  - The ✕ close button gains \`aria-label=\"Close\"\` and wraps its glyph in \`<span aria-hidden=\"true\">\` so AT reads \"Close\" and visual readers still see the ✕.
  - The backdrop-dismiss button gains \`aria-label=\"Close modal\"\` so it's clear when focused by keyboard / AT.

Visual unchanged.