### PR TITLE
test(sec): pin ParseLong negative-overflow returns 0 without throwing

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseLongNegativeOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseLongNegativeOverflowTests.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InsiderTradingFilingProcessorParseLongNegativeOverflowTests
+{
+    private static readonly MethodInfo ParseLongMethod =
+        typeof(InsiderTradingFilingProcessor).GetMethod(
+            "ParseLong",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // Symmetric sibling of the GH-1673 positive-overflow pin. The just-shipped
+    // clamp is `d > long.MaxValue || d < long.MinValue ? 0 : (long)d`; a
+    // refactor that drops the `< long.MinValue` half (or "tidies" the OR into
+    // a single Math.Abs comparison that mishandles the sign) would compile,
+    // pass the positive-overflow pin, and silently re-introduce the crash for
+    // any dirty Form 4 carrying a digit-only negative number below
+    // long.MinValue (-9.22e18). Pin the matching negative branch so both
+    // bounds are locked: ParseLong must return 0 (no throw) on any input
+    // that overflows the long range, regardless of sign.
+    [Fact]
+    public void ParseLong_NegativeOverflowDecimalString_DoesNotThrowAndReturnsZero()
+    {
+        // -19 nines = -9_999_999_999_999_999_999 ≈ -1.0e19, strictly below
+        // long.MinValue (~-9.22e18) but well inside decimal's range. Picks the
+        // exact branch: long.TryParse rejects, decimal.TryParse accepts, and
+        // without the clamp the cast would overflow.
+        long result = 0;
+        var act = () => result = (long)ParseLongMethod.Invoke(null, ["-9999999999999999999"]);
+
+        act.Should().NotThrow();
+        result.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the negative half of `InsiderTradingFilingProcessor.ParseLong`'s overflow clamp, which was shipped in #1677 / GH-1673 as `d > long.MaxValue || d < long.MinValue ? 0 : (long)d`. The positive half is pinned by `InsiderTradingFilingProcessorParseLongOverflowTests`; this PR adds the symmetric pin for the `d < long.MinValue` branch.
- A refactor dropping the `< long.MinValue` half (or "tidying" the OR into a single `Math.Abs` comparison that mishandles the sign) would compile, pass the positive-overflow pin, and silently re-introduce the `OverflowException` for any dirty Form 4 carrying a digit-only negative number below `long.MinValue` (-9.22e18) — wiping the insider's entire quarterly disclosure.
- Test feeds `ParseLong("-9999999999999999999")` (≈ −1.0e19, strictly below `long.MinValue` but inside decimal's range) and asserts no throw and result `== 0`.

## Code changes

- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseLongNegativeOverflowTests.cs` — new `[Fact]` invoking the private static `ParseLong` via reflection with a 19-digit negative input. Asserts the helper does not throw and returns `0`.