### PR TITLE
feat(holdings): add double-down report page with threshold filter

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -116,6 +116,45 @@ public class HoldingsActivityController : BaseController
         );
     }
 
+    [HttpGet("~/holdings/double-down")]
+    public async Task<IActionResult> DoubleDown(DateOnly? date, double? minPct, int page = 1)
+    {
+        var reportDates = await LoadAvailableReportDates();
+
+        var threshold = minPct ?? DoubleDownViewModel.DefaultMinPct;
+        if (threshold < 0)
+            threshold = 0;
+        var viewModel = new DoubleDownViewModel
+        {
+            AvailableDates = reportDates,
+            MinPctIncrease = threshold,
+            Page = Math.Max(1, page),
+        };
+        if (reportDates.Count < 2)
+            return View(viewModel);
+
+        var (selectedDate, previousDate) = ResolveSelectedAndPriorDate(date, reportDates);
+        viewModel.SelectedDate = selectedDate;
+        viewModel.PreviousDate = previousDate;
+        if (!previousDate.HasValue)
+            return View(viewModel);
+
+        var query = _holdingRepository
+            .GetDoubleDownPositions(selectedDate, previousDate.Value, threshold)
+            .OrderByDescending(p =>
+                (double)(p.CurrentShares - p.PreviousShares) / p.PreviousShares
+            );
+
+        viewModel.TotalCount = await query.CountAsync();
+        var skip = (viewModel.Page - 1) * DoubleDownViewModel.PageSize;
+        viewModel.Positions = await query
+            .Skip(skip)
+            .Take(DoubleDownViewModel.PageSize)
+            .ToListAsync();
+
+        return View(viewModel);
+    }
+
     [HttpGet("~/holdings/trends")]
     public async Task<IActionResult> Trends()
     {

--- a/src/Equibles.Web/ViewModels/Holdings/DoubleDownViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/DoubleDownViewModel.cs
@@ -1,0 +1,19 @@
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Web.ViewModels.Holdings;
+
+public class DoubleDownViewModel
+{
+    public const int PageSize = 100;
+    public const double DefaultMinPct = 50.0;
+
+    public List<DateOnly> AvailableDates { get; set; } = [];
+    public DateOnly SelectedDate { get; set; }
+    public DateOnly? PreviousDate { get; set; }
+    public double MinPctIncrease { get; set; } = DefaultMinPct;
+
+    public List<DoubleDownPosition> Positions { get; set; } = [];
+    public int Page { get; set; } = 1;
+    public int TotalCount { get; set; }
+    public int TotalPages => Math.Max(1, (TotalCount + PageSize - 1) / PageSize);
+}

--- a/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
@@ -1,0 +1,168 @@
+@using Equibles.Web.ViewModels.Holdings
+@model DoubleDownViewModel
+
+@{
+    ViewData["Title"] = "Double-Down Report";
+    ViewData["Description"] = "Institutional holders aggressively adding to positions — ranked by conviction (% share increase).";
+
+    var filterRoute = new Dictionary<string, string>();
+    if (Model.SelectedDate != default) {
+        filterRoute["date"] = Model.SelectedDate.ToString("yyyy-MM-dd");
+    }
+    if (Math.Abs(Model.MinPctIncrease - DoubleDownViewModel.DefaultMinPct) > 0.01) {
+        filterRoute["minPct"] = Model.MinPctIncrease.ToString("F0");
+    }
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold mb-2">Double-Down Report</h1>
+        <p class="text-base-content/60">
+            Positions where an institution increased its share count by
+            @Model.MinPctIncrease.ToString("F0")%+ quarter over quarter — ranked by conviction
+        </p>
+    </div>
+
+    @if (Model.AvailableDates.Count < 2) {
+        <div class="card bg-base-100 shadow-sm">
+            <div class="card-body items-center text-center py-12">
+                <div class="text-base-content/30 mb-3">
+                    <icon name="arrow-trending-up" size="12" />
+                </div>
+                <h2 class="text-base-content/60 mb-2">Not enough data</h2>
+                <p class="text-base-content/40 text-sm">The double-down report needs at least two quarters of 13F data.</p>
+            </div>
+        </div>
+    } else {
+        <!-- Controls -->
+        <form method="get" class="mb-6">
+            <div class="flex flex-wrap gap-3 items-end">
+                <label class="form-control">
+                    <span class="label-text text-sm mb-1">Report Date</span>
+                    <select name="date" class="select select-bordered" aria-label="Report date">
+                        @foreach (var d in Model.AvailableDates) {
+                            var isSelected = d == Model.SelectedDate;
+                            if (isSelected) {
+                                <option value="@d.ToString("yyyy-MM-dd")" selected>@d.ToString("MMM dd, yyyy")</option>
+                            } else {
+                                <option value="@d.ToString("yyyy-MM-dd")">@d.ToString("MMM dd, yyyy")</option>
+                            }
+                        }
+                    </select>
+                </label>
+                <label class="form-control">
+                    <span class="label-text text-sm mb-1">Min % Increase</span>
+                    <input type="number" name="minPct" value="@Model.MinPctIncrease.ToString("F0")"
+                           class="input input-bordered w-28" min="0" step="10"
+                           aria-label="Minimum percentage increase" />
+                </label>
+                <button type="submit" class="btn btn-primary">Apply</button>
+            </div>
+            @if (Model.PreviousDate.HasValue) {
+                <div class="text-xs text-base-content/50 mt-2">
+                    Comparing @Model.SelectedDate.ToString("MMM dd, yyyy") vs prior quarter @Model.PreviousDate.Value.ToString("MMM dd, yyyy")
+                </div>
+            }
+        </form>
+
+        <!-- Results Table -->
+        <div class="card bg-base-100 shadow-sm">
+            <div class="card-body p-0">
+                <div class="flex items-center justify-between px-4 pt-4 pb-2">
+                    <span class="text-sm text-base-content/60">@Model.TotalCount.ToString("N0") positions</span>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="table table-zebra table-sm" aria-label="Double-down positions" data-testid="double-down-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">Institution</th>
+                                <th scope="col">Stock</th>
+                                <th scope="col" class="text-right">Prior Shares</th>
+                                <th scope="col" class="text-right">Current Shares</th>
+                                <th scope="col" class="text-right">Change</th>
+                                <th scope="col" class="text-right hidden md:table-cell">Prior Value</th>
+                                <th scope="col" class="text-right hidden md:table-cell">Current Value</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var pos in Model.Positions) {
+                                <tr class="hover">
+                                    <td class="max-w-[200px]">
+                                        <a asp-action="Institution" asp-controller="Profiles" asp-route-cik="@pos.FilerCik"
+                                           class="font-semibold link link-primary truncate block">@pos.FilerName</a>
+                                        <span class="text-xs text-base-content/50 font-mono">@pos.FilerCik</span>
+                                    </td>
+                                    <td>
+                                        <a asp-action="Show" asp-controller="Stocks" asp-route-ticker="@pos.Ticker"
+                                           class="link link-primary font-mono">@pos.Ticker</a>
+                                        <span class="text-xs text-base-content/50 block truncate max-w-[150px]">@pos.StockName</span>
+                                    </td>
+                                    <td class="text-right font-mono">@pos.PreviousShares.ToString("N0")</td>
+                                    <td class="text-right font-mono">@pos.CurrentShares.ToString("N0")</td>
+                                    <td class="text-right">
+                                        <span class="font-mono text-success font-semibold">+@pos.PctChange.ToString("F1")%</span>
+                                        <span class="text-xs text-base-content/50 block">+@pos.DeltaShares.ToString("N0")</span>
+                                    </td>
+                                    <td class="text-right font-mono hidden md:table-cell">$@(pos.PreviousValue / 1_000).ToString("N0")k</td>
+                                    <td class="text-right font-mono hidden md:table-cell">$@(pos.CurrentValue / 1_000).ToString("N0")k</td>
+                                </tr>
+                            }
+                            @if (Model.Positions.Count == 0 && Model.PreviousDate.HasValue) {
+                                <tr>
+                                    <td colspan="7" class="text-center py-10 text-base-content/60">
+                                        No positions match the @Model.MinPctIncrease.ToString("F0")%+ threshold for this quarter.
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Pagination -->
+        @if (Model.TotalPages > 1) {
+            <nav class="flex justify-center mt-6" aria-label="Double-down pagination" data-testid="double-down-pager">
+                <div class="join">
+                    @if (Model.Page > 1) {
+                        <a asp-action="DoubleDown" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page - 1)"
+                           class="join-item btn btn-sm" aria-label="Go to previous page">Previous</a>
+                    }
+
+                    @{
+                        var startPage = Math.Max(1, Model.Page - 2);
+                        var endPage = Math.Min(Model.TotalPages, Model.Page + 2);
+                    }
+
+                    @if (startPage > 1) {
+                        <a asp-action="DoubleDown" asp-all-route-data="filterRoute" asp-route-page="1"
+                           class="join-item btn btn-sm" aria-label="Go to page 1">1</a>
+                        @if (startPage > 2) {
+                            <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
+                        }
+                    }
+
+                    @for (var i = startPage; i <= endPage; i++) {
+                        <a asp-action="DoubleDown" asp-all-route-data="filterRoute" asp-route-page="@i"
+                           class="join-item btn btn-sm @(i == Model.Page ? "btn-active" : "")"
+                           aria-label="Go to page @i"
+                           aria-current="@(i == Model.Page ? "page" : null)">@i</a>
+                    }
+
+                    @if (endPage < Model.TotalPages) {
+                        @if (endPage < Model.TotalPages - 1) {
+                            <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
+                        }
+                        <a asp-action="DoubleDown" asp-all-route-data="filterRoute" asp-route-page="@Model.TotalPages"
+                           class="join-item btn btn-sm" aria-label="Go to page @Model.TotalPages">@Model.TotalPages</a>
+                    }
+
+                    @if (Model.Page < Model.TotalPages) {
+                        <a asp-action="DoubleDown" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page + 1)"
+                           class="join-item btn btn-sm" aria-label="Go to next page">Next</a>
+                    }
+                </div>
+            </nav>
+        }
+    }
+</div>

