### PR TITLE
fix(sec): skip FTD upsert rows whose parent CommonStock disappeared mid-import

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -213,10 +213,39 @@ public class FtdImportService
     {
         using var scope = _scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        // Guards GH-1591: CompanySync can delete a CommonStock between
+        // BuildTickerMap and this flush. Without filtering, one stale
+        // CommonStockId trips FK_FailToDeliver_CommonStock_CommonStockId and
+        // rolls back the entire UpsertRange — dropping rows for surviving
+        // stocks alongside the orphan.
+        var stockIds = items.Select(i => i.CommonStockId).Distinct().ToHashSet();
+        var existingIds = (
+            await stockRepo
+                .GetAll()
+                .Where(s => stockIds.Contains(s.Id))
+                .Select(s => s.Id)
+                .ToListAsync()
+        ).ToHashSet();
+
+        var safeItems = items.Where(i => existingIds.Contains(i.CommonStockId)).ToList();
+        var skipped = items.Count - safeItems.Count;
+        if (skipped > 0)
+        {
+            _logger.LogWarning(
+                "FTD batch: skipping {Count} rows whose parent CommonStock was removed before flush",
+                skipped
+            );
+        }
+        if (safeItems.Count == 0)
+        {
+            return;
+        }
 
         await dbContext
             .Set<FailToDeliver>()
-            .UpsertRange(items)
+            .UpsertRange(safeItems)
             .On(f => new { f.CommonStockId, f.SettlementDate })
             .WhenMatched(
                 (existing, incoming) =>

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceMissingCommonStockTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceMissingCommonStockTests.cs
@@ -1,0 +1,202 @@
+using System.IO.Compression;
+using System.Text;
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Equibles.Worker;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Pins the contract from GH-1591: when a CommonStock row is removed between
+/// BuildTickerMap and FlushBatch, FtdImportService must persist rows for the
+/// surviving stocks instead of letting one stale CommonStockId fail the whole
+/// UpsertRange with FK_FailToDeliver_CommonStock_CommonStockId. Without the
+/// guard, Postgres rolls back the entire batch and no FailToDeliver row lands
+/// for any ticker in the same flush.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FtdImportServiceMissingCommonStockTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesDbContext> _contexts = [];
+
+    public FtdImportServiceMissingCommonStockTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.ResetAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private EquiblesDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesDbContext)).Returns(ctx);
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(CommonStockManager))
+                    .Returns(
+                        new CommonStockManager(
+                            new CommonStockRepository(ctx),
+                            Substitute.For<IPublishEndpoint>()
+                        )
+                    );
+                sp.GetService(typeof(FailToDeliverRepository))
+                    .Returns(new FailToDeliverRepository(ctx));
+                sp.GetService(typeof(TickerMapService)).Returns(new TickerMapService(scopeFactory));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    [Fact]
+    public async Task Import_CommonStockDeletedBeforeFlush_PersistsRowsForSurvivingStocks()
+    {
+        // Two stocks in the same FTD batch. AAPL will be removed mid-import to
+        // simulate the GH-1591 race; MSFT must survive. Pre-fix: Postgres
+        // rejects the whole UpsertRange with FK_FailToDeliver_CommonStock,
+        // rolling MSFT back too. Post-fix: AAPL is filtered out and MSFT lands.
+        var apple = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+            Cusip = "037833100",
+        };
+        var msft = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "0000789019",
+            Cusip = "594918104",
+        };
+
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().AddRange(apple, msft);
+            await seed.SaveChangesAsync();
+        }
+
+        var settlementDate = DateOnly.FromDateTime(DateTime.UtcNow).AddMonths(-1).AddDays(-1);
+        var csv =
+            "SETTLEMENT DATE|CUSIP|SYMBOL|QUANTITY (FAILS)|DESCRIPTION|PRICE\n"
+            + $"{settlementDate:yyyyMMdd}|037833100|AAPL|12345|APPLE INC|187.50\n"
+            + $"{settlementDate:yyyyMMdd}|594918104|MSFT|54321|MICROSOFT CORP|420.00\n";
+
+        var deletedOnce = false;
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient
+            .DownloadStream(Arg.Any<string>())
+            .Returns(_ =>
+            {
+                // Race: CompanySync removes AAPL after BuildTickerMap and before FlushBatch.
+                // We hook DownloadStream because it's the only side-effecting touchpoint that
+                // sits between those two points in the FTD import flow.
+                if (!deletedOnce)
+                {
+                    using var deleteCtx = _fixture.CreateDbContext();
+                    var staleApple = deleteCtx.Set<CommonStock>().Single(s => s.Ticker == "AAPL");
+                    deleteCtx.Set<CommonStock>().Remove(staleApple);
+                    deleteCtx.SaveChanges();
+                    deletedOnce = true;
+                }
+                return Task.FromResult<Stream>(BuildFtdZipStream(csv));
+            });
+
+        var sut = new FtdImportService(
+            CreateScopeFactory(),
+            secEdgarClient,
+            Substitute.For<ILogger<FtdImportService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(
+                new WorkerOptions
+                {
+                    MinSyncDate = settlementDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
+                }
+            )
+        );
+
+        await sut.Import(CancellationToken.None);
+
+        await using var verify = _fixture.CreateDbContext();
+
+        var msftRow = await verify
+            .Set<FailToDeliver>()
+            .SingleOrDefaultAsync(f =>
+                f.CommonStockId == msft.Id && f.SettlementDate == settlementDate
+            );
+        msftRow
+            .Should()
+            .NotBeNull(
+                "the surviving MSFT row must be persisted even when AAPL's parent row vanished "
+                    + "between BuildTickerMap and FlushBatch; pre-fix the FK violation on AAPL "
+                    + "rolls the whole UpsertRange back and MSFT is dropped too"
+            );
+        msftRow!.Quantity.Should().Be(54321);
+
+        var appleRow = await verify
+            .Set<FailToDeliver>()
+            .SingleOrDefaultAsync(f => f.CommonStockId == apple.Id);
+        appleRow
+            .Should()
+            .BeNull("the deleted AAPL parent must not get an orphan FailToDeliver row");
+    }
+
+    private static Stream BuildFtdZipStream(string csvBody)
+    {
+        var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("cnsfails.txt");
+            using var stream = entry.Open();
+            var bytes = Encoding.UTF8.GetBytes(csvBody);
+            stream.Write(bytes, 0, bytes.Length);
+        }
+        buffer.Position = 0;
+        return buffer;
+    }
+}


