### PR TITLE
refactor(cboe): extract ExponentialBackoff helper from DownloadWithRetry

### DIFF
--- a/src/Equibles.Integrations.Cboe/CboeClient.cs
+++ b/src/Equibles.Integrations.Cboe/CboeClient.cs
@@ -63,7 +63,7 @@ public class CboeClient : ICboeClient
 
             if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+                var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
                     "CBOE rate limited (429), retrying in {Delay}s (attempt {Attempt}/{Max})",
                     delay.TotalSeconds,
@@ -77,7 +77,7 @@ public class CboeClient : ICboeClient
 
             if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+                var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
                     "CBOE server error ({StatusCode}), retrying in {Delay}s (attempt {Attempt}/{Max})",
                     (int)response.StatusCode,
@@ -95,6 +95,9 @@ public class CboeClient : ICboeClient
 
         throw new HttpRequestException("Max retries exceeded for CBOE download");
     }
+
+    private static TimeSpan ExponentialBackoff(int attempt) =>
+        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
 
     private static List<CboePutCallRecord> ParsePutCallCsv(string content)
     {


### PR DESCRIPTION
## Summary

- Replace the duplicated `TimeSpan.FromSeconds(Math.Pow(2, attempt + 1))` formula in `CboeClient.DownloadWithRetry`'s 429 and 5xx retry branches with a single private static `ExponentialBackoff(int attempt)` helper.
- Mirrors the same parallel pattern landed for `YahooFinanceClient` (#1729), `FinraClient` (#1732), and `CftcClient` (#1733). Log templates, structured parameters, and call order unchanged — `CboeClientTests.DownloadWithRetry_TooManyRequestsThenOk_*` and `*_ServerErrorThenOk_*` pin the equivalence.

## Code changes

- `src/Equibles.Integrations.Cboe/CboeClient.cs` — both retry branches now read `var delay = ExponentialBackoff(attempt);` and the helper is added directly below the method.