### PR TITLE
feat(holdings): add Holdings/MostHeld page — 13F breadth ranking with deltas

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -112,6 +112,105 @@ public class HoldingsActivityController : BaseController
         return View(viewModel);
     }
 
+    [HttpGet("~/Holdings/MostHeld")]
+    public async Task<IActionResult> MostHeld(DateOnly? date, string sort, int page = 1)
+    {
+        var reportDates = await _holdingRepository
+            .GetAvailableReportDates()
+            .OrderByDescending(d => d)
+            .ToListAsync();
+
+        var normalizedSort = sort switch
+        {
+            HoldingsMostHeldViewModel.SortFilersDelta => HoldingsMostHeldViewModel.SortFilersDelta,
+            HoldingsMostHeldViewModel.SortValue => HoldingsMostHeldViewModel.SortValue,
+            _ => HoldingsMostHeldViewModel.SortFilers,
+        };
+        var viewModel = new HoldingsMostHeldViewModel
+        {
+            AvailableDates = reportDates,
+            Sort = normalizedSort,
+            Page = Math.Max(1, page),
+        };
+        if (reportDates.Count == 0)
+            return View(viewModel);
+
+        var requestedIndex = date.HasValue ? reportDates.IndexOf(date.Value) : -1;
+        var selectedIndex = requestedIndex < 0 ? 0 : requestedIndex;
+        var selectedDate = reportDates[selectedIndex];
+        viewModel.SelectedDate = selectedDate;
+
+        var previousDate =
+            selectedIndex < reportDates.Count - 1
+                ? reportDates[selectedIndex + 1]
+                : (DateOnly?)null;
+        viewModel.PreviousDate = previousDate;
+
+        // GetMostHeld needs both args; when no prior quarter exists we pass the
+        // same date — the previous-side columns end up mirroring current, and the
+        // view renders delta cells as "—" because PreviousDate is null.
+        var priorForRepo = previousDate ?? selectedDate;
+        var rankingQuery = _holdingRepository.GetMostHeld(selectedDate, priorForRepo);
+
+        viewModel.TotalRows = await rankingQuery.CountAsync();
+        viewModel.TotalUniverseFilers = await _holdingRepository
+            .GetUniqueFilerIds(selectedDate)
+            .CountAsync();
+        var skip = (viewModel.Page - 1) * HoldingsMostHeldViewModel.PageSize;
+
+        var orderedQuery = normalizedSort switch
+        {
+            HoldingsMostHeldViewModel.SortFilersDelta => rankingQuery
+                .OrderByDescending(a => a.CurrentFilerCount - a.PreviousFilerCount)
+                .ThenByDescending(a => a.CurrentFilerCount),
+            HoldingsMostHeldViewModel.SortValue => rankingQuery
+                .OrderByDescending(a => a.CurrentValue)
+                .ThenByDescending(a => a.CurrentFilerCount),
+            _ => rankingQuery
+                .OrderByDescending(a => a.CurrentFilerCount)
+                .ThenByDescending(a => a.CurrentValue),
+        };
+
+        var pageRows = await orderedQuery
+            .Skip(skip)
+            .Take(HoldingsMostHeldViewModel.PageSize)
+            .ToListAsync();
+
+        var stockIds = pageRows.Select(r => r.CommonStockId).ToList();
+        var stocks = await _commonStockRepository
+            .GetAll()
+            .Where(s => stockIds.Contains(s.Id))
+            .Select(s => new StockLabel
+            {
+                Id = s.Id,
+                Ticker = s.Ticker,
+                Name = s.Name,
+            })
+            .ToDictionaryAsync(s => s.Id);
+
+        var universe = viewModel.TotalUniverseFilers;
+        viewModel.Rows = pageRows
+            .Select(r =>
+            {
+                stocks.TryGetValue(r.CommonStockId, out var stock);
+                return new HoldingsMostHeldRow
+                {
+                    CommonStockId = r.CommonStockId,
+                    Ticker = stock?.Ticker ?? "—",
+                    Name = stock?.Name ?? "Unknown",
+                    CurrentFilerCount = r.CurrentFilerCount,
+                    PreviousFilerCount = r.PreviousFilerCount,
+                    CurrentValue = r.CurrentValue,
+                    PreviousValue = r.PreviousValue,
+                    PercentOfUniverse =
+                        universe > 0 ? (double)r.CurrentFilerCount / universe * 100.0 : 0,
+                };
+            })
+            .ToList();
+
+        return View(viewModel);
+    }
+
     private static HoldingsActivityRow MapChurnRow(
         Equibles.Holdings.Repositories.Models.MarketWideStockChurn churn,
         IDictionary<Guid, StockLabel> stocks

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsMostHeldRow.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsMostHeldRow.cs
@@ -1,0 +1,19 @@
+namespace Equibles.Web.ViewModels.Holdings;
+
+public class HoldingsMostHeldRow
+{
+    public Guid CommonStockId { get; set; }
+    public string Ticker { get; set; }
+    public string Name { get; set; }
+    public int CurrentFilerCount { get; set; }
+    public int PreviousFilerCount { get; set; }
+    public long CurrentValue { get; set; }
+    public long PreviousValue { get; set; }
+
+    public int DeltaFilerCount => CurrentFilerCount - PreviousFilerCount;
+    public long DeltaValue => CurrentValue - PreviousValue;
+
+    // % of distinct 13F filers reporting on SelectedDate that hold this stock —
+    // 0..100, computed against HoldingsMostHeldViewModel.TotalUniverseFilers.
+    public double PercentOfUniverse { get; set; }
+}

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsMostHeldViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsMostHeldViewModel.cs
@@ -1,0 +1,29 @@
+namespace Equibles.Web.ViewModels.Holdings;
+
+public class HoldingsMostHeldViewModel
+{
+    public const int PageSize = 100;
+    public const string SortFilers = "filers";
+    public const string SortFilersDelta = "filersDelta";
+    public const string SortValue = "value";
+
+    public List<DateOnly> AvailableDates { get; set; } = [];
+    public DateOnly SelectedDate { get; set; }
+    public DateOnly? PreviousDate { get; set; }
+
+    // Distinct filer count for SelectedDate — denominator for each row's
+    // PercentOfUniverse. Zero when no quarter is selected.
+    public int TotalUniverseFilers { get; set; }
+
+    // One of SortFilers / SortFilersDelta / SortValue. Normalised by the
+    // controller before assignment so the view can render the selector
+    // without re-validating.
+    public string Sort { get; set; } = SortFilers;
+
+    // 1-based page number; total rows + page count drive the pager footer.
+    public int Page { get; set; } = 1;
+    public int TotalRows { get; set; }
+    public int TotalPages => Math.Max(1, (TotalRows + PageSize - 1) / PageSize);
+
+    public List<HoldingsMostHeldRow> Rows { get; set; } = [];
+}

--- a/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
@@ -1,0 +1,151 @@
+@using Equibles.Web.ViewModels.Holdings
+@model HoldingsMostHeldViewModel
+@{
+    ViewData["Title"] = "Most-Held Stocks";
+    ViewData["Menu"] = "Holdings";
+
+    var pageSize = HoldingsMostHeldViewModel.PageSize;
+    var firstRowNumber = (Model.Page - 1) * pageSize + 1;
+}
+
+<h1 class="text-2xl font-bold mb-4">Most-Held Stocks</h1>
+
+@if (Model.AvailableDates.Count == 0) {
+    <div class="card bg-base-100 shadow-sm">
+        <div class="card-body items-center text-center py-12">
+            <div class="text-base-content/30 mb-3">
+                <icon name="building-office" size="12" />
+            </div>
+            <h2 class="text-base-content/60 mb-2">No 13F data yet</h2>
+            <p class="text-base-content/40 text-sm">Once at least one quarter of 13F filings has been ingested, the most-held ranking appears here.</p>
+        </div>
+    </div>
+} else {
+    <!-- ReportDate + sort selector + universe size header. -->
+    <div class="mb-4 text-sm">
+        <div class="flex flex-wrap items-center gap-x-5 gap-y-2 mb-1">
+            <div class="flex items-center gap-2 shrink-0">
+                <label for="most-held-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
+                <select id="most-held-date" class="select select-bordered select-sm"
+                    onchange="window.location.href='MostHeld?date=' + this.value + '&sort=@Model.Sort'">
+                    @foreach (var date in Model.AvailableDates) {
+                        var isSelected = date == Model.SelectedDate;
+                        if (isSelected) {
+                            <option value="@date.ToString("yyyy-MM-dd")" selected>@date.ToString("MMM dd, yyyy")</option>
+                        } else {
+                            <option value="@date.ToString("yyyy-MM-dd")">@date.ToString("MMM dd, yyyy")</option>
+                        }
+                    }
+                </select>
+            </div>
+            <div class="flex items-center gap-2 shrink-0">
+                <label for="most-held-sort" class="text-base-content/60 whitespace-nowrap">Sort by:</label>
+                <select id="most-held-sort" class="select select-bordered select-sm"
+                    onchange="window.location.href='MostHeld?date=@Model.SelectedDate.ToString("yyyy-MM-dd")&sort=' + this.value">
+                    <option value="@HoldingsMostHeldViewModel.SortFilers" selected="@(Model.Sort == HoldingsMostHeldViewModel.SortFilers)"># Filers</option>
+                    <option value="@HoldingsMostHeldViewModel.SortFilersDelta" selected="@(Model.Sort == HoldingsMostHeldViewModel.SortFilersDelta)">Δ Filers (QoQ)</option>
+                    <option value="@HoldingsMostHeldViewModel.SortValue" selected="@(Model.Sort == HoldingsMostHeldViewModel.SortValue)">Total $ Value</option>
+                </select>
+            </div>
+            @if (Model.PreviousDate.HasValue) {
+                <div class="text-xs text-base-content/50">vs prior quarter @Model.PreviousDate.Value.ToString("MMM dd, yyyy") · @Model.TotalUniverseFilers.ToString("N0") filers in the 13F universe</div>
+            } else {
+                <div class="text-xs text-base-content/50">@Model.TotalUniverseFilers.ToString("N0") filers in the 13F universe — no prior quarter, deltas not shown.</div>
+            }
+        </div>
+    </div>
+
+    <div class="card bg-base-100 shadow-sm" data-testid="most-held-table">
+        <div class="card-body p-4">
+            @if (Model.Rows.Count == 0) {
+                <div class="text-xs text-base-content/50">No stocks were held in the selected quarter.</div>
+            } else {
+                <div class="overflow-x-auto">
+                    <table class="table table-sm">
+                        <thead>
+                            <tr>
+                                <th scope="col" class="text-right w-12">#</th>
+                                <th scope="col">Ticker</th>
+                                <th scope="col">Company</th>
+                                <th scope="col" class="text-right"># 13F Filers</th>
+                                <th scope="col" class="text-right">Δ Filers (QoQ)</th>
+                                <th scope="col" class="text-right hidden md:table-cell">Total $ Value</th>
+                                <th scope="col" class="text-right hidden md:table-cell">Δ $ Value (QoQ)</th>
+                                <th scope="col" class="text-right hidden lg:table-cell">% of 13F Universe</th>
+                                <th scope="col" class="text-right">Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @{ var rowNumber = firstRowNumber; }
+                            @foreach (var row in Model.Rows) {
+                                var deltaFilersCss = row.DeltaFilerCount > 0 ? "text-success" : row.DeltaFilerCount < 0 ? "text-error" : "";
+                                var deltaFilersText = (row.DeltaFilerCount > 0 ? "+" : row.DeltaFilerCount < 0 ? "-" : "") + Math.Abs(row.DeltaFilerCount).ToString("N0");
+                                var deltaValueCss = row.DeltaValue > 0 ? "text-success" : row.DeltaValue < 0 ? "text-error" : "";
+                                var deltaValueText = (row.DeltaValue > 0 ? "+$" : row.DeltaValue < 0 ? "-$" : "$") + Math.Abs(row.DeltaValue).ToString("N0");
+                                <tr>
+                                    <td class="text-right text-base-content/60">@rowNumber.ToString("N0")</td>
+                                    <td class="font-mono">@row.Ticker</td>
+                                    <td class="max-w-xs truncate">@row.Name</td>
+                                    <td class="text-right font-mono">@row.CurrentFilerCount.ToString("N0")</td>
+                                    <td class="text-right font-mono @deltaFilersCss">
+                                        @if (Model.PreviousDate.HasValue) {
+                                            @deltaFilersText
+                                        } else {
+                                            <span class="text-base-content/40">—</span>
+                                        }
+                                    </td>
+                                    <td class="text-right font-mono hidden md:table-cell">$@row.CurrentValue.ToString("N0")</td>
+                                    <td class="text-right font-mono hidden md:table-cell @deltaValueCss">
+                                        @if (Model.PreviousDate.HasValue) {
+                                            @deltaValueText
+                                        } else {
+                                            <span class="text-base-content/40">—</span>
+                                        }
+                                    </td>
+                                    <td class="text-right font-mono hidden lg:table-cell">@row.PercentOfUniverse.ToString("F1")%</td>
+                                    <td class="text-right">
+                                        <a asp-controller="Stocks" asp-action="Holdings"
+                                           asp-route-ticker="@row.Ticker"
+                                           asp-route-date="@Model.SelectedDate.ToString("yyyy-MM-dd")"
+                                           class="btn btn-ghost btn-sm">View</a>
+                                    </td>
+                                </tr>
+                                rowNumber++;
+                            }
+                        </tbody>
+                    </table>
+                </div>
+
+                @if (Model.TotalPages > 1) {
+                    <!-- Pager footer — DaisyUI .join with prev/next links that preserve date+sort. -->
+                    <div class="flex items-center justify-between mt-3" data-testid="most-held-pager">
+                        <div class="text-xs text-base-content/60">
+                            Page @Model.Page.ToString("N0") of @Model.TotalPages.ToString("N0") · @Model.TotalRows.ToString("N0") stocks
+                        </div>
+                        <div class="join">
+                            @if (Model.Page > 1) {
+                                <a class="join-item btn btn-sm"
+                                   asp-action="MostHeld"
+                                   asp-route-date="@Model.SelectedDate.ToString("yyyy-MM-dd")"
+                                   asp-route-sort="@Model.Sort"
+                                   asp-route-page="@(Model.Page - 1)">«</a>
+                            } else {
+                                <button class="join-item btn btn-sm btn-disabled" disabled>«</button>
+                            }
+                            <button class="join-item btn btn-sm btn-active">@Model.Page.ToString("N0")</button>
+                            @if (Model.Page < Model.TotalPages) {
+                                <a class="join-item btn btn-sm"
+                                   asp-action="MostHeld"
+                                   asp-route-date="@Model.SelectedDate.ToString("yyyy-MM-dd")"
+                                   asp-route-sort="@Model.Sort"
+                                   asp-route-page="@(Model.Page + 1)">»</a>
+                            } else {
+                                <button class="join-item btn btn-sm btn-disabled" disabled>»</button>
+                            }
+                        </div>
+                    </div>
+                }
+            }
+        </div>
+    </div>
+}

--- a/tests/Equibles.FunctionalTests/Tests/HoldingsMostHeldSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HoldingsMostHeldSeededTests.cs
@@ -1,0 +1,135 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using Equibles.Holdings.Data.Models;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class HoldingsMostHeldSeededTests
+{
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public HoldingsMostHeldSeededTests(WebAppFixture web, PlaywrightFixture playwright)
+    {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task MostHeld_GetForTwoQuarterUniverse_RendersRankedTableAndSortSelector()
+    {
+        // Three stocks, five filers in the latest quarter, ranked by # of filers desc:
+        // AAPL = 5 filers, MSFT = 3 filers, NVDA = 1 filer.
+        var aaplId = Guid.NewGuid();
+        var msftId = Guid.NewGuid();
+        var nvdaId = Guid.NewGuid();
+        var prior = new DateOnly(2024, 9, 30);
+        var latest = new DateOnly(2024, 12, 31);
+
+        await _web.ResetAndSeedAsync(async db =>
+        {
+            db.AddRange(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                },
+                new CommonStock
+                {
+                    Id = msftId,
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corp.",
+                    Cik = "0000789019",
+                },
+                new CommonStock
+                {
+                    Id = nvdaId,
+                    Ticker = "NVDA",
+                    Name = "NVIDIA Corp.",
+                    Cik = "0001045810",
+                }
+            );
+
+            var holders = new InstitutionalHolder[5];
+            for (var i = 0; i < holders.Length; i++)
+            {
+                holders[i] = new InstitutionalHolder
+                {
+                    Cik = $"M{i + 1:D7}",
+                    Name = $"Filer {i + 1}",
+                };
+                db.Add(holders[i]);
+            }
+
+            // AAPL — 5 filers in latest, 1 filer in prior (so prior quarter exists).
+            for (var i = 0; i < 5; i++)
+                db.Add(MakeHolding(aaplId, holders[i].Id, latest, 100, 200_000));
+            db.Add(MakeHolding(aaplId, holders[0].Id, prior, 100, 180_000));
+
+            // MSFT — 3 filers in latest only.
+            for (var i = 0; i < 3; i++)
+                db.Add(MakeHolding(msftId, holders[i].Id, latest, 50, 100_000));
+
+            // NVDA — 1 filer in latest only.
+            db.Add(MakeHolding(nvdaId, holders[0].Id, latest, 10, 20_000));
+
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/Holdings/MostHeld");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        // Table renders; empty state does not.
+        await Assertions
+            .Expect(page.Locator("[data-testid='most-held-table']"))
+            .ToHaveCountAsync(1);
+        await Assertions
+            .Expect(page.Locator("h2").Filter(new() { HasTextString = "No 13F data yet" }))
+            .ToHaveCountAsync(0);
+
+        // Date selector and sort selector are both on the page.
+        await Assertions.Expect(page.Locator("select#most-held-date")).ToHaveCountAsync(1);
+        await Assertions.Expect(page.Locator("select#most-held-sort")).ToHaveCountAsync(1);
+
+        // Three rows in the body, in filer-count order: AAPL → MSFT → NVDA.
+        var bodyRows = page.Locator("[data-testid='most-held-table'] tbody tr");
+        await Assertions.Expect(bodyRows).ToHaveCountAsync(3);
+        await Assertions.Expect(bodyRows.Nth(0)).ToContainTextAsync("AAPL");
+        await Assertions.Expect(bodyRows.Nth(1)).ToContainTextAsync("MSFT");
+        await Assertions.Expect(bodyRows.Nth(2)).ToContainTextAsync("NVDA");
+
+        // Three rows total, so no pager footer is rendered.
+        await Assertions
+            .Expect(page.Locator("[data-testid='most-held-pager']"))
+            .ToHaveCountAsync(0);
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Value = value,
+            Shares = shares,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+        };
+}

--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerMostHeldTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerMostHeldTests.cs
@@ -1,0 +1,168 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the Holdings/MostHeld route end-to-end: the controller composes the
+/// per-stock ranking from <c>GetMostHeld</c> + <c>GetUniqueFilerIds</c> and the
+/// rendered HTML carries the table with the right stock order, the % of universe
+/// header, and the prior-quarter delta. Each seed exercises a different facet —
+/// empty state, single-quarter (no delta), and a multi-stock two-quarter ranking.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HoldingsActivityControllerMostHeldTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HoldingsActivityControllerMostHeldTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetMostHeld_NoHoldings_RendersEmptyState()
+    {
+        await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
+
+        var response = await _fixture.Client.GetAsync("/Holdings/MostHeld");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("No 13F data yet");
+        html.Should().NotContain("most-held-table");
+    }
+
+    [Fact]
+    public async Task GetMostHeld_SingleQuarter_RendersTableWithoutDeltaColumn()
+    {
+        var stockId = Guid.NewGuid();
+        var holderId = Guid.NewGuid();
+        var only = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = "1",
+                    Name = "Single Filer",
+                }
+            );
+            db.Add(MakeHolding(stockId, holderId, only, shares: 10_000, value: 1_000_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/MostHeld");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("most-held-table");
+        html.Should().Contain("AAPL");
+        html.Should().Contain("no prior quarter");
+    }
+
+    [Fact]
+    public async Task GetMostHeld_TwoQuartersThreeStocks_RanksByCurrentFilerCountDesc()
+    {
+        var aaplId = Guid.NewGuid();
+        var msftId = Guid.NewGuid();
+        var nvdaId = Guid.NewGuid();
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.AddRange(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                },
+                new CommonStock
+                {
+                    Id = msftId,
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corp.",
+                    Cik = "0000789019",
+                },
+                new CommonStock
+                {
+                    Id = nvdaId,
+                    Ticker = "NVDA",
+                    Name = "NVIDIA Corp.",
+                    Cik = "0001045810",
+                }
+            );
+
+            var holders = new List<InstitutionalHolder>();
+            for (var i = 0; i < 5; i++)
+            {
+                var h = new InstitutionalHolder { Cik = $"h{i}", Name = $"Filer {i}" };
+                holders.Add(h);
+                db.Add(h);
+            }
+            // AAPL: 5 filers (most held). MSFT: 3 filers. NVDA: 1 filer.
+            for (var i = 0; i < 5; i++)
+                db.Add(MakeHolding(aaplId, holders[i].Id, current, shares: 100, value: 200_000));
+            for (var i = 0; i < 3; i++)
+                db.Add(MakeHolding(msftId, holders[i].Id, current, shares: 50, value: 100_000));
+            db.Add(MakeHolding(nvdaId, holders[0].Id, current, shares: 10, value: 20_000));
+            // Anchor prior quarter so PreviousDate isn't null.
+            db.Add(MakeHolding(aaplId, holders[0].Id, prior, shares: 100, value: 180_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Holdings/MostHeld");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("most-held-table");
+        // Order must be AAPL → MSFT → NVDA (ranked by filer count desc).
+        var aaplIdx = html.IndexOf("AAPL", StringComparison.Ordinal);
+        var msftIdx = html.IndexOf("MSFT", StringComparison.Ordinal);
+        var nvdaIdx = html.IndexOf("NVDA", StringComparison.Ordinal);
+        aaplIdx.Should().BeGreaterThan(-1);
+        msftIdx.Should().BeGreaterThan(aaplIdx);
+        nvdaIdx.Should().BeGreaterThan(msftIdx);
+        // % of universe denominator is 5 distinct filers; AAPL → 100%, NVDA → 20%.
+        // Allow both en (100.0) and de/fr/pt (100,0) decimal separators — the page
+        // renders with the request's culture, not invariant.
+        html.Should().MatchRegex(@"100[\.,]0%");
+        html.Should().MatchRegex(@"20[\.,]0%");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber =
+                $"acc-{stockId:N}".Substring(0, 12)
+                + $"-{holderId:N}".Substring(0, 8)
+                + $"-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

- Slice 2/3 of #1010 (refs #1010).
- New \`GET ~/Holdings/MostHeld?date=…&sort=…&page=N\` action on the existing \`HoldingsActivityController\`, rendering the cross-sectional ranking of currently-held stocks with quarter-over-quarter delta filer count, delta dollar value, and the row's percent of the 13F universe.
- Sort selector toggles between \`# Filers\` (default), \`Δ Filers (QoQ)\`, and \`Total $ Value\`. Default page size is 100 rows; the pager footer renders when the result spans more than one page.
- Single-quarter case: the table still renders the ranking but delta columns render \`—\` and the header notes "no prior quarter, deltas not shown".

## Code changes

- \`src/Equibles.Web/Controllers/HoldingsActivityController.cs\` — new \`MostHeld\` action. Resolves selected/prior dates from \`GetAvailableReportDates\`, materialises the ranking via \`GetMostHeld\`, joins stock labels server-side, and computes \`PercentOfUniverse\` against \`GetUniqueFilerIds(selectedDate).Count()\`.
- \`src/Equibles.Web/ViewModels/Holdings/HoldingsMostHeldViewModel.cs\`, \`HoldingsMostHeldRow.cs\` — page-shape view model; \`PageSize\` + \`Sort\* constants are exposed on the view model so the view can render the selector without re-validating.
- \`src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml\` — DaisyUI table per the issue spec, with date + sort selectors and a join pager footer. Action-link "View" routes to the existing per-stock \`/stocks/{ticker}/holdings\` page.
- \`tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerMostHeldTests.cs\` — three view-render facts covering empty / single-quarter / two-quarter ranked paths.
- \`tests/Equibles.FunctionalTests/Tests/HoldingsMostHeldSeededTests.cs\` — Playwright e2e for the golden path (three-stock universe ranked AAPL → MSFT → NVDA, no pager footer).

## Test plan

- [x] View-render integration facts green (3/3).
- [x] Full Holdings test suite (unit + integration, \`Category!=Functional&Category!=Live\`) green: 224 unit + 223 integration.
- [x] csharpier tree-wide clean.
- [ ] Playwright e2e runs in CI (\`functional.yml\`) — added but not run locally.