### PR TITLE
feat: show confidential treatment flag on institution profiles

### DIFF
--- a/src/Equibles.Holdings.Data/Models/InstitutionalHolder.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalHolder.cs
@@ -30,6 +30,8 @@ public class InstitutionalHolder
 
     public FundClassification Classification { get; set; }
 
+    public bool ConfidentialTreatmentRequested { get; set; }
+
     public virtual List<InstitutionalHolding> Holdings { get; set; } = [];
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;

--- a/src/Equibles.Holdings.HostedService/Models/CoverPageRow.cs
+++ b/src/Equibles.Holdings.HostedService/Models/CoverPageRow.cs
@@ -9,4 +9,5 @@ public class CoverPageRow
     public string StateOrCountry { get; set; }
     public string Form13FFileNumber { get; set; }
     public string CrdNumber { get; set; }
+    public string ConfidentialTreatment { get; set; }
 }

--- a/src/Equibles.Holdings.HostedService/Models/Parsed13FFiling.cs
+++ b/src/Equibles.Holdings.HostedService/Models/Parsed13FFiling.cs
@@ -20,6 +20,7 @@ public class Parsed13FFiling
     public string StateOrCountry { get; set; }
     public string Form13FFileNumber { get; set; }
     public string CrdNumber { get; set; }
+    public bool ConfidentialTreatmentRequested { get; set; }
 
     /// <summary>Other-manager table: sequence number → manager name.</summary>
     public Dictionary<int, string> OtherManagers { get; set; } = [];

--- a/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
@@ -53,6 +53,9 @@ public class Filing13FXmlParser
             StateOrCountry = Value(Child(address, "stateOrCountry")),
             Form13FFileNumber = Value(Descendant(coverPage, "form13FFileNumber")),
             CrdNumber = Value(Descendant(coverPage, "crdNumber")),
+            ConfidentialTreatmentRequested = IsAmendmentValue(
+                Value(Descendant(coverPage, "confidentialTreatmentRequestedFlag"))
+            ),
         };
 
         var otherManagersScope = coverPage ?? root;

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -230,6 +230,7 @@ public class HoldingsImportService
             StateOrCountry = Get("FILINGMANAGER_STATEORCOUNTRY"),
             Form13FFileNumber = Get("FORM13FFILENUMBER"),
             CrdNumber = Get("CRDNUMBER"),
+            ConfidentialTreatment = Get("CONFIDENTIALTREATMENT"),
         };
         return true;
     }
@@ -361,6 +362,18 @@ public class HoldingsImportService
             cikToHolderId[holder.Cik] = holder.Id;
         }
 
+        foreach (var holder in existingHolders)
+        {
+            var submission = context.Submissions.Values.FirstOrDefault(s =>
+                string.Equals(s.Cik, holder.Cik, StringComparison.OrdinalIgnoreCase)
+            );
+            if (submission == null)
+                continue;
+            context.CoverPages.TryGetValue(submission.AccessionNumber, out var cp);
+            if (cp != null)
+                holder.ConfidentialTreatmentRequested = IsYes(cp.ConfidentialTreatment);
+        }
+
         var existingCiks = existingHolders
             .Select(h => h.Cik)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -381,6 +394,7 @@ public class HoldingsImportService
                 Form13FFileNumber = coverPage?.Form13FFileNumber,
                 CrdNumber = coverPage?.CrdNumber,
                 Classification = FundClassifierService.Classify(coverPage?.CompanyName),
+                ConfidentialTreatmentRequested = IsYes(coverPage?.ConfidentialTreatment),
             };
 
             holderRepo.Add(holder);
@@ -791,5 +805,14 @@ public class HoldingsImportService
             h.ReportDate,
             h.ShareType,
             h.OptionType
+        );
+
+    private static bool IsYes(string raw) =>
+        !string.IsNullOrEmpty(raw)
+        && (
+            raw.Equals("Y", StringComparison.OrdinalIgnoreCase)
+            || raw.Equals("yes", StringComparison.OrdinalIgnoreCase)
+            || raw.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || raw == "1"
         );
 }

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
@@ -25,7 +25,8 @@ public class Realtime13FArchiveBuilder
         );
         var coverPage = new StringBuilder(
             "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\t"
-                + "FILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+                + "FILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\t"
+                + "CONFIDENTIALTREATMENT\n"
         );
         var infoTable = new StringBuilder(
             "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMTTYPE\tPUTCALL\tSSHPRNAMT\tVOTING_AUTH_SOLE\t"
@@ -54,7 +55,8 @@ public class Realtime13FArchiveBuilder
                 Clean(filing.City),
                 Clean(filing.StateOrCountry),
                 Clean(filing.Form13FFileNumber),
-                Clean(filing.CrdNumber)
+                Clean(filing.CrdNumber),
+                filing.ConfidentialTreatmentRequested ? "Y" : "N"
             );
 
             foreach (var (seq, name) in filing.OtherManagers)

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -843,6 +843,14 @@ public class InstitutionalHoldingsTools
             "_QoQ turnover = (Σ |Δ shares × current price proxy|) / (2 × AUM), where the per-share price proxy is the current quarter's Value / Shares._"
         );
 
