### PR TITLE
feat(holdings): add ownership % column to holders CSV export

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -69,11 +69,13 @@ public class HoldingsExportController : BaseController
             "InstitutionalHolderCik",
             "Shares",
             "Value",
+            "OwnershipPercent",
             "ShareType",
             "OptionType",
             "AccessionNumber",
         ];
 
+        var sharesOut = stock.SharesOutStanding;
         var rows = holdings.Select(h =>
             new[]
             {
@@ -84,6 +86,9 @@ public class HoldingsExportController : BaseController
                 h.HolderCik,
                 CsvExportService.Format(h.Shares),
                 CsvExportService.Format(h.Value),
+                sharesOut > 0
+                    ? ((double)h.Shares / sharesOut * 100.0).ToString("F4")
+                    : string.Empty,
                 h.ShareType.ToString(),
                 h.OptionType?.ToString() ?? string.Empty,
                 h.AccessionNumber,

--- a/tests/Equibles.IntegrationTests/Web/HoldingsExportHoldersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsExportHoldersTests.cs
@@ -94,7 +94,7 @@ public class HoldingsExportHoldersTests
         body.Should()
             .Contain(
                 "Ticker,CompanyName,ReportDate,InstitutionalHolderName,InstitutionalHolderCik,"
-                    + "Shares,Value,ShareType,OptionType,AccessionNumber"
+                    + "Shares,Value,OwnershipPercent,ShareType,OptionType,AccessionNumber"
             );
         body.Should().Contain("AAPL,Apple Inc.,2024-12-31,Berkshire Hathaway,0001067983,");
         body.Should().Contain("1500000,250000000");


### PR DESCRIPTION
## Summary

- Add `OwnershipPercent` column to the per-stock 13F holders CSV export, computed as shares / shares outstanding.
- Slice 3/3 for #1855. Closes #1855.

Closes #1855

## Code changes

- `src/Equibles.Web/Controllers/HoldingsExportController.cs` — add `OwnershipPercent` header and compute column value from `stock.SharesOutStanding`