### PR TITLE
test(sec/mcp): add skipped repro for GH-2118 — RagSearchTools.ParseDocumentType EarningsCallTranscript

### DIFF
--- a/tests/Equibles.UnitTests/Sec/RagSearchToolsParseDocumentTypeEarningsCallTranscriptTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RagSearchToolsParseDocumentTypeEarningsCallTranscriptTests.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class RagSearchToolsParseDocumentTypeEarningsCallTranscriptTests
+{
+    [Fact(
+        Skip = "GH-2118 — ParseDocumentType rejects 'EarningsCallTranscript' advertised by the MCP tool description"
+    )]
+    public void ParseDocumentType_EarningsCallTranscriptFromMcpDescription_ResolvesToKnownDocumentType()
+    {
+        // RagSearchTools.DocumentTypeDescription is the [Description] attribute the
+        // MCP framework hands to the LLM as the contract for the `documentType`
+        // argument on SearchDocuments / SearchCompanyDocuments / SearchDocument /
+        // ListCompanyDocuments. It enumerates the allowed values verbatim:
+        //   "Document type filter. Allowed values: 'TenK', 'TenQ', 'EightK',
+        //    'TenKa', 'TenQa', 'EightKa', 'TwentyF', 'SixK', 'FortyF',
+        //    'EarningsCallTranscript'"
+        //
+        // ParseDocumentType is what consumes that argument. Every value listed in
+        // the description must round-trip through ParseDocumentType to a non-null
+        // DocumentType — otherwise the LLM follows the documented contract and the
+        // server silently drops the filter (null parsedType = no document-type
+        // filter), returning results from every filing type instead.
+        //
+        // Pin the contract on "EarningsCallTranscript" — there is no defined
+        // DocumentType for it, so the description and the parser disagree.
+        var method = typeof(RagSearchTools).GetMethod(
+            "ParseDocumentType",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (DocumentType)method.Invoke(null, ["EarningsCallTranscript"]);
+
+        result
+            .Should()
+            .NotBeNull(
+                "the MCP tool description advertises 'EarningsCallTranscript' as an allowed value"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Lane A finding: the `documentType` MCP argument description on `SearchDocuments` / `SearchCompanyDocuments` / `SearchDocument` / `ListCompanyDocuments` lists `EarningsCallTranscript` as an allowed value, but `RagSearchTools.ParseDocumentType` cannot resolve it — there is no matching `DocumentType` static instance.
- An LLM that follows the documented contract silently disables the document-type filter; results come back from every filing type instead of earnings-call transcripts only. No exception, no telemetry.
- Filed as GH-2118. The regression test in this PR is `[Fact(Skip = ...)]` and should be un-skipped as part of the fix (either register the type or drop the value from the description).

## Code changes

- `tests/Equibles.UnitTests/Sec/RagSearchToolsParseDocumentTypeEarningsCallTranscriptTests.cs` — single `[Fact(Skip = ...)]` that reflects into the private static `ParseDocumentType`, asserts the value advertised by the description resolves to a non-null `DocumentType`. Skipped — see GH-2118.