### PR TITLE
test(sec/insider): pin ParseBool lowercase-true arm

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseBoolLowercaseTrueTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseBoolLowercaseTrueTests.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Sibling to InsiderTradingFilingProcessorTests' ParseBool digit-one and
+/// digit-zero pins. Those cover the "1"/"0" SEC-XML representation. The
+/// `value is "1" or "true" or "True" or "TRUE"` predicate also accepts the
+/// textual xsd:boolean form — "true" (lowercase, the canonical XML Schema
+/// canonical-lexical form). A refactor that trims the predicate back to just
+/// the digit arms (intuitive to anyone reading "isDirector" as a numeric
+/// flag) would compile, pass the existing digit pins, and silently drop the
+/// every-textual-true encoding emitted by older filers and EDGAR's
+/// pre-XBRL ownership wire format.
+/// </summary>
+public class InsiderTradingFilingProcessorParseBoolLowercaseTrueTests
+{
+    [Fact]
+    public void ParseBool_LowercaseTrue_ReturnsTrue()
+    {
+        // The lowercase "true" arm is the canonical xsd:boolean form and the
+        // representation older Form 4 filings emit. Pin it explicitly so the
+        // arm survives a "simplify the predicate" refactor.
+        var method = typeof(InsiderTradingFilingProcessor).GetMethod(
+            "ParseBool",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+        var result = (bool)method.Invoke(null, ["true"])!;
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Lane B coverage pin for the `"true"` (lowercase) arm of
  `InsiderTradingFilingProcessor.ParseBool`. The existing tests in
  `InsiderTradingFilingProcessorTests` only exercise the digit arms
  ("1" / "0"); the textual arms ("true", "True", "TRUE") were unpinned, so a
  refactor that simplified the predicate to just the digit cases would compile
  cleanly and silently drop every textual-boolean isDirector/isOfficer/
  isTenPercentOwner flag.

## Code changes

- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseBoolLowercaseTrueTests.cs` —
  new `[Fact]` that reflectively invokes `ParseBool("true")` and asserts the
  result is `true`, exercising the canonical xsd:boolean lowercase arm of the
  four-arm pattern match.