--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -44,6 +44,7 @@
                                  are text-only, and the desktop dropdown should match. -->
                             <li><a asp-action="LatestFilings" asp-controller="HoldingsActivity">Latest 13F Filings</a></li>
                             <li><a asp-action="Trends" asp-controller="HoldingsActivity">13F Trends</a></li>
+                            <li><a asp-action="DoubleDown" asp-controller="HoldingsActivity">Double-Down Report</a></li>
                             <li><a asp-action="Index" asp-controller="EconomicData">Economic Data</a></li>
                             <li><a asp-action="Index" asp-controller="Cftc">Futures</a></li>
                             <li><a asp-action="Index" asp-controller="Market">Market</a></li>
@@ -126,6 +127,11 @@
                         <li>
                             <a asp-action="Trends" asp-controller="HoldingsActivity">
                                 <icon name="chart-bar" size="4" /> 13F Trends
+                            </a>
+                        </li>
+                        <li>
+                            <a asp-action="DoubleDown" asp-controller="HoldingsActivity">
+                                <icon name="arrow-trending-up" size="4" /> Double-Down Report
                             </a>
                         </li>
                         <li>


### PR DESCRIPTION
## Summary
- Slice 2/2 for #1850 (double-down report)
- Adds a paginated report page at `/holdings/double-down` showing positions where share-count increase exceeds a threshold, ranked by conviction (% increase)
- Includes report-date selector, configurable min % threshold, and navigation link

## Code changes
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — new `DoubleDown` action with date/threshold/page params
- `src/Equibles.Web/ViewModels/Holdings/DoubleDownViewModel.cs` — view model with pagination and threshold state
- `src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml` — Razor view with filter controls, table, and pagination
- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — "Double-Down Report" link in desktop and mobile nav

Closes #1850