### PR TITLE
fix(sec/normalizers): guard IsOnlyWhitespaceSpan no-span branch against dropping non-text visual cells

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs
@@ -169,7 +169,7 @@ internal class TableNormalizationStep : IHtmlNormalizationStep
 
         var spans = tempDoc.QuerySelectorAll("span").ToList();
         if (spans.Count == 0)
-            return true;
+            return false;
 
         foreach (var span in spans)
         {

--- a/tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepImageCellRowPreservationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepImageCellRowPreservationTests.cs
@@ -16,9 +16,7 @@ namespace Equibles.UnitTests.Sec.Normalizers;
 /// </summary>
 public class TableNormalizationStepImageCellRowPreservationTests
 {
-    [Fact(
-        Skip = "GH-1776 — IsOnlyWhitespaceSpan returns true when the cell HTML has zero <span> elements, so any row whose only content is an <img> (or other non-span visual element) is dropped by RemoveEmptyRows"
-    )]
+    [Fact]
     public void Execute_RowWithImageOnlyCell_PreservesRow()
     {
         // Cell content: a single <img> — no text, no spans. The contract for


### PR DESCRIPTION
## Summary

- `IsOnlyWhitespaceSpan` returned `true` when the parsed cell HTML contained zero `<span>` elements. `IsRowEmpty` interprets that as "this cell is visually empty", so `RemoveEmptyRows` dropped any row whose only content was an `<img>`, `<br>`, `<canvas>`, `<svg>`, etc. — including signature-image rows on SEC 10-K signature pages.
- Flipped the no-span branch to return `false`: the helper's contract is "is this cell only whitespace-bearing spans" — "no spans at all" should not satisfy that. Whitespace, `&nbsp;`, and whitespace-only span cases are still removed by the earlier branches in `IsRowEmpty`.
- Un-skipped the GH-1776 regression test pinning the expected behavior (row with image-only cell survives `RemoveEmptyRows`).

Closes #1776.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs` — `IsOnlyWhitespaceSpan` now returns `false` when there are no `<span>` elements, so non-text visual cells (img, br, svg, canvas, iframe, …) keep their parent row.
- `tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepImageCellRowPreservationTests.cs` — removed `Skip = "..."` from the regression test; passes on fixed code, failed on pre-fix code (`Expected rows.Length to be 2 … but found 1`).