### PR TITLE
fix(cboe): correct VIX put/call CSV column mapping

### DIFF
--- a/src/Equibles.Integrations.Cboe/CboeClient.cs
+++ b/src/Equibles.Integrations.Cboe/CboeClient.cs
@@ -42,7 +42,7 @@ public class CboeClient : ICboeClient
         _logger.LogDebug("Downloading CBOE put/call ratios from {Url}", url);
 
         var content = await DownloadWithRetry(url);
-        return ParsePutCallCsv(content);
+        return ParsePutCallCsv(content, csvType);
     }
 
     public async Task<List<CboeVixRecord>> DownloadVixHistory()
@@ -99,8 +99,14 @@ public class CboeClient : ICboeClient
     private static TimeSpan ExponentialBackoff(int attempt) =>
         TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
 
-    private static List<CboePutCallRecord> ParsePutCallCsv(string content)
+    // The VIX CSV ships columns in a different order than all other put/call
+    // CSVs: Date,Ratio,PutVol,CallVol,TotalVol vs Date,CallVol,PutVol,TotalVol,Ratio.
+    private static List<CboePutCallRecord> ParsePutCallCsv(
+        string content,
+        CboePutCallCsvType csvType
+    )
     {
+        var isVix = csvType == CboePutCallCsvType.Vix;
         var records = new List<CboePutCallRecord>();
         foreach (var fields in EnumerateCsvRows(content, minFields: 5))
         {
@@ -119,10 +125,10 @@ public class CboeClient : ICboeClient
                 new CboePutCallRecord
                 {
                     Date = date,
-                    CallVolume = ParseLong(fields[1]),
+                    CallVolume = ParseLong(fields[isVix ? 3 : 1]),
                     PutVolume = ParseLong(fields[2]),
-                    TotalVolume = ParseLong(fields[3]),
-                    PutCallRatio = ParseDecimal(fields[4]),
+                    TotalVolume = ParseLong(fields[isVix ? 4 : 3]),
+                    PutCallRatio = ParseDecimal(fields[isVix ? 1 : 4]),
                 }
             );
         }

--- a/tests/Equibles.UnitTests/Integrations/CboeClientTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientTests.cs
@@ -34,7 +34,9 @@ public class CboeClientTests
             + "Disclaimer: data provided by CBOE,,,,\n"
             + "01/15/2025,100000,80000,200000,0.80\n";
 
-        var records = (List<CboePutCallRecord>)ParsePutCallCsvMethod.Invoke(null, [csv]);
+        var records =
+            (List<CboePutCallRecord>)
+                ParsePutCallCsvMethod.Invoke(null, [csv, CboePutCallCsvType.Total]);
 
         records.Should().ContainSingle().Which.Date.Should().Be(new DateOnly(2025, 1, 15));
     }
@@ -74,7 +76,9 @@ public class CboeClientTests
             + "01/15/2025,100\n"
             + "01/16/2025,100000,80000,200000,0.80\n";
 
-        var records = (List<CboePutCallRecord>)ParsePutCallCsvMethod.Invoke(null, [csv]);
+        var records =
+            (List<CboePutCallRecord>)
+                ParsePutCallCsvMethod.Invoke(null, [csv, CboePutCallCsvType.Total]);
 
         records.Should().ContainSingle().Which.Date.Should().Be(new DateOnly(2025, 1, 16));
     }
@@ -227,7 +231,9 @@ public class CboeClientTests
         var csv =
             "Date,Call Volume,Put Volume,Total Volume,P/C Ratio\n" + "12/25/2024,100,200,300,2.0\n";
 
-        var records = (List<CboePutCallRecord>)ParsePutCallCsvMethod.Invoke(null, [csv]);
+        var records =
+            (List<CboePutCallRecord>)
+                ParsePutCallCsvMethod.Invoke(null, [csv, CboePutCallCsvType.Total]);
 
         records.Should().ContainSingle();
         var record = records[0];

--- a/tests/Equibles.UnitTests/Integrations/CboeClientVixPutCallColumnOrderTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientVixPutCallColumnOrderTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Equibles.Integrations.Cboe;
+using Equibles.Integrations.Cboe.Models;
+
+namespace Equibles.UnitTests.Integrations;
+
+// The VIX CSV column layout differs from all other put/call CSVs:
+// VIX:   Date, Ratio, PutVol, CallVol, TotalVol
+// Other: Date, CallVol, PutVol, TotalVol, Ratio
+// ParsePutCallCsv must swap indices when csvType is Vix.
+public class CboeClientVixPutCallColumnOrderTests
+{
+    private static readonly MethodInfo ParsePutCallCsvMethod = typeof(CboeClient).GetMethod(
+        "ParsePutCallCsv",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    [Fact]
+    public void ParsePutCallCsv_VixCsvType_MapsRatioFromFieldOneNotFieldFour()
+    {
+        var csv =
+            "Date,VIX Put/Call Ratio,VIX Put Volume,VIX Call Volume,Total VIX Options Volume\n"
+            + "01/02/2020,1.18,5095,4328,9423\n";
+
+        var records =
+            (List<CboePutCallRecord>)
+                ParsePutCallCsvMethod.Invoke(null, [csv, CboePutCallCsvType.Vix]);
+
+        records.Should().ContainSingle();
+        var record = records[0];
+        record.Date.Should().Be(new DateOnly(2020, 1, 2));
+        record.PutCallRatio.Should().Be(1.18m);
+        record.PutVolume.Should().Be(5095);
+        record.CallVolume.Should().Be(4328);
+        record.TotalVolume.Should().Be(9423);
+    }
+}


### PR DESCRIPTION
## Summary

- The VIX CSV from CBOE uses column order `Date, Ratio, PutVol, CallVol, TotalVol` — different from all other put/call CSVs (`Date, CallVol, PutVol, TotalVol, Ratio`).
- `ParsePutCallCsv` treated all types identically, storing VIX total volume (e.g. 401,141) as the put/call ratio and the actual ratio (e.g. 1.18) as call volume — visible as "P/C Ratio: 401,141.00" on the Market Indicators page.
- Added `csvType` parameter to `ParsePutCallCsv` and swapped field indices when `csvType == Vix`.

## Code changes

- `src/Equibles.Integrations.Cboe/CboeClient.cs` — `ParsePutCallCsv` now accepts `CboePutCallCsvType` and maps VIX columns to fields[1]=ratio, fields[2]=put, fields[3]=call, fields[4]=total (vs the standard fields[1]=call, fields[2]=put, fields[3]=total, fields[4]=ratio).
- `tests/Equibles.UnitTests/Integrations/CboeClientTests.cs` — updated existing reflection calls to pass the new `csvType` parameter.
- `tests/Equibles.UnitTests/Integrations/CboeClientVixPutCallColumnOrderTests.cs` — new test verifying VIX CSV parses ratio from field[1] with correct volume mapping.