### PR TITLE
test(insider): pin SearchInsiders Insider fallback for no-role-flag owners

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
@@ -501,4 +501,29 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
         result.Should().Contain("Anonymous Officer");
         result.Should().Contain("Officer");
     }
+
+    [Fact]
+    public async Task SearchInsiders_NoRoleFlags_ShowsInsiderFallback()
+    {
+        // Some SEC filings create an InsiderOwner with all role flags false and
+        // no officer title (e.g., a reporting person whose role wasn't classified).
+        // The role column must still show a label — "Insider" — not an empty cell.
+        DbContext
+            .Set<InsiderOwner>()
+            .Add(
+                CreateOwner(
+                    name: "Unclassified Person",
+                    isDirector: false,
+                    isOfficer: false,
+                    officerTitle: null,
+                    isTenPercentOwner: false
+                )
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().SearchInsiders("Unclassified");
+
+        result.Should().Contain("Unclassified Person");
+        result.Should().Contain("Insider");
+    }
 }


### PR DESCRIPTION
## Summary

- Adversarial test verifying that `SearchInsiders` shows "Insider" as the role label when an `InsiderOwner` has all role flags false and no officer title.
- Pins the `GetRole` fallback path — a regression would render an empty role column in the MCP tool's markdown table.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs` — added `SearchInsiders_NoRoleFlags_ShowsInsiderFallback`.