### PR TITLE
test(congress): add skipped repro for GH-1891 — Truncate zero maxLength

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateZeroMaxLengthTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateZeroMaxLengthTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Contract: Truncate(value, maxLength) returns at most maxLength characters.
+/// With maxLength=0 and a non-empty value, the result should be an empty string.
+/// The surrogate-pair guard indexes value[maxLength - 1], which becomes value[-1]
+/// when maxLength is 0 — throwing IndexOutOfRangeException instead of returning "".
+/// </summary>
+public class DisclosureParsingHelperTruncateZeroMaxLengthTests
+{
+    [Fact(Skip = "GH-1891 — Truncate throws IndexOutOfRangeException when maxLength is 0")]
+    public void Truncate_ZeroMaxLength_ReturnsEmptyString()
+    {
+        var act = () => DisclosureParsingHelper.Truncate("abc", 0);
+
+        act.Should().NotThrow("maxLength=0 must not index into value with a negative offset");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test found that `DisclosureParsingHelper.Truncate("abc", 0)` throws `IndexOutOfRangeException` — the surrogate-pair guard (#1889) indexes `value[maxLength - 1]` which becomes `value[-1]` when `maxLength` is 0.
- Test is `[Fact(Skip = "GH-1891 — ...")]` — un-skip as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateZeroMaxLengthTests.cs` — new skipped test asserting `Truncate("abc", 0)` does not throw; see GH-1891.