### PR TITLE
fix(web): institutions index uses per-filer latest report, not universe-latest

### DIFF
--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -45,19 +45,32 @@ public class InstitutionsController : BaseController
             .Select(h => (DateOnly?)h.ReportDate)
             .MaxAsync();
 
-        // Per-filer aggregate at the universe-latest report date. EF Core
-        // translates this to a single GROUP BY pushed to Postgres; the
-        // GroupJoin below preserves filers that didn't report in the latest
-        // quarter (their aggregate row is null → rendered as 0).
+        // Per-filer aggregate at each filer's OWN most-recent 13F report. The
+        // universe-latest approach drops historical filers (e.g. Scion's 2022
+        // book never shows up once the universe ticks past 2022), so the table
+        // would mis-report active book sizes as zero. The two-stage shape (max
+        // date per holder + join + group) translates to a single Postgres
+        // query with a self-join.
+        var perFilerLatest = _dbContext
+            .Set<InstitutionalHolding>()
+            .GroupBy(h => h.InstitutionalHolderId)
+            .Select(g => new { HolderId = g.Key, LatestDate = g.Max(h => h.ReportDate) });
+
         var aggByHolder = _dbContext
             .Set<InstitutionalHolding>()
-            .Where(h => latestReportDate != null && h.ReportDate == latestReportDate.Value)
+            .Join(
+                perFilerLatest,
+                h => new { Holder = h.InstitutionalHolderId, Date = h.ReportDate },
+                l => new { Holder = l.HolderId, Date = l.LatestDate },
+                (h, _) => h
+            )
             .GroupBy(h => h.InstitutionalHolderId)
             .Select(g => new
             {
                 HolderId = g.Key,
                 Positions = g.Count(),
                 Value = g.Sum(h => h.Value),
+                LatestDate = g.Max(h => h.ReportDate),
             });
 
         var holders = _holderRepository.Search(search ?? string.Empty);
@@ -95,6 +108,7 @@ public class InstitutionsController : BaseController
                 StateOrCountry = x.h.StateOrCountry,
                 PositionCount = x.agg != null ? x.agg.Positions : 0,
                 TotalValue = x.agg != null ? x.agg.Value : 0L,
+                LatestReportDate = x.agg != null ? (DateOnly?)x.agg.LatestDate : null,
             })
             .ToListAsync();
 

--- a/src/Equibles.Web/ViewModels/Institutions/InstitutionListItemViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Institutions/InstitutionListItemViewModel.cs
@@ -8,8 +8,11 @@ public class InstitutionListItemViewModel
     public string City { get; set; }
     public string StateOrCountry { get; set; }
 
-    // Per-filer aggregates at the universe's latest 13F report date. Zero when
-    // the filer didn't report in that quarter (e.g. quarterly skip / closure).
+    // Per-filer aggregates at each filer's own most-recent 13F report. Filers
+    // that have stopped filing keep their historical aggregate from their last
+    // report instead of dropping to zero just because the universe has moved
+    // on. Null when the filer has never reported a 13F.
     public int PositionCount { get; set; }
     public long TotalValue { get; set; }
+    public DateOnly? LatestReportDate { get; set; }
 }

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -22,7 +22,7 @@
         <p class="text-base-content/60">
             Browse @Model.TotalCount.ToString("N0") 13F filers
             @if (Model.LatestReportDate.HasValue) {
-                <span> · per-filer aggregates from the latest 13F quarter (@Model.LatestReportDate.Value.ToString("MMM dd, yyyy"))</span>
+                <span> · aggregates from each filer's most-recent 13F report (universe latest @Model.LatestReportDate.Value.ToString("MMM dd, yyyy"))</span>
             } else {
                 <span> · no 13F data ingested yet</span>
             }
@@ -68,6 +68,7 @@
                         <th scope="col" class="hidden lg:table-cell">Location</th>
                         <th scope="col" class="text-right"># Positions</th>
                         <th scope="col" class="text-right hidden md:table-cell">Total $ Value ($M)</th>
+                        <th scope="col" class="text-right hidden xl:table-cell">Last filed</th>
                         <th scope="col" class="w-8"><span class="sr-only">Open</span></th>
                     </tr>
                 </thead>
@@ -84,6 +85,7 @@
                             <td class="hidden lg:table-cell text-sm text-base-content/60">@(string.IsNullOrEmpty(location) ? "—" : location)</td>
                             <td class="text-right font-mono">@inst.PositionCount.ToString("N0")</td>
                             <td class="text-right font-mono hidden md:table-cell">@((inst.TotalValue / 1_000_000m).ToString("N1"))</td>
+                            <td class="text-right font-mono text-sm text-base-content/60 hidden xl:table-cell">@(inst.LatestReportDate?.ToString("yyyy-MM-dd") ?? "—")</td>
                             <td class="text-base-content/30">
                                 <icon name="chevron-right" size="4" />
                             </td>
