### PR TITLE
fix(web): add aria-labels to status page search and auto-refresh toggle

### DIFF
--- a/src/Equibles.Web/Views/Status/Index.cshtml
+++ b/src/Equibles.Web/Views/Status/Index.cshtml
@@ -32,7 +32,7 @@
                     <button class="btn btn-xs join-item btn-active" data-status-interval="5">5s</button>
                     <button class="btn btn-xs join-item" data-status-interval="30">30s</button>
                 </div>
-                <input type="checkbox" class="toggle toggle-sm toggle-success" checked data-status-toggle title="Auto-refresh" />
+                <input type="checkbox" class="toggle toggle-sm toggle-success" checked data-status-toggle title="Auto-refresh" aria-label="Auto-refresh" />
             </div>
         </div>
     </div>
@@ -217,7 +217,8 @@
             <form asp-action="Index" class="mb-4">
                 <input type="hidden" name="source" value="@sourceFilter" />
                 <input type="text" name="search" value="@search" placeholder="Search errors..."
-                       class="input input-bordered input-sm w-full max-w-md" />
+                       class="input input-bordered input-sm w-full max-w-md"
+                       aria-label="Search errors" />
             </form>
 
             @if (Model.RecentErrors.Count == 0) {


### PR DESCRIPTION
## Summary

- The error-search input and the auto-refresh toggle on the Status page had no associated `<label>` and no `aria-label`, so assistive tech announced them with empty or placeholder-derived names.
- Adding an `aria-label` on each input gives screen readers an explicit name without changing the visual layout.

## Code changes

- `src/Equibles.Web/Views/Status/Index.cshtml` — add `aria-label="Auto-refresh"` to the auto-refresh checkbox and `aria-label="Search errors"` to the search input.