### PR TITLE
test(sec): add skipped repro for GH-2013 — TryResolve spaced ampersand

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSpacedAmpersandTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSpacedAmpersandTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialConceptAliasesTryResolveSpacedAmpersandTests
+{
+    // Contract: "callers can use natural phrasing ('r&d')". Normalize converts
+    // spaces to hyphens, so "R & D" becomes "r-&-d" — which doesn't match the
+    // synonym key "r&d". Spaced ampersand is common in financial prose and MCP
+    // tool input; the normalization should not break the synonym lookup.
+    [Fact(Skip = "GH-2013 — Normalize inserts hyphens around &, breaking r&d synonym")]
+    public void TryResolve_SpacedAmpersandRd_ResolvesToResearchAndDevelopment()
+    {
+        var resolved = FinancialConceptAliases.TryResolve("R & D", out var concepts);
+
+        resolved.Should().BeTrue();
+        concepts.Should().ContainSingle();
+        concepts[0].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
+        concepts[0].Tag.Should().Be("ResearchAndDevelopmentExpense");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for `FinancialConceptAliases.TryResolve` — input `"R & D"` (spaced ampersand) fails to resolve because `Normalize` converts spaces to hyphens, producing `"r-&-d"` which doesn't match the synonym key `"r&d"`.
- Test is committed as `[Skip]` — see GH-2013 for the production bug.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSpacedAmpersandTests.cs` — skipped reproduction test pinning the normalization bug with spaced ampersand input.