### PR TITLE
refactor(yahoo): extract exponential-backoff and rate-limit-pause helpers in SendWithRetry

### DIFF
--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -341,21 +341,20 @@ public class YahooFinanceClient : IYahooFinanceClient
 
             if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+                var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
                     "Yahoo rate limited (429), retrying in {Delay}s (attempt {Attempt}/{Max})",
                     delay.TotalSeconds,
                     attempt + 1,
                     MaxRetries
                 );
-                RateLimiter.PauseFor(delay);
-                await Task.Delay(delay);
+                await WaitForRetry(delay);
                 continue;
             }
 
             if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+                var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
                     "Yahoo server error ({StatusCode}), retrying in {Delay}s (attempt {Attempt}/{Max})",
                     (int)response.StatusCode,
@@ -363,8 +362,7 @@ public class YahooFinanceClient : IYahooFinanceClient
                     attempt + 1,
                     MaxRetries
                 );
-                RateLimiter.PauseFor(delay);
-                await Task.Delay(delay);
+                await WaitForRetry(delay);
                 continue;
             }
 
@@ -373,6 +371,15 @@ public class YahooFinanceClient : IYahooFinanceClient
         }
 
         throw new HttpRequestException("Max retries exceeded for Yahoo Finance request");
+    }
+
+    private static TimeSpan ExponentialBackoff(int attempt) =>
+        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+
+    private static async Task WaitForRetry(TimeSpan delay)
+    {
+        RateLimiter.PauseFor(delay);
+        await Task.Delay(delay);
     }
 
     // ── Helpers ──


### PR DESCRIPTION
## Summary

- Collapse the duplicated `TimeSpan.FromSeconds(Math.Pow(2, attempt + 1))` and `RateLimiter.PauseFor + Task.Delay` sequence in `SendWithRetry`'s 429 and 5xx branches into two named helpers (`ExponentialBackoff`, `WaitForRetry`).
- Pure refactor — log templates, structured parameters, call order, and observable behavior unchanged. The existing `YahooFinanceClientRetryBackoffTests` and `YahooFinanceClientRetryExhaustionTests` integration tests pin the equivalence.

## Code changes

- `src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs` — replaced the inline backoff formula and pause/delay pair in the two retry branches with calls to the new private static helpers `ExponentialBackoff(int attempt)` and `WaitForRetry(TimeSpan delay)`. No public API change.