### PR TITLE
test(sec): add skipped repro for GH-2104 — NormalizeCompanyName Roman numeral false positive

### DIFF
--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameRomanNumeralFalsePositiveTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameRomanNumeralFalsePositiveTests.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Contract: NormalizeCompanyName title-cases ALL-CAPS names, preserving only
+/// real abbreviations (LLC, LP, …) and Roman numerals (I, II, III, IV, …) in
+/// uppercase. The Roman numeral regex matches any string that decomposes into
+/// valid Roman digits — including common English words like "MIX" (1009),
+/// "DIV" (504), and "LIV" (54). These are not numerals in a company-name
+/// context and should be title-cased normally.
+/// </summary>
+public class CompanySyncServiceNormalizeCompanyNameRomanNumeralFalsePositiveTests
+{
+    private static readonly MethodInfo NormalizeMethod = typeof(CompanySyncService).GetMethod(
+        "NormalizeCompanyName",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    private static string Normalize(string name) => (string)NormalizeMethod.Invoke(null, [name]);
+
+    [Fact(Skip = "GH-2104 — Roman numeral regex matches English words like MIX (1009)")]
+    public void AllCapsName_MixIsEnglishWord_NotRomanNumeral1009()
+    {
+        var result = Normalize("QUICK MIX CORP");
+
+        result.Should().Be("Quick Mix Corp");
+    }
+}


### PR DESCRIPTION
## Summary

- `NormalizeCompanyName` incorrectly keeps common English words like "MIX" uppercase because the Roman numeral regex matches them as valid numerals (MIX = 1009, DIV = 504, LIV = 54).
- Adds a skipped adversarial test that asserts the expected title-case behavior — see GH-2104.

## Code changes

- `tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameRomanNumeralFalsePositiveTests.cs` — new `[Fact(Skip)]` test asserting `"QUICK MIX CORP"` normalizes to `"Quick Mix Corp"` (currently produces `"Quick MIX Corp"`).