### PR TITLE
refactor(stock-price-tools): collapse two duplicated high/low/close projections into ExtractHighLowClose helper

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -194,9 +194,7 @@ public class StockPriceTools
                 if (error != null)
                     return error;
 
-                var highs = records.Select(p => p.High).ToList();
-                var lows = records.Select(p => p.Low).ToList();
-                var closes = records.Select(p => p.Close).ToList();
+                var (highs, lows, closes) = ExtractHighLowClose(records);
                 var (k, d) = TechnicalIndicatorService.ComputeStochastic(
                     highs,
                     lows,
@@ -262,9 +260,7 @@ public class StockPriceTools
                 if (error != null)
                     return error;
 
-                var highs = records.Select(p => p.High).ToList();
-                var lows = records.Select(p => p.Low).ToList();
-                var closes = records.Select(p => p.Close).ToList();
+                var (highs, lows, closes) = ExtractHighLowClose(records);
                 var atr = TechnicalIndicatorService.ComputeAtr(highs, lows, closes, period);
 
                 var result = StartTable(
@@ -396,6 +392,17 @@ public class StockPriceTools
             emitted++;
         }
     }
+
+    private static (
+        List<decimal> Highs,
+        List<decimal> Lows,
+        List<decimal> Closes
+    ) ExtractHighLowClose(List<DailyStockPrice> records) =>
+        (
+            records.Select(p => p.High).ToList(),
+            records.Select(p => p.Low).ToList(),
+            records.Select(p => p.Close).ToList()
+        );
 
     private static DateOnly ParseDateOr(string value, DateOnly fallback) =>
         !string.IsNullOrEmpty(value) && DateOnly.TryParse(value, out var parsed)


### PR DESCRIPTION
## Summary

- `GetStochasticOscillator` and `GetAverageTrueRange` each materialised the same three `records.Select(p => p.High|Low|Close).ToList()` lines before invoking `TechnicalIndicatorService`.
- Behavior-preserving: same projections, same materialization order, same `List<decimal>` instances handed to the indicator calculators.

## Code changes

- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — add a private static `ExtractHighLowClose(records)` helper returning a `(Highs, Lows, Closes)` tuple and replace the two inline 3-line projection blocks in `GetStochasticOscillator` and `GetAverageTrueRange` with calls to it. `GetOnBalanceVolume` is unchanged because it needs `(closes, volumes)`, a different shape. No public API or signature changes.