### PR TITLE
fix(holdings): validate day-of-month in TryParseDatePart before DateOnly construction

### DIFF
--- a/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
+++ b/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
@@ -195,6 +195,9 @@ public class Holdings13FRealtimeWorker : BaseScraperWorker
         if (!int.TryParse(part[5..], out var year))
             return null;
 
+        if (day < 1 || day > DateTime.DaysInMonth(year, monthNumber))
+            return null;
+
         return new DateOnly(year, monthNumber, day);
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateInvalidDayTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateInvalidDayTests.cs
@@ -10,7 +10,7 @@ namespace Equibles.UnitTests.Holdings;
 /// </summary>
 public class Holdings13FRealtimeWorkerParseDataSetEndDateInvalidDayTests
 {
-    [Fact(Skip = "GH-1911 — ParseDataSetEndDate throws on invalid day-of-month")]
+    [Fact]
     public void ParseDataSetEndDate_InvalidDayOfMonth_ReturnsNullInsteadOfThrowing()
     {
         // Feb has at most 29 days; day 31 should be gracefully rejected, not throw.


### PR DESCRIPTION
## Summary

- `TryParseDatePart` constructed a `DateOnly` from parsed day/month/year without validating the day against the month's range, causing `ArgumentOutOfRangeException` on invalid combinations like Feb 31.
- Added a bounds check (`DateTime.DaysInMonth`) before `DateOnly` construction so the method returns `null` per its contract.
- Un-skipped the regression test from GH-1911.

## Code changes

- `src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs` — added `day < 1 || day > DateTime.DaysInMonth(year, monthNumber)` guard in `TryParseDatePart` before `new DateOnly(year, monthNumber, day)`.
- `tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateInvalidDayTests.cs` — removed `Skip` attribute so the test runs in CI.

Closes #1911