### PR TITLE
test(holdings): pin ParseDataSetEndDate new-format happy path

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateNewFormatTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateNewFormatTests.cs
@@ -1,0 +1,21 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins the new-format parsing path ("01dec2025-28feb2026_form13f.zip") which
+/// exercises TryParseDatePart end-to-end — currently only exercised by
+/// invalid-input tests; no happy-path coverage existed.
+/// </summary>
+public class Holdings13FRealtimeWorkerParseDataSetEndDateNewFormatTests
+{
+    [Fact]
+    public void ParseDataSetEndDate_NewFormat_ReturnsEndDate()
+    {
+        var result = Holdings13FRealtimeWorker.ParseDataSetEndDate(
+            "01dec2025-28feb2026_form13f.zip"
+        );
+
+        result.Should().Be(new DateOnly(2026, 2, 28));
+    }
+}


### PR DESCRIPTION
## Summary

- Added a unit test pinning the happy-path behavior of `ParseDataSetEndDate` for new-format file names (`"01dec2025-28feb2026_form13f.zip"` → `2026-02-28`).
- Exercises `TryParseDatePart` end-to-end — previously only tested with invalid inputs.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateNewFormatTests.cs` — new test asserting correct date extraction from a new-format file name.