### PR TITLE
refactor(holdings-mcp): replace inline report-date lookups in ResolveCommonReportDate with existing GetReportDatesByHolder helper

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1089,16 +1089,8 @@ public class InstitutionalHoldingsTools
         string reportDate
     )
     {
-        var dates1 = await _holdingRepository
-            .GetHistoryByHolder(holder1)
-            .Select(h => h.ReportDate)
-            .Distinct()
-            .ToListAsync();
-        var dates2 = await _holdingRepository
-            .GetHistoryByHolder(holder2)
-            .Select(h => h.ReportDate)
-            .Distinct()
-            .ToListAsync();
+        var dates1 = await GetReportDatesByHolder(holder1).ToListAsync();
+        var dates2 = await GetReportDatesByHolder(holder2).ToListAsync();
         var common = dates1.Intersect(dates2).OrderByDescending(d => d).ToList();
         if (common.Count == 0)
             return (default, $"{holder1.Name} and {holder2.Name} share no common report dates.");


### PR DESCRIPTION
## Summary

- `ResolveCommonReportDate` inlined the same `GetHistoryByHolder(...).Select(h => h.ReportDate).Distinct().ToListAsync()` chain twice while every other caller in the file routed through the private `GetReportDatesByHolder` helper. Switch the two inline calls to the helper.
- Behavior-preserving: the helper additionally applies `OrderByDescending(d => d)`, but the call site immediately follows with `dates1.Intersect(dates2).OrderByDescending(d => d)`, so the final ordering is unchanged.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — replace the two 5-line inline lookups in `ResolveCommonReportDate` with `GetReportDatesByHolder(holder).ToListAsync()` calls.