### PR TITLE
test(sec/financialfacts): pin FinancialConceptAliases.TryResolve null-alias guard

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveNullTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveNullTests.cs
@@ -1,0 +1,18 @@
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialConceptAliasesTryResolveNullTests
+{
+    [Fact]
+    public void TryResolve_NullAlias_ReturnsFalseWithoutThrowing()
+    {
+        // Contract: TryResolve accepts free-form user input (MCP tool
+        // parameters). Null must not throw — it should normalize to empty,
+        // find no match, and return false.
+        var result = FinancialConceptAliases.TryResolve(null, out var concepts);
+
+        result.Should().BeFalse();
+        concepts.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `Normalize` null/whitespace guard and the `TryResolve` no-match return path — both previously at 0% coverage (Lane A adversarial, passed). Confirms null MCP tool input returns `false` without throwing.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveNullTests.cs` — new test asserting `TryResolve(null, out _)` returns false with an empty concept list.