### PR TITLE
fix(test): resolve duplicate close-price selector in StocksPriceSeededTests

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/StocksPriceSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksPriceSeededTests.cs
@@ -111,7 +111,8 @@ public class StocksPriceSeededTests
             .Expect(
                 page.Locator("div.font-mono.font-semibold")
                     .Filter(new() { HasTextString = $"${newestClose:N2}" })
+                    .First
             )
-            .ToHaveCountAsync(1);
+            .ToBeVisibleAsync();
     }
 }


### PR DESCRIPTION
## Summary

- The Key Metrics header card (`Show.cshtml`) and Price tab summary stats (`_PriceTab.cshtml`) both render the latest close price with `div.font-mono.font-semibold`, causing the Playwright locator to match 2 elements instead of 1
- Changed the assertion from `ToHaveCountAsync(1)` to `.First` + `ToBeVisibleAsync()` — verifies the price renders without being brittle about how many places it appears

## Code changes

- `tests/Equibles.FunctionalTests/Tests/StocksPriceSeededTests.cs` — use `.First` + `ToBeVisibleAsync()` instead of `ToHaveCountAsync(1)` for the close-price assertion