### PR TITLE
test(insider): pin Search AND semantics — cross-name tokens yield empty

### DIFF
--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderOwnerRepositoryPostgresSearchTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderOwnerRepositoryPostgresSearchTests.cs
@@ -55,4 +55,22 @@ public class InsiderOwnerRepositoryPostgresSearchTests : ParadeDbMcpTestBase
         results.Should().ContainSingle();
         results[0].OwnerCik.Should().Be("1");
     }
+
+    [Fact]
+    public async Task Search_CrossTokensFromDifferentNames_ReturnsEmpty()
+    {
+        // "Elon" lives in "Musk Elon", "Cook" lives in "Cook Timothy D" — but no
+        // single record contains both tokens, so AND semantics must yield zero rows.
+        DbContext.Add(new InsiderOwner { OwnerCik = "1", Name = "Musk Elon" });
+        DbContext.Add(new InsiderOwner { OwnerCik = "2", Name = "Cook Timothy D" });
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InsiderOwnerRepository(verify);
+
+        var results = await sut.Search("Elon Cook").AsNoTracking().ToListAsync();
+
+        results.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
## Summary

- Adversarial test verifying the tokenized insider search uses AND logic: a multi-token query like "Elon Cook" must not match records where each token appears in a *different* name ("Musk Elon" and "Cook Timothy D").
- Pins the correctness of the tokenization fix from #2046.

## Code changes

- `tests/Equibles.IntegrationTests/InsiderTrading/InsiderOwnerRepositoryPostgresSearchTests.cs` — added `Search_CrossTokensFromDifferentNames_ReturnsEmpty` asserting empty results when tokens are split across different records.