@@ -91,7 +93,7 @@
                     }
                     @if (Model.Institutions.Count == 0) {
                         <tr>
-                            <td colspan="6" class="text-center py-10 text-base-content/60">
+                            <td colspan="7" class="text-center py-10 text-base-content/60">
                                 @if (Model.LatestReportDate.HasValue) {
                                     <span>No institutions match these filters.</span>
                                 } else {

--- a/tests/Equibles.IntegrationTests/Web/InstitutionsControllerTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/InstitutionsControllerTests.cs
@@ -140,6 +140,82 @@ public class InstitutionsControllerTests
     }
 
     [Fact]
+    public async Task GetIndex_FilerLastReportedInOlderQuarter_StillShowsHistoricalAggregate()
+    {
+        // Regression for the universe-latest bug: Scion-style filers who only
+        // reported in an older quarter must still show their historical position
+        // count, not collapse to zero just because the universe has moved on.
+        var olderQuarter = new DateOnly(2022, 3, 31);
+        var currentQuarter = new DateOnly(2026, 3, 31);
+        var aaplId = Guid.NewGuid();
+        var msftId = Guid.NewGuid();
+        var scionId = Guid.NewGuid();
+        var activeId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            db.Add(
+                new CommonStock
+                {
+                    Id = msftId,
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corp.",
+                    Cik = "0000789019",
+                }
+            );
+
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = scionId,
+                    Cik = "0001649339",
+                    Name = "Scion Asset Management LLC",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = activeId,
+                    Cik = "0000050000",
+                    Name = "Active Fund LP",
+                }
+            );
+
+            // Scion only filed in 2022-Q1 — single AAPL position.
+            db.Add(MakeHolding(aaplId, scionId, olderQuarter));
+            // Active Fund anchors the universe at 2026-Q1 with one MSFT position.
+            db.Add(MakeHolding(msftId, activeId, currentQuarter));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions?sort=PositionsDescending");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+
+        // Both filers must appear with non-zero positions. The aggregate must come
+        // from each filer's own latest quarter, not the universe-latest.
+        var scionStart = html.IndexOf("Scion Asset Management LLC", StringComparison.Ordinal);
+        scionStart.Should().BeGreaterThan(-1);
+        var scionEnd = html.IndexOf("</tr>", scionStart, StringComparison.Ordinal);
+        scionEnd.Should().BeGreaterThan(scionStart);
+        var scionRow = html.Substring(scionStart, scionEnd - scionStart);
+        // The "Last filed" column carries each filer's own latest date.
+        scionRow.Should().Contain("2022-03-31");
+        // The # Positions cell carries "1" (not "0").
+        scionRow.Should().Contain(">1<");
+    }
+
+    [Fact]
     public async Task GetIndex_SearchByName_FiltersToMatches()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

The \`/institutions\` index was computing \`# Positions\` / \`Total \$ Value\` at the **universe-latest** \`ReportDate\`. Filers who'd stopped filing or only filed in an older quarter (e.g. Scion Asset Management's 2022-Q1 AAPL position) collapsed to "0 positions / \$0" on the index, even though the institution profile page itself was still reporting 1 position / \$36M from that same row. The two pages told contradicting stories.

Fix: switch the aggregate to each filer's OWN \`max(ReportDate)\` via a self-join on \`(HolderId, MaxDate)\`. Surface that date in a new "Last filed" column so the table makes clear which quarter each row's aggregate is anchored on.

## Code changes

- \`src/Equibles.Web/Controllers/InstitutionsController.cs\` — replace the single-quarter \`WHERE ReportDate == universeLatest\` filter with a per-filer max-date join: \`perFilerLatest\` (HolderId, LatestDate) joined back to \`InstitutionalHolding\` on the (HolderId, ReportDate) pair, then \`GROUP BY HolderId\` for counts + sums. Carries \`LatestDate\` out to the row view-model.
- \`src/Equibles.Web/ViewModels/Institutions/InstitutionListItemViewModel.cs\` — add nullable \`LatestReportDate\` field with a WHY-comment noting the per-filer semantic.
- \`src/Equibles.Web/Views/Institutions/Index.cshtml\` — new "Last filed" column (visible on \`xl:\` viewports), updated header to read "aggregates from each filer's most-recent 13F report (universe latest \<date\>)" instead of the previous misleading single-date framing.
- \`tests/Equibles.IntegrationTests/Web/InstitutionsControllerTests.cs\` — new regression fact (\`GetIndex_FilerLastReportedInOlderQuarter_StillShowsHistoricalAggregate\`) seeding a Scion-style 2022-only filer alongside a 2026 universe anchor, asserting both render with non-zero positions and Scion carries \`2022-03-31\` in its "Last filed" cell.

## Test plan

- [x] New regression fact green.
- [x] All 6 \`InstitutionsControllerTests\` green.
- [x] csharpier tree-wide clean.
- [x] Visually verified against the local stack.