### PR TITLE
test(common-stocks): pin CommonStockManager.SetCusip event publishing on change

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetCusipTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetCusipTests.cs
@@ -1,0 +1,54 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Messaging.Contracts.CommonStocks;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+// Lane B (coverage): exercises SetCusip — zero-hit today. The contract
+// (doc-comment) says: "When the value actually changes, publishes
+// StockCusipChanged. A no-op change publishes nothing."
+public class CommonStockManagerSetCusipTests
+{
+    private static EquiblesDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new EquiblesDbContext(options, [new CommonStocksModuleConfiguration()]);
+    }
+
+    [Fact]
+    public async Task SetCusip_NewValueDifferentFromCurrent_PublishesEventAndSaves()
+    {
+        var db = NewDb();
+        var repo = Substitute.For<CommonStockRepository>(db);
+        var publishEndpoint = Substitute.For<IPublishEndpoint>();
+        var sut = new CommonStockManager(repo, publishEndpoint);
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple",
+            Cusip = "037833100",
+        };
+
+        await sut.SetCusip(stock, "594918104");
+
+        stock.Cusip.Should().Be("594918104");
+        await publishEndpoint
+            .Received(1)
+            .Publish(
+                Arg.Is<StockCusipChanged>(e =>
+                    e.CommonStockId == stock.Id
+                    && e.PreviousCusip == "037833100"
+                    && e.Cusip == "594918104"
+                )
+            );
+        await repo.Received(1).SaveChanges();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Lane B (coverage) unit test for `CommonStockManager.SetCusip` — previously zero-hit.
- Verifies the contract: when the CUSIP actually changes, the method publishes a `StockCusipChanged` event (with correct previous/new CUSIP and stock ID), mutates the entity, and saves.
- Uses the established test pattern from sibling `SetFiscalYearEnd` tests: in-memory `EquiblesDbContext` + NSubstitute mock on `CommonStockRepository` and `IPublishEndpoint`.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetCusipTests.cs` — new test class with a single `[Fact]` covering the change-and-publish path.