### PR TITLE
fix(holdings): respect NEW HOLDINGS amendment type in 13F import

### DIFF
--- a/src/Equibles.Holdings.HostedService/Models/CoverPageRow.cs
+++ b/src/Equibles.Holdings.HostedService/Models/CoverPageRow.cs
@@ -4,6 +4,7 @@ public class CoverPageRow
 {
     public string AccessionNumber { get; set; }
     public string IsAmendment { get; set; }
+    public string AmendmentType { get; set; }
     public string CompanyName { get; set; }
     public string City { get; set; }
     public string StateOrCountry { get; set; }

--- a/src/Equibles.Holdings.HostedService/Models/Parsed13FFiling.cs
+++ b/src/Equibles.Holdings.HostedService/Models/Parsed13FFiling.cs
@@ -14,6 +14,7 @@ public class Parsed13FFiling
     public DateOnly FilingDate { get; set; }
     public DateOnly PeriodOfReport { get; set; }
     public bool IsAmendment { get; set; }
+    public string AmendmentType { get; set; }
 
     public string FilingManagerName { get; set; }
     public string City { get; set; }

--- a/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
@@ -48,6 +48,7 @@ public class Filing13FXmlParser
             FilingDate = filingDate,
             PeriodOfReport = ParseSecDate(Value(Descendant(coverPage, "reportCalendarOrQuarter"))),
             IsAmendment = IsAmendmentValue(Value(Descendant(coverPage, "isAmendment"))),
+            AmendmentType = Value(Descendant(coverPage, "amendmentType")),
             FilingManagerName = Value(Child(filingManager, "name")),
             City = Value(Child(address, "city")),
             StateOrCountry = Value(Child(address, "stateOrCountry")),

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -225,6 +225,7 @@ public class HoldingsImportService
         {
             AccessionNumber = accession,
             IsAmendment = Get("ISAMENDMENT"),
+            AmendmentType = Get("AMENDMENTTYPE"),
             CompanyName = Get("FILINGMANAGER_NAME"),
             City = Get("FILINGMANAGER_CITY"),
             StateOrCountry = Get("FILINGMANAGER_STATEORCOUNTRY"),
@@ -500,6 +501,18 @@ public class HoldingsImportService
             )
                 continue;
 
+            // "NEW HOLDINGS" amendments add positions to the existing portfolio;
+            // only "RESTATEMENT" amendments (and legacy filings without the field)
+            // replace the entire set.
+            if (IsNewHoldingsAmendment(accession, context))
+            {
+                _logger.LogInformation(
+                    "Amendment {Accession} is NEW HOLDINGS — merging without deleting existing positions",
+                    accession
+                );
+                continue;
+            }
+
             var existingHoldings = await holdingRepo
                 .GetAll()
                 .Where(h => h.InstitutionalHolderId == holderId && h.ReportDate == reportDate)
@@ -509,7 +522,7 @@ public class HoldingsImportService
             {
                 holdingRepo.Delete(existingHoldings);
                 _logger.LogInformation(
-                    "Deleted {Count} holdings for amendment {Accession}",
+                    "Deleted {Count} holdings for RESTATEMENT amendment {Accession}",
                     existingHoldings.Count,
                     accession
                 );
@@ -517,6 +530,16 @@ public class HoldingsImportService
         }
 
         await holdingRepo.SaveChanges();
+    }
+
+    private static bool IsNewHoldingsAmendment(string accession, ImportContext context)
+    {
+        return context.CoverPages.TryGetValue(accession, out var coverPage)
+            && string.Equals(
+                coverPage.AmendmentType,
+                "NEW HOLDINGS",
+                StringComparison.OrdinalIgnoreCase
+            );
     }
 
     private static bool TryResolveAmendmentTarget(

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
@@ -24,7 +24,7 @@ public class Realtime13FArchiveBuilder
             "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
         );
         var coverPage = new StringBuilder(
-            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\t"
+            "ACCESSION_NUMBER\tISAMENDMENT\tAMENDMENTTYPE\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\t"
                 + "FILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\t"
                 + "CONFIDENTIALTREATMENT\n"
         );
