### PR TITLE
feat(web): add compact number toggle to holdings tables

### DIFF
--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -73,12 +73,19 @@
             <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Holders:</span> <strong>@Model.HolderCount.ToString("N0")</strong></div>
             <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Value:</span> <strong>$@Model.TotalValue.ToString("N0")</strong></div>
             <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Shares:</span> <strong>@Model.TotalShares.ToString("N0")</strong></div>
-            <a class="btn btn-outline btn-sm ml-auto"
-               asp-controller="HoldingsExport" asp-action="Holders"
-               asp-route-ticker="@Model.Ticker" asp-route-date="@Model.SelectedDate.ToString("yyyy-MM-dd")"
-               data-testid="holdings-export-csv">
-                Download CSV
-            </a>
+            <div class="flex items-center gap-2 ml-auto">
+                <button type="button" class="btn btn-sm btn-ghost border border-base-300 btn-compact-toggle"
+                        onclick="toggleCompactNumbers()"
+                        title="Show compact numbers (1M, 1B)">
+                    1M
+                </button>
+                <a class="btn btn-outline btn-sm"
+                   asp-controller="HoldingsExport" asp-action="Holders"
+                   asp-route-ticker="@Model.Ticker" asp-route-date="@Model.SelectedDate.ToString("yyyy-MM-dd")"
+                   data-testid="holdings-export-csv">
+                    Download CSV
+                </a>
+            </div>
         </div>
         @{
             var dateParam = Model.SelectedDate.ToString("yyyy-MM-dd");
@@ -178,9 +185,9 @@
                                             var deltaValueText = (e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$") + Math.Abs(e.DeltaValue).ToString("N0");
                                             <tr>
                                                 <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
-                                                <td class="text-right font-mono @deltaSharesCss">@deltaSharesText</td>
+                                                <td class="text-right font-mono @deltaSharesCss" data-compact-number="@e.DeltaShares" data-compact-prefix="@(e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "")">@deltaSharesText</td>
                                                 <td class="text-right font-mono hidden md:table-cell @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
-                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss">@deltaValueText</td>
+                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss" data-compact-number="@Math.Abs(e.DeltaValue)" data-compact-prefix="@(e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$")">@deltaValueText</td>
                                             </tr>
                                         }
                                     </tbody>
@@ -239,13 +246,13 @@
                                             <partial name="_FundClassificationBadge" model="e.InstitutionalHolder.Classification" />
                                         }
                                     </td>
-                                    <td class="text-right font-mono whitespace-nowrap">@e.CurrentShares.ToString("N0")</td>
-                                    <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @deltaSharesCss">@deltaSharesText</td>
+                                    <td class="text-right font-mono whitespace-nowrap" data-compact-number="@e.CurrentShares">@e.CurrentShares.ToString("N0")</td>
+                                    <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @deltaSharesCss" data-compact-number="@e.DeltaShares" data-compact-prefix="@(e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "")">@deltaSharesText</td>
                                     <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
                                     <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap">@(own != null ? $"{own:F2}%" : "—")</td>
-                                    <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap">$@e.CurrentValue.ToString("N0")</td>
+                                    <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap" data-compact-number="@e.CurrentValue" data-compact-prefix="$">$@e.CurrentValue.ToString("N0")</td>
                                     <td class="text-right hidden xl:table-cell whitespace-nowrap text-base-content/60">@FormatQuarter(e.QuarterFirstOwned)</td>
-                                    <td class="text-right font-mono whitespace-nowrap @deltaValueCss">@deltaValueText</td>
+                                    <td class="text-right font-mono whitespace-nowrap @deltaValueCss" data-compact-number="@Math.Abs(e.DeltaValue)" data-compact-prefix="@(e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$")">@deltaValueText</td>
                                     <td class="text-right">
                                         @if (e.InstitutionalHolder?.Cik != null) {
                                             <a asp-controller="Stocks" asp-action="ShowHolder"
@@ -309,13 +316,13 @@
                                                 <partial name="_FundClassificationBadge" model="e.InstitutionalHolder.Classification" />
                                             }
                                         </td>
-                                        <td class="text-right font-mono">@e.CurrentShares.ToString("N0")</td>
-                                        <td class="text-right font-mono hidden md:table-cell @deltaSharesCss">@deltaSharesText</td>
+                                        <td class="text-right font-mono" data-compact-number="@e.CurrentShares">@e.CurrentShares.ToString("N0")</td>
+                                        <td class="text-right font-mono hidden md:table-cell @deltaSharesCss" data-compact-number="@e.DeltaShares" data-compact-prefix="@(e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "")">@deltaSharesText</td>
                                         <td class="text-right font-mono hidden md:table-cell @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
                                         <td class="text-right font-mono hidden lg:table-cell">@(own != null ? $"{own:F2}%" : "—")</td>
