### PR TITLE
test(holdings): add skipped repro for GH-1930 — HoldingsBacktestCalculator rebalance date overflow

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorRebalanceDateOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorRebalanceDateOverflowTests.cs
@@ -1,0 +1,48 @@
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Contract: Calculate must never throw for valid DateOnly inputs. The rebalance
+/// date is computed as ReportDate.AddDays(45); when the snapshot's ReportDate
+/// falls in November or December of year 9999, AddDays(45) overflows past
+/// DateOnly.MaxValue (9999-12-31). The existing near-max-date test uses
+/// ReportDate = 9994-09-30 (+45 = 9994-11-14, safe) and misses this path.
+/// </summary>
+public class HoldingsBacktestCalculatorRebalanceDateOverflowTests
+{
+    private static readonly Guid StockA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    [Fact(Skip = "GH-1930 — ReportDate.AddDays(45) overflows near DateOnly.MaxValue")]
+    public void Calculate_SnapshotReportDateNearMaxValue_DoesNotThrow()
+    {
+        // ReportDate 9999-11-20 + 45 days = 10000-01-04, which exceeds
+        // DateOnly.MaxValue and throws ArgumentOutOfRangeException inside
+        // the LINQ Select that computes RebalanceDate.
+        var from = new DateOnly(9999, 1, 1);
+        var to = DateOnly.MaxValue;
+        var snapshot = new BacktestQuarterSnapshot
+        {
+            ReportDate = new DateOnly(9999, 11, 20),
+            Positions =
+            [
+                new BacktestPosition
+                {
+                    CommonStockId = StockA,
+                    Shares = 1000,
+                    Value = 100_000,
+                    IsOption = false,
+                },
+            ],
+        };
+
+        var act = () =>
+            HoldingsBacktestCalculator.Calculate([snapshot], from, to, (_, _) => 100m, _ => 100m);
+
+        act.Should()
+            .NotThrow(
+                "ReportDate.AddDays(RebalanceDelayDays) near DateOnly.MaxValue must be clamped, not overflow"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test discovers that `HoldingsBacktestCalculator.Calculate` throws `ArgumentOutOfRangeException` when a snapshot's `ReportDate.AddDays(45)` overflows past `DateOnly.MaxValue` (e.g. report date in November/December 9999).
- The existing near-max-date test uses `ReportDate = 9994-09-30` which stays safely within bounds; this test targets the unclamped rebalance-date computation.
- Test is `[Skip]`-ped pending the production fix — see GH-1930.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorRebalanceDateOverflowTests.cs` — new skipped unit test that passes a `BacktestQuarterSnapshot` with `ReportDate = 9999-11-20` and asserts `Calculate` does not throw. Currently fails (skipped) because `AddDays(RebalanceDelayDays)` overflows.