### PR TITLE
refactor(screener): replace hand-rolled CSV builder with CsvExportService

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -128,38 +128,43 @@ public class HoldingsScreenerController : BaseController
 
     internal static string BuildCsv(IReadOnlyList<ScreenerRow> rows)
     {
-        var sb = new StringBuilder();
-        sb.AppendLine(
-            "Ticker,Name,Industry,CurrentFilerCount,PreviousFilerCount,DeltaFilerCount,"
-                + "CurrentValue,PreviousValue,DeltaValue,NewFilerCount,SoldOutFilerCount,PercentOfFloat"
-        );
+        string[] headers =
+        [
+            "Ticker",
+            "Name",
+            "Industry",
+            "CurrentFilerCount",
+            "PreviousFilerCount",
+            "DeltaFilerCount",
+            "CurrentValue",
+            "PreviousValue",
+            "DeltaValue",
+            "NewFilerCount",
+            "SoldOutFilerCount",
+            "PercentOfFloat",
+        ];
 
-        void AppendString(string value) =>
-            sb.Append(CsvExportService.EscapeField(value)).Append(',');
-        void AppendNumber(long value) =>
-            sb.Append(value.ToString(CultureInfo.InvariantCulture)).Append(',');
-
-        foreach (var r in rows)
-        {
-            AppendString(r.Ticker);
-            AppendString(r.Name);
-            AppendString(r.IndustryName);
-            AppendNumber(r.CurrentFilerCount);
-            AppendNumber(r.PreviousFilerCount);
-            AppendNumber(r.DeltaFilerCount);
-            AppendNumber(r.CurrentValue);
-            AppendNumber(r.PreviousValue);
-            AppendNumber(r.DeltaValue);
-            AppendNumber(r.NewFilerCount);
-            AppendNumber(r.SoldOutFilerCount);
-            sb.Append(
+        var csvRows = rows.Select(r =>
+            new[]
+            {
+                r.Ticker,
+                r.Name,
+                r.IndustryName,
+                CsvExportService.Format(r.CurrentFilerCount),
+                CsvExportService.Format(r.PreviousFilerCount),
+                CsvExportService.Format(r.DeltaFilerCount),
+                CsvExportService.Format(r.CurrentValue),
+                CsvExportService.Format(r.PreviousValue),
+                CsvExportService.Format(r.DeltaValue),
+                CsvExportService.Format(r.NewFilerCount),
+                CsvExportService.Format(r.SoldOutFilerCount),
                 r.PercentOfFloat.HasValue
                     ? r.PercentOfFloat.Value.ToString("F4", CultureInfo.InvariantCulture)
-                    : string.Empty
-            );
-            sb.AppendLine();
-        }
-        return sb.ToString();
+                    : string.Empty,
+            }
+        );
+
+        return CsvExportService.BuildCsv(headers, csvRows);
     }
 
     // Loads available report dates desc and resolves the selected/comparison dates from


### PR DESCRIPTION
## Summary

- `HoldingsScreenerController.BuildCsv` manually built CSV output with `StringBuilder` + local helper functions, duplicating the structure that `CsvExportService.BuildCsv` already provides.
- Replaced the hand-rolled loop with a call to `CsvExportService.BuildCsv`, matching the pattern used by all other CSV exports in the project (`HoldingsExportController`).
- Per-field formatting (InvariantCulture numbers, F4 PercentOfFloat) is preserved exactly.

## Code changes

- `src/Equibles.Web/Controllers/HoldingsScreenerController.cs` — Replaced the manual `StringBuilder` CSV loop with `CsvExportService.BuildCsv(headers, rows)`. Removed the `AppendString`/`AppendNumber` local functions. Kept the same field order, same number formatting, and same nullable-percent handling.