### PR TITLE
test(common-stocks): add skipped repro for GH-1873 — FiscalCalendar year underflow

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarQuarterEndDateYearUnderflowTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarQuarterEndDateYearUnderflowTests.cs
@@ -1,0 +1,27 @@
+using Equibles.CommonStocks.BusinessLogic;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Contract: GetQuarterEndDate accepts any (fiscalYear, fiscalQuarter,
+/// fiscalYearEndMonth) triple and returns a valid DateOnly. For off-calendar
+/// filers the quarter-end walks backwards from the FYE month, and for Q1 of
+/// fiscal year 1 with a non-December FYE, that walk reaches calendar year 0
+/// — which is outside DateOnly's valid range (year 1–9999). The method should
+/// either reject the input or clamp gracefully, not throw an unhandled
+/// ArgumentOutOfRangeException from the DateOnly constructor.
+/// </summary>
+public class FiscalCalendarQuarterEndDateYearUnderflowTests
+{
+    [Fact(Skip = "GH-1873 — GetQuarterEndDate year underflow to calendar year 0")]
+    public void GetQuarterEndDate_FiscalYear1MarchFyeQ1_DoesNotThrow()
+    {
+        // March FYE: Q1 ends in June of the PREVIOUS calendar year (fiscalYear - 1 = 0).
+        var act = () => FiscalCalendar.GetQuarterEndDate(1, 1, 3);
+
+        act.Should()
+            .NotThrow(
+                "GetQuarterEndDate should handle fiscal year 1 gracefully when the quarter walks to calendar year 0"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- `FiscalCalendar.GetQuarterEndDate(1, 1, 3)` throws `ArgumentOutOfRangeException` — the quarter-end computation walks to calendar year 0, outside `DateOnly`'s valid range.
- Added a skipped adversarial test reproducing the bug — see GH-1873 for the fix.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/FiscalCalendarQuarterEndDateYearUnderflowTests.cs` — new test asserting `GetQuarterEndDate` does not throw for fiscal year 1 with a non-December FYE; skipped pending GH-1873 fix.