### PR TITLE
test(holdings): add skipped repro for GH-1911 — ParseDataSetEndDate invalid day

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateInvalidDayTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateInvalidDayTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Contract: ParseDataSetEndDate returns null for unparseable file names.
+/// TryParseDatePart parses day/month/year from the string and constructs a
+/// DateOnly without validating the day-of-month — "31feb2026" passes string
+/// parsing but throws ArgumentOutOfRangeException at DateOnly construction.
+/// </summary>
+public class Holdings13FRealtimeWorkerParseDataSetEndDateInvalidDayTests
+{
+    [Fact(Skip = "GH-1911 — ParseDataSetEndDate throws on invalid day-of-month")]
+    public void ParseDataSetEndDate_InvalidDayOfMonth_ReturnsNullInsteadOfThrowing()
+    {
+        // Feb has at most 29 days; day 31 should be gracefully rejected, not throw.
+        var act = () =>
+            Holdings13FRealtimeWorker.ParseDataSetEndDate("01dec2025-31feb2026_form13f.zip");
+
+        act.Should().NotThrow("unparseable dates must return null, not throw");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test found that `Holdings13FRealtimeWorker.ParseDataSetEndDate` throws `ArgumentOutOfRangeException` on file names with invalid day-of-month (e.g., "31feb2026") instead of returning `null`.
- Test is `[Fact(Skip = "GH-1911 — ...")]` — un-skip as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateInvalidDayTests.cs` — new skipped test asserting `ParseDataSetEndDate("01dec2025-31feb2026_form13f.zip")` does not throw; see GH-1911.