### PR TITLE
test(market): pin PutCallRatio 404 on invalid enum type

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/MarketPutCallRatioInvalidTypeTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/MarketPutCallRatioInvalidTypeTests.cs
@@ -1,0 +1,34 @@
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class MarketPutCallRatioInvalidTypeTests
+{
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public MarketPutCallRatioInvalidTypeTests(WebAppFixture web, PlaywrightFixture playwright)
+    {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task PutCallRatio_InvalidType_Returns404()
+    {
+        // Contract: /market/putcallratio/{type} returns 404 when the type is not a valid
+        // CboePutCallRatioType enum member. The action guards with Enum.TryParse +
+        // Enum.IsDefined — the IsDefined check catches numeric strings (e.g. "999") that
+        // TryParse accepts but map to no named member.
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/market/putcallratio/notarealtype");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(404);
+    }
+}


### PR DESCRIPTION
## Summary

- Add an adversarial functional test for the `PutCallRatio` 404 path on invalid `type` parameter.
- The action guards with `Enum.TryParse` + `Enum.IsDefined` to reject both non-parseable strings and numeric-but-undefined enum values. This test pins that the guard works.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/MarketPutCallRatioInvalidTypeTests.cs` — new test class with one `[Fact]` that navigates to `/market/putcallratio/notarealtype` and asserts 404.