### PR TITLE
test(holdings): pin HoldingsActivityController.LatestFilings negative-page clamp

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerLatestFilingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerLatestFilingsTests.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Coverage: exercises the /holdings/filings route with no seeded data and
+/// a negative page parameter, verifying the page-clamp guard and empty-state
+/// rendering both work without error.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HoldingsActivityControllerLatestFilingsTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HoldingsActivityControllerLatestFilingsTests(WebHostFixture fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    public async Task LatestFilings_NegativePage_ReturnsOkWithClampedPage()
+    {
+        // page=-1 must be clamped to 1 and the view must render HTTP 200,
+        // not throw or return a 500 from a negative Skip value.
+        await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
+
+        var response = await _fixture.Client.GetAsync("/holdings/filings?page=-1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin `/holdings/filings` route and page-parameter clamping via a web integration test

## Code changes

- New file: `tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerLatestFilingsTests.cs`
- Lane A adversarial: `page=-1` must be clamped to 1 and render HTTP 200 (not a 500 from negative `Skip`)

## Test plan

- [x] `dotnet test --filter HoldingsActivityControllerLatestFilingsTests` — 1 passed
- [ ] CI validates