### PR TITLE
fix(holdings): aggregate cross-batch holdings at the accession boundary (closes #2110)

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -19,9 +19,6 @@ namespace Equibles.Holdings.HostedService.Services;
 [Service]
 public class HoldingsImportService
 {
-    private const int InsertBatchSize = 1000;
-    private const int MaxConsecutiveEmptyBatches = 5;
-
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<HoldingsImportService> _logger;
     private readonly WorkerOptions _workerOptions;
@@ -578,13 +575,32 @@ public class HoldingsImportService
         var totalSkipped = 0;
         var totalDuplicates = 0;
         var totalPending = 0;
-        var consecutiveEmptyBatches = 0;
+        string currentAccession = null;
 
         await foreach (var row in context.TsvParser.ParseEntry(infoTableEntry))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var accession = GetValue(row, "ACCESSION_NUMBER");
+
+            // Flush at the accession boundary, not at a fixed row count. Every
+            // row sharing an upsert key inside one filing lives in that filing's
+            // INFOTABLE section (a holder splits a position across otherManager
+            // codes so the same security can appear several times with rows
+            // scattered hundreds apart). FlushBatch's WhenMatched clause
+            // REPLACES — so if a key's rows fall in different flushes, only
+            // the last one's sum survives. SEC orders the bulk INFOTABLE by
+            // INFOTABLE_SK and the realtime archive by XML element order, so
+            // a single accession's rows are always contiguous; flushing only
+            // when the accession changes guarantees in-memory aggregation
+            // finishes before any UPSERT for that key runs.
+            if (currentAccession != null && accession != currentAccession && holdingsMap.Count > 0)
+            {
+                totalInserted += await FlushBatch(holdingsMap.Values.ToList(), cancellationToken);
+                holdingsMap.Clear();
+            }
+            currentAccession = accession;
+
             if (!context.Submissions.TryGetValue(accession, out var submission))
                 continue;
 
@@ -631,36 +647,11 @@ public class HoldingsImportService
                 holding.ManagerEntries.Add(managerEntry);
                 holdingsMap[uniqueKey] = holding;
             }
-
-            if (holdingsMap.Count >= InsertBatchSize)
-            {
-                var inserted = await FlushBatch(holdingsMap.Values.ToList(), cancellationToken);
-                totalInserted += inserted;
-                holdingsMap.Clear();
-
-                if (inserted == 0)
-                {
-                    consecutiveEmptyBatches++;
-                    if (consecutiveEmptyBatches >= MaxConsecutiveEmptyBatches)
-                    {
-                        _logger.LogInformation(
-                            "Stopping early: {Count} consecutive batches had no new holdings — data set appears fully imported",
-                            consecutiveEmptyBatches
-                        );
-                        break;
-                    }
-                }
-                else
-                {
-                    consecutiveEmptyBatches = 0;
-                }
-            }
         }
 
         if (holdingsMap.Count > 0)
         {
-            var inserted = await FlushBatch(holdingsMap.Values.ToList(), cancellationToken);
-            totalInserted += inserted;
+            totalInserted += await FlushBatch(holdingsMap.Values.ToList(), cancellationToken);
             holdingsMap.Clear();
         }
 

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceBatchFlushAggregationTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceBatchFlushAggregationTests.cs
@@ -1,0 +1,215 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// GH-2110 — when a single 13F-HR carries multiple INFOTABLE rows for the same
+/// (holder, stock, period, share-type, option-type) tuple (typical for large
+/// filers that split a position across <c>otherManager</c> codes) and those
+/// rows are scattered far enough apart in the file to span the in-memory flush
+/// boundary (<c>StreamAndInsertHoldings</c>'s <c>InsertBatchSize = 1000</c>
+/// unique keys), only the LAST batch's slice survives.
+///
+/// In-batch aggregation in <c>holdingsMap</c> is correct, but the
+/// <c>FlushBatch</c> upsert's <c>WhenMatched</c> clause overwrites the
+/// persisted row rather than accumulating, so a key that already flushed in an
+/// earlier batch gets its prior sum silently replaced.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsImportServiceBatchFlushAggregationTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesDbContext> _contexts = [];
+    private readonly CultureInfo _previousCulture;
+
+    public HoldingsImportServiceBatchFlushAggregationTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+        _previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        CultureInfo.CurrentCulture = _previousCulture;
+        return Task.CompletedTask;
+    }
+
+    private EquiblesDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesDbContext)).Returns(ctx);
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(InstitutionalHolderRepository))
+                    .Returns(new InstitutionalHolderRepository(ctx));
+                sp.GetService(typeof(InstitutionalHoldingRepository))
+                    .Returns(new InstitutionalHoldingRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    private HoldingsImportService CreateImporter(IStockPriceProvider priceProvider) =>
+        new(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            priceProvider
+        );
+
+    private static ZipArchive BuildArchive(params (string Name, string Body)[] entries)
+    {
+        var buffer = new MemoryStream();
+        using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, body) in entries)
+            {
+                var entry = writer.CreateEntry(name);
+                using var stream = entry.Open();
+                var bytes = Encoding.UTF8.GetBytes(body);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+        buffer.Position = 0;
+        return new ZipArchive(buffer, ZipArchiveMode.Read);
+    }
+
+    private static IStockPriceProvider PriceProviderReturning(
+        Dictionary<(Guid, DateOnly), decimal> prices
+    )
+    {
+        var provider = Substitute.For<IStockPriceProvider>();
+        provider
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(prices));
+        return provider;
+    }
+
+    [Fact(
+        Skip = "GH-2110 — cross-batch entries for the same upsert key get replaced instead of accumulated"
+    )]
+    public async Task ImportDataSet_SameKeyAcrossBatchBoundary_AccumulatesSharesNotReplaces()
+    {
+        // The flush triggers at 1000 unique keys in holdingsMap. To force the
+        // two AAPL rows into different batches: row 1 = AAPL (key #1), rows
+        // 2..1000 = 999 unique padding CUSIPs (keys #2..#1000) which trips the
+        // flush after row 1000, row 1001 = AAPL again — now in a fresh batch.
+        const int paddingCount = 999;
+
+        var apple = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+            Cusip = "037833100",
+        };
+        var padding = Enumerable
+            .Range(0, paddingCount)
+            .Select(i => new CommonStock
+            {
+                Id = Guid.NewGuid(),
+                Ticker = $"PAD{i:D4}",
+                Name = $"Padding {i}",
+                Cik = (1000000 + i).ToString("D10", CultureInfo.InvariantCulture),
+                Cusip = $"PAD{i:D6}",
+            })
+            .ToList();
+
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().Add(apple);
+            seed.Set<CommonStock>().AddRange(padding);
+            await seed.SaveChangesAsync();
+        }
+
+        var reportDate = new DateOnly(2025, 12, 31);
+        var prices = new Dictionary<(Guid, DateOnly), decimal> { [(apple.Id, reportDate)] = 250m };
+        foreach (var p in padding)
+            prices[(p.Id, reportDate)] = 1m;
+
+        const string coverHeader =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n";
+        const string infoHeader =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n";
+
+        var info = new StringBuilder(infoHeader);
+        // AAPL #1 — under otherManager 1, 100 shares.
+        info.Append("ACC-MULTI\t037833100\t100\tSH\t\tDEFINED\t0\t0\t100\tCOM\t1\n");
+        // 999 unique padding rows to fill out batch 1.
+        foreach (var p in padding)
+            info.Append($"ACC-MULTI\t{p.Cusip}\t10\tSH\t\tSOLE\t10\t0\t0\tCOM\t\n");
+        // AAPL #2 — under otherManager 2, 200 shares. Same upsert key as AAPL
+        // #1, but lands in batch 2 after the boundary flush + map clear.
+        info.Append("ACC-MULTI\t037833100\t200\tSH\t\tDEFINED\t0\t0\t200\tCOM\t2\n");
+
+        using var archive = BuildArchive(
+            (
+                "SUBMISSION.tsv",
+                "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+                    + "13F-HR\tACC-MULTI\t2026-01-29\t2025-12-31\t0000102909\n"
+            ),
+            (
+                "COVERPAGE.tsv",
+                coverHeader + "ACC-MULTI\tN\tVanguard Group\tMalvern\tPA\t028-06408\t\n"
+            ),
+            ("INFOTABLE.tsv", info.ToString())
+        );
+
+        var sut = CreateImporter(PriceProviderReturning(prices));
+        await sut.ImportDataSet(archive, new DateOnly(2025, 1, 1), CancellationToken.None);
+
+        using var verify = FreshContext();
+        var appleHoldings = await verify
+            .Set<InstitutionalHolding>()
+            .Where(h => h.CommonStockId == apple.Id)
+            .ToListAsync();
+
+        // Both AAPL rows share one upsert key — exactly one persisted row.
+        appleHoldings.Should().ContainSingle();
+        // Bug: only batch 2's 200 shares survives. Expected: 100 + 200 = 300.
+        appleHoldings[0].Shares.Should().Be(300L);
+        appleHoldings[0].Value.Should().Be(75_000L);
+        appleHoldings[0].VotingAuthNone.Should().Be(300L);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceBatchFlushAggregationTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceBatchFlushAggregationTests.cs
@@ -20,17 +20,17 @@ using Xunit;
 namespace Equibles.IntegrationTests.Holdings;
 
 /// <summary>
