### PR TITLE
test(errors): pin ErrorManager.Truncate surrogate pair boundary handling

### DIFF
--- a/tests/Equibles.UnitTests/Errors/ErrorManagerTruncateSurrogatePairTests.cs
+++ b/tests/Equibles.UnitTests/Errors/ErrorManagerTruncateSurrogatePairTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Equibles.Errors.BusinessLogic;
+
+namespace Equibles.UnitTests.Errors;
+
+// Lane A (adversarial): Truncate's contract says "caps a value to maxLength
+// UTF-16 units WITHOUT splitting a surrogate pair." A surrogate pair that
+// straddles the cut point (high surrogate at maxLength-1) must step back by
+// one, producing a shorter-than-maxLength result rather than a dangling lone
+// surrogate that corrupts the text column and JSON serialization.
+public class ErrorManagerTruncateSurrogatePairTests
+{
+    private static readonly MethodInfo TruncateMethod = typeof(ErrorManager).GetMethod(
+        "Truncate",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    [Fact]
+    public void Truncate_CutPointSplitsSurrogatePair_StepsBackToAvoidDanglingSurrogate()
+    {
+        // U+1F4A5 (COLLISION SYMBOL) is a surrogate pair: 💥 (2 UTF-16 units).
+        // Build a string of 9 ASCII chars + the emoji = 11 UTF-16 units.
+        // Truncate to 10: maxLength-1 = index 9 = \uD83D (high surrogate).
+        // Contract: step back to 9, yielding only the 9 ASCII chars.
+        var input = "123456789\U0001F4A5";
+        input.Length.Should().Be(11);
+
+        var result = (string)TruncateMethod.Invoke(null, [input, 10]);
+
+        result.Should().Be("123456789");
+        result.Length.Should().Be(9);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Lane A (adversarial) test for `ErrorManager.Truncate` — the private static method that caps strings to a max length without splitting UTF-16 surrogate pairs.
- Verifies that when a cut point lands on a high surrogate (index `maxLength - 1`), the method steps back by one to avoid producing a dangling lone surrogate that would corrupt the text column and JSON serialization.
- Uses a 9-ASCII-char + one emoji (U+1F4A5, 2 UTF-16 units = 11 total) string truncated to 10, asserting the result is 9 chars (the emoji is excluded entirely).

## Code changes

- `tests/Equibles.UnitTests/Errors/ErrorManagerTruncateSurrogatePairTests.cs` — new test class with a single `[Fact]` verifying surrogate-safe truncation.