### PR TITLE
fix(web): use <header> landmark for the navbar

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -19,7 +19,7 @@
     </a>
 
     <!-- Navbar -->
-    <div class="navbar bg-base-100 border-b border-base-200 min-h-0 h-14 sticky top-0 z-40">
+    <header class="navbar bg-base-100 border-b border-base-200 min-h-0 h-14 sticky top-0 z-40">
         <div class="max-w-6xl mx-auto w-full px-6 flex items-center">
             <div class="flex-1 flex items-center gap-6">
                 <a asp-action="Index" asp-controller="Home" class="flex items-center gap-2">
@@ -148,7 +148,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </header>
 
     <partial name="_VersionBanner" />
 


### PR DESCRIPTION
## Summary

- Every page rendered the global navbar inside a plain `<div>`, so no page exposed a `banner` landmark to assistive tech. Screen readers and skip-by-landmark keystrokes had nothing to anchor on at the top of the page.
- Swapping the outer `<div>` for `<header>` adds the landmark with zero visual change — the DaisyUI `navbar` styling is class-driven and applies the same way to either element.

## Code changes

- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — change the navbar wrapper from `<div class="navbar …">` to `<header class="navbar …">` and update the matching closing tag.