### PR TITLE
refactor(holdings-activity-controller): collapse duplicated stock-cell lookups into ResolveStockCells

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -192,12 +192,12 @@ public class HoldingsActivityController : BaseController
         viewModel.Rows = pageRows
             .Select(r =>
             {
-                stocks.TryGetValue(r.CommonStockId, out var stock);
+                var (ticker, name) = ResolveStockCells(stocks, r.CommonStockId);
                 return new HoldingsMostHeldRow
                 {
                     CommonStockId = r.CommonStockId,
-                    Ticker = stock?.Ticker ?? "—",
-                    Name = stock?.Name ?? "Unknown",
+                    Ticker = ticker,
+                    Name = name,
                     CurrentFilerCount = r.CurrentFilerCount,
                     PreviousFilerCount = r.PreviousFilerCount,
                     CurrentValue = r.CurrentValue,
@@ -216,12 +216,12 @@ public class HoldingsActivityController : BaseController
         IDictionary<Guid, StockLabel> stocks
     )
     {
-        stocks.TryGetValue(churn.CommonStockId, out var stock);
+        var (ticker, name) = ResolveStockCells(stocks, churn.CommonStockId);
         return new HoldingsActivityRow
         {
             CommonStockId = churn.CommonStockId,
-            Ticker = stock?.Ticker ?? "—",
-            Name = stock?.Name ?? "Unknown",
+            Ticker = ticker,
+            Name = name,
             NewFilerCount = churn.NewFilerCount,
             SoldOutFilerCount = churn.SoldOutFilerCount,
         };
@@ -232,17 +232,26 @@ public class HoldingsActivityController : BaseController
         IDictionary<Guid, StockLabel> stocks
     )
     {
-        stocks.TryGetValue(activity.CommonStockId, out var stock);
+        var (ticker, name) = ResolveStockCells(stocks, activity.CommonStockId);
         return new HoldingsActivityRow
         {
             CommonStockId = activity.CommonStockId,
-            Ticker = stock?.Ticker ?? "—",
-            Name = stock?.Name ?? "Unknown",
+            Ticker = ticker,
+            Name = name,
             DeltaShares = activity.DeltaShares,
             DeltaValue = activity.DeltaValue,
             CurrentFilerCount = activity.CurrentFilerCount,
             PreviousFilerCount = activity.PreviousFilerCount,
         };
+    }
+
+    private static (string Ticker, string Name) ResolveStockCells(
+        IDictionary<Guid, StockLabel> stocks,
+        Guid stockId
+    )
+    {
+        stocks.TryGetValue(stockId, out var stock);
+        return (stock?.Ticker ?? "—", stock?.Name ?? "Unknown");
     }
 
     private class StockLabel


### PR DESCRIPTION
## Summary

- Replace the duplicated `stocks.TryGetValue(id, out var stock); ... stock?.Ticker ?? \"—\", stock?.Name ?? \"Unknown\"` pattern in `MostHeld`'s Select projection, `MapChurnRow`, and `MapRow` with a single private static `ResolveStockCells(IDictionary<Guid, StockLabel>, Guid)` returning a `(Ticker, Name)` tuple.
- Mirrors the same parallel pattern landed for the MCP tools file in #1738. Same null-coalescing fallbacks (`"—"` / `"Unknown"`), same dictionary lookup semantics. No public API change — `HoldingsActivityRow` / `HoldingsMostHeldRow` projection still receives the identical strings in identical order.

## Code changes

- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — three call sites now read `var (ticker, name) = ResolveStockCells(stocks, ...);` and the helper is added next to `MapRow` / `MapChurnRow`.