### PR TITLE
chore: fix CSharpier formatting on three files

### DIFF
--- a/src/Equibles.Data/LikePattern.cs
+++ b/src/Equibles.Data/LikePattern.cs
@@ -6,10 +6,7 @@ public static class LikePattern
     // Use with EF.Functions.ILike(column, pattern, "\\").
     public static string Contains(string text)
     {
-        var escaped = text
-            .Replace("\\", "\\\\")
-            .Replace("%", "\\%")
-            .Replace("_", "\\_");
+        var escaped = text.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
         return $"%{escaped}%";
     }
 }

--- a/src/Equibles.Migrations/Migrations/20260525154444_AddConfidentialTreatmentToInstitutionalHolder.cs
+++ b/src/Equibles.Migrations/Migrations/20260525154444_AddConfidentialTreatmentToInstitutionalHolder.cs
@@ -15,7 +15,8 @@ namespace Equibles.Migrations.Migrations
                 table: "InstitutionalHolder",
                 type: "boolean",
                 nullable: false,
-                defaultValue: false);
+                defaultValue: false
+            );
         }
 
         /// <inheritdoc />
@@ -23,7 +24,8 @@ namespace Equibles.Migrations.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "ConfidentialTreatmentRequested",
-                table: "InstitutionalHolder");
+                table: "InstitutionalHolder"
+            );
         }
     }
 }

--- a/src/Equibles.Web/TagHelpers/CompactNumberTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/CompactNumberTagHelper.cs
@@ -4,7 +4,8 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 namespace Equibles.Web.TagHelpers;
 
 [HtmlTargetElement("compactable-number", TagStructure = TagStructure.WithoutEndTag)]
-public class CompactNumberTagHelper : TagHelper {
+public class CompactNumberTagHelper : TagHelper
+{
     [HtmlAttributeName("value")]
     public decimal Value { get; set; }
 
@@ -14,17 +15,25 @@ public class CompactNumberTagHelper : TagHelper {
     [HtmlAttributeName("sign")]
     public bool Sign { get; set; }
 
-    public override void Process(TagHelperContext context, TagHelperOutput output) {
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
         var absValue = Math.Abs(Value);
         var signPrefix = Sign
-            ? Value > 0 ? "+" : Value < 0 ? "-" : ""
+            ? Value > 0
+                ? "+"
+                : Value < 0
+                    ? "-"
+                    : ""
             : "";
         var displayPrefix = signPrefix + (Prefix ?? "");
         var formatted = displayPrefix + absValue.ToString("N0", CultureInfo.InvariantCulture);
 
         output.TagName = "span";
         output.TagMode = TagMode.StartTagAndEndTag;
-        output.Attributes.SetAttribute("data-compact-number", absValue.ToString(CultureInfo.InvariantCulture));
+        output.Attributes.SetAttribute(
+            "data-compact-number",
+            absValue.ToString(CultureInfo.InvariantCulture)
+        );
         if (!string.IsNullOrEmpty(displayPrefix))
             output.Attributes.SetAttribute("data-compact-prefix", displayPrefix);
         output.Content.SetContent(formatted);


### PR DESCRIPTION
## Summary

Fix CSharpier formatting violations on `main` that were failing CI lint.

## Code changes

- `src/Equibles.Data/LikePattern.cs` — collapse chained `.Replace()` onto one line
- `src/Equibles.Migrations/Migrations/20260525154444_AddConfidentialTreatmentToInstitutionalHolder.cs` — move closing `)` to its own line
- `src/Equibles.Web/TagHelpers/CompactNumberTagHelper.cs` — opening brace on new line, break long ternary and `SetAttribute` call