### PR TITLE
refactor(holdings): push descending sort into GetAvailableReportDates

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -566,11 +566,7 @@ public class InstitutionalHoldingsTools
         string Error
     )> ResolveMarketActivityDates(string reportDate)
     {
-        var reportDates = await _holdingRepository
-            .GetAvailableReportDates()
-            .Distinct()
-            .OrderByDescending(d => d)
-            .ToListAsync();
+        var reportDates = await _holdingRepository.GetAvailableReportDates().ToListAsync();
         if (reportDates.Count == 0)
             return (default, default, "No 13F holdings data available.");
 

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -53,9 +53,10 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         return GetAll().Where(h => h.InstitutionalHolderId == holder.Id);
     }
 
+    // Latest dates first — callers consistently treat index 0 as the newest filing window.
     public IQueryable<DateOnly> GetAvailableReportDates()
     {
-        return GetAll().Select(h => h.ReportDate).Distinct();
+        return GetAll().Select(h => h.ReportDate).Distinct().OrderByDescending(d => d);
     }
 
     public IQueryable<InstitutionalHolding> GetByAccessionNumber(string accessionNumber)

--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -425,7 +425,7 @@ public class HoldingsActivityController : BaseController
     }
 
     private Task<List<DateOnly>> LoadAvailableReportDates() =>
-        _holdingRepository.GetAvailableReportDates().OrderByDescending(d => d).ToListAsync();
+        _holdingRepository.GetAvailableReportDates().ToListAsync();
 
     private Task<Dictionary<Guid, StockLabel>> LoadStockLabels(List<Guid> stockIds) =>
         _commonStockRepository

--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -165,10 +165,7 @@ public class HoldingsExportController : BaseController
     [HttpGet("~/holdings/export/activity")]
     public async Task<IActionResult> Activity(DateOnly? date)
     {
-        var reportDates = await _holdingRepository
-            .GetAvailableReportDates()
-            .OrderByDescending(d => d)
-            .ToListAsync();
+        var reportDates = await _holdingRepository.GetAvailableReportDates().ToListAsync();
         if (reportDates.Count < 2)
             return NotFound();
 

--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -176,10 +176,7 @@ public class HoldingsScreenerController : BaseController
         DateOnly? Comparison
     )> ResolveScreenerDates(DateOnly? date, DateOnly? compareDate)
     {
-        var reportDates = await _holdingRepository
-            .GetAvailableReportDates()
-            .OrderByDescending(d => d)
-            .ToListAsync();
+        var reportDates = await _holdingRepository.GetAvailableReportDates().ToListAsync();
         if (reportDates.Count < 2)
             return (reportDates, null, null);
         var selected =


### PR DESCRIPTION
## Summary

- Four callers of `InstitutionalHoldingRepository.GetAvailableReportDates` each appended `.OrderByDescending(d => d)` immediately after the call, and the MCP caller also re-applied `.Distinct()` over an already-distinct query. Pulling the descending sort into the repository removes that duplication and prevents the next caller from forgetting it — every consumer treats index `0` as the newest filing window.
- Behavior-preserving: every caller continues to receive the same ordered list, and the only repository test (`HoldingsRepositoryTests.GetAvailableReportDates_*`) uses order-insensitive `BeEquivalentTo`.

## Code changes

- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — `GetAvailableReportDates` now appends `OrderByDescending(d => d)` and a one-line comment explains why.
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — drop the now-redundant `.OrderByDescending(d => d)` in `LoadAvailableReportDates`.
- `src/Equibles.Web/Controllers/HoldingsScreenerController.cs` — drop the redundant sort in `ResolveScreenerDates`.
- `src/Equibles.Web/Controllers/HoldingsExportController.cs` — drop the redundant sort in `Activity`.
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — drop the redundant `.Distinct().OrderByDescending(d => d)` in `ResolveMarketActivityDates`.