### PR TITLE
test(insider-trading): add skipped repro for GH-1964 — InsiderTradingTools.GetRole empty OfficerTitle

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsGetRoleEmptyOfficerTitleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsGetRoleEmptyOfficerTitleTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Mcp.Tools;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class InsiderTradingToolsGetRoleEmptyOfficerTitleTests
+{
+    private static readonly MethodInfo GetRoleMethod = typeof(InsiderTradingTools).GetMethod(
+        "GetRole",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    // GetRole uses `owner.OfficerTitle ?? "Officer"` to fall back when the
+    // title is null. But `??` does NOT fall through on empty string — an
+    // officer with OfficerTitle == "" produces an empty token in the
+    // comma-joined role list (e.g. "Director, " instead of
+    // "Director, Officer"). A caller would reasonably expect a non-empty
+    // label for every role flag that is set.
+    [Fact(Skip = "GH-1964 — GetRole returns empty string for officer with empty OfficerTitle")]
+    public void GetRole_OfficerWithEmptyTitle_FallsBackToOfficerLabel()
+    {
+        var owner = new InsiderOwner { IsOfficer = true, OfficerTitle = string.Empty };
+
+        var role = (string)GetRoleMethod.Invoke(null, [owner]);
+
+        role.Should().Be("Officer");
+    }
+}


### PR DESCRIPTION
## Summary

- Discovered a bug in `InsiderTradingTools.GetRole`: when `IsOfficer == true` and `OfficerTitle` is empty (not null), the `??` operator doesn't fall through, producing an empty role label instead of `"Officer"`. Filed as GH-1964. Test is committed as `[Skip]`.

## Code changes

- `tests/Equibles.UnitTests/Mcp/InsiderTradingToolsGetRoleEmptyOfficerTitleTests.cs` — skipped unit test reproducing the empty-OfficerTitle bug (see GH-1964).