### PR TITLE
fix(sec/normalizers): guard IsPartHeading split-result against delimiter-only suffix

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -126,10 +126,13 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
             var afterPart = upperText.Substring(5).Trim();
             if (!string.IsNullOrEmpty(afterPart))
             {
-                var firstWord = afterPart.Split(
+                var tokens = afterPart.Split(
                     [' ', '.', '-', ':'],
                     StringSplitOptions.RemoveEmptyEntries
-                )[0];
+                );
+                if (tokens.Length == 0)
+                    return false;
+                var firstWord = tokens[0];
                 return !string.IsNullOrEmpty(firstWord) && firstWord.All(char.IsLetter);
             }
         }

--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingDelimiterOnlySuffixTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingDelimiterOnlySuffixTests.cs
@@ -17,9 +17,7 @@ namespace Equibles.UnitTests.Sec.Normalizers;
 /// </summary>
 public class HeadingConversionStepIsPartHeadingDelimiterOnlySuffixTests
 {
-    [Fact(
-        Skip = "GH-1771 — IsPartHeading throws IndexOutOfRangeException when post-'PART ' suffix is all split delimiters"
-    )]
+    [Fact]
     public void IsPartHeading_PartFollowedByDelimiterOnlySuffix_ReturnsFalseWithoutThrowing()
     {
         var method = typeof(HeadingConversionStep).GetMethod(


### PR DESCRIPTION
## Summary

- `HeadingConversionStep.IsPartHeading` indexed `tokens[0]` without checking length, so input like `"Part -"` — where the post-`"PART "` suffix is entirely split delimiters — produced an empty array under `StringSplitOptions.RemoveEmptyEntries` and threw `IndexOutOfRangeException`. The throw bubbled through `HeadingConversionStep.Execute` and aborted normalization for the whole filing.
- Guard the indexer (`tokens.Length == 0` → return `false`) so the classifier honors its contract: every input answers true or false, never throws.
- Un-skip the GH-1771 regression test committed earlier in #1773.

closes #1771

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs` — split into a local `tokens` variable, return `false` when the split produced no entries, then index `tokens[0]` only on the safe path.
- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsPartHeadingDelimiterOnlySuffixTests.cs` — drop the `Skip` reason now that the bug is fixed.