### PR TITLE
refactor(web): rename <cn> tag to <compactable-number>

### DIFF
--- a/src/Equibles.Web/TagHelpers/CompactNumberTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/CompactNumberTagHelper.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace Equibles.Web.TagHelpers;
 
-[HtmlTargetElement("cn", TagStructure = TagStructure.WithoutEndTag)]
+[HtmlTargetElement("compactable-number", TagStructure = TagStructure.WithoutEndTag)]
 public class CompactNumberTagHelper : TagHelper {
     [HtmlAttributeName("value")]
     public decimal Value { get; set; }

--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -91,9 +91,9 @@
                                             <tr>
                                                 <td class="font-mono">@row.Ticker</td>
                                                 <td class="max-w-xs truncate">@row.Name</td>
-                                                <td class="text-right font-mono @deltaSharesCss"><cn value="@row.DeltaShares" sign /></td>
-                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss"><cn value="@row.DeltaValue" prefix="$" sign /></td>
-                                                <td class="text-right font-mono hidden lg:table-cell text-base-content/60"><cn value="@row.PreviousFilerCount" /> → <cn value="@row.CurrentFilerCount" /></td>
+                                                <td class="text-right font-mono @deltaSharesCss"><compactable-number value="@row.DeltaShares" sign /></td>
+                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss"><compactable-number value="@row.DeltaValue" prefix="$" sign /></td>
+                                                <td class="text-right font-mono hidden lg:table-cell text-base-content/60"><compactable-number value="@row.PreviousFilerCount" /> → <compactable-number value="@row.CurrentFilerCount" /></td>
                                                 <td class="text-right">
                                                     <a asp-controller="Stocks" asp-action="Holdings"
                                                        asp-route-ticker="@row.Ticker"
@@ -142,7 +142,7 @@
                                             <tr>
                                                 <td class="font-mono">@row.Ticker</td>
                                                 <td class="max-w-xs truncate">@row.Name</td>
-                                                <td class="text-right font-mono"><cn value="@board.FilerSelector(row)" /></td>
+                                                <td class="text-right font-mono"><compactable-number value="@board.FilerSelector(row)" /></td>
                                                 <td class="text-right">
                                                     <a asp-controller="Stocks" asp-action="Holdings"
                                                        asp-route-ticker="@row.Ticker"

--- a/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
@@ -84,18 +84,18 @@
                                     <td class="text-right text-base-content/60">@rowNumber.ToString("N0")</td>
                                     <td class="font-mono">@row.Ticker</td>
                                     <td class="max-w-xs truncate">@row.Name</td>
-                                    <td class="text-right font-mono"><cn value="@row.CurrentFilerCount" /></td>
+                                    <td class="text-right font-mono"><compactable-number value="@row.CurrentFilerCount" /></td>
                                     <td class="text-right font-mono @deltaFilersCss">
                                         @if (Model.PreviousDate.HasValue) {
-                                            <cn value="@row.DeltaFilerCount" sign />
+                                            <compactable-number value="@row.DeltaFilerCount" sign />
                                         } else {
                                             <span class="text-base-content/40">—</span>
                                         }
                                     </td>
-                                    <td class="text-right font-mono hidden md:table-cell"><cn value="@row.CurrentValue" prefix="$" /></td>
+                                    <td class="text-right font-mono hidden md:table-cell"><compactable-number value="@row.CurrentValue" prefix="$" /></td>
                                     <td class="text-right font-mono hidden md:table-cell @deltaValueCss">
                                         @if (Model.PreviousDate.HasValue) {
-                                            <cn value="@row.DeltaValue" prefix="$" sign />
+                                            <compactable-number value="@row.DeltaValue" prefix="$" sign />
                                         } else {
                                             <span class="text-base-content/40">—</span>
                                         }

--- a/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
+++ b/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
@@ -57,7 +57,7 @@
                                                 <a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@row.Ticker"
                                                    class="font-mono link link-primary">@row.Ticker</a>
                                             </td>
-                                            <td class="text-right font-mono text-success"><cn value="@row.Value" prefix="$" /></td>
+                                            <td class="text-right font-mono text-success"><compactable-number value="@row.Value" prefix="$" /></td>
                                             <td class="text-right text-sm text-base-content/60 hidden md:table-cell">@row.TransactionDate.ToString("MMM dd")</td>
                                         </tr>
                                     }
@@ -99,7 +99,7 @@
                                                 <a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@row.Ticker"
                                                    class="font-mono link link-primary">@row.Ticker</a>
                                             </td>
