### PR TITLE
refactor(cboe-import): collapse FlushPutCallBatch and FlushVixBatch into generic FlushBatch helper

### DIFF
--- a/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
+++ b/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
@@ -1,6 +1,7 @@
 using Equibles.Cboe.Data.Models;
 using Equibles.Cboe.Repositories;
 using Equibles.Core.AutoWiring;
+using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Cboe.Contracts;
@@ -128,7 +129,7 @@ public class CboeImportService
                 PutCallRatio = r.PutCallRatio,
             }),
             InsertBatchSize,
-            FlushPutCallBatch
+            FlushBatch<CboePutCallRatio, CboePutCallRatioRepository>
         );
 
         _logger.LogInformation(
@@ -177,7 +178,7 @@ public class CboeImportService
                     Close = r.Close,
                 }),
                 InsertBatchSize,
-                FlushVixBatch
+                FlushBatch<CboeVixDaily, CboeVixDailyRepository>
             );
 
             _logger.LogInformation("CBOE VIX: imported {Count} new daily records", totalInserted);
@@ -198,18 +199,12 @@ public class CboeImportService
         }
     }
 
-    private async Task FlushPutCallBatch(List<CboePutCallRatio> items)
+    private async Task FlushBatch<TEntity, TRepository>(List<TEntity> items)
+        where TEntity : class
+        where TRepository : BaseRepository<TEntity>
     {
         using var scope = _scopeFactory.CreateScope();
-        var repo = scope.ServiceProvider.GetRequiredService<CboePutCallRatioRepository>();
-        repo.AddRange(items);
-        await repo.SaveChanges();
-    }
-
-    private async Task FlushVixBatch(List<CboeVixDaily> items)
-    {
-        using var scope = _scopeFactory.CreateScope();
-        var repo = scope.ServiceProvider.GetRequiredService<CboeVixDailyRepository>();
+        var repo = scope.ServiceProvider.GetRequiredService<TRepository>();
         repo.AddRange(items);
         await repo.SaveChanges();
     }


### PR DESCRIPTION
## Summary

- `FlushPutCallBatch` and `FlushVixBatch` ran the identical `_scopeFactory.CreateScope()` + `GetRequiredService<TRepo>()` + `repo.AddRange(items)` + `repo.SaveChanges()` sequence, differing only in entity and repository type.
- Behavior-preserving: same scope lifetime, same DI resolution, same `AddRange`/`SaveChanges` calls, same exception types. `BatchPersister.Persist` accepts the generic method-group directly via `Func<List<TEntity>, Task>` conversion.

## Code changes

- `src/Equibles.Cboe.HostedService/Services/CboeImportService.cs` — replace `FlushPutCallBatch` and `FlushVixBatch` with a single private `FlushBatch<TEntity, TRepository>` constrained on `TRepository : BaseRepository<TEntity>`, and pass `FlushBatch<…>` as the `BatchPersister.Persist` callback. Add the `Equibles.Data` import for the `BaseRepository` constraint. No public API or signature changes.