### PR TITLE
test(stocks): add skipped repro for GH-2002 — SetFiscalYearEnd

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetFiscalYearEndInvalidDayForMonthTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetFiscalYearEndInvalidDayForMonthTests.cs
@@ -1,0 +1,38 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Exceptions;
+using Equibles.Data;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// SetFiscalYearEnd validates month 1-12 and day 1-31 independently, so
+/// month=2, day=31 passes even though February 31 never exists. Downstream
+/// code constructing a DateOnly from this would throw.
+/// </summary>
+public class CommonStockManagerSetFiscalYearEndInvalidDayForMonthTests
+{
+    [Fact(Skip = "GH-2002 — day validation is independent of month")]
+    public async Task SetFiscalYearEnd_February31_ThrowsDomainValidation()
+    {
+        var db = new EquiblesDbContext(
+            new DbContextOptionsBuilder<EquiblesDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options,
+            [new CommonStocksModuleConfiguration()]
+        );
+        var repository = Substitute.For<CommonStockRepository>(db);
+        var sut = new CommonStockManager(repository, Substitute.For<IPublishEndpoint>());
+        var stock = new CommonStock();
+
+        var act = () => sut.SetFiscalYearEnd(stock, 2, 31);
+
+        await act.Should().ThrowAsync<DomainValidationException>();
+        await repository.DidNotReceive().SaveChanges();
+    }
+}


### PR DESCRIPTION
## Summary

- Add adversarial test exposing that `CommonStockManager.SetFiscalYearEnd(stock, 2, 31)` succeeds without throwing — the day validation checks 1-31 independently of the month, so impossible dates like February 31 pass
- Test is committed as `[Skip]` — see GH-2002

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetFiscalYearEndInvalidDayForMonthTests.cs` — new skipped `[Fact]` asserting that month=2, day=31 should throw `DomainValidationException`