### PR TITLE
test(holdings): add skipped repro for GH-1937 — ParseDataSetEndDate year zero

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateYearZeroTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateYearZeroTests.cs
@@ -1,0 +1,21 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Contract: ParseDataSetEndDate returns null for unparseable file names.
+/// Old-format path computes DateTime.DaysInMonth(year, ...) which requires
+/// year >= 1 — year 0 throws ArgumentOutOfRangeException instead of returning null.
+/// </summary>
+public class Holdings13FRealtimeWorkerParseDataSetEndDateYearZeroTests
+{
+    [Fact(Skip = "GH-1937 — ParseDataSetEndDate throws on year 0 in old-format file names")]
+    public void ParseDataSetEndDate_OldFormatYearZero_ReturnsNullInsteadOfThrowing()
+    {
+        // Year 0 passes int.TryParse and quarter validation, but
+        // DateTime.DaysInMonth(0, ...) throws — violating the null-return contract.
+        var act = () => Holdings13FRealtimeWorker.ParseDataSetEndDate("0000q1_form13f.zip");
+
+        act.Should().NotThrow("unparseable dates must return null, not throw");
+    }
+}


### PR DESCRIPTION
## Summary

- Added a skipped regression test reproducing GH-1937: `ParseDataSetEndDate` throws `ArgumentOutOfRangeException` on old-format file names with year 0 (`"0000q1_form13f.zip"`) instead of returning `null` per its contract.
- Test is `[Skip]`-ped — un-skip when fixing GH-1937.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateYearZeroTests.cs` — new skipped test asserting `ParseDataSetEndDate` returns null (not throws) for year-zero input. See GH-1937.