### PR TITLE
feat(holdings): add trend aggregate queries for AUM and sector allocation

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -141,6 +141,70 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             });
     }
 
+    public IQueryable<AumSnapshot> GetAumByReportDate()
+    {
+        return GetAll()
+            .GroupBy(h => h.ReportDate)
+            .Select(g => new AumSnapshot
+            {
+                ReportDate = g.Key,
+                TotalValue = g.Sum(h => h.Value),
+                FilerCount = g.Select(h => h.InstitutionalHolderId).Distinct().Count(),
+                PositionCount = g.Count(),
+            });
+    }
+
+    public IQueryable<SectorAllocationSnapshot> GetSectorAllocationByReportDate()
+    {
+        var aggregated = GetAll()
+            .Join(
+                DbContext.Set<CommonStock>(),
+                h => h.CommonStockId,
+                s => s.Id,
+                (h, s) =>
+                    new
+                    {
+                        h.ReportDate,
+                        h.Value,
+                        s.IndustryId,
+                    }
+            )
+            .Join(
+                DbContext.Set<CommonStocks.Data.Models.Taxonomies.Industry>(),
+                x => x.IndustryId,
+                i => i.Id,
+                (x, i) =>
+                    new
+                    {
+                        x.ReportDate,
+                        x.Value,
+                        i.SectorId,
+                    }
+            )
+            .Where(x => x.SectorId != null)
+            .GroupBy(x => new { x.ReportDate, SectorId = (Guid)x.SectorId })
+            .Select(g => new
+            {
+                g.Key.ReportDate,
+                g.Key.SectorId,
+                TotalValue = g.Sum(x => x.Value),
+            });
+
+        return aggregated.Join(
+            DbContext.Set<CommonStocks.Data.Models.Taxonomies.Sector>(),
+            a => a.SectorId,
+            s => s.Id,
+            (a, s) =>
+                new SectorAllocationSnapshot
+                {
+                    ReportDate = a.ReportDate,
+                    SectorId = a.SectorId,
+                    SectorName = s.Name,
+                    TotalValue = a.TotalValue,
+                }
+        );
+    }
+
     // Recent filings feed: groups holdings by accession number to produce one row
     // per filing, ordered by import timestamp. Joins InstitutionalHolder for filer
     // metadata and uses a NOT EXISTS subquery to flag first-time filers (no holdings

--- a/src/Equibles.Holdings.Repositories/Models/AumSnapshot.cs
+++ b/src/Equibles.Holdings.Repositories/Models/AumSnapshot.cs
@@ -1,0 +1,9 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class AumSnapshot
+{
+    public DateOnly ReportDate { get; set; }
+    public long TotalValue { get; set; }
+    public int FilerCount { get; set; }
+    public int PositionCount { get; set; }
+}

--- a/src/Equibles.Holdings.Repositories/Models/SectorAllocationSnapshot.cs
+++ b/src/Equibles.Holdings.Repositories/Models/SectorAllocationSnapshot.cs
@@ -1,0 +1,9 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class SectorAllocationSnapshot
+{
+    public DateOnly ReportDate { get; set; }
+    public Guid? SectorId { get; set; }
+    public string SectorName { get; set; }
+    public long TotalValue { get; set; }
+}


### PR DESCRIPTION
## Summary
- Slice 1/2 for #1849 (13F trend charts)
- Adds `GetAumByReportDate()` — aggregates total AUM, filer count, and position count per report date
- Adds `GetSectorAllocationByReportDate()` — groups holdings value by sector per report date, joining through CommonStock → Industry → Sector

## Code changes
- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — two new query methods
- `src/Equibles.Holdings.Repositories/Models/AumSnapshot.cs` — DTO for per-quarter AUM aggregates
- `src/Equibles.Holdings.Repositories/Models/SectorAllocationSnapshot.cs` — DTO for per-quarter sector allocation

Refs #1849