### PR DESCRIPTION
## Summary

- Partially addresses #1591 — the FTD leg of the cold-start FK violations.
- CompanySync can delete a CommonStock between BuildTickerMap and the per-batch UpsertRange in FtdImportService. Postgres rejects the whole statement with FK_FailToDeliver_CommonStock_CommonStockId, rolling back every row in the batch — including FailToDeliver rows for stocks that still exist.
- Filtering items by the live CommonStockId set before UpsertRange keeps the rare race from dropping good rows alongside the orphan.
- The Yahoo and FinancialFacts legs of #1591 ship as separate PRs.

## Code changes

- \`src/Equibles.Sec.HostedService/Services/FtdImportService.cs\` — \`FlushBatch\` now resolves the \`CommonStockRepository\` from the same scope as the DbContext, looks up the live set of CommonStock IDs in the batch, filters out items whose parent disappeared, logs the skipped count, and only then runs the UpsertRange.
- \`tests/Equibles.IntegrationTests/Sec/FtdImportServiceMissingCommonStockTests.cs\` — new ParadeDB-backed regression test that seeds AAPL and MSFT, hooks the SEC EDGAR client substitute to delete AAPL on the first DownloadStream call (the window between BuildTickerMap and FlushBatch), and asserts that the MSFT FailToDeliver row survives while AAPL's does not. Fails on pre-fix code (the FK violation on AAPL rolls MSFT back too).

## Test plan

- [x] New regression test fails on unfixed code (MSFT row missing because the batch was rolled back).
- [x] Same test passes after the fix.
- [x] Full FtdImport integration suite green: 11 passed.