### PR TITLE
fix(sec/normalizers): word-boundary match for currency ISO codes

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 
@@ -13,6 +14,14 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
         ["JPY"] = ("¥", "Japanese Yen"),
         ["INR"] = ("₹", "Indian Rupees"),
     };
+
+    // Word-boundary match per code so acronyms like USDA / USDC / EUREKA that
+    // embed an ISO code as a substring are not mistaken for currency cells.
+    private static readonly Dictionary<string, Regex> CurrencyCodeRegexes =
+        CurrencyMap.Keys.ToDictionary(
+            code => code,
+            code => new Regex($@"\b{Regex.Escape(code)}\b", RegexOptions.Compiled)
+        );
 
     public void Execute(IHtmlDocument doc)
     {
@@ -98,7 +107,7 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
     {
         foreach (var (code, (symbol, _)) in CurrencyMap)
         {
-            if (text.Contains(symbol) || text.Contains(code))
+            if (text.Contains(symbol) || CurrencyCodeRegexes[code].IsMatch(text))
                 return code;
         }
         return null;
@@ -136,7 +145,8 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
     {
         foreach (var (code, (symbol, _)) in CurrencyMap)
         {
-            text = text.Replace(symbol, "").Replace(code, "");
+            text = text.Replace(symbol, "");
+            text = CurrencyCodeRegexes[code].Replace(text, "");
         }
         return text.Trim();
     }

--- a/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepCurrencyCodeSubstringFalsePositiveTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepCurrencyCodeSubstringFalsePositiveTests.cs
@@ -18,9 +18,7 @@ namespace Equibles.UnitTests.Sec.Normalizers;
 /// </summary>
 public class CurrencyConsolidationStepCurrencyCodeSubstringFalsePositiveTests
 {
-    [Fact(
-        Skip = "GH-1795 — DetectCurrency's text.Contains(code) branch substring-matches ISO codes inside unrelated acronyms (USDA/USDC/EUREKA), shredding labels and appending a misleading currency note"
-    )]
+    [Fact]
     public void Execute_LabelEmbedsCurrencyCodeAsSubstring_LeavesTableUnchanged()
     {
         // "USDA inspected facilities" embeds "USD" inside the acronym "USDA"


### PR DESCRIPTION
## Summary

- `CurrencyConsolidationStep.DetectCurrency` used `text.Contains(code)` for the textual-code branch, which substring-matches any 3-letter ISO code inside an unrelated uppercase acronym (`USDA`, `USDC`, `EUREKA`). A row label like `USDA inspected facilities` was treated as a currency cell, shredded to `A inspected facilities` through `RemoveCurrencySymbols`, and a misleading `All values are in US Dollars.` note was appended below the table.
- Pre-compile one `Regex` per code (`\b<code>\b`) once from `CurrencyMap`, then use those regexes in both `DetectCurrency` and `RemoveCurrencySymbols` so codes only match as standalone tokens. Symbols stay on `Contains` / `Replace` — they're non-word characters and don't need word-boundary semantics.
- Unskips the GH-1795 regression test that pinned the broken behavior.

closes #1795

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs` — add `System.Text.RegularExpressions` using; build a `CurrencyCodeRegexes` static map (one compiled `\b<code>\b` regex per `CurrencyMap` key); switch `DetectCurrency`'s code arm from `text.Contains(code)` to the regex's `IsMatch`; switch `RemoveCurrencySymbols`'s code arm from `text.Replace(code, "")` to the regex's `Replace(text, "")`.
- `tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepCurrencyCodeSubstringFalsePositiveTests.cs` — drop the `Skip = "GH-1795 …"` argument from the `[Fact]` attribute now that the contract holds.