### PR TITLE
fix(ci): align holdings tests and fix RateLimiter concurrent burst-through

### DIFF
--- a/src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs
+++ b/src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs
@@ -71,7 +71,7 @@ public class RateLimiter : IRateLimiter
 
     private void CleanupOldRequests(DateTime now)
     {
-        while (_requestTimes.Count > 0 && _requestTimes.Peek() < now - _timeWindow)
+        while (_requestTimes.Count > 0 && _requestTimes.Peek() <= now - _timeWindow)
         {
             _requestTimes.Dequeue();
         }

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkCycleTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkCycleTests.cs
@@ -86,7 +86,8 @@ public class HoldingsScraperWorkerDoWorkCycleTests : ParadeDbMcpTestBase
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(ProcessedDataSetRepository), new ProcessedDataSetRepository(DbContext)),
             (typeof(HoldingsDataSetClient), ThrowingDataSetClient()),
-            (typeof(HoldingsImportService), BuildImporter())
+            (typeof(HoldingsImportService), BuildImporter()),
+            (typeof(InstitutionalHolderRepository), new InstitutionalHolderRepository(DbContext))
         );
 
         var config = Substitute.For<IConfiguration>();

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkTests.cs
@@ -47,7 +47,8 @@ public class HoldingsScraperWorkerDoWorkTests : ParadeDbMcpTestBase
         // to RecalculatePendingValues (whose recalculator is intentionally not
         // registered → its own catch swallows, proving the cycle is resilient).
         var scopeFactory = ServiceScopeSubstitute.Create(
-            (typeof(ProcessedDataSetRepository), new ProcessedDataSetRepository(DbContext))
+            (typeof(ProcessedDataSetRepository), new ProcessedDataSetRepository(DbContext)),
+            (typeof(InstitutionalHolderRepository), new InstitutionalHolderRepository(DbContext))
         );
 
         var worker = new HoldingsScraperWorker(

--- a/tests/Equibles.IntegrationTests/Web/HoldingsExportHoldersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsExportHoldersTests.cs
@@ -94,10 +94,12 @@ public class HoldingsExportHoldersTests
         body.Should()
             .Contain(
                 "Ticker,CompanyName,ReportDate,InstitutionalHolderName,InstitutionalHolderCik,"
-                    + "Shares,Value,OwnershipPercent,ShareType,OptionType,AccessionNumber"
+                    + "PositionChange,CurrentShares,PreviousShares,DeltaShares,ChangePercent,"
+                    + "OwnershipPercent,CurrentValue,DeltaValue,QuarterFirstOwned"
             );
         body.Should().Contain("AAPL,Apple Inc.,2024-12-31,Berkshire Hathaway,0001067983,");
-        body.Should().Contain("1500000,250000000");
+        body.Should().Contain("1500000");
+        body.Should().Contain("250000000");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Fix 3 failing CI tests caused by the holdings CSV export column change and missing DI registration for `BackfillHolderClassifications`
- Fix `RateLimiter.CleanupOldRequests` boundary condition that allowed concurrent callers to burst past the rate limit
- Fix CSharpier formatting on the classification migration

## Code changes

- `src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs` — change `<` to `<=` in `CleanupOldRequests` so entries at the sliding-window boundary are evicted, preventing concurrent burst-through
- `src/Equibles.Migrations/Migrations/20260524004205_AddInstitutionalHolderClassification.cs` — CSharpier formatting fix
- `tests/Equibles.IntegrationTests/Web/HoldingsExportHoldersTests.cs` — update CSV header assertion to match the new position-change columns
- `tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkTests.cs` — register `InstitutionalHolderRepository` in the test scope
- `tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkCycleTests.cs` — register `InstitutionalHolderRepository` in the test scope