### PR TITLE
test(holdings): add skipped repro for GH-2000 — ClassifyChange

### DIFF
--- a/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperZeroSharesBothQuartersTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperZeroSharesBothQuartersTests.cs
@@ -1,0 +1,45 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Web.Services;
+using Equibles.Web.ViewModels.Stocks;
+
+namespace Equibles.UnitTests.Web;
+
+/// <summary>
+/// ClassifyChange checks previousShares == 0 before currentShares == previousShares,
+/// so (0, 0) returns New instead of Unchanged. A holder reporting 0 shares in both
+/// quarters (e.g. principal-only positions) hasn't newly entered — they're unchanged.
+/// </summary>
+public class HoldingsPositionGrouperZeroSharesBothQuartersTests
+{
+    [Fact(Skip = "GH-2000 — ClassifyChange checks previousShares==0 before equality")]
+    public void Group_ZeroSharesBothQuarters_ClassifiesAsUnchangedNotNew()
+    {
+        var holderId = Guid.NewGuid();
+        var holder = new InstitutionalHolder { Id = holderId, Name = "Test" };
+        var current = new InstitutionalHolding
+        {
+            Id = Guid.NewGuid(),
+            InstitutionalHolderId = holderId,
+            InstitutionalHolder = holder,
+            Shares = 0,
+            Value = 500,
+            FilingDate = new DateOnly(2025, 3, 15),
+            ReportDate = new DateOnly(2025, 3, 31),
+        };
+        var previous = new InstitutionalHolding
+        {
+            Id = Guid.NewGuid(),
+            InstitutionalHolderId = holderId,
+            InstitutionalHolder = holder,
+            Shares = 0,
+            Value = 400,
+            FilingDate = new DateOnly(2024, 12, 15),
+            ReportDate = new DateOnly(2024, 12, 31),
+        };
+
+        var result = HoldingsPositionGrouper.Group([current], [previous], null);
+
+        result[PositionChangeType.Unchanged].Should().ContainSingle();
+        result[PositionChangeType.New].Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Add adversarial test exposing that `HoldingsPositionGrouper.ClassifyChange(0, 0)` returns `New` instead of `Unchanged` — the `previousShares == 0` check fires before the equality check
- Test is committed as `[Skip]` — see GH-2000

## Code changes

- `tests/Equibles.UnitTests/Web/HoldingsPositionGrouperZeroSharesBothQuartersTests.cs` — new skipped `[Fact]` asserting a holder with 0 shares in both quarters should be classified as `Unchanged`, not `New`