### PR TITLE
feat(holdings-mcp): add GetMostHeldStocks for the 13F breadth ranking

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -33,6 +33,8 @@ public class InstitutionalHoldingsTools
         "exited",
     ];
 
+    private static readonly string[] ValidMostHeldSorts = ["filers", "filersdelta", "value"];
+
     private readonly InstitutionalHoldingRepository _holdingRepository;
     private readonly InstitutionalHolderRepository _holderRepository;
     private readonly CommonStockRepository _commonStockRepository;
@@ -674,6 +676,109 @@ public class InstitutionalHoldingsTools
             var count = normalizedBucket == "new-positions" ? r.NewFilerCount : r.SoldOutFilerCount;
             result.AppendLine(
                 $"| {i + 1} | {s?.Ticker ?? "—"} | {s?.Name ?? "Unknown"} | {count:N0} |"
+            );
+        }
+        return result.ToString();
+    }
+
+    [McpServerTool(Name = "GetMostHeldStocks")]
+    [Description(
+        "Get the cross-sectional ranking of stocks by institutional 13F breadth for a given quarter. Returns the stocks ranked by number of 13F filers reporting them as a holding (default), or by quarter-over-quarter change in filer count (warming / cooling heat map), or by total reported dollar value. Includes Δ filers vs the prior quarter, total value, Δ value, and the stock's share of the 13F universe. Use this to answer 'which stocks are most owned by institutions right now, and is breadth expanding or contracting?'"
+    )]
+    public Task<string> GetMostHeldStocks(
+        [Description("Report date in YYYY-MM-DD format (defaults to latest available)")]
+            string reportDate = null,
+        [Description(
+            "Sort by: 'filers' (default, # of 13F filers desc), 'filersDelta' (QoQ filer-count delta desc — heat map of warming names), or 'value' (current total reported $ value desc)"
+        )]
+            string sort = "filers",
+        [Description("Maximum number of stocks to return (default: 25)")] int maxResults = 25
+    )
+    {
+        return Execute(
+            async () =>
+            {
+                var normalizedSort = (sort ?? "filers").Trim().ToLowerInvariant();
+                if (!ValidMostHeldSorts.Contains(normalizedSort))
+                    return $"Unknown sort. Use one of: {string.Join(", ", ValidMostHeldSorts)}.";
+
+                var (targetDate, previousDate, error) = await ResolveMarketActivityDates(
+                    reportDate
+                );
+                if (error != null)
+                    return error;
+
+                var ranking = _holdingRepository.GetMostHeld(targetDate, previousDate);
+                ranking = normalizedSort switch
+                {
+                    "filersdelta" => ranking
+                        .OrderByDescending(a => a.CurrentFilerCount - a.PreviousFilerCount)
+                        .ThenByDescending(a => a.CurrentFilerCount),
+                    "value" => ranking
+                        .OrderByDescending(a => a.CurrentValue)
+                        .ThenByDescending(a => a.CurrentFilerCount),
+                    _ => ranking
+                        .OrderByDescending(a => a.CurrentFilerCount)
+                        .ThenByDescending(a => a.CurrentValue),
+                };
+                var rows = await ranking.Take(maxResults).ToListAsync();
+                if (rows.Count == 0)
+                    return $"No stocks were held by 13F filers as of {targetDate:yyyy-MM-dd}.";
+
+                var universeFilers = await _holdingRepository
+                    .GetUniqueFilerIds(targetDate)
+                    .CountAsync();
+                var stockIds = rows.Select(r => r.CommonStockId).ToList();
+                var stocks = await _commonStockRepository
+                    .GetAll()
+                    .Where(s => stockIds.Contains(s.Id))
+                    .ToDictionaryAsync(s => s.Id);
+
+                return RenderMostHeldStocksTable(
+                    targetDate,
+                    previousDate,
+                    normalizedSort,
+                    universeFilers,
+                    rows,
+                    stocks
+                );
+            },
+            "GetMostHeldStocks",
+            $"sort: {sort}, max: {maxResults}"
+        );
+    }
+
+    private static string RenderMostHeldStocksTable(
+        DateOnly targetDate,
+        DateOnly previousDate,
+        string sort,
+        int universeFilers,
+        List<MarketWideStockActivity> rows,
+        IDictionary<Guid, CommonStock> stocks
+    )
+    {
+        var result = new StringBuilder();
+        result.AppendLine($"Most-held 13F stocks as of {targetDate:yyyy-MM-dd}");
+        result.AppendLine(
+            $"vs prior quarter {previousDate:yyyy-MM-dd} · {universeFilers:N0} filers in the 13F universe"
+        );
+        result.AppendLine($"Sorted by: {sort}");
+        result.AppendLine();
+        result.AppendLine(
+            "| # | Ticker | Company | # Filers | Δ Filers (QoQ) | Total $ Value ($M) | Δ $ Value ($M) | % of 13F Universe |"
+        );
+        result.AppendLine(
+            "|---|--------|---------|----------|----------------|--------------------|----------------|-------------------|"
+        );
+        for (var i = 0; i < rows.Count; i++)
+        {
+            var r = rows[i];
+            stocks.TryGetValue(r.CommonStockId, out var s);
+            var pct = universeFilers > 0 ? (double)r.CurrentFilerCount / universeFilers * 100.0 : 0;
+            var deltaFilers = r.CurrentFilerCount - r.PreviousFilerCount;
+            var filerSign = deltaFilers > 0 ? "+" : "";
+            result.AppendLine(
+                $"| {i + 1} | {s?.Ticker ?? "—"} | {s?.Name ?? "Unknown"} | {r.CurrentFilerCount:N0} | {filerSign}{deltaFilers:N0} | {r.CurrentValue / 1_000_000m:N1} | {r.DeltaValue / 1_000_000m:+#,##0.0;-#,##0.0;0.0} | {pct:F1}% |"
             );
         }
         return result.ToString();

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksTests.cs
@@ -1,0 +1,208 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins <c>InstitutionalHoldingsTools.GetMostHeldStocks</c> — the MCP companion
+/// to the Holdings/MostHeld web page. The tool dispatches on the `sort`
+/// argument over the same <c>GetMostHeld</c> + <c>GetUniqueFilerIds</c> queries;
+/// each Fact exercises one branch (no data, unknown sort, default filers
+/// ranking, filersDelta ranking, max cap).
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetMostHeldStocksTests : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetMostHeldStocksTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetMostHeldStocks_NoData_ReportsNoHoldings()
+    {
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetMostHeldStocks();
+
+        output.Should().Contain("No 13F holdings data");
+    }
+
+    [Fact]
+    public async Task GetMostHeldStocks_UnknownSort_ReportsValidValues()
+    {
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetMostHeldStocks(sort: "garbage");
+
+        output.Should().Contain("Unknown sort");
+        output.Should().Contain("filers");
+        output.Should().Contain("filersdelta");
+        output.Should().Contain("value");
+    }
+
+    [Fact]
+    public async Task GetMostHeldStocks_DefaultSort_RanksByFilerCountDescending()
+    {
+        await SeedThreeStockUniverse();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetMostHeldStocks();
+
+        output.Should().Contain("Most-held 13F stocks as of 2024-12-31");
+        output.Should().Contain("Sorted by: filers");
+        output.Should().Contain("5 filers in the 13F universe");
+        output
+            .IndexOf("AAPL", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("MSFT", StringComparison.Ordinal));
+        output
+            .IndexOf("MSFT", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("NVDA", StringComparison.Ordinal));
+        // AAPL is held by 5 of 5 distinct filers → 100.0% of universe.
+        output.Should().Contain("100.0%");
+    }
+
+    [Fact]
+    public async Task GetMostHeldStocks_FilersDeltaSort_RanksByQoQFilerDeltaDescending()
+    {
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "C1",
+        };
+        var msft = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "C2",
+        };
+        var holders = new InstitutionalHolder[6];
+        for (var i = 0; i < holders.Length; i++)
+            holders[i] = new InstitutionalHolder { Cik = $"H{i + 1}", Name = $"Filer {i + 1}" };
+        DbContext.AddRange(aapl, msft);
+        DbContext.AddRange(holders.Cast<object>().ToArray());
+
+        // AAPL: prior 5 filers → current 6 filers (Δ +1, warming).
+        for (var i = 0; i < 5; i++)
+            DbContext.Add(MakeHolding(aapl, holders[i], prior, shares: 100, value: 100_000));
+        for (var i = 0; i < 6; i++)
+            DbContext.Add(MakeHolding(aapl, holders[i], current, shares: 100, value: 100_000));
+        // MSFT: prior 1 filer → current 5 filers (Δ +4, hotter than AAPL).
+        DbContext.Add(MakeHolding(msft, holders[0], prior, shares: 50, value: 50_000));
+        for (var i = 0; i < 5; i++)
+            DbContext.Add(MakeHolding(msft, holders[i], current, shares: 50, value: 50_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetMostHeldStocks(sort: "filersDelta");
+
+        output.Should().Contain("Sorted by: filersdelta");
+        // MSFT (Δ +4) should appear before AAPL (Δ +1).
+        output
+            .IndexOf("MSFT", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(output.IndexOf("AAPL", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetMostHeldStocks_MaxResults_TruncatesOutput()
+    {
+        await SeedThreeStockUniverse();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetMostHeldStocks(maxResults: 2);
+
+        // Only the top two (AAPL, MSFT) by filer count should appear.
+        output.Should().Contain("AAPL");
+        output.Should().Contain("MSFT");
+        output.Should().NotContain("NVDA");
+    }
+
+    private async Task SeedThreeStockUniverse()
+    {
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "C1",
+        };
+        var msft = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft Corp.",
+            Cik = "C2",
+        };
+        var nvda = new CommonStock
+        {
+            Ticker = "NVDA",
+            Name = "NVIDIA Corp.",
+            Cik = "C3",
+        };
+        DbContext.AddRange(aapl, msft, nvda);
+
+        var holders = new InstitutionalHolder[5];
+        for (var i = 0; i < holders.Length; i++)
+            holders[i] = new InstitutionalHolder { Cik = $"H{i + 1}", Name = $"Filer {i + 1}" };
+        DbContext.AddRange(holders.Cast<object>().ToArray());
+
+        // AAPL = 5 filers, MSFT = 3 filers, NVDA = 1 filer in the current quarter.
+        for (var i = 0; i < 5; i++)
+            DbContext.Add(MakeHolding(aapl, holders[i], current, shares: 100, value: 200_000));
+        for (var i = 0; i < 3; i++)
+            DbContext.Add(MakeHolding(msft, holders[i], current, shares: 50, value: 100_000));
+        DbContext.Add(MakeHolding(nvda, holders[0], current, shares: 10, value: 20_000));
+        // Anchor the prior quarter so ResolveMarketActivityDates finds a comparison.
+        DbContext.Add(MakeHolding(aapl, holders[0], prior, shares: 100, value: 180_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+    }
+
+    private InstitutionalHoldingsTools NewSut(Equibles.Data.EquiblesDbContext ctx) =>
+        new(
+            new InstitutionalHoldingRepository(ctx),
+            new InstitutionalHolderRepository(ctx),
+            new CommonStockRepository(ctx),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{stock.Ticker}-{reportDate:yyyyMMdd}",
+        };
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -268,6 +268,7 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("SearchInstitutions");
         toolNames.Should().Contain("GetTopBuyersSellers");
         toolNames.Should().Contain("GetMarketWide13FActivity");
+        toolNames.Should().Contain("GetMostHeldStocks");
         toolNames.Should().Contain("GetInstitutionSummary");
         toolNames.Should().Contain("GetInstitutionSectorAllocation");
         toolNames.Should().Contain("GetInstitutionQuarterlyActivity");
@@ -364,6 +365,7 @@ public class McpModuleToolDiscoveryTests
                     "SearchInstitutions",
                     "GetTopBuyersSellers",
                     "GetMarketWide13FActivity",
+                    "GetMostHeldStocks",
                     "GetInstitutionSummary",
                     "GetInstitutionSectorAllocation",
                     "GetInstitutionQuarterlyActivity",


### PR DESCRIPTION
## Summary

- Slice 3/3 of #1010 (closes #1010) — the MCP companion to the web page shipped in #1699.
- New \`GetMostHeldStocks\` tool on \`InstitutionalHoldingsTools\` that dispatches on \`sort\` (\`filers\` default, \`filersDelta\` for the warming-names heat map, \`value\` for $-weighted ranking) over the same \`GetMostHeld\` + \`GetUniqueFilerIds\` queries that back the web page. Renders a markdown table per the issue spec.
- Reuses \`ResolveMarketActivityDates\` so the tool fails clearly when no prior quarter exists, matching the pattern used by \`GetMarketWide13FActivity\`.

## Code changes

- \`src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs\` — new \`GetMostHeldStocks\` tool method, new \`RenderMostHeldStocksTable\` helper, and a small \`ValidMostHeldSorts\` whitelist for the sort argument validation.
- \`tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMostHeldStocksTests.cs\` — five ParadeDB-backed integration facts covering: no data, unknown sort, default filers ranking, filersDelta ranking, max-results cap.

## Test plan

- [x] New MCP integration facts green (5/5).
- [x] Full Holdings test suite (unit + integration, \`Category!=Functional&Category!=Live\`) green: 225 unit + 228 integration.
- [x] csharpier tree-wide clean.