### PR TITLE
chore: fix CSharpier formatting in migration

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260524004205_AddInstitutionalHolderClassification.cs
+++ b/src/Equibles.Migrations/Migrations/20260524004205_AddInstitutionalHolderClassification.cs
@@ -15,12 +15,14 @@ namespace Equibles.Migrations.Migrations
                 table: "InstitutionalHolder",
                 type: "integer",
                 nullable: false,
-                defaultValue: 0);
+                defaultValue: 0
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_InstitutionalHolder_Classification",
                 table: "InstitutionalHolder",
-                column: "Classification");
+                column: "Classification"
+            );
         }
 
         /// <inheritdoc />
@@ -28,11 +30,10 @@ namespace Equibles.Migrations.Migrations
         {
             migrationBuilder.DropIndex(
                 name: "IX_InstitutionalHolder_Classification",
-                table: "InstitutionalHolder");
+                table: "InstitutionalHolder"
+            );
 
-            migrationBuilder.DropColumn(
-                name: "Classification",
-                table: "InstitutionalHolder");
+            migrationBuilder.DropColumn(name: "Classification", table: "InstitutionalHolder");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fix CSharpier formatting in `AddInstitutionalHolderClassification` migration that was blocking all PR merges via the lint CI gate.

## Code changes

- `src/Equibles.Migrations/Migrations/20260524004205_AddInstitutionalHolderClassification.cs` — whitespace-only formatting fix (closing parentheses on separate lines per CSharpier rules).