### PR TITLE
fix(sec): infer FiscalYearEndMonth from 10-K when SEC metadata is null

### DIFF
--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -14,6 +14,7 @@ using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Extensions;
 using Equibles.Sec.HostedService.Models;
 using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Polly;
@@ -132,6 +133,7 @@ public class DocumentScraper : IDocumentScraper
             scope.ServiceProvider.GetRequiredService<IDocumentPersistenceService>();
 
         var commonStockManager = scope.ServiceProvider.GetRequiredService<CommonStockManager>();
+        var documentRepository = scope.ServiceProvider.GetRequiredService<DocumentRepository>();
 
         var company = await companyRepository.Get(companyUntracked.Id);
 
@@ -146,7 +148,12 @@ public class DocumentScraper : IDocumentScraper
             // Detect the fiscal year-end before fetching filings: the metadata
             // call primes the SEC client's submissions cache so the first
             // GetCompanyFilings hits the same URL and adds no extra request.
-            await UpdateFiscalYearEnd(company, secEdgarClient, commonStockManager);
+            await UpdateFiscalYearEnd(
+                company,
+                secEdgarClient,
+                commonStockManager,
+                documentRepository
+            );
 
             foreach (var documentType in _options.DocumentTypesToSync)
             {
@@ -191,28 +198,65 @@ public class DocumentScraper : IDocumentScraper
 
     /// <summary>
     /// Reads SEC EDGAR's submissions <c>fiscalYearEnd</c> for the company and
-    /// persists it when it changed. Best-effort: a metadata failure is logged
-    /// and reported but never blocks document scraping, since fiscal-year
-    /// metadata is a nice-to-have enrichment, not a prerequisite for filings.
-    /// Errors are still reported (consistent with the other per-company steps)
-    /// so a systemic SEC-schema change that breaks parsing surfaces on the
-    /// dashboard instead of silently disabling fiscal detection platform-wide.
+    /// persists it when it changed. Falls back to inferring the fiscal year-end
+    /// from the most recent 10-K filing's period-end date when the metadata API
+    /// returns null. Best-effort: a metadata failure is logged and reported but
+    /// never blocks document scraping, since fiscal-year metadata is a
+    /// nice-to-have enrichment, not a prerequisite for filings.
     /// </summary>
     private async Task UpdateFiscalYearEnd(
         CommonStock company,
         ISecEdgarClient secEdgarClient,
-        CommonStockManager commonStockManager
+        CommonStockManager commonStockManager,
+        DocumentRepository documentRepository
     )
     {
         try
         {
             var metadata = await secEdgarClient.GetCompanyMetadata(company.Cik);
-            if (metadata?.FiscalYearEndMonth is not { } month)
+            if (metadata?.FiscalYearEndMonth is { } month)
             {
+                await commonStockManager.SetFiscalYearEnd(
+                    company,
+                    month,
+                    metadata.FiscalYearEndDay
+                );
                 return;
             }
 
-            await commonStockManager.SetFiscalYearEnd(company, month, metadata.FiscalYearEndDay);
+            // SEC metadata lacks fiscal year-end — infer from most recent 10-K.
+            // A 10-K's ReportingForDate is the period end, which is the fiscal
+            // year-end by definition.
+            var latestTenK = await documentRepository
+                .GetByCompany(company)
+                .Where(d => d.DocumentType == DocumentType.TenK)
+                .OrderByDescending(d => d.ReportingForDate)
+                .Select(d => new { d.ReportingForDate })
+                .FirstOrDefaultAsync();
+
+            if (latestTenK is not null)
+            {
+                _logger.LogInformation(
+                    "SEC metadata has no fiscal year-end for {Ticker}; inferred from 10-K period ending {Date}",
+                    company.Ticker,
+                    latestTenK.ReportingForDate
+                );
+                await commonStockManager.SetFiscalYearEnd(
+                    company,
+                    latestTenK.ReportingForDate.Month,
+                    latestTenK.ReportingForDate.Day
+                );
+                return;
+            }
+
+            if (company.FiscalYearEndMonth is null)
+            {
+                _logger.LogWarning(
+                    "No fiscal year-end source for {Ticker} (CIK: {Cik}): SEC metadata returned null and no 10-K filings exist",
+                    company.Ticker,
+                    company.Cik
+                );
+            }
         }
         catch (Exception ex)
         {

--- a/tests/Equibles.UnitTests/Sec/DocumentOnlyModuleConfiguration.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentOnlyModuleConfiguration.cs
@@ -1,0 +1,28 @@
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Registers only <see cref="Document"/> for in-memory tests — excludes
+/// <c>Chunk</c> whose <c>Pgvector.Vector</c> property is incompatible
+/// with the in-memory EF Core provider.
+/// </summary>
+internal sealed class DocumentOnlyModuleConfiguration : IModuleConfiguration
+{
+    public void ConfigureEntities(ModelBuilder builder)
+    {
+        var conv = new ValueConverter<DocumentType, string>(
+            v => v.Value,
+            v => DocumentType.FromValue(v) ?? new DocumentType(v)
+        );
+
+        builder.Entity<Document>(b =>
+        {
+            b.Property(e => e.DocumentType).HasConversion(conv);
+            b.Ignore(e => e.Chunks);
+        });
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperDeferredRetryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperDeferredRetryTests.cs
@@ -7,12 +7,14 @@ using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
+using Equibles.Media.Data;
 using Equibles.Sec.BusinessLogic;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService;
 using Equibles.Sec.HostedService.Configuration;
 using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,7 +42,14 @@ public class DocumentScraperDeferredRetryTests
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .EnableServiceProviderCaching(false)
             .Options;
-        var ctx = new EquiblesDbContext(dbOptions, [new CommonStocksModuleConfiguration()]);
+        var ctx = new EquiblesDbContext(
+            dbOptions,
+            [
+                new CommonStocksModuleConfiguration(),
+                new DocumentOnlyModuleConfiguration(),
+                new MediaModuleConfiguration(),
+            ]
+        );
         ctx.Database.EnsureCreated();
         ctx.Set<CommonStock>()
             .Add(
@@ -93,6 +102,7 @@ public class DocumentScraperDeferredRetryTests
         var services = new ServiceCollection();
         services.AddSingleton(ctx);
         services.AddScoped<CommonStockRepository>();
+        services.AddScoped<DocumentRepository>();
         // DocumentScraper resolves CommonStockManager per scope to persist the
         // SEC-sourced fiscal year-end; IPublishEndpoint is an unrelated ctor
         // dep (SetCusip outbox event) the fiscal-year path never uses.

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperProcessCompanyScopeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperProcessCompanyScopeTests.cs
@@ -7,12 +7,14 @@ using Equibles.Core.Configuration;
 using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
+using Equibles.Media.Data;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService;
 using Equibles.Sec.HostedService.Configuration;
 using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Models;
 using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -41,7 +43,14 @@ public class DocumentScraperProcessCompanyScopeTests
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .EnableServiceProviderCaching(false)
             .Options;
-        var ctx = new EquiblesDbContext(options, [new CommonStocksModuleConfiguration()]);
+        var ctx = new EquiblesDbContext(
+            options,
+            [
+                new CommonStocksModuleConfiguration(),
+                new DocumentOnlyModuleConfiguration(),
+                new MediaModuleConfiguration(),
+            ]
+        );
         ctx.Database.EnsureCreated();
         return ctx;
     }
@@ -54,6 +63,7 @@ public class DocumentScraperProcessCompanyScopeTests
         var services = new ServiceCollection();
         services.AddSingleton(dbContext);
         services.AddScoped<CommonStockRepository>();
+        services.AddScoped<DocumentRepository>();
         // DocumentScraper resolves CommonStockManager per scope to persist the
         // SEC-sourced fiscal year-end; IPublishEndpoint is an unrelated ctor
         // dep (SetCusip outbox event) the fiscal-year path never uses.

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
@@ -8,12 +8,14 @@ using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
+using Equibles.Media.Data;
 using Equibles.Sec.BusinessLogic;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService;
 using Equibles.Sec.HostedService.Configuration;
 using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -428,8 +430,8 @@ public class DocumentScraperTests
     [Fact]
     public async Task ScrapeDocuments_SecReportsNoFiscalYearEnd_LeavesStockUnchanged()
     {
-        // The substitute returns null metadata by default; the stock's
-        // fiscal-year columns must stay null rather than throw or be zeroed.
+        // The substitute returns null metadata by default and no 10-K filings
+        // exist; the stock's fiscal-year columns must stay null.
         var harness = new Harness();
         await using var dbContext = harness.CreateDbContext();
         var company = SeedCompany(dbContext, ticker: "ACME", cik: "0000123456");
@@ -439,6 +441,26 @@ public class DocumentScraperTests
         var persisted = await dbContext.Set<CommonStock>().SingleAsync(c => c.Id == company.Id);
         persisted.FiscalYearEndMonth.Should().BeNull();
         persisted.FiscalYearEndDay.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ScrapeDocuments_SecReportsNoFiscalYearEnd_InfersFiscalYearEndFromTenK()
+    {
+        // When the SEC metadata API returns null fiscal year-end, the scraper
+        // falls back to the most recent 10-K filing's period-end date.
+        var harness = new Harness();
+        await using var dbContext = harness.CreateDbContext();
+        var company = SeedCompany(dbContext, ticker: "BY", cik: "0001712762");
+
+        SeedDocument(dbContext, company, DocumentType.TenK, new DateOnly(2024, 12, 31));
+        SeedDocument(dbContext, company, DocumentType.TenK, new DateOnly(2023, 12, 31));
+        SeedDocument(dbContext, company, DocumentType.TenQ, new DateOnly(2024, 9, 30));
+
+        await harness.BuildScraper(dbContext).ScrapeDocuments();
+
+        var persisted = await dbContext.Set<CommonStock>().SingleAsync(c => c.Id == company.Id);
+        persisted.FiscalYearEndMonth.Should().Be(12);
+        persisted.FiscalYearEndDay.Should().Be(31);
     }
 
     // ── helpers ──
@@ -469,6 +491,28 @@ public class DocumentScraperTests
         return stock;
     }
 
+    private static void SeedDocument(
+        EquiblesDbContext dbContext,
+        CommonStock company,
+        DocumentType documentType,
+        DateOnly reportingForDate
+    )
+    {
+        dbContext
+            .Set<Document>()
+            .Add(
+                new Document
+                {
+                    CommonStockId = company.Id,
+                    DocumentType = documentType,
+                    ReportingDate = reportingForDate,
+                    ReportingForDate = reportingForDate,
+                    ContentId = Guid.NewGuid(),
+                }
+            );
+        dbContext.SaveChanges();
+    }
+
     private sealed class Harness
     {
         public ICompanySyncService CompanySync { get; } = Substitute.For<ICompanySyncService>();
@@ -489,7 +533,12 @@ public class DocumentScraperTests
                 .UseInMemoryDatabase(Guid.NewGuid().ToString())
                 .EnableServiceProviderCaching(false)
                 .Options;
-            var modules = new IModuleConfiguration[] { new CommonStocksModuleConfiguration() };
+            var modules = new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new DocumentOnlyModuleConfiguration(),
+                new MediaModuleConfiguration(),
+            };
             var dbContext = new EquiblesDbContext(options, modules);
             dbContext.Database.EnsureCreated();
             return dbContext;
@@ -511,6 +560,7 @@ public class DocumentScraperTests
             // registration would invalidate the context after the first scope.
             services.AddSingleton(dbContext);
             services.AddScoped<CommonStockRepository>();
+            services.AddScoped<DocumentRepository>();
             // DocumentScraper now resolves CommonStockManager per scope to
             // persist the SEC-sourced fiscal year-end. IPublishEndpoint is an
             // unrelated CommonStockManager ctor dep (SetCusip outbox event);

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperUpdateFiscalYearEndErrorIsolationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperUpdateFiscalYearEndErrorIsolationTests.cs
@@ -7,10 +7,12 @@ using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
+using Equibles.Media.Data;
 using Equibles.Sec.HostedService;
 using Equibles.Sec.HostedService.Configuration;
 using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -39,7 +41,14 @@ public class DocumentScraperUpdateFiscalYearEndErrorIsolationTests
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .EnableServiceProviderCaching(false)
             .Options;
-        var dbContext = new EquiblesDbContext(options, [new CommonStocksModuleConfiguration()]);
+        var dbContext = new EquiblesDbContext(
+            options,
+            [
+                new CommonStocksModuleConfiguration(),
+                new DocumentOnlyModuleConfiguration(),
+                new MediaModuleConfiguration(),
+            ]
+        );
         dbContext.Database.EnsureCreated();
         var company = new CommonStock
         {
@@ -59,6 +68,7 @@ public class DocumentScraperUpdateFiscalYearEndErrorIsolationTests
         var services = new ServiceCollection();
         services.AddSingleton(dbContext);
         services.AddScoped<CommonStockRepository>();
+        services.AddScoped<DocumentRepository>();
         services.AddSingleton(Substitute.For<IPublishEndpoint>());
         services.AddScoped<CommonStockManager>();
         services.AddSingleton(secEdgarClient);


### PR DESCRIPTION
## Summary

- When the SEC EDGAR metadata API returns null `fiscalYearEnd` (~50 US companies like BY, ACRE, MYFW, HRTG), fall back to the most recent 10-K filing's `ReportingForDate` — the period-end date of an annual report is the fiscal year-end by definition
- Log a warning when neither the metadata API nor a 10-K filing is available, making the gap visible in logs instead of silent
- No extra SEC API calls — the fallback queries documents already in the database

Closes #2054

## Code changes

- **`DocumentScraper.UpdateFiscalYearEnd`** — restructured to try SEC metadata first, then 10-K fallback, then log warning. Added `DocumentRepository` parameter for the DB query.
- **`DocumentOnlyModuleConfiguration`** — new shared test utility that registers only `Document` (ignores `Chunk` with its pgvector dependency) for in-memory EF Core tests.
- **`DocumentScraperTests`** — new test `ScrapeDocuments_SecReportsNoFiscalYearEnd_InfersFiscalYearEndFromTenK` verifying the fallback with multiple 10-K filings.
- **4 test harnesses** — registered `DocumentRepository` + module configurations to match the new DI requirement.