### PR TITLE
feat: scrape and persist company website URL from SEC EDGAR

### DIFF
--- a/src/Equibles.Integrations.Sec/Models/CompanyMetadata.cs
+++ b/src/Equibles.Integrations.Sec/Models/CompanyMetadata.cs
@@ -14,6 +14,8 @@ public class CompanyMetadata
     /// </summary>
     public string FiscalYearEnd { get; set; }
 
+    public string Website { get; set; }
+
     /// <summary>
     /// Month (1-12) parsed from <see cref="FiscalYearEnd"/>, or null when the
     /// value is missing or not a valid calendar MMDD date.

--- a/src/Equibles.Integrations.Sec/Models/Responses/SecApiResponse.cs
+++ b/src/Equibles.Integrations.Sec/Models/Responses/SecApiResponse.cs
@@ -24,6 +24,9 @@ internal class SecApiResponse
     [JsonProperty("fiscalYearEnd")]
     public string FiscalYearEnd { get; set; }
 
+    [JsonProperty("website")]
+    public string Website { get; set; }
+
     [JsonProperty("filings")]
     public FilingsContainer Filings { get; set; } = new();
 }

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -123,6 +123,7 @@ public class SecEdgarClient : ISecEdgarClient
                 EntityType = apiResponse.EntityType,
                 Exchanges = apiResponse.Exchanges ?? [],
                 FiscalYearEnd = apiResponse.FiscalYearEnd,
+                Website = apiResponse.Website,
             };
         }
         catch (HttpRequestException ex)

--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -173,10 +173,12 @@ public class CompanySyncService : ICompanySyncService
     {
         var existingStock = state.ExistingStocks.First(cs => cs.Cik == secCompany.Cik);
         var normalizedName = NormalizeCompanyName(secCompany.Name);
+        var missingWebsite = existingStock.Website == null;
         var needsUpdate =
             existingStock.Ticker != primaryTicker
             || existingStock.Name != normalizedName
-            || !(existingStock.SecondaryTickers ?? []).SequenceEqual(secondaryTickers);
+            || !(existingStock.SecondaryTickers ?? []).SequenceEqual(secondaryTickers)
+            || missingWebsite;
 
         if (!needsUpdate)
             return;
@@ -235,12 +237,25 @@ public class CompanySyncService : ICompanySyncService
         var oldTicker = existingStock.Ticker;
         var oldName = existingStock.Name;
         var oldSecondaryTickers = existingStock.SecondaryTickers.ToList();
+        var oldWebsite = existingStock.Website;
 
         try
         {
+            if (missingWebsite)
+                existingStock.Website = await FetchWebsite(secCompany.Cik);
+
             existingStock.Ticker = primaryTicker;
             existingStock.Name = normalizedName;
             existingStock.SecondaryTickers = secondaryTickers;
+
+            if (
+                existingStock.Ticker == oldTicker
+                && existingStock.Name == oldName
+                && oldSecondaryTickers.SequenceEqual(existingStock.SecondaryTickers)
+                && existingStock.Website == oldWebsite
+            )
+                return;
+
             await state.CommonStockManager.Update(existingStock);
 
             if (oldTicker != primaryTicker)
@@ -263,6 +278,7 @@ public class CompanySyncService : ICompanySyncService
             existingStock.Ticker = oldTicker;
             existingStock.Name = oldName;
             existingStock.SecondaryTickers = oldSecondaryTickers;
+            existingStock.Website = oldWebsite;
             state.DbContext.Entry(existingStock).State = EntityState.Unchanged;
             _logger.LogError(
                 ex,
@@ -316,11 +332,13 @@ public class CompanySyncService : ICompanySyncService
         {
             await DeleteAndUntrack(obsoleteStock, state);
 
+            var website = await FetchWebsite(secCompany.Cik);
             var newStock = await CreateCommonStock(
                 secCompany,
                 primaryTicker,
                 secondaryTickers,
-                state
+                state,
+                website
             );
 
             AddAndTrack(newStock, secCompany.Cik, primaryTicker, state);
@@ -355,7 +373,14 @@ public class CompanySyncService : ICompanySyncService
         CommonStock newStock = null;
         try
         {
-            newStock = await CreateCommonStock(secCompany, primaryTicker, secondaryTickers, state);
+            var website = await FetchWebsite(secCompany.Cik);
+            newStock = await CreateCommonStock(
+                secCompany,
+                primaryTicker,
+                secondaryTickers,
+                state,
+                website
+            );
 
             AddAndTrack(newStock, secCompany.Cik, primaryTicker, state);
             _logger.LogDebug(
@@ -568,11 +593,26 @@ public class CompanySyncService : ICompanySyncService
         return secondaryCikToParent;
     }
 
+    private async Task<string> FetchWebsite(string cik)
+    {
+        try
+        {
+            var metadata = await _secEdgarClient.GetCompanyMetadata(cik);
+            return metadata?.Website?.Trim();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch website for CIK {Cik}, skipping", cik);
+            return null;
+        }
+    }
+
     private static Task<CommonStock> CreateCommonStock(
         CompanyInfo secCompany,
         string primaryTicker,
         List<string> secondaryTickers,
-        StockSyncState state
+        StockSyncState state,
+        string website = null
     ) =>
         state.CommonStockManager.Create(
             new CommonStock
@@ -584,6 +624,7 @@ public class CompanySyncService : ICompanySyncService
                 Description = $"Company with tickers: {string.Join(", ", secCompany.Tickers)}",
                 MarketCapitalization = 0,
                 SharesOutStanding = 0,
+                Website = website,
             }
         );
 


### PR DESCRIPTION
## Summary

- Extract the `website` field from SEC EDGAR's submissions API (`data.sec.gov/submissions/CIK{cik}.json`) and persist it to `CommonStock.Website` during the company sync cycle
- Fetch website when creating new stocks and backfill existing stocks with `Website == null`
- No database migration needed — the `Website` column already exists

## Code changes

- **`SecApiResponse.cs`** — Added `[JsonProperty("website")]` property to deserialize the field from SEC JSON
- **`CompanyMetadata.cs`** — Added `Website` property to the public DTO
- **`SecEdgarClient.cs`** — Maps `Website` from API response to metadata DTO in `GetCompanyMetadata()`
- **`CompanySyncService.cs`** — Main logic:
  - `FetchWebsite(cik)` helper calls `GetCompanyMetadata` and extracts website (trims whitespace, catches `HttpRequestException` to avoid blocking sync)
  - `CreateNewStock` and `ReplaceObsoleteStock` fetch website before creating the stock
  - `UpdateExistingStock` checks for `Website == null` and fetches during the update cycle (with rollback support)
  - Skips no-op updates when website fetch fails and no other fields changed
  - Uses `== null` guard (not `IsNullOrEmpty`) so stocks with empty-string website from SEC are not re-fetched on every sync

Closes #2056