### PR TITLE
feat(holdings): add current combined quarter view

### DIFF
--- a/src/Equibles.Holdings.Repositories/CombinedQuarterHelper.cs
+++ b/src/Equibles.Holdings.Repositories/CombinedQuarterHelper.cs
@@ -1,0 +1,12 @@
+namespace Equibles.Holdings.Repositories;
+
+public static class CombinedQuarterHelper
+{
+    public const int FilingDeadlineDays = 45;
+
+    public static bool IsFilingWindowOpen(DateOnly latestReportDate)
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        return today <= latestReportDate.AddDays(FilingDeadlineDays);
+    }
+}

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -507,4 +507,243 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             .GroupBy(h => h.InstitutionalHolderId)
             .Select(g => new KeyValuePair<Guid, DateOnly>(g.Key, g.Min(h => h.ReportDate)));
     }
+
+    // "Current combined" quarter: best-available holdings per holder. Uses current-
+    // quarter data for holders who already filed, falls back to the previous quarter
+    // for holders who haven't. The NOT EXISTS subquery identifies non-filers.
+    public IQueryable<InstitutionalHolding> GetCombinedQuarter(DateOnly current, DateOnly previous)
+    {
+        return GetAll()
+            .Where(h =>
+                h.ReportDate == current
+                || (
+                    h.ReportDate == previous
+                    && !DbContext
+                        .Set<InstitutionalHolding>()
+                        .Any(c =>
+                            c.ReportDate == current
+                            && c.InstitutionalHolderId == h.InstitutionalHolderId
+                        )
+                )
+            );
+    }
+
+    // Combined-quarter variant of GetQuarterlyActivity. The "current" side aggregates
+    // the combined view (current filers + previous-quarter fallback for non-filers).
+    // The "previous" side uses the actual previous quarter for delta comparison. For
+    // non-filers the combined shares equal their previous shares, so the delta is zero.
+    public IQueryable<MarketWideStockActivity> GetQuarterlyActivityCombined(
+        DateOnly current,
+        DateOnly previous
+    )
+    {
+        return GetAll()
+            .Where(h => h.ReportDate == current || h.ReportDate == previous)
+            .GroupBy(h => h.CommonStockId)
+            .Select(g => new MarketWideStockActivity
+            {
+                CommonStockId = g.Key,
+                CurrentShares =
+                    g.Where(h =>
+                            h.ReportDate == current
+                            || (
+                                h.ReportDate == previous
+                                && !DbContext
+                                    .Set<InstitutionalHolding>()
+                                    .Any(c =>
+                                        c.ReportDate == current
+                                        && c.InstitutionalHolderId == h.InstitutionalHolderId
+                                    )
+                            )
+                        )
+                        .Sum(h => (long?)h.Shares)
+                    ?? 0L,
+                PreviousShares = g.Sum(h => h.ReportDate == previous ? h.Shares : 0L),
+                CurrentValue =
+                    g.Where(h =>
+                            h.ReportDate == current
+                            || (
+                                h.ReportDate == previous
+                                && !DbContext
+                                    .Set<InstitutionalHolding>()
+                                    .Any(c =>
+                                        c.ReportDate == current
+                                        && c.InstitutionalHolderId == h.InstitutionalHolderId
+                                    )
+                            )
+                        )
+                        .Sum(h => (long?)h.Value)
+                    ?? 0L,
+                PreviousValue = g.Sum(h => h.ReportDate == previous ? h.Value : 0L),
+                CurrentFilerCount = g.Where(h =>
+                        h.ReportDate == current
+                        || (
+                            h.ReportDate == previous
+                            && !DbContext
+                                .Set<InstitutionalHolding>()
+                                .Any(c =>
+                                    c.ReportDate == current
+                                    && c.InstitutionalHolderId == h.InstitutionalHolderId
+                                )
+                        )
+                    )
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+                PreviousFilerCount = g.Where(h => h.ReportDate == previous)
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+            });
+    }
+
+    public IQueryable<MarketWideStockActivity> GetMostHeldCombined(
+        DateOnly current,
+        DateOnly previous
+    ) => GetQuarterlyActivityCombined(current, previous).Where(a => a.CurrentFilerCount > 0);
+
+    public IQueryable<Guid> GetUniqueFilerIdsCombined(DateOnly current, DateOnly previous)
+    {
+        return GetCombinedQuarter(current, previous)
+            .Select(h => h.InstitutionalHolderId)
+            .Distinct();
+    }
+
+    // Combined-quarter variant of churn detection. "New" = holder appears in the
+    // combined view but not in the previous quarter. "Sold-out" = holder appears in
+    // the previous quarter but not in the combined view.
+    public IQueryable<MarketWideStockChurn> GetQuarterlyNewSoldOutPositionsCombined(
+        DateOnly current,
+        DateOnly previous
+    )
+    {
+        return GetAll()
+            .Where(h => h.ReportDate == current || h.ReportDate == previous)
+            .GroupBy(h => h.CommonStockId)
+            .Select(g => new MarketWideStockChurn
+            {
+                CommonStockId = g.Key,
+                // New: in current quarter and not in previous (only actual current-quarter filers
+                // can introduce genuinely new positions).
+                NewFilerCount = g.Where(h =>
+                        h.ReportDate == current
+                        && !DbContext
+                            .Set<InstitutionalHolding>()
+                            .Any(p =>
+                                p.ReportDate == previous
+                                && p.CommonStockId == h.CommonStockId
+                                && p.InstitutionalHolderId == h.InstitutionalHolderId
+                            )
+                    )
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+                // Sold-out: in previous and not in the combined view. A holder counts as
+                // sold-out only if they filed the current quarter (proving they dropped
+                // the position). Non-filers are assumed to still hold.
+                SoldOutFilerCount = g.Where(h =>
+                        h.ReportDate == previous
+                        && DbContext
+                            .Set<InstitutionalHolding>()
+                            .Any(c =>
+                                c.ReportDate == current
+                                && c.InstitutionalHolderId == h.InstitutionalHolderId
+                            )
+                        && !DbContext
+                            .Set<InstitutionalHolding>()
+                            .Any(c =>
+                                c.ReportDate == current
+                                && c.CommonStockId == h.CommonStockId
+                                && c.InstitutionalHolderId == h.InstitutionalHolderId
+                            )
+                    )
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+            });
+    }
+
+    public IQueryable<DoubleDownPosition> GetDoubleDownPositionsCombined(
+        DateOnly current,
+        DateOnly previous,
+        double minPctIncrease
+    )
+    {
+        var aggregated = GetAll()
+            .Where(h => h.ReportDate == current || h.ReportDate == previous)
+            .GroupBy(h => new { h.InstitutionalHolderId, h.CommonStockId })
+            .Select(g => new
+            {
+                g.Key.InstitutionalHolderId,
+                g.Key.CommonStockId,
+                CurrentShares = g.Where(h =>
+                        h.ReportDate == current
+                        || (
+                            h.ReportDate == previous
+                            && !DbContext
+                                .Set<InstitutionalHolding>()
+                                .Any(c =>
+                                    c.ReportDate == current
+                                    && c.InstitutionalHolderId == h.InstitutionalHolderId
+                                )
+                        )
+                    )
+                    .Sum(h => (long?)h.Shares)
+                    ?? 0L,
+                PreviousShares = g.Sum(h => h.ReportDate == previous ? h.Shares : 0L),
+                CurrentValue = g.Where(h =>
+                        h.ReportDate == current
+                        || (
+                            h.ReportDate == previous
+                            && !DbContext
+                                .Set<InstitutionalHolding>()
+                                .Any(c =>
+                                    c.ReportDate == current
+                                    && c.InstitutionalHolderId == h.InstitutionalHolderId
+                                )
+                        )
+                    )
+                    .Sum(h => (long?)h.Value)
+                    ?? 0L,
+                PreviousValue = g.Sum(h => h.ReportDate == previous ? h.Value : 0L),
+            })
+            .Where(a => a.PreviousShares > 0 && a.CurrentShares > a.PreviousShares)
+            .Where(a =>
+                (double)(a.CurrentShares - a.PreviousShares) / a.PreviousShares * 100.0
+                >= minPctIncrease
+            );
+
+        return aggregated
+            .Join(
+                DbContext.Set<InstitutionalHolder>(),
+                a => a.InstitutionalHolderId,
+                h => h.Id,
+                (a, h) =>
+                    new
+                    {
+                        a,
+                        FilerName = h.Name,
+                        FilerCik = h.Cik,
+                    }
+            )
+            .Join(
+                DbContext.Set<CommonStock>(),
+                x => x.a.CommonStockId,
+                s => s.Id,
+                (x, s) =>
+                    new DoubleDownPosition
+                    {
+                        InstitutionalHolderId = x.a.InstitutionalHolderId,
+                        FilerName = x.FilerName,
+                        FilerCik = x.FilerCik,
+                        CommonStockId = x.a.CommonStockId,
+                        Ticker = s.Ticker,
+                        StockName = s.Name,
+                        CurrentShares = x.a.CurrentShares,
+                        PreviousShares = x.a.PreviousShares,
+                        CurrentValue = x.a.CurrentValue,
+                        PreviousValue = x.a.PreviousValue,
+                    }
+            );
+    }
 }

