### PR TITLE
fix(holdings): use InvariantCulture for date formatting in Realtime13FArchiveBuilder

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO.Compression;
 using System.Text;
 using Equibles.Core.AutoWiring;
@@ -40,8 +41,8 @@ public class Realtime13FArchiveBuilder
                 submission,
                 formType,
                 Clean(filing.AccessionNumber),
-                filing.FilingDate.ToString("yyyy-MM-dd"),
-                filing.PeriodOfReport.ToString("yyyy-MM-dd"),
+                filing.FilingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                filing.PeriodOfReport.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
                 Clean(filing.Cik)
             );
 

--- a/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderBuildCultureTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderBuildCultureTests.cs
@@ -13,7 +13,7 @@ namespace Equibles.UnitTests.Holdings;
 /// </summary>
 public class Realtime13FArchiveBuilderBuildCultureTests
 {
-    [Fact(Skip = "GH-1894 — Build emits Hijri dates on non-Gregorian culture threads")]
+    [Fact]
     public void Build_HijriCultureThread_EmitsGregorianIsoDates()
     {
         var prev = CultureInfo.CurrentCulture;


### PR DESCRIPTION
## Summary

- `Realtime13FArchiveBuilder.Build` formatted `FilingDate` and `PeriodOfReport` via `ToString("yyyy-MM-dd")` without specifying `CultureInfo.InvariantCulture`, producing Hijri calendar dates (`1445-09-05`) instead of Gregorian ISO (`2024-03-15`) on threads with non-Gregorian cultures (e.g., `ar-SA`).
- Added `CultureInfo.InvariantCulture` to both `ToString` calls.
- Enabled the skipped regression test from GH-1894.

Closes #1894

## Code changes

- `src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs` — added `CultureInfo.InvariantCulture` to `ToString("yyyy-MM-dd")` on lines 43–44; added `using System.Globalization`.
- `tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderBuildCultureTests.cs` — removed `Skip` to enable the regression test.