### PR TITLE
feat(web): add Institutions index page (/institutions)

### DIFF
--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -1,0 +1,114 @@
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.ViewModels.Institutions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Web.Controllers;
+
+public class InstitutionsController : BaseController
+{
+    private readonly InstitutionalHolderRepository _holderRepository;
+    private readonly EquiblesDbContext _dbContext;
+
+    public InstitutionsController(
+        InstitutionalHolderRepository holderRepository,
+        EquiblesDbContext dbContext,
+        ILogger<InstitutionsController> logger
+    )
+        : base(logger)
+    {
+        _holderRepository = holderRepository;
+        _dbContext = dbContext;
+    }
+
+    [HttpGet("~/institutions")]
+    public async Task<IActionResult> Index(
+        string search,
+        InstitutionSort sort = InstitutionSort.Name,
+        int page = 1
+    )
+    {
+        ViewData["Title"] = "Institutions";
+
+        // page is a client-supplied query value; a non-positive page would emit
+        // Skip((page-1)*pageSize) = a negative OFFSET, which PostgreSQL rejects.
+        if (page < 1)
+            page = 1;
+
+        const int pageSize = 50;
+
+        var latestReportDate = await _dbContext
+            .Set<InstitutionalHolding>()
+            .Select(h => (DateOnly?)h.ReportDate)
+            .MaxAsync();
+
+        // Per-filer aggregate at the universe-latest report date. EF Core
+        // translates this to a single GROUP BY pushed to Postgres; the
+        // GroupJoin below preserves filers that didn't report in the latest
+        // quarter (their aggregate row is null → rendered as 0).
+        var aggByHolder = _dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h => latestReportDate != null && h.ReportDate == latestReportDate.Value)
+            .GroupBy(h => h.InstitutionalHolderId)
+            .Select(g => new
+            {
+                HolderId = g.Key,
+                Positions = g.Count(),
+                Value = g.Sum(h => h.Value),
+            });
+
+        var holders = _holderRepository.Search(search ?? string.Empty);
+        var joined = holders.GroupJoin(
+            aggByHolder,
+            h => h.Id,
+            a => a.HolderId,
+            (h, ags) => new { h, agg = ags.FirstOrDefault() }
+        );
+
+        var ordered = sort switch
+        {
+            InstitutionSort.PositionsDescending => joined
+                .OrderByDescending(x => x.agg != null ? x.agg.Positions : 0)
+                .ThenBy(x => x.h.Name)
+                .ThenBy(x => x.h.Id),
+            InstitutionSort.ValueDescending => joined
+                .OrderByDescending(x => x.agg != null ? x.agg.Value : 0L)
+                .ThenBy(x => x.h.Name)
+                .ThenBy(x => x.h.Id),
+            _ => joined.OrderBy(x => x.h.Name).ThenBy(x => x.h.Id),
+        };
+
+        var totalCount = await ordered.CountAsync();
+
+        var pageRows = await ordered
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(x => new InstitutionListItemViewModel
+            {
+                Id = x.h.Id,
+                Cik = x.h.Cik,
+                Name = x.h.Name,
+                City = x.h.City,
+                StateOrCountry = x.h.StateOrCountry,
+                PositionCount = x.agg != null ? x.agg.Positions : 0,
+                TotalValue = x.agg != null ? x.agg.Value : 0L,
+            })
+            .ToListAsync();
+
+        var viewModel = new InstitutionBrowserViewModel
+        {
+            Institutions = pageRows,
+            Search = search,
+            Sort = sort,
+            LatestReportDate = latestReportDate,
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = totalCount,
+        };
+
+        return View(viewModel);
+    }
+}

--- a/src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs
@@ -1,0 +1,17 @@
+namespace Equibles.Web.ViewModels.Institutions;
+
+public class InstitutionBrowserViewModel
+{
+    public List<InstitutionListItemViewModel> Institutions { get; set; } = [];
+    public string Search { get; set; }
+    public InstitutionSort Sort { get; set; } = InstitutionSort.Name;
+
+    // Latest universe-wide 13F report date — drives the per-filer aggregates
+    // and the page subtitle. Null when no holdings have been ingested yet.
+    public DateOnly? LatestReportDate { get; set; }
+
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 50;
+    public int TotalCount { get; set; }
+    public int TotalPages => Math.Max(1, (TotalCount + PageSize - 1) / PageSize);
+}

