### PR TITLE
fix(sec): use InvariantCulture for date in GetDailyIndex URL

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -386,7 +386,7 @@ public class SecEdgarClient : ISecEdgarClient
         // fixed-width layout, so column-offset parsing is fragile. The master
         // index is unambiguous: CIK|Company Name|Form Type|Date Filed|File Name.
         var url =
-            $"{FilesBaseUrl}/Archives/edgar/daily-index/{date.Year}/QTR{quarter}/master.{date:yyyyMMdd}.idx";
+            $"{FilesBaseUrl}/Archives/edgar/daily-index/{date.Year}/QTR{quarter}/master.{date.ToString("yyyyMMdd", System.Globalization.CultureInfo.InvariantCulture)}.idx";
 
         using var response = await SendWithRetryAsync(url, cancellationToken);
 

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientGetDailyIndexCultureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientGetDailyIndexCultureTests.cs
@@ -1,0 +1,61 @@
+using System.Globalization;
+using System.Net;
+using Equibles.Integrations.Sec;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// GetDailyIndex builds the SEC EDGAR master-index URL using string
+/// interpolation {date:yyyyMMdd}. Without InvariantCulture the date portion
+/// uses the thread's Hijri calendar on ar-SA, producing a URL that 404s.
+/// </summary>
+public class SecEdgarClientGetDailyIndexCultureTests
+{
+    [Fact]
+    public async Task GetDailyIndex_HijriCultureThread_UrlContainsGregorianDate()
+    {
+        string capturedUrl = null;
+        var handler = new CaptureUrlHandler(url =>
+        {
+            capturedUrl = url;
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection([new("Sec:ContactEmail", "test@test.com")])
+            .Build();
+        var client = new SecEdgarClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<SecEdgarClient>>(),
+            config
+        );
+
+        var prev = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+
+            await client.GetDailyIndex(new DateOnly(2024, 3, 15));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = prev;
+        }
+
+        capturedUrl.Should().Contain("20240315", "URL date must be Gregorian, not Hijri");
+    }
+
+    private class CaptureUrlHandler : HttpMessageHandler
+    {
+        private readonly Func<string, HttpResponseMessage> _factory;
+
+        public CaptureUrlHandler(Func<string, HttpResponseMessage> factory) => _factory = factory;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) => Task.FromResult(_factory(request.RequestUri!.ToString()));
+    }
+}


### PR DESCRIPTION
## Summary

- `SecEdgarClient.GetDailyIndex` used `{date:yyyyMMdd}` in string interpolation without `CultureInfo.InvariantCulture`, producing Hijri dates (`14450905`) on `ar-SA` threads instead of Gregorian (`20240315`), causing SEC EDGAR URL 404s.
- Changed to `date.ToString("yyyyMMdd", CultureInfo.InvariantCulture)`.
- Added regression test with a `CaptureUrlHandler` to verify the URL format.

Closes #1901

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — replaced `{date:yyyyMMdd}` with `date.ToString("yyyyMMdd", CultureInfo.InvariantCulture)` in the URL construction at line 389.
- `tests/Equibles.UnitTests/Sec/SecEdgarClientGetDailyIndexCultureTests.cs` — new test with injected `HttpMessageHandler` capturing the URL, asserting Gregorian date under `ar-SA` culture.