### PR TITLE
refactor(realtime-13f): extract LoadProcessedSet helper for processed-accession lookup

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
@@ -198,11 +198,7 @@ public class Realtime13FIngestionService
         await using var scope = _scopeFactory.CreateAsyncScope();
         var repo = scope.ServiceProvider.GetRequiredService<ProcessedFilingRepository>();
 
-        var processed = await repo.GetByAccessionNumbers(accessionNumbers.ToList())
-            .Select(p => p.AccessionNumber)
-            .ToListAsync(cancellationToken);
-
-        return new HashSet<string>(processed, StringComparer.OrdinalIgnoreCase);
+        return await LoadProcessedSet(repo, accessionNumbers, cancellationToken);
     }
 
     private async Task RecordProcessed(
@@ -218,10 +214,7 @@ public class Realtime13FIngestionService
 
         // Re-check inside the write scope: a parallel sweep (or the quarterly
         // worker) may have recorded some of these between discovery and now.
-        var existing = await repo.GetByAccessionNumbers(accessionNumbers.ToList())
-            .Select(p => p.AccessionNumber)
-            .ToListAsync(cancellationToken);
-        var existingSet = new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase);
+        var existingSet = await LoadProcessedSet(repo, accessionNumbers, cancellationToken);
 
         foreach (var accession in accessionNumbers)
         {
@@ -230,6 +223,19 @@ public class Realtime13FIngestionService
         }
 
         await repo.SaveChanges();
+    }
+
+    private static async Task<HashSet<string>> LoadProcessedSet(
+        ProcessedFilingRepository repo,
+        IEnumerable<string> accessionNumbers,
+        CancellationToken cancellationToken
+    )
+    {
+        var processed = await repo.GetByAccessionNumbers(accessionNumbers.ToList())
+            .Select(p => p.AccessionNumber)
+            .ToListAsync(cancellationToken);
+
+        return new HashSet<string>(processed, StringComparer.OrdinalIgnoreCase);
     }
 
     private async Task<Parsed13FFiling> ParseFiling(


### PR DESCRIPTION
## Summary

- `LoadProcessedAccessions` and `RecordProcessed` both materialised the same `GetByAccessionNumbers → Select(AccessionNumber) → ToListAsync` query into a case-insensitive `HashSet<string>`. Collapse the two copies into one private static helper.
- Behavior-preserving: same EF query, same case-insensitive HashSet, same cancellation propagation. The per-method `AsyncServiceScope` ownership stays where it was (each callsite still opens and disposes its own scope).

## Code changes

- `src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs` — add `LoadProcessedSet(repo, accessionNumbers, cancellationToken)` and replace the two inline query+HashSet blocks in `LoadProcessedAccessions` and `RecordProcessed` with calls to it. No public API or signature changes.