### PR TITLE
docs(guide): add how-to — change how far back data syncs

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -20,6 +20,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Add a FINRA API key (free short-volume data)](how-to-set-up-finra-api-key.md)
 - [Enable semantic search over SEC filings](how-to-enable-embedding-search.md)
 - [Sync only a chosen list of tickers](how-to-restrict-ticker-sync.md)
+- [Change how far back data syncs](how-to-change-sync-start-date.md)
 - [Upgrade to the latest release](how-to-upgrade.md)
 - [Back up and restore your database](how-to-back-up-and-restore.md)
 - [Check worker health and recent errors](how-to-view-status-and-errors.md)

--- a/docs/guide/how-to-change-sync-start-date.md
+++ b/docs/guide/how-to-change-sync-start-date.md
@@ -1,0 +1,34 @@
+# Change how far back data syncs
+
+This how-to shows you how to change the earliest date scrapers fetch from on a fresh install. Use this to pull more history (back to 2000) for deeper analysis, or to skip older data for a faster first run.
+
+You need to set this **before** the first `docker compose up` (or before any data has been written). Once a scraper has stored a row, it resumes from `max(date) + 1` and ignores this setting.
+
+## Steps
+
+1. **Open `.env`** in the project root. If the file doesn't exist yet, copy it from the template:
+
+    ```bash
+    cp .env.example .env
+    ```
+
+2. **Add or edit** the `Worker__MinSyncDate` line. Use ISO date format (`YYYY-MM-DD`):
+
+    ```env
+    # .env — start syncing from 2024 instead of the default 2020
+    Worker__MinSyncDate=2024-01-01
+    ```
+
+    The default is `2020-01-01`. The supported floor is `2000-01-01`.
+
+3. **Start the stack** (or restart it if it was already running):
+
+    ```bash
+    docker compose up -d
+    ```
+
+4. **Confirm the setting took effect.** Open the [Status page](http://localhost:8080/status) and watch the data counts. The further back the date, the longer the initial backfill — SEC filings and 13F holdings from 2000 can take hours.
+
+## Already running with data?
+
+If scrapers have already stored data, changing `Worker__MinSyncDate` has no effect — they will pick up from `max(date) + 1` per scraper. To re-pull older history you need to drop and reseed the affected tables first (see [Back up and restore your database](how-to-back-up-and-restore.md) for the safe order of operations).


### PR DESCRIPTION
## Summary

- Adds a user-facing how-to for changing `Worker__MinSyncDate` — covers the multi-step task (edit `.env` before first run, pick an ISO date between `2000-01-01` and the default `2020-01-01`, restart Docker, watch Status).
- Surfaces the "fresh install only" gotcha explicitly — once a scraper has stored a row it resumes from `max(date) + 1` and ignores the setting.
- Closes a guide gap — the setting was documented in `README.md` and `docs/technical/operations.md` but had no entry in the user-facing guide.

## Code changes

- `docs/guide/how-to-change-sync-start-date.md` — new file. Numbered steps with `.env` snippet, Docker restart, Status-page confirmation, and a separate section explaining what to do when data already exists (link to backup-and-restore how-to).
- `docs/guide/README.md` — appends one TOC bullet under `## How-to guides`.