### PR TITLE
refactor(worker): add BatchPersister overload for standard repository flush

### DIFF
--- a/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
+++ b/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
@@ -1,7 +1,6 @@
 using Equibles.Cboe.Data.Models;
 using Equibles.Cboe.Repositories;
 using Equibles.Core.AutoWiring;
-using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Cboe.Contracts;
@@ -118,7 +117,10 @@ public class CboeImportService
             return;
         }
 
-        var totalInserted = await BatchPersister.Persist(
+        var totalInserted = await BatchPersister.Persist<
+            CboePutCallRatio,
+            CboePutCallRatioRepository
+        >(
             newRecords.Select(r => new CboePutCallRatio
             {
                 RatioType = ratioType,
@@ -129,7 +131,7 @@ public class CboeImportService
                 PutCallRatio = r.PutCallRatio,
             }),
             InsertBatchSize,
-            FlushBatch<CboePutCallRatio, CboePutCallRatioRepository>
+            _scopeFactory
         );
 
         _logger.LogInformation(
@@ -168,7 +170,7 @@ public class CboeImportService
                 return;
             }
 
-            var totalInserted = await BatchPersister.Persist(
+            var totalInserted = await BatchPersister.Persist<CboeVixDaily, CboeVixDailyRepository>(
                 newRecords.Select(r => new CboeVixDaily
                 {
                     Date = r.Date,
@@ -178,7 +180,7 @@ public class CboeImportService
                     Close = r.Close,
                 }),
                 InsertBatchSize,
-                FlushBatch<CboeVixDaily, CboeVixDailyRepository>
+                _scopeFactory
             );
 
             _logger.LogInformation("CBOE VIX: imported {Count} new daily records", totalInserted);
@@ -197,15 +199,5 @@ public class CboeImportService
                 ex.StackTrace
             );
         }
-    }
-
-    private async Task FlushBatch<TEntity, TRepository>(List<TEntity> items)
-        where TEntity : class
-        where TRepository : BaseRepository<TEntity>
-    {
-        using var scope = _scopeFactory.CreateScope();
-        var repo = scope.ServiceProvider.GetRequiredService<TRepository>();
-        repo.AddRange(items);
-        await repo.SaveChanges();
     }
 }

--- a/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
+++ b/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
@@ -214,11 +214,10 @@ public class CftcImportService
                 .ToHashSet();
         }
 
-        var totalInserted = await BatchPersister.Persist(
-            MapNewReports(),
-            InsertBatchSize,
-            FlushBatch
-        );
+        var totalInserted = await BatchPersister.Persist<
+            CftcPositionReport,
+            CftcPositionReportRepository
+        >(MapNewReports(), InsertBatchSize, _scopeFactory);
 
         if (totalInserted > 0)
         {
@@ -278,14 +277,6 @@ public class CftcImportService
         }
 
         await contractRepo.SaveChanges();
-    }
-
-    private async Task FlushBatch(List<CftcPositionReport> items)
-    {
-        using var scope = _scopeFactory.CreateScope();
-        var repo = scope.ServiceProvider.GetRequiredService<CftcPositionReportRepository>();
-        repo.AddRange(items);
-        await repo.SaveChanges();
     }
 
     private static CftcPositionReport BuildPositionReport(

--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -100,18 +100,10 @@ public class ShortVolumeImportService
 
             var aggregated = AggregateVolumesByStock(records, tickerMap, date);
 
-            var totalInserted = await BatchPersister.Persist(
-                aggregated.Values,
-                InsertBatchSize,
-                async batch =>
-                {
-                    using var scope = _scopeFactory.CreateScope();
-                    var repo =
-                        scope.ServiceProvider.GetRequiredService<DailyShortVolumeRepository>();
-                    repo.AddRange(batch);
-                    await repo.SaveChanges();
-                }
-            );
+            var totalInserted = await BatchPersister.Persist<
+                DailyShortVolume,
+                DailyShortVolumeRepository
+            >(aggregated.Values, InsertBatchSize, _scopeFactory);
 
             _logger.LogInformation(
                 "Imported {Count} short volume records for {Date}",

--- a/src/Equibles.Fred.HostedService/Services/FredImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredImportService.cs
@@ -181,11 +181,10 @@ public class FredImportService
             );
         }
 
-        var totalInserted = await BatchPersister.Persist(
-            observations,
-            InsertBatchSize,
-            FlushObservationBatch
-        );
+        var totalInserted = await BatchPersister.Persist<
+            FredObservation,
+            FredObservationRepository
+        >(observations, InsertBatchSize, _scopeFactory);
 
         await UpdateSeriesMetadata(series.Id, latestObservationDate);
 
@@ -203,14 +202,6 @@ public class FredImportService
             totalInserted,
             curated.SeriesId
         );
-    }
-
-    private async Task FlushObservationBatch(List<FredObservation> batch)
-    {
-        using var scope = _scopeFactory.CreateScope();
-        var repo = scope.ServiceProvider.GetRequiredService<FredObservationRepository>();
-        repo.AddRange(batch);
-        await repo.SaveChanges();
     }
 
     private async Task UpdateSeriesMetadata(Guid seriesId, DateOnly latestObservationDate)

--- a/src/Equibles.Worker/BatchPersister.cs
+++ b/src/Equibles.Worker/BatchPersister.cs
@@ -1,3 +1,6 @@
+using Equibles.Data;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Equibles.Worker;
 
 public static class BatchPersister
@@ -30,5 +33,26 @@ public static class BatchPersister
         }
 
         return totalInserted;
+    }
+
+    public static Task<int> Persist<TEntity, TRepository>(
+        IEnumerable<TEntity> items,
+        int batchSize,
+        IServiceScopeFactory scopeFactory
+    )
+        where TEntity : class
+        where TRepository : BaseRepository<TEntity>
+    {
+        return Persist(
+            items,
+            batchSize,
+            async batch =>
+            {
+                using var scope = scopeFactory.CreateScope();
+                var repo = scope.ServiceProvider.GetRequiredService<TRepository>();
+                repo.AddRange(batch);
+                await repo.SaveChanges();
+            }
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Four import services (Cboe, Cftc, Fred, Finra short volume) each had a near-identical flush delegate: create scope → resolve repository → AddRange → SaveChanges.
- Added a `Persist<TEntity, TRepository>` overload to `BatchPersister` that internalizes this standard pattern, accepting `IServiceScopeFactory` instead of a custom delegate.
- Removed the per-service private `FlushBatch` methods and inline lambdas that duplicated the same logic.

## Code changes

- `src/Equibles.Worker/BatchPersister.cs` — Added `Persist<TEntity, TRepository>(items, batchSize, scopeFactory)` overload that creates a scope, resolves the repository, calls AddRange + SaveChanges per batch.
- `src/Equibles.Cboe.HostedService/Services/CboeImportService.cs` — Replaced two `FlushBatch<T,R>` method-group references with the new overload; removed the generic private `FlushBatch` method.
- `src/Equibles.Cftc.HostedService/Services/CftcImportService.cs` — Replaced `FlushBatch` method-group reference; removed private `FlushBatch` method.
- `src/Equibles.Fred.HostedService/Services/FredImportService.cs` — Replaced `FlushObservationBatch` method-group reference; removed private `FlushObservationBatch` method.
- `src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs` — Replaced inline lambda with the new overload.