### PR TITLE
fix(sec): require word boundary after "Part" in PaginationRemovalStep

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs
@@ -24,12 +24,7 @@ internal class PaginationRemovalStep : IHtmlNormalizationStep
 
             // Check element after HR for Part header
             var nextSibling = FindFirstMeaningfulSibling(hr, forward: true);
-            if (
-                nextSibling != null
-                && nextSibling
-                    .TextContent.Trim()
-                    .StartsWith("Part", StringComparison.OrdinalIgnoreCase)
-            )
+            if (nextSibling != null && IsPartHeader(nextSibling.TextContent))
             {
                 elementsToRemove.Add(nextSibling);
             }
@@ -39,6 +34,21 @@ internal class PaginationRemovalStep : IHtmlNormalizationStep
                 element.Parent?.RemoveChild(element);
             }
         }
+    }
+
+    // Mirrors HeadingConversionStep.IsPartHeading: only treat the after-HR
+    // sibling as a Part header when "Part" is followed by a whitespace
+    // boundary, so ordinary words that merely start with "Part" (Partnership,
+    // Particular, …) are not deleted.
+    private static bool IsPartHeader(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        var upperText = text.ToUpperInvariant().Trim();
+        return upperText.StartsWith("PART")
+            && upperText.Length > 4
+            && char.IsWhiteSpace(upperText[4]);
     }
 
     private static INode FindFirstMeaningfulSibling(INode node, bool forward)

--- a/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartPrefixWordBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartPrefixWordBoundaryTests.cs
@@ -16,9 +16,7 @@ namespace Equibles.UnitTests.Sec.Normalizers;
 /// </summary>
 public class PaginationRemovalStepPartPrefixWordBoundaryTests
 {
-    [Fact(
-        Skip = "GH-1780 — PaginationRemovalStep.Execute uses StartsWith(\"Part\") without a word-boundary guard, removing paragraphs that merely start with a Part-prefixed word"
-    )]
+    [Fact]
     public void Execute_HrFollowedByParagraphStartingWithPartPrefixedWord_PreservesParagraph()
     {
         // The paragraph after the <hr> is "Partnership agreement", not a Part


### PR DESCRIPTION
## Summary

Closes #1780. `PaginationRemovalStep` removed any paragraph following an `<hr>` whose text started with the four characters `"Part"` — including ordinary body content like `"Partnership agreement"`, `"Particular circumstances"`, or `"Parts inventory"`. The check used `text.StartsWith("Part", OrdinalIgnoreCase)` with no word-boundary guard, so prefix-only matches were mis-classified as canonical SEC 10-K Part headers and silently deleted.

The fix mirrors the guard already in `HeadingConversionStep.IsPartHeading`: only treat the after-`<hr>` sibling as a Part header when `"Part"` is followed by a whitespace boundary. Canonical headers (`"Part I"`, `"Part II"`, including the U+00A0 form SEC EDGAR emits) still match; prefix-only words no longer do.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs` — replace the raw `StartsWith("Part", …)` check with a private `IsPartHeader` helper that additionally requires `char.IsWhiteSpace` at position 4.
- `tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartPrefixWordBoundaryTests.cs` — new regression test: an `<hr>` followed by `<p>Partnership agreement…</p>` keeps the paragraph after running the step (fails on pre-fix code, passes after).

## Test plan

- [x] `dotnet test tests/Equibles.UnitTests/Equibles.UnitTests.csproj --filter "FullyQualifiedName~Sec.Normalizers"` — 79/79 pass
- [x] New regression test fails on pre-fix code, passes on the fixed branch
- [x] `dotnet tool run csharpier format` on changed files