### PR TITLE
feat(holdings): wire fund classification into import pipeline and UI

### DIFF
--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -1,6 +1,7 @@
 using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
+using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.HostedService.Services;
 using Equibles.Holdings.Repositories;
 using Equibles.Worker;
@@ -94,6 +95,8 @@ public class HoldingsScraperWorker : BaseScraperWorker
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {
+        await BackfillHolderClassifications(stoppingToken);
+
         var startDate = _workerOptions.MinSyncDate ?? new DateTime(2020, 1, 1);
         var minReportDate = DateOnly.FromDateTime(startDate);
         var fileNames = HoldingsDataSetClient.GetDataSetFileNames(startDate);
@@ -352,5 +355,36 @@ public class HoldingsScraperWorker : BaseScraperWorker
             MaxRetries
         );
         return false;
+    }
+
+    private async Task BackfillHolderClassifications(CancellationToken cancellationToken)
+    {
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<InstitutionalHolderRepository>();
+
+        var unclassified = await repo.GetUnclassified().ToListAsync(cancellationToken);
+        if (unclassified.Count == 0)
+            return;
+
+        var classified = 0;
+        foreach (var holder in unclassified)
+        {
+            var result = FundClassifierService.Classify(holder.Name);
+            if (result != FundClassification.Unknown)
+            {
+                holder.Classification = result;
+                classified++;
+            }
+        }
+
+        if (classified > 0)
+        {
+            await repo.SaveChanges();
+            Logger.LogInformation(
+                "Backfilled fund classification for {Classified}/{Total} unclassified holders",
+                classified,
+                unclassified.Count
+            );
+        }
     }
 }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -380,6 +380,7 @@ public class HoldingsImportService
                 StateOrCountry = coverPage?.StateOrCountry,
                 Form13FFileNumber = coverPage?.Form13FFileNumber,
                 CrdNumber = coverPage?.CrdNumber,
+                Classification = FundClassifierService.Classify(coverPage?.CompanyName),
             };
 
             holderRepo.Add(holder);

--- a/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
@@ -23,4 +23,10 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
     {
         return GetAll().Where(h => EF.Functions.ILike(h.Name, $"%{search}%"));
     }
