### PR TITLE
fix(holdings): align integration test CIKs with TrimStart('0') normalization

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
@@ -207,9 +207,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
         holding.AccessionNumber.Should().Be("ACC-001");
         holding.ManagerEntries.Should().ContainSingle().Which.Shares.Should().Be(1000);
         // UpsertInstitutionalHolders side-effect: the new CIK was inserted with cover-page metadata.
-        var holder = await verify
-            .Set<InstitutionalHolder>()
-            .SingleAsync(h => h.Cik == "0001067983");
+        var holder = await verify.Set<InstitutionalHolder>().SingleAsync(h => h.Cik == "1067983");
         holder.Name.Should().Be("Berkshire Hathaway");
         holder.City.Should().Be("Omaha");
     }
@@ -486,7 +484,7 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
         var holder = new InstitutionalHolder
         {
             Id = Guid.NewGuid(),
-            Cik = "0001067983",
+            Cik = "1067983",
             Name = "Berkshire Hathaway",
         };
         var reportDate = new DateOnly(2024, 9, 30);


### PR DESCRIPTION
## Summary

- `TryParseSubmissionRow` strips leading zeros from SEC CIKs via `TrimStart('0')`. Two integration tests used zero-padded CIKs (`"0001067983"`) in seed data and assertions, mismatching the normalized form (`"1067983"`).
- Test 1 (`FullyValidArchive`): holder assertion queried by untrimmed CIK — no match.
- Test 2 (`AmendmentFiling`): seeded holder had untrimmed CIK, so the import created a second holder and the amendment delete targeted the wrong one.

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs` — changed holder CIK assertion from `"0001067983"` to `"1067983"` in the happy-path test; changed seeded holder CIK from `"0001067983"` to `"1067983"` in the amendment test.