### PR TITLE
test(holdings): pin ParseDataSetEndDate leap-year Feb 29 acceptance

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateLeapYearFeb29Tests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateLeapYearFeb29Tests.cs
@@ -1,0 +1,23 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// TryParseDatePart validates the day against DateTime.DaysInMonth, so
+/// February 29 is accepted in leap years and rejected otherwise. A refactor
+/// that hardcoded a max-day-per-month table with February = 28 would silently
+/// reject every Q1-ending data set whose publication window spans a leap-year
+/// boundary (e.g. "01dec2023-29feb2024_form13f.zip").
+/// </summary>
+public class Holdings13FRealtimeWorkerParseDataSetEndDateLeapYearFeb29Tests
+{
+    [Fact]
+    public void ParseDataSetEndDate_LeapYearFeb29_ParsesSuccessfully()
+    {
+        var result = Holdings13FRealtimeWorker.ParseDataSetEndDate(
+            "01dec2023-29feb2024_form13f.zip"
+        );
+
+        result.Should().Be(new DateOnly(2024, 2, 29));
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `Holdings13FRealtimeWorker.ParseDataSetEndDate` correctly accepts February 29 in leap years via `DateTime.DaysInMonth`.
- A refactor that hardcoded a max-day-per-month table with February = 28 would silently reject every Q1-ending data set whose window spans a leap-year boundary (e.g. `01dec2023-29feb2024_form13f.zip`).
- Four sibling tests cover new format, old format, invalid day, and year zero — none exercise the leap-year boundary.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateLeapYearFeb29Tests.cs` — new unit test: input `"01dec2023-29feb2024_form13f.zip"`, asserts result is `DateOnly(2024, 2, 29)`.