### PR TITLE
test(common-stocks): pin FiscalCalendar GetPeriod ↔ GetQuarterEndDate round-trip identity

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarRoundTripTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarRoundTripTests.cs
@@ -1,0 +1,35 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Contract from the GetQuarterEndDate doc comment: "Round-trips with GetPeriod:
+/// GetPeriod(GetQuarterEndDate(y, q, m), m) == new FiscalPeriod(y, q)."
+/// This property must hold for every valid (year, quarter, month) triple —
+/// failure means the two methods disagree on period boundaries, which would
+/// silently mislabel financial data for off-calendar filers.
+/// </summary>
+public class FiscalCalendarRoundTripTests
+{
+    [Fact]
+    public void GetPeriodOfQuarterEndDate_AllMonthsAllQuarters_RoundTrips()
+    {
+        const int testYear = 2025;
+        for (var month = 1; month <= 12; month++)
+        {
+            for (var quarter = 1; quarter <= 4; quarter++)
+            {
+                var endDate = FiscalCalendar.GetQuarterEndDate(testYear, quarter, month);
+                var roundTripped = FiscalCalendar.GetPeriod(endDate, month);
+
+                roundTripped
+                    .Should()
+                    .Be(
+                        new FiscalPeriod(testYear, quarter),
+                        $"month={month} quarter={quarter} → endDate={endDate}"
+                    );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the documented round-trip contract: `GetPeriod(GetQuarterEndDate(y, q, m), m) == new FiscalPeriod(y, q)` for all 48 valid `(quarter, fiscalYearEndMonth)` combinations.
- Catches any future regression where the two methods disagree on period boundaries — would silently mislabel financial data for off-calendar filers (~40% of S&P 500).

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/FiscalCalendarRoundTripTests.cs` — new test exhaustively verifying the round-trip property across all 12 fiscal-year-end months × 4 quarters.