--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -24,7 +24,7 @@ public class HoldingsActivityController : BaseController
     }
 
     [HttpGet("~/holdings/activity")]
-    public async Task<IActionResult> Activity(DateOnly? date)
+    public async Task<IActionResult> Activity(DateOnly? date, bool combined = false)
     {
         var reportDates = await LoadAvailableReportDates();
 
@@ -32,18 +32,34 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count == 0)
             return View(viewModel);
 
-        var (selectedDate, previousDate) = ResolveSelectedAndPriorDate(date, reportDates);
-        viewModel.SelectedDate = selectedDate;
-        viewModel.PreviousDate = previousDate;
-        if (!previousDate.HasValue)
+        var isCombinedAvailable =
+            reportDates.Count >= 2 && CombinedQuarterHelper.IsFilingWindowOpen(reportDates[0]);
+        viewModel.IsCombinedAvailable = isCombinedAvailable;
+
+        if (combined && isCombinedAvailable)
+        {
+            viewModel.IsCombinedSelected = true;
+            viewModel.SelectedDate = reportDates[0];
+            viewModel.PreviousDate = reportDates[1];
+        }
+        else
+        {
+            var (sel, prev) = ResolveSelectedAndPriorDate(date, reportDates);
+            viewModel.SelectedDate = sel;
+            viewModel.PreviousDate = prev;
+        }
+
+        if (!viewModel.PreviousDate.HasValue)
             return View(viewModel);
 
