### PR TITLE
feat(holdings): enrich holders table with ownership %, change %, first owned

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -477,4 +477,16 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
                 FilerCount = g.Select(h => h.InstitutionalHolderId).Distinct().Count(),
             });
     }
+
+    public IQueryable<KeyValuePair<Guid, DateOnly>> GetFirstOwnedQuarters(
+        CommonStock stock,
+        IEnumerable<Guid> holderIds
+    )
+    {
+        var ids = holderIds.ToList();
+        return GetAll()
+            .Where(h => h.CommonStockId == stock.Id && ids.Contains(h.InstitutionalHolderId))
+            .GroupBy(h => h.InstitutionalHolderId)
+            .Select(g => new KeyValuePair<Guid, DateOnly>(g.Key, g.Min(h => h.ReportDate)));
+    }
 }

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -133,6 +133,18 @@ public class StockTabService
             allPrevious,
             filersWithCurrentQuarterFilings
         );
+
+        var allChanges = grouped.SelectMany(g => g.Value).ToList();
+        var holderIds = allChanges.Select(h => h.InstitutionalHolderId).Distinct().ToList();
+        var firstOwned = await _institutionalHoldingRepository
+            .GetFirstOwnedQuarters(stock, holderIds)
+            .ToDictionaryAsync(kv => kv.Key, kv => kv.Value);
+        foreach (var change in allChanges)
+        {
+            if (firstOwned.TryGetValue(change.InstitutionalHolderId, out var quarter))
+                change.QuarterFirstOwned = quarter;
+        }
+
         var bucketCounts = grouped.ToDictionary(g => g.Key, g => g.Value.Count);
         var (topBuyers, topSellers) = HoldingsTopMoversSelector.Select(
             grouped,
@@ -147,6 +159,7 @@ public class StockTabService
             TotalValue = allCurrent.Sum(h => h.Value),
             TotalShares = allCurrent.Sum(h => h.Shares),
             HolderCount = allCurrent.Select(h => h.InstitutionalHolderId).Distinct().Count(),
+            SharesOutstanding = stock.SharesOutStanding,
             GroupedHolders = grouped,
             BucketCounts = bucketCounts,
             TopBuyers = topBuyers,

--- a/src/Equibles.Web/ViewModels/Stocks/HolderPositionChange.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/HolderPositionChange.cs
@@ -17,6 +17,14 @@ public class HolderPositionChange
 
     public PositionChangeType ChangeType { get; set; }
 
+    public DateOnly? QuarterFirstOwned { get; set; }
+
     public long DeltaShares => CurrentShares - PreviousShares;
     public long DeltaValue => CurrentValue - PreviousValue;
+
+    public double? ChangePercent =>
+        PreviousShares > 0 ? (double)DeltaShares / PreviousShares * 100.0 : null;
+
+    public double? OwnershipPercent(long sharesOutstanding) =>
+        sharesOutstanding > 0 ? (double)CurrentShares / sharesOutstanding * 100.0 : null;
 }

--- a/src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs
@@ -8,6 +8,7 @@ public class HoldingsTabViewModel
     public long TotalValue { get; set; }
     public long TotalShares { get; set; }
     public int HolderCount { get; set; }
+    public long SharesOutstanding { get; set; }
 
     public Dictionary<PositionChangeType, List<HolderPositionChange>> GroupedHolders { get; set; } =
     [];

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -27,6 +27,19 @@
         };
     }
 
+    static string FormatPct(double? pct)
+    {
+        if (pct == null) return "—";
+        var sign = pct > 0 ? "+" : "";
+        return $"{sign}{pct:F1}%";
+    }
+
+    static string PctCss(double? pct) =>
+        pct > 0 ? "text-success" : pct < 0 ? "text-error" : "";
+
+    static string FormatQuarter(DateOnly? date) =>
+        date == null ? "—" : $"Q{(date.Value.Month - 1) / 3 + 1} {date.Value.Year}";
+
 }
 
 @if (Model.AvailableDates.Count == 0) {
@@ -117,6 +130,7 @@
                                         <tr>
                                             <th scope="col">Institution</th>
                                             <th scope="col" class="text-right">Δ Shares</th>
+                                            <th scope="col" class="text-right hidden md:table-cell">Chg %</th>
                                             <th scope="col" class="text-right hidden md:table-cell">Δ Value (USD)</th>
                                         </tr>
                                     </thead>
@@ -129,6 +143,7 @@
                                             <tr>
                                                 <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
                                                 <td class="text-right font-mono @deltaSharesCss">@deltaSharesText</td>
+                                                <td class="text-right font-mono hidden md:table-cell @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
                                                 <td class="text-right font-mono hidden md:table-cell @deltaValueCss">@deltaValueText</td>
                                             </tr>
                                         }
@@ -163,9 +178,11 @@
                             <tr>
                                 <th scope="col">Holder</th>
                                 <th scope="col" class="text-right">Current Shares</th>
-                                <th scope="col" class="text-right hidden md:table-cell">Previous Shares</th>
-                                <th scope="col" class="text-right">Δ Shares</th>
+                                <th scope="col" class="text-right hidden md:table-cell">Δ Shares</th>
+                                <th scope="col" class="text-right hidden md:table-cell">Chg %</th>
+                                <th scope="col" class="text-right hidden lg:table-cell">Own %</th>
                                 <th scope="col" class="text-right hidden lg:table-cell">Current Value (USD)</th>
