### PR TITLE
refactor(short-data-tools): collapse two duplicated stock-by-ticker lookups into ResolveStockByTicker helper

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
@@ -52,11 +53,9 @@ public class ShortDataTools
         return Execute(
             async () =>
             {
-                var stock = await _commonStockRepository.GetByTicker(
-                    ticker.Trim().ToUpperInvariant()
-                );
-                if (stock == null)
-                    return $"Stock '{ticker}' not found.";
+                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
 
                 var query = _shortVolumeRepository.GetHistoryByStock(stock);
 
@@ -115,11 +114,9 @@ public class ShortDataTools
         return Execute(
             async () =>
             {
-                var stock = await _commonStockRepository.GetByTicker(
-                    ticker.Trim().ToUpperInvariant()
-                );
-                if (stock == null)
-                    return $"Stock '{ticker}' not found.";
+                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
 
                 var query = _shortInterestRepository.GetHistoryByStock(stock);
 
@@ -243,4 +240,12 @@ public class ShortDataTools
 
     private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
         !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
+
+    private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
+    {
+        var stock = await _commonStockRepository.GetByTicker(ticker.Trim().ToUpperInvariant());
+        if (stock == null)
+            return (null, $"Stock '{ticker}' not found.");
+        return (stock, null);
+    }
 }


### PR DESCRIPTION
## Summary

- `GetShortVolume` and `GetShortInterest` each opened with the same `_commonStockRepository.GetByTicker(ticker.Trim().ToUpperInvariant())` + null check + `"Stock '{ticker}' not found."` return.
- Behavior-preserving: same `Trim().ToUpperInvariant()` normalization before the DB lookup, same error string referencing the *original* user-supplied ticker, same control flow at each callsite. Mirrors the helper just landed in `InstitutionalHoldingsTools` (#1764).

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — add a private `ResolveStockByTicker(ticker)` returning `(Stock, Error)` and replace the two inline 5-line `GetByTicker` + null-check blocks at the top of `GetShortVolume` and `GetShortInterest` with calls to it. Add the `Equibles.CommonStocks.Data.Models` import for the helper's `CommonStock` return type. No public API or signature changes.