### PR TITLE
fix: prefer shortest institution name match to avoid subsidiary collisions

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1275,7 +1275,11 @@ public class InstitutionalHoldingsTools
     }
 
     private Task<InstitutionalHolder> FindHolderByName(string name) =>
-        _holderRepository.Search(name ?? string.Empty).OrderBy(h => h.Name).FirstOrDefaultAsync();
+        _holderRepository
+            .Search(name ?? string.Empty)
+            .OrderBy(h => h.Name.Length)
+            .ThenBy(h => h.Name)
+            .FirstOrDefaultAsync();
 
     private async Task<(InstitutionalHolder Holder, string Error)> ResolveHolderByName(string name)
     {

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs
@@ -120,6 +120,28 @@ public class InstitutionalHoldingsToolsGetInstitutionSummaryTests : ParadeDbMcpT
         output.Should().NotContain("vs prior quarter");
     }
 
+    [Fact]
+    public async Task GetInstitutionSummary_AmbiguousName_PrefersShortestMatch()
+    {
+        // "BlackRock" matches both "BlackRock, Inc." (parent) and
+        // "BlackRock Advisors LLC" (subsidiary). The parent is the intended
+        // match — it has the shorter name and is the primary 13F filer.
+        DbContext.AddRange(
+            new InstitutionalHolder { Cik = "00080001", Name = "BlackRock Advisors LLC" },
+            new InstitutionalHolder { Cik = "00080002", Name = "BlackRock, Inc." }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        var output = await sut.GetInstitutionSummary("BlackRock");
+
+        output.Should().Contain("BlackRock, Inc.");
+        output.Should().NotContain("BlackRock Advisors");
+    }
+
     private InstitutionalHoldingsTools NewSut(Equibles.Data.EquiblesDbContext ctx) =>
         new(
             new InstitutionalHoldingRepository(ctx),


### PR DESCRIPTION
## Summary

- `FindHolderByName` used `.OrderBy(h => h.Name)` (alphabetical), which picked subsidiaries like "BlackRock Advisors LLC" over the parent "BlackRock, Inc." — causing "no common report dates" errors in `GetConsensusHoldings` and `GetFundOverlap`.
- Changed to `.OrderBy(h => h.Name.Length).ThenBy(h => h.Name)` so shorter names (parent entities) are preferred.

Closes #2044

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — changed `FindHolderByName` ordering from alphabetical to shortest-name-first.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionSummaryTests.cs` — added `GetInstitutionSummary_AmbiguousName_PrefersShortestMatch` regression test.