-/// GH-2110 — when a single 13F-HR carries multiple INFOTABLE rows for the same
-/// (holder, stock, period, share-type, option-type) tuple (typical for large
-/// filers that split a position across <c>otherManager</c> codes) and those
-/// rows are scattered far enough apart in the file to span the in-memory flush
-/// boundary (<c>StreamAndInsertHoldings</c>'s <c>InsertBatchSize = 1000</c>
-/// unique keys), only the LAST batch's slice survives.
-///
-/// In-batch aggregation in <c>holdingsMap</c> is correct, but the
-/// <c>FlushBatch</c> upsert's <c>WhenMatched</c> clause overwrites the
-/// persisted row rather than accumulating, so a key that already flushed in an
-/// earlier batch gets its prior sum silently replaced.
+/// Regression for GH-2110. A single 13F-HR can carry many INFOTABLE rows for
+/// the same (holder, stock, period, share-type, option-type) tuple — large
+/// filers split a position across <c>otherManager</c> codes and the matching
+/// rows end up scattered hundreds apart in the filing. Previously
+/// <c>StreamAndInsertHoldings</c> flushed every 1000 keys then reset the
+/// in-memory aggregator, and <c>FlushBatch</c>'s <c>WhenMatched</c> clause
+/// REPLACED the persisted row, so only the last flush's slice survived. The
+/// fix flushes at the accession boundary instead, keeping every row of one
+/// filing in the same aggregator before any UPSERT runs. This test pins that
+/// behaviour by interleaving the two same-key rows with enough other tracked
+/// rows that any return to row-count batching would re-trigger the bug.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class HoldingsImportServiceBatchFlushAggregationTests : IAsyncLifetime
@@ -125,15 +125,14 @@ public class HoldingsImportServiceBatchFlushAggregationTests : IAsyncLifetime
         return provider;
     }
 
