### PR TITLE
perf(web): drop unused Inter font weight 300

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Head.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Head.cshtml
@@ -40,7 +40,7 @@
 <!-- Google Fonts - Inter -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 
 <link rel="stylesheet" type="text/css" href="~/dist/main.css" asp-append-version="true" />
 


### PR DESCRIPTION
## Summary
- Font weight 300 (light) is loaded from Google Fonts but never used in any view or source file.
- Removing it reduces the font CSS and WOFF2 download size.

## Code changes
- `src/Equibles.Web/Views/Shared/_Head.cshtml` — removed `300;` from the Google Fonts `wght` parameter.

## Test plan
- [ ] Verify pages render with correct typography (no visual regression)