### PR TITLE
chore(release): v1.1.1

### DIFF
--- a/src/Equibles.Web/Equibles.Web.csproj
+++ b/src/Equibles.Web/Equibles.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <!-- Running version surfaced by the update-notification banner. Bump on each release to match the git tag. -->
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Equibles.IntegrationTests/Web/VersionCheckServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/VersionCheckServiceTests.cs
@@ -119,7 +119,7 @@ public class VersionCheckServiceTests
 
         Assert.True(result.UpdateAvailable);
         Assert.Equal("99.0.0", result.LatestVersion);
-        Assert.Equal("1.1.0", result.CurrentVersion);
+        Assert.Equal("1.1.1", result.CurrentVersion);
         Assert.Equal(
             "https://github.com/daniel3303/Equibles/releases/tag/v99.0.0",
             result.ReleaseUrl
@@ -129,20 +129,20 @@ public class VersionCheckServiceTests
     [Fact]
     public async Task Get_SameVersion_DoesNotReportUpdate()
     {
-        var handler = new StubHttpMessageHandler("{\"tag_name\":\"v1.1.0\"}");
+        var handler = new StubHttpMessageHandler("{\"tag_name\":\"v1.1.1\"}");
         var sut = CreateService(handler);
 
         var result = await WaitForRefresh(sut);
 
         Assert.False(result.UpdateAvailable);
-        Assert.Equal("1.1.0", result.LatestVersion);
+        Assert.Equal("1.1.1", result.LatestVersion);
     }
 
     [Fact]
     public async Task Get_FourSegmentSameVersionTag_DoesNotReportSpuriousUpdate()
     {
-        // Regression: "v1.1.0.0" must not compare as newer than assembly "1.1.0".
-        var handler = new StubHttpMessageHandler("{\"tag_name\":\"v1.1.0.0\"}");
+        // Regression: "v1.1.1.0" must not compare as newer than assembly "1.1.1".
+        var handler = new StubHttpMessageHandler("{\"tag_name\":\"v1.1.1.0\"}");
         var sut = CreateService(handler);
 
         var result = await WaitForRefresh(sut);


### PR DESCRIPTION
## Summary

Cut release v1.1.1. The CHANGELOG section for 1.1.1 was already moved out of `## [Unreleased]` in #1805 — this PR bumps the running-version assembly metadata and refreshes the matching tests so the release tag, assembly version, and update-banner test fixtures all align.

## Code changes

- `src/Equibles.Web/Equibles.Web.csproj` — `<Version>` 1.1.0 → 1.1.1. Surfaced by the in-app update-notification banner via `VersionCheckService`.
- `tests/Equibles.IntegrationTests/Web/VersionCheckServiceTests.cs` — bump hardcoded version strings to match the new assembly version:
  - `Get_NewerReleaseAvailable_ReportsUpdate` — expected `CurrentVersion` 1.1.0 → 1.1.1.
  - `Get_SameVersion_DoesNotReportUpdate` — GitHub tag fixture `v1.1.0` → `v1.1.1` and matching assertion.
  - `Get_FourSegmentSameVersionTag_DoesNotReportSpuriousUpdate` — tag fixture `v1.1.0.0` → `v1.1.1.0` and matching comment.

After merge: annotated tag `v1.1.1` on the squashed merge commit + GitHub Release with the 1.1.1 section of `CHANGELOG.md` as release notes.