### PR TITLE
refactor(web): add <cn> tag helper for compact number formatting

### DIFF
--- a/src/Equibles.Web/TagHelpers/CompactNumberTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/CompactNumberTagHelper.cs
@@ -1,0 +1,32 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.Web.TagHelpers;
+
+[HtmlTargetElement("cn", TagStructure = TagStructure.WithoutEndTag)]
+public class CompactNumberTagHelper : TagHelper {
+    [HtmlAttributeName("value")]
+    public decimal Value { get; set; }
+
+    [HtmlAttributeName("prefix")]
+    public string Prefix { get; set; }
+
+    [HtmlAttributeName("sign")]
+    public bool Sign { get; set; }
+
+    public override void Process(TagHelperContext context, TagHelperOutput output) {
+        var absValue = Math.Abs(Value);
+        var signPrefix = Sign
+            ? Value > 0 ? "+" : Value < 0 ? "-" : ""
+            : "";
+        var displayPrefix = signPrefix + (Prefix ?? "");
+        var formatted = displayPrefix + absValue.ToString("N0", CultureInfo.InvariantCulture);
+
+        output.TagName = "span";
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.Attributes.SetAttribute("data-compact-number", absValue.ToString(CultureInfo.InvariantCulture));
+        if (!string.IsNullOrEmpty(displayPrefix))
+            output.Attributes.SetAttribute("data-compact-prefix", displayPrefix);
+        output.Content.SetContent(formatted);
+    }
+}

--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -88,14 +88,12 @@
                                         @foreach (var row in board.Rows) {
                                             var deltaSharesCss = row.DeltaShares > 0 ? "text-success" : row.DeltaShares < 0 ? "text-error" : "";
                                             var deltaValueCss = row.DeltaValue > 0 ? "text-success" : row.DeltaValue < 0 ? "text-error" : "";
-                                            var deltaSharesText = (row.DeltaShares > 0 ? "+" : row.DeltaShares < 0 ? "-" : "") + Math.Abs(row.DeltaShares).ToString("N0");
-                                            var deltaValueText = (row.DeltaValue > 0 ? "+$" : row.DeltaValue < 0 ? "-$" : "$") + Math.Abs(row.DeltaValue).ToString("N0");
                                             <tr>
                                                 <td class="font-mono">@row.Ticker</td>
                                                 <td class="max-w-xs truncate">@row.Name</td>
-                                                <td class="text-right font-mono @deltaSharesCss">@deltaSharesText</td>
-                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss">@deltaValueText</td>
-                                                <td class="text-right font-mono hidden lg:table-cell text-base-content/60">@row.PreviousFilerCount.ToString("N0") → @row.CurrentFilerCount.ToString("N0")</td>
+                                                <td class="text-right font-mono @deltaSharesCss"><cn value="@row.DeltaShares" sign /></td>
+                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss"><cn value="@row.DeltaValue" prefix="$" sign /></td>
+                                                <td class="text-right font-mono hidden lg:table-cell text-base-content/60"><cn value="@row.PreviousFilerCount" /> → <cn value="@row.CurrentFilerCount" /></td>
                                                 <td class="text-right">
                                                     <a asp-controller="Stocks" asp-action="Holdings"
                                                        asp-route-ticker="@row.Ticker"
@@ -144,7 +142,7 @@
                                             <tr>
                                                 <td class="font-mono">@row.Ticker</td>
                                                 <td class="max-w-xs truncate">@row.Name</td>
-                                                <td class="text-right font-mono">@board.FilerSelector(row).ToString("N0")</td>
+                                                <td class="text-right font-mono"><cn value="@board.FilerSelector(row)" /></td>
                                                 <td class="text-right">
                                                     <a asp-controller="Stocks" asp-action="Holdings"
                                                        asp-route-ticker="@row.Ticker"

--- a/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
@@ -79,25 +79,23 @@
                             @{ var rowNumber = firstRowNumber; }
                             @foreach (var row in Model.Rows) {
                                 var deltaFilersCss = row.DeltaFilerCount > 0 ? "text-success" : row.DeltaFilerCount < 0 ? "text-error" : "";
-                                var deltaFilersText = (row.DeltaFilerCount > 0 ? "+" : row.DeltaFilerCount < 0 ? "-" : "") + Math.Abs(row.DeltaFilerCount).ToString("N0");
                                 var deltaValueCss = row.DeltaValue > 0 ? "text-success" : row.DeltaValue < 0 ? "text-error" : "";
-                                var deltaValueText = (row.DeltaValue > 0 ? "+$" : row.DeltaValue < 0 ? "-$" : "$") + Math.Abs(row.DeltaValue).ToString("N0");
                                 <tr>
                                     <td class="text-right text-base-content/60">@rowNumber.ToString("N0")</td>
                                     <td class="font-mono">@row.Ticker</td>
                                     <td class="max-w-xs truncate">@row.Name</td>
-                                    <td class="text-right font-mono">@row.CurrentFilerCount.ToString("N0")</td>
+                                    <td class="text-right font-mono"><cn value="@row.CurrentFilerCount" /></td>
                                     <td class="text-right font-mono @deltaFilersCss">
                                         @if (Model.PreviousDate.HasValue) {
-                                            @deltaFilersText
+                                            <cn value="@row.DeltaFilerCount" sign />
                                         } else {
                                             <span class="text-base-content/40">—</span>
                                         }
                                     </td>
-                                    <td class="text-right font-mono hidden md:table-cell">$@row.CurrentValue.ToString("N0")</td>
+                                    <td class="text-right font-mono hidden md:table-cell"><cn value="@row.CurrentValue" prefix="$" /></td>
                                     <td class="text-right font-mono hidden md:table-cell @deltaValueCss">
                                         @if (Model.PreviousDate.HasValue) {
-                                            @deltaValueText
+                                            <cn value="@row.DeltaValue" prefix="$" sign />
                                         } else {
                                             <span class="text-base-content/40">—</span>
                                         }

--- a/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
+++ b/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
@@ -57,7 +57,7 @@
                                                 <a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@row.Ticker"
                                                    class="font-mono link link-primary">@row.Ticker</a>
                                             </td>
-                                            <td class="text-right font-mono text-success">$@row.Value.ToString("N0")</td>
+                                            <td class="text-right font-mono text-success"><cn value="@row.Value" prefix="$" /></td>
                                             <td class="text-right text-sm text-base-content/60 hidden md:table-cell">@row.TransactionDate.ToString("MMM dd")</td>
                                         </tr>
                                     }
@@ -99,7 +99,7 @@
                                                 <a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@row.Ticker"
                                                    class="font-mono link link-primary">@row.Ticker</a>
                                             </td>
-                                            <td class="text-right font-mono text-error">$@row.Value.ToString("N0")</td>
+                                            <td class="text-right font-mono text-error"><cn value="@row.Value" prefix="$" /></td>
                                             <td class="text-right text-sm text-base-content/60 hidden md:table-cell">@row.TransactionDate.ToString("MMM dd")</td>
                                         </tr>
                                     }
