### PR TITLE
feat(holdings): add stock count and filing count to AUM aggregates

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -213,6 +213,8 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
                 TotalValue = g.Sum(h => h.Value),
                 FilerCount = g.Select(h => h.InstitutionalHolderId).Distinct().Count(),
                 PositionCount = g.Count(),
+                StockCount = g.Select(h => h.CommonStockId).Distinct().Count(),
+                FilingCount = g.Select(h => h.AccessionNumber).Distinct().Count(),
             });
     }
 

--- a/src/Equibles.Holdings.Repositories/Models/AumSnapshot.cs
+++ b/src/Equibles.Holdings.Repositories/Models/AumSnapshot.cs
@@ -6,4 +6,8 @@ public class AumSnapshot
     public long TotalValue { get; set; }
     public int FilerCount { get; set; }
     public int PositionCount { get; set; }
+    public int StockCount { get; set; }
+    public int FilingCount { get; set; }
+
+    public double AvgPositionsPerFiler => FilerCount > 0 ? (double)PositionCount / FilerCount : 0;
 }


### PR DESCRIPTION
## Summary
- Slice 1/2 for #1852 (13F aggregate stats dashboard)
- Extends `AumSnapshot` with `StockCount`, `FilingCount`, and computed `AvgPositionsPerFiler`
- Updates `GetAumByReportDate()` query to include the new distinct-count aggregates

## Code changes
- `src/Equibles.Holdings.Repositories/Models/AumSnapshot.cs` — three new properties
- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — updated GROUP BY projection

Refs #1852