### PR TITLE
test(stocks): pin CommonStockManager.Create negative MarketCapitalization validation

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerCreateNegativeMarketCapTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerCreateNegativeMarketCapTests.cs
@@ -1,0 +1,45 @@
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Exceptions;
+using Equibles.Data;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class CommonStockManagerCreateNegativeMarketCapTests
+{
+    private static EquiblesDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new EquiblesDbContext(options, [new CommonStocksModuleConfiguration()]);
+    }
+
+    [Fact]
+    public async Task Create_NegativeMarketCapitalization_ThrowsDomainValidationException()
+    {
+        // Contract: MarketCapitalization is a monetary total and must never be
+        // negative — the validator should reject it before persist.
+        var db = NewDb();
+        var repo = Substitute.For<CommonStockRepository>(db);
+        var sut = new CommonStockManager(repo, Substitute.For<IPublishEndpoint>());
+        var stock = new CommonStock
+        {
+            Ticker = "TEST",
+            Name = "Test Corp",
+            Cik = "0000099999",
+            MarketCapitalization = -1,
+        };
+
+        var act = () => sut.Create(stock);
+
+        (await act.Should().ThrowAsync<DomainValidationException>()).WithMessage(
+            "*MarketCapitalization*"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `ValidateCommonStock` branch that rejects negative `MarketCapitalization` — previously at 0% coverage (Lane A adversarial, passed).

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/CommonStockManagerCreateNegativeMarketCapTests.cs` — new test asserting `Create` throws `DomainValidationException` when `MarketCapitalization` is negative.