@@ -150,9 +150,9 @@
                                                 @row.TransactionCodeLabel
                                             </span>
                                         </td>
-                                        <td class="text-right font-mono">@row.Shares.ToString("N0")</td>
+                                        <td class="text-right font-mono"><cn value="@row.Shares" /></td>
                                         <td class="text-right font-mono hidden md:table-cell">$@row.PricePerShare.ToString("N2")</td>
-                                        <td class="text-right font-mono font-semibold">$@row.Value.ToString("N0")</td>
+                                        <td class="text-right font-mono font-semibold"><cn value="@row.Value" prefix="$" /></td>
                                         <td class="text-right text-sm text-base-content/60 hidden lg:table-cell">@row.TransactionDate.ToString("MMM dd, yyyy")</td>
                                     </tr>
                                 }

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -67,7 +67,7 @@
                         <th scope="col" class="hidden md:table-cell">CIK</th>
                         <th scope="col" class="hidden lg:table-cell">Location</th>
                         <th scope="col" class="text-right"># Positions</th>
-                        <th scope="col" class="text-right hidden md:table-cell">Total $ Value ($M)</th>
+                        <th scope="col" class="text-right hidden md:table-cell">Total $ Value</th>
                         <th scope="col" class="text-right hidden xl:table-cell">Last filed</th>
                         <th scope="col" class="w-8"><span class="sr-only">Open</span></th>
                     </tr>
