### PR TITLE
refactor(holdings-mcp): lift GetInstitutionQuarterlyActivity bucket validation behind ValidInstitutionActivityBuckets array

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -25,6 +25,14 @@ public class InstitutionalHoldingsTools
         "sold-out-positions",
     ];
 
+    private static readonly string[] ValidInstitutionActivityBuckets =
+    [
+        "initiated",
+        "increased",
+        "reduced",
+        "exited",
+    ];
+
     private readonly InstitutionalHoldingRepository _holdingRepository;
     private readonly InstitutionalHolderRepository _holderRepository;
     private readonly CommonStockRepository _commonStockRepository;
@@ -832,10 +840,7 @@ public class InstitutionalHoldingsTools
                 var normalizedBucket = bucket?.Trim().ToLowerInvariant();
                 if (
                     !string.IsNullOrEmpty(normalizedBucket)
-                    && normalizedBucket != "initiated"
-                    && normalizedBucket != "increased"
-                    && normalizedBucket != "reduced"
-                    && normalizedBucket != "exited"
+                    && !ValidInstitutionActivityBuckets.Contains(normalizedBucket)
                 )
                     return "Unknown bucket. Use one of: initiated, increased, reduced, exited (or omit).";
 


### PR DESCRIPTION
## Summary

Mirrors the precedent set by PR #1626 for `GetMarketWide13FActivity`: replace the four-way negated equality chain validating the institution-activity `bucket` argument with a single `!ValidInstitutionActivityBuckets.Contains(normalizedBucket)` call against a class-level static array.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — add `ValidInstitutionActivityBuckets = ["initiated", "increased", "reduced", "exited"]` alongside the existing `ValidActivityBuckets`, and replace the four `!= "x" && != "y" && …` inequality chain in `GetInstitutionQuarterlyActivity` with `!ValidInstitutionActivityBuckets.Contains(normalizedBucket)`. The outer `!string.IsNullOrEmpty(normalizedBucket) &&` short-circuit and the error message string are unchanged, so empty/null `bucket` still means "all four buckets".