### PR TITLE
fix(insider-trading): handle empty OfficerTitle in GetRole fallback

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -218,7 +218,7 @@ public class InsiderTradingTools
         if (owner.IsDirector)
             roles.Add("Director");
         if (owner.IsOfficer)
-            roles.Add(owner.OfficerTitle ?? "Officer");
+            roles.Add(string.IsNullOrEmpty(owner.OfficerTitle) ? "Officer" : owner.OfficerTitle);
         if (owner.IsTenPercentOwner)
             roles.Add("10% Owner");
         return roles.Count > 0 ? string.Join(", ", roles) : "Insider";

--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsGetRoleEmptyOfficerTitleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsGetRoleEmptyOfficerTitleTests.cs
@@ -17,7 +17,7 @@ public class InsiderTradingToolsGetRoleEmptyOfficerTitleTests
     // comma-joined role list (e.g. "Director, " instead of
     // "Director, Officer"). A caller would reasonably expect a non-empty
     // label for every role flag that is set.
-    [Fact(Skip = "GH-1964 — GetRole returns empty string for officer with empty OfficerTitle")]
+    [Fact]
     public void GetRole_OfficerWithEmptyTitle_FallsBackToOfficerLabel()
     {
         var owner = new InsiderOwner { IsOfficer = true, OfficerTitle = string.Empty };


### PR DESCRIPTION
## Summary

- `GetRole` used `??` to fall back on null `OfficerTitle`, but `??` doesn't catch empty strings — officers with `OfficerTitle == ""` produced blank role tokens (e.g., `"Director, "` instead of `"Director, Officer"`).
- Replaced `??` with `string.IsNullOrEmpty` check so both null and empty fall back to `"Officer"`.

## Code changes

- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — replaced `owner.OfficerTitle ?? "Officer"` with `string.IsNullOrEmpty(owner.OfficerTitle) ? "Officer" : owner.OfficerTitle`.
- `tests/Equibles.UnitTests/Mcp/InsiderTradingToolsGetRoleEmptyOfficerTitleTests.cs` — removed `Skip` attribute to activate the regression test.

Closes #1964