### PR TITLE
fix(web): wrap home CTA row on narrow viewports

### DIFF
--- a/src/Equibles.Web/Views/Home/Index.cshtml
+++ b/src/Equibles.Web/Views/Home/Index.cshtml
@@ -9,7 +9,7 @@
         SEC filings, institutional holdings, insider trading, congressional trades, and short data — all self-hosted.
     </p>
 
-    <div class="flex justify-center gap-4 mb-16">
+    <div class="flex flex-wrap justify-center gap-4 mb-16">
         <a asp-action="Index" asp-controller="Stocks" class="btn btn-primary">
             <icon name="chart-bar" size="5" /> Stocks
         </a>


### PR DESCRIPTION
## Summary

- The home page's three CTA buttons (Stocks / Economic Data / GitHub) sat on a single non-wrapping flex row, so at 375 px the GitHub button overflowed the right edge and forced a horizontal scrollbar on the whole page.
- Adding `flex-wrap` lets the row break onto a second line on narrow viewports while keeping the existing layout on tablet/desktop.

## Code changes

- `src/Equibles.Web/Views/Home/Index.cshtml` — add `flex-wrap` to the CTA button row.