### PR TITLE
test(sec): add skipped repro for GH-1679 — FtdImportService.GetFileNames Thai culture

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceGetFileNamesThaiCultureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceGetFileNamesThaiCultureTests.cs
@@ -1,0 +1,33 @@
+using System.Globalization;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FtdImportServiceGetFileNamesThaiCultureTests
+{
+    // Contract: file names follow SEC EDGAR's literal cnsfails{YYYYMM}{a|b}.zip
+    // URL scheme, where YYYY is the *Gregorian* year. The body builds each name
+    // via `current.ToString("yyyyMM")` with no IFormatProvider — under th-TH
+    // (and other cultures whose default DateTimeFormatInfo.Calendar is non-
+    // Gregorian), DateOnly.ToString honors the culture's calendar, so the year
+    // formats in Buddhist (Gregorian + 543). 2017-06 then renders as "256006",
+    // every URL 404s, and the scrape silently produces zero records on Thai-
+    // locale hosts. Parallel precedent: FredImportServiceParseDateHijriCulture.
+    [Fact(Skip = "GH-1679 — GetFileNames emits Buddhist-calendar year under th-TH")]
+    public void GetFileNames_UnderThaiCulture_EmitsGregorianYearInFileName()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("th-TH");
+
+            var fileNames = FtdImportService.GetFileNames(new DateOnly(2017, 6, 1));
+
+            fileNames.Should().Contain("cnsfails201706b.zip");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped adversarial test pinning that `FtdImportService.GetFileNames` must emit Gregorian year/month in SEC EDGAR URLs regardless of host culture.
- The test fails today under `th-TH`: `current.ToString("yyyyMM")` with no `IFormatProvider` honors the Thai Buddhist calendar, so 2017-06 renders as "256006" — every URL the scraper builds 404s on Thai-locale hosts.
- Skipped — see GH-1679; un-skip as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Sec/FtdImportServiceGetFileNamesThaiCultureTests.cs` — new `[Fact(Skip = "GH-1679 — ...")]` setting `CultureInfo.CurrentCulture = new CultureInfo("th-TH")` and asserting the resulting file-name list contains `cnsfails201706b.zip`. Parallel to the FRED Hijri precedent (`FredImportServiceParseDateHijriCultureTests`).