### PR TITLE
feat(holdings): add recent filings query with new-filer detection

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -141,6 +141,60 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             });
     }
 
+    // Recent filings feed: groups holdings by accession number to produce one row
+    // per filing, ordered by import timestamp. Joins InstitutionalHolder for filer
+    // metadata and uses a NOT EXISTS subquery to flag first-time filers (no holdings
+    // from any earlier report date).
+    public IQueryable<RecentFiling> GetRecentFilings()
+    {
+        var filings = GetAll()
+            .GroupBy(h => new
+            {
+                h.AccessionNumber,
+                h.InstitutionalHolderId,
+                h.FilingDate,
+                h.ReportDate,
+                h.IsAmendment,
+            })
+            .Select(g => new
+            {
+                g.Key.AccessionNumber,
+                g.Key.InstitutionalHolderId,
+                g.Key.FilingDate,
+                g.Key.ReportDate,
+                g.Key.IsAmendment,
+                PositionCount = g.Count(),
+                TotalValue = g.Sum(h => h.Value),
+                ImportedAt = g.Min(h => h.CreationTime),
+            });
+
+        return filings.Join(
+            DbContext.Set<InstitutionalHolder>(),
+            f => f.InstitutionalHolderId,
+            h => h.Id,
+            (f, h) =>
+                new RecentFiling
+                {
+                    AccessionNumber = f.AccessionNumber,
+                    InstitutionalHolderId = f.InstitutionalHolderId,
+                    FilerName = h.Name,
+                    FilerCik = h.Cik,
+                    FilingDate = f.FilingDate,
+                    ReportDate = f.ReportDate,
+                    PositionCount = f.PositionCount,
+                    TotalValue = f.TotalValue,
+                    IsAmendment = f.IsAmendment,
+                    ImportedAt = f.ImportedAt,
+                    IsNewFiler = !DbContext
+                        .Set<InstitutionalHolding>()
+                        .Any(prior =>
+                            prior.InstitutionalHolderId == f.InstitutionalHolderId
+                            && prior.ReportDate < f.ReportDate
+                        ),
+                }
+        );
+    }
+
     // Cross-sectional 13F screener. Aggregates per-stock filer-count / total-value /
     // new-position / sold-out-position metrics across the two snapshots in a single SQL
     // round trip, joins CommonStock + Industry for display columns and the % of float

--- a/src/Equibles.Holdings.Repositories/Models/RecentFiling.cs
+++ b/src/Equibles.Holdings.Repositories/Models/RecentFiling.cs
@@ -1,0 +1,16 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class RecentFiling
+{
+    public string AccessionNumber { get; set; }
+    public Guid InstitutionalHolderId { get; set; }
+    public string FilerName { get; set; }
+    public string FilerCik { get; set; }
+    public DateOnly FilingDate { get; set; }
+    public DateOnly ReportDate { get; set; }
+    public int PositionCount { get; set; }
+    public long TotalValue { get; set; }
+    public bool IsAmendment { get; set; }
+    public DateTime ImportedAt { get; set; }
+    public bool IsNewFiler { get; set; }
+}


### PR DESCRIPTION
## Summary
- Slice 1/2 for #1848 (latest 13F filings feed)
- Adds `GetRecentFilings()` to `InstitutionalHoldingRepository` — groups holdings by accession number, computes per-filing aggregates (position count, total value, amendment flag), joins `InstitutionalHolder` for filer metadata, and flags first-time CIKs via a `NOT EXISTS` subquery
- Adds `RecentFiling` DTO in `Equibles.Holdings.Repositories.Models`

## Code changes
- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — new `GetRecentFilings()` method returning `IQueryable<RecentFiling>`
- `src/Equibles.Holdings.Repositories/Models/RecentFiling.cs` — DTO for per-filing aggregated data

Refs #1848