### PR TITLE
fix(worker): clamp SyncDateResolver.Resolve to DateOnly.MaxValue on overflow

### DIFF
--- a/src/Equibles.Worker/SyncDateResolver.cs
+++ b/src/Equibles.Worker/SyncDateResolver.cs
@@ -14,7 +14,9 @@ public static class SyncDateResolver
     {
         if (latestDateInDb != default)
         {
-            return latestDateInDb.AddDays(1);
+            return latestDateInDb == DateOnly.MaxValue
+                ? DateOnly.MaxValue
+                : latestDateInDb.AddDays(1);
         }
 
         return workerOptions.MinSyncDate.HasValue

--- a/tests/Equibles.UnitTests/Core/SyncDateResolverMaxValueOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Core/SyncDateResolverMaxValueOverflowTests.cs
@@ -13,7 +13,7 @@ namespace Equibles.UnitTests.Core;
 /// </summary>
 public class SyncDateResolverMaxValueOverflowTests
 {
-    [Fact(Skip = "GH-1878 — AddDays(1) overflows on DateOnly.MaxValue")]
+    [Fact]
     public void Resolve_LatestDateIsMaxValue_DoesNotThrow()
     {
         var act = () => SyncDateResolver.Resolve(DateOnly.MaxValue, new WorkerOptions());


### PR DESCRIPTION
## Summary

- `SyncDateResolver.Resolve(DateOnly.MaxValue, ...)` threw `ArgumentOutOfRangeException` because `AddDays(1)` on Dec 31, 9999 overflows `DateOnly`'s valid range. Every domain worker (Yahoo, FRED, CFTC, FTD) routes through this helper.
- Added a guard: when `latestDateInDb == DateOnly.MaxValue`, return `DateOnly.MaxValue` instead of adding a day.
- Enabled the skipped regression test from GH-1878.

Closes #1878

## Code changes

- `src/Equibles.Worker/SyncDateResolver.cs` — added `DateOnly.MaxValue` equality check before `AddDays(1)`.
- `tests/Equibles.UnitTests/Core/SyncDateResolverMaxValueOverflowTests.cs` — removed `Skip` to enable the regression test.