### PR TITLE
fix(sec): silence FTD pre-2021 404 stack-trace noise

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -99,8 +99,11 @@ public class FtdImportService
                 }
                 else
                 {
+                    // Pre-2021 FTD ZIPs (cnsfails20*) routinely return 404 — SEC
+                    // moved their archive. The plain warning carries the only
+                    // useful signal ("URL may have changed"); the exception's
+                    // stack trace adds nothing but noise, so drop it.
                     _logger.LogWarning(
-                        ex,
                         "FTD file {File} returned 404 but is older than 2 months — possible URL change",
                         fileName
                     );


### PR DESCRIPTION
## Summary

Pre-2021 FTD ZIPs (\`cnsfails20*\`) routinely return 404 because SEC moved their archive. The handler at \`FtdImportService.Import:90-107\` catches that path and logs a warning ("URL may have changed"), so this is expected behaviour — but the call was \`LogWarning(ex, ...)\`, which makes Serilog dump the full \`HttpRequestException\` stack trace below the warning message. Result: a cold-start tick fills the worker log with what looks like a dozen+ unhandled errors when none of them actually are.

The message text already names the cause; drop the exception arg so only the message lands.

## Code changes

- \`src/Equibles.Sec.HostedService/Services/FtdImportService.cs\` — remove \`ex\` from the not-recent-FTD-file warning. WHY comment kept inline.

The other arm (\`HttpRequestException\` without 404 — line 111) still logs the exception, since arbitrary HTTP failures genuinely warrant the stack trace.

## Test plan

- [x] All 11 \`FtdImport\` integration facts green.
- [x] csharpier tree-wide clean.