### PR TITLE
test(sec/financialfacts): pin TryMapTaxonomy dei arm

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapTaxonomyDeiTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapTaxonomyDeiTests.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Sibling to FinancialFactsImportServiceTryMapTaxonomyNullKeyTests. The
+/// null-key default-arm path is pinned. Of the five positive arms
+/// (us-gaap / dei / ifrs-full / srt / invest), only us-gaap is implicitly
+/// exercised by end-to-end import tests. The "dei" arm is independently
+/// load-bearing — DEI (Document and Entity Information) facts ship with
+/// every SEC XBRL filing for entity metadata (registrant name, CIK,
+/// fiscal-year-end, filer category). A refactor that pared the switch back
+/// to just `us-gaap` (intuitive: "we only persist us-gaap facts") would
+/// compile, pass every other pin, and silently drop every DEI fact at
+/// ingest — leaving the FinancialConcepts table without the entity-shape
+/// rows downstream dashboards key off.
+/// </summary>
+public class FinancialFactsImportServiceTryMapTaxonomyDeiTests
+{
+    [Fact]
+    public void TryMapTaxonomy_DeiKey_MapsToDeiTaxonomyAndReturnsTrue()
+    {
+        // The "dei" wire key (lowercase, matching SEC's submission JSON keys)
+        // must round-trip into FactTaxonomy.Dei via the out parameter.
+        var method = typeof(FinancialFactsImportService).GetMethod(
+            "TryMapTaxonomy",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+        var args = new object[] { "dei", default(FactTaxonomy) };
+
+        var resolved = (bool)method.Invoke(null, args)!;
+
+        resolved.Should().BeTrue();
+        args[1].Should().Be(FactTaxonomy.Dei);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Lane B coverage pin for the `"dei"` arm of
  `FinancialFactsImportService.TryMapTaxonomy`. Only the null-key default arm
  is currently pinned; the four non-`us-gaap` positive arms are unpinned, and
  DEI ships with every SEC XBRL filing.
- A refactor that pared the switch back to just `us-gaap` (intuitive
  simplification) would compile, pass every other pin, and silently drop every
  DEI fact at ingest.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapTaxonomyDeiTests.cs` —
  new `[Fact]` that reflectively invokes `TryMapTaxonomy("dei", out _)` and
  asserts both the boolean return and the resolved `FactTaxonomy.Dei` value.