### PR TITLE
fix(sec/normalizers): re-apply per-row IsEmptyCell gate in currency consolidation pass

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs
@@ -120,7 +120,12 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
                 var currentCell = cells[colIndex];
                 var nextCell = cells[colIndex + 1];
 
-                var cleanTitle = RemoveCurrencySymbols(currentCell.TextContent.Trim());
+                var currentText = currentCell.TextContent.Trim();
+                var nextText = nextCell.TextContent.Trim();
+                if (string.IsNullOrWhiteSpace(currentText) || !IsEmptyCell(nextText))
+                    continue;
+
+                var cleanTitle = RemoveCurrencySymbols(currentText);
                 nextCell.InnerHtml = cleanTitle;
                 currentCell.Remove();
             }

--- a/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepNonEmptyNextCellPreservationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepNonEmptyNextCellPreservationTests.cs
@@ -16,9 +16,7 @@ namespace Equibles.UnitTests.Sec.Normalizers;
 /// </summary>
 public class CurrencyConsolidationStepNonEmptyNextCellPreservationTests
 {
-    [Fact(
-        Skip = "GH-1778 — ProcessCurrencyColumnsForConsolidation does not re-apply the per-row IsEmptyCell(nextCell) gate, so header labels in non-empty next cells are overwritten"
-    )]
+    [Fact]
     public void Execute_HeaderRowWithLabelInNextCell_PreservesLabelDuringConsolidation()
     {
         // Two-row table: row 0 has cells ["", "Q1", ""] — a header with a


### PR DESCRIPTION
## Summary

- `CurrencyConsolidationStep.ProcessCurrencyColumnsForConsolidation` was overwriting the next-cell content of every row in any column nominated for consolidation, ignoring the per-row gate that `ShouldConsolidateColumn` enforces. Header rows with column labels (e.g. `Q1`) whose next cell was non-empty had those labels destroyed when other rows in the same column hit the currency-and-empty-next gate.
- Re-apply the per-row gate (current cell non-empty AND next cell empty) in the processing pass so rows that fail the gate are skipped intact.
- Unskips the GH-1778 regression test that pinned the broken behavior.

closes #1778

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs` — in `ProcessCurrencyColumnsForConsolidation`, skip the row when the current cell is empty or the next cell is non-empty, mirroring the per-row condition that `ShouldConsolidateColumn` uses to nominate the column.
- `tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepNonEmptyNextCellPreservationTests.cs` — drop the `Skip = "GH-1778 …"` argument from the `[Fact]` attribute now that the contract holds.