### PR TITLE
test(holdings): pin Filing13FXmlParser.ParseSecDate null-input guard

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseSecDateNullTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseSecDateNullTests.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Filing13FXmlParserParseSecDateNullTests
+{
+    [Fact]
+    public void ParseSecDate_NullInput_ReturnsMinValueNotThrow()
+    {
+        // Contract (doc-comment): "Returns DateOnly.MinValue when unparseable
+        // so the downstream pipeline filters the filing out rather than crashing."
+        // Null is the degenerate unparseable case.
+        var parse = typeof(Filing13FXmlParser).GetMethod(
+            "ParseSecDate",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+        var result = (DateOnly)parse.Invoke(null, [null])!;
+
+        result.Should().Be(DateOnly.MinValue);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `ParseSecDate` null/whitespace guard — previously at 0% coverage (Lane A adversarial, passed). Confirms null input returns `DateOnly.MinValue` per the doc-comment contract rather than throwing.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseSecDateNullTests.cs` — new test asserting `ParseSecDate(null)` returns `DateOnly.MinValue`.