-        // Pull the top N stocks by absolute Δ value in each direction. The cap is
-        // applied server-side so the controller never materializes the full per-stock
-        // aggregation for the whole universe.
-        var movers = _holdingRepository
-            .GetQuarterlyActivity(selectedDate, previousDate.Value)
-            .Where(a => a.CurrentShares != a.PreviousShares);
+        var selectedDate = viewModel.SelectedDate;
+        var previousDate = viewModel.PreviousDate.Value;
+
+        var movers = (
+            viewModel.IsCombinedSelected
+                ? _holdingRepository.GetQuarterlyActivityCombined(selectedDate, previousDate)
+                : _holdingRepository.GetQuarterlyActivity(selectedDate, previousDate)
+        ).Where(a => a.CurrentShares != a.PreviousShares);
 
         var topBuysAgg = await movers
             .Where(a => a.CurrentShares > a.PreviousShares)
@@ -56,13 +72,9 @@ public class HoldingsActivityController : BaseController
             .Take(HoldingsActivityViewModel.RowCap)
             .ToListAsync();
 
-        // New / Sold-out per-stock churn — runs as a separate aggregation because the
-        // set-difference of (stock, holder) pairs across quarters can't live inside the
-        // same GROUP BY as the share/value totals.
-        var churn = _holdingRepository.GetQuarterlyNewSoldOutPositions(
-            selectedDate,
-            previousDate.Value
-        );
+        var churn = viewModel.IsCombinedSelected
+            ? _holdingRepository.GetQuarterlyNewSoldOutPositionsCombined(selectedDate, previousDate)
+            : _holdingRepository.GetQuarterlyNewSoldOutPositions(selectedDate, previousDate);
         var newPositionsAgg = await churn
             .Where(c => c.NewFilerCount > 0)
             .OrderByDescending(c => c.NewFilerCount)
@@ -128,7 +140,12 @@ public class HoldingsActivityController : BaseController
     }
 
     [HttpGet("~/holdings/double-down")]
-    public async Task<IActionResult> DoubleDown(DateOnly? date, double? minPct, int page = 1)
+    public async Task<IActionResult> DoubleDown(
+        DateOnly? date,
+        double? minPct,
+        int page = 1,
+        bool combined = false
+    )
     {
         var reportDates = await LoadAvailableReportDates();
 
@@ -144,17 +161,37 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count < 2)
             return View(viewModel);
 
