### PR TITLE
docs(guide): add FAQ entry — wipe the database and start over

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -9,3 +9,7 @@ The web portal checks GitHub Releases on a schedule and shows a banner when a ne
 ## How much disk space does Equibles need?
 
 Plan for about 5 GB to start, growing over time as scrapers backfill more history. The database (held in the `db-data` Docker volume) is by far the largest consumer; the cached SEC filings are smaller. Pulling the full default range (2020 onwards) for every U.S. ticker is the baseline — restricting to a [chosen list of tickers](how-to-restrict-ticker-sync.md) or [a later sync start date](how-to-change-sync-start-date.md) keeps it much smaller, while extending back to 2000 makes it substantially larger. Enabling the [embedding profile](how-to-enable-embedding-search.md) adds roughly 3 GB more (~2 GB Ollama image, ~1.2 GB BGE-M3 model, plus per-chunk vectors).
+
+## How do I wipe the database and start over?
+
+Run `docker compose down -v` from the project root. The `-v` flag deletes the `db-data` Docker volume along with the containers, so the next `docker compose up` starts with an empty database and the scrapers backfill from scratch using whatever `Worker__MinSyncDate` and `Worker__TickersToSync` are currently set in `.env`. This is destructive — if you want to keep a copy of the current data first, take a snapshot using [Back up and restore your database](how-to-back-up-and-restore.md) before running the command.


### PR DESCRIPTION
## Summary

- Appends one FAQ entry under `docs/guide/faq.md` covering `docker compose down -v` — wipe the `db-data` volume and start fresh.
- Surfaces a hint that was buried at the end of the install tutorial; now operators looking to re-pull history with a different `Worker__MinSyncDate` or clean up a bad config can find it directly.
- Cross-links the backup how-to as the safe-first-step pointer.

## Code changes

- `docs/guide/faq.md` — appends one `## How do I wipe the database and start over?` entry with a 3-sentence answer (the command, what it does, the destructive caveat + link to backup-and-restore).