### PR TITLE
refactor(senate): extract ExponentialBackoff helper from FetchWithRetry

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
@@ -218,7 +218,7 @@ public class SenateDisclosureClient : IAsyncDisposable
                     );
                     throw;
                 }
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+                var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
                     "Browser fetch error for {Url}, retrying in {Delay}s (attempt {Attempt}/{MaxRetries}): {Message}",
                     url,
@@ -237,7 +237,7 @@ public class SenateDisclosureClient : IAsyncDisposable
             var isRetryable = status == 429 || status >= 500;
             if (isRetryable && attempt < MaxRetries)
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+                var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
                     "Senate eFD returned {Status} for {Url}, retrying in {Delay}s (attempt {Attempt}/{MaxRetries})",
                     status,
@@ -274,6 +274,9 @@ public class SenateDisclosureClient : IAsyncDisposable
             $"Max retries ({MaxRetries}) exceeded for Senate eFD request: {url}"
         );
     }
+
+    private static TimeSpan ExponentialBackoff(int attempt) =>
+        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
 
     public async ValueTask DisposeAsync()
     {


### PR DESCRIPTION
## Summary

- Replace the duplicated `TimeSpan.FromSeconds(Math.Pow(2, attempt + 1))` formula in `SenateDisclosureClient.FetchWithRetry`'s two retry branches (browser-exception catch and HTTP 429/5xx) with a single private static `ExponentialBackoff(int attempt)` helper.
- Mirrors the same parallel pattern landed for the SEC-EDGAR-adjacent clients in #1729, #1732, #1733, #1734, and #1735. Log templates, structured parameters, and the conditional `RateLimiter.PauseFor` on 429 are unchanged — `SenateDisclosureClientFetchTests` (covering the browser-exception retry, the 429 retry, and exhaustion) pins the equivalence.

## Code changes

- `src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs` — both retry branches now read `var delay = ExponentialBackoff(attempt);` and the helper is added directly below the method.