### PR TITLE
fix(holdings): use InvariantCulture for year in FormatDatePart

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsDataSetClient.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsDataSetClient.cs
@@ -134,10 +134,10 @@ public class HoldingsDataSetClient
         return fileNames;
     }
 
-    private static string FormatDatePart(DateOnly date)
+    internal static string FormatDatePart(DateOnly date)
     {
         return date.ToString("dd", CultureInfo.InvariantCulture)
             + date.ToString("MMM", CultureInfo.InvariantCulture).ToLower()
-            + date.ToString("yyyy");
+            + date.ToString("yyyy", CultureInfo.InvariantCulture);
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/HoldingsDataSetClientFormatDatePartCultureTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsDataSetClientFormatDatePartCultureTests.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// FormatDatePart builds SEC URL date segments like "01mar2024". The day and
+/// month already use InvariantCulture, but the year uses bare ToString("yyyy")
+/// which emits Hijri years on ar-SA threads — producing URLs that 404.
+/// </summary>
+public class HoldingsDataSetClientFormatDatePartCultureTests
+{
+    [Fact]
+    public void FormatDatePart_HijriCultureThread_EmitsGregorianYear()
+    {
+        var prev = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+
+            var result = HoldingsDataSetClient.FormatDatePart(new DateOnly(2024, 3, 1));
+
+            result.Should().Be("01mar2024", "year must be Gregorian, not Hijri");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = prev;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `HoldingsDataSetClient.FormatDatePart` formatted the year via `date.ToString("yyyy")` without `CultureInfo.InvariantCulture`, emitting Hijri years (`1445`) on `ar-SA` threads — producing SEC URLs that 404.
- Added `CultureInfo.InvariantCulture` to the year `ToString` call, matching the day and month components.
- Added regression test; changed method visibility from `private` to `internal` (established `InternalsVisibleTo` pattern).

Closes #1897

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsDataSetClient.cs` — added `CultureInfo.InvariantCulture` to `ToString("yyyy")` on line 141; changed `FormatDatePart` from `private` to `internal` for testability.
- `tests/Equibles.UnitTests/Holdings/HoldingsDataSetClientFormatDatePartCultureTests.cs` — new test asserting `FormatDatePart` emits Gregorian year under `ar-SA` culture.