### PR TITLE
refactor(holdings-activity-controller): collapse duplicated available-report-date lookups into LoadAvailableReportDates helper

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -26,10 +26,7 @@ public class HoldingsActivityController : BaseController
     [HttpGet("~/holdings/activity")]
     public async Task<IActionResult> Activity(DateOnly? date)
     {
-        var reportDates = await _holdingRepository
-            .GetAvailableReportDates()
-            .OrderByDescending(d => d)
-            .ToListAsync();
+        var reportDates = await LoadAvailableReportDates();
 
         var viewModel = new HoldingsActivityViewModel { AvailableDates = reportDates };
         if (reportDates.Count == 0)
@@ -108,10 +105,7 @@ public class HoldingsActivityController : BaseController
     [HttpGet("~/Holdings/MostHeld")]
     public async Task<IActionResult> MostHeld(DateOnly? date, string sort, int page = 1)
     {
-        var reportDates = await _holdingRepository
-            .GetAvailableReportDates()
-            .OrderByDescending(d => d)
-            .ToListAsync();
+        var reportDates = await LoadAvailableReportDates();
 
         var normalizedSort = sort switch
         {
@@ -230,6 +224,9 @@ public class HoldingsActivityController : BaseController
             PreviousFilerCount = activity.PreviousFilerCount,
         };
     }
+
+    private Task<List<DateOnly>> LoadAvailableReportDates() =>
+        _holdingRepository.GetAvailableReportDates().OrderByDescending(d => d).ToListAsync();
 
     private static (DateOnly Selected, DateOnly? Previous) ResolveSelectedAndPriorDate(
         DateOnly? requested,


### PR DESCRIPTION
## Summary

- `Activity` and `MostHeld` both materialised the same `_holdingRepository.GetAvailableReportDates().OrderByDescending(d => d).ToListAsync()` query.
- Behavior-preserving: identical EF translation, descending order, exception/cancellation behavior. Mirrors the `LoadReportDates*` helper pattern recently introduced in `ProfilesController` (#1746) and `HoldingsExportController` (#1754).

## Code changes

- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — add `LoadAvailableReportDates()` helper and replace the two inline `GetAvailableReportDates().OrderByDescending(d => d).ToListAsync()` calls in `Activity` and `MostHeld` with calls to it. No public API or signature changes.