### PR TITLE
fix(web): expose search forms as search landmarks

### DIFF
--- a/src/Equibles.Web/Views/Search/Index.cshtml
+++ b/src/Equibles.Web/Views/Search/Index.cshtml
@@ -36,6 +36,7 @@
     </div>
 
     <form id="global-search-form" method="get" asp-controller="Search" asp-action="Index"
+          role="search" aria-label="Site search"
           data-results-url="@Url.Action("Results")">
         <!-- Sticky search bar: stays visible while the user scrolls through long result lists.
              instant-search.js progressively enhances this; without JS it submits a normal GET. -->

--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -47,7 +47,7 @@
                 @{
                     var activeSearchQuery = Context.Request.Query["q"].ToString();
                 }
-                <form asp-controller="Search" asp-action="Index" method="get" class="hidden lg:block">
+                <form asp-controller="Search" asp-action="Index" method="get" role="search" aria-label="Global search" class="hidden lg:block">
                     <div class="join">
                         <input id="navbar-search-input" type="search" name="q" value="@activeSearchQuery"
                                class="input input-sm input-bordered join-item w-48 xl:w-64"


### PR DESCRIPTION
## Summary

- The navbar search and the \`/Search\` page form were generic \`<form>\` elements with no landmark role. Assistive tech navigating by landmark could find \"main navigation\" and \"mobile navigation\" but couldn't jump straight to the search input.

## Code changes

- \`src/Equibles.Web/Views/Shared/_Layout.cshtml\` — navbar search form: \`role=\"search\"\` + \`aria-label=\"Global search\"\`.
- \`src/Equibles.Web/Views/Search/Index.cshtml\` — page search form: \`role=\"search\"\` + \`aria-label=\"Site search\"\`.

Visual unchanged.