### PR TITLE
refactor(profiles-controller): collapse three duplicated GetByHolder+Include lookups into LoadHoldingsByHolderWithStock helper

### DIFF
--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -141,14 +141,8 @@ public class ProfilesController : BaseController
             );
 
         var prior = distinctReportDates[selectedIndex + 1];
-        var currentHoldings = await _institutionalHoldingRepository
-            .GetByHolder(holder, selected)
-            .Include(h => h.CommonStock)
-            .ToListAsync();
-        var previousHoldings = await _institutionalHoldingRepository
-            .GetByHolder(holder, prior)
-            .Include(h => h.CommonStock)
-            .ToListAsync();
+        var currentHoldings = await LoadHoldingsByHolderWithStock(holder, selected);
+        var previousHoldings = await LoadHoldingsByHolderWithStock(holder, prior);
 
         var grouped = HolderQuarterlyActivityCalculator.Group(currentHoldings, previousHoldings);
 
@@ -400,10 +394,7 @@ public class ProfilesController : BaseController
             new List<(InstitutionalHolder Holder, IReadOnlyList<InstitutionalHolding> Holdings)>();
         foreach (var holder in holders)
         {
-            var holdings = await _institutionalHoldingRepository
-                .GetByHolder(holder, selected)
-                .Include(h => h.CommonStock)
-                .ToListAsync();
+            var holdings = await LoadHoldingsByHolderWithStock(holder, selected);
             perFund.Add((holder, holdings));
         }
         return perFund;
@@ -415,6 +406,15 @@ public class ProfilesController : BaseController
             .Select(h => h.ReportDate)
             .Distinct()
             .OrderByDescending(d => d)
+            .ToListAsync();
+
+    private Task<List<InstitutionalHolding>> LoadHoldingsByHolderWithStock(
+        InstitutionalHolder holder,
+        DateOnly reportDate
+    ) =>
+        _institutionalHoldingRepository
+            .GetByHolder(holder, reportDate)
+            .Include(h => h.CommonStock)
             .ToListAsync();
 
     private static DateOnly ResolveSelectedDate(DateOnly? requested, List<DateOnly> available) =>


### PR DESCRIPTION
## Summary

- `BuildQuarterlyActivity` (selected and prior holdings) and `LoadPerFundHoldings` each ran the same `_institutionalHoldingRepository.GetByHolder(holder, date).Include(h => h.CommonStock).ToListAsync()` query — three occurrences in total.
- Behavior-preserving: same EF query, same eager-loaded `CommonStock`, same exception/cancellation behavior. Mirrors the `LoadHoldingsByHolderWithStock` helper already present in `InstitutionalHoldingsTools`.

## Code changes

- `src/Equibles.Web/Controllers/ProfilesController.cs` — add a private `LoadHoldingsByHolderWithStock(holder, reportDate)` helper and replace the three inline `GetByHolder(...).Include(h => h.CommonStock).ToListAsync()` calls in `BuildQuarterlyActivity` (×2) and `LoadPerFundHoldings` (×1). No public API or signature changes.