### PR TITLE
docs(guide): add FAQ entry — disable update-available banner

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -23,3 +23,9 @@ Task-focused recipes for someone who has Equibles running.
 - [Upgrade to the latest release](how-to-upgrade.md)
 - [Back up and restore your database](how-to-back-up-and-restore.md)
 - [Check worker health and recent errors](how-to-view-status-and-errors.md)
+
+## FAQ
+
+Short answers to recurring questions.
+
+- [Frequently asked questions](faq.md) — recurring questions about running Equibles, answered in a few sentences each.

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -1,0 +1,7 @@
+# Frequently asked questions
+
+Short answers to recurring questions about running Equibles. For step-by-step instructions, see the [how-to guides](README.md#how-to-guides).
+
+## How do I disable the "update available" banner on the web portal?
+
+The web portal checks GitHub Releases on a schedule and shows a banner when a newer version is published. To turn the check off, set `CHECK_FOR_UPDATES=false` in your `.env` file (or environment) and restart the `web` service. The banner stays hidden until you flip the setting back to `true`. To actually upgrade when an update is available, see [Upgrade to the latest release](how-to-upgrade.md).


### PR DESCRIPTION
## Summary

- Adds the first FAQ entry under `docs/guide/` covering how to disable the portal's "update available" banner via `CHECK_FOR_UPDATES`.
- Adds a `## FAQ` section to the guide index linking to the new `faq.md`.
- Closes a guide gap — the update-check is described in the README but had no entry in the user-facing guide.

## Code changes

- `docs/guide/faq.md` — new file. Intro paragraph + one entry: "How do I disable the 'update available' banner on the web portal?" with a 3-sentence answer pointing at `CHECK_FOR_UPDATES` and the upgrade how-to.
- `docs/guide/README.md` — appends a `## FAQ` section with a one-line link to `faq.md`.