### PR TITLE
test(holdings): pin TryResolveAmendmentTarget returns false for unknown CIK

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetUnknownCikTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetUnknownCikTests.cs
@@ -1,0 +1,53 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceTryResolveAmendmentTargetUnknownCikTests
+{
+    private static readonly MethodInfo TryResolveAmendmentTargetMethod =
+        typeof(HoldingsImportService).GetMethod(
+            "TryResolveAmendmentTarget",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // The sibling NullCik pin covers `Cik == null`. This pin covers the
+    // ADJACENT arm — a well-formed Cik that simply isn't in
+    // `context.CikToHolderId` (an amendment for a filer outside this import
+    // batch's universe, or one whose first-seen filing failed earlier in the
+    // pipeline). The body uses `TryGetValue`; a regression that "simplified"
+    // it to `_dict[submission.Cik]` would throw KeyNotFoundException on the
+    // first orphan amendment and abort the whole amendment-reconciliation
+    // pass — the strict-Try*-never-throws contract demands a clean `false`.
+    [Fact]
+    public void TryResolveAmendmentTarget_CikNotInHolderMap_ReturnsFalseWithoutThrowing()
+    {
+        var accession = "0000950123-24-006478";
+        var submission = new SubmissionRow
+        {
+            AccessionNumber = accession,
+            Cik = "0009999999",
+            PeriodOfReport = "2024-09-30",
+        };
+        var context = new ImportContext
+        {
+            CoverPages = new Dictionary<string, CoverPageRow>
+            {
+                [accession] = new() { AccessionNumber = accession, IsAmendment = "Y" },
+            },
+            CikToHolderId = new Dictionary<string, Guid>
+            {
+                // A DIFFERENT CIK is mapped — submission.Cik is intentionally absent.
+                ["0001067983"] = Guid.NewGuid(),
+            },
+        };
+        var args = new object[] { accession, submission, context, null, null };
+
+        bool resolved = false;
+        var act = () => resolved = (bool)TryResolveAmendmentTargetMethod.Invoke(null, args);
+
+        act.Should().NotThrow();
+        resolved.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- `TryResolveAmendmentTarget`'s `CikToHolderId.TryGetValue` guard (lines 524-525) was uncovered. Sibling pin to `NullCikTests` (handles `Cik == null`); this one handles the adjacent arm — a well-formed Cik that's simply not in the holder map (orphan amendment, or a filer whose first-seen filing failed earlier).
- Adversarial Lane A: a regression that "simplified" the dictionary call to `_dict[submission.Cik]` would throw `KeyNotFoundException` on the first orphan amendment and abort the entire amendment-reconciliation pass.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryResolveAmendmentTargetUnknownCikTests.cs` — new reflection-based unit test feeding a submission whose Cik isn't in `context.CikToHolderId`; asserts the method returns `false` without throwing.