### PR TITLE
fix(holdings): classify 0-shares-both-quarters as Unchanged not New

### DIFF
--- a/src/Equibles.Web/Services/HoldingsPositionGrouper.cs
+++ b/src/Equibles.Web/Services/HoldingsPositionGrouper.cs
@@ -88,10 +88,10 @@ public static class HoldingsPositionGrouper
 
     private static PositionChangeType ClassifyChange(long currentShares, long previousShares)
     {
-        if (previousShares == 0)
-            return PositionChangeType.New;
         if (currentShares == previousShares)
             return PositionChangeType.Unchanged;
+        if (previousShares == 0)
+            return PositionChangeType.New;
         return currentShares > previousShares
             ? PositionChangeType.Increased
             : PositionChangeType.Reduced;

--- a/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperZeroSharesBothQuartersTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsPositionGrouperZeroSharesBothQuartersTests.cs
@@ -11,7 +11,7 @@ namespace Equibles.UnitTests.Web;
 /// </summary>
 public class HoldingsPositionGrouperZeroSharesBothQuartersTests
 {
-    [Fact(Skip = "GH-2000 — ClassifyChange checks previousShares==0 before equality")]
+    [Fact]
     public void Group_ZeroSharesBothQuarters_ClassifiesAsUnchangedNotNew()
     {
         var holderId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

- `ClassifyChange` checked `previousShares == 0` before the equality test, so `(0, 0)` returned `New` — a holder with 0 shares in both quarters (e.g., principal-only 13F positions) was incorrectly shown as new.
- Reordered to check `currentShares == previousShares` first so equal shares (including 0 == 0) are classified as `Unchanged`.

## Code changes

- `src/Equibles.Web/Services/HoldingsPositionGrouper.cs` — swapped the equality check above the `previousShares == 0` guard in `ClassifyChange`.
- `tests/Equibles.UnitTests/Web/HoldingsPositionGrouperZeroSharesBothQuartersTests.cs` — removed `Skip` attribute to activate the regression test.

Closes #2000