### PR TITLE
test(sec): pin InlineXbrlParser.Parse drops fact when measure has empty local name

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserEmptyMeasureLocalNameTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserEmptyMeasureLocalNameTests.cs
@@ -1,0 +1,44 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InlineXbrlParserEmptyMeasureLocalNameTests
+{
+    private const string DocOpen =
+        "<html "
+        + "xmlns=\"http://www.w3.org/1999/xhtml\" "
+        + "xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\" "
+        + "xmlns:ixt=\"http://www.xbrl.org/inlineXBRL/transformation/2015-02-26\" "
+        + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+        + "xmlns:xbrldi=\"http://xbrl.org/2006/xbrldi\" "
+        + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+        + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2018-01-31\" "
+        + "><body><div style=\"display:none\"><ix:header><ix:resources>";
+
+    private const string ResourcesEnd = "</ix:resources></ix:header></div>";
+
+    private const string DocClose = "</body></html>";
+
+    // StripPrefix's doc comment: "Returns null when the QName has a prefix
+    // but an empty local name (e.g. 'iso4217:'); such a measure is unresolvable."
+    // A fact whose unit is unresolvable must be silently dropped — not recorded
+    // with an empty unit string.
+    [Fact]
+    public void Parse_MeasureWithPrefixColonButEmptyLocalName_DropsFactSilently()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2024-06-30</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"bad\"><xbrli:measure>iso4217:</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<p><ix:nonFraction name=\"us-gaap:Assets\" contextRef=\"C1\" unitRef=\"bad\" decimals=\"-6\">100000</ix:nonFraction></p>"
+            + DocClose;
+
+        var facts = new InlineXbrlParser().Parse(html);
+
+        facts.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the `InlineXbrlParser.Parse` contract when a unit's `xbrli:measure` has a QName prefix followed by a colon but an empty local name (e.g., `"iso4217:"`).
- Confirms the parser silently drops facts referencing such unresolvable units, exercising the `StripPrefix` → `ResolveUnit` → `TryParseFact` null-propagation chain.

## Code changes

- `tests/Equibles.UnitTests/Sec/InlineXbrlParserEmptyMeasureLocalNameTests.cs` — new test class with a single `[Fact]` that feeds an iXBRL document whose only unit has measure text `"iso4217:"` and asserts the parsed facts list is empty.