-                                        <td class="text-right font-mono hidden lg:table-cell">$@e.CurrentValue.ToString("N0")</td>
+                                        <td class="text-right font-mono hidden lg:table-cell" data-compact-number="@e.CurrentValue" data-compact-prefix="$">$@e.CurrentValue.ToString("N0")</td>
                                         <td class="text-right hidden xl:table-cell text-base-content/60">@FormatQuarter(e.QuarterFirstOwned)</td>
-                                        <td class="text-right font-mono @deltaValueCss">@deltaValueText</td>
+                                        <td class="text-right font-mono @deltaValueCss" data-compact-number="@Math.Abs(e.DeltaValue)" data-compact-prefix="@(e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$")">@deltaValueText</td>
                                         <td class="text-right">
                                             @if (e.InstitutionalHolder?.Cik != null) {
                                                 <a asp-controller="Stocks" asp-action="ShowHolder"

--- a/src/Equibles.Web/src/index.js
+++ b/src/Equibles.Web/src/index.js
@@ -24,3 +24,4 @@ import './js/search-keyboard';
 import './js/global-search-shortcut';
 import './js/search-clear';
 import './js/copy-button';
+import './js/compact-numbers';

--- a/src/Equibles.Web/src/js/compact-numbers.js
+++ b/src/Equibles.Web/src/js/compact-numbers.js
@@ -1,0 +1,52 @@
+/**
+ * Compact number toggle for tables.
+ *
+ * Add data-compact-number to any <td> that contains a numeric value.
+ * A toggle button (.btn-compact-toggle) switches between full and compact display.
+ * State persists via localStorage.
+ */
+
+const STORAGE_KEY = 'compactNumbers';
+
+function formatCompact(value) {
+    const abs = Math.abs(value);
+    if (abs >= 1e12) return (value / 1e12).toFixed(1) + 'T';
+    if (abs >= 1e9) return (value / 1e9).toFixed(1) + 'B';
+    if (abs >= 1e6) return (value / 1e6).toFixed(1) + 'M';
+    if (abs >= 1e3) return (value / 1e3).toFixed(0) + 'K';
+    return value.toLocaleString('en-US');
+}
+
+function applyFormat(compact) {
+    document.querySelectorAll('[data-compact-number]').forEach(cell => {
+        if (compact) {
+            if (!cell.dataset.fullText) cell.dataset.fullText = cell.textContent;
+            const raw = parseFloat(cell.dataset.compactNumber);
+            if (isNaN(raw)) return;
+            const prefix = cell.dataset.compactPrefix || '';
+            cell.textContent = prefix + formatCompact(raw);
+        } else if (cell.dataset.fullText) {
+            cell.textContent = cell.dataset.fullText;
+        }
+    });
+
+    document.querySelectorAll('.btn-compact-toggle').forEach(btn => {
+        btn.classList.toggle('btn-active', compact);
+        btn.title = compact ? 'Show full numbers' : 'Show compact numbers (1M, 1B)';
+    });
+}
+
+function toggle() {
+    const current = localStorage.getItem(STORAGE_KEY) === 'true';
+    const next = !current;
+    localStorage.setItem(STORAGE_KEY, next);
+    applyFormat(next);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    if (localStorage.getItem(STORAGE_KEY) === 'true') {
+        applyFormat(true);
+    }
+});
+
+window.toggleCompactNumbers = toggle;


### PR DESCRIPTION
## Summary
- Adds a "1M" toggle button next to Download CSV in the holdings tab
- Switches numeric columns (Shares, Value, Δ Shares, Δ Value) between full format (1,144,695,425) and compact display (1.1B)
- Applies to All Holders table, per-bucket tables, and top movers cards
- State persists in localStorage across page reloads

## Code changes
- **`src/js/compact-numbers.js`** — new JS module: `formatCompact()` formatter, `applyFormat()` to toggle all `[data-compact-number]` cells, localStorage persistence
- **`src/index.js`** — imports the new module
- **`Views/Stocks/_HoldingsTab.cshtml`** — adds `data-compact-number` and `data-compact-prefix` attributes to Shares/Value/Δ cells in all three table sections (top movers, all holders, per-bucket); adds the toggle button