### PR TITLE
refactor(holdings): extract combined-quarter date selection into shared helper

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -32,22 +32,11 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count == 0)
             return View(viewModel);
 
-        var isCombinedAvailable =
-            reportDates.Count >= 2 && CombinedQuarterHelper.IsFilingWindowOpen(reportDates[0]);
-        viewModel.IsCombinedAvailable = isCombinedAvailable;
-
-        if (combined && isCombinedAvailable)
-        {
-            viewModel.IsCombinedSelected = true;
-            viewModel.SelectedDate = reportDates[0];
-            viewModel.PreviousDate = reportDates[1];
-        }
-        else
-        {
-            var (sel, prev) = ResolveSelectedAndPriorDate(date, reportDates);
-            viewModel.SelectedDate = sel;
-            viewModel.PreviousDate = prev;
-        }
+        var dateSelection = ResolveCombinedDateSelection(date, combined, reportDates);
+        viewModel.IsCombinedAvailable = dateSelection.IsCombinedAvailable;
+        viewModel.IsCombinedSelected = dateSelection.IsCombinedSelected;
+        viewModel.SelectedDate = dateSelection.SelectedDate;
+        viewModel.PreviousDate = dateSelection.PreviousDate;
 
         if (!viewModel.PreviousDate.HasValue)
             return View(viewModel);
@@ -161,21 +150,11 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count < 2)
             return View(viewModel);
 
-        var isCombinedAvailable = CombinedQuarterHelper.IsFilingWindowOpen(reportDates[0]);
-        viewModel.IsCombinedAvailable = isCombinedAvailable;
-
-        if (combined && isCombinedAvailable)
-        {
-            viewModel.IsCombinedSelected = true;
-            viewModel.SelectedDate = reportDates[0];
-            viewModel.PreviousDate = reportDates[1];
-        }
-        else
-        {
-            var (sel, prev) = ResolveSelectedAndPriorDate(date, reportDates);
-            viewModel.SelectedDate = sel;
-            viewModel.PreviousDate = prev;
-        }
+        var dateSelection = ResolveCombinedDateSelection(date, combined, reportDates);
+        viewModel.IsCombinedAvailable = dateSelection.IsCombinedAvailable;
+        viewModel.IsCombinedSelected = dateSelection.IsCombinedSelected;
+        viewModel.SelectedDate = dateSelection.SelectedDate;
+        viewModel.PreviousDate = dateSelection.PreviousDate;
 
         if (!viewModel.PreviousDate.HasValue)
             return View(viewModel);
@@ -251,22 +230,11 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count == 0)
             return View(viewModel);
 
-        var isCombinedAvailable =
-            reportDates.Count >= 2 && CombinedQuarterHelper.IsFilingWindowOpen(reportDates[0]);
-        viewModel.IsCombinedAvailable = isCombinedAvailable;
-
-        if (combined && isCombinedAvailable)
-        {
-            viewModel.IsCombinedSelected = true;
-            viewModel.SelectedDate = reportDates[0];
-            viewModel.PreviousDate = reportDates[1];
-        }
-        else
-        {
-            var (sel, prev) = ResolveSelectedAndPriorDate(date, reportDates);
-            viewModel.SelectedDate = sel;
-            viewModel.PreviousDate = prev;
-        }
+        var dateSelection = ResolveCombinedDateSelection(date, combined, reportDates);
+        viewModel.IsCombinedAvailable = dateSelection.IsCombinedAvailable;
+        viewModel.IsCombinedSelected = dateSelection.IsCombinedSelected;
+        viewModel.SelectedDate = dateSelection.SelectedDate;
+        viewModel.PreviousDate = dateSelection.PreviousDate;
 
         var selectedDate = viewModel.SelectedDate;
         var priorForRepo = viewModel.PreviousDate ?? selectedDate;
@@ -370,21 +338,11 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count < 2)
             return View(viewModel);
 
-        var isCombinedAvailable = CombinedQuarterHelper.IsFilingWindowOpen(reportDates[0]);
-        viewModel.IsCombinedAvailable = isCombinedAvailable;
-
-        if (combined && isCombinedAvailable)
-        {
-            viewModel.IsCombinedSelected = true;
-            viewModel.SelectedDate = reportDates[0];
-            viewModel.PreviousDate = reportDates[1];
-        }
-        else
-        {
-            var (sel, prev) = ResolveSelectedAndPriorDate(date, reportDates);
-            viewModel.SelectedDate = sel;
-            viewModel.PreviousDate = prev;
-        }
+        var dateSelection = ResolveCombinedDateSelection(date, combined, reportDates);
+        viewModel.IsCombinedAvailable = dateSelection.IsCombinedAvailable;
+        viewModel.IsCombinedSelected = dateSelection.IsCombinedSelected;
+        viewModel.SelectedDate = dateSelection.SelectedDate;
+        viewModel.PreviousDate = dateSelection.PreviousDate;
 
         if (!viewModel.PreviousDate.HasValue)
             return View(viewModel);
@@ -480,6 +438,23 @@ public class HoldingsActivityController : BaseController
                 Name = s.Name,
             })
             .ToDictionaryAsync(s => s.Id);
+
+    private static (
+        bool IsCombinedAvailable,
+        bool IsCombinedSelected,
+        DateOnly SelectedDate,
+        DateOnly? PreviousDate
+    ) ResolveCombinedDateSelection(DateOnly? date, bool combined, List<DateOnly> reportDates)
+    {
+        var isCombinedAvailable =
+            reportDates.Count >= 2 && CombinedQuarterHelper.IsFilingWindowOpen(reportDates[0]);
+
+        if (combined && isCombinedAvailable)
+            return (true, true, reportDates[0], reportDates[1]);
+
+        var (sel, prev) = ResolveSelectedAndPriorDate(date, reportDates);
+        return (isCombinedAvailable, false, sel, prev);
+    }
 
     private static (DateOnly Selected, DateOnly? Previous) ResolveSelectedAndPriorDate(
         DateOnly? requested,


### PR DESCRIPTION
## Summary

- The `Activity`, `DoubleDown`, `MostHeld`, and `HeatMap` actions in `HoldingsActivityController` each had a near-identical ~15-line block resolving combined-quarter date selection (checking filing-window availability, choosing combined vs standard dates, falling back to user-requested date).
- Collapsed all four instances into a single `ResolveCombinedDateSelection` static helper that returns a tuple of `(IsCombinedAvailable, IsCombinedSelected, SelectedDate, PreviousDate)`.
- Net result: -62 lines, +37 lines (including the new helper).

## Code changes

- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — Added `ResolveCombinedDateSelection` private static helper; replaced four inline combined-quarter resolution blocks with calls to it. No behavioral change — the helper computes identical values.