### PR TITLE
fix(holdings): exclude un-filed holders from the per-stock Sold-Out bucket

### DIFF
--- a/src/Equibles.Web/Services/HoldingsPositionGrouper.cs
+++ b/src/Equibles.Web/Services/HoldingsPositionGrouper.cs
@@ -5,9 +5,20 @@ namespace Equibles.Web.Services;
 
 public static class HoldingsPositionGrouper
 {
+    /// <param name="filersWithCurrentQuarterFilings">
+    /// Set of <see cref="InstitutionalHolder"/> ids known to have filed a 13F
+    /// for the current quarter (against any stock). Holders that filed last
+    /// quarter but are not in this set are treated as "not-yet-filed" rather
+    /// than "Sold-Out" — without this filter, a freshly-ingested universe
+    /// (or any quarter shortly after the 45-day SEC deadline) reports the
+    /// entire backlog of un-filed holders as having exited the stock.
+    /// Pass <c>null</c> to disable the filter and fall back to the pre-fix
+    /// behaviour (every previous-only holder lands in Sold-Out).
+    /// </param>
     public static Dictionary<PositionChangeType, List<HolderPositionChange>> Group(
         IReadOnlyList<InstitutionalHolding> currentHoldings,
-        IReadOnlyList<InstitutionalHolding> previousHoldings
+        IReadOnlyList<InstitutionalHolding> previousHoldings,
+        IReadOnlySet<Guid> filersWithCurrentQuarterFilings
     )
     {
         var currentByHolder = AggregateByHolder(currentHoldings);
@@ -44,6 +55,16 @@ public static class HoldingsPositionGrouper
         foreach (var (holderId, previous) in previousByHolder)
         {
             if (currentByHolder.ContainsKey(holderId))
+                continue;
+
+            // A holder that didn't file ANY 13F for the current quarter
+            // hasn't sold out — they just haven't reported yet. Skip them
+            // from the Sold-Out bucket unless the caller explicitly opts
+            // out of the filter (filersWithCurrentQuarterFilings == null).
+            if (
+                filersWithCurrentQuarterFilings != null
+                && !filersWithCurrentQuarterFilings.Contains(holderId)
+            )
                 continue;
 
             result[PositionChangeType.SoldOut]

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -102,7 +102,23 @@ public class StockTabService
                 .ToListAsync()
             : [];
 
-        var grouped = HoldingsPositionGrouper.Group(allCurrent, allPrevious);
+        // Universe-wide set of filers known to have filed a 13F for the
+        // selected quarter — drives the Sold-Out bucket filter so filers who
+        // simply haven't reported yet aren't mislabelled as exiting the stock.
+        var filersWithCurrentQuarterFilings = (
+            await _institutionalHoldingRepository
+                .GetAll()
+                .Where(h => h.ReportDate == selectedDate)
+                .Select(h => h.InstitutionalHolderId)
+                .Distinct()
+                .ToListAsync()
+        ).ToHashSet();
+
+        var grouped = HoldingsPositionGrouper.Group(
+            allCurrent,
+            allPrevious,
+            filersWithCurrentQuarterFilings
+        );
         var bucketCounts = grouped.ToDictionary(g => g.Key, g => g.Value.Count);
         var (topBuyers, topSellers) = HoldingsTopMoversSelector.Select(
             grouped,

--- a/tests/Equibles.FunctionalTests/Tests/StocksHoldingsSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksHoldingsSeededTests.cs
@@ -163,6 +163,7 @@ public class StocksHoldingsSeededTests
         // Expected Top Buyers: Holder 5 (+2_000), Holder 1 (+500).
         // Expected Top Sellers: Holder 3 (-1_000), Holder 2 (-200).
         var stockId = Guid.NewGuid();
+        var anchorStockId = Guid.NewGuid();
         var prior = new DateOnly(2025, 6, 30);
         var latest = new DateOnly(2025, 9, 30);
 
@@ -177,6 +178,19 @@ public class StocksHoldingsSeededTests
                     Cik = "0000789019",
                 }
             );
+            // Anchor stock — gives Holder 3 a Q2 13F filing on a different
+            // ticker so the Sold-Out filter recognises them as "filed this
+            // quarter, just not for MSFT" (genuine signal) instead of
+            // "hasn't filed yet" (which is now correctly excluded).
+            db.Add(
+                new CommonStock
+                {
+                    Id = anchorStockId,
+                    Ticker = "ANCH",
+                    Name = "Anchor Corp.",
+                    Cik = "0000999999",
+                }
+            );
 
             var holders = new InstitutionalHolder[5];
             for (var i = 0; i < holders.Length; i++)
@@ -188,6 +202,23 @@ public class StocksHoldingsSeededTests
                 };
                 db.Add(holders[i]);
             }
