### PR TITLE
feat(holdings): add daily filing activity badge to stock page

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -462,4 +462,19 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
                     : null,
         });
     }
+
+    public IQueryable<FilingActivitySummary> GetFilingActivitySummary(
+        CommonStock stock,
+        DateOnly since
+    )
+    {
+        return GetAll()
+            .Where(h => h.CommonStockId == stock.Id && h.FilingDate >= since)
+            .GroupBy(h => h.CommonStockId)
+            .Select(g => new FilingActivitySummary
+            {
+                FilingCount = g.Select(h => h.AccessionNumber).Distinct().Count(),
+                FilerCount = g.Select(h => h.InstitutionalHolderId).Distinct().Count(),
+            });
+    }
 }

--- a/src/Equibles.Holdings.Repositories/Models/FilingActivitySummary.cs
+++ b/src/Equibles.Holdings.Repositories/Models/FilingActivitySummary.cs
@@ -1,0 +1,7 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+public class FilingActivitySummary
+{
+    public int FilingCount { get; set; }
+    public int FilerCount { get; set; }
+}

--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -14,14 +14,18 @@ namespace Equibles.Web.Controllers;
 
 public class StocksController : BaseController
 {
+    private const int FilingActivityDays = 30;
+
     private readonly CommonStockRepository _commonStockRepository;
     private readonly InstitutionalHolderRepository _institutionalHolderRepository;
+    private readonly InstitutionalHoldingRepository _institutionalHoldingRepository;
     private readonly DocumentRepository _documentRepository;
     private readonly StockTabService _stockTabService;
 
     public StocksController(
         CommonStockRepository commonStockRepository,
         InstitutionalHolderRepository institutionalHolderRepository,
+        InstitutionalHoldingRepository institutionalHoldingRepository,
         DocumentRepository documentRepository,
         StockTabService stockTabService,
         ILogger<StocksController> logger
@@ -30,6 +34,7 @@ public class StocksController : BaseController
     {
         _commonStockRepository = commonStockRepository;
         _institutionalHolderRepository = institutionalHolderRepository;
+        _institutionalHoldingRepository = institutionalHoldingRepository;
         _documentRepository = documentRepository;
         _stockTabService = stockTabService;
     }
@@ -183,6 +188,15 @@ public class StocksController : BaseController
             return NotFound();
 
         var viewModel = BuildStockViewModel(stock, activeTab);
+
+        var since = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-FilingActivityDays);
+        var filingActivity = await _institutionalHoldingRepository
+            .GetFilingActivitySummary(stock, since)
+            .FirstOrDefaultAsync();
+        viewModel.RecentFilingCount = filingActivity?.FilingCount ?? 0;
+        viewModel.RecentFilerCount = filingActivity?.FilerCount ?? 0;
+        viewModel.FilingActivityDays = FilingActivityDays;
+
         ViewData["TabViewModel"] = await loadTab(stock);
         return View("Show", viewModel);
     }

--- a/src/Equibles.Web/ViewModels/Stocks/StockDetailViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/StockDetailViewModel.cs
@@ -6,4 +6,8 @@ public class StockDetailViewModel
 {
     public CommonStock Stock { get; set; }
     public string ActiveTab { get; set; }
+
+    public int RecentFilingCount { get; set; }
+    public int RecentFilerCount { get; set; }
+    public int FilingActivityDays { get; set; }
 }

--- a/src/Equibles.Web/Views/Stocks/Show.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Show.cshtml
@@ -63,6 +63,15 @@
                             <a href="@stock.Website" target="_blank" rel="noopener" class="text-sm text-primary hover:underline truncate block">@stock.Website</a>
                         </div>
                     }
+                    @if (Model.RecentFilingCount > 0) {
+                        <div>
+                            <div class="text-xs text-base-content/50 uppercase tracking-wider">13F Activity (@(Model.FilingActivityDays)d)</div>
+                            <div class="flex items-center gap-2">
+                                <span class="badge badge-info badge-sm">@Model.RecentFilingCount filings</span>
+                                <span class="badge badge-ghost badge-sm">@Model.RecentFilerCount filers</span>
+                            </div>
+                        </div>
+                    }
                 </div>
             </div>
         </div>

--- a/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
@@ -274,6 +274,7 @@ public class StocksControllerTests : IDisposable
     private readonly EquiblesDbContext _dbContext;
     private readonly CommonStockRepository _commonStockRepository;
     private readonly InstitutionalHolderRepository _institutionalHolderRepository;
+    private readonly InstitutionalHoldingRepository _institutionalHoldingRepository;
     private readonly DocumentRepository _documentRepository;
     private readonly StockTabService _stockTabService;
     private readonly ILogger<StocksController> _logger = Substitute.For<
@@ -295,6 +296,7 @@ public class StocksControllerTests : IDisposable
 
         _commonStockRepository = new CommonStockRepository(_dbContext);
         _institutionalHolderRepository = new InstitutionalHolderRepository(_dbContext);
