### PR TITLE
fix(congress): prevent Truncate from splitting surrogate pairs

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -205,8 +205,14 @@ public static partial class DisclosureParsingHelper
     private static string GetCleanCell(List<string> cells, int index) =>
         CleanSentinel(GetCell(cells, index));
 
-    public static string Truncate(string value, int maxLength) =>
-        value?.Length > maxLength ? value[..maxLength] : value;
+    public static string Truncate(string value, int maxLength)
+    {
+        if (value == null || value.Length <= maxLength)
+            return value;
+
+        var end = char.IsHighSurrogate(value[maxLength - 1]) ? maxLength - 1 : maxLength;
+        return value[..end];
+    }
 
     public static DateOnly? ParseDate(string text)
     {

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateSurrogatePairTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateSurrogatePairTests.cs
@@ -15,7 +15,7 @@ namespace Equibles.UnitTests.Congress;
 public class DisclosureParsingHelperTruncateSurrogatePairTests
 {
     // Truncate should not produce a string containing an unpaired surrogate.
-    [Fact(Skip = "GH-1885 — Truncate splits surrogate pairs")]
+    [Fact]
     public void Truncate_MaxLengthSplitsSurrogatePair_ResultContainsNoOrphanSurrogate()
     {
         // "🏛" (U+1F3DB, Classical Building) is a surrogate pair: 🏛


### PR DESCRIPTION
## Summary

- `DisclosureParsingHelper.Truncate` used `value[..maxLength]` which counts UTF-16 code units, splitting surrogate pairs (emoji, CJK Extension B) and producing orphan surrogates that corrupt on PostgreSQL/JSON round-trips.
- Applied the same fix pattern already established in `ErrorManager.Truncate` (GH-1838): back off by one code unit when `maxLength` lands on a high surrogate.
- Enabled the skipped regression test from GH-1885.

Closes #1885

## Code changes

- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — expanded expression-bodied `Truncate` into a method body with a `char.IsHighSurrogate` guard before slicing.
- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateSurrogatePairTests.cs` — removed `Skip` to enable the regression test.