### PR TITLE
refactor(insider-trading-tools): collapse two duplicated stock-by-ticker lookups into ResolveStockByTicker helper

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
@@ -48,9 +49,9 @@ public class InsiderTradingTools
         return Execute(
             async () =>
             {
-                var stock = await _commonStockRepository.GetByTicker(ticker);
-                if (stock == null)
-                    return $"Stock '{ticker}' not found.";
+                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
 
                 var transactions = await _transactionRepository
                     .GetByStock(stock)
@@ -108,9 +109,9 @@ public class InsiderTradingTools
         return Execute(
             async () =>
             {
-                var stock = await _commonStockRepository.GetByTicker(ticker);
-                if (stock == null)
-                    return $"Stock '{ticker}' not found.";
+                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
 
                 var byStock = _transactionRepository.GetByStock(stock);
 
@@ -221,5 +222,13 @@ public class InsiderTradingTools
         if (owner.IsTenPercentOwner)
             roles.Add("10% Owner");
         return roles.Count > 0 ? string.Join(", ", roles) : "Insider";
+    }
+
+    private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
+    {
+        var stock = await _commonStockRepository.GetByTicker(ticker);
+        if (stock == null)
+            return (null, $"Stock '{ticker}' not found.");
+        return (stock, null);
     }
 }


### PR DESCRIPTION
## Summary

- `GetInsiderTransactions` and `GetInsiderOwnership` each opened with the same `_commonStockRepository.GetByTicker(ticker)` + null check + `"Stock '{ticker}' not found."` return.
- Behavior-preserving: same DB call, same error string, same control flow at each callsite. Mirrors the helper just landed in `InstitutionalHoldingsTools` (#1764) and `ShortDataTools` (#1765).

## Code changes

- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — add a private `ResolveStockByTicker(ticker)` returning `(Stock, Error)` and replace the two inline `GetByTicker` + null-check blocks at the top of `GetInsiderTransactions` and `GetInsiderOwnership` with calls to it. Add the `Equibles.CommonStocks.Data.Models` import for the helper's `CommonStock` return type. No public API or signature changes.