### PR TITLE
fix(holdings): validate year range in ParseDataSetEndDate before DaysInMonth

### DIFF
--- a/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
+++ b/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
@@ -154,6 +154,7 @@ public class Holdings13FRealtimeWorker : BaseScraperWorker
             && int.TryParse(name[..4], out var year)
             && int.TryParse(name[5..], out var quarter)
             && quarter is >= 1 and <= 4
+            && year is >= 1 and <= 9999
         )
         {
             var endMonth = quarter * 3;
@@ -192,7 +193,7 @@ public class Holdings13FRealtimeWorker : BaseScraperWorker
         if (monthNumber == 0)
             return null;
 
-        if (!int.TryParse(part[5..], out var year))
+        if (!int.TryParse(part[5..], out var year) || year is < 1 or > 9999)
             return null;
 
         if (day < 1 || day > DateTime.DaysInMonth(year, monthNumber))

--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateYearZeroTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateYearZeroTests.cs
@@ -9,7 +9,7 @@ namespace Equibles.UnitTests.Holdings;
 /// </summary>
 public class Holdings13FRealtimeWorkerParseDataSetEndDateYearZeroTests
 {
-    [Fact(Skip = "GH-1937 — ParseDataSetEndDate throws on year 0 in old-format file names")]
+    [Fact]
     public void ParseDataSetEndDate_OldFormatYearZero_ReturnsNullInsteadOfThrowing()
     {
         // Year 0 passes int.TryParse and quarter validation, but


### PR DESCRIPTION
## Summary

- Both the old-format (`2023q4`) and new-format (`28feb2026`) paths in `ParseDataSetEndDate` passed parsed year values directly to `DateTime.DaysInMonth` and `new DateOnly` without checking the valid range [1, 9999]. Year 0 (or negative/10000+) threw `ArgumentOutOfRangeException` instead of returning `null` per the method's contract.
- Added year range validation (`year is >= 1 and <= 9999`) in both code paths.
- Un-skipped the regression test from GH-1937.

## Code changes

- `src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs` — added `&& year is >= 1 and <= 9999` guard in the old-format conditional; added `|| year is < 1 or > 9999` to `TryParseDatePart`'s year-parse check.
- `tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateYearZeroTests.cs` — removed `Skip` attribute so the test runs in CI.

Closes #1937