### PR TITLE
fix(web): load bundle.js as ES module to prevent global scope collisions

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Scripts.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Scripts.cshtml
@@ -1,1 +1,1 @@
-<script type="text/javascript" src="~/dist/bundle.js" asp-append-version="true"></script>
+<script type="module" src="~/dist/bundle.js" asp-append-version="true"></script>


### PR DESCRIPTION
## Summary
- The Vite bundle outputs top-level `const` declarations (e.g. `St` from AOS library) that end up in the global scope when loaded as `type="text/javascript"`
- Browser extensions declaring the same minified identifiers cause `SyntaxError: Identifier 'St' has already been declared` on every page load
- Switching to `type="module"` scopes all declarations to the module, eliminating collisions while preserving explicit `window.*` global assignments (`showMessage`, `showLoader`, etc.)

## Code changes
- `src/Equibles.Web/Views/Shared/_Scripts.cshtml`: changed `type="text/javascript"` to `type="module"`

## Test plan
- [ ] Verify no JS console errors on page load (the `SyntaxError: Identifier 'St' has already been declared` should be gone)
- [ ] Verify toast messages still appear (flash messages use pure HTML, not `showMessage()`)
- [ ] Verify form submissions with loader overlay still work
- [ ] Verify AJAX modals open and close correctly
- [ ] Verify AOS scroll animations still trigger