-                                            <td class="text-right font-mono text-error"><cn value="@row.Value" prefix="$" /></td>
+                                            <td class="text-right font-mono text-error"><compactable-number value="@row.Value" prefix="$" /></td>
                                             <td class="text-right text-sm text-base-content/60 hidden md:table-cell">@row.TransactionDate.ToString("MMM dd")</td>
                                         </tr>
                                     }
@@ -150,9 +150,9 @@
                                                 @row.TransactionCodeLabel
                                             </span>
                                         </td>
-                                        <td class="text-right font-mono"><cn value="@row.Shares" /></td>
+                                        <td class="text-right font-mono"><compactable-number value="@row.Shares" /></td>
                                         <td class="text-right font-mono hidden md:table-cell">$@row.PricePerShare.ToString("N2")</td>
-                                        <td class="text-right font-mono font-semibold"><cn value="@row.Value" prefix="$" /></td>
+                                        <td class="text-right font-mono font-semibold"><compactable-number value="@row.Value" prefix="$" /></td>
                                         <td class="text-right text-sm text-base-content/60 hidden lg:table-cell">@row.TransactionDate.ToString("MMM dd, yyyy")</td>
                                     </tr>
                                 }

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -83,8 +83,8 @@
                             </td>
                             <td class="hidden md:table-cell font-mono text-sm text-base-content/60">@inst.Cik</td>
                             <td class="hidden lg:table-cell text-sm text-base-content/60">@(string.IsNullOrEmpty(location) ? "—" : location)</td>
-                            <td class="text-right font-mono"><cn value="@inst.PositionCount" /></td>
-                            <td class="text-right font-mono hidden md:table-cell"><cn value="@inst.TotalValue" prefix="$" /></td>
+                            <td class="text-right font-mono"><compactable-number value="@inst.PositionCount" /></td>
+                            <td class="text-right font-mono hidden md:table-cell"><compactable-number value="@inst.TotalValue" prefix="$" /></td>
                             <td class="text-right font-mono text-sm text-base-content/60 hidden xl:table-cell">@(inst.LatestReportDate?.ToString("yyyy-MM-dd") ?? "—")</td>
                             <td class="text-base-content/30">
                                 <icon name="chevron-right" size="4" />

--- a/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
+++ b/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
@@ -131,17 +131,17 @@
                                     <td class="font-mono text-sm">@record.Date.ToString("yyyy-MM-dd")</td>
                                     <td class="text-right tabular-nums">
                                         @if (record.CallVolume != null) {
-                                            <cn value="@((decimal)record.CallVolume)" />
+                                            <compactable-number value="@((decimal)record.CallVolume)" />
                                         }
                                     </td>
                                     <td class="text-right tabular-nums">
                                         @if (record.PutVolume != null) {
-                                            <cn value="@((decimal)record.PutVolume)" />
+                                            <compactable-number value="@((decimal)record.PutVolume)" />
                                         }
                                     </td>
                                     <td class="text-right tabular-nums hidden sm:table-cell">
                                         @if (record.TotalVolume != null) {
-                                            <cn value="@((decimal)record.TotalVolume)" />
+                                            <compactable-number value="@((decimal)record.TotalVolume)" />
                                         }
                                     </td>
                                     <td class="text-right font-semibold tabular-nums">@record.PutCallRatio?.ToString("N2")</td>

--- a/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
@@ -94,14 +94,14 @@
                                 @foreach (var slice in row.Slices) {
                                     <td class="text-right font-mono">
                                         @if (slice.Shares > 0) {
-                                            <cn value="@slice.Shares" />
+                                            <compactable-number value="@slice.Shares" />
                                         } else {
                                             <text>—</text>
                                         }
                                     </td>
                                     <td class="text-right font-mono text-base-content/60">@(slice.Value > 0 ? slice.PercentOfPortfolio.ToString("F1") + "%" : "—")</td>
                                 }
-                                <td class="text-right font-mono"><cn value="@row.CombinedValue" prefix="$" /></td>
+                                <td class="text-right font-mono"><compactable-number value="@row.CombinedValue" prefix="$" /></td>
                             </tr>
                         }
                     </tbody>

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -49,11 +49,11 @@
                 <div class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200 w-full">
                     <div class="stat">
                         <div class="stat-title">Reported AUM</div>
