### PR TITLE
test(web): add skipped repro for GH-2108 — SafeRound decimal boundary

### DIFF
--- a/tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundDecimalMaxValueBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundDecimalMaxValueBoundaryTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+/// <summary>
+/// (double)decimal.MaxValue rounds up to 2^96 (decimal.MaxValue + 1) because
+/// double can't represent 2^96 - 1 exactly. The guard uses strict '>' so
+/// the boundary value passes through to the (decimal) cast, which throws
+/// OverflowException — the exact failure mode SafeRound exists to prevent.
+/// </summary>
+public class StatisticsExtensionsSafeRoundDecimalMaxValueBoundaryTests
+{
+    [Fact(Skip = "GH-2108 — strict > guard misses (double)decimal.MaxValue boundary")]
+    public void SafeRound_DoubleDecimalMaxValue_ReturnsNullInsteadOfThrowing()
+    {
+        var value = (double)decimal.MaxValue;
+
+        var result = value.SafeRound(2);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- `StatisticsExtensions.SafeRound` uses strict `>` / `<` guards against `(double)decimal.MaxValue` / `MinValue`, but the double representation of those boundaries rounds past the decimal range. The guard lets the boundary through, and the `(decimal)` cast throws `OverflowException`.
- Adds a skipped adversarial test — skipped, see GH-2108.

## Code changes

- `tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundDecimalMaxValueBoundaryTests.cs` — new `[Fact(Skip)]` test asserting `((double)decimal.MaxValue).SafeRound(2)` returns `null` (currently throws `OverflowException`).