### PR TITLE
refactor(holdings-mcp): collapse duplicated stock-id lookups into LoadStocksByIds helper

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -616,11 +616,7 @@ public class InstitutionalHoldingsTools
         if (rows.Count == 0)
             return result + "_No stocks moved in this direction this quarter._";
 
-        var stockIds = rows.Select(r => r.CommonStockId).ToList();
-        var stocks = await _commonStockRepository
-            .GetAll()
-            .Where(s => stockIds.Contains(s.Id))
-            .ToDictionaryAsync(s => s.Id);
+        var stocks = await LoadStocksByIds(rows.Select(r => r.CommonStockId).ToList());
 
         result.AppendLine("| # | Ticker | Company | Δ Shares | Δ Value ($M) |");
         result.AppendLine("|---|--------|---------|---------|-------------|");
@@ -660,11 +656,7 @@ public class InstitutionalHoldingsTools
         if (rows.Count == 0)
             return result + "_No stocks in this bucket this quarter._";
 
-        var stockIds = rows.Select(r => r.CommonStockId).ToList();
-        var stocks = await _commonStockRepository
-            .GetAll()
-            .Where(s => stockIds.Contains(s.Id))
-            .ToDictionaryAsync(s => s.Id);
+        var stocks = await LoadStocksByIds(rows.Select(r => r.CommonStockId).ToList());
 
         var label = normalizedBucket == "new-positions" ? "# Filers Initiated" : "# Filers Exited";
         result.AppendLine($"| # | Ticker | Company | {label} |");
@@ -728,11 +720,7 @@ public class InstitutionalHoldingsTools
                 var universeFilers = await _holdingRepository
                     .GetUniqueFilerIds(targetDate)
                     .CountAsync();
-                var stockIds = rows.Select(r => r.CommonStockId).ToList();
-                var stocks = await _commonStockRepository
-                    .GetAll()
-                    .Where(s => stockIds.Contains(s.Id))
-                    .ToDictionaryAsync(s => s.Id);
+                var stocks = await LoadStocksByIds(rows.Select(r => r.CommonStockId).ToList());
 
                 return RenderMostHeldStocksTable(
                     targetDate,
@@ -1309,6 +1297,12 @@ public class InstitutionalHoldingsTools
             .GetByHolder(holder, reportDate)
             .Include(h => h.CommonStock)
             .ToListAsync();
+
+    private Task<Dictionary<Guid, CommonStock>> LoadStocksByIds(List<Guid> stockIds) =>
+        _commonStockRepository
+            .GetAll()
+            .Where(s => stockIds.Contains(s.Id))
+            .ToDictionaryAsync(s => s.Id);
 
     private async Task<(
         InstitutionalHolder Holder,


### PR DESCRIPTION
## Summary

- Replace three near-identical four-line blocks in `InstitutionalHoldingsTools.cs` (one each in `RenderMarketActivityMovers`, `RenderMarketActivityChurn`, and the `GetMostHeldStocks` lambda) that select `CommonStockId`s and load the matching `CommonStock`s into a dictionary.
- Extract a single private `LoadStocksByIds(List<Guid> stockIds)` helper alongside the existing `LoadHoldingsByHolderWithStock`. Same `IQueryable<CommonStock>.Where(s => stockIds.Contains(s.Id)).ToDictionaryAsync(s => s.Id)` query, same return type, same lazy semantics. No public API change.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — three call sites updated to `await LoadStocksByIds(rows.Select(r => r.CommonStockId).ToList());`. Helper added in the existing private-helpers band.