-                        <div class="stat-value text-2xl font-mono"><cn value="@Model.Summary.ReportedAum" prefix="$" /></div>
+                        <div class="stat-value text-2xl font-mono"><compactable-number value="@Model.Summary.ReportedAum" prefix="$" /></div>
                     </div>
                     <div class="stat">
                         <div class="stat-title"># Positions</div>
-                        <div class="stat-value text-2xl font-mono"><cn value="@Model.Summary.PositionCount" /></div>
+                        <div class="stat-value text-2xl font-mono"><compactable-number value="@Model.Summary.PositionCount" /></div>
                     </div>
                     <div class="stat">
                         <div class="stat-title">Top 10 concentration</div>
@@ -101,7 +101,7 @@
                                         }
                                     </td>
                                     <td class="text-right font-mono">@slice.PositionCount.ToString("N0")</td>
-                                    <td class="text-right font-mono"><cn value="@slice.TotalValue" prefix="$" /></td>
+                                    <td class="text-right font-mono"><compactable-number value="@slice.TotalValue" prefix="$" /></td>
                                     <td class="text-right font-mono">@slice.PercentOfPortfolio.ToString("F1")%</td>
                                 </tr>
                             }
@@ -203,10 +203,10 @@
                                                 <tr>
                                                     <td class="font-mono">@row.Ticker</td>
                                                     <td class="max-w-xs truncate">@row.Name</td>
-                                                    <td class="text-right font-mono"><cn value="@row.PreviousShares" /></td>
-                                                    <td class="text-right font-mono"><cn value="@row.CurrentShares" /></td>
-                                                    <td class="text-right font-mono @deltaSharesCss"><cn value="@row.DeltaShares" sign /></td>
-                                                    <td class="text-right font-mono @deltaValueCss"><cn value="@row.DeltaValue" prefix="$" sign /></td>
+                                                    <td class="text-right font-mono"><compactable-number value="@row.PreviousShares" /></td>
+                                                    <td class="text-right font-mono"><compactable-number value="@row.CurrentShares" /></td>
+                                                    <td class="text-right font-mono @deltaSharesCss"><compactable-number value="@row.DeltaShares" sign /></td>
+                                                    <td class="text-right font-mono @deltaValueCss"><compactable-number value="@row.DeltaValue" prefix="$" sign /></td>
                                                     <td class="text-right font-mono">@row.PercentOfPortfolio.ToString("F1")%</td>
                                                 </tr>
                                             }
@@ -253,8 +253,8 @@
                                 </td>
                                 <td class="max-w-xs truncate">@holding.Company</td>
                                 <td class="hidden lg:table-cell">@holding.ReportDate.ToString("yyyy-MM-dd")</td>
-                                <td class="text-right"><cn value="@holding.Shares" /></td>
-                                <td class="text-right"><cn value="@holding.Value" prefix="$" /></td>
+                                <td class="text-right"><compactable-number value="@holding.Shares" /></td>
+                                <td class="text-right"><compactable-number value="@holding.Value" prefix="$" /></td>
                             </tr>
                         }
                     </tbody>

--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -110,8 +110,8 @@
                                 : (double?)null;
                             <tr>
                                 <td>@h.ReportDate.ToString("yyyy-MM-dd")</td>
