### PR TITLE
refactor(mcp): extract Execute/ReportError boilerplate into McpToolRunner

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -17,8 +17,7 @@ public class CboeTools
 {
     private readonly CboePutCallRatioRepository _putCallRepository;
     private readonly CboeVixDailyRepository _vixRepository;
-    private readonly ErrorManager _errorManager;
-    private readonly ILogger<CboeTools> _logger;
+    private readonly McpToolRunner _runner;
 
     public CboeTools(
         CboePutCallRatioRepository putCallRepository,
@@ -29,8 +28,11 @@ public class CboeTools
     {
         _putCallRepository = putCallRepository;
         _vixRepository = vixRepository;
-        _errorManager = errorManager;
-        _logger = logger;
+        _runner = new McpToolRunner(
+            logger,
+            (tool, msg, stack, ctx) =>
+                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
+        );
     }
 
     [McpServerTool(Name = "GetPutCallRatios")]
@@ -48,7 +50,7 @@ public class CboeTools
             int maxResults = 60
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 if (!Enum.TryParse<CboePutCallRatioType>(type, true, out var ratioType))
@@ -109,7 +111,7 @@ public class CboeTools
             int maxResults = 60
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var start = McpToolExecutor.ParseDateOr(
@@ -148,13 +150,5 @@ public class CboeTools
             "GetVixHistory",
             $"startDate: {startDate}"
         );
-    }
-
-    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
-        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
-
-    private Task ReportError(string toolName, string message, string stackTrace, string context)
-    {
-        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
 }

--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -17,8 +17,7 @@ public class CftcTools
 {
     private readonly CftcContractRepository _contractRepository;
     private readonly CftcPositionReportRepository _reportRepository;
-    private readonly ErrorManager _errorManager;
-    private readonly ILogger<CftcTools> _logger;
+    private readonly McpToolRunner _runner;
 
     public CftcTools(
         CftcContractRepository contractRepository,
@@ -29,8 +28,11 @@ public class CftcTools
     {
         _contractRepository = contractRepository;
         _reportRepository = reportRepository;
-        _errorManager = errorManager;
-        _logger = logger;
+        _runner = new McpToolRunner(
+            logger,
+            (tool, msg, stack, ctx) =>
+                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
+        );
     }
 
     [McpServerTool(Name = "GetCftcPositioning")]
@@ -50,7 +52,7 @@ public class CftcTools
             int maxResults = 52
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var contract = await _contractRepository
@@ -115,7 +117,7 @@ public class CftcTools
             string category = null
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 IQueryable<CftcContract> contractQuery;
@@ -195,7 +197,7 @@ public class CftcTools
         [Description("Maximum number of results to return (default: 20)")] int maxResults = 20
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var contracts = await _contractRepository
@@ -226,13 +228,5 @@ public class CftcTools
             "SearchCftcMarkets",
             $"query: {query}"
         );
-    }
-
-    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
-        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
-
-    private Task ReportError(string toolName, string message, string stackTrace, string context)
-    {
-        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
 }

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -19,8 +19,7 @@ public class CongressTools
     private readonly CongressionalTradeRepository _tradeRepository;
     private readonly CongressMemberRepository _memberRepository;
     private readonly CommonStockRepository _commonStockRepository;
-    private readonly ErrorManager _errorManager;
-    private readonly ILogger<CongressTools> _logger;
+    private readonly McpToolRunner _runner;
 
     public CongressTools(
         CongressionalTradeRepository tradeRepository,
@@ -33,8 +32,11 @@ public class CongressTools
         _tradeRepository = tradeRepository;
         _memberRepository = memberRepository;
         _commonStockRepository = commonStockRepository;
-        _errorManager = errorManager;
-        _logger = logger;
+        _runner = new McpToolRunner(
+            logger,
+            (tool, msg, stack, ctx) =>
+                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
+        );
     }
 
     [McpServerTool(Name = "GetCongressionalTrades")]
@@ -53,7 +55,7 @@ public class CongressTools
             int maxResults = 50
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var stock = await _commonStockRepository.GetByTicker(
@@ -123,7 +125,7 @@ public class CongressTools
             int maxResults = 50
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var member = await _memberRepository.GetByName(memberName.Trim());
@@ -185,7 +187,7 @@ public class CongressTools
         [Description("Maximum number of results to return (default: 20)")] int maxResults = 20
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var members = await _memberRepository
@@ -213,14 +215,6 @@ public class CongressTools
             "SearchCongressMembers",
             $"query: {query}"
         );
-    }
-
-    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
-        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
-
-    private Task ReportError(string toolName, string message, string stackTrace, string context)
-    {
-        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
 
     private static IQueryable<CongressionalTrade> ApplyTransactionTypeFilter(

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -18,8 +18,7 @@ public class ShortDataTools
     private readonly DailyShortVolumeRepository _shortVolumeRepository;
     private readonly ShortInterestRepository _shortInterestRepository;
     private readonly CommonStockRepository _commonStockRepository;
-    private readonly ErrorManager _errorManager;
-    private readonly ILogger<ShortDataTools> _logger;
+    private readonly McpToolRunner _runner;
 
     public ShortDataTools(
         DailyShortVolumeRepository shortVolumeRepository,
@@ -32,8 +31,11 @@ public class ShortDataTools
         _shortVolumeRepository = shortVolumeRepository;
         _shortInterestRepository = shortInterestRepository;
         _commonStockRepository = commonStockRepository;
-        _errorManager = errorManager;
-        _logger = logger;
+        _runner = new McpToolRunner(
+            logger,
+            (tool, msg, stack, ctx) =>
+                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
+        );
     }
 
     [McpServerTool(Name = "GetShortVolume")]
@@ -50,7 +52,7 @@ public class ShortDataTools
             int maxResults = 90
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var (stock, stockError) = await ResolveStockByTicker(ticker);
@@ -114,7 +116,7 @@ public class ShortDataTools
             int maxResults = 24
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var (stock, stockError) = await ResolveStockByTicker(ticker);
@@ -178,7 +180,7 @@ public class ShortDataTools
         [Description("Maximum number of results to return (default: 50)")] int maxResults = 50
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var latestDate = await _shortInterestRepository
@@ -232,14 +234,6 @@ public class ShortDataTools
             "GetShortInterestSnapshot",
             $"minDaysToCover: {minDaysToCover}"
         );
-    }
-
-    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
-        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
-
-    private Task ReportError(string toolName, string message, string stackTrace, string context)
-    {
-        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
 
     private static string FormatSignedChange(long change) =>

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -16,8 +16,7 @@ public class FredTools
 {
     private readonly FredSeriesRepository _seriesRepository;
     private readonly FredObservationRepository _observationRepository;
-    private readonly ErrorManager _errorManager;
-    private readonly ILogger<FredTools> _logger;
+    private readonly McpToolRunner _runner;
 
     public FredTools(
         FredSeriesRepository seriesRepository,
@@ -28,8 +27,11 @@ public class FredTools
     {
         _seriesRepository = seriesRepository;
         _observationRepository = observationRepository;
-        _errorManager = errorManager;
-        _logger = logger;
+        _runner = new McpToolRunner(
+            logger,
+            (tool, msg, stack, ctx) =>
+                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
+        );
     }
 
     [McpServerTool(Name = "GetEconomicIndicator")]
@@ -47,7 +49,7 @@ public class FredTools
             int maxResults = 100
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var series = await _seriesRepository
@@ -108,7 +110,7 @@ public class FredTools
             string category = null
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 IQueryable<FredSeries> seriesQuery;
@@ -182,7 +184,7 @@ public class FredTools
         [Description("Maximum number of results to return (default: 20)")] int maxResults = 20
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var series = await _seriesRepository
@@ -213,13 +215,5 @@ public class FredTools
             "SearchEconomicIndicators",
             $"query: {query}"
         );
-    }
-
-    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
-        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
-
-    private Task ReportError(string toolName, string message, string stackTrace, string context)
-    {
-        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
 }

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -38,8 +38,7 @@ public class InstitutionalHoldingsTools
     private readonly InstitutionalHoldingRepository _holdingRepository;
     private readonly InstitutionalHolderRepository _holderRepository;
     private readonly CommonStockRepository _commonStockRepository;
-    private readonly ErrorManager _errorManager;
-    private readonly ILogger<InstitutionalHoldingsTools> _logger;
+    private readonly McpToolRunner _runner;
 
     public InstitutionalHoldingsTools(
         InstitutionalHoldingRepository holdingRepository,
@@ -52,8 +51,11 @@ public class InstitutionalHoldingsTools
         _holdingRepository = holdingRepository;
         _holderRepository = holderRepository;
         _commonStockRepository = commonStockRepository;
-        _errorManager = errorManager;
-        _logger = logger;
+        _runner = new McpToolRunner(
+            logger,
+            (tool, msg, stack, ctx) =>
+                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
+        );
     }
 
     [McpServerTool(Name = "GetTopHolders")]
@@ -67,7 +69,7 @@ public class InstitutionalHoldingsTools
         [Description("Maximum number of holders to return (default: 20)")] int maxResults = 20
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var (stock, stockError) = await ResolveStockByTicker(ticker);
@@ -155,7 +157,7 @@ public class InstitutionalHoldingsTools
             int maxPeriods = 8
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var (stock, stockError) = await ResolveStockByTicker(ticker);
@@ -222,7 +224,7 @@ public class InstitutionalHoldingsTools
         [Description("Maximum number of holdings to return (default: 20)")] int maxResults = 20
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var holders = await _holderRepository.Search(institutionName).Take(5).ToListAsync();
@@ -289,7 +291,7 @@ public class InstitutionalHoldingsTools
         [Description("Maximum number of results to return (default: 10)")] int maxResults = 10
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var holders = await _holderRepository
@@ -333,7 +335,7 @@ public class InstitutionalHoldingsTools
             int maxResults = 10
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var (stock, stockError) = await ResolveStockByTicker(ticker);
@@ -511,7 +513,7 @@ public class InstitutionalHoldingsTools
         [Description("Maximum number of stocks to return (default: 20)")] int maxResults = 20
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var normalizedBucket = (bucket ?? string.Empty).Trim().ToLowerInvariant();
@@ -685,7 +687,7 @@ public class InstitutionalHoldingsTools
         [Description("Maximum number of stocks to return (default: 25)")] int maxResults = 25
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var normalizedSort = (sort ?? "filers").Trim().ToLowerInvariant();
@@ -781,7 +783,7 @@ public class InstitutionalHoldingsTools
             string reportDate = null
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var (holder, reportDates, targetDate, error) = await ResolveHolderAndTargetDate(
@@ -884,7 +886,7 @@ public class InstitutionalHoldingsTools
             string reportDate = null
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var (holder, _, targetDate, error) = await ResolveHolderAndTargetDate(
@@ -925,7 +927,7 @@ public class InstitutionalHoldingsTools
             int maxResults = 20
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var normalizedBucket = bucket?.Trim().ToLowerInvariant();
@@ -1052,7 +1054,7 @@ public class InstitutionalHoldingsTools
         [Description("Maximum number of stocks to return (default: 30)")] int maxResults = 30
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var (holder1, holder1Error) = await ResolveHolderByName(institutionName1);
@@ -1171,7 +1173,7 @@ public class InstitutionalHoldingsTools
         [Description("Maximum number of stocks to return (default: 30)")] int maxResults = 30
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var names = (institutionNames ?? string.Empty)
@@ -1264,14 +1266,6 @@ public class InstitutionalHoldingsTools
             );
         }
         return result.ToString();
-    }
-
-    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
-        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
-
-    private Task ReportError(string toolName, string message, string stackTrace, string context)
-    {
-        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
 
     private Task<InstitutionalHolder> FindHolderByName(string name) =>

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -19,8 +19,7 @@ public class InsiderTradingTools
     private readonly InsiderTransactionRepository _transactionRepository;
     private readonly InsiderOwnerRepository _ownerRepository;
     private readonly CommonStockRepository _commonStockRepository;
-    private readonly ErrorManager _errorManager;
-    private readonly ILogger<InsiderTradingTools> _logger;
+    private readonly McpToolRunner _runner;
 
     public InsiderTradingTools(
         InsiderTransactionRepository transactionRepository,
@@ -33,8 +32,11 @@ public class InsiderTradingTools
         _transactionRepository = transactionRepository;
         _ownerRepository = ownerRepository;
         _commonStockRepository = commonStockRepository;
-        _errorManager = errorManager;
-        _logger = logger;
+        _runner = new McpToolRunner(
+            logger,
+            (tool, msg, stack, ctx) =>
+                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
+        );
     }
 
     [McpServerTool(Name = "GetInsiderTransactions")]
@@ -46,7 +48,7 @@ public class InsiderTradingTools
         [Description("Maximum number of transactions to return (default: 50)")] int maxResults = 50
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var (stock, stockError) = await ResolveStockByTicker(ticker);
@@ -106,7 +108,7 @@ public class InsiderTradingTools
         [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var (stock, stockError) = await ResolveStockByTicker(ticker);
@@ -169,7 +171,7 @@ public class InsiderTradingTools
         [Description("Maximum number of results (default: 10)")] int maxResults = 10
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var insiders = await _ownerRepository.Search(query).Take(maxResults).ToListAsync();
@@ -202,14 +204,6 @@ public class InsiderTradingTools
             "SearchInsiders",
             $"query: {query}"
         );
-    }
-
-    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
-        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
-
-    private Task ReportError(string toolName, string message, string stackTrace, string context)
-    {
-        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
 
     private static string GetRole(InsiderOwner owner)

--- a/src/Equibles.Mcp/McpToolRunner.cs
+++ b/src/Equibles.Mcp/McpToolRunner.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Mcp;
+
+public class McpToolRunner
+{
+    private readonly ILogger _logger;
+    private readonly Func<string, string, string, string, Task> _reportError;
+
+    public McpToolRunner(ILogger logger, Func<string, string, string, string, Task> reportError)
+    {
+        _logger = logger;
+        _reportError = reportError;
+    }
+
+    public Task<string> Execute(
+        Func<Task<string>> action,
+        string toolName,
+        string context,
+        string errorMessage = null
+    ) => McpToolExecutor.Execute(action, _logger, toolName, context, _reportError, errorMessage);
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -28,8 +28,7 @@ public class FinancialFactsTools
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
     private readonly CommonStockRepository _commonStockRepository;
-    private readonly ErrorManager _errorManager;
-    private readonly ILogger<FinancialFactsTools> _logger;
+    private readonly McpToolRunner _runner;
 
     public FinancialFactsTools(
         FinancialFactRepository financialFactRepository,
@@ -42,8 +41,11 @@ public class FinancialFactsTools
         _financialFactRepository = financialFactRepository;
         _financialConceptRepository = financialConceptRepository;
         _commonStockRepository = commonStockRepository;
-        _errorManager = errorManager;
-        _logger = logger;
+        _runner = new McpToolRunner(
+            logger,
+            (tool, msg, stack, ctx) =>
+                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
+        );
     }
 
     [McpServerTool(Name = "GetFinancialFact")]
@@ -72,7 +74,7 @@ public class FinancialFactsTools
             bool asOriginallyReported = false
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 if (string.IsNullOrWhiteSpace(ticker))
@@ -166,7 +168,7 @@ public class FinancialFactsTools
         [Description("Fiscal period: 'FY' (default) or 'Q1'..'Q4'")] string fiscalPeriod = "FY"
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 if (string.IsNullOrWhiteSpace(concept))
@@ -415,13 +417,5 @@ public class FinancialFactsTools
         return "Supported: "
             + $"{string.Join(", ", FinancialConceptAliases.SupportedAliases)} "
             + "(common synonyms like 'sales', 'r&d', 'ocf' also work).";
-    }
-
-    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
-        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
-
-    private Task ReportError(string toolName, string message, string stackTrace, string context)
-    {
-        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
 }

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -23,8 +23,7 @@ public class FinancialStatementTools
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
     private readonly CommonStockRepository _commonStockRepository;
-    private readonly ErrorManager _errorManager;
-    private readonly ILogger<FinancialStatementTools> _logger;
+    private readonly McpToolRunner _runner;
 
     public FinancialStatementTools(
         FinancialFactRepository financialFactRepository,
@@ -37,8 +36,11 @@ public class FinancialStatementTools
         _financialFactRepository = financialFactRepository;
         _financialConceptRepository = financialConceptRepository;
         _commonStockRepository = commonStockRepository;
-        _errorManager = errorManager;
-        _logger = logger;
+        _runner = new McpToolRunner(
+            logger,
+            (tool, msg, stack, ctx) =>
+                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
+        );
     }
 
     [McpServerTool(Name = "GetFinancialStatement")]
@@ -64,7 +66,7 @@ public class FinancialStatementTools
             string period = null
     )
     {
-        return McpToolExecutor.Execute(
+        return _runner.Execute(
             async () =>
             {
                 if (string.IsNullOrWhiteSpace(ticker))
@@ -139,11 +141,9 @@ public class FinancialStatementTools
                     latestByConcept
                 );
             },
-            _logger,
             "GetFinancialStatement",
             $"ticker: {FactMarkdown.Clean(ticker)}, statement: {FactMarkdown.Clean(statement)}, "
-                + $"year: {year}, period: {FactMarkdown.Clean(period)}",
-            ReportError
+                + $"year: {year}, period: {FactMarkdown.Clean(period)}"
         );
     }
 
