### PR TITLE
test(insider-trading): add skipped repro for GH-2014 — GetRole whitespace OfficerTitle

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsGetRoleWhitespaceOfficerTitleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsGetRoleWhitespaceOfficerTitleTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Mcp.Tools;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class InsiderTradingToolsGetRoleWhitespaceOfficerTitleTests
+{
+    private static readonly MethodInfo GetRoleMethod = typeof(InsiderTradingTools).GetMethod(
+        "GetRole",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    // string.IsNullOrEmpty does not catch whitespace-only strings.
+    // A whitespace-only OfficerTitle should fall back to "Officer"
+    // just like null and empty do — it's not a meaningful label.
+    [Fact(
+        Skip = "GH-2014 — GetRole returns whitespace for officer with whitespace-only OfficerTitle"
+    )]
+    public void GetRole_OfficerWithWhitespaceTitle_FallsBackToOfficerLabel()
+    {
+        var owner = new InsiderOwner { IsOfficer = true, OfficerTitle = "   " };
+
+        var role = (string)GetRoleMethod.Invoke(null, [owner]);
+
+        role.Should().Be("Officer");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an adversarial test that exposes a bug in `GetRole`: `string.IsNullOrEmpty` does not catch whitespace-only `OfficerTitle`, producing a blank role token instead of falling back to `"Officer"`.
- Test is committed as `[Skip]` — see GH-2014 for the production fix.

## Code changes

- `tests/Equibles.UnitTests/Mcp/InsiderTradingToolsGetRoleWhitespaceOfficerTitleTests.cs` — new skipped test asserting whitespace-only `OfficerTitle` falls back to `"Officer"`.