### PR TITLE
fix(holdings): remove Prior → New column from top movers cards

### DIFF
--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -118,7 +118,6 @@
                                             <th scope="col">Institution</th>
                                             <th scope="col" class="text-right">Δ Shares</th>
                                             <th scope="col" class="text-right hidden md:table-cell">Δ Value (USD)</th>
-                                            <th scope="col" class="text-right hidden lg:table-cell">Prior → New</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -131,7 +130,6 @@
                                                 <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
                                                 <td class="text-right font-mono @deltaSharesCss">@deltaSharesText</td>
                                                 <td class="text-right font-mono hidden md:table-cell @deltaValueCss">@deltaValueText</td>
-                                                <td class="text-right font-mono hidden lg:table-cell text-base-content/60 whitespace-nowrap">@e.PreviousShares.ToString("N0") → @e.CurrentShares.ToString("N0")</td>
                                             </tr>
                                         }
                                     </tbody>


### PR DESCRIPTION
## Summary
- The Top Buyers / Top Sellers summary cards clip content when side-by-side at lg breakpoint — the table (745px) overflows the card container (544px) with no visible scrollbar on macOS
- Removed the "Prior → New" column from these summary cards since the same data is already shown in the expanded All Holders table below
- The remaining 3 columns (Institution, Δ Shares, Δ Value) fit within the card width

## Code changes
- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml`: removed "Prior → New" `<th>` and `<td>` from the top movers card table

## Test plan
- [ ] Verify Top Buyers and Top Sellers cards no longer clip content at the right edge
- [ ] Verify the expanded All Holders table still shows all columns including Prior/Current shares
- [ ] Verify mobile layout (single column) still looks correct