### PR TITLE
test(sec/normalizers): add skipped repro for GH-1771 IsPartHeading crash

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingDelimiterOnlySuffixTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingDelimiterOnlySuffixTests.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+/// <summary>
+/// IsPartHeading is a discriminator: given any string, it returns true when the
+/// text matches the canonical SEC 10-K "PART [letter-word]" pattern and false
+/// otherwise. Returning false is the entire purpose of the negative branch — a
+/// throw is a contract violation, because every caller treats the bool as a
+/// classification answer. The internal pipeline (HeadingConversionStep.Execute
+/// → ClassifyHeadingTag → IsPartHeading) feeds in arbitrary span text harvested
+/// from SEC EDGAR HTML, including separator-only fragments like "Part —" or
+/// "Part -" that show up as visual section dividers. None of those callers
+/// guard against the helper throwing, so an exception here bubbles up and
+/// aborts the whole document normalization.
+/// </summary>
+public class HeadingConversionStepIsPartHeadingDelimiterOnlySuffixTests
+{
+    [Fact(
+        Skip = "GH-1771 — IsPartHeading throws IndexOutOfRangeException when post-'PART ' suffix is all split delimiters"
+    )]
+    public void IsPartHeading_PartFollowedByDelimiterOnlySuffix_ReturnsFalseWithoutThrowing()
+    {
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "IsPartHeading",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var step = new HeadingConversionStep();
+
+        // "Part -" passes every guard up to the Split: it starts with "PART", is
+        // longer than 4 chars, has whitespace at index 4, and the substring after
+        // position 5 trims to non-empty "-". A canonical roman-numeral suffix
+        // ("I", "II", "IV") splits into a letter-only first word; an
+        // all-delimiter suffix ("-") splits into nothing under
+        // StringSplitOptions.RemoveEmptyEntries. The method should answer "no,
+        // not a part heading" — not throw.
+        bool Invoke()
+        {
+            try
+            {
+                return (bool)method.Invoke(step, ["Part -"])!;
+            }
+            catch (TargetInvocationException ex)
+            {
+                throw ex.InnerException!;
+            }
+        }
+
+        var act = Invoke;
+
+        act.Should()
+            .NotThrow(
+                "IsPartHeading is a classifier — every input must return true or false, never throw"
+            );
+        Invoke().Should().BeFalse("'-' is not a canonical SEC 10-K roman-numeral part suffix");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an adversarial regression test that pins the expected behavior of
  `HeadingConversionStep.IsPartHeading` when the post-"PART " token is composed
  entirely of split delimiters (e.g. `"Part -"`).
- The test currently fails with `IndexOutOfRangeException` — skipped under
  `GH-1771` so the suite stays green until the production fix lands.
- Un-skip the test as part of resolving GH-1771.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingDelimiterOnlySuffixTests.cs` —
  new `[Fact(Skip = "GH-1771 — …")]` invoking `IsPartHeading` via reflection on a
  delimiter-only suffix and asserting the classifier returns `false` without
  throwing.