### PR TITLE
fix(sec): guard FiscalPeriodResolver.CreateSafe against year overflow

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
@@ -113,6 +113,10 @@ internal static class FiscalPeriodResolver
     // never throws.
     private static DateOnly CreateSafe(int year, int month, int day)
     {
+        if (year < 1)
+            return DateOnly.MinValue;
+        if (year > 9999)
+            return DateOnly.MaxValue;
         var maxDay = DateTime.DaysInMonth(year, month);
         return new DateOnly(year, month, Math.Min(day, maxDay));
     }

--- a/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverYearOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FiscalPeriodResolverYearOverflowTests.cs
@@ -11,7 +11,7 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class FiscalPeriodResolverYearOverflowTests
 {
-    [Fact(Skip = "GH-1876 — CreateSafe overflows to year 10000")]
+    [Fact]
     public void Resolve_PeriodEndInYear9999_DoesNotThrow()
     {
         // A quarterly period ending Dec 31 9999 with a December FYE triggers


### PR DESCRIPTION
## Summary

- `FiscalPeriodResolver.Resolve` threw `ArgumentOutOfRangeException` when `periodEnd.Year` was 9999 because the candidate array computed `periodEnd.Year + 1 = 10000`, and `CreateSafe(10000, ...)` called `DateTime.DaysInMonth(10000, ...)` which rejects year > 9999.
- Guarded `CreateSafe` to return `DateOnly.MinValue`/`DateOnly.MaxValue` for out-of-range years, so the method returns `null` instead of throwing.
- Enabled the skipped regression test from GH-1876.

Closes #1876

## Code changes

- `src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs` — added year range guards (< 1 → `DateOnly.MinValue`, > 9999 → `DateOnly.MaxValue`) at the top of `CreateSafe`.
- `tests/Equibles.UnitTests/Sec/FiscalPeriodResolverYearOverflowTests.cs` — removed `Skip` to enable the regression test.