### PR TITLE
refactor(sec): make IDocumentPersistenceService.Save accessionNumber optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- `IDocumentPersistenceService.Save` accepts `accessionNumber` as an optional
+  parameter (`= null`) so non-SEC document callers (e.g. earnings-call
+  transcripts) don't have to thread a value they don't have. SEC scrapers
+  still pass the accession number explicitly; the FinancialFacts importer
+  continues to link facts to documents via the existing
+  `WHERE AccessionNumber IS NOT NULL` filter.
+
 ### Deprecated
 
 ### Removed

--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -39,7 +39,7 @@ public class DocumentPersistenceService : IDocumentPersistenceService
         DateOnly reportingDate,
         DateOnly reportingForDate,
         string sourceUrl,
-        string accessionNumber,
+        string accessionNumber = null,
         CancellationToken cancellationToken = default
     )
     {

--- a/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
@@ -20,7 +20,7 @@ public interface IDocumentPersistenceService
         DateOnly reportingDate,
         DateOnly reportingForDate,
         string sourceUrl,
-        string accessionNumber,
+        string accessionNumber = null,
         CancellationToken cancellationToken = default
     );
 }


### PR DESCRIPTION
## Summary

`IDocumentPersistenceService.Save` had a required `string accessionNumber` parameter added in #1xxx so SEC FinancialFacts could link XBRL facts back to their source filing. The downside: every other caller (e.g. earnings-call transcript ingestion in downstream consumers) now has to thread a value they don't have, since transcripts never carry an SEC accession number.

This PR makes the parameter optional (`= null`). SEC scrapers still pass the accession number explicitly, and the FinancialFacts importer's `accession → DocumentId` map keeps working — it already filters on `AccessionNumber IS NOT NULL` (see `FinancialFactsImportService.cs:333-342`).

## Code changes

- `src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs` — `string accessionNumber = null` default.
- `src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs` — mirror the default on the implementation.
- `CHANGELOG.md` — Unreleased / Changed entry.

## Test plan

- [x] `dotnet build src/Equibles.Sec.HostedService/Equibles.Sec.HostedService.csproj` clean
- [x] `dotnet test --filter "FullyQualifiedName~Sec.DocumentPersistence|FullyQualifiedName~Sec.DocumentScraper"` — 19 / 19 pass
- [x] SEC `DocumentScraper.cs:530-540` still calls with explicit `filing.AccessionNumber` (no behavioural change)