### PR TITLE
refactor(holdings-export-controller): collapse two duplicated stock-cell lookups into ResolveStockCells helper

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -264,14 +264,14 @@ public class HoldingsExportController : BaseController
         IDictionary<Guid, StockLabel> stocks
     )
     {
-        stocks.TryGetValue(row.CommonStockId, out var stock);
+        var (ticker, name) = ResolveStockCells(stocks, row.CommonStockId);
         return
         [
             board,
             CsvExportService.Format(current),
             CsvExportService.Format(previous),
-            stock?.Ticker ?? string.Empty,
-            stock?.Name ?? string.Empty,
+            ticker,
+            name,
             CsvExportService.Format((long)row.CurrentFilerCount),
             CsvExportService.Format((long)row.PreviousFilerCount),
             CsvExportService.Format(row.CurrentShares - row.PreviousShares),
@@ -289,14 +289,14 @@ public class HoldingsExportController : BaseController
         IDictionary<Guid, StockLabel> stocks
     )
     {
-        stocks.TryGetValue(row.CommonStockId, out var stock);
+        var (ticker, name) = ResolveStockCells(stocks, row.CommonStockId);
         return
         [
             board,
             CsvExportService.Format(current),
             CsvExportService.Format(previous),
-            stock?.Ticker ?? string.Empty,
-            stock?.Name ?? string.Empty,
+            ticker,
+            name,
             string.Empty,
             string.Empty,
             string.Empty,
@@ -304,6 +304,15 @@ public class HoldingsExportController : BaseController
             CsvExportService.Format((long)row.NewFilerCount),
             CsvExportService.Format((long)row.SoldOutFilerCount),
         ];
+    }
+
+    private static (string Ticker, string Name) ResolveStockCells(
+        IDictionary<Guid, StockLabel> stocks,
+        Guid stockId
+    )
+    {
+        stocks.TryGetValue(stockId, out var stock);
+        return (stock?.Ticker ?? string.Empty, stock?.Name ?? string.Empty);
     }
 
     private record StockLabel(Guid Id, string Ticker, string Name);


### PR DESCRIPTION
## Summary

- `ActivityRow` and `ChurnRow` both ran `stocks.TryGetValue(row.CommonStockId, out var stock); ... stock?.Ticker ?? string.Empty, stock?.Name ?? string.Empty` to emit the ticker/name CSV cells.
- Behavior-preserving: same dictionary lookup semantics, same `string.Empty` fallbacks (deliberately distinct from the `"—" / "Unknown"` fallbacks used by the markdown-table renderers — CSV cells must stay empty when no stock is resolved).

## Code changes

- `src/Equibles.Web/Controllers/HoldingsExportController.cs` — add a private static `ResolveStockCells(stocks, stockId)` returning `(Ticker, Name)` and replace the two inline `TryGetValue` + null-coalesce blocks in `ActivityRow` and `ChurnRow` with calls to it. No public API or signature changes.