### PR TITLE
refactor(holdings-mcp): collapse two duplicated per-holder report-date intersections

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1089,13 +1089,24 @@ public class InstitutionalHoldingsTools
         string reportDate
     )
     {
-        var dates1 = await GetReportDatesByHolder(holder1).ToListAsync();
-        var dates2 = await GetReportDatesByHolder(holder2).ToListAsync();
-        var common = dates1.Intersect(dates2).OrderByDescending(d => d).ToList();
+        var common = await ComputeCommonReportDates([holder1, holder2]);
         if (common.Count == 0)
             return (default, $"{holder1.Name} and {holder2.Name} share no common report dates.");
 
         return (ResolveReportDate(reportDate, common), null);
+    }
+
+    private async Task<List<DateOnly>> ComputeCommonReportDates(IList<InstitutionalHolder> holders)
+    {
+        var perHolder = new List<List<DateOnly>>(holders.Count);
+        foreach (var holder in holders)
+            perHolder.Add(await GetReportDatesByHolder(holder).ToListAsync());
+
+        return perHolder
+            .Skip(1)
+            .Aggregate((IEnumerable<DateOnly>)perHolder[0], (acc, next) => acc.Intersect(next))
+            .OrderByDescending(d => d)
+            .ToList();
     }
 
     private static string RenderOverlapTable(
@@ -1188,20 +1199,7 @@ public class InstitutionalHoldingsTools
                 if (holders.Count < 2)
                     return $"Could not resolve enough institutions. Missing: {string.Join(", ", missing)}.";
 
-                var perHolderDates = new List<List<DateOnly>>();
-                foreach (var holder in holders)
-                {
-                    var dates = await GetReportDatesByHolder(holder).ToListAsync();
-                    perHolderDates.Add(dates);
-                }
-                var common = perHolderDates
-                    .Skip(1)
-                    .Aggregate(
-                        (IEnumerable<DateOnly>)perHolderDates[0],
-                        (acc, next) => acc.Intersect(next)
-                    )
-                    .OrderByDescending(d => d)
-                    .ToList();
+                var common = await ComputeCommonReportDates(holders);
                 if (common.Count == 0)
                     return "The selected institutions share no common report dates.";
 


### PR DESCRIPTION
## Summary

- Extracts the duplicated "load each holder's report dates, intersect, sort desc" logic from `ResolveCommonReportDate` (2-holder) and the `GetConsensusHoldings` inline block (N-holder) into one private helper `ComputeCommonReportDates(IList<InstitutionalHolder>)`.
- Behavior-preserving: both call sites kept their distinct error strings, the helper's `Aggregate`-over-`Intersect` is identical to `a.Intersect(b)` for N=2, and `ResolveReportDate` continues to pick the date.
- Build green, csharpier check clean, 11/11 unit + 66/66 integration `InstitutionalHoldingsTools` tests pass (plus 231 / 238 across the broader holdings projects).

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — adds `ComputeCommonReportDates(IList<InstitutionalHolder>)`. `ResolveCommonReportDate` and `GetConsensusHoldings` both delegate to it; net diff −2 lines, −1 inline aggregation block.