--- a/src/Equibles.Web/ViewModels/Institutions/InstitutionListItemViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Institutions/InstitutionListItemViewModel.cs
@@ -1,0 +1,15 @@
+namespace Equibles.Web.ViewModels.Institutions;
+
+public class InstitutionListItemViewModel
+{
+    public Guid Id { get; set; }
+    public string Cik { get; set; }
+    public string Name { get; set; }
+    public string City { get; set; }
+    public string StateOrCountry { get; set; }
+
+    // Per-filer aggregates at the universe's latest 13F report date. Zero when
+    // the filer didn't report in that quarter (e.g. quarterly skip / closure).
+    public int PositionCount { get; set; }
+    public long TotalValue { get; set; }
+}

--- a/src/Equibles.Web/ViewModels/Institutions/InstitutionSort.cs
+++ b/src/Equibles.Web/ViewModels/Institutions/InstitutionSort.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Web.ViewModels.Institutions;
+
+public enum InstitutionSort
+{
+    [Display(Name = "Name")]
+    Name = 0,
+
+    [Display(Name = "# Positions (latest 13F)")]
+    PositionsDescending = 1,
+
+    [Display(Name = "Total $ Value (latest 13F)")]
+    ValueDescending = 2,
+}

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -1,0 +1,165 @@
+@using Equibles.Web.ViewModels.Institutions
+@model InstitutionBrowserViewModel
+
+@{
+    ViewData["Title"] = "Institutions";
+    ViewData["Description"] = "Browse and search the 13F institutional filer universe — fund managers, advisers, banks, and trusts that file Form 13F with the SEC.";
+
+    // Active filters carried across pagination links so paging never drops them.
+    var filterRoute = new Dictionary<string, string>();
+    if (!string.IsNullOrEmpty(Model.Search)) {
+        filterRoute["search"] = Model.Search;
+    }
+    if (Model.Sort != InstitutionSort.Name) {
+        filterRoute["sort"] = Model.Sort.ToString();
+    }
+    var hasFilters = filterRoute.Count > 0;
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold mb-2">Institutions</h1>
+        <p class="text-base-content/60">
+            Browse @Model.TotalCount.ToString("N0") 13F filers
+            @if (Model.LatestReportDate.HasValue) {
+                <span> · per-filer aggregates from the latest 13F quarter (@Model.LatestReportDate.Value.ToString("MMM dd, yyyy"))</span>
+            } else {
+                <span> · no 13F data ingested yet</span>
+            }
+        </p>
+    </div>
+
+    <!-- Search + sort (plain query-param names, bound to InstitutionsController.Index) -->
+    <form method="get" class="mb-6">
+        <div class="flex flex-wrap gap-3 items-end">
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">Search</span>
+                <input type="text" name="search" value="@Model.Search"
+                       class="input input-bordered w-64"
+                       aria-label="Search institutions by name"
+                       placeholder="Institution name..." />
+            </label>
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">Sort by</span>
+                <select name="sort" class="select select-bordered" aria-label="Sort institutions">
+                    @foreach (var option in Html.GetEnumSelectList<InstitutionSort>()) {
+                        <option value="@option.Value"
+                                selected="@(option.Value == ((int)Model.Sort).ToString())">
+                            @option.Text
+                        </option>
+                    }
+                </select>
+            </label>
+            <button type="submit" class="btn btn-primary">Apply</button>
+            @if (hasFilters) {
+                <a asp-action="Index" class="btn btn-ghost">Clear</a>
+            }
+        </div>
+    </form>
+
+    <!-- Results Table -->
+    <div class="card bg-base-100 shadow-sm">
+        <div class="overflow-x-auto">
+            <table class="table table-zebra table-sm" aria-label="Institutions" data-testid="institutions-table">
+                <thead>
+                    <tr>
+                        <th scope="col">Name</th>
+                        <th scope="col" class="hidden md:table-cell">CIK</th>
+                        <th scope="col" class="hidden lg:table-cell">Location</th>
+                        <th scope="col" class="text-right"># Positions</th>
+                        <th scope="col" class="text-right hidden md:table-cell">Total $ Value ($M)</th>
+                        <th scope="col" class="w-8"><span class="sr-only">Open</span></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var inst in Model.Institutions) {
+                        var location = string.Join(", ", new[] { inst.City, inst.StateOrCountry }.Where(s => !string.IsNullOrEmpty(s)));
+                        <tr class="hover cursor-pointer institution-row"
+                            data-href="@Url.Action("Institution", "Profiles", new { cik = inst.Cik })">
+                            <td class="max-w-xs">
+                                <a asp-action="Institution" asp-controller="Profiles" asp-route-cik="@inst.Cik"
+                                   class="font-semibold link link-primary">@inst.Name</a>
+                            </td>
+                            <td class="hidden md:table-cell font-mono text-sm text-base-content/60">@inst.Cik</td>
+                            <td class="hidden lg:table-cell text-sm text-base-content/60">@(string.IsNullOrEmpty(location) ? "—" : location)</td>
+                            <td class="text-right font-mono">@inst.PositionCount.ToString("N0")</td>
+                            <td class="text-right font-mono hidden md:table-cell">@((inst.TotalValue / 1_000_000m).ToString("N1"))</td>
+                            <td class="text-base-content/30">
+                                <icon name="chevron-right" size="4" />
+                            </td>
+                        </tr>
+                    }
+                    @if (Model.Institutions.Count == 0) {
+                        <tr>
+                            <td colspan="6" class="text-center py-10 text-base-content/60">
+                                @if (Model.LatestReportDate.HasValue) {
+                                    <span>No institutions match these filters.</span>
+                                } else {
+                                    <span>No 13F filers have been ingested yet. The Most-Held and per-institution pages light up once the worker finishes its first 13F cycle.</span>
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- Pagination -->
+    @if (Model.TotalPages > 1) {
+        <nav class="flex justify-center mt-6" aria-label="Institutions pagination" data-testid="institutions-pager">
+            <div class="join">
+                @if (Model.Page > 1) {
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page - 1)"
+                       class="join-item btn btn-sm" aria-label="Go to previous page">Previous</a>
+                }
+
+                @{
+                    var startPage = Math.Max(1, Model.Page - 2);
+                    var endPage = Math.Min(Model.TotalPages, Model.Page + 2);
+                }
+
+                @if (startPage > 1) {
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="1"
+                       class="join-item btn btn-sm" aria-label="Go to page 1">1</a>
+                    @if (startPage > 2) {
+                        <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
+                    }
+                }
+
+                @for (var i = startPage; i <= endPage; i++) {
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@i"
+                       class="join-item btn btn-sm @(i == Model.Page ? "btn-active" : "")"
+                       aria-label="Go to page @i"
+                       aria-current="@(i == Model.Page ? "page" : null)">@i</a>
+                }
+
+                @if (endPage < Model.TotalPages) {
+                    @if (endPage < Model.TotalPages - 1) {
+                        <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
+                    }
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@Model.TotalPages"
+                       class="join-item btn btn-sm" aria-label="Go to page @Model.TotalPages">@Model.TotalPages</a>
+                }
+
+                @if (Model.Page < Model.TotalPages) {
+                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page + 1)"
+                       class="join-item btn btn-sm" aria-label="Go to next page">Next</a>
+                }
+            </div>
+        </nav>
+    }
+</div>
+
+@section Scripts {
+    <script>
+    // Row-click navigation: same UX as the Stocks index — clicking anywhere on
+    // a row (other than an inner link) navigates to the institution profile.
+    document.querySelectorAll('.institution-row').forEach(function(row) {
+        row.addEventListener('click', function(e) {
+            if (e.target.closest('a')) return; // let native link clicks through
+            window.location.href = this.dataset.href;
+        });
+    });
+    </script>
+}

