### PR TITLE
feat(web): navbar reshuffle — add Institutions, group Economic Data/Futures/Market under More

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -28,9 +28,35 @@
                 <nav class="hidden lg:flex items-center gap-6 whitespace-nowrap" aria-label="Main navigation">
                     <a asp-action="Index" asp-controller="Home" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">Home</a>
                     <a asp-action="Index" asp-controller="Stocks" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">Stocks</a>
-                    <a asp-action="Index" asp-controller="EconomicData" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">Economic Data</a>
-                    <a asp-action="Index" asp-controller="Cftc" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">Futures</a>
-                    <a asp-action="Index" asp-controller="Market" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">Market</a>
+                    <a asp-action="Index" asp-controller="Institutions" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">Institutions</a>
+                    <!-- "More" groups the less-visited datasets (Economic Data / Futures / Market)
+                         behind a DaisyUI dropdown so the primary nav stays readable on medium viewports. -->
+                    <div class="dropdown dropdown-bottom">
+                        <button type="button" tabindex="0"
+                                class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors flex items-center gap-1 cursor-pointer"
+                                aria-haspopup="menu" aria-controls="navbar-more-menu">
+                            More
+                            <icon name="chevron-down" size="3" />
+                        </button>
+                        <ul id="navbar-more-menu" tabindex="0" role="menu" aria-label="More datasets"
+                            class="dropdown-content menu bg-base-100 rounded-box z-50 w-56 p-2 shadow-lg border border-base-200 mt-2">
+                            <li>
+                                <a asp-action="Index" asp-controller="EconomicData">
+                                    <icon name="presentation-chart-line" size="4" /> Economic Data
+                                </a>
+                            </li>
+                            <li>
+                                <a asp-action="Index" asp-controller="Cftc">
+                                    <icon name="scale" size="4" /> Futures
+                                </a>
+                            </li>
+                            <li>
+                                <a asp-action="Index" asp-controller="Market">
+                                    <icon name="chart-bar-square" size="4" /> Market
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
                     <a asp-action="Connect" asp-controller="Home" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">MCP</a>
                     <a asp-action="Index" asp-controller="Status" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors flex items-center gap-1">
                         Status
@@ -93,6 +119,11 @@
                         <li>
                             <a asp-action="Index" asp-controller="Stocks">
                                 <icon name="chart-bar" size="4" /> Stocks
+                            </a>
+                        </li>
+                        <li>
+                            <a asp-action="Index" asp-controller="Institutions">
+                                <icon name="building-library" size="4" /> Institutions
                             </a>
                         </li>
                         <li>

--- a/tests/Equibles.IntegrationTests/Web/LayoutNavbarTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/LayoutNavbarTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the shared layout's top navbar shape: the Institutions link is present
+/// between Stocks and the More dropdown, and the dropdown carries Economic Data
+/// / Futures / Market. Each fact hits the homepage (any page renders the same
+/// layout) and asserts on the response HTML — cheap and stable.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class LayoutNavbarTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public LayoutNavbarTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetHome_DesktopNav_ContainsInstitutionsLinkBetweenStocksAndMoreDropdown()
+    {
+        var response = await _fixture.Client.GetAsync("/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+
+        var stocksIdx = html.IndexOf("href=\"/stocks\"", StringComparison.Ordinal);
+        var institutionsIdx = html.IndexOf("href=\"/institutions\"", StringComparison.Ordinal);
+        var moreIdx = html.IndexOf("navbar-more-menu", StringComparison.Ordinal);
+
+        stocksIdx.Should().BeGreaterThan(-1);
+        institutionsIdx
+            .Should()
+            .BeGreaterThan(stocksIdx, "Institutions sits between Stocks and More");
+        moreIdx.Should().BeGreaterThan(institutionsIdx, "More dropdown follows Institutions");
+    }
+
+    [Fact]
+    public async Task GetHome_MoreDropdown_GroupsEconomicDataFuturesAndMarket()
+    {
+        var response = await _fixture.Client.GetAsync("/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+
+        // Slice the rendered HTML around the More dropdown's <ul> so the three
+        // links are matched inside it rather than coincidentally elsewhere on
+        // the page.
+        var ulStart = html.IndexOf("id=\"navbar-more-menu\"", StringComparison.Ordinal);
+        ulStart.Should().BeGreaterThan(-1);
+        var ulEnd = html.IndexOf("</ul>", ulStart, StringComparison.Ordinal);
+        ulEnd.Should().BeGreaterThan(ulStart);
+        var dropdown = html.Substring(ulStart, ulEnd - ulStart);
+
+        dropdown.Should().Contain("Economic Data");
+        dropdown.Should().Contain("Futures");
+        dropdown.Should().Contain("Market");
+    }
+
+    [Fact]
+    public async Task GetHome_MobileNav_ContainsInstitutionsLinkFlat()
+    {
+        var response = await _fixture.Client.GetAsync("/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+
+        // The mobile dropdown keeps a flat list — Institutions should appear
+        // alongside the rest, not nested behind a sub-dropdown.
+        var mobileStart = html.IndexOf("id=\"mobile-nav-menu\"", StringComparison.Ordinal);
+        mobileStart.Should().BeGreaterThan(-1);
+        var mobileEnd = html.IndexOf("</ul>", mobileStart, StringComparison.Ordinal);
+        mobileEnd.Should().BeGreaterThan(mobileStart);
+        var mobileMenu = html.Substring(mobileStart, mobileEnd - mobileStart);
+
+        mobileMenu.Should().Contain("Institutions");
+        mobileMenu.Should().Contain("Economic Data");
+        mobileMenu.Should().Contain("Futures");
+        mobileMenu.Should().Contain("Market");
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #1720.
- Primary nav order: \`Home · Stocks · Institutions · More ▾ · MCP · Status\`.
- New DaisyUI \`More\` dropdown groups \`Economic Data\`, \`Futures\`, \`Market\` so the row stays readable on medium viewports.
- Mobile menu (hamburger) keeps a flat list — \`Institutions\` inserted between Stocks and Economic Data; no nested sub-dropdown.

## Code changes

- \`src/Equibles.Web/Views/Shared/_Layout.cshtml\` — desktop \`<nav>\` and mobile dropdown.
- \`tests/Equibles.IntegrationTests/Web/LayoutNavbarTests.cs\` — three view-render facts pinning desktop order (Stocks → Institutions → More), the dropdown's grouped link set, and the flat mobile list.

## Test plan

- [x] 3 new view-render facts green.
- [x] csharpier tree-wide clean.
- [x] Rebuilt the web container locally and visually verified the navbar.