### PR TITLE
test(media): pin FileManager.SaveFile happy-path validation and entity assembly

### DIFF
--- a/tests/Equibles.UnitTests/Media/FileManagerSaveFileTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerSaveFileTests.cs
@@ -1,0 +1,37 @@
+using Equibles.Data;
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.Repositories;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Media;
+
+// Lane B (coverage): pins the happy-path of FileManager.SaveFile — extension
+// extraction, allowlist gate, MIME-type resolution, and File entity assembly.
+// All 27 lines of SaveFile were zero-hit in unit coverage.
+public class FileManagerSaveFileTests
+{
+    private readonly FileManager _sut;
+    private readonly FileRepository _repository;
+
+    public FileManagerSaveFileTests()
+    {
+        _repository = Substitute.For<FileRepository>((EquiblesDbContext)null);
+        _sut = new FileManager(_repository);
+    }
+
+    [Fact]
+    public async Task SaveFile_ValidPdf_ReturnsFileWithCorrectProperties()
+    {
+        var content = "fake-pdf-content"u8.ToArray();
+
+        var file = await _sut.SaveFile(content, "quarterly-report.pdf");
+
+        file.Extension.Should().Be("pdf");
+        file.Name.Should().Be("quarterly-report");
+        file.Size.Should().Be(content.Length);
+        file.ContentType.Should().Be("application/pdf");
+        file.FileContent.Should().NotBeNull();
+        file.FileContent.Bytes.Should().BeEquivalentTo(content);
+        _repository.Received(1).Add(file);
+    }
+}


### PR DESCRIPTION
## Summary

- Add a unit test for `FileManager.SaveFile` — all 27 lines were zero-hit in unit coverage (integration tests exist but don't contribute to unit coverage).
- Pins the happy-path contract: extension extraction, allowlist gate, MIME-type resolution, and `File` entity assembly.

## Code changes

- `tests/Equibles.UnitTests/Media/FileManagerSaveFileTests.cs` — new test class with one `[Fact]` that calls `SaveFile` with a valid `.pdf` file, then asserts the returned entity's `Extension`, `Name`, `Size`, `ContentType`, `FileContent`, and that `Repository.Add` was called.