@@ -83,8 +83,8 @@
                             </td>
                             <td class="hidden md:table-cell font-mono text-sm text-base-content/60">@inst.Cik</td>
                             <td class="hidden lg:table-cell text-sm text-base-content/60">@(string.IsNullOrEmpty(location) ? "—" : location)</td>
-                            <td class="text-right font-mono">@inst.PositionCount.ToString("N0")</td>
-                            <td class="text-right font-mono hidden md:table-cell">@((inst.TotalValue / 1_000_000m).ToString("N1"))</td>
+                            <td class="text-right font-mono"><cn value="@inst.PositionCount" /></td>
+                            <td class="text-right font-mono hidden md:table-cell"><cn value="@inst.TotalValue" prefix="$" /></td>
                             <td class="text-right font-mono text-sm text-base-content/60 hidden xl:table-cell">@(inst.LatestReportDate?.ToString("yyyy-MM-dd") ?? "—")</td>
                             <td class="text-base-content/30">
                                 <icon name="chevron-right" size="4" />

--- a/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
+++ b/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
@@ -129,9 +129,21 @@
                             @foreach (var record in tableRecords) {
                                 <tr>
                                     <td class="font-mono text-sm">@record.Date.ToString("yyyy-MM-dd")</td>
-                                    <td class="text-right tabular-nums">@record.CallVolume?.ToString("N0")</td>
-                                    <td class="text-right tabular-nums">@record.PutVolume?.ToString("N0")</td>
-                                    <td class="text-right tabular-nums hidden sm:table-cell">@record.TotalVolume?.ToString("N0")</td>
+                                    <td class="text-right tabular-nums">
+                                        @if (record.CallVolume != null) {
+                                            <cn value="@((decimal)record.CallVolume)" />
+                                        }
+                                    </td>
+                                    <td class="text-right tabular-nums">
+                                        @if (record.PutVolume != null) {
+                                            <cn value="@((decimal)record.PutVolume)" />
+                                        }
+                                    </td>
+                                    <td class="text-right tabular-nums hidden sm:table-cell">
+                                        @if (record.TotalVolume != null) {
+                                            <cn value="@((decimal)record.TotalVolume)" />
+                                        }
+                                    </td>
                                     <td class="text-right font-semibold tabular-nums">@record.PutCallRatio?.ToString("N2")</td>
                                 </tr>
                             }

--- a/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
@@ -92,10 +92,16 @@
                                 <td class="font-mono">@row.Ticker</td>
                                 <td class="max-w-xs truncate">@row.Name</td>
                                 @foreach (var slice in row.Slices) {
-                                    <td class="text-right font-mono">@(slice.Shares > 0 ? slice.Shares.ToString("N0") : "—")</td>
+                                    <td class="text-right font-mono">
+                                        @if (slice.Shares > 0) {
+                                            <cn value="@slice.Shares" />
+                                        } else {
+                                            <text>—</text>
+                                        }
+                                    </td>
                                     <td class="text-right font-mono text-base-content/60">@(slice.Value > 0 ? slice.PercentOfPortfolio.ToString("F1") + "%" : "—")</td>
                                 }
-                                <td class="text-right font-mono">$@row.CombinedValue.ToString("N0")</td>
+                                <td class="text-right font-mono"><cn value="@row.CombinedValue" prefix="$" /></td>
                             </tr>
                         }
                     </tbody>

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -49,11 +49,11 @@
                 <div class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200 w-full">
                     <div class="stat">
                         <div class="stat-title">Reported AUM</div>
-                        <div class="stat-value text-2xl font-mono">$@Model.Summary.ReportedAum.ToString("N0")</div>
+                        <div class="stat-value text-2xl font-mono"><cn value="@Model.Summary.ReportedAum" prefix="$" /></div>
                     </div>
                     <div class="stat">
                         <div class="stat-title"># Positions</div>
-                        <div class="stat-value text-2xl font-mono">@Model.Summary.PositionCount.ToString("N0")</div>
+                        <div class="stat-value text-2xl font-mono"><cn value="@Model.Summary.PositionCount" /></div>
                     </div>
                     <div class="stat">
                         <div class="stat-title">Top 10 concentration</div>
@@ -101,7 +101,7 @@
                                         }
                                     </td>
                                     <td class="text-right font-mono">@slice.PositionCount.ToString("N0")</td>
