### PR TITLE
fix(stocks): validate fiscal year-end day against its month

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -73,6 +73,11 @@ public class CommonStockManager
             );
         }
 
+        if (day is not null && day > DateTime.DaysInMonth(2000, month))
+        {
+            throw new DomainValidationException($"Day {day} is invalid for month {month}");
+        }
+
         if (commonStock.FiscalYearEndMonth == month && commonStock.FiscalYearEndDay == day)
         {
             return;

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetFiscalYearEndInvalidDayForMonthTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetFiscalYearEndInvalidDayForMonthTests.cs
@@ -17,7 +17,7 @@ namespace Equibles.UnitTests.CommonStocks;
 /// </summary>
 public class CommonStockManagerSetFiscalYearEndInvalidDayForMonthTests
 {
-    [Fact(Skip = "GH-2002 — day validation is independent of month")]
+    [Fact]
     public async Task SetFiscalYearEnd_February31_ThrowsDomainValidation()
     {
         var db = new EquiblesDbContext(


### PR DESCRIPTION
## Summary

- `SetFiscalYearEnd` validated month (1-12) and day (1-31) independently, so `SetFiscalYearEnd(stock, 2, 31)` passed — February 31 doesn't exist.
- Added a `DateTime.DaysInMonth(2000, month)` check (leap year to allow Feb 29) after the independent range checks.

## Code changes

- `src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs` — added day-for-month validation using `DaysInMonth`.
- `tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetFiscalYearEndInvalidDayForMonthTests.cs` — removed `Skip` attribute to activate the regression test.

Closes #2002