### PR TITLE
fix(ci): repair broken tests and upgrade to GA .NET 10 SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5
         with:
           dotnet-version: '10.0.x'
-          dotnet-quality: 'preview'
 
       - name: Restore tools
         run: dotnet tool restore
@@ -51,7 +50,6 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5
         with:
           dotnet-version: '10.0.x'
-          dotnet-quality: 'preview'
 
       - name: Restore
         run: dotnet restore Equibles.sln

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5
         with:
           dotnet-version: '10.0.x'
-          dotnet-quality: 'preview'
 
       - name: Restore
         run: dotnet restore Equibles.sln

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5
         with:
           dotnet-version: '10.0.x'
-          dotnet-quality: 'preview'
 
       - name: Restore
         run: dotnet restore Equibles.sln

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceResolveTickerCollisionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceResolveTickerCollisionTests.cs
@@ -50,7 +50,6 @@ public class CompanySyncServiceResolveTickerCollisionTests
         Set("ExistingStocks", new List<CommonStock>());
         Set("ExistingCiks", new HashSet<string>());
         Set("ExistingPrimaryTickers", new HashSet<string>());
-        Set("ExistingSecondaryTickers", new HashSet<string>());
         Set("PrimaryTickerToStock", new Dictionary<string, CommonStock>());
         Set("SecondaryCikToParent", new Dictionary<string, CommonStock>());
         return state;

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs
@@ -67,7 +67,6 @@ public class CompanySyncServiceUpdateExistingBranchATests
         Set("ExistingStocks", new List<CommonStock> { existingStock });
         Set("ExistingCiks", new HashSet<string> { existingStock.Cik });
         Set("ExistingPrimaryTickers", new HashSet<string> { existingStock.Ticker, primaryTicker });
-        Set("ExistingSecondaryTickers", new HashSet<string>());
         Set(
             "PrimaryTickerToStock",
             new Dictionary<string, CommonStock> { [primaryTicker] = tickerHolder }


### PR DESCRIPTION
## Summary

- The refactoring in 4c79617 removed `ExistingSecondaryTickers` from `StockSyncState` but didn't update two reflection-based test files that still set the property, causing `NullReferenceException` from `GetProperty` returning null.
- All three CI workflows (`ci.yml`, `functional.yml`, `smoke.yml`) were pinned to `dotnet-quality: 'preview'`, resolving to .NET 10 RC2 even though .NET 10 is now GA.

## Code changes

- **`CompanySyncServiceResolveTickerCollisionTests.cs`** — removed dead `Set("ExistingSecondaryTickers", ...)` call from `EmptyState()`.
- **`CompanySyncServiceUpdateExistingBranchATests.cs`** — removed dead `Set("ExistingSecondaryTickers", ...)` call from `BuildState()`.
- **`ci.yml`, `functional.yml`, `smoke.yml`** — dropped `dotnet-quality: 'preview'` so CI uses the GA .NET 10 SDK.