### PR TITLE
test(holdings): pin DoubleDownPosition.PctChange zero-denominator guard

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/DoubleDownPositionPctChangeTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/DoubleDownPositionPctChangeTests.cs
@@ -1,0 +1,21 @@
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Contract: PctChange = (CurrentShares - PreviousShares) / PreviousShares * 100.
+/// When PreviousShares is 0, must return 0 (not throw DivideByZeroException).
+/// </summary>
+public class DoubleDownPositionPctChangeTests
+{
+    [Fact]
+    public void PctChange_PreviousSharesZero_ReturnsZeroInsteadOfThrowing()
+    {
+        var position = new DoubleDownPosition { CurrentShares = 500, PreviousShares = 0 };
+
+        var act = () => position.PctChange;
+
+        act.Should().NotThrow();
+        position.PctChange.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin `DoubleDownPosition.PctChange` division-by-zero guard when `PreviousShares` is 0

## Code changes

- New file: `tests/Equibles.UnitTests/Holdings/DoubleDownPositionPctChangeTests.cs`
- Lane A adversarial: `PreviousShares=0, CurrentShares=500` → asserts `PctChange` returns 0 without throwing `DivideByZeroException`

## Test plan

- [x] `dotnet test --filter DoubleDownPositionPctChangeTests` — 1 passed
- [ ] CI validates