-                                <td class="text-right font-mono"><cn value="@h.Value" prefix="$" /></td>
-                                <td class="text-right font-mono"><cn value="@h.Shares" /></td>
+                                <td class="text-right font-mono"><compactable-number value="@h.Value" prefix="$" /></td>
+                                <td class="text-right font-mono"><compactable-number value="@h.Shares" /></td>
                                 <td class="text-right font-mono hidden md:table-cell">
                                     @if (changePercent.HasValue) {
                                         var css = changePercent.Value > 0 ? "text-success" : changePercent.Value < 0 ? "text-error" : "";

--- a/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
@@ -37,9 +37,9 @@
                     @foreach (var ftd in Model.FailsToDeliver.OrderByDescending(f => f.SettlementDate)) {
                         <tr>
                             <td>@ftd.SettlementDate.ToString("yyyy-MM-dd")</td>
-                            <td class="text-right font-mono"><cn value="@ftd.Quantity" /></td>
+                            <td class="text-right font-mono"><compactable-number value="@ftd.Quantity" /></td>
                             <td class="text-right font-mono">$@ftd.Price.ToString("F2")</td>
-                            <td class="text-right font-mono"><cn value="@(ftd.Quantity * ftd.Price)" prefix="$" /></td>
+                            <td class="text-right font-mono"><compactable-number value="@(ftd.Quantity * ftd.Price)" prefix="$" /></td>
                         </tr>
                     }
                 </tbody>

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -71,8 +71,8 @@
                 </select>
             </div>
             <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Holders:</span> <strong>@Model.HolderCount.ToString("N0")</strong></div>
-            <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Value:</span> <strong><cn value="@Model.TotalValue" prefix="$" /></strong></div>
-            <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Shares:</span> <strong><cn value="@Model.TotalShares" /></strong></div>
+            <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Value:</span> <strong><compactable-number value="@Model.TotalValue" prefix="$" /></strong></div>
+            <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Shares:</span> <strong><compactable-number value="@Model.TotalShares" /></strong></div>
             <div class="flex items-center gap-2 ml-auto">
                 <label class="flex items-center gap-1.5 cursor-pointer" title="Toggle compact numbers (1M, 1B)">
                     <span class="text-xs text-base-content/60">Compact</span>
@@ -183,9 +183,9 @@
                                             var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
                                             <tr>
                                                 <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
-                                                <td class="text-right font-mono @deltaSharesCss"><cn value="@e.DeltaShares" sign /></td>
+                                                <td class="text-right font-mono @deltaSharesCss"><compactable-number value="@e.DeltaShares" sign /></td>
                                                 <td class="text-right font-mono hidden md:table-cell @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
-                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss"><cn value="@e.DeltaValue" prefix="$" sign /></td>
+                                                <td class="text-right font-mono hidden md:table-cell @deltaValueCss"><compactable-number value="@e.DeltaValue" prefix="$" sign /></td>
                                             </tr>
                                         }
                                     </tbody>
@@ -242,13 +242,13 @@
                                             <partial name="_FundClassificationBadge" model="e.InstitutionalHolder.Classification" />
                                         }
                                     </td>
-                                    <td class="text-right font-mono whitespace-nowrap"><cn value="@e.CurrentShares" /></td>
-                                    <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @deltaSharesCss"><cn value="@e.DeltaShares" sign /></td>
+                                    <td class="text-right font-mono whitespace-nowrap"><compactable-number value="@e.CurrentShares" /></td>
+                                    <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @deltaSharesCss"><compactable-number value="@e.DeltaShares" sign /></td>
                                     <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
                                     <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap">@(own != null ? $"{own:F2}%" : "—")</td>
-                                    <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap"><cn value="@e.CurrentValue" prefix="$" /></td>
+                                    <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap"><compactable-number value="@e.CurrentValue" prefix="$" /></td>
                                     <td class="text-right hidden xl:table-cell whitespace-nowrap text-base-content/60">@FormatQuarter(e.QuarterFirstOwned)</td>
-                                    <td class="text-right font-mono whitespace-nowrap @deltaValueCss"><cn value="@e.DeltaValue" prefix="$" sign /></td>
+                                    <td class="text-right font-mono whitespace-nowrap @deltaValueCss"><compactable-number value="@e.DeltaValue" prefix="$" sign /></td>
                                     <td class="text-right">
                                         @if (e.InstitutionalHolder?.Cik != null) {
                                             <a asp-controller="Stocks" asp-action="ShowHolder"
@@ -310,13 +310,13 @@
                                                 <partial name="_FundClassificationBadge" model="e.InstitutionalHolder.Classification" />
                                             }
                                         </td>
-                                        <td class="text-right font-mono"><cn value="@e.CurrentShares" /></td>
-                                        <td class="text-right font-mono hidden md:table-cell @deltaSharesCss"><cn value="@e.DeltaShares" sign /></td>
+                                        <td class="text-right font-mono"><compactable-number value="@e.CurrentShares" /></td>
+                                        <td class="text-right font-mono hidden md:table-cell @deltaSharesCss"><compactable-number value="@e.DeltaShares" sign /></td>
                                         <td class="text-right font-mono hidden md:table-cell @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
                                         <td class="text-right font-mono hidden lg:table-cell">@(own != null ? $"{own:F2}%" : "—")</td>
-                                        <td class="text-right font-mono hidden lg:table-cell"><cn value="@e.CurrentValue" prefix="$" /></td>
+                                        <td class="text-right font-mono hidden lg:table-cell"><compactable-number value="@e.CurrentValue" prefix="$" /></td>
                                         <td class="text-right hidden xl:table-cell text-base-content/60">@FormatQuarter(e.QuarterFirstOwned)</td>
