### PR TITLE
test(holdings): pin ParseDataSetEndDate new-format unrecognized month returns null

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateInvalidMonthTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateInvalidMonthTests.cs
@@ -1,0 +1,18 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Holdings13FRealtimeWorkerParseDataSetEndDateInvalidMonthTests
+{
+    [Fact]
+    public void ParseDataSetEndDate_NewFormatUnrecognizedMonth_ReturnsNull()
+    {
+        // Contract: the new-format parser expects a 3-letter month abbreviation
+        // (jan–dec). An unrecognized abbreviation must yield null, not throw.
+        var result = Holdings13FRealtimeWorker.ParseDataSetEndDate(
+            "01dec2025-28xyz2026_form13f.zip"
+        );
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `TryParseDatePart` invalid-month branch in the new-format parser — previously at 0% coverage (Lane A adversarial, passed). Confirms an unrecognized 3-letter month abbreviation returns null instead of throwing.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateInvalidMonthTests.cs` — new test asserting `ParseDataSetEndDate("01dec2025-28xyz2026_form13f.zip")` returns null.