### PR TITLE
fix(congress): handle negative maxLength in Truncate

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
+++ b/src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs
@@ -207,6 +207,8 @@ public static partial class DisclosureParsingHelper
 
     public static string Truncate(string value, int maxLength)
     {
+        if (maxLength <= 0)
+            return value == null ? value : string.Empty;
         if (value == null || value.Length <= maxLength)
             return value;
 

--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateNegativeMaxLengthTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateNegativeMaxLengthTests.cs
@@ -10,7 +10,7 @@ public class DisclosureParsingHelperTruncateNegativeMaxLengthTests
     // passes maxLength directly into the Range indexer (value[..end]) without
     // clamping; a negative end index is not a valid Range bound and throws
     // ArgumentOutOfRangeException at runtime.
-    [Fact(Skip = "GH-2019 — negative maxLength hits invalid Range bound")]
+    [Fact]
     public void Truncate_NegativeMaxLength_DoesNotThrow()
     {
         var act = () => DisclosureParsingHelper.Truncate("hello", -1);


### PR DESCRIPTION
## Summary

- `DisclosureParsingHelper.Truncate` passed negative `maxLength` directly into the Range indexer (`value[..end]`), throwing `ArgumentOutOfRangeException`.
- Added an early return that clamps `maxLength <= 0` to empty string (preserving null passthrough).

## Code changes

- `src/Equibles.Congress.HostedService/Services/DisclosureParsingHelper.cs` — added `if (maxLength <= 0)` guard before the existing null/length check.
- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateNegativeMaxLengthTests.cs` — removed `Skip` attribute to activate the regression test.

Closes #2019