+        if (holder.ConfidentialTreatmentRequested)
+        {
+            result.AppendLine();
+            result.AppendLine(
+                "⚠️ **Confidential Treatment** — This manager has requested confidential treatment for one or more investments in the most recent 13F filing. The portfolio shown may be incomplete."
+            );
+        }
+
         return result.ToString();
     }
 

--- a/src/Equibles.Migrations/Migrations/20260525154444_AddConfidentialTreatmentToInstitutionalHolder.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260525154444_AddConfidentialTreatmentToInstitutionalHolder.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260525154444_AddConfidentialTreatmentToInstitutionalHolder")]
+    partial class AddConfidentialTreatmentToInstitutionalHolder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260525154444_AddConfidentialTreatmentToInstitutionalHolder.cs
+++ b/src/Equibles.Migrations/Migrations/20260525154444_AddConfidentialTreatmentToInstitutionalHolder.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConfidentialTreatmentToInstitutionalHolder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ConfidentialTreatmentRequested",
+                table: "InstitutionalHolder",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ConfidentialTreatmentRequested",
+                table: "InstitutionalHolder");
+        }
+    }
+}

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -85,6 +85,7 @@ public class ProfilesController : BaseController
                 Name = holder.Name,
                 Cik = holder.Cik,
                 Classification = holder.Classification,
+                ConfidentialTreatmentRequested = holder.ConfidentialTreatmentRequested,
                 Location = ProfileFormatting.JoinLocation(holder.City, holder.StateOrCountry),
                 Holdings = holdings,
                 Summary = summary,

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
@@ -9,6 +9,7 @@ public class InstitutionProfileViewModel
     public string Cik { get; set; }
     public string Location { get; set; }
     public FundClassification Classification { get; set; }
+    public bool ConfidentialTreatmentRequested { get; set; }
     public List<HoldingRowViewModel> Holdings { get; set; } = [];
     public InstitutionPortfolioSummary Summary { get; set; } = new();
     public List<IndustryAllocationSlice> IndustryAllocation { get; set; } = [];

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -35,6 +35,16 @@
         }
     </div>
 
+    @if (Model.ConfidentialTreatmentRequested) {
+        <div role="alert" class="alert alert-warning mb-8" data-testid="confidential-treatment-alert">
+            <icon name="exclamation-triangle" size="5" />
+            <span>
+                <strong>Confidential Treatment</strong> — This manager has requested confidential treatment
+                for one or more investments in the most recent 13F filing. The portfolio shown may be incomplete.
+            </span>
+        </div>
+    }
+
     @if (Model.Summary.LatestReportDate.HasValue) {
         <!-- Portfolio summary header — derived from the latest report date for this holder. -->
         <div class="card bg-base-100 shadow-sm mb-8" data-testid="institution-summary">

--- a/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderCleanSanitizationTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderCleanSanitizationTests.cs
@@ -36,7 +36,7 @@ public class Realtime13FArchiveBuilderCleanSanitizationTests
         var dataRow = dataLines.Length > 1 ? dataLines[1] : "";
         var fields = dataRow.Split('\t');
 
-        fields.Should().HaveCount(7, "a clean row has exactly 7 TSV columns");
+        fields.Should().HaveCount(8, "a clean row has exactly 8 TSV columns");
         fields[2].Should().Be("ACME Fund Management LLC");
         fields[3].Should().Be("NEW YORK");
     }


### PR DESCRIPTION
## Summary

- Parse the `<confidentialTreatmentRequestedFlag>` from 13F-HR cover page XML and store it on `InstitutionalHolder`.
- Show a warning banner on the web institution profile when the flag is set.
- Include a note in the `GetInstitutionSummary` MCP tool output.

Closes #2073

## Code changes

- `src/Equibles.Holdings.Data/Models/InstitutionalHolder.cs` — added `ConfidentialTreatmentRequested` bool property.
- `src/Equibles.Holdings.HostedService/Models/Parsed13FFiling.cs` — added field to the parsed DTO.
- `src/Equibles.Holdings.HostedService/Models/CoverPageRow.cs` — added field to the TSV row model.
- `src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs` — extract `confidentialTreatmentRequestedFlag` from cover page XML.
- `src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs` — include `CONFIDENTIALTREATMENT` column in synthetic TSV.
- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — read the flag from TSV, set it on new and existing holders.
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — append confidential treatment note to `GetInstitutionSummary` output.
- `src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs` — added flag to view model.
- `src/Equibles.Web/Controllers/ProfilesController.cs` — pass flag to view model.
- `src/Equibles.Web/Views/Profiles/Institution.cshtml` — render DaisyUI warning alert when flag is set.
- `src/Equibles.Migrations/` — EF migration adding the boolean column with `false` default.
- `tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderCleanSanitizationTests.cs` — updated expected column count for the new TSV column.