### PR TITLE
feat(holdings): add FilingType enum to InstitutionalHolding

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -7,7 +7,7 @@ public class HoldingsModuleConfiguration : Equibles.Data.IModuleConfiguration
 {
     public void ConfigureEntities(ModelBuilder builder)
     {
-        // Holdings unique index: include OptionType with NULLS NOT DISTINCT (cannot be expressed via attributes)
+        // Holdings unique index: include OptionType and FilingType with NULLS NOT DISTINCT (cannot be expressed via attributes)
         builder
             .Entity<InstitutionalHolding>()
             .HasIndex(h => new
@@ -17,6 +17,7 @@ public class HoldingsModuleConfiguration : Equibles.Data.IModuleConfiguration
                 h.ReportDate,
                 h.ShareType,
                 h.OptionType,
+                h.FilingType,
             })
             .IsUnique()
             .AreNullsDistinct(false);

--- a/src/Equibles.Holdings.Data/Models/FilingType.cs
+++ b/src/Equibles.Holdings.Data/Models/FilingType.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Holdings.Data.Models;
+
+public enum FilingType
+{
+    [Display(Name = "Form 13F")]
+    Form13F,
+
+    [Display(Name = "Schedule 13D")]
+    Schedule13D,
+
+    [Display(Name = "Schedule 13G")]
+    Schedule13G,
+}

--- a/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
@@ -16,6 +16,7 @@ namespace Equibles.Holdings.Data.Models;
 // /Stocks/{ticker}/Holdings run as an index-only scan.
 [Index(nameof(FilingDate))]
 [Index(nameof(ReportDate))]
+[Index(nameof(FilingType))]
 public class InstitutionalHolding
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
@@ -35,6 +36,7 @@ public class InstitutionalHolding
     public ShareType ShareType { get; set; }
     public OptionType? OptionType { get; set; }
     public InvestmentDiscretion InvestmentDiscretion { get; set; }
+    public FilingType FilingType { get; set; }
 
     public long VotingAuthSole { get; set; }
     public long VotingAuthShared { get; set; }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -709,6 +709,7 @@ public class HoldingsImportService
             ShareType = shareType,
             OptionType = optionType,
             InvestmentDiscretion = discretion,
+            FilingType = FilingType.Form13F,
             VotingAuthSole = votingAuthSole,
             VotingAuthShared = votingAuthShared,
             VotingAuthNone = votingAuthNone,
@@ -747,6 +748,7 @@ public class HoldingsImportService
                 h.ReportDate,
                 h.ShareType,
                 h.OptionType,
+                h.FilingType,
             })
             .WhenMatched(
                 (existing, incoming) =>
@@ -794,9 +796,10 @@ public class HoldingsImportService
         Guid institutionalHolderId,
         DateOnly reportDate,
         ShareType shareType,
-        OptionType? optionType
+        OptionType? optionType,
+        FilingType filingType
     ) =>
-        $"{commonStockId}|{institutionalHolderId}|{reportDate}|{(int)shareType}|{optionType?.ToString() ?? ""}";
+        $"{commonStockId}|{institutionalHolderId}|{reportDate}|{(int)shareType}|{optionType?.ToString() ?? ""}|{(int)filingType}";
 
     private static string BuildHoldingKey(InstitutionalHolding h) =>
         BuildHoldingKey(
@@ -804,7 +807,8 @@ public class HoldingsImportService
             h.InstitutionalHolderId,
             h.ReportDate,
             h.ShareType,
-            h.OptionType
+            h.OptionType,
+            h.FilingType
         );
 
     private static bool IsYes(string raw) =>

