### PR TITLE
docs(guide): add how-to — view quarterly holdings activity

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -28,6 +28,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Back up and restore your database](how-to-back-up-and-restore.md)
 - [Change the log level for troubleshooting](how-to-change-log-level.md)
 - [Use the 13F holdings screener](how-to-use-holdings-screener.md)
+- [View quarterly holdings activity across the market](how-to-view-holdings-activity.md)
 - [Check worker health and recent errors](how-to-view-status-and-errors.md)
 
 ## FAQ

--- a/docs/guide/how-to-view-holdings-activity.md
+++ b/docs/guide/how-to-view-holdings-activity.md
@@ -1,0 +1,30 @@
+# View quarterly holdings activity across the market
+
+This guide shows you how to use the 13F Quarterly Activity page to see which stocks institutions are buying and selling the most, and which stocks gained or lost institutional holders entirely.
+
+## Open the activity page
+
+1. Go to `http://localhost:8080` and click **Holdings** in the top navigation, then **Activity** (or go directly to `http://localhost:8080/holdings/activity`).
+
+2. The page needs at least two quarters of 13F data to compare. If you see a "No 13F data yet" message, the worker is still backfilling — check back after the initial sync completes.
+
+## Choose a report date
+
+Use the **Report Date** dropdown at the top to pick which quarter to view. The page compares the selected quarter against the previous quarter and ranks stocks by the size of the change.
+
+## Read the four boards
+
+The page shows four ranked boards, each highlighting a different dimension of institutional activity:
+
+| Board | What it shows |
+|-------|--------------|
+| **Top Buys** | Stocks where institutions increased their positions the most by dollar value. These are the largest net purchases across all 13F filers. |
+| **Top Sells** | Stocks where institutions reduced their positions the most by dollar value. These are the largest net sales. |
+| **New Positions** | Stocks that gained the most brand-new institutional holders — institutions that had zero shares in the prior quarter and now hold a position. |
+| **Sold-Out Positions** | Stocks that lost the most institutional holders entirely — institutions that held shares in the prior quarter and now report zero. |
+
+Each board lists stocks ranked by the relevant metric, with the ticker, company name, and the magnitude of the change.
+
+## Export the data
+
+Click **Download CSV** at the top of the page to export all four boards for the selected quarter as a single CSV file.


### PR DESCRIPTION
## Summary

- Adds a new how-to guide for the 13F Quarterly Activity page on the web portal.
- Documents all four activity boards: Top Buys, Top Sells, New Positions, and Sold-Out Positions.
- Covers selecting a report date, reading the ranked boards, and exporting to CSV.
- **Lane**: Expand (guide index bullet + new how-to page).

## Code changes

- `docs/guide/how-to-view-holdings-activity.md` — new how-to page.
- `docs/guide/README.md` — one bullet added under "How-to guides".