### PR TITLE
fix(sec): format FTD file-name year with InvariantCulture

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -333,7 +333,7 @@ public class FtdImportService
 
         while (current <= now)
         {
-            var yearMonth = current.ToString("yyyyMM");
+            var yearMonth = current.ToString("yyyyMM", CultureInfo.InvariantCulture);
 
             // The 'a' file for June 2017 doesn't exist — only 'b' is available
             if (current != OldestAvailableDate)

--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceGetFileNamesThaiCultureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceGetFileNamesThaiCultureTests.cs
@@ -13,7 +13,7 @@ public class FtdImportServiceGetFileNamesThaiCultureTests
     // formats in Buddhist (Gregorian + 543). 2017-06 then renders as "256006",
     // every URL 404s, and the scrape silently produces zero records on Thai-
     // locale hosts. Parallel precedent: FredImportServiceParseDateHijriCulture.
-    [Fact(Skip = "GH-1679 — GetFileNames emits Buddhist-calendar year under th-TH")]
+    [Fact]
     public void GetFileNames_UnderThaiCulture_EmitsGregorianYearInFileName()
     {
         var original = CultureInfo.CurrentCulture;


### PR DESCRIPTION
## Summary

- Closes #1679. `FtdImportService.GetFileNames` built each SEC EDGAR URL fragment with `current.ToString("yyyyMM")` and no `IFormatProvider`. On a host whose `CultureInfo.CurrentCulture` is `th-TH` (Buddhist calendar, the most common non-Gregorian default), `DateOnly.ToString` honored the culture's calendar and the year rendered as Gregorian + 543 — every URL was wrong (`cnsfails256006b.zip` instead of `cnsfails201706b.zip`), every download 404'd, and the `FailToDeliver` table stayed empty without an error visible beyond per-file `LogWarning`s.
- One-line hardening: pass `CultureInfo.InvariantCulture` to `ToString`, mirroring the parse-side hardening already established for FRED (#1501 / #1655) and `InsiderTradingFilingProcessor.TryParseTransactionDate`. Unskips the pre-existing regression test.

## Code changes

- `src/Equibles.Sec.HostedService/Services/FtdImportService.cs` — `current.ToString("yyyyMM")` → `current.ToString("yyyyMM", CultureInfo.InvariantCulture)` inside `GetFileNames`. `System.Globalization` is already imported. Pure formatting hardening; Gregorian-default cultures (en-US, invariant, etc.) are bit-for-bit unaffected.
- `tests/Equibles.UnitTests/Sec/FtdImportServiceGetFileNamesThaiCultureTests.cs` — dropped the `Skip = "GH-1679 …"` attribute so the regression test now runs and locks the contract.