-                                        <td class="text-right font-mono @deltaValueCss"><cn value="@e.DeltaValue" prefix="$" sign /></td>
+                                        <td class="text-right font-mono @deltaValueCss"><compactable-number value="@e.DeltaValue" prefix="$" sign /></td>
                                         <td class="text-right">
                                             @if (e.InstitutionalHolder?.Cik != null) {
                                                 <a asp-controller="Stocks" asp-action="ShowHolder"

--- a/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
@@ -56,16 +56,16 @@
                             <td class="max-w-xs truncate">@(t.InsiderOwner?.Name ?? "Unknown")</td>
                             <td class="hidden md:table-cell text-sm text-base-content/60">@role</td>
                             <td><span class="badge @badgeClass badge-sm tooltip tooltip-right cursor-help" data-tip="@typeTooltip">@typeLabel</span></td>
-                            <td class="text-right font-mono"><cn value="@t.Shares" /></td>
+                            <td class="text-right font-mono"><compactable-number value="@t.Shares" /></td>
                             <td class="text-right font-mono hidden md:table-cell">@(t.PricePerShare > 0 ? $"${t.PricePerShare:N2}" : "—")</td>
                             <td class="text-right font-mono hidden lg:table-cell">
                                 @if (t.PricePerShare > 0) {
-                                    <cn value="@(t.Shares * t.PricePerShare)" prefix="$" />
+                                    <compactable-number value="@(t.Shares * t.PricePerShare)" prefix="$" />
                                 } else {
                                     <text>—</text>
                                 }
                             </td>
-                            <td class="text-right font-mono hidden lg:table-cell"><cn value="@t.SharesOwnedAfter" /></td>
+                            <td class="text-right font-mono hidden lg:table-cell"><compactable-number value="@t.SharesOwnedAfter" /></td>
                         </tr>
                     }
                 </tbody>

--- a/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
@@ -39,14 +39,14 @@
                     @foreach (var si in Model.ShortInterests.OrderByDescending(s => s.SettlementDate)) {
                         <tr>
                             <td>@si.SettlementDate.ToString("yyyy-MM-dd")</td>
-                            <td class="text-right font-mono"><cn value="@si.CurrentShortPosition" /></td>
-                            <td class="text-right font-mono"><cn value="@si.PreviousShortPosition" /></td>
+                            <td class="text-right font-mono"><compactable-number value="@si.CurrentShortPosition" /></td>
+                            <td class="text-right font-mono"><compactable-number value="@si.PreviousShortPosition" /></td>
                             <td class="text-right font-mono @(si.ChangeInShortPosition > 0 ? "text-error" : si.ChangeInShortPosition < 0 ? "text-success" : "")">
-                                <cn value="@si.ChangeInShortPosition" sign />
+                                <compactable-number value="@si.ChangeInShortPosition" sign />
                             </td>
                             <td class="text-right font-mono hidden md:table-cell">
                                 @if (si.AverageDailyVolume != null) {
-                                    <cn value="@((decimal)si.AverageDailyVolume)" />
+                                    <compactable-number value="@((decimal)si.AverageDailyVolume)" />
                                 } else {
                                     <text>—</text>
                                 }

--- a/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
@@ -39,9 +39,9 @@
                         var shortPct = sv.TotalVolume > 0 ? (double)sv.ShortVolume / sv.TotalVolume * 100 : 0;
                         <tr>
                             <td>@sv.Date.ToString("yyyy-MM-dd")</td>
-                            <td class="text-right font-mono"><cn value="@sv.ShortVolume" /></td>
-                            <td class="text-right font-mono"><cn value="@sv.ShortExemptVolume" /></td>
-                            <td class="text-right font-mono"><cn value="@sv.TotalVolume" /></td>
+                            <td class="text-right font-mono"><compactable-number value="@sv.ShortVolume" /></td>
+                            <td class="text-right font-mono"><compactable-number value="@sv.ShortExemptVolume" /></td>
+                            <td class="text-right font-mono"><compactable-number value="@sv.TotalVolume" /></td>
                             <td class="text-right font-mono">@shortPct.ToString("F1")%</td>
                         </tr>
                     }


### PR DESCRIPTION
## Summary
- Renames the `<cn>` tag helper to `<compactable-number>` for clarity

## Code changes
- **`CompactNumberTagHelper.cs`** — `HtmlTargetElement` changed from `"cn"` to `"compactable-number"`
- **14 Razor views** — all `<cn .../>` usages renamed to `<compactable-number .../>`