### PR TITLE
refactor(holdings-mcp): use GetReportDatesByHolder helper inside ResolveCommonReportDate

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1089,16 +1089,8 @@ public class InstitutionalHoldingsTools
         string reportDate
     )
     {
-        var dates1 = await _holdingRepository
-            .GetHistoryByHolder(holder1)
-            .Select(h => h.ReportDate)
-            .Distinct()
-            .ToListAsync();
-        var dates2 = await _holdingRepository
-            .GetHistoryByHolder(holder2)
-            .Select(h => h.ReportDate)
-            .Distinct()
-            .ToListAsync();
+        var dates1 = await GetReportDatesByHolder(holder1).ToListAsync();
+        var dates2 = await GetReportDatesByHolder(holder2).ToListAsync();
         var common = dates1.Intersect(dates2).OrderByDescending(d => d).ToList();
         if (common.Count == 0)
             return (default, $"{holder1.Name} and {holder2.Name} share no common report dates.");


### PR DESCRIPTION
## Summary

- Collapse two inline `GetHistoryByHolder(...).Select(h => h.ReportDate).Distinct().ToListAsync()` calls inside `ResolveCommonReportDate` into the existing private `GetReportDatesByHolder` helper that the rest of the file already uses (`GetConsensusHoldings`, `ResolveHolderAndTargetDate`).
- Behavior-preserving: the helper adds an `OrderByDescending(d => d)` that the inline path lacked, but the result feeds straight into `dates1.Intersect(dates2).OrderByDescending(d => d).ToList()` — the final sort makes input ordering irrelevant.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — replace the two inline date-list queries in `ResolveCommonReportDate` with `GetReportDatesByHolder(holder).ToListAsync()` calls. No public API or signature changes.