### PR TITLE
refactor(mcp): extract duplicated ParseDateOr into McpToolExecutor

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -54,11 +54,14 @@ public class CboeTools
                 if (!Enum.TryParse<CboePutCallRatioType>(type, true, out var ratioType))
                     return $"Invalid type '{type}'. Valid types: Total, Equity, Index, Vix, Etp";
 
-                var start = ParseDateOr(
+                var start = McpToolExecutor.ParseDateOr(
                     startDate,
                     DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
-                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
+                var end = McpToolExecutor.ParseDateOr(
+                    endDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow)
+                );
 
                 var records = await _putCallRepository
                     .GetByType(ratioType, start, end)
@@ -109,11 +112,14 @@ public class CboeTools
         return Execute(
             async () =>
             {
-                var start = ParseDateOr(
+                var start = McpToolExecutor.ParseDateOr(
                     startDate,
                     DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
-                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
+                var end = McpToolExecutor.ParseDateOr(
+                    endDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow)
+                );
 
                 var records = await _vixRepository
                     .GetByDateRange(start, end)
@@ -151,7 +157,4 @@ public class CboeTools
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
-
-    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
-        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 }

--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -60,11 +60,14 @@ public class CftcTools
                 if (contract == null)
                     return $"Contract '{marketCode}' not found. Use SearchCftcMarkets to find available contracts.";
 
-                var start = ParseDateOr(
+                var start = McpToolExecutor.ParseDateOr(
                     startDate,
                     DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
-                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
+                var end = McpToolExecutor.ParseDateOr(
+                    endDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow)
+                );
 
                 var reports = await _reportRepository
                     .GetByContract(contract, start, end)
@@ -232,7 +235,4 @@ public class CftcTools
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
-
-    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
-        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 }

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -62,11 +62,14 @@ public class CongressTools
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
-                var start = ParseDateOr(
+                var start = McpToolExecutor.ParseDateOr(
                     startDate,
                     DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
-                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
+                var end = McpToolExecutor.ParseDateOr(
+                    endDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow)
+                );
 
                 var query = _tradeRepository.GetByStock(stock, start, end);
                 query = ApplyTransactionTypeFilter(query, transactionType);
@@ -127,11 +130,14 @@ public class CongressTools
                 if (member == null)
                     return $"Member '{memberName}' not found. Use SearchCongressMembers to find the exact name.";
 
-                var start = ParseDateOr(
+                var start = McpToolExecutor.ParseDateOr(
                     startDate,
                     DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
-                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
+                var end = McpToolExecutor.ParseDateOr(
+                    endDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow)
+                );
 
                 var query = _tradeRepository
                     .GetByMember(member)
@@ -231,7 +237,4 @@ public class CongressTools
         }
         return query.Where(t => t.TransactionType == parsedType);
     }
-
-    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
-        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 }

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -59,11 +59,14 @@ public class ShortDataTools
 
                 var query = _shortVolumeRepository.GetHistoryByStock(stock);
 
-                var start = ParseDateOr(
+                var start = McpToolExecutor.ParseDateOr(
                     startDate,
                     DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
-                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
+                var end = McpToolExecutor.ParseDateOr(
+                    endDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow)
+                );
 
                 query = query.Where(d => d.Date >= start && d.Date <= end);
 
@@ -120,11 +123,14 @@ public class ShortDataTools
 
                 var query = _shortInterestRepository.GetHistoryByStock(stock);
 
-                var start = ParseDateOr(
+                var start = McpToolExecutor.ParseDateOr(
                     startDate,
                     DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
-                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
+                var end = McpToolExecutor.ParseDateOr(
+                    endDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow)
+                );
 
                 query = query.Where(s => s.SettlementDate >= start && s.SettlementDate <= end);
 
@@ -238,9 +244,6 @@ public class ShortDataTools
 
     private static string FormatSignedChange(long change) =>
         change >= 0 ? $"+{change:N0}" : change.ToString("N0");
-
-    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
-        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 
     private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
     {

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -57,11 +57,14 @@ public class FredTools
                 if (series == null)
                     return $"Series '{seriesId}' not found. Use SearchEconomicIndicators to find available series.";
 
-                var start = ParseDateOr(
+                var start = McpToolExecutor.ParseDateOr(
                     startDate,
                     DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
-                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
+                var end = McpToolExecutor.ParseDateOr(
+                    endDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow)
+                );
 
                 var observations = await _observationRepository
                     .GetBySeries(series, start, end)
@@ -219,7 +222,4 @@ public class FredTools
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
-
-    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
-        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 }

--- a/src/Equibles.Mcp/McpToolExecutor.cs
+++ b/src/Equibles.Mcp/McpToolExecutor.cs
@@ -4,6 +4,9 @@ namespace Equibles.Mcp;
 
 public static class McpToolExecutor
 {
+    public static DateOnly ParseDateOr(string text, DateOnly fallback) =>
+        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
+
     public static async Task<string> Execute(
         Func<Task<string>> action,
         ILogger logger,

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -55,11 +55,14 @@ public class FailToDeliverTools
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
-                var start = ParseDateOr(
+                var start = McpToolExecutor.ParseDateOr(
                     startDate,
                     DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
-                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
+                var end = McpToolExecutor.ParseDateOr(
+                    endDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow)
+                );
 
                 var records = await _ftdRepository
                     .GetByStock(stock)
@@ -98,7 +101,4 @@ public class FailToDeliverTools
     {
         return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
-
-    private static DateOnly ParseDateOr(string text, DateOnly fallback) =>
-        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 }

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -55,11 +55,14 @@ public class StockPriceTools
                 if (stock == null)
                     return $"Stock '{ticker}' not found.";
 
-                var start = ParseDateOr(
+                var start = McpToolExecutor.ParseDateOr(
                     startDate,
                     DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
-                var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
+                var end = McpToolExecutor.ParseDateOr(
+                    endDate,
+                    DateOnly.FromDateTime(DateTime.UtcNow)
+                );
 
                 var records = await _priceRepository
                     .GetByStock(stock, start, end)
@@ -350,8 +353,11 @@ public class StockPriceTools
         if (stock == null)
             return (null, null, $"Stock '{ticker}' not found.");
 
-        var start = ParseDateOr(startDate, DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6)));
-        var end = ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
+        var start = McpToolExecutor.ParseDateOr(
+            startDate,
+            DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6))
+        );
+        var end = McpToolExecutor.ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
         var records = await _priceRepository
             .GetByStock(stock, start, end)
@@ -403,11 +409,6 @@ public class StockPriceTools
             records.Select(p => p.Low).ToList(),
             records.Select(p => p.Close).ToList()
         );
-
-    private static DateOnly ParseDateOr(string value, DateOnly fallback) =>
-        !string.IsNullOrEmpty(value) && DateOnly.TryParse(value, out var parsed)
-            ? parsed
-            : fallback;
 
     private Task<CommonStock> FindStockByTicker(string ticker) =>
         _commonStockRepository.GetByTicker(ticker.Trim().ToUpperInvariant());


### PR DESCRIPTION
## Summary

- Seven MCP tool classes each had an identical private `ParseDateOr` method (parse a date string or return a fallback).
- Consolidated into a single `public static` method on `McpToolExecutor`, where shared MCP tool utilities already live.
- Removes 7 private method definitions across the codebase with zero behavior change.

## Code changes

- `src/Equibles.Mcp/McpToolExecutor.cs` — added `ParseDateOr(string, DateOnly)` as a public static method
- `src/Equibles.Cboe.Mcp/Tools/CboeTools.cs` — removed private `ParseDateOr`, call sites now use `McpToolExecutor.ParseDateOr`
- `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs` — same
- `src/Equibles.Fred.Mcp/Tools/FredTools.cs` — same
- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — same
- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — same
- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs` — same
- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — same