### PR TITLE
feat(holdings): add FundClassification enum and rules-based classifier

### DIFF
--- a/src/Equibles.Holdings.Data/Models/FundClassification.cs
+++ b/src/Equibles.Holdings.Data/Models/FundClassification.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Holdings.Data.Models;
+
+public enum FundClassification
+{
+    [Display(Name = "Unknown")]
+    Unknown = 0,
+
+    [Display(Name = "Bank")]
+    Bank = 1,
+
+    [Display(Name = "Insurance Company")]
+    InsuranceCompany = 2,
+
+    [Display(Name = "Pension Fund")]
+    PensionFund = 3,
+
+    [Display(Name = "Mutual Fund")]
+    MutualFund = 4,
+
+    [Display(Name = "Hedge Fund")]
+    HedgeFund = 5,
+
+    [Display(Name = "Private Equity")]
+    PrivateEquity = 6,
+
+    [Display(Name = "Venture Capital")]
+    VentureCapital = 7,
+
+    [Display(Name = "Endowment")]
+    Endowment = 8,
+
+    [Display(Name = "Sovereign Wealth Fund")]
+    SovereignWealthFund = 9,
+
+    [Display(Name = "Family Office")]
+    FamilyOffice = 10,
+
+    [Display(Name = "Broker-Dealer")]
+    BrokerDealer = 11,
+}

--- a/src/Equibles.Holdings.Data/Models/InstitutionalHolder.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalHolder.cs
@@ -5,6 +5,7 @@ namespace Equibles.Holdings.Data.Models;
 
 [Index(nameof(Cik), IsUnique = true)]
 [Index(nameof(Name))]
