### PR TITLE
test(web): pin HeroIcons.Render solid SVG fill and no-stroke attributes

### DIFF
--- a/tests/Equibles.UnitTests/Web/HeroIconsRenderSolidTests.cs
+++ b/tests/Equibles.UnitTests/Web/HeroIconsRenderSolidTests.cs
@@ -1,0 +1,21 @@
+using Equibles.Web.TagHelpers;
+
+namespace Equibles.UnitTests.Web;
+
+// Lane B (coverage): exercises the solid branch of HeroIcons.Render — the
+// sibling test covers outline only. Solid SVGs use fill="currentColor" and
+// omit stroke attributes; a regression that hardcodes the outline attributes
+// would produce double-rendered icons (filled AND stroked).
+public class HeroIconsRenderSolidTests
+{
+    [Fact]
+    public void Render_SolidIcon_ProducesSvgWithFillAndNoStroke()
+    {
+        var svg = HeroIcons.Render("plus", HeroIcons.IconStyle.Solid);
+
+        svg.Should().Contain("fill=\"currentColor\"");
+        svg.Should().NotContain("stroke=");
+        svg.Should().NotContain("stroke-linecap");
+        svg.Should().Contain("class=\"size-6 inline-block shrink-0\"");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Lane B (coverage) test for `HeroIcons.Render` solid branch — the sibling test only covers outline.
- Verifies that solid SVGs use `fill="currentColor"`, omit stroke attributes, and default to `size-6` with no custom CSS class.
- A regression that hardcodes outline attributes for all styles would produce double-rendered icons (filled AND stroked).

## Code changes

- `tests/Equibles.UnitTests/Web/HeroIconsRenderSolidTests.cs` — new test class with a single `[Fact]` covering the solid rendering path.