### PR TITLE
refactor(cftc): extract ExponentialBackoff helper from DownloadWithRetry

### DIFF
--- a/src/Equibles.Integrations.Cftc/CftcClient.cs
+++ b/src/Equibles.Integrations.Cftc/CftcClient.cs
@@ -53,7 +53,7 @@ public class CftcClient : ICftcClient
 
             if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+                var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
                     "CFTC rate limited (429), retrying in {Delay}s (attempt {Attempt}/{Max})",
                     delay.TotalSeconds,
@@ -67,7 +67,7 @@ public class CftcClient : ICftcClient
 
             if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+                var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
                     "CFTC server error ({StatusCode}), retrying in {Delay}s (attempt {Attempt}/{Max})",
                     (int)response.StatusCode,
@@ -90,6 +90,9 @@ public class CftcClient : ICftcClient
 
         throw new HttpRequestException("Max retries exceeded for CFTC download");
     }
+
+    private static TimeSpan ExponentialBackoff(int attempt) =>
+        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
 
     private async Task<List<CftcReportRecord>> ParseZipArchive(Stream zipStream)
     {


### PR DESCRIPTION
## Summary

- Replace the duplicated `TimeSpan.FromSeconds(Math.Pow(2, attempt + 1))` formula in `CftcClient.DownloadWithRetry`'s 429 and 5xx retry branches with a single private static `ExponentialBackoff(int attempt)` helper.
- Mirrors the same parallel pattern landed for `YahooFinanceClient` (#1729) and `FinraClient` (#1732). Log templates, structured parameters, and call order unchanged — `CftcClientDownloadRateLimitedTests` and `CftcClientDownloadRetryTests` pin the equivalence.

## Code changes

- `src/Equibles.Integrations.Cftc/CftcClient.cs` — both retry branches now read `var delay = ExponentialBackoff(attempt);` and the helper is added directly below the method.