@@ -286,9 +286,4 @@ public class FinancialStatementTools
             SecFiscalPeriod.FullYear => 5,
             _ => 0,
         };
-
-    private Task ReportError(string toolName, string message, string stackTrace, string context)
-    {
-        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
-    }
 }

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -16,8 +16,7 @@ public class FailToDeliverTools
 {
     private readonly FailToDeliverRepository _ftdRepository;
     private readonly CommonStockRepository _commonStockRepository;
-    private readonly ErrorManager _errorManager;
-    private readonly ILogger<FailToDeliverTools> _logger;
+    private readonly McpToolRunner _runner;
 
     public FailToDeliverTools(
         FailToDeliverRepository ftdRepository,
@@ -28,8 +27,11 @@ public class FailToDeliverTools
     {
         _ftdRepository = ftdRepository;
         _commonStockRepository = commonStockRepository;
-        _errorManager = errorManager;
-        _logger = logger;
+        _runner = new McpToolRunner(
+            logger,
+            (tool, msg, stack, ctx) =>
+                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
+        );
     }
 
     [McpServerTool(Name = "GetFailsToDeliver")]
@@ -46,7 +48,7 @@ public class FailToDeliverTools
             int maxResults = 90
     )
     {
-        return McpToolExecutor.Execute(
+        return _runner.Execute(
             async () =>
             {
                 var stock = await _commonStockRepository.GetByTicker(
@@ -90,15 +92,8 @@ public class FailToDeliverTools
 
                 return result.ToString();
             },
-            _logger,
             "GetFailsToDeliver",
-            $"ticker: {ticker}",
-            ReportError
+            $"ticker: {ticker}"
         );
-    }
-
-    private Task ReportError(string toolName, string message, string stackTrace, string context)
-    {
-        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
 }

--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -20,8 +20,7 @@ public class RagSearchTools
 
     private readonly IRagManager _ragManager;
     private readonly ISecDocumentService _secDocumentService;
-    private readonly ErrorManager _errorManager;
-    private readonly ILogger<RagSearchTools> _logger;
+    private readonly McpToolRunner _runner;
 
     public RagSearchTools(
         IRagManager ragManager,
@@ -32,8 +31,11 @@ public class RagSearchTools
     {
         _ragManager = ragManager;
         _secDocumentService = secDocumentService;
-        _errorManager = errorManager;
-        _logger = logger;
+        _runner = new McpToolRunner(
+            logger,
+            (tool, msg, stack, ctx) =>
+                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
+        );
     }
 
     [McpServerTool(Name = "SearchDocuments")]
@@ -48,7 +50,7 @@ public class RagSearchTools
         [Description("Optional end date filter in YYYY-MM-DD format")] DateTime? endDate = null
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var parsedType = ParseDocumentType(documentType);
@@ -79,7 +81,7 @@ public class RagSearchTools
         [Description("Optional end date filter in YYYY-MM-DD format")] DateTime? endDate = null
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var parsedType = ParseDocumentType(documentType);
@@ -108,7 +110,7 @@ public class RagSearchTools
         [Description("Maximum number of results to return (default: 5)")] int maxResults = 5
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var chunks = await _ragManager.SearchRelevantChunksByDocument(
@@ -136,7 +138,7 @@ public class RagSearchTools
         [Description(DocumentTypeDescription)] string documentType = null
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var parsedType = ParseDocumentType(documentType);
@@ -183,14 +185,6 @@ public class RagSearchTools
             "ListCompanyDocuments",
             $"ticker: {ticker}"
         );
-    }
-
-    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
-        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
-
-    private Task ReportError(string toolName, string message, string stackTrace, string context)
-    {
-        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
     }
 
     private static DocumentType ParseDocumentType(string documentType)

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -18,8 +18,7 @@ public class StockPriceTools
 {
     private readonly DailyStockPriceRepository _priceRepository;
     private readonly CommonStockRepository _commonStockRepository;
-    private readonly ErrorManager _errorManager;
-    private readonly ILogger<StockPriceTools> _logger;
+    private readonly McpToolRunner _runner;
 
     public StockPriceTools(
         DailyStockPriceRepository priceRepository,
@@ -30,8 +29,11 @@ public class StockPriceTools
     {
         _priceRepository = priceRepository;
         _commonStockRepository = commonStockRepository;
-        _errorManager = errorManager;
-        _logger = logger;
+        _runner = new McpToolRunner(
+            logger,
+            (tool, msg, stack, ctx) =>
+                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
+        );
     }
 
     [McpServerTool(Name = "GetStockPrices")]
@@ -48,7 +50,7 @@ public class StockPriceTools
             int maxResults = 250
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var stock = await FindStockByTicker(ticker);
@@ -102,7 +104,7 @@ public class StockPriceTools
             string tickers
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var tickerList = tickers
@@ -183,7 +185,7 @@ public class StockPriceTools
             int maxResults = 60
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 if (kPeriod < 2 || dPeriod < 1)
@@ -249,7 +251,7 @@ public class StockPriceTools
             int maxResults = 60
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 if (period < 2)
@@ -307,7 +309,7 @@ public class StockPriceTools
             int maxResults = 60
     )
     {
-        return Execute(
+        return _runner.Execute(
             async () =>
             {
                 var (stock, records, error) = await LoadAscendingPriceWindow(
@@ -412,12 +414,4 @@ public class StockPriceTools
 
     private Task<CommonStock> FindStockByTicker(string ticker) =>
         _commonStockRepository.GetByTicker(ticker.Trim().ToUpperInvariant());
-
-    private Task<string> Execute(Func<Task<string>> work, string toolName, string context) =>
-        McpToolExecutor.Execute(work, _logger, toolName, context, ReportError);
-
-    private Task ReportError(string toolName, string message, string stackTrace, string context)
-    {
-        return _errorManager.Create(ErrorSource.McpTool, toolName, message, stackTrace, context);
-    }
 }


### PR DESCRIPTION
## Summary

- Every MCP tool class had identical private `Execute` and `ReportError` methods that bound the logger and error-manager to `McpToolExecutor.Execute`.
- Introduced `McpToolRunner` — an instance class in `Equibles.Mcp` that takes `ILogger` + error-reporting delegate once in the constructor and exposes a single `Execute` method.
- Removes 22 boilerplate methods across 12 MCP tool files (net -48 lines) with no new dependencies on `Equibles.Mcp`.

## Code changes

- `src/Equibles.Mcp/McpToolRunner.cs` — new instance class wrapping `McpToolExecutor.Execute` with pre-bound logger and error callback
- `src/Equibles.Cboe.Mcp/Tools/CboeTools.cs` — replaced `_errorManager` + `_logger` fields with `_runner`, removed `Execute` + `ReportError`
- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs` — same
- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — same
- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — same
- `src/Equibles.Fred.Mcp/Tools/FredTools.cs` — same
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — same
- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — same
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — same
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs` — replaced direct `McpToolExecutor.Execute` call + `ReportError` with `_runner.Execute`
- `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs` — same as FinancialStatementTools
- `src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs` — replaced `_errorManager` + `_logger` with `_runner`, removed `Execute` + `ReportError`
- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — same