### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [1.1.0] — 2026-05-22
+
+### Added
+
 #### Holdings / 13F
 
 - Near-real-time 13F-HR ingestion — picks up new 13F filings shortly after
@@ -285,5 +299,6 @@ First tagged release.
 - Background worker — scrapers and document processor.
 - Docker Compose stack (ParadeDB + web + MCP + worker), with an optional vector-embedding profile.
 
-[Unreleased]: https://github.com/daniel3303/Equibles/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/daniel3303/Equibles/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/daniel3303/Equibles/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/daniel3303/Equibles/releases/tag/v1.0.0

--- a/src/Equibles.Web/Equibles.Web.csproj
+++ b/src/Equibles.Web/Equibles.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <!-- Running version surfaced by the update-notification banner. Bump on each release to match the git tag. -->
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Equibles.IntegrationTests/Web/VersionCheckServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/VersionCheckServiceTests.cs
@@ -119,7 +119,7 @@ public class VersionCheckServiceTests
 
         Assert.True(result.UpdateAvailable);
         Assert.Equal("99.0.0", result.LatestVersion);
-        Assert.Equal("1.0.0", result.CurrentVersion);
+        Assert.Equal("1.1.0", result.CurrentVersion);
         Assert.Equal(
             "https://github.com/daniel3303/Equibles/releases/tag/v99.0.0",
             result.ReleaseUrl
@@ -129,20 +129,20 @@ public class VersionCheckServiceTests
     [Fact]
     public async Task Get_SameVersion_DoesNotReportUpdate()
     {
-        var handler = new StubHttpMessageHandler("{\"tag_name\":\"v1.0.0\"}");
+        var handler = new StubHttpMessageHandler("{\"tag_name\":\"v1.1.0\"}");
         var sut = CreateService(handler);
 
         var result = await WaitForRefresh(sut);
 
         Assert.False(result.UpdateAvailable);
-        Assert.Equal("1.0.0", result.LatestVersion);
+        Assert.Equal("1.1.0", result.LatestVersion);
     }
 
     [Fact]
     public async Task Get_FourSegmentSameVersionTag_DoesNotReportSpuriousUpdate()
     {
-        // Regression: "v1.0.0.0" must not compare as newer than assembly "1.0.0".
-        var handler = new StubHttpMessageHandler("{\"tag_name\":\"v1.0.0.0\"}");
+        // Regression: "v1.1.0.0" must not compare as newer than assembly "1.1.0".
+        var handler = new StubHttpMessageHandler("{\"tag_name\":\"v1.1.0.0\"}");
         var sut = CreateService(handler);
 
         var result = await WaitForRefresh(sut);


### PR DESCRIPTION
## Summary

Cuts `v1.1.0` — the first tagged release since `v1.0.0` (2026-05-15).

84 `feat` and 115 `fix` commits land in this version, plus accessibility and security work. The full set of user-visible changes was curated into the `[Unreleased]` section earlier today (#1725); this PR just moves that block into the dated `## [1.1.0] — 2026-05-22` section, opens a fresh `## [Unreleased]`, and bumps the version element on the Web project that drives the in-app update-notification banner.

No breaking changes — minor bump per semver.

## Code changes

- `CHANGELOG.md` — rename `## [Unreleased]` → `## [1.1.0] — 2026-05-22`, insert a fresh empty `## [Unreleased]` at the top with the standard Keep-a-Changelog sub-section headers, add a new compare-link footer entry for `1.1.0`, and re-point the `[Unreleased]` footer to `v1.1.0...HEAD`.
- `src/Equibles.Web/Equibles.Web.csproj` — `Version` element bumped: `1.0.0` → `1.1.0`.
- `tests/Equibles.IntegrationTests/Web/VersionCheckServiceTests.cs` — bump the hardcoded `"1.0.0"` assertions / GitHub-Releases stub tags to `"1.1.0"` so the assembly-version assertion lines up with the new build.

## After merge

- Tag the squashed merge commit as `v1.1.0`.
- Create the GitHub Release with the `## [1.1.0]` CHANGELOG section as notes.
- No publish workflow runs from the tag — the repo doesn't ship one, the Release itself is the artifact.