### PR TITLE
fix: tokenize insider search query to match names regardless of token order

### DIFF
--- a/src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs
+++ b/src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs
@@ -21,6 +21,14 @@ public class InsiderOwnerRepository : BaseRepository<InsiderOwner>
 
     public IQueryable<InsiderOwner> Search(string search)
     {
-        return GetAll().Where(o => EF.Functions.ILike(o.Name, $"%{search}%"));
+        var tokens = search.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var query = GetAll();
+        foreach (var token in tokens)
+        {
+            var t = token;
+            query = query.Where(o => EF.Functions.ILike(o.Name, $"%{t}%"));
+        }
+
+        return query;
     }
 }

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderOwnerRepositoryPostgresSearchTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderOwnerRepositoryPostgresSearchTests.cs
@@ -38,4 +38,21 @@ public class InsiderOwnerRepositoryPostgresSearchTests : ParadeDbMcpTestBase
         results.Should().ContainSingle();
         results[0].OwnerCik.Should().Be("1");
     }
+
+    [Fact]
+    public async Task Search_ReversedNameOrder_MatchesAllTokens()
+    {
+        DbContext.Add(new InsiderOwner { OwnerCik = "1", Name = "Musk Elon" });
+        DbContext.Add(new InsiderOwner { OwnerCik = "2", Name = "Cook Timothy D" });
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InsiderOwnerRepository(verify);
+
+        var results = await sut.Search("Elon Musk").AsNoTracking().ToListAsync();
+
+        results.Should().ContainSingle();
+        results[0].OwnerCik.Should().Be("1");
+    }
 }


### PR DESCRIPTION
## Summary

- `SearchInsiders` failed when users searched with "First Last" order (e.g., "Elon Musk") because the database stores names in "Last First" format (e.g., "Musk Elon") and the search did a single substring match on the full query string.
- The fix tokenizes the search query by whitespace and requires each token to match independently via `ILike`, so "Elon Musk" now matches "Musk Elon".

Closes #2034

## Code changes

- `src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs` — split search input into tokens and chain `ILike` conditions (AND) so each token must appear somewhere in the name, regardless of order.
- `tests/Equibles.IntegrationTests/InsiderTrading/InsiderOwnerRepositoryPostgresSearchTests.cs` — added regression test `Search_ReversedNameOrder_MatchesAllTokens` confirming "Elon Musk" matches "Musk Elon".