### PR TITLE
refactor(mcp): extract repeated stock-not-found message into McpToolExecutor.StockNotFound

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -62,7 +62,7 @@ public class CongressTools
                     ticker.Trim().ToUpperInvariant()
                 );
                 if (stock == null)
-                    return $"Stock '{ticker}' not found.";
+                    return McpToolExecutor.StockNotFound(ticker);
 
                 var start = McpToolExecutor.ParseDateOr(
                     startDate,

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -243,7 +243,7 @@ public class ShortDataTools
     {
         var stock = await _commonStockRepository.GetByTicker(ticker.Trim().ToUpperInvariant());
         if (stock == null)
-            return (null, $"Stock '{ticker}' not found.");
+            return (null, McpToolExecutor.StockNotFound(ticker));
         return (stock, null);
     }
 }

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1291,7 +1291,7 @@ public class InstitutionalHoldingsTools
     {
         var stock = await _commonStockRepository.GetByTicker(ticker);
         if (stock == null)
-            return (null, $"Stock '{ticker}' not found.");
+            return (null, McpToolExecutor.StockNotFound(ticker));
         return (stock, null);
     }
 

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -224,7 +224,7 @@ public class InsiderTradingTools
     {
         var stock = await _commonStockRepository.GetByTicker(ticker);
         if (stock == null)
-            return (null, $"Stock '{ticker}' not found.");
+            return (null, McpToolExecutor.StockNotFound(ticker));
         return (stock, null);
     }
 }

--- a/src/Equibles.Mcp/McpToolExecutor.cs
+++ b/src/Equibles.Mcp/McpToolExecutor.cs
@@ -7,6 +7,8 @@ public static class McpToolExecutor
     public static DateOnly ParseDateOr(string text, DateOnly fallback) =>
         !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 
+    public static string StockNotFound(string ticker) => $"Stock '{ticker}' not found.";
+
     public static async Task<string> Execute(
         Func<Task<string>> action,
         ILogger logger,

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -87,7 +87,7 @@ public class FinancialFactsTools
                     ticker.Trim().ToUpperInvariant()
                 );
                 if (stock == null)
-                    return $"Stock '{ticker}' not found.";
+                    return McpToolExecutor.StockNotFound(ticker);
 
                 if (!FinancialConceptAliases.TryResolve(concept, out var conceptRefs))
                     return $"Unknown concept '{concept}'. {SupportedAliasesNote()}";

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -76,7 +76,7 @@ public class FinancialStatementTools
                     ticker.Trim().ToUpperInvariant()
                 );
                 if (stock == null)
-                    return $"Stock '{ticker}' not found.";
+                    return McpToolExecutor.StockNotFound(ticker);
 
                 if (!TryParseStatement(statement, out var statementType))
                     return $"Unknown statement '{statement}'. Use 'income', 'balance', or 'cashflow'.";

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -55,7 +55,7 @@ public class FailToDeliverTools
                     ticker.Trim().ToUpperInvariant()
                 );
                 if (stock == null)
-                    return $"Stock '{ticker}' not found.";
+                    return McpToolExecutor.StockNotFound(ticker);
 
                 var start = McpToolExecutor.ParseDateOr(
                     startDate,

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -55,7 +55,7 @@ public class StockPriceTools
             {
                 var stock = await FindStockByTicker(ticker);
                 if (stock == null)
-                    return $"Stock '{ticker}' not found.";
+                    return McpToolExecutor.StockNotFound(ticker);
 
                 var start = McpToolExecutor.ParseDateOr(
                     startDate,
@@ -353,7 +353,7 @@ public class StockPriceTools
     {
         var stock = await FindStockByTicker(ticker);
         if (stock == null)
-            return (null, null, $"Stock '{ticker}' not found.");
+            return (null, null, McpToolExecutor.StockNotFound(ticker));
 
         var start = McpToolExecutor.ParseDateOr(
             startDate,


### PR DESCRIPTION
## Summary

- Nine MCP tool callsites across eight files emitted the same `\$\"Stock '{ticker}' not found.\"` literal. Folding it into a shared `McpToolExecutor.StockNotFound` helper matches the existing `McpToolExecutor.ParseDateOr` pattern and removes the literal duplication.
- Behaviour is byte-identical — existing integration tests (`InsiderTradingToolsTests`, `ShortDataToolsTests`, `StockPriceTools*Tests`, `FinancialFactsToolsTests`, `FinancialStatementToolsTests`) assert on the same string and continue to pass.

## Code changes

- `src/Equibles.Mcp/McpToolExecutor.cs` — new `StockNotFound(string ticker)` helper alongside the existing `ParseDateOr`.
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs`, `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs`, `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — `(null, McpToolExecutor.StockNotFound(ticker))` inside each module's private `ResolveStockByTicker` helper.
- `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs`, `src/Equibles.Congress.Mcp/Tools/CongressTools.cs`, `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs`, `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs` — inline `return McpToolExecutor.StockNotFound(ticker);` in tools that fail fast inline.
- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — same swap at both callsites (the direct-return arm and the `(null, null, …)` tuple arm).