--- a/src/Equibles.Migrations/Migrations/20260525170524_AddFilingTypeToInstitutionalHolding.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260525170524_AddFilingTypeToInstitutionalHolding.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260525170524_AddFilingTypeToInstitutionalHolding")]
+    partial class AddFilingTypeToInstitutionalHolding
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260525170524_AddFilingTypeToInstitutionalHolding.cs
+++ b/src/Equibles.Migrations/Migrations/20260525170524_AddFilingTypeToInstitutionalHolding.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFilingTypeToInstitutionalHolding : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_CommonStockId_InstitutionalHolderId_Re~",
+                table: "InstitutionalHolding"
+            );
+
+            migrationBuilder.AddColumn<int>(
+                name: "FilingType",
+                table: "InstitutionalHolding",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0
+            );
+
+            migrationBuilder
+                .CreateIndex(
+                    name: "IX_InstitutionalHolding_CommonStockId_InstitutionalHolderId_Re~",
+                    table: "InstitutionalHolding",
+                    columns: new[]
+                    {
+                        "CommonStockId",
+                        "InstitutionalHolderId",
+                        "ReportDate",
+                        "ShareType",
+                        "OptionType",
+                        "FilingType",
+                    },
+                    unique: true
+                )
+                .Annotation("Npgsql:NullsDistinct", false);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_FilingType",
+                table: "InstitutionalHolding",
+                column: "FilingType"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_CommonStockId_InstitutionalHolderId_Re~",
+                table: "InstitutionalHolding"
+            );
+
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_FilingType",
+                table: "InstitutionalHolding"
+            );
+
+            migrationBuilder.DropColumn(name: "FilingType", table: "InstitutionalHolding");
+
+            migrationBuilder
+                .CreateIndex(
+                    name: "IX_InstitutionalHolding_CommonStockId_InstitutionalHolderId_Re~",
+                    table: "InstitutionalHolding",
+                    columns: new[]
+                    {
+                        "CommonStockId",
+                        "InstitutionalHolderId",
+                        "ReportDate",
+                        "ShareType",
+                        "OptionType",
+                    },
+                    unique: true
+                )
+                .Annotation("Npgsql:NullsDistinct", false);
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildHoldingKeyOptionTypeTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildHoldingKeyOptionTypeTests.cs
@@ -35,7 +35,14 @@ public class HoldingsImportServiceBuildHoldingKeyOptionTypeTests
         var method = typeof(HoldingsImportService).GetMethod(
             "BuildHoldingKey",
             BindingFlags.NonPublic | BindingFlags.Static,
-            [typeof(Guid), typeof(Guid), typeof(DateOnly), typeof(ShareType), typeof(OptionType?)]
+            [
+                typeof(Guid),
+                typeof(Guid),
+                typeof(DateOnly),
+                typeof(ShareType),
+                typeof(OptionType?),
+                typeof(FilingType),
+            ]
         );
 
         var stockId = Guid.NewGuid();
@@ -45,14 +52,76 @@ public class HoldingsImportServiceBuildHoldingKeyOptionTypeTests
         var callKey = (string)
             method.Invoke(
                 null,
-                [stockId, holderId, reportDate, ShareType.Shares, (OptionType?)OptionType.Call]
+                [
+                    stockId,
+                    holderId,
+                    reportDate,
+                    ShareType.Shares,
+                    (OptionType?)OptionType.Call,
+                    FilingType.Form13F,
+                ]
             );
         var putKey = (string)
             method.Invoke(
                 null,
-                [stockId, holderId, reportDate, ShareType.Shares, (OptionType?)OptionType.Put]
+                [
+                    stockId,
+                    holderId,
+                    reportDate,
+                    ShareType.Shares,
+                    (OptionType?)OptionType.Put,
+                    FilingType.Form13F,
+                ]
             );
 
         callKey.Should().NotBe(putKey);
+    }
+
+    [Fact]
+    public void BuildHoldingKey_DiffersByFilingTypeWhenAllOtherFieldsMatch_Keeps13FAnd13DSeparate()
+    {
+        var method = typeof(HoldingsImportService).GetMethod(
+            "BuildHoldingKey",
+            BindingFlags.NonPublic | BindingFlags.Static,
+            [
+                typeof(Guid),
+                typeof(Guid),
+                typeof(DateOnly),
+                typeof(ShareType),
+                typeof(OptionType?),
+                typeof(FilingType),
+            ]
+        );
+
+        var stockId = Guid.NewGuid();
+        var holderId = Guid.NewGuid();
+        var reportDate = new DateOnly(2024, 12, 31);
+
+        var key13F = (string)
+            method.Invoke(
+                null,
+                [
+                    stockId,
+                    holderId,
+                    reportDate,
+                    ShareType.Shares,
+                    (OptionType?)null,
+                    FilingType.Form13F,
+                ]
+            );
+        var key13D = (string)
+            method.Invoke(
+                null,
+                [
+                    stockId,
+                    holderId,
+                    reportDate,
+                    ShareType.Shares,
+                    (OptionType?)null,
+                    FilingType.Schedule13D,
+                ]
+            );
+
+        key13F.Should().NotBe(key13D);
     }
 }


### PR DESCRIPTION
## Summary

- Add a `FilingType` enum (`Form13F`, `Schedule13D`, `Schedule13G`) to `InstitutionalHolding` to track the SEC filing source of each holding record.
- Include `FilingType` in the unique constraint and upsert key so the same stock/holder/quarter can have distinct rows per filing type.
- Existing rows default to `Form13F` via the migration.

Refs #1864

## Code changes

- `src/Equibles.Holdings.Data/Models/FilingType.cs` — new enum with `[Display]` attributes
- `src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs` — add `FilingType` property and `[Index]`
- `src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs` — add `FilingType` to the unique index composite key
- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — set `FilingType.Form13F` on new holdings, include in upsert key and `BuildHoldingKey`
- `src/Equibles.Migrations/Migrations/…AddFilingTypeToInstitutionalHolding.cs` — EF migration (column + indexes)
- `tests/…/HoldingsImportServiceBuildHoldingKeyOptionTypeTests.cs` — update existing test for new parameter, add test verifying `FilingType` differentiates keys