### PR TITLE
style(home): make feature cards clickable links

### DIFF
--- a/src/Equibles.Web/Views/Home/Index.cshtml
+++ b/src/Equibles.Web/Views/Home/Index.cshtml
@@ -22,47 +22,47 @@
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-left">
-        <div class="card bg-base-100 shadow-sm">
+        <a asp-controller="Search" asp-action="Index" asp-route-category="SEC Filings" class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow no-underline text-inherit">
             <div class="card-body">
                 <h2 class="card-title text-lg">SEC Filings</h2>
                 <p class="text-sm text-base-content/70">10-K, 10-Q, 8-K annual and quarterly reports with full-text search via ParadeDB.</p>
             </div>
-        </div>
-        <div class="card bg-base-100 shadow-sm">
+        </a>
+        <a asp-controller="Institutions" asp-action="Index" class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow no-underline text-inherit">
             <div class="card-body">
                 <h2 class="card-title text-lg">Institutional Holdings</h2>
                 <p class="text-sm text-base-content/70">Who owns what from SEC 13F-HR filings. Top holders, ownership history, and portfolio views.</p>
             </div>
-        </div>
-        <div class="card bg-base-100 shadow-sm">
+        </a>
+        <a href="~/insider-trading/dashboard" class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow no-underline text-inherit">
             <div class="card-body">
                 <h2 class="card-title text-lg">Insider Trading</h2>
                 <p class="text-sm text-base-content/70">Director, officer, and 10% owner transactions from SEC Form 3 and Form 4 filings.</p>
             </div>
-        </div>
-        <div class="card bg-base-100 shadow-sm">
+        </a>
+        <a asp-controller="Search" asp-action="Index" asp-route-category="Congress" class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow no-underline text-inherit">
             <div class="card-body">
                 <h2 class="card-title text-lg">Congressional Trades</h2>
                 <p class="text-sm text-base-content/70">Stock trades by members of Congress from House and Senate financial disclosures.</p>
             </div>
-        </div>
-        <div class="card bg-base-100 shadow-sm">
+        </a>
+        <a asp-controller="Stocks" asp-action="Index" class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow no-underline text-inherit">
             <div class="card-body">
                 <h2 class="card-title text-lg">Short Data</h2>
                 <p class="text-sm text-base-content/70">Daily short volume, short interest, and fails-to-deliver from FINRA.</p>
             </div>
-        </div>
-        <div class="card bg-base-100 shadow-sm">
+        </a>
+        <a asp-controller="Stocks" asp-action="Index" class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow no-underline text-inherit">
             <div class="card-body">
                 <h2 class="card-title text-lg">Stock Prices</h2>
                 <p class="text-sm text-base-content/70">Daily OHLCV prices from Yahoo Finance with SMA, RSI, and MACD technical indicators.</p>
             </div>
-        </div>
-        <div class="card bg-base-100 shadow-sm">
+        </a>
+        <a asp-controller="Home" asp-action="Connect" class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow no-underline text-inherit">
             <div class="card-body">
                 <h2 class="card-title text-lg">MCP Server</h2>
                 <p class="text-sm text-base-content/70">Model Context Protocol server for AI assistants — give Claude or ChatGPT access to financial data.</p>
             </div>
-        </div>
+        </a>
     </div>
 </div>


### PR DESCRIPTION
## Summary

- Home page feature cards (SEC Filings, Institutional Holdings, Insider Trading, etc.) were static `<div>` elements with no navigation — users expect cards describing features to be clickable
- Wrapped each card in an `<a>` tag pointing to the relevant browse page (Institutions, Insider Trading dashboard, Search with category filter, Stocks, MCP connect)
- Added `hover:shadow-md transition-shadow` for visual hover feedback

## Code changes

- `src/Equibles.Web/Views/Home/Index.cshtml` — replaced 7 `<div class="card">` wrappers with `<a>` tags using `asp-controller`/`asp-action` tag helpers (or direct `href` for custom routes)

## Test plan

- [x] Build passes (0 errors)
- [x] All 3,199 unit + integration tests pass
- [x] Verified cards render correctly in browser at 1280px
- [x] Verified `cursor: pointer` on all cards
- [x] Verified clicking "Institutional Holdings" card navigates to `/institutions`
- [x] Verified link targets via JS inspection: SEC Filings → search, Institutions → /institutions, Insider Trading → /insider-trading/dashboard, Congressional Trades → search, Short Data → /stocks, Stock Prices → /stocks, MCP Server → /home/connect