### PR TITLE
fix(web): use <h2> for ajax modal title to fix heading-skip

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Modals.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Modals.cshtml
@@ -4,7 +4,7 @@
         <button type="button" aria-label="Close" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2 modal-close">
             <span aria-hidden="true">✕</span>
         </button>
-        <h3 id="ajax-modal-title" class="modal-title text-lg font-medium mb-4 title-text"></h3>
+        <h2 id="ajax-modal-title" class="modal-title text-lg font-medium mb-4 title-text"></h2>
         <div class="modal-body flex-1 overflow-y-auto"></div>
     </div>
     <form method="dialog" class="modal-backdrop">


### PR DESCRIPTION
## Summary

- The shared ajax modal placed its title in an empty `<h3>` rendered on every page. On pages whose only visible heading is the `<h1>` (e.g. `/stocks`), this produced an `h1 → h3` ordering with no intervening `<h2>`, which accessibility audits flag as a skipped heading level.
- Promoting the modal title to `<h2>` removes the false skip. The element still has the same `id`, classes, and `.title-text` JS selector hook, so behavior and visual styling are unchanged.

## Code changes

- `src/Equibles.Web/Views/Shared/_Modals.cshtml` — change the modal title from `<h3>` to `<h2>` (id, classes, and aria-labelledby target preserved).