### PR TITLE
fix(sec/financialfacts): trim measure text in StandaloneXbrlParser.ResolveUnit

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
@@ -195,8 +195,8 @@ public class StandaloneXbrlParser
         {
             var numerator = divide.Element(NumeratorElement);
             var denominator = divide.Element(DenominatorElement);
-            var numeratorMeasure = numerator?.Element(MeasureElement)?.Value;
-            var denominatorMeasure = denominator?.Element(MeasureElement)?.Value;
+            var numeratorMeasure = numerator?.Element(MeasureElement)?.Value?.Trim();
+            var denominatorMeasure = denominator?.Element(MeasureElement)?.Value?.Trim();
             if (string.IsNullOrEmpty(numeratorMeasure) || string.IsNullOrEmpty(denominatorMeasure))
                 return null;
             var numeratorLocal = StripPrefix(numeratorMeasure);
@@ -207,7 +207,7 @@ public class StandaloneXbrlParser
         }
 
         var measure = unitElement.Element(MeasureElement);
-        var measureValue = measure?.Value;
+        var measureValue = measure?.Value?.Trim();
         if (string.IsNullOrEmpty(measureValue))
             return null;
         return StripPrefix(measureValue);

--- a/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserPaddedMeasureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserPaddedMeasureTests.cs
@@ -15,9 +15,7 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class StandaloneXbrlParserPaddedMeasureTests
 {
-    [Fact(
-        Skip = "GH-1799 — StandaloneXbrlParser.ResolveUnit does not trim measure text, so a padded QName like \"  iso4217:USD  \" emits Unit=\"USD  \" instead of \"USD\""
-    )]
+    [Fact]
     public void Parse_MeasureHasSurroundingWhitespace_TrimsBeforeResolving()
     {
         // Both parsers receive the same logical input; both must produce the


### PR DESCRIPTION
## Summary

- Per the XBRL spec, `xbrli:measure` is typed as `xs:QName`, whose whitespace facet is `collapse` — leading/trailing whitespace around the QName must be discarded before resolving the measure. `InlineXbrlParser.ResolveUnit` already honoured this; `StandaloneXbrlParser.ResolveUnit` did not, so a padded measure like `  iso4217:USD  ` emitted a fact with `Unit = "USD  "` instead of `"USD"`. Downstream FinancialFacts tools key off `Unit` (`USD`, `shares/USD`) to render the value column, so the two parsers disagreeing on the same logical input caused silent misclassification.
- Trim the measure text (single and divide variants) before the empty check and `StripPrefix` call, mirroring `InlineXbrlParser.ResolveUnit`.
- Unskips the GH-1799 regression test that pinned the broken behavior.

closes #1799

## Code changes

- `src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs` — `ResolveUnit` now calls `.Trim()` on `measureValue`, `numeratorMeasure`, and `denominatorMeasure` (each via `?.Value?.Trim()`) before the `IsNullOrEmpty` check and `StripPrefix` call, matching `InlineXbrlParser.ResolveUnit`.
- `tests/Equibles.UnitTests/Sec/StandaloneXbrlParserPaddedMeasureTests.cs` — drop the `Skip = "GH-1799 …"` argument from the `[Fact]` attribute now that the contract holds.