-    [Fact(
-        Skip = "GH-2110 — cross-batch entries for the same upsert key get replaced instead of accumulated"
-    )]
+    [Fact]
     public async Task ImportDataSet_SameKeyAcrossBatchBoundary_AccumulatesSharesNotReplaces()
     {
-        // The flush triggers at 1000 unique keys in holdingsMap. To force the
-        // two AAPL rows into different batches: row 1 = AAPL (key #1), rows
-        // 2..1000 = 999 unique padding CUSIPs (keys #2..#1000) which trips the
-        // flush after row 1000, row 1001 = AAPL again — now in a fresh batch.
+        // Spacing the two AAPL rows with 999 unique padding CUSIPs reproduces
+        // the original failure: under the old InsertBatchSize=1000 logic the
+        // second AAPL row landed in a fresh batch and the upsert replaced the
+        // first batch's 100 shares. The accession-boundary flush keeps both
+        // rows aggregated regardless of how far apart they sit.
         const int paddingCount = 999;
 
         var apple = new CommonStock
@@ -174,13 +173,13 @@ public class HoldingsImportServiceBatchFlushAggregationTests : IAsyncLifetime
             "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n";
 
         var info = new StringBuilder(infoHeader);
-        // AAPL #1 — under otherManager 1, 100 shares.
+        // AAPL under otherManager 1, 100 shares.
         info.Append("ACC-MULTI\t037833100\t100\tSH\t\tDEFINED\t0\t0\t100\tCOM\t1\n");
-        // 999 unique padding rows to fill out batch 1.
+        // 999 unique padding rows separating the two AAPL rows.
         foreach (var p in padding)
             info.Append($"ACC-MULTI\t{p.Cusip}\t10\tSH\t\tSOLE\t10\t0\t0\tCOM\t\n");
-        // AAPL #2 — under otherManager 2, 200 shares. Same upsert key as AAPL
-        // #1, but lands in batch 2 after the boundary flush + map clear.
+        // AAPL under otherManager 2, 200 shares. Same upsert key as the
+        // first AAPL row but rows apart from it in the INFOTABLE stream.
         info.Append("ACC-MULTI\t037833100\t200\tSH\t\tDEFINED\t0\t0\t200\tCOM\t2\n");
 
         using var archive = BuildArchive(
@@ -207,7 +206,8 @@ public class HoldingsImportServiceBatchFlushAggregationTests : IAsyncLifetime
 
         // Both AAPL rows share one upsert key — exactly one persisted row.
         appleHoldings.Should().ContainSingle();
-        // Bug: only batch 2's 200 shares survives. Expected: 100 + 200 = 300.
+        // 100 + 200 across both otherManager codes. Pre-fix the persisted
+        // row was 200 because the second row's batch replaced the first's.
         appleHoldings[0].Shares.Should().Be(300L);
         appleHoldings[0].Value.Should().Be(75_000L);
         appleHoldings[0].VotingAuthNone.Should().Be(300L);


### PR DESCRIPTION
## Summary

`StreamAndInsertHoldings` was flushing every 1000 unique keys and clearing the in-memory aggregator. `FlushBatch`'s `WhenMatched` clause REPLACES the persisted row, so when a filer split a position across `otherManager` codes and the matching rows sat hundreds apart in the INFOTABLE, only the LAST batch's slice survived. Vanguard Group Inc's Q4 2025 13F has seven APPLE INC rows scattered across the 17,686-row filing — the imported AAPL position came out as 39M shares instead of 1.43B.

This PR flushes at the accession boundary instead. SEC orders both the quarterly bulk INFOTABLE (by `INFOTABLE_SK`) and the realtime archive (by XML element order) so a single filing's rows are always contiguous; the accession boundary is the natural batch boundary and guarantees every row of one filing reaches the same `FlushBatch` call before any UPSERT runs. No row-count threshold remains — memory is bounded by one filing's unique-key count (low thousands at most for the largest filers).

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — replace the `InsertBatchSize`-based flush with an `ACCESSION_NUMBER` change detector. Drops the `InsertBatchSize` / `MaxConsecutiveEmptyBatches` constants and the dead `consecutiveEmptyBatches` early-stop branch (`FlushBatch` always returned the input row count, so the `inserted == 0` path was unreachable).
- `tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceBatchFlushAggregationTests.cs` — added as a skipped repro pinning the bug; this PR un-skips it now that the fix is in place. Builds a single accession with two AAPL rows separated by 999 unique padding CUSIPs and asserts the persisted row sums to 300 shares (pre-fix: 200, only the second flush survived).

Closes #2110.

Full Holdings integration suite (250 tests) passes locally.