-        var (selectedDate, previousDate) = ResolveSelectedAndPriorDate(date, reportDates);
-        viewModel.SelectedDate = selectedDate;
-        viewModel.PreviousDate = previousDate;
-        if (!previousDate.HasValue)
+        var isCombinedAvailable = CombinedQuarterHelper.IsFilingWindowOpen(reportDates[0]);
+        viewModel.IsCombinedAvailable = isCombinedAvailable;
+
+        if (combined && isCombinedAvailable)
+        {
+            viewModel.IsCombinedSelected = true;
+            viewModel.SelectedDate = reportDates[0];
+            viewModel.PreviousDate = reportDates[1];
+        }
+        else
+        {
+            var (sel, prev) = ResolveSelectedAndPriorDate(date, reportDates);
+            viewModel.SelectedDate = sel;
+            viewModel.PreviousDate = prev;
+        }
+
+        if (!viewModel.PreviousDate.HasValue)
             return View(viewModel);
 
-        var query = _holdingRepository
-            .GetDoubleDownPositions(selectedDate, previousDate.Value, threshold)
-            .OrderByDescending(p =>
-                (double)(p.CurrentShares - p.PreviousShares) / p.PreviousShares
-            );
+        var selectedDate = viewModel.SelectedDate;
+        var previousDate = viewModel.PreviousDate.Value;
+
+        var query = (
+            viewModel.IsCombinedSelected
+                ? _holdingRepository.GetDoubleDownPositionsCombined(
+                    selectedDate,
+                    previousDate,
+                    threshold
+                )
+                : _holdingRepository.GetDoubleDownPositions(selectedDate, previousDate, threshold)
+        ).OrderByDescending(p => (double)(p.CurrentShares - p.PreviousShares) / p.PreviousShares);
 
         viewModel.TotalCount = await query.CountAsync();
         var skip = (viewModel.Page - 1) * DoubleDownViewModel.PageSize;
@@ -190,7 +227,12 @@ public class HoldingsActivityController : BaseController
     }
 
     [HttpGet("~/Holdings/MostHeld")]
-    public async Task<IActionResult> MostHeld(DateOnly? date, string sort, int page = 1)
+    public async Task<IActionResult> MostHeld(
+        DateOnly? date,
+        string sort,
+        int page = 1,
+        bool combined = false
+    )
     {
         var reportDates = await LoadAvailableReportDates();
 
@@ -209,20 +251,36 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count == 0)
             return View(viewModel);
 
-        var (selectedDate, previousDate) = ResolveSelectedAndPriorDate(date, reportDates);
-        viewModel.SelectedDate = selectedDate;
-        viewModel.PreviousDate = previousDate;
+        var isCombinedAvailable =
+            reportDates.Count >= 2 && CombinedQuarterHelper.IsFilingWindowOpen(reportDates[0]);
+        viewModel.IsCombinedAvailable = isCombinedAvailable;
 
-        // GetMostHeld needs both args; when no prior quarter exists we pass the
-        // same date — the previous-side columns end up mirroring current, and the
-        // view renders delta cells as "—" because PreviousDate is null.
-        var priorForRepo = previousDate ?? selectedDate;
-        var rankingQuery = _holdingRepository.GetMostHeld(selectedDate, priorForRepo);
+        if (combined && isCombinedAvailable)
+        {
+            viewModel.IsCombinedSelected = true;
+            viewModel.SelectedDate = reportDates[0];
+            viewModel.PreviousDate = reportDates[1];
+        }
+        else
+        {
+            var (sel, prev) = ResolveSelectedAndPriorDate(date, reportDates);
+            viewModel.SelectedDate = sel;
+            viewModel.PreviousDate = prev;
+        }
+
+        var selectedDate = viewModel.SelectedDate;
+        var priorForRepo = viewModel.PreviousDate ?? selectedDate;
+
+        var rankingQuery = viewModel.IsCombinedSelected
+            ? _holdingRepository.GetMostHeldCombined(selectedDate, priorForRepo)
+            : _holdingRepository.GetMostHeld(selectedDate, priorForRepo);
 
         viewModel.TotalRows = await rankingQuery.CountAsync();