+[Index(nameof(Classification))]
 public class InstitutionalHolder
 {
     public Guid Id { get; set; } = Guid.NewGuid();
@@ -26,6 +27,8 @@ public class InstitutionalHolder
 
     [MaxLength(32)]
     public string CrdNumber { get; set; }
+
+    public FundClassification Classification { get; set; }
 
     public virtual List<InstitutionalHolding> Holdings { get; set; } = [];
 

--- a/src/Equibles.Holdings.HostedService/Services/FundClassifierService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/FundClassifierService.cs
@@ -1,0 +1,61 @@
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+public static class FundClassifierService
+{
+    private static readonly (string Pattern, FundClassification Classification)[] Rules =
+    [
+        ("SOVEREIGN WEALTH", FundClassification.SovereignWealthFund),
+        ("FAMILY OFFICE", FundClassification.FamilyOffice),
+        ("VENTURE CAPITAL", FundClassification.VentureCapital),
+        ("VENTURE PARTNERS", FundClassification.VentureCapital),
+        ("PRIVATE EQUITY", FundClassification.PrivateEquity),
+        ("BUYOUT", FundClassification.PrivateEquity),
+        ("PENSION", FundClassification.PensionFund),
+        ("RETIREMENT", FundClassification.PensionFund),
+        ("SUPERANNUATION", FundClassification.PensionFund),
+        ("ENDOWMENT", FundClassification.Endowment),
+        ("UNIVERSITY", FundClassification.Endowment),
+        ("FOUNDATION", FundClassification.Endowment),
+        ("INSURANCE", FundClassification.InsuranceCompany),
+        ("ASSURANCE", FundClassification.InsuranceCompany),
+        ("REINSURANCE", FundClassification.InsuranceCompany),
+        ("UNDERWRITER", FundClassification.InsuranceCompany),
+        ("LIFE INS", FundClassification.InsuranceCompany),
+        ("MUTUAL FUND", FundClassification.MutualFund),
+        ("MUTUAL LIFE", FundClassification.InsuranceCompany),
+        ("INDEX FUND", FundClassification.MutualFund),
+        ("EXCHANGE TRADED FUND", FundClassification.MutualFund),
+        ("ETF", FundClassification.MutualFund),
+        ("HEDGE FUND", FundClassification.HedgeFund),
+        ("BROKER", FundClassification.BrokerDealer),
+        ("BROKERAGE", FundClassification.BrokerDealer),
+        ("SECURITIES", FundClassification.BrokerDealer),
+        ("BANCORP", FundClassification.Bank),
+        ("BANCSHARES", FundClassification.Bank),
+        ("BANKERS", FundClassification.Bank),
+        ("NATIONAL BANK", FundClassification.Bank),
+        ("STATE BANK", FundClassification.Bank),
+        ("SAVINGS BANK", FundClassification.Bank),
+        ("BANK OF", FundClassification.Bank),
+        ("BANK ", FundClassification.Bank),
+        ("TRUST CO", FundClassification.Bank),
+    ];
+
+    public static FundClassification Classify(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return FundClassification.Unknown;
+
+        var upper = name.ToUpperInvariant();
+
+        foreach (var (pattern, classification) in Rules)
+        {
+            if (upper.Contains(pattern))
+                return classification;
+        }
+
+        return FundClassification.Unknown;
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260524004205_AddInstitutionalHolderClassification.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260524004205_AddInstitutionalHolderClassification.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524004205_AddInstitutionalHolderClassification")]
+    partial class AddInstitutionalHolderClassification
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260524004205_AddInstitutionalHolderClassification.cs
+++ b/src/Equibles.Migrations/Migrations/20260524004205_AddInstitutionalHolderClassification.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstitutionalHolderClassification : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Classification",
+                table: "InstitutionalHolder",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolder_Classification",
+                table: "InstitutionalHolder",
+                column: "Classification");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolder_Classification",
+                table: "InstitutionalHolder");
+
+            migrationBuilder.DropColumn(
+                name: "Classification",
+                table: "InstitutionalHolder");
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/FundClassifierServiceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundClassifierServiceTests.cs
@@ -1,0 +1,163 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class FundClassifierServiceTests
+{
+    [Theory]
+    [InlineData("JPMORGAN CHASE BANK NA", FundClassification.Bank)]
+    [InlineData("BANK OF AMERICA CORP", FundClassification.Bank)]
+    [InlineData("FIRST BANCSHARES INC", FundClassification.Bank)]
+    [InlineData("ZIONS BANCORP NA", FundClassification.Bank)]
+    [InlineData("NORTHERN TRUST CO", FundClassification.Bank)]
+    [InlineData("PEOPLES SAVINGS BANK", FundClassification.Bank)]
+    [InlineData("NATIONAL BANK OF CANADA", FundClassification.Bank)]
+    [InlineData("STATE BANK OF INDIA", FundClassification.Bank)]
+    public void Classify_BankNames_ReturnsBank(string name, FundClassification expected)
+    {
+        FundClassifierService.Classify(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("METLIFE INSURANCE CO", FundClassification.InsuranceCompany)]
+    [InlineData("PRUDENTIAL INSURANCE CO", FundClassification.InsuranceCompany)]
+    [InlineData("SWISS REINSURANCE CO", FundClassification.InsuranceCompany)]
+    [InlineData("GREAT WEST LIFE ASSURANCE", FundClassification.InsuranceCompany)]
+    [InlineData("NEW YORK LIFE INS CO", FundClassification.InsuranceCompany)]
+    public void Classify_InsuranceNames_ReturnsInsuranceCompany(
+        string name,
+        FundClassification expected
+    )
+    {
+        FundClassifierService.Classify(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("CALIFORNIA PUBLIC EMPLOYEES RETIREMENT SYSTEM", FundClassification.PensionFund)]
+    [InlineData("ONTARIO TEACHERS PENSION PLAN", FundClassification.PensionFund)]
+    [InlineData("AUSTRALIAN SUPERANNUATION FUND", FundClassification.PensionFund)]
+    public void Classify_PensionNames_ReturnsPensionFund(string name, FundClassification expected)
+    {
+        FundClassifierService.Classify(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("VANGUARD INDEX FUND", FundClassification.MutualFund)]
+    [InlineData("SPDR S&P 500 ETF", FundClassification.MutualFund)]
+    [InlineData("FIDELITY MUTUAL FUND", FundClassification.MutualFund)]
+    public void Classify_MutualFundNames_ReturnsMutualFund(string name, FundClassification expected)
+    {
+        FundClassifierService.Classify(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("CITADEL HEDGE FUND LP", FundClassification.HedgeFund)]
+    public void Classify_HedgeFundNames_ReturnsHedgeFund(string name, FundClassification expected)
+    {
+        FundClassifierService.Classify(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("BLACKSTONE PRIVATE EQUITY PARTNERS", FundClassification.PrivateEquity)]
+    [InlineData("KKR BUYOUT FUND", FundClassification.PrivateEquity)]
+    public void Classify_PrivateEquityNames_ReturnsPrivateEquity(
+        string name,
+        FundClassification expected
+    )
+    {
+        FundClassifierService.Classify(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("SEQUOIA VENTURE CAPITAL", FundClassification.VentureCapital)]
+    [InlineData("KLEINER PERKINS VENTURE PARTNERS", FundClassification.VentureCapital)]
+    public void Classify_VentureCapitalNames_ReturnsVentureCapital(
+        string name,
+        FundClassification expected
+    )
+    {
+        FundClassifierService.Classify(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("HARVARD UNIVERSITY ENDOWMENT", FundClassification.Endowment)]
+    [InlineData("YALE ENDOWMENT FUND", FundClassification.Endowment)]
+    [InlineData("BILL AND MELINDA GATES FOUNDATION", FundClassification.Endowment)]
+    [InlineData("STANFORD UNIVERSITY", FundClassification.Endowment)]
+    public void Classify_EndowmentNames_ReturnsEndowment(string name, FundClassification expected)
+    {
+        FundClassifierService.Classify(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("NORWAY SOVEREIGN WEALTH FUND", FundClassification.SovereignWealthFund)]
+    public void Classify_SovereignWealthFundNames_ReturnsSovereignWealthFund(
+        string name,
+        FundClassification expected
+    )
+    {
+        FundClassifierService.Classify(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("SOROS FAMILY OFFICE", FundClassification.FamilyOffice)]
+    public void Classify_FamilyOfficeNames_ReturnsFamilyOffice(
+        string name,
+        FundClassification expected
+    )
+    {
+        FundClassifierService.Classify(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("GOLDMAN SACHS SECURITIES LLC", FundClassification.BrokerDealer)]
+    [InlineData("INTERACTIVE BROKERS GROUP", FundClassification.BrokerDealer)]
+    [InlineData("TD AMERITRADE BROKERAGE", FundClassification.BrokerDealer)]
+    public void Classify_BrokerDealerNames_ReturnsBrokerDealer(
+        string name,
+        FundClassification expected
+    )
+    {
+        FundClassifierService.Classify(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("BERKSHIRE HATHAWAY INC", FundClassification.Unknown)]
+    [InlineData("VANGUARD GROUP INC", FundClassification.Unknown)]
+    [InlineData("BLACKROCK INC", FundClassification.Unknown)]
+    public void Classify_GenericAssetManagers_ReturnsUnknown(
+        string name,
+        FundClassification expected
+    )
+    {
+        FundClassifierService.Classify(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Classify_NullOrEmptyName_ReturnsUnknown(string name)
+    {
+        FundClassifierService.Classify(name).Should().Be(FundClassification.Unknown);
+    }
+
+    [Fact]
+    public void Classify_IsCaseInsensitive()
+    {
+        FundClassifierService
+            .Classify("jpmorgan chase bank na")
+            .Should()
+            .Be(FundClassification.Bank);
+    }
+
+    [Fact]
+    public void Classify_MutualLifeInsurance_MatchesInsuranceNotMutualFund()
+    {
+        FundClassifierService
+            .Classify("MUTUAL LIFE INSURANCE CO")
+            .Should()
+            .Be(FundClassification.InsuranceCompany);
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 1/2 for #1861 — data layer and classification logic.
- Added `FundClassification` enum with 12 values (Unknown through BrokerDealer) and a `Classification` column on `InstitutionalHolder` with a database index.
- Created `FundClassifierService` with ordered rules-based name matching — classifies filers by keywords in their name (e.g., "BANK", "INSURANCE", "PENSION").
- 41 unit tests covering all classification categories, edge cases, case insensitivity, and rule priority.

## Code changes

- `src/Equibles.Holdings.Data/Models/FundClassification.cs` — new enum with `[Display]` attributes.
- `src/Equibles.Holdings.Data/Models/InstitutionalHolder.cs` — added `Classification` property and `[Index]`.
- `src/Equibles.Holdings.HostedService/Services/FundClassifierService.cs` — static classifier with ordered keyword rules.
- `src/Equibles.Migrations/Migrations/20260524*` — adds `Classification` integer column (default 0) and index.
- `tests/Equibles.UnitTests/Holdings/FundClassifierServiceTests.cs` — 41 parameterised tests.

Refs #1861