### PR TITLE
test(web): pin HeroIcons.Render outline SVG generation with custom class

### DIFF
--- a/tests/Equibles.UnitTests/Web/HeroIconsRenderTests.cs
+++ b/tests/Equibles.UnitTests/Web/HeroIconsRenderTests.cs
@@ -1,0 +1,28 @@
+using Equibles.Web.TagHelpers;
+
+namespace Equibles.UnitTests.Web;
+
+// Lane B (coverage): exercises HeroIcons.Render — entirely zero-hit today.
+// Covers the outline path (stroke attributes, fill="none"), the size class
+// injection, and the custom CSS class append.
+public class HeroIconsRenderTests
+{
+    [Fact]
+    public void Render_KnownOutlineIcon_ProducesWellFormedSvgWithStrokeAttributes()
+    {
+        var svg = HeroIcons.Render(
+            "plus",
+            HeroIcons.IconStyle.Outline,
+            size: "5",
+            cssClass: "text-red-500"
+        );
+
+        svg.Should().StartWith("<svg ");
+        svg.Should().Contain("class=\"size-5 inline-block shrink-0 text-red-500\"");
+        svg.Should().Contain("fill=\"none\"");
+        svg.Should().Contain("stroke=\"currentColor\"");
+        svg.Should().Contain("stroke-width=\"1.5\"");
+        svg.Should().Contain("stroke-linecap=\"round\"");
+        svg.Should().EndWith("</svg>");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Lane B (coverage) unit test for `HeroIcons.Render` — the static SVG generator, previously entirely untested.
- Exercises the outline style path (stroke attributes, `fill="none"`), size class injection, and custom CSS class append.
- Asserts well-formed SVG output with all expected attributes for a known icon ("plus").

## Code changes

- `tests/Equibles.UnitTests/Web/HeroIconsRenderTests.cs` — new test class with a single `[Fact]` covering outline SVG rendering.