### PR TITLE
fix(web): catch decimal.MaxValue boundary in SafeRound guard

### DIFF
--- a/src/Equibles.Web/Extensions/StatisticsExtensions.cs
+++ b/src/Equibles.Web/Extensions/StatisticsExtensions.cs
@@ -12,8 +12,8 @@ public static class StatisticsExtensions
     {
         if (
             !double.IsFinite(value)
-            || value > (double)decimal.MaxValue
-            || value < (double)decimal.MinValue
+            || value >= (double)decimal.MaxValue
+            || value <= (double)decimal.MinValue
         )
             return null;
         return (decimal?)Math.Round(value, digits);

--- a/tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundDecimalMaxValueBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundDecimalMaxValueBoundaryTests.cs
@@ -10,7 +10,7 @@ namespace Equibles.UnitTests.Web;
 /// </summary>
 public class StatisticsExtensionsSafeRoundDecimalMaxValueBoundaryTests
 {
-    [Fact(Skip = "GH-2108 — strict > guard misses (double)decimal.MaxValue boundary")]
+    [Fact]
     public void SafeRound_DoubleDecimalMaxValue_ReturnsNullInsteadOfThrowing()
     {
         var value = (double)decimal.MaxValue;


### PR DESCRIPTION
## Summary

- `(double)decimal.MaxValue` rounds up to `2^96` (decimal.MaxValue + 1) because double can't represent `2^96 - 1` exactly, so the strict `>` guard let the boundary value through to the `(decimal)` cast — which threw `OverflowException`, the exact failure mode `SafeRound` exists to prevent.
- Switch the boundary comparisons to `>=` / `<=` and un-skip the regression test added in #2109.

## Code changes

- `src/Equibles.Web/Extensions/StatisticsExtensions.cs` — change `>` to `>=` and `<` to `<=` in the `(double)decimal.MaxValue` / `MinValue` guards.
- `tests/Equibles.UnitTests/Web/StatisticsExtensionsSafeRoundDecimalMaxValueBoundaryTests.cs` — drop the `Skip = "..."` on the regression test so it runs.

Closes #2108