### PR TITLE
test(media): pin FileManager.SaveFile rejection of non-allowlisted extensions

### DIFF
--- a/tests/Equibles.UnitTests/Media/FileManagerSaveFileRejectedExtensionTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerSaveFileRejectedExtensionTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Data;
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.Repositories;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Media;
+
+// Lane A (adversarial): SaveFile's allowlist must reject non-accepted
+// extensions. A .exe payload must throw ArgumentException — accepting it
+// would let an attacker persist and serve an executable.
+public class FileManagerSaveFileRejectedExtensionTests
+{
+    [Fact]
+    public async Task SaveFile_DisallowedExtension_ThrowsArgumentException()
+    {
+        var repository = Substitute.For<FileRepository>((EquiblesDbContext)null);
+        var sut = new FileManager(repository);
+
+        var act = () => sut.SaveFile("malicious"u8.ToArray(), "payload.exe");
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*extension*not allowed*");
+    }
+}


### PR DESCRIPTION
## Summary

- Add an adversarial unit test verifying `FileManager.SaveFile` rejects non-allowlisted file extensions (`.exe`) with `ArgumentException`.
- Pins a security-critical contract: the allowlist must block dangerous extensions from being persisted and later served.

## Code changes

- `tests/Equibles.UnitTests/Media/FileManagerSaveFileRejectedExtensionTests.cs` — new test calling `SaveFile` with a `.exe` filename, asserting `ArgumentException` with a message matching `*extension*not allowed*`.