### PR TITLE
refactor(data): extract LIKE metacharacter escaping into LikePattern helper

### DIFF
--- a/src/Equibles.Data/LikePattern.cs
+++ b/src/Equibles.Data/LikePattern.cs
@@ -1,0 +1,15 @@
+namespace Equibles.Data;
+
+public static class LikePattern
+{
+    // Escapes LIKE metacharacters and wraps in % for a contains match.
+    // Use with EF.Functions.ILike(column, pattern, "\\").
+    public static string Contains(string text)
+    {
+        var escaped = text
+            .Replace("\\", "\\\\")
+            .Replace("%", "\\%")
+            .Replace("_", "\\_");
+        return $"%{escaped}%";
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts the duplicated 3-line LIKE metacharacter escape chain (`\`, `%`, `_`) into a static `LikePattern.Contains()` helper in `Equibles.Data`
- Centralizes the escaping logic so all repository `Search` methods can call one method instead of inlining the same pattern

## Code changes

- `src/Equibles.Data/LikePattern.cs` — new static helper with `Contains(string text)` that escapes LIKE metacharacters and wraps in `%..%` for contains matching