### PR TITLE
test(congress): add skipped repro for GH-2019 — Truncate negative maxLength

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateNegativeMaxLengthTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateNegativeMaxLengthTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperTruncateNegativeMaxLengthTests
+{
+    // Contract: Truncate(value, maxLength) returns a string no longer than
+    // maxLength. A negative maxLength is semantically equivalent to zero —
+    // there is no length the caller is willing to accept. The implementation
+    // passes maxLength directly into the Range indexer (value[..end]) without
+    // clamping; a negative end index is not a valid Range bound and throws
+    // ArgumentOutOfRangeException at runtime.
+    [Fact(Skip = "GH-2019 — negative maxLength hits invalid Range bound")]
+    public void Truncate_NegativeMaxLength_DoesNotThrow()
+    {
+        var act = () => DisclosureParsingHelper.Truncate("hello", -1);
+
+        act.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for `DisclosureParsingHelper.Truncate` — passing a negative `maxLength` throws `ArgumentOutOfRangeException` because the value is used directly as a `Range` end index without clamping.
- Test is committed as `[Skip]` — see GH-2019 for the production bug.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateNegativeMaxLengthTests.cs` — skipped reproduction test pinning the negative-maxLength crash.