### PR TITLE
fix(ci): add Node.js setup and Vite build to functional test workflow

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -27,6 +27,16 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: src/Equibles.Web/package-lock.json
+
+      - name: Build frontend assets
+        working-directory: src/Equibles.Web
+        run: npm ci && npm run build
+
       - name: Restore
         run: dotnet restore Equibles.sln
 


### PR DESCRIPTION
## Summary

- Since `714e0b3` removed `wwwroot/dist/` from version control, the functional test workflow has no frontend assets (chart.js, bundle.js, main.css) — causing `HoldingsTrendsSeededTests` to time out waiting for Chart.js initialization on every CI run.
- Adds `actions/setup-node@v4` and an `npm ci && npm run build` step before the .NET build so Vite produces the dist bundles.

## Code changes

- `.github/workflows/functional.yml` — added Node.js 20 setup (with npm cache) and a `Build frontend assets` step using the same commands as the Dockerfile.