### PR TITLE
fix(sec): trim ParseTransactionCode so whitespace-padded codes resolve

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -464,7 +464,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
     internal static TransactionCode ParseTransactionCode(string code)
     {
-        return code?.ToUpperInvariant() switch
+        return code?.Trim().ToUpperInvariant() switch
         {
             "P" => TransactionCode.Purchase,
             "S" => TransactionCode.Sale,

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCodeWhitespacePaddedTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCodeWhitespacePaddedTests.cs
@@ -32,9 +32,7 @@ public class InsiderTradingFilingProcessorParseTransactionCodeWhitespacePaddedTe
     private static TransactionCode ParseTransactionCode(string code) =>
         (TransactionCode)ParseTransactionCodeMethod.Invoke(null, [code]);
 
-    [Fact(
-        Skip = "GH-2120 — ParseTransactionCode exact-match misclassifies whitespace-padded codes as Other"
-    )]
+    [Fact]
     public void ParseTransactionCode_WhitespacePaddedCode_ResolvesToCorrespondingCode()
     {
         var result = ParseTransactionCode(" P ");


### PR DESCRIPTION
## Summary

- Sibling fix to GH-2106 / PR #2117 in the same file. `ParseTransactionCode` switched on `code?.ToUpperInvariant()` with exact single-letter patterns, so any whitespace around the code (e.g. `" P "`) fell through to `TransactionCode.Other` — silently misclassifying Form 4 transactions. Trim before the switch.
- Un-skip the GH-2120 regression test from PR #2121.

## Code changes

- `src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — `ParseTransactionCode` now matches on `code?.Trim().ToUpperInvariant()`. Null in still resolves to `Other` (no `Trim()` invocation on null).
- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCodeWhitespacePaddedTests.cs` — drop `Skip = "..."` so the GH-2120 regression test runs.

Closes #2120