### PR TITLE
test(web): pin HeroIcons.Get solid-to-outline fallback for outline-only icons

### DIFF
--- a/tests/Equibles.UnitTests/Web/HeroIconsGetSolidFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Web/HeroIconsGetSolidFallbackTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Web.TagHelpers;
+
+namespace Equibles.UnitTests.Web;
+
+// Lane A (adversarial): Get's contract is "look up by name+style; if the
+// requested style doesn't exist, fall back to the outline variant." The
+// sibling Render test only exercises an icon that has both variants, so the
+// fallback branch is untested. A refactor that drops the GetValueOrDefault
+// fallback (e.g. replacing the ternary with a direct TryGetValue return)
+// would silently turn every outline-only icon invisible when requested as
+// solid — the tag helper renders nothing for an empty path.
+public class HeroIconsGetSolidFallbackTests
+{
+    [Fact]
+    public void Get_SolidRequestedButOnlyOutlineExists_ReturnsOutlinePathData()
+    {
+        // "circle-stack" has only an outline variant in the Icons dictionary.
+        var outlinePath = HeroIcons.Get("circle-stack", HeroIcons.IconStyle.Outline);
+        var solidPath = HeroIcons.Get("circle-stack", HeroIcons.IconStyle.Solid);
+
+        outlinePath.Should().NotBeNullOrEmpty();
+        solidPath.Should().Be(outlinePath);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Lane A (adversarial) test for `HeroIcons.Get` — the solid-to-outline fallback branch that fires when an icon exists only as outline.
- A refactor that drops the `GetValueOrDefault` fallback would silently turn every outline-only icon invisible when requested as solid — the tag helper renders nothing for an empty path.
- Uses "circle-stack" (outline-only in the icon dictionary) and asserts that requesting it as solid returns the same path data as requesting it as outline.

## Code changes

- `tests/Equibles.UnitTests/Web/HeroIconsGetSolidFallbackTests.cs` — new test class with a single `[Fact]` verifying the fallback path.