### PR TITLE
refactor(holdings-export-controller): collapse two duplicated report-date lookups into LoadReportDates helper

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Web.Controllers.Abstract;
 using Equibles.Web.Services;
@@ -37,12 +38,7 @@ public class HoldingsExportController : BaseController
         if (stock == null)
             return NotFound();
 
-        var reportDates = await _holdingRepository
-            .GetHistoryByStock(stock)
-            .Select(h => h.ReportDate)
-            .Distinct()
-            .OrderByDescending(d => d)
-            .ToListAsync();
+        var reportDates = await LoadReportDates(_holdingRepository.GetHistoryByStock(stock));
         if (reportDates.Count == 0)
             return NotFound();
 
@@ -108,12 +104,7 @@ public class HoldingsExportController : BaseController
         if (holder == null)
             return NotFound();
 
-        var reportDates = await _holdingRepository
-            .GetHistoryByHolder(holder)
-            .Select(h => h.ReportDate)
-            .Distinct()
-            .OrderByDescending(d => d)
-            .ToListAsync();
+        var reportDates = await LoadReportDates(_holdingRepository.GetHistoryByHolder(holder));
         if (reportDates.Count == 0)
             return NotFound();
 
@@ -261,6 +252,9 @@ public class HoldingsExportController : BaseController
 
     private static DateOnly ResolveSelectedDate(DateOnly? requested, List<DateOnly> available) =>
         requested.HasValue && available.Contains(requested.Value) ? requested.Value : available[0];
+
+    private static Task<List<DateOnly>> LoadReportDates(IQueryable<InstitutionalHolding> query) =>
+        query.Select(h => h.ReportDate).Distinct().OrderByDescending(d => d).ToListAsync();
 
     private static string[] ActivityRow(
         string board,


### PR DESCRIPTION
## Summary

- `Holders` and `Institution` both materialised the same `Select(h => h.ReportDate).Distinct().OrderByDescending(d => d).ToListAsync()` query against an `IQueryable<InstitutionalHolding>`, differing only in the source method (`GetHistoryByStock` vs `GetHistoryByHolder`).
- Behavior-preserving: same EF translation, same ordering, same exception/cancellation behavior. Mirrors the pattern of `LoadReportDatesByHolder` in `ProfilesController` (#1746).

## Code changes

- `src/Equibles.Web/Controllers/HoldingsExportController.cs` — add `LoadReportDates(IQueryable<InstitutionalHolding>)` and replace the two inline date-list queries in `Holders` and `Institution` with calls to it. Add the `Equibles.Holdings.Data.Models` import for the parameter type. No public API or signature changes.