### PR TITLE
fix(web): drop icons from desktop More dropdown items

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -40,21 +40,11 @@
                         </button>
                         <ul id="navbar-more-menu" tabindex="0" role="menu" aria-label="More datasets"
                             class="dropdown-content menu bg-base-100 rounded-box z-50 w-56 p-2 shadow-lg border border-base-200 mt-2">
-                            <li>
-                                <a asp-action="Index" asp-controller="EconomicData">
-                                    <icon name="presentation-chart-line" size="4" /> Economic Data
-                                </a>
-                            </li>
-                            <li>
-                                <a asp-action="Index" asp-controller="Cftc">
-                                    <icon name="scale" size="4" /> Futures
-                                </a>
-                            </li>
-                            <li>
-                                <a asp-action="Index" asp-controller="Market">
-                                    <icon name="chart-bar-square" size="4" /> Market
-                                </a>
-                            </li>
+                            <!-- No icons — the top nav peers (Home/Stocks/Institutions/MCP/Status)
+                                 are text-only, and the desktop dropdown should match. -->
+                            <li><a asp-action="Index" asp-controller="EconomicData">Economic Data</a></li>
+                            <li><a asp-action="Index" asp-controller="Cftc">Futures</a></li>
+                            <li><a asp-action="Index" asp-controller="Market">Market</a></li>
                         </ul>
                     </div>
                     <a asp-action="Connect" asp-controller="Home" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">MCP</a>


### PR DESCRIPTION
## Summary

The HeroIcons names \`scale\` (Futures) and \`chart-bar-square\` (Market) aren't in this project's icon set, so the tag helper rendered them empty — Economic Data was the only item showing an icon, which looked broken (mismatched + lopsided rows in the dropdown). Strip all three; the top-nav peers (Home / Stocks / Institutions / MCP / Status) are text-only too, so this restores consistency across the desktop nav.

## Code changes

- \`src/Equibles.Web/Views/Shared/_Layout.cshtml\` — remove the three \`<icon>\` tags inside the More dropdown's \`<li>\`s and collapse each into a one-liner.

The "More ▾" chevron stays — it signals the dropdown affordance and serves a different role than the per-item icons.