### PR TITLE
test(holdings): pin HoldingsActivityController.Trends empty-state rendering

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerTrendsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerTrendsTests.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Coverage: exercises the /holdings/trends route end-to-end with no seeded
+/// data, verifying the view renders without error when both AUM and sector
+/// allocation queries return empty results.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HoldingsActivityControllerTrendsTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HoldingsActivityControllerTrendsTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task Trends_NoHoldings_ReturnsOk()
+    {
+        await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
+
+        var response = await _fixture.Client.GetAsync("/holdings/trends");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin `/holdings/trends` route and empty-state view rendering via a web integration test

## Code changes

- New file: `tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerTrendsTests.cs`
- Lane B coverage: verifies the Trends action renders HTTP 200 with no seeded data (exercises both `GetAumByReportDate` and `GetSectorAllocationByReportDate` returning empty results through the view)

## Test plan

- [x] `dotnet test --filter HoldingsActivityControllerTrendsTests` — 1 passed
- [ ] CI validates