### PR TITLE
perf(web): enable Brotli + Gzip response compression

### DIFF
--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using Equibles.Core.AutoWiring;
 using Equibles.Data;
 using Equibles.Data.Extensions;
@@ -8,6 +9,7 @@ using Equibles.Web.FlashMessage;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using Serilog.Events;
@@ -125,6 +127,21 @@ public partial class Program
         builder.Services.AddSession();
         builder.Services.AddFlashMessage();
         builder.Services.AddHealthChecks();
+
+        builder.Services.AddResponseCompression(options =>
+        {
+            options.EnableForHttps = true;
+            options.Providers.Add<BrotliCompressionProvider>();
+            options.Providers.Add<GzipCompressionProvider>();
+        });
+        builder.Services.Configure<BrotliCompressionProviderOptions>(options =>
+        {
+            options.Level = CompressionLevel.Fastest;
+        });
+        builder.Services.Configure<GzipCompressionProviderOptions>(options =>
+        {
+            options.Level = CompressionLevel.Fastest;
+        });
     }
 
     public static async Task ApplyMigrationsAsync(WebApplication app)
@@ -143,6 +160,7 @@ public partial class Program
             app.UseExceptionHandler("/Home/Error");
         }
 
+        app.UseResponseCompression();
         app.UseStaticFiles();
         app.UseRouting();
         app.UseSession();


### PR DESCRIPTION
## Summary
- Static assets (248 KB JS bundle, 173 KB CSS) and HTML responses were served uncompressed — no `Content-Encoding` header, full payload on every request.
- Added ASP.NET Core `ResponseCompression` middleware with Brotli (primary) and Gzip (fallback) providers, enabled for HTTPS, using `CompressionLevel.Fastest` for minimal CPU overhead.
- Expected ~60–70 % reduction in transfer sizes for text-based responses (JS, CSS, HTML, JSON).

## Code changes
- `src/Equibles.Web/Program.cs` — registered `AddResponseCompression` with Brotli + Gzip providers in `ConfigureServices`; added `UseResponseCompression()` before `UseStaticFiles()` in `ConfigurePipeline`.

## Test plan
- [ ] Rebuild Docker image and verify `Content-Encoding: br` (or `gzip`) header on `/dist/bundle.js` and `/dist/main.css`
- [ ] Confirm HTML responses (e.g., `/`, `/stocks`) also return compressed
- [ ] Spot-check that pages render correctly after compression