### PR TITLE
test(holdings): pin ParseDataSetEndDate old-format happy path

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateOldFormatTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateOldFormatTests.cs
@@ -1,0 +1,19 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins the old-format parsing path ("2023q4_form13f.zip") which computes
+/// the last day of the quarter — previously only exercised by invalid-input
+/// tests; no happy-path coverage existed.
+/// </summary>
+public class Holdings13FRealtimeWorkerParseDataSetEndDateOldFormatTests
+{
+    [Fact]
+    public void ParseDataSetEndDate_OldFormatQ4_ReturnsDecember31()
+    {
+        var result = Holdings13FRealtimeWorker.ParseDataSetEndDate("2023q4_form13f.zip");
+
+        result.Should().Be(new DateOnly(2023, 12, 31));
+    }
+}


### PR DESCRIPTION
## Summary

- Added a unit test pinning the happy-path behavior of `ParseDataSetEndDate` for old-format file names (`"2023q4_form13f.zip"` → `2023-12-31`).
- Exercises the quarter-end-date computation path — previously only tested with invalid inputs (year zero).

## Code changes

- `tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateOldFormatTests.cs` — new test asserting correct date extraction from an old-format file name.