### PR TITLE
fix(sec): collapse spaced ampersand in FinancialConceptAliases.Normalize

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs
@@ -107,6 +107,7 @@ public static class FinancialConceptAliases
         return alias
             .Trim()
             .ToLowerInvariant()
+            .Replace(" & ", "&")
             .Replace(' ', '-')
             .Replace('_', '-')
             .Replace("/", "-");

--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSpacedAmpersandTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSpacedAmpersandTests.cs
@@ -9,7 +9,7 @@ public class FinancialConceptAliasesTryResolveSpacedAmpersandTests
     // spaces to hyphens, so "R & D" becomes "r-&-d" — which doesn't match the
     // synonym key "r&d". Spaced ampersand is common in financial prose and MCP
     // tool input; the normalization should not break the synonym lookup.
-    [Fact(Skip = "GH-2013 — Normalize inserts hyphens around &, breaking r&d synonym")]
+    [Fact]
     public void TryResolve_SpacedAmpersandRd_ResolvesToResearchAndDevelopment()
     {
         var resolved = FinancialConceptAliases.TryResolve("R & D", out var concepts);


### PR DESCRIPTION
## Summary

- `Normalize` converted spaces to hyphens before collapsing `" & "` to `"&"`, so `"R & D"` became `"r-&-d"` — missing the `"r&d"` synonym key.
- Added `.Replace(" & ", "&")` before the space→hyphen step so spaced ampersand input resolves correctly.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Data/Statements/FinancialConceptAliases.cs` — added `.Replace(" & ", "&")` in `Normalize` before `.Replace(' ', '-')`.
- `tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSpacedAmpersandTests.cs` — removed `Skip` attribute to activate the regression test.

Closes #2013