### PR TITLE
feat(holdings): add latest 13F filings page with new-filer badges

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -93,6 +93,29 @@ public class HoldingsActivityController : BaseController
         return View(viewModel);
     }
 
+    [HttpGet("~/holdings/filings")]
+    public async Task<IActionResult> LatestFilings(int page = 1)
+    {
+        if (page < 1)
+            page = 1;
+
+        var query = _holdingRepository.GetRecentFilings().OrderByDescending(f => f.ImportedAt);
+
+        var totalCount = await query.CountAsync();
+        var skip = (page - 1) * LatestFilingsViewModel.PageSize;
+
+        var filings = await query.Skip(skip).Take(LatestFilingsViewModel.PageSize).ToListAsync();
+
+        return View(
+            new LatestFilingsViewModel
+            {
+                Filings = filings,
+                Page = page,
+                TotalCount = totalCount,
+            }
+        );
+    }
+
     [HttpGet("~/Holdings/MostHeld")]
     public async Task<IActionResult> MostHeld(DateOnly? date, string sort, int page = 1)
     {

--- a/src/Equibles.Web/ViewModels/Holdings/LatestFilingsViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/LatestFilingsViewModel.cs
@@ -1,0 +1,13 @@
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Web.ViewModels.Holdings;
+
+public class LatestFilingsViewModel
+{
+    public const int PageSize = 50;
+
+    public List<RecentFiling> Filings { get; set; } = [];
+    public int Page { get; set; } = 1;
+    public int TotalCount { get; set; }
+    public int TotalPages => Math.Max(1, (TotalCount + PageSize - 1) / PageSize);
+}

--- a/src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml
@@ -1,0 +1,128 @@
+@using Equibles.Web.ViewModels.Holdings
+@model LatestFilingsViewModel
+
+@{
+    ViewData["Title"] = "Latest 13F Filings";
+    ViewData["Description"] = "Most recently imported SEC 13F-HR filings, ordered by import timestamp. First-time filers are flagged.";
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold mb-2">Latest 13F Filings</h1>
+        <p class="text-base-content/60">
+            @Model.TotalCount.ToString("N0") filings imported
+        </p>
+    </div>
+
+    <!-- Results Table -->
+    <div class="card bg-base-100 shadow-sm">
+        <div class="overflow-x-auto">
+            <table class="table table-zebra table-sm" aria-label="Latest 13F filings" data-testid="latest-filings-table">
+                <thead>
+                    <tr>
+                        <th scope="col">Filer</th>
+                        <th scope="col" class="hidden md:table-cell">CIK</th>
+                        <th scope="col" class="text-right">Positions</th>
+                        <th scope="col" class="text-right hidden md:table-cell">Value ($M)</th>
+                        <th scope="col" class="hidden lg:table-cell">Report Date</th>
+                        <th scope="col" class="hidden xl:table-cell">Filed</th>
+                        <th scope="col" class="hidden lg:table-cell">Imported</th>
+                        <th scope="col" class="w-8"><span class="sr-only">Open</span></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var filing in Model.Filings) {
+                        <tr class="hover cursor-pointer filing-row"
+                            data-href="@Url.Action("Institution", "Profiles", new { cik = filing.FilerCik })">
+                            <td class="max-w-xs">
+                                <div class="flex items-center gap-2">
+                                    <a asp-action="Institution" asp-controller="Profiles" asp-route-cik="@filing.FilerCik"
+                                       class="font-semibold link link-primary truncate">@filing.FilerName</a>
+                                    @if (filing.IsNewFiler) {
+                                        <span class="badge badge-info badge-xs whitespace-nowrap" title="First 13F filing for this CIK">New</span>
+                                    }
+                                    @if (filing.IsAmendment) {
+                                        <span class="badge badge-warning badge-xs" title="Amended filing (13F-HR/A)">A</span>
+                                    }
+                                </div>
+                            </td>
+                            <td class="hidden md:table-cell font-mono text-sm text-base-content/60">@filing.FilerCik</td>
+                            <td class="text-right font-mono">@filing.PositionCount.ToString("N0")</td>
+                            <td class="text-right font-mono hidden md:table-cell">@((filing.TotalValue / 1_000_000m).ToString("N1"))</td>
+                            <td class="hidden lg:table-cell text-sm text-base-content/60">@filing.ReportDate.ToString("MMM dd, yyyy")</td>
+                            <td class="hidden xl:table-cell text-sm text-base-content/60">@filing.FilingDate.ToString("MMM dd, yyyy")</td>
+                            <td class="hidden lg:table-cell text-sm text-base-content/60">@filing.ImportedAt.ToString("MMM dd, yyyy HH:mm")</td>
+                            <td class="text-base-content/30">
+                                <icon name="chevron-right" size="4" />
+                            </td>
+                        </tr>
+                    }
+                    @if (Model.Filings.Count == 0) {
+                        <tr>
+                            <td colspan="8" class="text-center py-10 text-base-content/60">
+                                No 13F filings have been imported yet. The feed populates once the worker finishes its first 13F cycle.
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- Pagination -->
+    @if (Model.TotalPages > 1) {
+        <nav class="flex justify-center mt-6" aria-label="Filings pagination" data-testid="filings-pager">
+            <div class="join">
+                @if (Model.Page > 1) {
+                    <a asp-action="LatestFilings" asp-route-page="@(Model.Page - 1)"
+                       class="join-item btn btn-sm" aria-label="Go to previous page">Previous</a>
+                }
+
+                @{
+                    var startPage = Math.Max(1, Model.Page - 2);
+                    var endPage = Math.Min(Model.TotalPages, Model.Page + 2);
+                }
+
+                @if (startPage > 1) {
+                    <a asp-action="LatestFilings" asp-route-page="1"
+                       class="join-item btn btn-sm" aria-label="Go to page 1">1</a>
+                    @if (startPage > 2) {
+                        <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
+                    }
+                }
+
+                @for (var i = startPage; i <= endPage; i++) {
+                    <a asp-action="LatestFilings" asp-route-page="@i"
+                       class="join-item btn btn-sm @(i == Model.Page ? "btn-active" : "")"
+                       aria-label="Go to page @i"
+                       aria-current="@(i == Model.Page ? "page" : null)">@i</a>
+                }
+
+                @if (endPage < Model.TotalPages) {
+                    @if (endPage < Model.TotalPages - 1) {
+                        <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
+                    }
+                    <a asp-action="LatestFilings" asp-route-page="@Model.TotalPages"
+                       class="join-item btn btn-sm" aria-label="Go to page @Model.TotalPages">@Model.TotalPages</a>
+                }
+
+                @if (Model.Page < Model.TotalPages) {
+                    <a asp-action="LatestFilings" asp-route-page="@(Model.Page + 1)"
+                       class="join-item btn btn-sm" aria-label="Go to next page">Next</a>
+                }
+            </div>
+        </nav>
+    }
+</div>
+
+@section Scripts {
+    <script>
+    // Row-click navigation
+    document.querySelectorAll('.filing-row').forEach(function(row) {
+        row.addEventListener('click', function(e) {
+            if (e.target.closest('a')) return;
+            window.location.href = this.dataset.href;
+        });
+    });
+    </script>
+}

--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -42,6 +42,7 @@
                             class="dropdown-content menu bg-base-100 rounded-box z-50 w-56 p-2 shadow-lg border border-base-200 mt-2">
                             <!-- No icons — the top nav peers (Home/Stocks/Institutions/MCP/Status)
                                  are text-only, and the desktop dropdown should match. -->
+                            <li><a asp-action="LatestFilings" asp-controller="HoldingsActivity">Latest 13F Filings</a></li>
                             <li><a asp-action="Index" asp-controller="EconomicData">Economic Data</a></li>
                             <li><a asp-action="Index" asp-controller="Cftc">Futures</a></li>
                             <li><a asp-action="Index" asp-controller="Market">Market</a></li>
@@ -114,6 +115,11 @@
                         <li>
                             <a asp-action="Index" asp-controller="Institutions">
                                 <icon name="building-library" size="4" /> Institutions
+                            </a>
+                        </li>
+                        <li>
+                            <a asp-action="LatestFilings" asp-controller="HoldingsActivity">
+                                <icon name="document-text" size="4" /> Latest 13F Filings
                             </a>
                         </li>
                         <li>


### PR DESCRIPTION
## Summary
- Slice 2/2 for #1848 (latest 13F filings feed)
- Adds a paginated feed page at `/holdings/filings` showing recently imported 13F-HR filings ordered by import timestamp
- Each row shows filer name/CIK, position count, total value, report date, filing date, import timestamp
- "New" badge on first-time CIKs (no prior report date), "A" badge on amendments (13F-HR/A)
- Navigation link in the "More" dropdown (desktop + mobile)

## Code changes
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — new `LatestFilings` action at `~/holdings/filings`
- `src/Equibles.Web/ViewModels/Holdings/LatestFilingsViewModel.cs` — paginated view model wrapping `RecentFiling` DTOs
- `src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml` — Razor view with table, pagination, empty state, row-click navigation
- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — "Latest 13F Filings" link in desktop and mobile nav dropdowns

Closes #1848