--- a/tests/Equibles.IntegrationTests/Web/InstitutionsControllerTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/InstitutionsControllerTests.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the /institutions index page: the controller composes the per-filer
+/// snapshot aggregate at the universe-latest report date and the rendered
+/// HTML carries the listing with the right names, position counts, search
+/// filter, and sort order.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class InstitutionsControllerTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public InstitutionsControllerTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetIndex_NoHoldings_RendersEmptyStateWithNoQuarterNotice()
+    {
+        await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
+
+        var response = await _fixture.Client.GetAsync("/institutions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("no 13F data ingested yet");
+        html.Should().Contain("institutions-table");
+    }
+
+    [Fact]
+    public async Task GetIndex_HoldersWithoutHoldings_ListsThemWithZeroAggregates()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(new InstitutionalHolder { Cik = "0000001", Name = "Acme Capital" });
+            db.Add(new InstitutionalHolder { Cik = "0000002", Name = "Berkshire Hathaway Inc" });
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Acme Capital");
+        html.Should().Contain("Berkshire Hathaway Inc");
+        // Both filers appear with zero positions since no holdings exist yet.
+        html.Should().Contain(">0<");
+    }
+
+    [Fact]
+    public async Task GetIndex_DefaultSort_RanksByNameAscending()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(new InstitutionalHolder { Cik = "0000001", Name = "Zebra Asset Management" });
+            db.Add(new InstitutionalHolder { Cik = "0000002", Name = "Alpha Capital" });
+            db.Add(new InstitutionalHolder { Cik = "0000003", Name = "Mid Fund LLC" });
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        var alphaIdx = html.IndexOf("Alpha Capital", StringComparison.Ordinal);
+        var midIdx = html.IndexOf("Mid Fund LLC", StringComparison.Ordinal);
+        var zebraIdx = html.IndexOf("Zebra Asset Management", StringComparison.Ordinal);
+        alphaIdx.Should().BeGreaterThan(-1);
+        midIdx.Should().BeGreaterThan(alphaIdx);
+        zebraIdx.Should().BeGreaterThan(midIdx);
+    }
+
+    [Fact]
+    public async Task GetIndex_SortByPositionsDesc_PutsHigherPositionCountFirst()
+    {
+        var quarter = new DateOnly(2024, 12, 31);
+        var aaplId = Guid.NewGuid();
+        var msftId = Guid.NewGuid();
+        var bigId = Guid.NewGuid();
+        var smallId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            db.Add(
+                new CommonStock
+                {
+                    Id = msftId,
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corp.",
+                    Cik = "0000789019",
+                }
+            );
+
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = bigId,
+                    Cik = "0000010",
+                    Name = "Big Fund LP",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = smallId,
+                    Cik = "0000020",
+                    Name = "Small Boutique LLC",
+                }
+            );
+
+            // Big Fund holds two stocks; Small Boutique holds one.
+            db.Add(MakeHolding(aaplId, bigId, quarter));
+            db.Add(MakeHolding(msftId, bigId, quarter));
+            db.Add(MakeHolding(aaplId, smallId, quarter));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions?sort=PositionsDescending");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        // Big Fund (2 positions) should appear before Small Boutique (1 position).
+        var bigIdx = html.IndexOf("Big Fund LP", StringComparison.Ordinal);
+        var smallIdx = html.IndexOf("Small Boutique LLC", StringComparison.Ordinal);
+        bigIdx.Should().BeGreaterThan(-1);
+        smallIdx.Should().BeGreaterThan(bigIdx);
+    }
+
+    [Fact]
+    public async Task GetIndex_SearchByName_FiltersToMatches()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(new InstitutionalHolder { Cik = "0000001", Name = "Vanguard Group" });
+            db.Add(new InstitutionalHolder { Cik = "0000002", Name = "BlackRock Inc." });
+            db.Add(new InstitutionalHolder { Cik = "0000003", Name = "Capital Group" });
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions?search=vanguard");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Vanguard Group");
+        html.Should().NotContain("BlackRock Inc.");
+        html.Should().NotContain("Capital Group");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = 1_000,
+            Value = 1_000_000,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber =
+                $"acc-{holderId:N}".Substring(0, 12) + $"-{stockId:N}".Substring(0, 8),
+        };
+}


