### PR TITLE
test(sec): pin FactMarkdown.Value null-unit falls through to dimensionless format

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownValueNullUnitTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownValueNullUnitTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// FactMarkdown.Value routes the unit through three category checks
+/// (per-share, USD prefix, bare-currency) before falling through to the
+/// dimensionless / ratio format. All three checks short-circuit safely on
+/// `unit == null` via `u != null && …`. The existing per-unit pins all
+/// supply a real unit string; the null-unit fallback is untested. A
+/// regression that null-coalesced the unit to "USD" or that dropped the
+/// `u != null` guard on `isWholeMagnitude` would silently format ratio
+/// values as `$1` (USD-prefixed and rounded) instead of the documented
+/// dimensionless `1.2345`.
+/// </summary>
+public class FactMarkdownValueNullUnitTests
+{
+    [Fact]
+    public void Value_NullUnit_FallsThroughToDimensionlessFormatWithoutDollarPrefix()
+    {
+        var result = FactMarkdown.Value(1234.5678m, null);
+
+        result.Should().Be("1234.5678");
+    }
+}


### PR DESCRIPTION
## Summary

- `FactMarkdown.Value` routes through three unit-category checks (per-share, USD, bare-currency) before falling through to the dimensionless format. The `u != null` short-circuits on all three checks are uncovered — every existing per-unit pin supplies a real string.
- Adversarial Lane A: a regression that null-coalesced the unit to "USD" or dropped a `u != null` guard would format ratio values as `$1` (USD-prefixed and rounded) instead of the documented `1.2345`.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownValueNullUnitTests.cs` — new single-fact test that calls `Value(1234.5678m, null)` and asserts the output is exactly `"1234.5678"` (no `$`, no rounding).