### PR TITLE
feat(stocks): inline key metrics on stock overview

### DIFF
--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -205,6 +205,7 @@ public class StocksController : BaseController
         viewModel.RecentFilingCount = filingActivity?.FilingCount ?? 0;
         viewModel.RecentFilerCount = filingActivity?.FilerCount ?? 0;
         viewModel.FilingActivityDays = FilingActivityDays;
+        viewModel.KeyMetrics = await _stockTabService.LoadKeyMetrics(stock);
 
         ViewData["TabViewModel"] = await loadTab(stock);
         return View("Show", viewModel);

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -409,6 +409,50 @@ public class StockTabService
             _ => 0,
         };
 
+    public async Task<KeyMetricsViewModel> LoadKeyMetrics(CommonStock stock)
+    {
+        var vm = new KeyMetricsViewModel { MarketCapitalization = stock.MarketCapitalization };
+
+        var recentPrices = await _dailyStockPriceRepository
+            .GetByStock(stock)
+            .OrderByDescending(p => p.Date)
+            .Take(252)
+            .ToListAsync();
+
+        if (recentPrices.Count > 0)
+        {
+            vm.LatestClose = recentPrices[0].Close;
+            vm.High52Week = recentPrices.Max(p => p.High);
+            vm.Low52Week = recentPrices.Min(p => p.Low);
+        }
+
+        var epsConcept = await _financialConceptRepository
+            .GetMatching([FactTaxonomy.UsGaap], ["EarningsPerShareDiluted"])
+            .Select(c => c.Id)
+            .FirstOrDefaultAsync();
+
+        if (epsConcept != Guid.Empty)
+        {
+            var epsFact = await _financialFactRepository
+                .GetByStock(stock)
+                .Where(f =>
+                    f.FinancialConceptId == epsConcept && f.FiscalPeriod == SecFiscalPeriod.FullYear
+                )
+                .OrderByDescending(f => f.FiscalYear)
+                .ThenByDescending(f => f.FiledDate)
+                .FirstOrDefaultAsync();
+
+            if (epsFact != null)
+            {
+                vm.EpsDiluted = epsFact.Value;
+                if (vm.LatestClose.HasValue && epsFact.Value != 0)
+                    vm.PeRatio = Math.Round(vm.LatestClose.Value / epsFact.Value, 2);
+            }
+        }
+
+        return vm;
+    }
+
     public async Task<HolderDetailViewModel> LoadHolderDetail(
         CommonStock stock,
         InstitutionalHolder holder

--- a/src/Equibles.Web/ViewModels/Stocks/KeyMetricsViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/KeyMetricsViewModel.cs
@@ -1,0 +1,11 @@
+namespace Equibles.Web.ViewModels.Stocks;
+
+public class KeyMetricsViewModel
+{
+    public decimal? LatestClose { get; set; }
+    public decimal? High52Week { get; set; }
+    public decimal? Low52Week { get; set; }
+    public double MarketCapitalization { get; set; }
+    public decimal? EpsDiluted { get; set; }
+    public decimal? PeRatio { get; set; }
+}

--- a/src/Equibles.Web/ViewModels/Stocks/StockDetailViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/StockDetailViewModel.cs
@@ -10,4 +10,6 @@ public class StockDetailViewModel
     public int RecentFilingCount { get; set; }
     public int RecentFilerCount { get; set; }
     public int FilingActivityDays { get; set; }
+
+    public KeyMetricsViewModel KeyMetrics { get; set; }
 }

