### PR TITLE
refactor(holdings-mcp): collapse three duplicated stock-by-ticker lookups into ResolveStockByTicker helper

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -70,9 +70,9 @@ public class InstitutionalHoldingsTools
         return Execute(
             async () =>
             {
-                var stock = await _commonStockRepository.GetByTicker(ticker);
-                if (stock == null)
-                    return $"Stock '{ticker}' not found.";
+                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
 
                 var (targetDate, found) = await TryResolveLatestReportDate(
                     reportDate,
@@ -158,9 +158,9 @@ public class InstitutionalHoldingsTools
         return Execute(
             async () =>
             {
-                var stock = await _commonStockRepository.GetByTicker(ticker);
-                if (stock == null)
-                    return $"Stock '{ticker}' not found.";
+                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
 
                 var reportDates = await GetReportDatesByStock(stock).Take(maxPeriods).ToListAsync();
 
@@ -336,9 +336,9 @@ public class InstitutionalHoldingsTools
         return Execute(
             async () =>
             {
-                var stock = await _commonStockRepository.GetByTicker(ticker);
-                if (stock == null)
-                    return $"Stock '{ticker}' not found.";
+                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
 
                 var reportDates = await GetReportDatesByStock(stock).ToListAsync();
 
@@ -1278,6 +1278,14 @@ public class InstitutionalHoldingsTools
 
     private Task<InstitutionalHolder> FindHolderByName(string name) =>
         _holderRepository.Search(name ?? string.Empty).OrderBy(h => h.Name).FirstOrDefaultAsync();
+
+    private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
+    {
+        var stock = await _commonStockRepository.GetByTicker(ticker);
+        if (stock == null)
+            return (null, $"Stock '{ticker}' not found.");
+        return (stock, null);
+    }
 
     private Task<List<InstitutionalHolding>> LoadHoldingsByHolderWithStock(
         InstitutionalHolder holder,


### PR DESCRIPTION
## Summary

- `GetTopHolders`, `GetOwnershipHistory`, and `GetTopBuyersSellers` each opened with the same `_commonStockRepository.GetByTicker(ticker)` + null check + `"Stock '{ticker}' not found."` return.
- Behavior-preserving: same EF call, same error message, same control flow at each callsite.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — add a private `ResolveStockByTicker(ticker)` returning `(Stock, Error)` and replace the three inline 3-line `GetByTicker` + null-check blocks at the top of `GetTopHolders`, `GetOwnershipHistory`, and `GetTopBuyersSellers` with calls to it. No public API or signature changes.