-        viewModel.TotalUniverseFilers = await _holdingRepository
-            .GetUniqueFilerIds(selectedDate)
-            .CountAsync();
+        viewModel.TotalUniverseFilers = viewModel.IsCombinedSelected
+            ? await _holdingRepository
+                .GetUniqueFilerIdsCombined(selectedDate, priorForRepo)
+                .CountAsync()
+            : await _holdingRepository.GetUniqueFilerIds(selectedDate).CountAsync();
         var skip = (viewModel.Page - 1) * HoldingsMostHeldViewModel.PageSize;
 
         var orderedQuery = normalizedSort switch
@@ -304,7 +362,7 @@ public class HoldingsActivityController : BaseController
     }
 
     [HttpGet("~/holdings/heatmap")]
-    public async Task<IActionResult> HeatMap(DateOnly? date)
+    public async Task<IActionResult> HeatMap(DateOnly? date, bool combined = false)
     {
         var reportDates = await LoadAvailableReportDates();
 
@@ -312,24 +370,52 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count < 2)
             return View(viewModel);
 
-        var (selectedDate, previousDate) = ResolveSelectedAndPriorDate(date, reportDates);
-        viewModel.SelectedDate = selectedDate;
-        viewModel.PreviousDate = previousDate;
-        if (!previousDate.HasValue)
+        var isCombinedAvailable = CombinedQuarterHelper.IsFilingWindowOpen(reportDates[0]);
+        viewModel.IsCombinedAvailable = isCombinedAvailable;
+
+        if (combined && isCombinedAvailable)
+        {
+            viewModel.IsCombinedSelected = true;
+            viewModel.SelectedDate = reportDates[0];
+            viewModel.PreviousDate = reportDates[1];
+        }
+        else
+        {
+            var (sel, prev) = ResolveSelectedAndPriorDate(date, reportDates);
+            viewModel.SelectedDate = sel;
+            viewModel.PreviousDate = prev;
+        }
+
+        if (!viewModel.PreviousDate.HasValue)
             return View(viewModel);
 
-        var totalFilers = await _holdingRepository.GetUniqueFilerIds(selectedDate).CountAsync();
+        var selectedDate = viewModel.SelectedDate;
+        var previousDate = viewModel.PreviousDate.Value;
+
+        var totalFilers = viewModel.IsCombinedSelected
+            ? await _holdingRepository
+                .GetUniqueFilerIdsCombined(selectedDate, previousDate)
+                .CountAsync()
+            : await _holdingRepository.GetUniqueFilerIds(selectedDate).CountAsync();
         viewModel.TotalUniverseFilers = totalFilers;
 
-        var activity = await _holdingRepository
-            .GetQuarterlyActivity(selectedDate, previousDate.Value)
+        var activity = await (
+            viewModel.IsCombinedSelected
+                ? _holdingRepository.GetQuarterlyActivityCombined(selectedDate, previousDate)
+                : _holdingRepository.GetQuarterlyActivity(selectedDate, previousDate)
+        )
             .Where(a => a.CurrentFilerCount >= 3)
             .ToListAsync();
 
         var churnLookup = (
-            await _holdingRepository
-                .GetQuarterlyNewSoldOutPositions(selectedDate, previousDate.Value)
-                .ToListAsync()
+            await (
+                viewModel.IsCombinedSelected
+                    ? _holdingRepository.GetQuarterlyNewSoldOutPositionsCombined(
+                        selectedDate,
+                        previousDate
+                    )
+                    : _holdingRepository.GetQuarterlyNewSoldOutPositions(selectedDate, previousDate)
+            ).ToListAsync()
         ).ToDictionary(c => c.CommonStockId);
 
         var stockIds = activity.Select(a => a.CommonStockId).ToList();

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -69,6 +69,9 @@ public class StockTabService
             .OrderByDescending(d => d)
             .ToListAsync();
 
+        var isCombinedAvailable =
+            reportDates.Count >= 2 && CombinedQuarterHelper.IsFilingWindowOpen(reportDates[0]);
+
         var selectedDate = date ?? reportDates.FirstOrDefault();
 
         if (selectedDate == default)
@@ -78,6 +81,7 @@ public class StockTabService
                 AvailableDates = reportDates,
                 SelectedDate = selectedDate,
                 Ticker = stock.Ticker,
+                IsCombinedAvailable = isCombinedAvailable,
             };
         }
 
@@ -166,6 +170,7 @@ public class StockTabService
             TopSellers = topSellers,
             TotalBuyerCount = HoldingsTopMoversSelector.CountBuyers(grouped),
             TotalSellerCount = HoldingsTopMoversSelector.CountSellers(grouped),
