### PR TITLE
test(sec): add skipped repro for GH-2120 — ParseTransactionCode whitespace

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCodeWhitespacePaddedTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCodeWhitespacePaddedTests.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Sibling-contract pin to ParseBool (GH-2106 / PR #2117). Both `ParseBool`
+/// and `ParseTransactionCode` live in `InsiderTradingFilingProcessor`,
+/// both consume raw text extracted from SEC Form 4 XML, and both used
+/// exact-string matching that silently misclassified whitespace-padded
+/// input. ParseBool was fixed to trim. ParseTransactionCode's switch
+/// expression still requires an exact single-letter match, so " P " (with
+/// any insignificant whitespace SEC filings carry — common in malformed
+/// or pretty-printed XML) falls through to `TransactionCode.Other`,
+/// silently misclassifying a Purchase as Other and dropping the trade
+/// from buy/sell aggregations.
+///
+/// The single current caller (`ParseTransaction`) pre-trims, masking the
+/// defect today. The pin guards the helper's own contract so a future
+/// caller reusing it (or a refactor that drops the caller's `.Trim()`)
+/// can't silently regress the same way ParseBool did.
+/// </summary>
+public class InsiderTradingFilingProcessorParseTransactionCodeWhitespacePaddedTests
+{
+    private static readonly MethodInfo ParseTransactionCodeMethod =
+        typeof(InsiderTradingFilingProcessor).GetMethod(
+            "ParseTransactionCode",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static TransactionCode ParseTransactionCode(string code) =>
+        (TransactionCode)ParseTransactionCodeMethod.Invoke(null, [code]);
+
+    [Fact(
+        Skip = "GH-2120 — ParseTransactionCode exact-match misclassifies whitespace-padded codes as Other"
+    )]
+    public void ParseTransactionCode_WhitespacePaddedCode_ResolvesToCorrespondingCode()
+    {
+        var result = ParseTransactionCode(" P ");
+
+        result.Should().Be(TransactionCode.Purchase);
+    }
+}


### PR DESCRIPTION
## Summary

- Mirrors GH-2106's repro shape against `ParseTransactionCode`, the sibling parser a few lines below `ParseBool` in `InsiderTradingFilingProcessor`.
- `" P "` falls through the exact-match `switch` to `TransactionCode.Other` instead of `Purchase` — silently misclassifying Form 4 transactions if any caller (current or future) skips trimming. The single current production caller pre-trims, masking the defect today; the helper's own contract is still unsafe.
- Skipped until the production helper trims its input — tracked in GH-2120.

## Code changes

- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCodeWhitespacePaddedTests.cs` — new `[Fact(Skip = "GH-2120 — ...")]` asserting `ParseTransactionCode(" P ") == TransactionCode.Purchase`. Uses reflection to reach the `internal static` helper, same pattern as the GH-2106 test that just shipped in PR #2117. Skipped — see GH-2120.

Related: #2120