### PR DESCRIPTION
## Summary

- Closes #1719.
- New \`GET ~/institutions\` action and view that lists the 13F filer universe with search-by-name + sort (Name / # Positions desc / Total \$ Value desc) + 50-row pagination. Mirrors the Stocks index layout — row-click navigates to the existing \`/institutions/{cik}\` profile page.
- Per-filer aggregates (\`# Positions\`, \`Total \$ Value\`) come from a single \`GROUP BY\` at the universe-latest 13F report date; filers that didn't report in that quarter still appear with zero counts via \`GroupJoin\`.

## Code changes

- \`src/Equibles.Web/Controllers/InstitutionsController.cs\` — new controller with one \`Index\` action.
- \`src/Equibles.Web/ViewModels/Institutions/\` — \`InstitutionListItemViewModel\`, \`InstitutionBrowserViewModel\`, \`InstitutionSort\` enum (with \`[Display]\` attributes for the sort selector).
- \`src/Equibles.Web/Views/Institutions/Index.cshtml\` — DaisyUI table with search/sort filter bar, join pager, row-click navigation.
- \`tests/Equibles.IntegrationTests/Web/InstitutionsControllerTests.cs\` — five view-render facts covering empty state, holders without holdings, default name sort, positions-desc sort, and search filtering.

The navbar entry that surfaces this page is a separate change tracked in #1720.

## Test plan

- [x] 5 new view-render facts green.
- [x] csharpier tree-wide clean.