### PR TITLE
fix(holdings): clamp rebalance date to DateOnly.MaxValue on overflow

### DIFF
--- a/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
@@ -45,7 +45,15 @@ public static class HoldingsBacktestCalculator
         }
 
         var ordered = snapshots
-            .Select(s => (Snapshot: s, RebalanceDate: s.ReportDate.AddDays(RebalanceDelayDays)))
+            .Select(s =>
+                (
+                    Snapshot: s,
+                    RebalanceDate: s.ReportDate.DayNumber
+                    > DateOnly.MaxValue.DayNumber - RebalanceDelayDays
+                        ? DateOnly.MaxValue
+                        : s.ReportDate.AddDays(RebalanceDelayDays)
+                )
+            )
             .OrderBy(x => x.RebalanceDate)
             .ToList();
 

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorRebalanceDateOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorRebalanceDateOverflowTests.cs
@@ -14,7 +14,7 @@ public class HoldingsBacktestCalculatorRebalanceDateOverflowTests
 {
     private static readonly Guid StockA = Guid.Parse("11111111-1111-1111-1111-111111111111");
 
-    [Fact(Skip = "GH-1930 — ReportDate.AddDays(45) overflows near DateOnly.MaxValue")]
+    [Fact]
     public void Calculate_SnapshotReportDateNearMaxValue_DoesNotThrow()
     {
         // ReportDate 9999-11-20 + 45 days = 10000-01-04, which exceeds


### PR DESCRIPTION
## Summary

- `HoldingsBacktestCalculator.Calculate` computed rebalance dates as `ReportDate.AddDays(45)` without overflow protection. When `ReportDate` fell in Nov/Dec 9999, `AddDays(45)` exceeded `DateOnly.MaxValue` and threw `ArgumentOutOfRangeException`.
- Added a `DayNumber` bounds check to clamp to `DateOnly.MaxValue` when the addition would overflow, consistent with the existing horizon clamp for `from.AddYears(MaxYears)`.
- Un-skipped the regression test from GH-1930.

## Code changes

- `src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs` — replaced `s.ReportDate.AddDays(RebalanceDelayDays)` with a conditional that clamps to `DateOnly.MaxValue` when `DayNumber > DateOnly.MaxValue.DayNumber - RebalanceDelayDays`.
- `tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorRebalanceDateOverflowTests.cs` — removed `Skip` attribute.

Closes #1930