+
+            // Holder 3 reports a Q2 13F against the anchor stock — proves to
+            // the Sold-Out filter that they ARE filing the latest quarter,
+            // they just exited MSFT.
+            db.Add(
+                new InstitutionalHolding
+                {
+                    CommonStockId = anchorStockId,
+                    InstitutionalHolderId = holders[2].Id,
+                    ReportDate = latest,
+                    FilingDate = latest.AddDays(45),
+                    Value = 1_000_000,
+                    Shares = 1_000,
+                    ShareType = ShareType.Shares,
+                    InvestmentDiscretion = InvestmentDiscretion.Sole,
+                }
+            );
 
             // Q1 (prior) — holders 1..4 only
             for (var i = 0; i < 4; i++)

--- a/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperMultipleFilingsLatestHoldingTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperMultipleFilingsLatestHoldingTests.cs
@@ -37,7 +37,11 @@ public class HoldingsPositionGrouperMultipleFilingsLatestHoldingTests
             ReportDate = new DateOnly(2024, 12, 31),
         };
 
-        var result = HoldingsPositionGrouper.Group([earlier, later], []);
+        var result = HoldingsPositionGrouper.Group(
+            [earlier, later],
+            [],
+            filersWithCurrentQuarterFilings: null
+        );
 
         var entry = result[PositionChangeType.New].Should().ContainSingle().Subject;
         entry.CurrentHolding.Id.Should().Be(later.Id);

--- a/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperTests.cs
@@ -9,7 +9,7 @@ public class HoldingsPositionGrouperTests
     [Fact]
     public void Group_BothInputsEmpty_ReturnsEmptyBuckets()
     {
-        var result = HoldingsPositionGrouper.Group([], []);
+        var result = HoldingsPositionGrouper.Group([], [], filersWithCurrentQuarterFilings: null);
 
         result.Should().ContainKey(PositionChangeType.New).WhoseValue.Should().BeEmpty();
         result.Should().ContainKey(PositionChangeType.Increased).WhoseValue.Should().BeEmpty();
@@ -24,7 +24,11 @@ public class HoldingsPositionGrouperTests
         var holderId = Guid.NewGuid();
         var current = Holding(holderId, shares: 100, value: 1000);
 
-        var result = HoldingsPositionGrouper.Group([current], []);
+        var result = HoldingsPositionGrouper.Group(
+            [current],
+            [],
+            filersWithCurrentQuarterFilings: null
+        );
 
         result[PositionChangeType.New].Should().HaveCount(1);
         result[PositionChangeType.New][0].InstitutionalHolderId.Should().Be(holderId);
@@ -40,7 +44,11 @@ public class HoldingsPositionGrouperTests
         var holderId = Guid.NewGuid();
         var previous = Holding(holderId, shares: 100, value: 1000);
 
-        var result = HoldingsPositionGrouper.Group([], [previous]);
+        var result = HoldingsPositionGrouper.Group(
+            [],
+            [previous],
+            filersWithCurrentQuarterFilings: null
+        );
 
         result[PositionChangeType.SoldOut].Should().HaveCount(1);
         var entry = result[PositionChangeType.SoldOut][0];
@@ -59,7 +67,11 @@ public class HoldingsPositionGrouperTests
         var current = Holding(holderId, shares: 150, value: 1500);
         var previous = Holding(holderId, shares: 100, value: 1000);
 
-        var result = HoldingsPositionGrouper.Group([current], [previous]);
+        var result = HoldingsPositionGrouper.Group(
+            [current],
+            [previous],
+            filersWithCurrentQuarterFilings: null
+        );
 
         result[PositionChangeType.Increased].Should().HaveCount(1);
         result[PositionChangeType.Increased][0].DeltaShares.Should().Be(50);
@@ -72,7 +84,11 @@ public class HoldingsPositionGrouperTests
         var current = Holding(holderId, shares: 60, value: 600);
         var previous = Holding(holderId, shares: 100, value: 1000);
 
-        var result = HoldingsPositionGrouper.Group([current], [previous]);
+        var result = HoldingsPositionGrouper.Group(
+            [current],
+            [previous],
+            filersWithCurrentQuarterFilings: null
+        );
 
         result[PositionChangeType.Reduced].Should().HaveCount(1);
         result[PositionChangeType.Reduced][0].DeltaShares.Should().Be(-40);
@@ -85,7 +101,11 @@ public class HoldingsPositionGrouperTests
         var current = Holding(holderId, shares: 100, value: 1100);
         var previous = Holding(holderId, shares: 100, value: 1000);
 
-        var result = HoldingsPositionGrouper.Group([current], [previous]);
+        var result = HoldingsPositionGrouper.Group(
+            [current],
+            [previous],
+            filersWithCurrentQuarterFilings: null
+        );
 
         result[PositionChangeType.Unchanged].Should().HaveCount(1);
         result[PositionChangeType.Unchanged][0].DeltaShares.Should().Be(0);
@@ -100,7 +120,11 @@ public class HoldingsPositionGrouperTests
         var current2 = Holding(holderId, shares: 70, value: 700);
         var previous = Holding(holderId, shares: 100, value: 1000);
 
-        var result = HoldingsPositionGrouper.Group([current1, current2], [previous]);
+        var result = HoldingsPositionGrouper.Group(
+            [current1, current2],
+            [previous],
+            filersWithCurrentQuarterFilings: null
+        );
 
         // Two filings sum to 100 shares — same as previous → Unchanged.
         result[PositionChangeType.Unchanged].Should().HaveCount(1);
@@ -131,7 +155,11 @@ public class HoldingsPositionGrouperTests
             Holding(soldOutId, 100, 1000),
         };
 