-                                    <td class="text-right font-mono">$@slice.TotalValue.ToString("N0")</td>
+                                    <td class="text-right font-mono"><cn value="@slice.TotalValue" prefix="$" /></td>
                                     <td class="text-right font-mono">@slice.PercentOfPortfolio.ToString("F1")%</td>
                                 </tr>
                             }
@@ -203,10 +203,10 @@
                                                 <tr>
                                                     <td class="font-mono">@row.Ticker</td>
                                                     <td class="max-w-xs truncate">@row.Name</td>
-                                                    <td class="text-right font-mono">@row.PreviousShares.ToString("N0")</td>
-                                                    <td class="text-right font-mono">@row.CurrentShares.ToString("N0")</td>
-                                                    <td class="text-right font-mono @deltaSharesCss">@((row.DeltaShares > 0 ? "+" : row.DeltaShares < 0 ? "-" : "") + Math.Abs(row.DeltaShares).ToString("N0"))</td>
-                                                    <td class="text-right font-mono @deltaValueCss">@((row.DeltaValue > 0 ? "+$" : row.DeltaValue < 0 ? "-$" : "$") + Math.Abs(row.DeltaValue).ToString("N0"))</td>
+                                                    <td class="text-right font-mono"><cn value="@row.PreviousShares" /></td>
+                                                    <td class="text-right font-mono"><cn value="@row.CurrentShares" /></td>
+                                                    <td class="text-right font-mono @deltaSharesCss"><cn value="@row.DeltaShares" sign /></td>
+                                                    <td class="text-right font-mono @deltaValueCss"><cn value="@row.DeltaValue" prefix="$" sign /></td>
                                                     <td class="text-right font-mono">@row.PercentOfPortfolio.ToString("F1")%</td>
                                                 </tr>
                                             }
@@ -221,7 +221,14 @@
         </div>
     }
 
-    <h2 class="text-xl font-semibold mb-3">Recent holdings</h2>
+    <div class="flex items-center justify-between mb-3">
+        <h2 class="text-xl font-semibold m-0">Recent holdings</h2>
+        <label class="flex items-center gap-1.5 cursor-pointer" title="Toggle compact numbers (1M, 1B)">
+            <span class="text-xs text-base-content/60">Compact</span>
+            <input type="checkbox" class="toggle toggle-xs toggle-primary btn-compact-toggle"
+                   onchange="toggleCompactNumbers()" />
+        </label>
+    </div>
     @if (Model.Holdings.Count == 0) {
         <div class="text-base-content/60 py-8">No reported holdings.</div>
     } else {
@@ -246,8 +253,8 @@
                                 </td>
                                 <td class="max-w-xs truncate">@holding.Company</td>
                                 <td class="hidden lg:table-cell">@holding.ReportDate.ToString("yyyy-MM-dd")</td>
-                                <td class="text-right">@holding.Shares.ToString("N0")</td>
-                                <td class="text-right">@holding.Value.ToString("N0")</td>
+                                <td class="text-right"><cn value="@holding.Shares" /></td>
+                                <td class="text-right"><cn value="@holding.Value" prefix="$" /></td>
                             </tr>
                         }
                     </tbody>

--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -66,7 +66,14 @@
             .OrderBy(h => h.ReportDate)
             .ToList();
 
