### PR TITLE
fix(sec): infer FiscalYearEndMonth from 20-F/40-F for foreign filers

### DIFF
--- a/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
@@ -62,4 +62,13 @@ public interface ISecEdgarClient
         string accessionNumber,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Returns the most recent <c>reportDate</c> for a given form type from the
+    /// SEC submissions feed's <c>filings.recent</c> section. Uses the cached
+    /// submissions payload when available (zero extra SEC requests after
+    /// <see cref="GetCompanyMetadata"/>). Only examines recent filings — no
+    /// archive fetching. Returns null when no filing of the given type exists.
+    /// </summary>
+    Task<DateOnly?> GetMostRecentReportDate(string cik, DocumentTypeFilter formType);
 }

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -232,6 +232,52 @@ public class SecEdgarClient : ISecEdgarClient
         }
     }
 
+    public async Task<DateOnly?> GetMostRecentReportDate(string cik, DocumentTypeFilter formType)
+    {
+        try
+        {
+            var formattedCik = FormatCik(cik);
+            var url = BuildUrl($"/submissions/CIK{formattedCik}.json");
+
+            string content;
+            if (_cachedContent != null && _cachedContent.Url == url)
+            {
+                content = _cachedContent.Content;
+            }
+            else
+            {
+                using var response = await SendWithRetryAsync(url);
+                response.EnsureSuccessStatusCode();
+                content = await response.Content.ReadAsStringAsync();
+                _cachedContent = new CachedResponse(url, content);
+            }
+
+            var apiResponse = JsonConvert.DeserializeObject<SecApiResponse>(content);
+            var recentFilings = MapToFilingData(apiResponse?.Filings?.Recent, cik);
+
+            var formName = formType.GetFormName();
+            return recentFilings
+                .Where(f => f.Form == formName && f.ReportDate != DateOnly.MinValue)
+                .OrderByDescending(f => f.ReportDate)
+                .Select(f => (DateOnly?)f.ReportDate)
+                .FirstOrDefault();
+        }
+        catch (HttpRequestException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Could not retrieve most recent {FormType} report date for CIK {Cik}",
+                formType,
+                cik
+            );
+            return null;
+        }
+    }
+
     private async Task<List<FilingData>> GetArchiveFilings(
         FilingsContainer filings,
         string cik,

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -198,11 +198,10 @@ public class DocumentScraper : IDocumentScraper
 
     /// <summary>
     /// Reads SEC EDGAR's submissions <c>fiscalYearEnd</c> for the company and
-    /// persists it when it changed. Falls back to inferring the fiscal year-end
-    /// from the most recent 10-K filing's period-end date when the metadata API
-    /// returns null. Best-effort: a metadata failure is logged and reported but
-    /// never blocks document scraping, since fiscal-year metadata is a
-    /// nice-to-have enrichment, not a prerequisite for filings.
+    /// persists it when it changed. Fallback chain when the metadata API returns
+    /// null: most recent 10-K period-end → 20-F report date → 40-F report date.
+    /// Best-effort: a failure is logged and reported but never blocks document
+    /// scraping, since fiscal-year metadata is a nice-to-have enrichment.
     /// </summary>
     private async Task UpdateFiscalYearEnd(
         CommonStock company,
@@ -249,10 +248,42 @@ public class DocumentScraper : IDocumentScraper
                 return;
             }
 
+            // No 10-K filings — try annual foreign-filer forms from the
+            // cached submissions JSON (zero extra SEC requests).
+            var twentyFDate = await secEdgarClient.GetMostRecentReportDate(
+                company.Cik,
+                DocumentTypeFilter.TwentyF
+            );
+            if (twentyFDate is { } twentyF)
+            {
+                _logger.LogInformation(
+                    "SEC metadata has no fiscal year-end for {Ticker}; inferred from 20-F report date {Date}",
+                    company.Ticker,
+                    twentyF
+                );
+                await commonStockManager.SetFiscalYearEnd(company, twentyF.Month, twentyF.Day);
+                return;
+            }
+
+            var fortyFDate = await secEdgarClient.GetMostRecentReportDate(
+                company.Cik,
+                DocumentTypeFilter.FortyF
+            );
+            if (fortyFDate is { } fortyF)
+            {
+                _logger.LogInformation(
+                    "SEC metadata has no fiscal year-end for {Ticker}; inferred from 40-F report date {Date}",
+                    company.Ticker,
+                    fortyF
+                );
+                await commonStockManager.SetFiscalYearEnd(company, fortyF.Month, fortyF.Day);
+                return;
+            }
+
             if (company.FiscalYearEndMonth is null)
             {
                 _logger.LogWarning(
-                    "No fiscal year-end source for {Ticker} (CIK: {Cik}): SEC metadata returned null and no 10-K filings exist",
+                    "No fiscal year-end source for {Ticker} (CIK: {Cik}): SEC metadata returned null, no 10-K filings exist, and no 20-F/40-F found in recent submissions",
                     company.Ticker,
                     company.Cik
                 );

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
@@ -463,6 +463,53 @@ public class DocumentScraperTests
         persisted.FiscalYearEndDay.Should().Be(31);
     }
 
+    [Fact]
+    public async Task ScrapeDocuments_SecReportsNoFiscalYearEnd_InfersFiscalYearEndFromTwentyF()
+    {
+        // Foreign filers have no 10-K filings — the scraper falls back to the
+        // most recent 20-F report date from the cached SEC submissions JSON.
+        var harness = new Harness();
+        await using var dbContext = harness.CreateDbContext();
+        var company = SeedCompany(dbContext, ticker: "BABA", cik: "0001577552");
+
+        harness
+            .SecEdgarClient.GetMostRecentReportDate("0001577552", DocumentTypeFilter.TwentyF)
+            .Returns(new DateOnly(2024, 3, 31));
+
+        await harness.BuildScraper(dbContext).ScrapeDocuments();
+
+        var persisted = await dbContext.Set<CommonStock>().SingleAsync(c => c.Id == company.Id);
+        persisted.FiscalYearEndMonth.Should().Be(3);
+        persisted.FiscalYearEndDay.Should().Be(31);
+    }
+
+    [Fact]
+    public async Task ScrapeDocuments_SecReportsNoFiscalYearEnd_InfersFiscalYearEndFromFortyF()
+    {
+        // Canadian cross-listed companies file 40-F instead of 20-F. The scraper
+        // tries 20-F first, then falls back to 40-F.
+        var harness = new Harness();
+        await using var dbContext = harness.CreateDbContext();
+        var company = SeedCompany(dbContext, ticker: "CNQ", cik: "0001193125");
+
+        harness
+            .SecEdgarClient.GetMostRecentReportDate("0001193125", DocumentTypeFilter.TwentyF)
+            .Returns((DateOnly?)null);
+        harness
+            .SecEdgarClient.GetMostRecentReportDate("0001193125", DocumentTypeFilter.FortyF)
+            .Returns(new DateOnly(2024, 12, 31));
+
+        await harness.BuildScraper(dbContext).ScrapeDocuments();
+
+        var persisted = await dbContext.Set<CommonStock>().SingleAsync(c => c.Id == company.Id);
+        persisted.FiscalYearEndMonth.Should().Be(12);
+        persisted.FiscalYearEndDay.Should().Be(31);
+
+        await harness
+            .SecEdgarClient.Received(1)
+            .GetMostRecentReportDate("0001193125", DocumentTypeFilter.TwentyF);
+    }
+
     // ── helpers ──
 
     private static FilingData BuildFiling(string cik, string accession, string form) =>


### PR DESCRIPTION
## Summary

- ~400 foreign companies/ADRs have `FiscalYearEndMonth = NULL` because they file 20-F or 40-F instead of 10-K, and the existing fallback chain (SEC metadata → 10-K period-end) never reaches them
- Extends `UpdateFiscalYearEnd` with two new tiers that extract the most recent 20-F and 40-F `reportDate` from the already-cached SEC submissions JSON — zero extra HTTP requests
- Covers Canadian cross-listed companies (40-F filers) in addition to other foreign private issuers (20-F filers)

Closes #2053

## Code changes

- **`ISecEdgarClient` / `SecEdgarClient`** — new `GetMostRecentReportDate(cik, formType)` method that reads from the cached `/submissions/CIK*.json` payload (no archive fetching, no extra SEC requests)
- **`DocumentScraper.UpdateFiscalYearEnd`** — extended fallback chain: SEC metadata → 10-K DB → 20-F API → 40-F API → log warning
- **`DocumentScraperTests`** — two new tests: 20-F inference for foreign filers, 40-F inference for Canadian cross-listed companies (with ordering assertion)