### PR TITLE
fix(holdings): register ProcessedDataSetRepository in DoWork integration test

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/Holdings13FRealtimeWorkerDoWorkTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Holdings13FRealtimeWorkerDoWorkTests.cs
@@ -4,6 +4,7 @@ using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Holdings.HostedService;
 using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
@@ -98,6 +99,8 @@ public class Holdings13FRealtimeWorkerDoWorkTests : IAsyncLifetime
                 _contexts.Add(ctx);
                 var sp = Substitute.For<IServiceProvider>();
                 sp.GetService(typeof(EquiblesDbContext)).Returns(ctx);
+                sp.GetService(typeof(ProcessedDataSetRepository))
+                    .Returns(new ProcessedDataSetRepository(ctx));
                 var importService = new HoldingsImportService(
                     scopeFactory,
                     Substitute.For<ILogger<HoldingsImportService>>(),


### PR DESCRIPTION
## Summary

- `ComputeLookbackDays` resolves `ProcessedDataSetRepository` from the DI scope to compute the realtime lookback window.
- The `DoWork_EmptyDailyIndex` integration test's mock service provider was missing this registration, causing `GetRequiredService` to throw.

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/Holdings13FRealtimeWorkerDoWorkTests.cs` — added `ProcessedDataSetRepository` registration to the mock `IServiceProvider` and the corresponding `using` directive.