### PR TITLE
fix(finra): use InvariantCulture for date formatting in FINRA API requests

### DIFF
--- a/src/Equibles.Integrations.Finra/FinraClient.cs
+++ b/src/Equibles.Integrations.Finra/FinraClient.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
@@ -68,7 +69,7 @@ public class FinraClient : IFinraClient
 
     public async Task<List<ShortVolumeRecord>> GetDailyShortVolume(DateOnly date)
     {
-        var dateStr = date.ToString("yyyy-MM-dd");
+        var dateStr = date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         _logger.LogDebug("Fetching daily short volume for {Date}", dateStr);
 
         var results = new List<ShortVolumeRecord>();
@@ -123,7 +124,7 @@ public class FinraClient : IFinraClient
         IReadOnlyList<string> symbols
     )
     {
-        var dateStr = settlementDate.ToString("yyyy-MM-dd");
+        var dateStr = settlementDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         _logger.LogDebug(
             "Fetching short interest for settlement date {Date}{Filter}",
             dateStr,
@@ -187,8 +188,12 @@ public class FinraClient : IFinraClient
 
     public async Task<List<DateOnly>> GetShortInterestSettlementDatesAfter(DateOnly afterDate)
     {
-        var startDateStr = afterDate.AddDays(1).ToString("yyyy-MM-dd");
-        var endDateStr = DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd");
+        var startDateStr = afterDate
+            .AddDays(1)
+            .ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var endDateStr = DateOnly
+            .FromDateTime(DateTime.UtcNow)
+            .ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
         _logger.LogDebug("Discovering settlement dates after {Date}", afterDate);
 

--- a/tests/Equibles.UnitTests/Finra/FinraClientGetDailyShortVolumeCultureTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraClientGetDailyShortVolumeCultureTests.cs
@@ -14,9 +14,7 @@ namespace Equibles.UnitTests.Finra;
 /// </summary>
 public class FinraClientGetDailyShortVolumeCultureTests
 {
-    [Fact(
-        Skip = "GH-1915 — GetDailyShortVolume sends Hijri dates on non-Gregorian culture threads"
-    )]
+    [Fact]
     public async Task GetDailyShortVolume_HijriCultureThread_SendsGregorianDateInRequest()
     {
         string capturedBody = null;


### PR DESCRIPTION
## Summary

- All four `ToString("yyyy-MM-dd")` calls in `FinraClient` formatted dates using the thread's current culture. On threads with non-Gregorian calendars (e.g., `ar-SA`/Hijri), this produced Hijri dates in the API request body, causing the FINRA API to return no results.
- Added `CultureInfo.InvariantCulture` to all four calls.
- Un-skipped the regression test from GH-1915.

## Code changes

- `src/Equibles.Integrations.Finra/FinraClient.cs` — added `using System.Globalization` and `CultureInfo.InvariantCulture` parameter to `ToString("yyyy-MM-dd")` at lines 72, 127, 191, 192.
- `tests/Equibles.UnitTests/Finra/FinraClientGetDailyShortVolumeCultureTests.cs` — removed `Skip` attribute so the test runs in CI.

Closes #1915