### PR TITLE
test(sec): pin InlineXbrlParser negative scale shifts decimal left

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserNegativeScaleTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserNegativeScaleTests.cs
@@ -1,0 +1,44 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InlineXbrlParserNegativeScaleTests
+{
+    private const string DocOpen =
+        "<html "
+        + "xmlns=\"http://www.w3.org/1999/xhtml\" "
+        + "xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\" "
+        + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+        + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2018-01-31\""
+        + "><body><div style=\"display:none\"><ix:header><ix:resources>";
+
+    private const string ResourcesEnd = "</ix:resources></ix:header></div>";
+
+    private const string DocClose = "</body></html>";
+
+    // TryApplyScaleAndSign's WHY-comment documents: "Positive scale shifts the
+    // value up; negative shifts down." Negative `scale` is documented and goes
+    // through Math.Pow → double → decimal — a precision-sensitive path that
+    // existing tests never exercise (only scale="6" and a scale="29" overflow
+    // case are pinned). A regression that drops the multiplier when scale<0
+    // (e.g. an early-return on `scale <= 0`) would leave value=12345 unscaled
+    // instead of shifting to 12.345.
+    [Fact]
+    public void Parse_NegativeScaleAttribute_ShiftsDecimalPointLeft()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"us-gaap:Revenues\" contextRef=\"C1\" unitRef=\"u\" scale=\"-3\">12345</ix:nonFraction>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Value.Should().Be(12.345m);
+    }
+}


### PR DESCRIPTION
## Summary

- `TryApplyScaleAndSign`'s docstring promises "Positive scale shifts the value up; negative shifts down", but no existing test exercises a negative `scale` attribute — only `scale="6"` (positive) and `scale="29"` (overflow) are pinned.
- Adversarial Lane A test: derived expectation from the contract (12345 with `scale="-3"` should be 12.345m), not the implementation. The negative-scale path goes through `Math.Pow(10, scale)` → `double` → `decimal` — a precision-sensitive code path worth pinning.

## Code changes

- `tests/Equibles.UnitTests/Sec/InlineXbrlParserNegativeScaleTests.cs` — new single-fact test that feeds an iXBRL `nonFraction` with `scale="-3"` and asserts the resulting decimal is exactly 12.345m.