### PR TITLE
fix(sec): trim ParseBool input so whitespace-padded SEC values are truthy

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -482,7 +482,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
     internal static bool ParseBool(string value)
     {
-        return value is "1" or "true" or "True" or "TRUE";
+        return value?.Trim() is "1" or "true" or "True" or "TRUE";
     }
 
     internal static long ParseLong(string value)

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseBoolWhitespacePaddedTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseBoolWhitespacePaddedTests.cs
@@ -21,7 +21,7 @@ public class InsiderTradingFilingProcessorParseBoolWhitespacePaddedTests
 
     private static bool ParseBool(string value) => (bool)ParseBoolMethod.Invoke(null, [value]);
 
-    [Fact(Skip = "GH-2106 — ParseBool exact-match drops whitespace-padded truthy values")]
+    [Fact]
     public void ParseBool_WhitespacePaddedOne_ReturnsTrue()
     {
         var result = ParseBool(" 1 ");


### PR DESCRIPTION
## Summary

- Callers feed `InsiderTradingFilingProcessor.ParseBool` with `XElement.Value` directly. Malformed SEC filings preserve insignificant whitespace around boolean text (e.g. `<isDirector> 1 </isDirector>`), and the exact-match pattern silently returned `false` — dropping `isDirector`/`isOfficer`/`isTenPercentOwner` flags on insider owners.
- Trim before the pattern match (`value?.Trim() is "1" or "true" or "True" or "TRUE"`) and un-skip the regression test from #2107.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — `ParseBool` now matches on `value?.Trim()` so whitespace-padded truthy values resolve to `true`. Null in still resolves to `false`.
- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseBoolWhitespacePaddedTests.cs` — drop the `Skip = "..."` on the GH-2106 regression test so it runs.

Closes #2106