### PR TITLE
fix(sec): extend name normalization for higher roman numerals and parenthesized abbreviations

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -572,7 +572,7 @@ public class CompanySyncService : ICompanySyncService
     };
 
     private static readonly Regex RomanNumeralPattern = new(
-        @"^(I{1,3}|IV|VI{0,3}|IX|XI{0,3}|XIV|XV)$",
+        @"^M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$",
         RegexOptions.IgnoreCase | RegexOptions.Compiled
     );
 
@@ -589,8 +589,14 @@ public class CompanySyncService : ICompanySyncService
         var words = titleCased.Split(' ');
         for (var i = 0; i < words.Length; i++)
         {
-            var stripped = words[i].TrimEnd('.', ',', ';', ')');
-            if (UpperCaseAbbreviations.Contains(stripped) || RomanNumeralPattern.IsMatch(stripped))
+            var stripped = words[i].TrimStart('(').TrimEnd('.', ',', ';', ')');
+            if (
+                stripped.Length > 0
+                && (
+                    UpperCaseAbbreviations.Contains(stripped)
+                    || RomanNumeralPattern.IsMatch(stripped)
+                )
+            )
             {
                 words[i] = words[i].ToUpperInvariant();
             }

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameTests.cs
@@ -46,16 +46,36 @@ public class CompanySyncServiceNormalizeCompanyNameTests
     }
 
     [Theory]
+    [InlineData("SOME COMPANY (LLC)", "Some Company (LLC)")]
+    [InlineData("TRUST (LP)", "Trust (LP)")]
+    [InlineData("HOLDING (PLC)", "Holding (PLC)")]
+    public void ParenthesizedAbbreviations_StayUpperCase(string input, string expected)
+    {
+        Normalize(input).Should().Be(expected);
+    }
+
+    [Theory]
     [InlineData("HENRY SCHEIN III", "Henry Schein III")]
     [InlineData("FORD MOTOR IV", "Ford Motor IV")]
     [InlineData("SOME FUND II", "Some Fund II")]
     [InlineData("CAPITAL GROUP IX", "Capital Group IX")]
     [InlineData("VENTURE FUND XV", "Venture Fund XV")]
     [InlineData("SERIES I", "Series I")]
+    [InlineData("FUND V", "Fund V")]
     [InlineData("FUND VI", "Fund VI")]
     [InlineData("TRUST VII", "Trust VII")]
+    [InlineData("VENTURE PARTNERS VIII", "Venture Partners VIII")]
     [InlineData("PARTNERS XIV", "Partners XIV")]
     public void RomanNumerals_StayUpperCase(string input, string expected)
+    {
+        Normalize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("APOLLO INVESTMENT FUND XVI LP", "Apollo Investment Fund XVI LP")]
+    [InlineData("WARBURG PINCUS PRIVATE EQUITY XX LP", "Warburg Pincus Private Equity XX LP")]
+    [InlineData("FUND XXV LLC", "Fund XXV LLC")]
+    public void HighRomanNumerals_StayUpperCase(string input, string expected)
     {
         Normalize(input).Should().Be(expected);
     }


### PR DESCRIPTION
## Summary

- Extends the roman numeral regex from I–XV to the full valid range (I–MMMCMXCIX), fixing fund names like "FUND XX LP" → "Fund XX LP" instead of "Fund Xx Lp"
- Adds `TrimStart('(')` to abbreviation matching so parenthesized forms like "(LLC)" are correctly uppercased instead of remaining as "(Llc)"
- Adds test coverage for high roman numerals (XVI, XX, XXV) and parenthesized abbreviations

Refs #2059

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — replaced limited roman numeral regex with a full pattern; added `TrimStart('(')` and `stripped.Length > 0` guard to the word-matching loop
- `tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameTests.cs` — added `ParenthesizedAbbreviations_StayUpperCase`, `HighRomanNumerals_StayUpperCase` theories, and extra cases (V, VIII) to the existing roman numeral theory