+            IsCombinedAvailable = isCombinedAvailable,
         };
     }
 
@@ -178,18 +183,23 @@ public class StockTabService
             .OrderByDescending(d => d)
             .ToListAsync();
 
-        if (reportDates.Count == 0)
+        if (reportDates.Count < 2)
         {
             return new HoldingsTabViewModel
             {
                 AvailableDates = reportDates,
                 Ticker = stock.Ticker,
                 IsCombinedView = true,
+                IsCombinedAvailable = false,
             };
         }
 
+        var current = reportDates[0];
+        var previous = reportDates[1];
+
         var allCombined = await _institutionalHoldingRepository
-            .GetLatestByStock(stock)
+            .GetCombinedQuarter(current, previous)
+            .Where(h => h.CommonStockId == stock.Id)
             .Include(h => h.InstitutionalHolder)
             .ToListAsync();
 
@@ -233,6 +243,7 @@ public class StockTabService
         return new HoldingsTabViewModel
         {
             AvailableDates = reportDates,
+            SelectedDate = current,
             Ticker = stock.Ticker,
             TotalValue = allCombined.Sum(h => h.Value),
             TotalShares = allCombined.Sum(h => h.Shares),
@@ -241,6 +252,7 @@ public class StockTabService
             GroupedHolders = grouped,
             BucketCounts = grouped.ToDictionary(g => g.Key, g => g.Value.Count),
             IsCombinedView = true,
+            IsCombinedAvailable = true,
         };
     }
 

--- a/src/Equibles.Web/ViewModels/Holdings/DoubleDownViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/DoubleDownViewModel.cs
@@ -10,6 +10,8 @@ public class DoubleDownViewModel
     public List<DateOnly> AvailableDates { get; set; } = [];
     public DateOnly SelectedDate { get; set; }
     public DateOnly? PreviousDate { get; set; }
+    public bool IsCombinedAvailable { get; set; }
+    public bool IsCombinedSelected { get; set; }
     public double MinPctIncrease { get; set; } = DefaultMinPct;
 
     public List<DoubleDownPosition> Positions { get; set; } = [];

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsActivityViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsActivityViewModel.cs
@@ -5,6 +5,8 @@ public class HoldingsActivityViewModel
     public List<DateOnly> AvailableDates { get; set; } = [];
     public DateOnly SelectedDate { get; set; }
     public DateOnly? PreviousDate { get; set; }
+    public bool IsCombinedAvailable { get; set; }
+    public bool IsCombinedSelected { get; set; }
 
     public List<HoldingsActivityRow> TopBuys { get; set; } = [];
     public List<HoldingsActivityRow> TopSells { get; set; } = [];

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsHeatMapViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsHeatMapViewModel.cs
@@ -5,6 +5,8 @@ public class HoldingsHeatMapViewModel
     public List<DateOnly> AvailableDates { get; set; } = [];
     public DateOnly SelectedDate { get; set; }
     public DateOnly? PreviousDate { get; set; }
+    public bool IsCombinedAvailable { get; set; }
+    public bool IsCombinedSelected { get; set; }
     public List<HeatMapPoint> Points { get; set; } = [];
     public int TotalUniverseFilers { get; set; }
 

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsMostHeldViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsMostHeldViewModel.cs
@@ -10,9 +10,9 @@ public class HoldingsMostHeldViewModel
     public List<DateOnly> AvailableDates { get; set; } = [];
     public DateOnly SelectedDate { get; set; }
     public DateOnly? PreviousDate { get; set; }
+    public bool IsCombinedAvailable { get; set; }
+    public bool IsCombinedSelected { get; set; }
 
-    // Distinct filer count for SelectedDate — denominator for each row's
-    // PercentOfUniverse. Zero when no quarter is selected.
     public int TotalUniverseFilers { get; set; }
 
     // One of SortFilers / SortFilersDelta / SortValue. Normalised by the

--- a/src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs
@@ -23,6 +23,7 @@ public class HoldingsTabViewModel
 
     public HashSet<PositionChangeType> ActiveTypes { get; set; }
 
+    public bool IsCombinedAvailable { get; set; }
     public bool IsCombinedView { get; set; }
 
     public bool IsTypeActive(PositionChangeType type) =>

--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -24,9 +24,16 @@
             <div class="flex items-center gap-2 shrink-0">
                 <label for="activity-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
                 <select id="activity-date" class="select select-bordered select-sm"
