### PR TITLE
refactor(views): extract repeated empty-table-row markup into EmptyTableRowTagHelper

### DIFF
--- a/src/Equibles.Web/TagHelpers/EmptyTableRowTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/EmptyTableRowTagHelper.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.Web.TagHelpers;
+
+[HtmlTargetElement("empty-row")]
+public class EmptyTableRowTagHelper : TagHelper
+{
+    [HtmlAttributeName("colspan")]
+    public int Colspan { get; set; }
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        output.TagName = "tr";
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.Attributes.Clear();
+        output.PreContent.SetHtmlContent(
+            $"<td colspan=\"{Colspan}\" class=\"text-center py-10 text-base-content/60\">"
+        );
+        output.PostContent.SetHtmlContent("</td>");
+    }
+}

--- a/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
@@ -119,11 +119,9 @@
                                 </tr>
                             }
                             @if (Model.Positions.Count == 0 && Model.PreviousDate.HasValue) {
-                                <tr>
-                                    <td colspan="7" class="text-center py-10 text-base-content/60">
-                                        No positions match the @Model.MinPctIncrease.ToString("F0")%+ threshold for this quarter.
-                                    </td>
-                                </tr>
+                                <empty-row colspan="7">
+                                    No positions match the @Model.MinPctIncrease.ToString("F0")%+ threshold for this quarter.
+                                </empty-row>
                             }
                         </tbody>
                     </table>

--- a/src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml
@@ -58,11 +58,9 @@
                         </tr>
                     }
                     @if (Model.Filings.Count == 0) {
-                        <tr>
-                            <td colspan="8" class="text-center py-10 text-base-content/60">
-                                No 13F filings have been imported yet. The feed populates once the worker finishes its first 13F cycle.
-                            </td>
-                        </tr>
+                        <empty-row colspan="8">
+                            No 13F filings have been imported yet. The feed populates once the worker finishes its first 13F cycle.
+                        </empty-row>
                     }
                 </tbody>
             </table>

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -92,15 +92,13 @@
                         </tr>
                     }
                     @if (Model.Institutions.Count == 0) {
-                        <tr>
-                            <td colspan="7" class="text-center py-10 text-base-content/60">
-                                @if (Model.LatestReportDate.HasValue) {
-                                    <span>No institutions match these filters.</span>
-                                } else {
-                                    <span>No 13F filers have been ingested yet. The Most-Held and per-institution pages light up once the worker finishes its first 13F cycle.</span>
-                                }
-                            </td>
-                        </tr>
+                        <empty-row colspan="7">
+                            @if (Model.LatestReportDate.HasValue) {
+                                <span>No institutions match these filters.</span>
+                            } else {
+                                <span>No 13F filers have been ingested yet. The Most-Held and per-institution pages light up once the worker finishes its first 13F cycle.</span>
+                            }
+                        </empty-row>
                     }
                 </tbody>
             </table>

--- a/src/Equibles.Web/Views/Stocks/Index.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Index.cshtml
@@ -88,11 +88,9 @@
                         </tr>
                     }
                     @if (Model.Stocks.Count == 0) {
-                        <tr>
-                            <td colspan="4" class="text-center py-10 text-base-content/60">
-                                No stocks match these filters.
-                            </td>
-                        </tr>
+                        <empty-row colspan="4">
+                            No stocks match these filters.
+                        </empty-row>
                     }
                 </tbody>
             </table>


### PR DESCRIPTION
## Summary

- Four list views (Stocks, Institutions, HoldingsActivity LatestFilings, HoldingsActivity DoubleDown) each spelled out the same empty-state row: `<tr><td colspan="N" class="text-center py-10 text-base-content/60">…</td></tr>`. Folding it into a new `<empty-row colspan="N">` tag helper centralises the empty-state styling so future visual tweaks land in one place.
- Behaviour-preserving — the tag helper renders identical HTML and existing view-render tests stay green.

## Code changes

- `src/Equibles.Web/TagHelpers/EmptyTableRowTagHelper.cs` — new tag helper that wraps child content in `<tr><td colspan="N" class="text-center py-10 text-base-content/60">…</td></tr>`, matching the existing `CompactNumberTagHelper`/`HeroIconTagHelper` pattern in the same directory.
- `src/Equibles.Web/Views/Institutions/Index.cshtml`, `src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml`, `src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml`, `src/Equibles.Web/Views/Stocks/Index.cshtml` — swap the inline `<tr><td colspan="…" class="…">…</td></tr>` for the new `<empty-row colspan="…">…</empty-row>` element. Inner content (including conditional Razor in `Institutions/Index.cshtml` and `@Model` interpolation in `DoubleDown.cshtml`) is preserved as the tag helper's child content.