+
+    public IQueryable<InstitutionalHolder> GetUnclassified()
+    {
+        return GetAll()
+            .Where(h => h.Classification == FundClassification.Unknown && h.Name != null);
+    }
 }

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -84,6 +84,7 @@ public class ProfilesController : BaseController
             {
                 Name = holder.Name,
                 Cik = holder.Cik,
+                Classification = holder.Classification,
                 Location = ProfileFormatting.JoinLocation(holder.City, holder.StateOrCountry),
                 Holdings = holdings,
                 Summary = summary,

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
@@ -1,3 +1,4 @@
+using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories.Models;
 
 namespace Equibles.Web.ViewModels.Profiles;
@@ -7,6 +8,7 @@ public class InstitutionProfileViewModel
     public string Name { get; set; }
     public string Cik { get; set; }
     public string Location { get; set; }
+    public FundClassification Classification { get; set; }
     public List<HoldingRowViewModel> Holdings { get; set; } = [];
     public InstitutionPortfolioSummary Summary { get; set; } = new();
     public List<IndustryAllocationSlice> IndustryAllocation { get; set; } = [];

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -7,7 +7,10 @@
 <div class="max-w-6xl mx-auto px-6 py-12">
     <div class="mb-8 flex flex-wrap items-start justify-between gap-3">
         <div>
-            <h1 class="text-3xl font-bold mb-2">@Model.Name</h1>
+            <h1 class="text-3xl font-bold mb-2">
+                @Model.Name
+                <partial name="_FundClassificationBadge" model="Model.Classification" />
+            </h1>
             <p class="text-base-content/60">
                 Institutional holder@(string.IsNullOrWhiteSpace(Model.Location) ? "" : " · " + Model.Location) · CIK @Model.Cik
             </p>

--- a/src/Equibles.Web/Views/Shared/_FundClassificationBadge.cshtml
+++ b/src/Equibles.Web/Views/Shared/_FundClassificationBadge.cshtml
@@ -1,0 +1,20 @@
+@using Equibles.Holdings.Data.Models
+@model FundClassification
+
+@if (Model != FundClassification.Unknown) {
+    var (label, css) = Model switch {
+        FundClassification.Bank => ("Bank", "badge-primary"),
+        FundClassification.InsuranceCompany => ("Insurance", "badge-warning"),
+        FundClassification.PensionFund => ("Pension", "badge-info"),
+        FundClassification.MutualFund => ("Mutual Fund", "badge-success"),
+        FundClassification.HedgeFund => ("Hedge Fund", "badge-error"),
+        FundClassification.PrivateEquity => ("Private Equity", "badge-secondary"),
+        FundClassification.VentureCapital => ("Venture Capital", "badge-accent"),
+        FundClassification.Endowment => ("Endowment", "badge-info"),
+        FundClassification.SovereignWealthFund => ("Sovereign Wealth", "badge-primary"),
+        FundClassification.FamilyOffice => ("Family Office", "badge-ghost"),
+        FundClassification.BrokerDealer => ("Broker-Dealer", "badge-neutral"),
+        _ => ("", ""),
+    };
+    <span class="badge @css badge-sm" data-testid="fund-classification">@label</span>
+}

--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -24,6 +24,7 @@
         <div class="card-body p-4 lg:p-6">
             <div class="flex items-baseline gap-3 mb-1">
                 <h1 class="text-2xl font-bold">@holder.Name</h1>
+                <partial name="_FundClassificationBadge" model="holder.Classification" />
             </div>
 
             <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4 pt-4 border-t border-base-200">

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -233,7 +233,12 @@
                                 var deltaValueText = (e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$") + Math.Abs(e.DeltaValue).ToString("N0");
                                 var own = e.OwnershipPercent(Model.SharesOutstanding);
                                 <tr>
-                                    <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
+                                    <td class="max-w-xs truncate">
+                                        @(e.InstitutionalHolder?.Name ?? "Unknown")
+                                        @if (e.InstitutionalHolder != null) {
+                                            <partial name="_FundClassificationBadge" model="e.InstitutionalHolder.Classification" />
+                                        }
+                                    </td>
                                     <td class="text-right font-mono whitespace-nowrap">@e.CurrentShares.ToString("N0")</td>
                                     <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @deltaSharesCss">@deltaSharesText</td>
                                     <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
@@ -298,7 +303,12 @@
                                     var deltaValueText = (e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$") + Math.Abs(e.DeltaValue).ToString("N0");
                                     var own = e.OwnershipPercent(Model.SharesOutstanding);
                                     <tr>
-                                        <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
+                                        <td class="max-w-xs truncate">
+                                            @(e.InstitutionalHolder?.Name ?? "Unknown")
+                                            @if (e.InstitutionalHolder != null) {
+                                                <partial name="_FundClassificationBadge" model="e.InstitutionalHolder.Classification" />
+                                            }
+                                        </td>
                                         <td class="text-right font-mono">@e.CurrentShares.ToString("N0")</td>
                                         <td class="text-right font-mono hidden md:table-cell @deltaSharesCss">@deltaSharesText</td>
                                         <td class="text-right font-mono hidden md:table-cell @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>


### PR DESCRIPTION
## Summary

- Slice 2/2 for #1861 — wires the classifier into the data pipeline and renders badges.
- New holders are classified during import; existing holders are backfilled on the first scraper cycle.
- Classification badges appear in all holder tables (holdings tab, bucket panels) and detail pages (holder profile, institution profile).
- Closes #1861

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — added `FundClassifierService.Classify()` call when creating new holders.
- `src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs` — added `BackfillHolderClassifications` method called at the start of each cycle; reclassifies holders with `Unknown` classification.
- `src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs` — added `GetUnclassified()` query.
- `src/Equibles.Web/Views/Shared/_FundClassificationBadge.cshtml` — new shared partial rendering a DaisyUI badge per classification type.
- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml` — added badge next to holder name in all-holders and bucket tables.
- `src/Equibles.Web/Views/Stocks/ShowHolder.cshtml` — added badge next to holder name on detail page.
- `src/Equibles.Web/Views/Profiles/Institution.cshtml` — added badge next to institution name.
- `src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs` — added `Classification` property.
- `src/Equibles.Web/Controllers/ProfilesController.cs` — passes `Classification` to the view model.