### PR TITLE
Normalize company names with abbreviation and roman numeral handling

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Equibles.CommonStocks.BusinessLogic;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
@@ -523,11 +524,33 @@ public class CompanySyncService : ICompanySyncService
         return long.TryParse(cik, out var n) ? n : long.MaxValue;
     }
 
-    // SEC EDGAR returns some names in ALL CAPS (e.g. "AMAZON COM INC",
-    // "MICROSOFT CORP") and others in branded mixed case (e.g. "Apple Inc.",
-    // "Meta Platforms, Inc."). When a name is uniformly upper-cased we treat it
-    // as legacy formatting and convert it to Title Case; mixed-case names are
-    // trusted as-is.
+    private static readonly HashSet<string> UpperCaseAbbreviations = new(
+        StringComparer.OrdinalIgnoreCase
+    )
+    {
+        "LLC",
+        "LLP",
+        "LP",
+        "PLC",
+        "NV",
+        "SA",
+        "AG",
+        "SE",
+        "AB",
+        "ASA",
+        "ETF",
+        "ADR",
+        "REIT",
+        "USA",
+        "US",
+        "UK",
+    };
+
+    private static readonly Regex RomanNumeralPattern = new(
+        @"^(I{1,3}|IV|VI{0,3}|IX|XI{0,3}|XIV|XV)$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled
+    );
+
     private static string NormalizeCompanyName(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
@@ -536,7 +559,19 @@ public class CompanySyncService : ICompanySyncService
         if (name.Any(char.IsLower))
             return name;
 
-        return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(name.ToLowerInvariant());
+        var titleCased = CultureInfo.InvariantCulture.TextInfo.ToTitleCase(name.ToLowerInvariant());
+
+        var words = titleCased.Split(' ');
+        for (var i = 0; i < words.Length; i++)
+        {
+            var stripped = words[i].TrimEnd('.', ',', ';', ')');
+            if (UpperCaseAbbreviations.Contains(stripped) || RomanNumeralPattern.IsMatch(stripped))
+            {
+                words[i] = words[i].ToUpperInvariant();
+            }
+        }
+
+        return string.Join(' ', words);
     }
 
     // Subsidiaries we already decided about: each entry maps a subsidiary CIK to

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameTests.cs
@@ -22,7 +22,51 @@ public class CompanySyncServiceNormalizeCompanyNameTests
     [InlineData("MICROSOFT CORP", "Microsoft Corp")]
     [InlineData("NVIDIA CORP", "Nvidia Corp")]
     [InlineData("BERKSHIRE HATHAWAY INC", "Berkshire Hathaway Inc")]
+    [InlineData("GENERAL ELECTRIC CO", "General Electric Co")]
     public void AllCapsName_IsTitleCased(string input, string expected)
+    {
+        Normalize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("BLACKSTONE GROUP LP", "Blackstone Group LP")]
+    [InlineData("APOLLO GLOBAL MANAGEMENT LLC", "Apollo Global Management LLC")]
+    [InlineData("BROOKFIELD ASSET MANAGEMENT LLP", "Brookfield Asset Management LLP")]
+    [InlineData("BARCLAYS PLC", "Barclays PLC")]
+    [InlineData("UNILEVER NV", "Unilever NV")]
+    [InlineData("SIEMENS AG", "Siemens AG")]
+    [InlineData("SAP SE", "Sap SE")]
+    [InlineData("ATLAS COPCO AB", "Atlas Copco AB")]
+    [InlineData("EQUINOR ASA", "Equinor ASA")]
+    [InlineData("ISHARES MSCI USA ETF", "Ishares Msci USA ETF")]
+    [InlineData("BARCLAYS PLC.", "Barclays PLC.")]
+    public void CorporateAbbreviations_StayUpperCase(string input, string expected)
+    {
+        Normalize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("HENRY SCHEIN III", "Henry Schein III")]
+    [InlineData("FORD MOTOR IV", "Ford Motor IV")]
+    [InlineData("SOME FUND II", "Some Fund II")]
+    [InlineData("CAPITAL GROUP IX", "Capital Group IX")]
+    [InlineData("VENTURE FUND XV", "Venture Fund XV")]
+    [InlineData("SERIES I", "Series I")]
+    [InlineData("FUND VI", "Fund VI")]
+    [InlineData("TRUST VII", "Trust VII")]
+    [InlineData("PARTNERS XIV", "Partners XIV")]
+    public void RomanNumerals_StayUpperCase(string input, string expected)
+    {
+        Normalize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("APOLLO FUND III LP", "Apollo Fund III LP")]
+    [InlineData("KKR REAL ESTATE IV LLC", "Kkr Real Estate IV LLC")]
+    public void CombinedAbbreviationsAndRomanNumerals_AllStayUpperCase(
+        string input,
+        string expected
+    )
     {
         Normalize(input).Should().Be(expected);
     }
@@ -49,8 +93,6 @@ public class CompanySyncServiceNormalizeCompanyNameTests
     [Fact]
     public void SingleCapitalLetter_IsTitleCased()
     {
-        // Defensive: a one-character ticker-as-name shouldn't be left
-        // shouting just because there's no lowercase letter to detect.
         Normalize("X").Should().Be("X");
     }
 }


### PR DESCRIPTION
## Summary

- Improves SEC company name normalization to preserve known uppercase corporate abbreviations (LLC, LLP, LP, PLC, NV, SA, AG, SE, AB, ASA, ETF, ADR, REIT, USA, US, UK) and roman numerals (I–XV) after title-casing
- Previously, ALL-CAPS names like "APOLLO GLOBAL MANAGEMENT LLC" became "Apollo Global Management Llc" — now correctly produces "Apollo Global Management LLC"
- Existing names will be corrected on the next SEC company sync cycle

Refs #2059

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — added `UpperCaseAbbreviations` hash set and `RomanNumeralPattern` regex; `NormalizeCompanyName` now post-processes `ToTitleCase` output to restore known abbreviations and roman numerals to uppercase
- `tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameTests.cs` — added test cases for corporate abbreviations (LP, LLC, LLP, PLC, NV, AG, SE, AB, ASA, ETF, USA), roman numerals (I–XV), and combined scenarios