### PR TITLE
fix(common-stocks): guard GetPeriod against fiscal year overflow past 9999

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/FiscalCalendar.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/FiscalCalendar.cs
@@ -41,6 +41,15 @@ public static class FiscalCalendar
         // calendar year; a date after it belongs to the one ending next year.
         var fiscalYear = date.Month <= fiscalYearEndMonth ? date.Year : date.Year + 1;
 
+        if (fiscalYear > 9999)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(date),
+                date,
+                "The resulting fiscal year falls outside DateOnly's supported range (1–9999)."
+            );
+        }
+
         var fiscalStartMonth = fiscalYearEndMonth % 12 + 1;
         var monthsIntoYear = (date.Month - fiscalStartMonth + 12) % 12;
         var quarter = monthsIntoYear / MonthsPerQuarter + 1;

--- a/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarGetPeriodYearOverflowTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/FiscalCalendarGetPeriodYearOverflowTests.cs
@@ -11,7 +11,7 @@ namespace Equibles.UnitTests.CommonStocks;
 /// </summary>
 public class FiscalCalendarGetPeriodYearOverflowTests
 {
-    [Fact(Skip = "GH-1884 — GetPeriod year overflow to fiscal year 10000")]
+    [Fact]
     public void GetPeriod_MaxValueDateWithNonDecemberFye_ThrowsArgumentOutOfRange()
     {
         // Dec 31, 9999 with June FYE: fiscalYear = 9999 + 1 = 10000.


### PR DESCRIPTION
## Summary

- `FiscalCalendar.GetPeriod` computed `fiscalYear = date.Year + 1` when the date falls after the FYE month, silently producing fiscal year 10000 for `DateOnly.MaxValue` with a non-December FYE — outside `DateOnly`'s supported range and impossible to round-trip through `GetQuarterEndDate`.
- Added a guard after the fiscal year computation that throws `ArgumentOutOfRangeException` on the `date` parameter when the result exceeds 9999, consistent with `GetQuarterEndDate`'s existing guard.
- Enabled the skipped regression test from GH-1884.

Closes #1884

## Code changes

- `src/Equibles.CommonStocks.BusinessLogic/FiscalCalendar.cs` — added `fiscalYear > 9999` guard after line 42, throwing `ArgumentOutOfRangeException` on `date`.
- `tests/Equibles.UnitTests/CommonStocks/FiscalCalendarGetPeriodYearOverflowTests.cs` — removed `Skip` to enable the regression test.