### PR TITLE
fix(sec/normalizers): teach IsColumnEmpty to recognize non-text visual cells

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs
@@ -138,26 +138,36 @@ internal class TableNormalizationStep : IHtmlNormalizationStep
 
         foreach (var cell in cells)
         {
-            var cellText = cell.TextContent.Trim();
-            var cellHtml = cell.InnerHtml.Trim();
-
-            if (IsMeaningfulText(cellText) && cellText != " ")
+            if (!IsCellEmpty(cell))
             {
                 return false;
             }
+        }
 
-            if (
-                !string.IsNullOrWhiteSpace(cellHtml)
-                && cellHtml != "&nbsp;"
-                && cellHtml != "&#160;"
-                && !cellHtml.Contains(
-                    "white-space:pre-wrap;font-family:Arial;font-kerning:none;min-width:fit-content;\"> </span>"
-                )
-                && !IsOnlyWhitespaceSpan(cellHtml)
+        return true;
+    }
+
+    private bool IsCellEmpty(IElement cell)
+    {
+        var cellText = cell.TextContent.Trim();
+        var cellHtml = cell.InnerHtml.Trim();
+
+        if (IsMeaningfulText(cellText) && cellText != " ")
+        {
+            return false;
+        }
+
+        if (
+            !string.IsNullOrWhiteSpace(cellHtml)
+            && cellHtml != "&nbsp;"
+            && cellHtml != "&#160;"
+            && !cellHtml.Contains(
+                "white-space:pre-wrap;font-family:Arial;font-kerning:none;min-width:fit-content;\"> </span>"
             )
-            {
-                return false;
-            }
+            && !IsOnlyWhitespaceSpan(cellHtml)
+        )
+        {
+            return false;
         }
 
         return true;
@@ -208,13 +218,9 @@ internal class TableNormalizationStep : IHtmlNormalizationStep
         foreach (var row in rows)
         {
             var cells = HtmlElementExtensions.DirectChildCells(row);
-            if (colIndex < cells.Count)
+            if (colIndex < cells.Count && !IsCellEmpty(cells[colIndex]))
             {
-                var cellText = cells[colIndex].TextContent.Trim();
-                if (IsMeaningfulText(cellText))
-                {
-                    return false;
-                }
+                return false;
             }
         }
 

--- a/tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepImageOnlyColumnPreservationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepImageOnlyColumnPreservationTests.cs
@@ -15,9 +15,7 @@ namespace Equibles.UnitTests.Sec.Normalizers;
 /// </summary>
 public class TableNormalizationStepImageOnlyColumnPreservationTests
 {
-    [Fact(
-        Skip = "GH-1797 — IsColumnEmpty looks at cell.TextContent only; a column whose cells each contain only an <img> (or other non-text visual element) is dropped by RemoveEmptyColumns"
-    )]
+    [Fact]
     public void Execute_ColumnWhereEveryCellIsImageOnly_PreservesColumn()
     {
         // The right column on every row is a single <img> — no text, no


### PR DESCRIPTION
## Summary

- `IsColumnEmpty` checked `cell.TextContent` only, so a column whose cells each contained only an `<img>` (or any other non-text visual element — `<br>`, `<canvas>`, `<svg>`, `<iframe>`) had empty text on every row and was dropped by `RemoveEmptyColumns`. Same bug class as GH-1776, but on the column path.
- Extracted the row-side cell-emptiness rules into `IsCellEmpty(IElement)` and routed both `IsRowEmpty` and `IsColumnEmpty` through it. `IsCellEmpty` is the existing row-side check verbatim — whitespace, `&nbsp;`, `&#160;`, the known whitespace-span pattern, and `IsOnlyWhitespaceSpan` are all the criteria for "empty"; anything else (including an image) is not. No behavior change for rows.
- Un-skipped the GH-1797 regression test pinning the expected behavior (image-only column survives `RemoveEmptyColumns`).

Closes #1797.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs` — extracted `IsCellEmpty` from `IsRowEmpty`; routed `IsColumnEmpty` through it so the column path honors the same HTML-aware emptiness rules as the row path.
- `tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepImageOnlyColumnPreservationTests.cs` — removed `Skip = "..."`; passes on fixed code, failed on pre-fix code (`Expected cells.Length to be 2 … but found 1`).