### PR TITLE
fix(holdings): clamp backtest horizon to DateOnly.MaxValue on near-boundary dates

### DIFF
--- a/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
@@ -33,7 +33,7 @@ public static class HoldingsBacktestCalculator
             return result;
         }
 
-        var horizonCap = from.AddYears(MaxYears);
+        var horizonCap = from.Year > 9999 - MaxYears ? DateOnly.MaxValue : from.AddYears(MaxYears);
         if (to > horizonCap)
             to = horizonCap;
         result.EndDate = to;
@@ -77,7 +77,7 @@ public static class HoldingsBacktestCalculator
 
         Rebalance(holdings, ordered[snapshotIdx].Snapshot, startDate, portfolioValue, priceOf);
 
-        for (var day = startDate; day <= to; day = day.AddDays(1))
+        for (var day = startDate; ; day = day.AddDays(1))
         {
             // Advance through any rebalance dates that fall on/before `day`. Mark to market
             // with the prior holdings first so the rebalance uses an honest portfolio value.
@@ -101,6 +101,9 @@ public static class HoldingsBacktestCalculator
                     BenchmarkValue = Math.Round(benchValue, 4),
                 }
             );
+
+            if (day >= to)
+                break;
         }
 
         if (result.Points.Count > 0)

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorNearMaxDateOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorNearMaxDateOverflowTests.cs
@@ -15,7 +15,7 @@ public class HoldingsBacktestCalculatorNearMaxDateOverflowTests
 {
     private static readonly Guid StockA = Guid.Parse("11111111-1111-1111-1111-111111111111");
 
-    [Fact(Skip = "GH-1846 — AddYears overflow on dates near DateOnly.MaxValue")]
+    [Fact]
     public void Calculate_FromNearDateOnlyMaxValue_DoesNotThrow()
     {
         var from = new DateOnly(9995, 1, 1);


### PR DESCRIPTION
## Summary

- `HoldingsBacktestCalculator.Calculate` threw `ArgumentOutOfRangeException` when `from.Year > 9989` because `from.AddYears(10)` overflows `DateOnly.MaxValue`.
- A second overflow occurred in the daily loop when `day.AddDays(1)` overflowed on `DateOnly.MaxValue`.
- Added horizon clamp guard and restructured the daily loop to break before incrementing past `DateOnly.MaxValue`.
- Enabled the skipped regression test from GH-1846.

Closes #1846

## Code changes

- `src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs` — guarded `AddYears` with `from.Year > 9999 - MaxYears` → `DateOnly.MaxValue` clamp; restructured `for` loop to `break` after processing the last day instead of overflowing on increment.
- `tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorNearMaxDateOverflowTests.cs` — removed `Skip` to enable the regression test.