### PR TITLE
test(holdings): pin HoldingsExportController.Sanitize whitespace-only fallback

### DIFF
--- a/tests/Equibles.UnitTests/Web/HoldingsExportControllerSanitizeWhitespaceTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsExportControllerSanitizeWhitespaceTests.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using Equibles.Web.Controllers;
+
+namespace Equibles.UnitTests.Web;
+
+public class HoldingsExportControllerSanitizeWhitespaceTests
+{
+    private static readonly MethodInfo SanitizeMethod = typeof(HoldingsExportController).GetMethod(
+        "Sanitize",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    [Fact]
+    public void Sanitize_WhitespaceOnlyInput_ReturnsFallback()
+    {
+        // Contract: CIK values become part of the Content-Disposition filename.
+        // Whitespace-only input must produce a safe fallback, not an empty or
+        // whitespace filename that corrupts the header.
+        var result = (string)SanitizeMethod.Invoke(null, ["   "]);
+
+        result.Should().Be("institution");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `Sanitize` whitespace-only guard branch — previously at 0% coverage (Lane A adversarial, passed). Confirms whitespace CIK input produces the safe `"institution"` fallback for Content-Disposition filenames.

## Code changes

- `tests/Equibles.UnitTests/Web/HoldingsExportControllerSanitizeWhitespaceTests.cs` — new test asserting `Sanitize("   ")` returns `"institution"`.