### PR TITLE
fix(congress): guard Truncate against IndexOutOfRangeException when maxLength is 0

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -210,7 +210,8 @@ public static partial class DisclosureParsingHelper
         if (value == null || value.Length <= maxLength)
             return value;
 
-        var end = char.IsHighSurrogate(value[maxLength - 1]) ? maxLength - 1 : maxLength;
+        var end =
+            maxLength > 0 && char.IsHighSurrogate(value[maxLength - 1]) ? maxLength - 1 : maxLength;
         return value[..end];
     }
 

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateZeroMaxLengthTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateZeroMaxLengthTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Contract: Truncate(value, maxLength) returns at most maxLength characters.
+/// With maxLength=0 and a non-empty value, the result should be an empty string.
+/// The surrogate-pair guard indexes value[maxLength - 1], which becomes value[-1]
+/// when maxLength is 0 — throwing IndexOutOfRangeException instead of returning "".
+/// </summary>
+public class DisclosureParsingHelperTruncateZeroMaxLengthTests
+{
+    [Fact]
+    public void Truncate_ZeroMaxLength_ReturnsEmptyString()
+    {
+        var act = () => DisclosureParsingHelper.Truncate("abc", 0);
+
+        act.Should().NotThrow("maxLength=0 must not index into value with a negative offset");
+    }
+}


### PR DESCRIPTION
## Summary

- `DisclosureParsingHelper.Truncate("abc", 0)` threw `IndexOutOfRangeException` because the surrogate-pair guard (#1889) indexed `value[maxLength - 1]`, which becomes `value[-1]` when `maxLength` is 0.
- Added `maxLength > 0 &&` guard before the `char.IsHighSurrogate` check, so `maxLength = 0` falls through to `value[..0]` → empty string.
- Added regression test.

Closes #1891

## Code changes

- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — added `maxLength > 0` guard before `value[maxLength - 1]` index.
- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateZeroMaxLengthTests.cs` — new test asserting `Truncate("abc", 0)` does not throw.