### PR TITLE
refactor(fred): extract ExponentialBackoff helper from SendWithRetry

### DIFF
--- a/src/Equibles.Integrations.Fred/FredClient.cs
+++ b/src/Equibles.Integrations.Fred/FredClient.cs
@@ -116,7 +116,7 @@ public class FredClient : IFredClient
 
             if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+                var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
                     "FRED rate limited (429), retrying in {Delay}s (attempt {Attempt}/{Max})",
                     delay.TotalSeconds,
@@ -130,7 +130,7 @@ public class FredClient : IFredClient
 
             if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+                var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
                     "FRED server error ({StatusCode}), retrying in {Delay}s (attempt {Attempt}/{Max})",
                     (int)response.StatusCode,
@@ -148,4 +148,7 @@ public class FredClient : IFredClient
 
         throw new HttpRequestException("Max retries exceeded for FRED API request");
     }
+
+    private static TimeSpan ExponentialBackoff(int attempt) =>
+        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
 }


### PR DESCRIPTION
## Summary

- Replace the duplicated `TimeSpan.FromSeconds(Math.Pow(2, attempt + 1))` formula in `FredClient.SendWithRetry`'s 429 and 5xx retry branches with a single private static `ExponentialBackoff(int attempt)` helper.
- Mirrors the same parallel pattern landed for `YahooFinanceClient` (#1729), `FinraClient` (#1732), `CftcClient` (#1733), and `CboeClient` (#1734). Log templates, structured parameters, `RateLimiter.PauseFor` ordering, and call order unchanged — `FredClientRateLimitRetryTests` and `FredClientSeriesMetadataRetryTests` pin the equivalence.

## Code changes

- `src/Equibles.Integrations.Fred/FredClient.cs` — both retry branches now read `var delay = ExponentialBackoff(attempt);` and the helper is added directly below the method.