+                                <th scope="col" class="text-right hidden xl:table-cell">First Owned</th>
                                 <th scope="col" class="text-right">Δ Value (USD)</th>
                                 <th scope="col" class="text-right">Action</th>
                             </tr>
@@ -177,12 +194,15 @@
                                 var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
                                 var deltaSharesText = (e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "") + Math.Abs(e.DeltaShares).ToString("N0");
                                 var deltaValueText = (e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$") + Math.Abs(e.DeltaValue).ToString("N0");
+                                var own = e.OwnershipPercent(Model.SharesOutstanding);
                                 <tr>
                                     <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
                                     <td class="text-right font-mono whitespace-nowrap">@e.CurrentShares.ToString("N0")</td>
-                                    <td class="text-right font-mono hidden md:table-cell whitespace-nowrap">@e.PreviousShares.ToString("N0")</td>
-                                    <td class="text-right font-mono whitespace-nowrap @deltaSharesCss">@deltaSharesText</td>
+                                    <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @deltaSharesCss">@deltaSharesText</td>
+                                    <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
+                                    <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap">@(own != null ? $"{own:F2}%" : "—")</td>
                                     <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap">$@e.CurrentValue.ToString("N0")</td>
+                                    <td class="text-right hidden xl:table-cell whitespace-nowrap text-base-content/60">@FormatQuarter(e.QuarterFirstOwned)</td>
                                     <td class="text-right font-mono whitespace-nowrap @deltaValueCss">@deltaValueText</td>
                                     <td class="text-right">
                                         @if (e.InstitutionalHolder?.Cik != null) {
@@ -223,9 +243,11 @@
                                 <tr>
                                     <th scope="col">Holder</th>
                                     <th scope="col" class="text-right">Current Shares</th>
-                                    <th scope="col" class="text-right hidden md:table-cell">Previous Shares</th>
-                                    <th scope="col" class="text-right">Δ Shares</th>
+                                    <th scope="col" class="text-right hidden md:table-cell">Δ Shares</th>
+                                    <th scope="col" class="text-right hidden md:table-cell">Chg %</th>
+                                    <th scope="col" class="text-right hidden lg:table-cell">Own %</th>
                                     <th scope="col" class="text-right hidden lg:table-cell">Current Value (USD)</th>
+                                    <th scope="col" class="text-right hidden xl:table-cell">First Owned</th>
                                     <th scope="col" class="text-right">Δ Value (USD)</th>
                                     <th scope="col" class="text-right">Action</th>
                                 </tr>
@@ -236,12 +258,15 @@
                                     var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
                                     var deltaSharesText = (e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "") + Math.Abs(e.DeltaShares).ToString("N0");
                                     var deltaValueText = (e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$") + Math.Abs(e.DeltaValue).ToString("N0");
+                                    var own = e.OwnershipPercent(Model.SharesOutstanding);
                                     <tr>
                                         <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
                                         <td class="text-right font-mono">@e.CurrentShares.ToString("N0")</td>
-                                        <td class="text-right font-mono hidden md:table-cell">@e.PreviousShares.ToString("N0")</td>
-                                        <td class="text-right font-mono @deltaSharesCss">@deltaSharesText</td>
+                                        <td class="text-right font-mono hidden md:table-cell @deltaSharesCss">@deltaSharesText</td>
+                                        <td class="text-right font-mono hidden md:table-cell @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
+                                        <td class="text-right font-mono hidden lg:table-cell">@(own != null ? $"{own:F2}%" : "—")</td>
                                         <td class="text-right font-mono hidden lg:table-cell">$@e.CurrentValue.ToString("N0")</td>
+                                        <td class="text-right hidden xl:table-cell text-base-content/60">@FormatQuarter(e.QuarterFirstOwned)</td>
                                         <td class="text-right font-mono @deltaValueCss">@deltaValueText</td>
                                         <td class="text-right">
                                             @if (e.InstitutionalHolder?.Cik != null) {


### PR DESCRIPTION
## Summary

- Add three new columns to all holders tables on the stock Holdings tab: ownership % (shares / outstanding), change % (delta / prior shares), and quarter first owned (earliest report date for this filer-stock pair).
- Batch-query earliest report dates via `GetFirstOwnedQuarters` repository method to avoid N+1 queries.
- Slice 1/3 for #1855.

Refs #1855

## Code changes

- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — add `GetFirstOwnedQuarters(stock, holderIds)` batch query
- `src/Equibles.Web/ViewModels/Stocks/HolderPositionChange.cs` — add `QuarterFirstOwned`, `ChangePercent`, `OwnershipPercent(sharesOutstanding)` properties
- `src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs` — add `SharesOutstanding` property
- `src/Equibles.Web/Services/StockTabService.cs` — populate `QuarterFirstOwned` from batch query, pass `SharesOutstanding`
- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml` — render Chg %, Own %, First Owned columns in all three table areas (top movers, all holders, buckets) with responsive visibility and color coding