-        <h2 class="text-lg font-semibold mb-3">Holdings in @stock.Ticker</h2>
+        <div class="flex items-center justify-between mb-3">
+            <h2 class="text-lg font-semibold m-0">Holdings in @stock.Ticker</h2>
+            <label class="flex items-center gap-1.5 cursor-pointer" title="Toggle compact numbers (1M, 1B)">
+                <span class="text-xs text-base-content/60">Compact</span>
+                <input type="checkbox" class="toggle toggle-xs toggle-primary btn-compact-toggle"
+                       onchange="toggleCompactNumbers()" />
+            </label>
+        </div>
 
         <!-- Position Over Time Chart -->
         @if (chartHoldings.Count >= 2) {
@@ -103,8 +110,8 @@
                                 : (double?)null;
                             <tr>
                                 <td>@h.ReportDate.ToString("yyyy-MM-dd")</td>
-                                <td class="text-right font-mono">$@h.Value.ToString("N0")</td>
-                                <td class="text-right font-mono">@h.Shares.ToString("N0")</td>
+                                <td class="text-right font-mono"><cn value="@h.Value" prefix="$" /></td>
+                                <td class="text-right font-mono"><cn value="@h.Shares" /></td>
                                 <td class="text-right font-mono hidden md:table-cell">
                                     @if (changePercent.HasValue) {
                                         var css = changePercent.Value > 0 ? "text-success" : changePercent.Value < 0 ? "text-error" : "";

--- a/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
@@ -37,9 +37,9 @@
                     @foreach (var ftd in Model.FailsToDeliver.OrderByDescending(f => f.SettlementDate)) {
                         <tr>
                             <td>@ftd.SettlementDate.ToString("yyyy-MM-dd")</td>
-                            <td class="text-right font-mono">@ftd.Quantity.ToString("N0")</td>
+                            <td class="text-right font-mono"><cn value="@ftd.Quantity" /></td>
                             <td class="text-right font-mono">$@ftd.Price.ToString("F2")</td>
-                            <td class="text-right font-mono">$@((ftd.Quantity * ftd.Price).ToString("N0"))</td>
+                            <td class="text-right font-mono"><cn value="@(ftd.Quantity * ftd.Price)" prefix="$" /></td>
                         </tr>
                     }
                 </tbody>

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -71,8 +71,8 @@
                 </select>
             </div>
             <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Holders:</span> <strong>@Model.HolderCount.ToString("N0")</strong></div>
-            <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Value:</span> <strong>$@Model.TotalValue.ToString("N0")</strong></div>
-            <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Shares:</span> <strong>@Model.TotalShares.ToString("N0")</strong></div>
+            <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Value:</span> <strong><cn value="@Model.TotalValue" prefix="$" /></strong></div>
+            <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Shares:</span> <strong><cn value="@Model.TotalShares" /></strong></div>
             <div class="flex items-center gap-2 ml-auto">
                 <label class="flex items-center gap-1.5 cursor-pointer" title="Toggle compact numbers (1M, 1B)">
                     <span class="text-xs text-base-content/60">Compact</span>
@@ -181,13 +181,11 @@
                                         @foreach (var e in card.Entries) {
                                             var deltaSharesCss = e.DeltaShares > 0 ? "text-success" : e.DeltaShares < 0 ? "text-error" : "";
                                             var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
-                                            var deltaSharesText = (e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "") + Math.Abs(e.DeltaShares).ToString("N0");
-                                            var deltaValueText = (e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$") + Math.Abs(e.DeltaValue).ToString("N0");
                                             <tr>
                                                 <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
-                                                <td class="text-right font-mono @deltaSharesCss" data-compact-number="@e.DeltaShares" data-compact-prefix="@(e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "")">@deltaSharesText</td>
+                                                <td class="text-right font-mono @deltaSharesCss"><cn value="@e.DeltaShares" sign /></td>
                                                 <td class="text-right font-mono hidden md:table-cell @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
-                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss" data-compact-number="@Math.Abs(e.DeltaValue)" data-compact-prefix="@(e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$")">@deltaValueText</td>
+                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss"><cn value="@e.DeltaValue" prefix="$" sign /></td>
                                             </tr>
                                         }
                                     </tbody>
@@ -236,8 +234,6 @@
                                 var e = x.Entry;
                                 var deltaSharesCss = e.DeltaShares > 0 ? "text-success" : e.DeltaShares < 0 ? "text-error" : "";
                                 var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
-                                var deltaSharesText = (e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "") + Math.Abs(e.DeltaShares).ToString("N0");
-                                var deltaValueText = (e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$") + Math.Abs(e.DeltaValue).ToString("N0");
                                 var own = e.OwnershipPercent(Model.SharesOutstanding);
                                 <tr>
                                     <td class="max-w-xs truncate">
@@ -246,13 +242,13 @@
                                             <partial name="_FundClassificationBadge" model="e.InstitutionalHolder.Classification" />
                                         }
                                     </td>
-                                    <td class="text-right font-mono whitespace-nowrap" data-compact-number="@e.CurrentShares">@e.CurrentShares.ToString("N0")</td>
-                                    <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @deltaSharesCss" data-compact-number="@e.DeltaShares" data-compact-prefix="@(e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "")">@deltaSharesText</td>
+                                    <td class="text-right font-mono whitespace-nowrap"><cn value="@e.CurrentShares" /></td>
+                                    <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @deltaSharesCss"><cn value="@e.DeltaShares" sign /></td>
                                     <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
                                     <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap">@(own != null ? $"{own:F2}%" : "—")</td>
-                                    <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap" data-compact-number="@e.CurrentValue" data-compact-prefix="$">$@e.CurrentValue.ToString("N0")</td>
+                                    <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap"><cn value="@e.CurrentValue" prefix="$" /></td>
                                     <td class="text-right hidden xl:table-cell whitespace-nowrap text-base-content/60">@FormatQuarter(e.QuarterFirstOwned)</td>
-                                    <td class="text-right font-mono whitespace-nowrap @deltaValueCss" data-compact-number="@Math.Abs(e.DeltaValue)" data-compact-prefix="@(e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$")">@deltaValueText</td>
+                                    <td class="text-right font-mono whitespace-nowrap @deltaValueCss"><cn value="@e.DeltaValue" prefix="$" sign /></td>
                                     <td class="text-right">
                                         @if (e.InstitutionalHolder?.Cik != null) {
                                             <a asp-controller="Stocks" asp-action="ShowHolder"
@@ -306,8 +302,6 @@
                                 @foreach (var e in sorted) {
                                     var deltaSharesCss = e.DeltaShares > 0 ? "text-success" : e.DeltaShares < 0 ? "text-error" : "";
                                     var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
-                                    var deltaSharesText = (e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "") + Math.Abs(e.DeltaShares).ToString("N0");
-                                    var deltaValueText = (e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$") + Math.Abs(e.DeltaValue).ToString("N0");
                                     var own = e.OwnershipPercent(Model.SharesOutstanding);
                                     <tr>
                                         <td class="max-w-xs truncate">
@@ -316,13 +310,13 @@
                                                 <partial name="_FundClassificationBadge" model="e.InstitutionalHolder.Classification" />
                                             }
                                         </td>
-                                        <td class="text-right font-mono" data-compact-number="@e.CurrentShares">@e.CurrentShares.ToString("N0")</td>
-                                        <td class="text-right font-mono hidden md:table-cell @deltaSharesCss" data-compact-number="@e.DeltaShares" data-compact-prefix="@(e.DeltaShares > 0 ? "+" : e.DeltaShares < 0 ? "-" : "")">@deltaSharesText</td>
+                                        <td class="text-right font-mono"><cn value="@e.CurrentShares" /></td>
+                                        <td class="text-right font-mono hidden md:table-cell @deltaSharesCss"><cn value="@e.DeltaShares" sign /></td>
                                         <td class="text-right font-mono hidden md:table-cell @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
                                         <td class="text-right font-mono hidden lg:table-cell">@(own != null ? $"{own:F2}%" : "—")</td>
-                                        <td class="text-right font-mono hidden lg:table-cell" data-compact-number="@e.CurrentValue" data-compact-prefix="$">$@e.CurrentValue.ToString("N0")</td>
+                                        <td class="text-right font-mono hidden lg:table-cell"><cn value="@e.CurrentValue" prefix="$" /></td>
                                         <td class="text-right hidden xl:table-cell text-base-content/60">@FormatQuarter(e.QuarterFirstOwned)</td>
-                                        <td class="text-right font-mono @deltaValueCss" data-compact-number="@Math.Abs(e.DeltaValue)" data-compact-prefix="@(e.DeltaValue > 0 ? "+$" : e.DeltaValue < 0 ? "-$" : "$")">@deltaValueText</td>
+                                        <td class="text-right font-mono @deltaValueCss"><cn value="@e.DeltaValue" prefix="$" sign /></td>
                                         <td class="text-right">
                                             @if (e.InstitutionalHolder?.Cik != null) {
                                                 <a asp-controller="Stocks" asp-action="ShowHolder"

--- a/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
@@ -56,10 +56,16 @@
                             <td class="max-w-xs truncate">@(t.InsiderOwner?.Name ?? "Unknown")</td>
                             <td class="hidden md:table-cell text-sm text-base-content/60">@role</td>
                             <td><span class="badge @badgeClass badge-sm tooltip tooltip-right cursor-help" data-tip="@typeTooltip">@typeLabel</span></td>
-                            <td class="text-right font-mono">@t.Shares.ToString("N0")</td>
+                            <td class="text-right font-mono"><cn value="@t.Shares" /></td>
                             <td class="text-right font-mono hidden md:table-cell">@(t.PricePerShare > 0 ? $"${t.PricePerShare:N2}" : "—")</td>
-                            <td class="text-right font-mono hidden lg:table-cell">@(t.PricePerShare > 0 ? $"${(t.Shares * t.PricePerShare):N0}" : "—")</td>
-                            <td class="text-right font-mono hidden lg:table-cell">@t.SharesOwnedAfter.ToString("N0")</td>
+                            <td class="text-right font-mono hidden lg:table-cell">
+                                @if (t.PricePerShare > 0) {
+                                    <cn value="@(t.Shares * t.PricePerShare)" prefix="$" />
+                                } else {
+                                    <text>—</text>
+                                }
+                            </td>
+                            <td class="text-right font-mono hidden lg:table-cell"><cn value="@t.SharesOwnedAfter" /></td>
                         </tr>
                     }
                 </tbody>

--- a/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
@@ -39,12 +39,18 @@
                     @foreach (var si in Model.ShortInterests.OrderByDescending(s => s.SettlementDate)) {
                         <tr>
                             <td>@si.SettlementDate.ToString("yyyy-MM-dd")</td>
-                            <td class="text-right font-mono">@si.CurrentShortPosition.ToString("N0")</td>
-                            <td class="text-right font-mono">@si.PreviousShortPosition.ToString("N0")</td>
+                            <td class="text-right font-mono"><cn value="@si.CurrentShortPosition" /></td>
+                            <td class="text-right font-mono"><cn value="@si.PreviousShortPosition" /></td>
                             <td class="text-right font-mono @(si.ChangeInShortPosition > 0 ? "text-error" : si.ChangeInShortPosition < 0 ? "text-success" : "")">
-                                @(si.ChangeInShortPosition > 0 ? "+" : "")@si.ChangeInShortPosition.ToString("N0")
+                                <cn value="@si.ChangeInShortPosition" sign />
                             </td>
-                            <td class="text-right font-mono hidden md:table-cell">@(si.AverageDailyVolume?.ToString("N0") ?? "—")</td>
+                            <td class="text-right font-mono hidden md:table-cell">
+                                @if (si.AverageDailyVolume != null) {
+                                    <cn value="@((decimal)si.AverageDailyVolume)" />
+                                } else {
+                                    <text>—</text>
+                                }
+                            </td>
                             <td class="text-right font-mono">@(si.DaysToCover?.ToString("F2") ?? "—")</td>
                         </tr>
                     }

--- a/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
@@ -39,9 +39,9 @@
                         var shortPct = sv.TotalVolume > 0 ? (double)sv.ShortVolume / sv.TotalVolume * 100 : 0;
                         <tr>
                             <td>@sv.Date.ToString("yyyy-MM-dd")</td>
-                            <td class="text-right font-mono">@sv.ShortVolume.ToString("N0")</td>
-                            <td class="text-right font-mono">@sv.ShortExemptVolume.ToString("N0")</td>
-                            <td class="text-right font-mono">@sv.TotalVolume.ToString("N0")</td>
+                            <td class="text-right font-mono"><cn value="@sv.ShortVolume" /></td>
+                            <td class="text-right font-mono"><cn value="@sv.ShortExemptVolume" /></td>
+                            <td class="text-right font-mono"><cn value="@sv.TotalVolume" /></td>
                             <td class="text-right font-mono">@shortPct.ToString("F1")%</td>
                         </tr>
                     }


### PR DESCRIPTION
## Summary
- Introduces `CompactNumberTagHelper` (`<cn>`) that renders a `<span>` with `data-compact-number` attributes
- Replaces manual `ToString("N0")` + `data-compact-number` attribute boilerplate across 13 views
- Compact toggle (already in _HoldingsTab) now works on all pages with `<cn>` tags

## Code changes
- **`TagHelpers/CompactNumberTagHelper.cs`** — new tag helper: accepts `value` (decimal), `prefix` (optional), `sign` (bool for +/- prefix)
- **13 Razor views** — replaced `ToString("N0")` with `<cn>` for shares, dollar values, volumes, AUM, deltas
- Added compact toggle to Institution profile and ShowHolder pages
- Not changed: percentages, dates, prices, small counts