### PR TITLE
fix(web): add aria-labels to MCP-client accordion radios

### DIFF
--- a/src/Equibles.Web/Views/Home/Connect.cshtml
+++ b/src/Equibles.Web/Views/Home/Connect.cshtml
@@ -45,7 +45,7 @@
 
     <!-- Claude Desktop -->
     <div class="collapse collapse-arrow bg-base-100 shadow-sm mb-3">
-        <input type="radio" name="client-accordion" checked="checked" />
+        <input type="radio" name="client-accordion" checked="checked" aria-label="Claude Desktop" />
         <div class="collapse-title font-semibold">Claude Desktop</div>
         <div class="collapse-content text-sm">
             <p class="mb-2">Add this to your Claude Desktop config file:</p>
@@ -73,7 +73,7 @@
 
     <!-- Claude Code -->
     <div class="collapse collapse-arrow bg-base-100 shadow-sm mb-3">
-        <input type="radio" name="client-accordion" />
+        <input type="radio" name="client-accordion" aria-label="Claude Code" />
         <div class="collapse-title font-semibold">Claude Code</div>
         <div class="collapse-content text-sm">
             <p class="mb-2">Run this command in your terminal:</p>
@@ -96,7 +96,7 @@
 
     <!-- ChatGPT Desktop -->
     <div class="collapse collapse-arrow bg-base-100 shadow-sm mb-3">
-        <input type="radio" name="client-accordion" />
+        <input type="radio" name="client-accordion" aria-label="ChatGPT Desktop" />
         <div class="collapse-title font-semibold">ChatGPT Desktop</div>
         <div class="collapse-content text-sm">
             <p class="mb-2">Add this to your ChatGPT Desktop config file:</p>
@@ -124,7 +124,7 @@
 
     <!-- Other MCP Clients -->
     <div class="collapse collapse-arrow bg-base-100 shadow-sm mb-3">
-        <input type="radio" name="client-accordion" />
+        <input type="radio" name="client-accordion" aria-label="Other MCP Clients" />
         <div class="collapse-title font-semibold">Other MCP Clients</div>
         <div class="collapse-content text-sm">
             <p class="mb-3">Any MCP-compatible client can connect using HTTP transport:</p>


### PR DESCRIPTION
## Summary

- The four `client-accordion` radio inputs on `/home/connect` (Claude Desktop / Claude Code / ChatGPT Desktop / Other MCP Clients) had no `<label>` association — the accordion titles were `<div>`s, not labels — so screen readers announced each radio without a name.
- Adding an `aria-label` on each radio matching its accordion title gives assistive tech an explicit name; the visual layout is unchanged.

## Code changes

- `src/Equibles.Web/Views/Home/Connect.cshtml` — add `aria-label="…"` to each of the four `name="client-accordion"` radio inputs.