### PR TITLE
test(common-stocks): add skipped repro for GH-1884 — FiscalCalendar.GetPeriod year overflow

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarGetPeriodYearOverflowTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarGetPeriodYearOverflowTests.cs
@@ -1,0 +1,22 @@
+using Equibles.CommonStocks.BusinessLogic;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Contract: GetPeriod computes fiscalYear = date.Year + 1 when the date falls
+/// after the FYE month. For DateOnly.MaxValue (Dec 31, 9999) with a non-December
+/// FYE, this produces fiscal year 10000 — outside DateOnly's supported range
+/// (1–9999) and impossible to round-trip through GetQuarterEndDate, which guards
+/// against the same overflow. GetPeriod should reject the overflow consistently.
+/// </summary>
+public class FiscalCalendarGetPeriodYearOverflowTests
+{
+    [Fact(Skip = "GH-1884 — GetPeriod year overflow to fiscal year 10000")]
+    public void GetPeriod_MaxValueDateWithNonDecemberFye_ThrowsArgumentOutOfRange()
+    {
+        // Dec 31, 9999 with June FYE: fiscalYear = 9999 + 1 = 10000.
+        var act = () => FiscalCalendar.GetPeriod(DateOnly.MaxValue, fiscalYearEndMonth: 6);
+
+        act.Should().ThrowExactly<ArgumentOutOfRangeException>().WithParameterName("date");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped adversarial test reproducing GH-1884: `FiscalCalendar.GetPeriod(DateOnly.MaxValue, fiscalYearEndMonth: 6)` silently returns `FiscalPeriod(10000, 2)` instead of throwing — the `date.Year + 1` computation overflows `DateOnly`'s supported range.
- Test is `[Fact(Skip = "GH-1884 — ...")]` — un-skip as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/FiscalCalendarGetPeriodYearOverflowTests.cs` — new test asserting `GetPeriod` throws `ArgumentOutOfRangeException` on `date` when the computed fiscal year exceeds 9999; skipped — see GH-1884.