### PR TITLE
docs(guide): add FAQ entry — how much disk space does Equibles need

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -5,3 +5,7 @@ Short answers to recurring questions about running Equibles. For step-by-step in
 ## How do I disable the "update available" banner on the web portal?
 
 The web portal checks GitHub Releases on a schedule and shows a banner when a newer version is published. To turn the check off, set `CHECK_FOR_UPDATES=false` in your `.env` file (or environment) and restart the `web` service. The banner stays hidden until you flip the setting back to `true`. To actually upgrade when an update is available, see [Upgrade to the latest release](how-to-upgrade.md).
+
+## How much disk space does Equibles need?
+
+Plan for about 5 GB to start, growing over time as scrapers backfill more history. The database (held in the `db-data` Docker volume) is by far the largest consumer; the cached SEC filings are smaller. Pulling the full default range (2020 onwards) for every U.S. ticker is the baseline — restricting to a [chosen list of tickers](how-to-restrict-ticker-sync.md) or [a later sync start date](how-to-change-sync-start-date.md) keeps it much smaller, while extending back to 2000 makes it substantially larger. Enabling the [embedding profile](how-to-enable-embedding-search.md) adds roughly 3 GB more (~2 GB Ollama image, ~1.2 GB BGE-M3 model, plus per-chunk vectors).


### PR DESCRIPTION
## Summary

- Appends one FAQ entry under `docs/guide/faq.md` answering the common "how much disk space?" question for self-hosted users.
- Frames the ~5 GB starter figure from the tutorial against growth drivers users can actually control (ticker filter, sync start date, full 2000-back history) and the embedding profile's ~3 GB footprint.
- No TOC change — `faq.md` is already linked from the guide index.

## Code changes

- `docs/guide/faq.md` — appends one `## How much disk space does Equibles need?` entry with a 4-sentence answer linking back to the relevant how-tos (`how-to-restrict-ticker-sync`, `how-to-change-sync-start-date`, `how-to-enable-embedding-search`).