### PR TITLE
test(holdings): add skipped repro for GH-1997 — FundClassifierService.Classify

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/FundClassifierServiceBankTrailingWordTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundClassifierServiceBankTrailingWordTests.cs
@@ -1,0 +1,18 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// The "BANK " rule (trailing space) won't match holder names where "BANK"
+/// is the final word. Real 13F filers like "Deutsche Bank" are misclassified
+/// as Unknown because the name contains no character after "BANK".
+/// </summary>
+public class FundClassifierServiceBankTrailingWordTests
+{
+    [Fact(Skip = "GH-1997 — BANK pattern requires trailing space, misses end-of-string")]
+    public void Classify_BankAsLastWord_ReturnsBank()
+    {
+        FundClassifierService.Classify("Deutsche Bank").Should().Be(FundClassification.Bank);
+    }
+}


### PR DESCRIPTION
## Summary

- Add adversarial test exposing that `FundClassifierService.Classify("Deutsche Bank")` returns `Unknown` instead of `Bank` — the `"BANK "` pattern requires a trailing space, missing end-of-string matches
- Test is committed as `[Skip]` — see GH-1997

## Code changes

- `tests/Equibles.UnitTests/Holdings/FundClassifierServiceBankTrailingWordTests.cs` — new skipped `[Fact]` asserting bank names ending with "BANK" (no trailing characters) should classify as `Bank`