### PR TITLE
fix(sec/financialfacts): drop xbrl facts whose measure has empty local name

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -194,18 +194,29 @@ public class InlineXbrlParser
                     : FindFirstChildByLocalName(denominator, MeasureLocalName)?.TextContent;
             if (string.IsNullOrEmpty(numeratorMeasure) || string.IsNullOrEmpty(denominatorMeasure))
                 return null;
-            return $"{StripPrefix(numeratorMeasure.Trim())}/{StripPrefix(denominatorMeasure.Trim())}";
+            var numeratorLocal = StripPrefix(numeratorMeasure.Trim());
+            var denominatorLocal = StripPrefix(denominatorMeasure.Trim());
+            if (numeratorLocal == null || denominatorLocal == null)
+                return null;
+            return $"{numeratorLocal}/{denominatorLocal}";
         }
 
         var measure = FindFirstChildByLocalName(unitElement, MeasureLocalName);
         var measureValue = measure?.TextContent?.Trim();
-        return string.IsNullOrEmpty(measureValue) ? null : StripPrefix(measureValue);
+        if (string.IsNullOrEmpty(measureValue))
+            return null;
+        return StripPrefix(measureValue);
     }
 
+    // Returns null when the QName has a prefix but an empty local name
+    // (e.g. "iso4217:"); such a measure is unresolvable.
     private static string StripPrefix(string qname)
     {
         var colonIdx = qname.IndexOf(':');
-        return colonIdx >= 0 ? qname.Substring(colonIdx + 1) : qname;
+        if (colonIdx < 0)
+            return qname;
+        var local = qname.Substring(colonIdx + 1);
+        return local.Length == 0 ? null : local;
     }
 
     private static bool TryParseFact(

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
@@ -199,18 +199,29 @@ public class StandaloneXbrlParser
             var denominatorMeasure = denominator?.Element(MeasureElement)?.Value;
             if (string.IsNullOrEmpty(numeratorMeasure) || string.IsNullOrEmpty(denominatorMeasure))
                 return null;
-            return $"{StripPrefix(numeratorMeasure)}/{StripPrefix(denominatorMeasure)}";
+            var numeratorLocal = StripPrefix(numeratorMeasure);
+            var denominatorLocal = StripPrefix(denominatorMeasure);
+            if (numeratorLocal == null || denominatorLocal == null)
+                return null;
+            return $"{numeratorLocal}/{denominatorLocal}";
         }
 
         var measure = unitElement.Element(MeasureElement);
         var measureValue = measure?.Value;
-        return string.IsNullOrEmpty(measureValue) ? null : StripPrefix(measureValue);
+        if (string.IsNullOrEmpty(measureValue))
+            return null;
+        return StripPrefix(measureValue);
     }
 
+    // Returns null when the QName has a prefix but an empty local name
+    // (e.g. "iso4217:"); such a measure is unresolvable.
     private static string StripPrefix(string qname)
     {
         var colonIdx = qname.IndexOf(':');
-        return colonIdx >= 0 ? qname.Substring(colonIdx + 1) : qname;
+        if (colonIdx < 0)
+            return qname;
+        var local = qname.Substring(colonIdx + 1);
+        return local.Length == 0 ? null : local;
     }
 
     private static bool TryParseFact(

--- a/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserPrefixOnlyMeasureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserPrefixOnlyMeasureTests.cs
@@ -14,9 +14,7 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class StandaloneXbrlParserPrefixOnlyMeasureTests
 {
-    [Fact(
-        Skip = "GH-1774 — ResolveUnit returns empty string instead of null when measure has empty local name, so the fact is emitted with Unit=\"\""
-    )]
+    [Fact]
     public void Parse_MeasureIsPrefixOnlyQName_SkipsFactsReferencingThatUnit()
     {
         // The unit's <xbrli:measure> is "iso4217:" — well-formed XML, but


### PR DESCRIPTION
## Summary

- `StandaloneXbrlParser` / `InlineXbrlParser` were emitting facts with `Unit = ""` when a `<xbrli:measure>` was a prefix-only QName such as `iso4217:`. `StripPrefix` returned `""` and `ResolveUnit` stored the unit under its id, so the fact ended up in the output with an empty unit. Downstream FinancialFacts tools key every value column off `Unit`, so an empty-unit fact is unusable.
- Treats an empty local name as unresolvable in both parsers, matching the existing missing-measure contract. The fact is now dropped, yielding zero facts for the affected unit.
- Un-skips the regression test pinned in GH-1774.

## Code changes

- `src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs` — `StripPrefix` now returns `null` when the QName has a prefix but an empty local name; `ResolveUnit` returns `null` for both the simple-measure path and the divide path when either side is unresolvable.
- `src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs` — same change for parity.
- `tests/Equibles.UnitTests/Sec/StandaloneXbrlParserPrefixOnlyMeasureTests.cs` — dropped the `Skip = "..."` so the regression test runs.

closes #1774