@@ -51,6 +51,7 @@ public class Realtime13FArchiveBuilder
                 coverPage,
                 Clean(filing.AccessionNumber),
                 filing.IsAmendment ? "Y" : "N",
+                Clean(filing.AmendmentType),
                 Clean(filing.FilingManagerName),
                 Clean(filing.City),
                 Clean(filing.StateOrCountry),

--- a/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderCleanSanitizationTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderCleanSanitizationTests.cs
@@ -36,9 +36,9 @@ public class Realtime13FArchiveBuilderCleanSanitizationTests
         var dataRow = dataLines.Length > 1 ? dataLines[1] : "";
         var fields = dataRow.Split('\t');
 
-        fields.Should().HaveCount(8, "a clean row has exactly 8 TSV columns");
-        fields[2].Should().Be("ACME Fund Management LLC");
-        fields[3].Should().Be("NEW YORK");
+        fields.Should().HaveCount(9, "a clean row has exactly 9 TSV columns");
+        fields[3].Should().Be("ACME Fund Management LLC");
+        fields[4].Should().Be("NEW YORK");
     }
 
     private static string ReadEntry(ZipArchive archive, string name)

--- a/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderTests.cs
@@ -220,8 +220,8 @@ public class Realtime13FArchiveBuilderTests
         var dataLine = content.Split('\n')[1];
         var fields = dataLine.Split('\t');
 
-        // Manager name is field index 2; tabs must be replaced with spaces
-        fields[2].Should().Be("ACME Fund Management");
+        // Manager name is field index 3 (after ACCESSION_NUMBER, ISAMENDMENT, AMENDMENTTYPE)
+        fields[3].Should().Be("ACME Fund Management");
     }
 
     [Fact]
@@ -235,7 +235,7 @@ public class Realtime13FArchiveBuilderTests
         var dataLine = content.Split('\n')[1];
         var fields = dataLine.Split('\t');
 
-        fields[2].Should().Be("ACME Fund Management");
+        fields[3].Should().Be("ACME Fund Management");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- 13F-HR/A amendments have two types: `RESTATEMENT` (complete replacement) and `NEW HOLDINGS` (additive). `HandleAmendments` treated both as complete replacements, deleting all existing holdings before reimporting — wiping out portfolios when a `NEW HOLDINGS` amendment was processed.
- Parse the `amendmentType` field from both the quarterly TSV (`COVERPAGE.AMENDMENTTYPE`) and real-time XML (`<amendmentType>`), and skip deletion for `NEW HOLDINGS` amendments.
- Real-world impact: VANGUARD CAPITAL MANAGEMENT LLC (CIK 2100119) Q1 2026 portfolio dropped from ~3,982 holdings to 80 after a `NEW HOLDINGS` amendment was processed.

## Code changes

- **`CoverPageRow.cs`** / **`Parsed13FFiling.cs`** — added `AmendmentType` property
- **`Filing13FXmlParser.cs`** — parse `<amendmentType>` from cover page XML
- **`Realtime13FArchiveBuilder.cs`** — write `AMENDMENTTYPE` column to synthetic COVERPAGE.tsv
- **`HoldingsImportService.cs`** — read `AMENDMENTTYPE` in `TryParseCoverPageRow`; `HandleAmendments` skips deletion when amendment type is `NEW HOLDINGS`
- **Unit tests** — updated COVERPAGE field index assertions for the new column

## Data recovery

After deploying, `ProcessedFiling` records for affected accession numbers must be deleted so the real-time worker re-processes the original + restatement filings and rebuilds the full portfolios. The `NEW HOLDINGS` amendments will then correctly merge without deletion.

Closes #2088