### PR TITLE
docs(guide): add how-to — search for stocks, filings, institutions, and more

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -31,6 +31,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Use the 13F holdings screener](how-to-use-holdings-screener.md)
 - [View quarterly holdings activity across the market](how-to-view-holdings-activity.md)
 - [Check worker health and recent errors](how-to-view-status-and-errors.md)
+- [Search for stocks, filings, institutions, and more](how-to-search.md)
 
 ## FAQ
 

--- a/docs/guide/how-to-search.md
+++ b/docs/guide/how-to-search.md
@@ -1,0 +1,54 @@
+# Search for stocks, filings, institutions, and more
+
+Use the global search to find anything in Equibles — stocks, SEC filings, economic indicators, institutional holders, insiders, congress members, and futures contracts — from one search box.
+
+## Open the search page
+
+1. Click the **magnifying glass icon** in the navigation bar, or go to `/Search` in your browser.
+2. Type a query in the search box — a ticker, company name, person, indicator, or keyword.
+3. Results appear instantly as you type, grouped by category.
+
+## Narrow results by category
+
+By default, search returns results across all seven categories. To focus on one:
+
+1. Use the **Category** filter in the left sidebar (desktop) or tap **Filters** on mobile.
+2. Select the category you want — for example, **SEC Filings** or **Institutions**.
+3. The results update immediately, showing up to 50 matches in the selected category instead of the top 6 per category in the overview.
+
+To go back to the full overview, select **All categories**.
+
+## Filter SEC filings by date
+
+The **Filed between** date filter narrows results to filings within a specific date range. This is most useful when searching SEC filings:
+
+1. Open the filters sidebar.
+2. Set a **From** date, a **To** date, or both under **Filed between**.
+3. The results update to show only filings filed within that window.
+
+Other categories (stocks, institutions, etc.) are not affected by the date filter.
+
+## Change the sort order
+
+Results default to **Relevance** — the best matches appear first. To sort alphabetically instead:
+
+1. Open the filters sidebar.
+2. Change **Sort by** to **Name (A–Z)**.
+
+## Clear all filters
+
+Click **Clear all** at the top of the filters sidebar to reset the category, sort, and date filters in one step. Your search query stays in the box.
+
+## What each category searches
+
+| Category | What it matches |
+|----------|----------------|
+| **Stocks** | Company name and ticker symbol |
+| **SEC Filings** | Full-text content of 10-K, 10-Q, 8-K, and other filings |
+| **Economic Indicators** | FRED series name and description |
+| **Institutions** | Institutional holder name (13F filers) |
+| **Insiders** | Insider name (directors, officers, 10% owners) |
+| **Congress** | Congress member name |
+| **Futures** | CFTC contract name |
+
+For full-text search within a specific SEC filing (searching inside one document rather than across all filings), see the filing detail page on the [stock profile](tutorial-explore-stock.md).


### PR DESCRIPTION
## Summary

- **Expand lane**: added a new how-to guide covering the global search feature (7 categories, filters, date range, sort).
- Added a TOC entry in `docs/guide/README.md` under How-to guides.

## Code changes

- `docs/guide/how-to-search.md` — new how-to page: how to use global search, narrow by category, filter SEC filings by date, change sort order, and what each category matches.
- `docs/guide/README.md` — added one bullet linking to the new how-to page.