### PR TITLE
feat(holdings): add pairwise overlap matrix computation

### DIFF
--- a/src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs
@@ -68,6 +68,38 @@ public static class FundOverlapCalculator
         return result;
     }
 
+    public static PairwiseOverlapMatrix ComputePairwiseOverlap(FundOverlapResult overlap)
+    {
+        var n = overlap.Funds.Count;
+        var matrix = new int[n][];
+        for (var i = 0; i < n; i++)
+            matrix[i] = new int[n];
+
+        foreach (var row in overlap.Rows)
+        {
+            for (var i = 0; i < n; i++)
+            {
+                if (row.Slices[i].Value <= 0)
+                    continue;
+                for (var j = i; j < n; j++)
+                {
+                    if (row.Slices[j].Value <= 0)
+                        continue;
+                    matrix[i][j]++;
+                    if (i != j)
+                        matrix[j][i]++;
+                }
+            }
+        }
+
+        return new PairwiseOverlapMatrix
+        {
+            ReportDate = overlap.ReportDate,
+            Funds = overlap.Funds,
+            SharedTickerCounts = matrix,
+        };
+    }
+
     private static (FundOverlapRow Row, long MinValue, long MaxValue, bool AllHaveIt) BuildStockRow(
         Guid stockId,
         List<FundAggregate> fundAggregates

--- a/src/Equibles.Holdings.Repositories/Models/PairwiseOverlapMatrix.cs
+++ b/src/Equibles.Holdings.Repositories/Models/PairwiseOverlapMatrix.cs
@@ -1,0 +1,8 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class PairwiseOverlapMatrix
+{
+    public DateOnly ReportDate { get; set; }
+    public List<FundOverlapFund> Funds { get; set; } = [];
+    public int[][] SharedTickerCounts { get; set; } = [];
+}


### PR DESCRIPTION
## Summary
- Slice 1/2 for #1851 (institution overlap matrix)
- Adds `ComputePairwiseOverlap()` to `FundOverlapCalculator` — derives an N×N matrix of shared ticker counts from a `FundOverlapResult`
- Adds `PairwiseOverlapMatrix` DTO

## Code changes
- `src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs` — new static method
- `src/Equibles.Holdings.Repositories/Models/PairwiseOverlapMatrix.cs` — DTO for the matrix

Refs #1851