--- a/src/Equibles.Web/Views/Stocks/Show.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Show.cshtml
@@ -78,6 +78,71 @@
     </div>
 
     @{
+        var km = Model.KeyMetrics;
+        bool hasAnyMetric = km != null && (km.LatestClose.HasValue || km.MarketCapitalization > 0 || km.EpsDiluted.HasValue);
+        string FormatMarketCap(double cap) => cap switch {
+            >= 1e12 => (cap / 1e12).ToString("F2") + "T",
+            >= 1e9 => (cap / 1e9).ToString("F2") + "B",
+            >= 1e6 => (cap / 1e6).ToString("F2") + "M",
+            > 0 => cap.ToString("N0"),
+            _ => null
+        };
+    }
+    @if (hasAnyMetric) {
+        <!-- Key Metrics -->
+        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-6">
+            @if (km.LatestClose.HasValue) {
+                <div class="card bg-base-100 shadow-sm">
+                    <div class="card-body p-3">
+                        <div class="text-xs text-base-content/50 uppercase tracking-wider">Price</div>
+                        <div class="font-mono font-semibold text-lg">$@km.LatestClose.Value.ToString("N2")</div>
+                    </div>
+                </div>
+            }
+            @if (km.MarketCapitalization > 0) {
+                <div class="card bg-base-100 shadow-sm">
+                    <div class="card-body p-3">
+                        <div class="text-xs text-base-content/50 uppercase tracking-wider">Market Cap</div>
+                        <div class="font-mono font-semibold text-lg">$@FormatMarketCap(km.MarketCapitalization)</div>
+                    </div>
+                </div>
+            }
+            @if (km.PeRatio.HasValue) {
+                <div class="card bg-base-100 shadow-sm">
+                    <div class="card-body p-3">
+                        <div class="text-xs text-base-content/50 uppercase tracking-wider">P/E Ratio</div>
+                        <div class="font-mono font-semibold text-lg">@km.PeRatio.Value.ToString("N2")</div>
+                    </div>
+                </div>
+            }
+            @if (km.EpsDiluted.HasValue) {
+                <div class="card bg-base-100 shadow-sm">
+                    <div class="card-body p-3">
+                        <div class="text-xs text-base-content/50 uppercase tracking-wider">EPS (Diluted)</div>
+                        <div class="font-mono font-semibold text-lg">$@km.EpsDiluted.Value.ToString("N2")</div>
+                    </div>
+                </div>
+            }
+            @if (km.High52Week.HasValue) {
+                <div class="card bg-base-100 shadow-sm">
+                    <div class="card-body p-3">
+                        <div class="text-xs text-base-content/50 uppercase tracking-wider">52W High</div>
+                        <div class="font-mono font-semibold text-lg">$@km.High52Week.Value.ToString("N2")</div>
+                    </div>
+                </div>
+            }
+            @if (km.Low52Week.HasValue) {
+                <div class="card bg-base-100 shadow-sm">
+                    <div class="card-body p-3">
+                        <div class="text-xs text-base-content/50 uppercase tracking-wider">52W Low</div>
+                        <div class="font-mono font-semibold text-lg">$@km.Low52Week.Value.ToString("N2")</div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+
+    @{
         // Each "tab" is a full-page navigation, not an in-page tabpanel — so
         // ARIA tab/tablist roles would mislead assistive tech (they expect
         // arrow-key panel switching). Render as a <nav> landmark with normal

--- a/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
@@ -25,6 +25,7 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
 using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -287,6 +288,7 @@ public class StocksControllerTests : IDisposable
             new CommonStocksModuleConfiguration(),
             new MediaModuleConfiguration(),
             new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
             new HoldingsModuleConfiguration(),
             new FinraModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),
@@ -881,6 +883,7 @@ public class StatusControllerTests : IDisposable
             new CommonStocksModuleConfiguration(),
             new MediaModuleConfiguration(),
             new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
             new HoldingsModuleConfiguration(),
             new FinraModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadHolderDetailTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadHolderDetailTests.cs
@@ -12,6 +12,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Services;
@@ -40,6 +41,7 @@ public class StockTabServiceLoadHolderDetailTests : IDisposable
             new CommonStocksModuleConfiguration(),
             new MediaModuleConfiguration(),
             new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
             new FinraModuleConfiguration(),
             new HoldingsModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Web/StockTabServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServiceTests.cs
@@ -17,6 +17,7 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
 using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Services;
@@ -39,6 +40,7 @@ public class StockTabServiceTests : IDisposable
             new CommonStocksModuleConfiguration(),
             new MediaModuleConfiguration(),
             new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
             new FinraModuleConfiguration(),
             new HoldingsModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerCongressionalTradesTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerCongressionalTradesTabTests.cs
@@ -12,6 +12,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -45,6 +46,7 @@ public class StocksControllerCongressionalTradesTabTests : IDisposable
             new CommonStocksModuleConfiguration(),
             new MediaModuleConfiguration(),
             new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
             new HoldingsModuleConfiguration(),
             new FinraModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerDocumentsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerDocumentsTabTests.cs
@@ -12,6 +12,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -45,6 +46,7 @@ public class StocksControllerDocumentsTabTests : IDisposable
             new CommonStocksModuleConfiguration(),
             new MediaModuleConfiguration(),
             new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
             new HoldingsModuleConfiguration(),
             new FinraModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerFtdTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerFtdTabTests.cs
@@ -12,6 +12,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -44,6 +45,7 @@ public class StocksControllerFtdTabTests : IDisposable
             new CommonStocksModuleConfiguration(),
             new MediaModuleConfiguration(),
             new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
             new HoldingsModuleConfiguration(),
             new FinraModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerHoldingsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerHoldingsTabTests.cs
@@ -12,6 +12,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -46,6 +47,7 @@ public class StocksControllerHoldingsTabTests : IDisposable
             new CommonStocksModuleConfiguration(),
             new MediaModuleConfiguration(),
             new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
             new HoldingsModuleConfiguration(),
             new FinraModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerInsiderTradingTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerInsiderTradingTabTests.cs
@@ -12,6 +12,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -45,6 +46,7 @@ public class StocksControllerInsiderTradingTabTests : IDisposable
             new CommonStocksModuleConfiguration(),
             new MediaModuleConfiguration(),
             new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
             new HoldingsModuleConfiguration(),
             new FinraModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShortInterestTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShortInterestTabTests.cs
@@ -12,6 +12,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -45,6 +46,7 @@ public class StocksControllerShortInterestTabTests : IDisposable
             new CommonStocksModuleConfiguration(),
             new MediaModuleConfiguration(),
             new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
             new HoldingsModuleConfiguration(),
             new FinraModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShortVolumeTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShortVolumeTabTests.cs
@@ -12,6 +12,7 @@ using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.Data;
+using Equibles.Sec.FinancialFacts.Data;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Controllers;
@@ -45,6 +46,7 @@ public class StocksControllerShortVolumeTabTests : IDisposable
             new CommonStocksModuleConfiguration(),
             new MediaModuleConfiguration(),
             new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
             new HoldingsModuleConfiguration(),
             new FinraModuleConfiguration(),
             new InsiderTradingModuleConfiguration(),


### PR DESCRIPTION
## Summary

- Display Price, Market Cap, P/E Ratio, EPS (Diluted), 52W High, and 52W Low as card metrics between the stock header and tab navigation on every stock detail page.
- Metrics are derived from existing `DailyStockPrice` (latest close, 52-week range) and `FinancialFact` (trailing annual EPS via `EarningsPerShareDiluted`). P/E is computed as close / EPS.
- No new data sources, migrations, or dependencies required.

Closes #1856

## Code changes

- `src/Equibles.Web/ViewModels/Stocks/KeyMetricsViewModel.cs` — New view model holding Price, Market Cap, P/E, EPS, 52W High/Low.
- `src/Equibles.Web/Services/StockTabService.cs` — Added `LoadKeyMetrics()` method that queries recent prices and the latest full-year EPS fact.
- `src/Equibles.Web/ViewModels/Stocks/StockDetailViewModel.cs` — Added `KeyMetrics` property.
- `src/Equibles.Web/Controllers/StocksController.cs` — `ShowStockTab()` now calls `LoadKeyMetrics()`.
- `src/Equibles.Web/Views/Stocks/Show.cshtml` — Renders a 6-column metric card grid between the header and tab nav, conditionally hidden when no data is available.
- `tests/Equibles.IntegrationTests/Web/*.cs` (11 files) — Added `FinancialFactsModuleConfiguration` to test DB contexts so the `FinancialConcept` entity is available during `LoadKeyMetrics`.