### PR TITLE
refactor(yahoo): collapse ApplyBrowserHeaders overloads onto a single HttpRequestHeaders helper

### DIFF
--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Common.RateLimiter;
 using Equibles.Integrations.Yahoo.Contracts;
@@ -384,21 +385,17 @@ public class YahooFinanceClient : IYahooFinanceClient
 
     // ── Helpers ──
 
-    private static void ApplyBrowserHeaders(HttpClient client)
-    {
-        client.DefaultRequestHeaders.UserAgent.ParseAdd(BrowserUserAgent);
-        client.DefaultRequestHeaders.TryAddWithoutValidation(
-            "Accept",
-            "text/html,application/json,*/*"
-        );
-        client.DefaultRequestHeaders.TryAddWithoutValidation("Accept-Language", "en-US,en;q=0.9");
-    }
+    private static void ApplyBrowserHeaders(HttpClient client) =>
+        ApplyBrowserHeaders(client.DefaultRequestHeaders);
 
-    private static void ApplyBrowserHeaders(HttpRequestMessage request)
+    private static void ApplyBrowserHeaders(HttpRequestMessage request) =>
+        ApplyBrowserHeaders(request.Headers);
+
+    private static void ApplyBrowserHeaders(HttpRequestHeaders headers)
     {
-        request.Headers.UserAgent.ParseAdd(BrowserUserAgent);
-        request.Headers.TryAddWithoutValidation("Accept", "text/html,application/json,*/*");
-        request.Headers.TryAddWithoutValidation("Accept-Language", "en-US,en;q=0.9");
+        headers.UserAgent.ParseAdd(BrowserUserAgent);
+        headers.TryAddWithoutValidation("Accept", "text/html,application/json,*/*");
+        headers.TryAddWithoutValidation("Accept-Language", "en-US,en;q=0.9");
     }
 
     private static long ToUnixTimestamp(DateOnly date)


### PR DESCRIPTION
## Summary

- Both `ApplyBrowserHeaders` overloads (one for `HttpClient`, one for `HttpRequestMessage`) wrote the same three browser headers in the same order to the same underlying `HttpRequestHeaders` collection.
- Replace the duplicated bodies with a single shared helper on `HttpRequestHeaders` and have the two public-shaped overloads delegate to it, so future header changes only edit one place.

## Code changes

- `src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs` — add `using System.Net.Http.Headers;`; introduce `private static void ApplyBrowserHeaders(HttpRequestHeaders headers)` carrying the three header writes; rewrite the existing `HttpClient` and `HttpRequestMessage` overloads as one-liners delegating to the new helper (`client.DefaultRequestHeaders` / `request.Headers` both being `HttpRequestHeaders`). No call-site changes; both reflection-based `ApplyBrowserHeaders_*` unit tests still resolve their respective overloads.