### PR TITLE
fix(holdings): narrow filer-universe query to only gap holders

### DIFF
--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -96,17 +96,39 @@ public class StockTabService
             ? await LoadHoldingsByStockWithHolder(stock, previousDate.Value)
             : [];
 
-        // Universe-wide set of filers known to have filed a 13F for the
-        // selected quarter — drives the Sold-Out bucket filter so filers who
-        // simply haven't reported yet aren't mislabelled as exiting the stock.
-        var filersWithCurrentQuarterFilings = (
-            await _institutionalHoldingRepository
-                .GetAll()
-                .Where(h => h.ReportDate == selectedDate)
-                .Select(h => h.InstitutionalHolderId)
-                .Distinct()
-                .ToListAsync()
-        ).ToHashSet();
+        // Narrow the Sold-Out filter to only holders who were in the previous
+        // quarter but are absent from the current quarter for this stock. The
+        // old query fetched ALL distinct filers market-wide for the quarter —
+        // millions of rows — just to build a HashSet. We only need to know
+        // whether each "gap" holder filed any 13F this quarter at all.
+        var currentHolderIds = allCurrent
+            .Select(h => h.InstitutionalHolderId)
+            .ToHashSet();
+        var previousOnlyHolderIds = allPrevious
+            .Select(h => h.InstitutionalHolderId)
+            .Where(id => !currentHolderIds.Contains(id))
+            .Distinct()
+            .ToList();
+
+        HashSet<Guid> filersWithCurrentQuarterFilings;
+        if (previousOnlyHolderIds.Count == 0)
+        {
+            filersWithCurrentQuarterFilings = [];
+        }
+        else
+        {
+            filersWithCurrentQuarterFilings = (
+                await _institutionalHoldingRepository
+                    .GetAll()
+                    .Where(h =>
+                        h.ReportDate == selectedDate
+                        && previousOnlyHolderIds.Contains(h.InstitutionalHolderId)
+                    )
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .ToListAsync()
+            ).ToHashSet();
+        }
 
         var grouped = HoldingsPositionGrouper.Group(
             allCurrent,

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -101,9 +101,7 @@ public class StockTabService
         // old query fetched ALL distinct filers market-wide for the quarter —
         // millions of rows — just to build a HashSet. We only need to know
         // whether each "gap" holder filed any 13F this quarter at all.
-        var currentHolderIds = allCurrent
-            .Select(h => h.InstitutionalHolderId)
-            .ToHashSet();
+        var currentHolderIds = allCurrent.Select(h => h.InstitutionalHolderId).ToHashSet();
         var previousOnlyHolderIds = allPrevious
             .Select(h => h.InstitutionalHolderId)
             .Where(id => !currentHolderIds.Contains(id))


### PR DESCRIPTION
## Summary

The `/stocks/{ticker}/holdings` page was extremely slow because the Sold-Out bucket filter fetched ALL distinct filers market-wide for the quarter — a full table scan over millions of rows. Replaced with a targeted query that only checks the small set of holders who were in the previous quarter but absent from the current quarter for the specific stock, hitting the `(InstitutionalHolderId, ReportDate)` composite index efficiently.

## Code changes

- **`src/Equibles.Web/Services/StockTabService.cs`** — Compute the "gap" set (previous-only holder IDs) in memory from already-loaded holdings, then query only those IDs against the current quarter instead of scanning the entire table.