-        var result = HoldingsPositionGrouper.Group(current, previous);
+        var result = HoldingsPositionGrouper.Group(
+            current,
+            previous,
+            filersWithCurrentQuarterFilings: null
+        );
 
         result[PositionChangeType.New]
             .Should()
@@ -158,6 +186,48 @@ public class HoldingsPositionGrouperTests
             .ContainSingle()
             .Which.InstitutionalHolderId.Should()
             .Be(soldOutId);
+    }
+
+    [Fact]
+    public void Group_PreviousHolderDidNotFileCurrentQuarter_ExcludedFromSoldOut()
+    {
+        // Regression for the AAPL "Sold out" tab listing Vanguard / BlackRock /
+        // etc. on a freshly-ingested universe: a holder who appears at the
+        // previous report date but has filed NO 13F for the current quarter
+        // hasn't sold out — they just haven't filed yet. The filter set is
+        // the universe-wide list of holders known to have filed for the
+        // current quarter (against any stock).
+        var holderId = Guid.NewGuid();
+        var previous = Holding(holderId, shares: 100, value: 1000);
+
+        var result = HoldingsPositionGrouper.Group(
+            [],
+            [previous],
+            filersWithCurrentQuarterFilings: new HashSet<Guid>()
+        );
+
+        result[PositionChangeType.SoldOut].Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Group_PreviousHolderFiledCurrentQuarterButExcludesStock_ClassifiesAsSoldOut()
+    {
+        // Counter-case: when the holder IS in the filers-who-reported set but
+        // doesn't carry this stock, that's a genuine Sold-Out signal.
+        var holderId = Guid.NewGuid();
+        var previous = Holding(holderId, shares: 100, value: 1000);
+
+        var result = HoldingsPositionGrouper.Group(
+            [],
+            [previous],
+            filersWithCurrentQuarterFilings: new HashSet<Guid> { holderId }
+        );
+
+        result[PositionChangeType.SoldOut]
+            .Should()
+            .ContainSingle()
+            .Which.InstitutionalHolderId.Should()
+            .Be(holderId);
     }
 
     private static InstitutionalHolding Holding(Guid holderId, long shares, long value)


### PR DESCRIPTION
## Summary

The Stock Holdings tab's **Sold-Out** bucket was listing 5,924 holders — Vanguard, BlackRock, State Street, Geode, FMR, Berkshire and the rest — as having exited an AAPL position with deltas of -\$300M+. They hadn't: they simply hadn't filed their 13F for the current quarter yet. \`HoldingsPositionGrouper.Group\` classified "appears in previous quarter, missing in current quarter" → "Sold-Out" unconditionally, which is a real-world Sold-Out signal only **after** the universe is fully reported for the quarter.

The fix introduces a \`filersWithCurrentQuarterFilings\` set parameter: the universe-wide ids of holders known to have reported a 13F for the selected quarter against any stock. A holder in the previous quarter but missing from that set is now treated as "not-yet-filed" and skipped, instead of being labelled Sold-Out.

Passing \`null\` keeps the legacy behaviour (no filter), so existing callers that have no reasonable way to compute the set can opt out.

## Code changes

- \`src/Equibles.Web/Services/HoldingsPositionGrouper.cs\` — new required \`IReadOnlySet<Guid> filersWithCurrentQuarterFilings\` parameter; the Sold-Out loop skips holders not in the set when the set is non-null. WHY-comment documents the AAPL repro.
- \`src/Equibles.Web/Services/StockTabService.cs\` — \`LoadHoldingsTab\` materialises the universe-wide set in a separate \`Distinct\` query against \`InstitutionalHolding\` filtered on the selected quarter, and passes it to \`Group\`.
- \`tests/Equibles.UnitTests/Web/HoldingsPositionGrouperTests.cs\` — two new regression facts: one with an empty filer set (proves the holder is **not** in Sold-Out — the bug), one with the holder included in the set (proves the genuine Sold-Out signal still fires). Existing tests pass \`null\` to keep their legacy semantics.
- \`tests/Equibles.UnitTests/Web/HoldingsPositionGrouperMultipleFilingsLatestHoldingTests.cs\` — call-site bump to the new signature.

## Test plan

- [x] 11 \`HoldingsPositionGrouper\` unit facts green (including the 2 new regression facts).
- [x] 231 unit + 261 integration \`Holdings\` facts green tree-wide.
- [x] csharpier tree-wide clean.

## Note

The complementary \`Initiated / Increased / Reduced / Exited\` grouping for the **per-fund** institution profile lives in \`HolderQuarterlyActivityCalculator\` and has the symmetric issue (filers absent from "previous" misclassified as Initiated when they merely haven't been backfilled yet). That'll need the same treatment but follows in a separate PR.