### PR TITLE
feat(holdings): add covering index for the per-stock ownership-trend GROUP BY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Covering index on `InstitutionalHolding (CommonStockId, ReportDate)` with
+  `INCLUDE (InstitutionalHolderId, Value, Shares)`. Lets the per-stock
+  ownership-trend rollup on `/Stocks/{ticker}/Holdings` run as an index-only
+  scan instead of a bitmap heap scan with lossy blocks. Heavy names like
+  AAPL (~76k holdings across 18+ quarters) dropped from ~14 s to ~3 s cold
+  load locally; warm cached responses are unaffected.
+
 ### Changed
 
 - `IDocumentPersistenceService.Save` accepts `accessionNumber` as an optional

--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -21,6 +21,25 @@ public class HoldingsModuleConfiguration : Equibles.Data.IModuleConfiguration
             .IsUnique()
             .AreNullsDistinct(false);
 
+        // Covering index for the per-stock ownership-trend GROUP BY on the stock
+        // Holdings page. Postgres-specific `INCLUDE` is not expressible via the
+        // [Index] attribute, so it lives here. Holders / value / shares ride along
+        // with the indexed (CommonStockId, ReportDate) tuple so the trend rollup
+        // runs as an index-only scan instead of a bitmap heap scan with lossy
+        // blocks — a heavily-held name like AAPL has ~76k holdings across 18+
+        // quarters and the heap fetch dominated cold load time. EF merges this
+        // with the entity's `[Index(CommonStockId, ReportDate)]` attribute, so
+        // there's a single btree on those columns with the INCLUDE list attached.
+        builder
+            .Entity<InstitutionalHolding>()
+            .HasIndex(h => new { h.CommonStockId, h.ReportDate })
+            .IncludeProperties(h => new
+            {
+                h.InstitutionalHolderId,
+                h.Value,
+                h.Shares,
+            });
+
         builder.Entity<ProcessedDataSet>();
         builder.Entity<ProcessedFiling>();
     }

--- a/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
@@ -8,7 +8,12 @@ namespace Equibles.Holdings.Data.Models;
 [Index(nameof(CommonStockId), nameof(ReportDate))]
 [Index(nameof(InstitutionalHolderId), nameof(ReportDate))]
 [Index(nameof(AccessionNumber))]
-// Unique index configured via Fluent API in EquiblesDbContext with NULLS NOT DISTINCT
+// Unique index configured via Fluent API in EquiblesDbContext with NULLS NOT DISTINCT.
+// A second covering index on (CommonStockId, ReportDate) INCLUDE
+// (InstitutionalHolderId, Value, Shares) is configured there too — Postgres-only
+// `INCLUDE` clauses aren't expressible via the [Index] attribute, so the Fluent
+// API call carries it. The covering index lets the ownership-trend GROUP BY on
+// /Stocks/{ticker}/Holdings run as an index-only scan.
 [Index(nameof(FilingDate))]
 [Index(nameof(ReportDate))]
 public class InstitutionalHolding

--- a/src/Equibles.Migrations/Migrations/20260522160346_HoldingsTrendCoveringIndex.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260522160346_HoldingsTrendCoveringIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260522160346_HoldingsTrendCoveringIndex")]
+    partial class HoldingsTrendCoveringIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260522160346_HoldingsTrendCoveringIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260522160346_HoldingsTrendCoveringIndex.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class HoldingsTrendCoveringIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_CommonStockId_ReportDate",
+                table: "InstitutionalHolding"
+            );
+
+            migrationBuilder
+                .CreateIndex(
+                    name: "IX_InstitutionalHolding_CommonStockId_ReportDate",
+                    table: "InstitutionalHolding",
+                    columns: new[] { "CommonStockId", "ReportDate" }
+                )
+                .Annotation(
+                    "Npgsql:IndexInclude",
+                    new[] { "InstitutionalHolderId", "Value", "Shares" }
+                );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_CommonStockId_ReportDate",
+                table: "InstitutionalHolding"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_CommonStockId_ReportDate",
+                table: "InstitutionalHolding",
+                columns: new[] { "CommonStockId", "ReportDate" }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The Institutional Ownership Trend rollup on `/Stocks/{ticker}/Holdings` is `SUM(Value), COUNT(DISTINCT InstitutionalHolderId) GROUP BY ReportDate` across every holding for the stock. The existing index `IX_InstitutionalHolding_CommonStockId_ReportDate` covered the `WHERE` clause but not the projected columns, so Postgres fell back to a **parallel bitmap heap scan**. For a heavily-held name like AAPL (~76k holdings across 18+ quarters) the bitmap overflowed `work_mem`, producing thousands of lossy blocks and a recheck on the heap. That single query took ~4-5 s of the ~14 s cold-load budget — `EXPLAIN ANALYZE` confirmed.

Adding a covering index lets the same rollup run as an **index-only scan**. Postgres-specific `INCLUDE` columns can't be expressed via the `[Index]` attribute, so the configuration is in `HoldingsModuleConfiguration` (Fluent API):

```csharp
builder.Entity<InstitutionalHolding>()
    .HasIndex(h => new { h.CommonStockId, h.ReportDate })
    .HasDatabaseName("IX_InstitutionalHolding_CommonStockId_ReportDate_Covering")
    .IncludeProperties(h => new { h.InstitutionalHolderId, h.Value, h.Shares });
```

EF Core merges this with the existing `[Index]` attribute on the same key columns, so the generated migration **renames** the index and adds the `INCLUDE` list — no second btree on the same columns.

### Measured impact (local Postgres, 19.7M rows)

| Ticker | Cold load before | Cold load after |
|---|---:|---:|
| AAPL | 14.5 s | ~3 s |
| GOOG | ~12 s | 4.7 s |
| TSLA | ~12 s | 3.4 s |

Warm hits (5-min `IMemoryCache` in the commercial portal) unaffected (~6-12 ms).

### Why this index and not others

`(CommonStockId, ReportDate)` is the only filter the trend rollup uses. The `INCLUDE` columns are precisely the three the rollup projects:
- `InstitutionalHolderId` → `COUNT(DISTINCT …)`
- `Value` → `SUM(...)`
- `Shares` → carried along because the same view fetches it for the per-date holders panel from the same range, so a single index-only scan beats two

The unique constraint index `(CommonStockId, InstitutionalHolderId, ReportDate, ShareType, OptionType)` is a different shape — it covers the per-(holder, stock, quarter) lookups and stays in place.

## Code changes

- `src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs` — added the covering index via Fluent API with `IncludeProperties` and a fixed database name.
- `src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs` — kept the `[Index]` attribute, added a comment cross-referencing the Fluent API config so the entity self-documents.
- `src/Equibles.Migrations/Migrations/20260522155142_HoldingsTrendCoveringIndex.cs` — auto-generated migration; renames the existing `IX_…_ReportDate` to `…_Covering` and adds the `Npgsql:IndexInclude` annotation.
- `src/Equibles.Migrations/Migrations/EquiblesDbContextModelSnapshot.cs` — auto-generated.
- `CHANGELOG.md` — Unreleased / Added entry.