-                    onchange="window.location.href='Activity?date=' + this.value">
+                    onchange="var v=this.value; window.location.href = v==='combined' ? 'Activity?combined=true' : 'Activity?date=' + v">
+                    @if (Model.IsCombinedAvailable) {
+                        if (Model.IsCombinedSelected) {
+                            <option value="combined" selected>Current Combined</option>
+                        } else {
+                            <option value="combined">Current Combined</option>
+                        }
+                    }
                     @foreach (var date in Model.AvailableDates) {
-                        var isSelected = date == Model.SelectedDate;
+                        var isSelected = !Model.IsCombinedSelected && date == Model.SelectedDate;
                         if (isSelected) {
                             <option value="@date.ToString("yyyy-MM-dd")" selected>@date.ToString("MMM dd, yyyy")</option>
                         } else {

--- a/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
@@ -6,7 +6,9 @@
     ViewData["Description"] = "Institutional holders aggressively adding to positions — ranked by conviction (% share increase).";
 
     var filterRoute = new Dictionary<string, string>();
-    if (Model.SelectedDate != default) {
+    if (Model.IsCombinedSelected) {
+        filterRoute["combined"] = "true";
+    } else if (Model.SelectedDate != default) {
         filterRoute["date"] = Model.SelectedDate.ToString("yyyy-MM-dd");
     }
     if (Math.Abs(Model.MinPctIncrease - DoubleDownViewModel.DefaultMinPct) > 0.01) {
@@ -36,12 +38,21 @@
     } else {
         <!-- Controls -->
         <form method="get" class="mb-6">
+            <input type="hidden" name="combined" id="dd-combined-flag" value="@(Model.IsCombinedSelected ? "true" : "")" />
             <div class="flex flex-wrap gap-3 items-end">
                 <label class="form-control">
                     <span class="label-text text-sm mb-1">Report Date</span>
-                    <select name="date" class="select select-bordered" aria-label="Report date">
+                    <select name="date" id="dd-date-select" class="select select-bordered" aria-label="Report date"
+                        onchange="document.getElementById('dd-combined-flag').value = this.value==='combined' ? 'true' : ''; if(this.value==='combined') this.name=''; else this.name='date';">
+                        @if (Model.IsCombinedAvailable) {
+                            if (Model.IsCombinedSelected) {
+                                <option value="combined" selected>Current Combined</option>
+                            } else {
+                                <option value="combined">Current Combined</option>
+                            }
+                        }
                         @foreach (var d in Model.AvailableDates) {
-                            var isSelected = d == Model.SelectedDate;
+                            var isSelected = !Model.IsCombinedSelected && d == Model.SelectedDate;
                             if (isSelected) {
                                 <option value="@d.ToString("yyyy-MM-dd")" selected>@d.ToString("MMM dd, yyyy")</option>
                             } else {

--- a/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
@@ -30,9 +30,16 @@
                 <div class="flex items-center gap-2 shrink-0">
                     <label for="heatmap-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
                     <select id="heatmap-date" class="select select-bordered select-sm"
-                        onchange="window.location.href='HeatMap?date=' + this.value">
+                        onchange="var v=this.value; window.location.href = v==='combined' ? 'HeatMap?combined=true' : 'HeatMap?date=' + v">
+                        @if (Model.IsCombinedAvailable) {
+                            if (Model.IsCombinedSelected) {
+                                <option value="combined" selected>Current Combined</option>
+                            } else {
+                                <option value="combined">Current Combined</option>
+                            }
+                        }
                         @foreach (var d in Model.AvailableDates) {
-                            var sel = d == Model.SelectedDate;
+                            var sel = !Model.IsCombinedSelected && d == Model.SelectedDate;
                             if (sel) {
                                 <option value="@d.ToString("yyyy-MM-dd")" selected>@d.ToString("MMM dd, yyyy")</option>
                             } else {

--- a/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
@@ -26,10 +26,22 @@
         <div class="flex flex-wrap items-center gap-x-5 gap-y-2 mb-1">
             <div class="flex items-center gap-2 shrink-0">
                 <label for="most-held-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
+                @{
+                    var mostHeldDateParam = Model.IsCombinedSelected
+                        ? "combined=true"
+                        : "date=" + Model.SelectedDate.ToString("yyyy-MM-dd");
+                }
                 <select id="most-held-date" class="select select-bordered select-sm"
-                    onchange="window.location.href='MostHeld?date=' + this.value + '&sort=@Model.Sort'">
+                    onchange="var v=this.value; window.location.href = v==='combined' ? 'MostHeld?combined=true&sort=@Model.Sort' : 'MostHeld?date=' + v + '&sort=@Model.Sort'">
+                    @if (Model.IsCombinedAvailable) {
+                        if (Model.IsCombinedSelected) {
+                            <option value="combined" selected>Current Combined</option>
+                        } else {
+                            <option value="combined">Current Combined</option>
+                        }
+                    }
                     @foreach (var date in Model.AvailableDates) {
-                        var isSelected = date == Model.SelectedDate;
+                        var isSelected = !Model.IsCombinedSelected && date == Model.SelectedDate;
                         if (isSelected) {
                             <option value="@date.ToString("yyyy-MM-dd")" selected>@date.ToString("MMM dd, yyyy")</option>
                         } else {
@@ -41,7 +53,7 @@
             <div class="flex items-center gap-2 shrink-0">
                 <label for="most-held-sort" class="text-base-content/60 whitespace-nowrap">Sort by:</label>
                 <select id="most-held-sort" class="select select-bordered select-sm"
-                    onchange="window.location.href='MostHeld?date=@Model.SelectedDate.ToString("yyyy-MM-dd")&sort=' + this.value">
+                    onchange="window.location.href='MostHeld?@(mostHeldDateParam)&sort=' + this.value">
                     <option value="@HoldingsMostHeldViewModel.SortFilers" selected="@(Model.Sort == HoldingsMostHeldViewModel.SortFilers)"># Filers</option>
                     <option value="@HoldingsMostHeldViewModel.SortFilersDelta" selected="@(Model.Sort == HoldingsMostHeldViewModel.SortFilersDelta)">Δ Filers (QoQ)</option>
                     <option value="@HoldingsMostHeldViewModel.SortValue" selected="@(Model.Sort == HoldingsMostHeldViewModel.SortValue)">Total $ Value</option>

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -60,10 +60,12 @@
                 <label for="holdings-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
                 <select id="holdings-date" class="select select-bordered select-sm"
                     onchange="var v=this.value; window.location.href = v==='combined' ? 'Holdings?combined=true' : 'Holdings?date=' + v">
-                    @if (Model.IsCombinedView) {
-                        <option value="combined" selected>Current Combined</option>
-                    } else {
-                        <option value="combined">Current Combined</option>
+                    @if (Model.IsCombinedAvailable || Model.IsCombinedView) {
+                        if (Model.IsCombinedView) {
+                            <option value="combined" selected>Current Combined</option>
+                        } else {
+                            <option value="combined">Current Combined</option>
+                        }
                     }
                     @foreach (var date in Model.AvailableDates) {
                         var isSelected = !Model.IsCombinedView && date == Model.SelectedDate;


### PR DESCRIPTION
## Summary

- Add "current combined" quarter support to the holdings module
- During the 13F filing window (~45 days after quarter end), blend current-quarter filings with previous-quarter fallback for funds that haven't filed yet
- `CombinedQuarterHelper.IsFilingWindowOpen()` determines availability
- Repository methods: `GetCombinedQuarter`, `GetQuarterlyActivityCombined`, `GetMostHeldCombined`, `GetQuarterlyNewSoldOutPositionsCombined`, `GetDoubleDownPositionsCombined`, `GetUniqueFilerIdsCombined`
- All date dropdowns (Activity, MostHeld, HeatMap, DoubleDown, Stock Holdings Tab) show "Current Combined" option when the filing window is open

## Code changes

- **`CombinedQuarterHelper.cs`** (new) — static helper with filing window check (45-day deadline)
- **`InstitutionalHoldingRepository.cs`** — 6 new combined-quarter query methods using NOT EXISTS subqueries for holder-level fallback
- **`HoldingsActivityController.cs`** — `combined` param on Activity, MostHeld, HeatMap, DoubleDown actions
- **`StockTabService.cs`** — `LoadHoldingsCombinedTab` now uses `GetCombinedQuarter(current, previous)` instead of `GetLatestByStock`; `IsCombinedAvailable` set in `LoadHoldingsTab`
- **View models** — `IsCombinedAvailable` + `IsCombinedSelected` on all holdings VMs
- **Views** — "Current Combined" option in all date dropdowns, gated by `IsCombinedAvailable`

Refs daniel3303/EquiblesCommercial#637