### PR TITLE
fix(holdings): classify banks where BANK is the last word

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/FundClassifierService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/FundClassifierService.cs
@@ -48,7 +48,7 @@ public static class FundClassifierService
         if (string.IsNullOrWhiteSpace(name))
             return FundClassification.Unknown;
 
-        var upper = name.ToUpperInvariant();
+        var upper = name.ToUpperInvariant() + " ";
 
         foreach (var (pattern, classification) in Rules)
         {

--- a/tests/Equibles.UnitTests/Holdings/FundClassifierServiceBankTrailingWordTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundClassifierServiceBankTrailingWordTests.cs
@@ -10,7 +10,7 @@ namespace Equibles.UnitTests.Holdings;
 /// </summary>
 public class FundClassifierServiceBankTrailingWordTests
 {
-    [Fact(Skip = "GH-1997 — BANK pattern requires trailing space, misses end-of-string")]
+    [Fact]
     public void Classify_BankAsLastWord_ReturnsBank()
     {
         FundClassifierService.Classify("Deutsche Bank").Should().Be(FundClassification.Bank);


### PR DESCRIPTION
## Summary

- `FundClassifierService.Classify` used `Contains("BANK ")` (trailing space) to avoid matching substrings like "BANKRUPTCY", but this missed names ending with "BANK" (e.g., "Deutsche Bank").
- Appending a trailing space to the uppercased input before pattern matching makes end-of-string behave like a word boundary — all 41 existing tests still pass.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/FundClassifierService.cs` — changed `name.ToUpperInvariant()` to `name.ToUpperInvariant() + " "`.
- `tests/Equibles.UnitTests/Holdings/FundClassifierServiceBankTrailingWordTests.cs` — removed `Skip` attribute to activate the regression test.

Closes #1997