### PR TITLE
refactor(house): extract ExponentialBackoff helper from SendWithRetryAsync

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -314,7 +314,7 @@ public partial class HouseDisclosureClient
 
             if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+                var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
                     "House disclosure rate limited (429), retrying in {Delay}s",
                     delay.TotalSeconds
@@ -327,7 +327,7 @@ public partial class HouseDisclosureClient
 
             if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+                var delay = ExponentialBackoff(attempt);
                 _logger.LogWarning(
                     "House disclosure server error ({StatusCode}), retrying in {Delay}s",
                     (int)response.StatusCode,
@@ -345,6 +345,9 @@ public partial class HouseDisclosureClient
             $"Max retries ({MaxRetries}) exceeded for House disclosure request: {url}"
         );
     }
+
+    private static TimeSpan ExponentialBackoff(int attempt) =>
+        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
 
     // Owner codes: SP (Spouse), JT (Joint), DC (Dependent Child), or at line start
     [GeneratedRegex(@"^(SP|JT|DC|Self)\b", RegexOptions.IgnoreCase)]


### PR DESCRIPTION
## Summary

- Replace the duplicated `TimeSpan.FromSeconds(Math.Pow(2, attempt + 1))` formula in `HouseDisclosureClient.SendWithRetryAsync`'s 429 and 5xx retry branches with a single private static `ExponentialBackoff(int attempt)` helper.
- Last client in the series after #1729 (Yahoo), #1732 (Finra), #1733 (Cftc), #1734 (Cboe), #1735 (Fred), and #1736 (Senate). Log templates, structured parameters, `RateLimiter.PauseFor` ordering, and `response.Dispose` timing unchanged — `HouseDisclosureClientTests` cover both retry paths.

## Code changes

- `src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs` — both retry branches now read `var delay = ExponentialBackoff(attempt);` and the helper is added directly below the method.