### PR TITLE
fix(insider-trading): handle whitespace-only OfficerTitle in GetRole

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -218,7 +218,9 @@ public class InsiderTradingTools
         if (owner.IsDirector)
             roles.Add("Director");
         if (owner.IsOfficer)
-            roles.Add(string.IsNullOrEmpty(owner.OfficerTitle) ? "Officer" : owner.OfficerTitle);
+            roles.Add(
+                string.IsNullOrWhiteSpace(owner.OfficerTitle) ? "Officer" : owner.OfficerTitle
+            );
         if (owner.IsTenPercentOwner)
             roles.Add("10% Owner");
         return roles.Count > 0 ? string.Join(", ", roles) : "Insider";

--- a/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsGetRoleWhitespaceOfficerTitleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/InsiderTradingToolsGetRoleWhitespaceOfficerTitleTests.cs
@@ -14,9 +14,7 @@ public class InsiderTradingToolsGetRoleWhitespaceOfficerTitleTests
     // string.IsNullOrEmpty does not catch whitespace-only strings.
     // A whitespace-only OfficerTitle should fall back to "Officer"
     // just like null and empty do — it's not a meaningful label.
-    [Fact(
-        Skip = "GH-2014 — GetRole returns whitespace for officer with whitespace-only OfficerTitle"
-    )]
+    [Fact]
     public void GetRole_OfficerWithWhitespaceTitle_FallsBackToOfficerLabel()
     {
         var owner = new InsiderOwner { IsOfficer = true, OfficerTitle = "   " };


### PR DESCRIPTION
## Summary

- `GetRole` used `string.IsNullOrEmpty` which doesn't catch whitespace-only strings — an officer with `OfficerTitle == "   "` produced a blank role token.
- Replaced with `string.IsNullOrWhiteSpace` so whitespace-only falls back to `"Officer"`, matching null/empty behavior.

## Code changes

- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — changed `IsNullOrEmpty` → `IsNullOrWhiteSpace` in `GetRole`.
- `tests/Equibles.UnitTests/Mcp/InsiderTradingToolsGetRoleWhitespaceOfficerTitleTests.cs` — removed `Skip` attribute to activate the regression test.

Closes #2014