### PR TITLE
fix(sec): clamp ParseLong decimal fallback to avoid OverflowException

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -489,7 +489,10 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
     {
         if (string.IsNullOrEmpty(value))
             return 0;
-        return long.TryParse(value, out var result) ? result : (long)ParseDecimal(value);
+        if (long.TryParse(value, out var result))
+            return result;
+        var d = ParseDecimal(value);
+        return d > long.MaxValue || d < long.MinValue ? 0 : (long)d;
     }
 
     internal static decimal ParseDecimal(string value)

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseLongOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseLongOverflowTests.cs
@@ -30,7 +30,7 @@ public class InsiderTradingFilingProcessorParseLongOverflowTests
     // existing decimal-fallback pin covers the well-formed-fractional case
     // ("1234.5678"); this pin covers the overflow case that would crash the
     // filing processor.
-    [Fact(Skip = "GH-1673 — ParseLong throws OverflowException on out-of-range digit-only input")]
+    [Fact]
     public void ParseLong_OverflowDecimalString_DoesNotThrow()
     {
         // 19 nines = 9_999_999_999_999_999_999 ≈ 1.0e19, strictly greater than


### PR DESCRIPTION
## Summary

- Closes #1673. `InsiderTradingFilingProcessor.ParseLong` threw `OverflowException` on a digit-only string that overflowed `long` but parsed as a decimal: `long.TryParse` failed (out of range), execution fell to `(long)ParseDecimal(value)`, `decimal.TryParse` accepted the value (decimal holds up to ~7.9e28), and the explicit `(long)decimal` cast threw because the result exceeded `long.MaxValue` (~9.2e18). The caller chain (`ParseAllTransactions` → `Process`) treats any throw as "drop the whole filing", so a single out-of-range share count in a Form 4 wiped an insider's entire quarterly disclosure rather than producing a fall-back 0.
- Two-line clamp around the decimal cast: if the decimal exceeds either `long.MaxValue` or `long.MinValue`, return `0` — matching the defensive "return safe default" convention of every sibling `Parse*` helper in this processor (`ParseBool`, `ParseDecimal`, `ParseTransactionCode`, `TryParseTransactionDate`). Unskips the pre-existing regression test.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — `ParseLong` now bails out of the decimal-fallback path when the decimal exceeds `long`'s range (returns `0`) instead of casting and throwing. The single-statement ternary is unrolled into an if + range check for clarity; well-formed-fractional inputs (`"1234.5678"` → `1234`, pinned by an existing test) are unaffected.
- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseLongOverflowTests.cs` — dropped the `Skip = "GH-1673 …"` attribute so the regression test now runs and locks the no-throw contract.