### PR TITLE
perf(web): add Cache-Control headers for static assets

### DIFF
--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -161,7 +161,27 @@ public partial class Program
         }
 
         app.UseResponseCompression();
-        app.UseStaticFiles();
+
+        app.UseStaticFiles(
+            new StaticFileOptions
+            {
+                OnPrepareResponse = ctx =>
+                {
+                    var headers = ctx.Context.Response.Headers;
+
+                    if (ctx.Context.Request.Path.StartsWithSegments("/dist"))
+                    {
+                        // Vite-built assets use asp-append-version (content hash query string),
+                        // so they can be cached indefinitely — a new hash busts the cache on deploy.
+                        headers.CacheControl = "public, max-age=31536000, immutable";
+                    }
+                    else
+                    {
+                        headers.CacheControl = "public, max-age=86400";
+                    }
+                },
+            }
+        );
         app.UseRouting();
         app.UseSession();
         app.UseAuthentication();


### PR DESCRIPTION
## Summary
- Static assets had no `Cache-Control` headers — browsers relied on heuristic caching via ETags, leading to unnecessary conditional requests on every visit.
- Vite-built assets (`/dist/*`) now get `public, max-age=31536000, immutable` since `asp-append-version` provides content-hash cache busting on deploy.
- Other static files (favicons, images) get `public, max-age=86400` (24 hours).

## Code changes
- `src/Equibles.Web/Program.cs` — replaced bare `UseStaticFiles()` with `UseStaticFiles(StaticFileOptions)` using `OnPrepareResponse` to set cache headers based on request path.

## Test plan
- [ ] Verify `/dist/bundle.js` response has `Cache-Control: public, max-age=31536000, immutable`
- [ ] Verify `/favicon/favicon/favicon-32x32.png` response has `Cache-Control: public, max-age=86400`
- [ ] Confirm pages still render correctly