### PR TITLE
test(sec): pin FiscalPeriodResolver.Resolve quarterly period resolution path

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverQuarterlyResolutionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverQuarterlyResolutionTests.cs
@@ -1,0 +1,29 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+// Lane B (coverage): exercises the quarterly resolution path in Resolve
+// (lines 67-108) — zero-hit today. Existing tests cover annual/instant
+// periods and the FYE-validation guard; the quarter/half/nine-month
+// duration classification and endingFye matching are uncovered.
+public class FiscalPeriodResolverQuarterlyResolutionTests
+{
+    [Fact]
+    public void Resolve_CalendarQ1QuarterPeriod_ReturnsQ1OfCorrectFiscalYear()
+    {
+        // FYE Dec 31, period Jan 1 - Mar 31 = 90 days (within 80-100 quarter range).
+        // Ending FYE = Dec 31, 2024. Prior FYE = Dec 31, 2023. FiscalYearStart = Jan 1, 2024.
+        // MonthsElapsed = Mar - Jan = 2 months. Switch: <= 4 => Q1.
+        var result = FiscalPeriodResolver.Resolve(
+            periodStart: new DateOnly(2024, 1, 1),
+            periodEnd: new DateOnly(2024, 3, 31),
+            fyeMonth: 12,
+            fyeDay: 31
+        );
+
+        result.Should().NotBeNull();
+        result.Value.Year.Should().Be(2024);
+        result.Value.Period.Should().Be(SecFiscalPeriod.Q1);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Lane B (coverage) unit test for `FiscalPeriodResolver.Resolve` exercising the quarterly period resolution path (lines 67–108), which is entirely zero-hit today.
- Existing tests cover annual/instant periods and FYE-validation guards; this test covers the duration classification (`isQuarter`), `endingFye` candidate matching, fiscal-year-start derivation, and the `monthsElapsed` switch for quarter assignment.
- Uses a calendar-year Q1 period (Jan 1 – Mar 31, FYE Dec 31) and asserts both the fiscal year (2024) and the period (Q1).

## Code changes

- `tests/Equibles.UnitTests/Sec/FiscalPeriodResolverQuarterlyResolutionTests.cs` — new test class with a single `[Fact]` covering the quarterly resolution path.