### PR TITLE
refactor(holdings-screener): collapse BuildCsv field-append duplication into two local helpers

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -133,19 +133,25 @@ public class HoldingsScreenerController : BaseController
             "Ticker,Name,Industry,CurrentFilerCount,PreviousFilerCount,DeltaFilerCount,"
                 + "CurrentValue,PreviousValue,DeltaValue,NewFilerCount,SoldOutFilerCount,PercentOfFloat"
         );
+
+        void AppendString(string value) =>
+            sb.Append(CsvExportService.EscapeField(value)).Append(',');
+        void AppendNumber(long value) =>
+            sb.Append(value.ToString(CultureInfo.InvariantCulture)).Append(',');
+
         foreach (var r in rows)
         {
-            sb.Append(CsvExportService.EscapeField(r.Ticker)).Append(',');
-            sb.Append(CsvExportService.EscapeField(r.Name)).Append(',');
-            sb.Append(CsvExportService.EscapeField(r.IndustryName)).Append(',');
-            sb.Append(r.CurrentFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
-            sb.Append(r.PreviousFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
-            sb.Append(r.DeltaFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
-            sb.Append(r.CurrentValue.ToString(CultureInfo.InvariantCulture)).Append(',');
-            sb.Append(r.PreviousValue.ToString(CultureInfo.InvariantCulture)).Append(',');
-            sb.Append(r.DeltaValue.ToString(CultureInfo.InvariantCulture)).Append(',');
-            sb.Append(r.NewFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
-            sb.Append(r.SoldOutFilerCount.ToString(CultureInfo.InvariantCulture)).Append(',');
+            AppendString(r.Ticker);
+            AppendString(r.Name);
+            AppendString(r.IndustryName);
+            AppendNumber(r.CurrentFilerCount);
+            AppendNumber(r.PreviousFilerCount);
+            AppendNumber(r.DeltaFilerCount);
+            AppendNumber(r.CurrentValue);
+            AppendNumber(r.PreviousValue);
+            AppendNumber(r.DeltaValue);
+            AppendNumber(r.NewFilerCount);
+            AppendNumber(r.SoldOutFilerCount);
             sb.Append(
                 r.PercentOfFloat.HasValue
                     ? r.PercentOfFloat.Value.ToString("F4", CultureInfo.InvariantCulture)


### PR DESCRIPTION
## Summary

- Collapses the twelve repeated `sb.Append(...).Append(',')` chains in `HoldingsScreenerController.BuildCsv` into two local helpers (`AppendString` for escaped string columns, `AppendNumber` for invariant-culture numeric columns).
- Behaviour-preserving — each helper performs the same `Append(...).Append(',')` chain on the same captured `StringBuilder`, so field order, escape rule, invariant-culture formatting, and AppendLine row terminator are unchanged.
- The trailing nullable `PercentOfFloat` column stays inline because its format string (`F4`) and null fallback differ from the other numeric columns.

## Code changes

- `src/Equibles.Web/Controllers/HoldingsScreenerController.cs` — refactor `BuildCsv` to use two local functions for the repeated string-field and integer-field append patterns.