### PR TITLE
test(web): pin HoldingsExportController.Sanitize all-stripped fallback

### DIFF
--- a/tests/Equibles.UnitTests/Web/HoldingsExportControllerSanitizeAllStrippedFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsExportControllerSanitizeAllStrippedFallbackTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Equibles.Web.Controllers;
+
+namespace Equibles.UnitTests.Web;
+
+public class HoldingsExportControllerSanitizeAllStrippedFallbackTests
+{
+    // Sanitize has two fallback paths that both return "institution":
+    //   (1) IsNullOrWhiteSpace(value) on the WAY IN (the early-return arm), and
+    //   (2) IsNullOrEmpty(safe) AFTER the allowlist filter (when every char was
+    //       stripped).
+    // The sibling PathTraversal pin exercises a PARTIAL strip ("123/../456" →
+    // "123456" — never hits a fallback). Arm (2) is unpinned: a refactor that
+    // dropped the post-filter IsNullOrEmpty check on the assumption that
+    // IsNullOrWhiteSpace upstream covers it would return "" for inputs that
+    // contain only disallowed characters — producing a Content-Disposition
+    // filename like `holdings-.csv`. Pin the all-stripped arm so any regression
+    // that lets through the empty string fails here.
+    [Fact]
+    public void Sanitize_InputWithOnlyDisallowedCharacters_FallsBackToInstitution()
+    {
+        var method = typeof(HoldingsExportController).GetMethod(
+            "Sanitize",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (string)method.Invoke(null, ["!!!"]);
+
+        result.Should().Be("institution");
+    }
+}


### PR DESCRIPTION
## Summary

- `Sanitize` has two `"institution"` fallback arms: the early-return `IsNullOrWhiteSpace(value)` check and the post-filter `IsNullOrEmpty(safe)` check. The existing path-traversal pin only exercises a partial strip — neither fallback arm is reached.
- Adversarial Lane A: a regression dropping the post-filter check (under the mistaken assumption the upstream `IsNullOrWhiteSpace` guard is enough) would return an empty string for inputs like `"!!!"` and produce malformed `Content-Disposition` filenames like `holdings-.csv`.

## Code changes

- `tests/Equibles.UnitTests/Web/HoldingsExportControllerSanitizeAllStrippedFallbackTests.cs` — new single-fact reflection-based test that invokes `Sanitize("!!!")` and asserts the result is exactly `"institution"`.