+        _institutionalHoldingRepository = new InstitutionalHoldingRepository(_dbContext);
         _documentRepository = new DocumentRepository(_dbContext);
         _stockTabService = new StockTabService(
             new InstitutionalHoldingRepository(_dbContext),
@@ -321,6 +323,7 @@ public class StocksControllerTests : IDisposable
         var controller = new StocksController(
             _commonStockRepository,
             _institutionalHolderRepository,
+            _institutionalHoldingRepository,
             _documentRepository,
             _stockTabService,
             _logger

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerCongressionalTradesTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerCongressionalTradesTabTests.cs
@@ -77,6 +77,7 @@ public class StocksControllerCongressionalTradesTabTests : IDisposable
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),
             new InstitutionalHolderRepository(_dbContext),
+            new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
             Substitute.For<ILogger<StocksController>>()

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerDocumentsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerDocumentsTabTests.cs
@@ -77,6 +77,7 @@ public class StocksControllerDocumentsTabTests : IDisposable
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),
             new InstitutionalHolderRepository(_dbContext),
+            new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
             Substitute.For<ILogger<StocksController>>()

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerFinancialsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerFinancialsTabTests.cs
@@ -136,6 +136,7 @@ public class StocksControllerFinancialsTabTests : IDisposable
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),
             new InstitutionalHolderRepository(_dbContext),
+            new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
             Substitute.For<ILogger<StocksController>>()

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerFtdTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerFtdTabTests.cs
@@ -76,6 +76,7 @@ public class StocksControllerFtdTabTests : IDisposable
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),
             new InstitutionalHolderRepository(_dbContext),
+            new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
             Substitute.For<ILogger<StocksController>>()

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerHoldingsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerHoldingsTabTests.cs
@@ -78,6 +78,7 @@ public class StocksControllerHoldingsTabTests : IDisposable
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),
             new InstitutionalHolderRepository(_dbContext),
+            new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
             Substitute.For<ILogger<StocksController>>()

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerInsiderTradingTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerInsiderTradingTabTests.cs
@@ -77,6 +77,7 @@ public class StocksControllerInsiderTradingTabTests : IDisposable
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),
             new InstitutionalHolderRepository(_dbContext),
+            new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
             Substitute.For<ILogger<StocksController>>()

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerPriceNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerPriceNotFoundTests.cs
@@ -41,6 +41,7 @@ public class StocksControllerPriceNotFoundTests : IDisposable
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),
             institutionalHolderRepository: null!,
+            institutionalHoldingRepository: null!,
             documentRepository: null!,
             // Must 404 before any tab load — a dropped null-stock guard would
             // NRE here instead of returning NotFound.

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShortInterestTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShortInterestTabTests.cs
@@ -77,6 +77,7 @@ public class StocksControllerShortInterestTabTests : IDisposable
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),
             new InstitutionalHolderRepository(_dbContext),
+            new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
             Substitute.For<ILogger<StocksController>>()

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShortVolumeTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShortVolumeTabTests.cs
@@ -77,6 +77,7 @@ public class StocksControllerShortVolumeTabTests : IDisposable
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),
             new InstitutionalHolderRepository(_dbContext),
+            new InstitutionalHoldingRepository(_dbContext),
             new DocumentRepository(_dbContext),
             stockTabService,
             Substitute.For<ILogger<StocksController>>()

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentCrossTickerTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentCrossTickerTests.cs
@@ -61,6 +61,7 @@ public class StocksControllerShowDocumentCrossTickerTests
         var sut = new StocksController(
             new CommonStockRepository(ctx),
             institutionalHolderRepository: null!,
+            institutionalHoldingRepository: null!,
             new DocumentRepository(ctx),
             stockTabService: null!,
             Substitute.For<ILogger<StocksController>>()

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentHappyTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentHappyTests.cs
@@ -71,6 +71,7 @@ public class StocksControllerShowDocumentHappyTests
         var sut = new StocksController(
             new CommonStockRepository(ctx),
             institutionalHolderRepository: null!,
+            institutionalHoldingRepository: null!,
             new DocumentRepository(ctx),
             stockTabService: null!,
             Substitute.For<ILogger<StocksController>>()

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShowHolderNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShowHolderNotFoundTests.cs
@@ -46,6 +46,7 @@ public class StocksControllerShowHolderNotFoundTests : IDisposable
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),
             new InstitutionalHolderRepository(_dbContext),
+            institutionalHoldingRepository: null!,
             new DocumentRepository(_dbContext),
             // LoadHolderDetail must never be reached on this path, so the
             // service is intentionally null — a regression that dropped the


### PR DESCRIPTION
## Summary

- Count distinct 13F filings and filers mentioning a stock over the last 30 days via a new `GetFilingActivitySummary` repository query.
- Display the counts as badges ("X filings", "Y filers") in the stock page header info grid, shown only when there is recent activity.

Closes #1854

## Code changes

- `src/Equibles.Holdings.Repositories/Models/FilingActivitySummary.cs` — new projection model for the aggregate query
- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — add `GetFilingActivitySummary(stock, since)` query method
- `src/Equibles.Web/Controllers/StocksController.cs` — inject `InstitutionalHoldingRepository`, load 30-day filing activity in `ShowStockTab`
- `src/Equibles.Web/ViewModels/Stocks/StockDetailViewModel.cs` — add `RecentFilingCount`, `RecentFilerCount`, `FilingActivityDays` properties
- `src/Equibles.Web/Views/Stocks/Show.cshtml` — render badge-info and badge-ghost badges in the stock header info grid
- `tests/Equibles.IntegrationTests/Web/StocksController*Tests.cs` (13 files) — pass new constructor parameter to existing tests