### PR TITLE
test(web): add skipped repro for GH-2123 — ParsePositionTypes undefined numeric input

### DIFF
--- a/tests/Equibles.UnitTests/Web/StocksControllerParsePositionTypesUndefinedNumericTests.cs
+++ b/tests/Equibles.UnitTests/Web/StocksControllerParsePositionTypesUndefinedNumericTests.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using Equibles.Web.Controllers;
+using Equibles.Web.ViewModels.Stocks;
+
+namespace Equibles.UnitTests.Web;
+
+public class StocksControllerParsePositionTypesUndefinedNumericTests
+{
+    [Fact(
+        Skip = "GH-2123 — ParsePositionTypes accepts numeric input with no matching PositionChangeType member"
+    )]
+    public void ParsePositionTypes_NumericValueWithNoMatchingEnumMember_RejectsToPreventPollutedFilter()
+    {
+        // ParsePositionTypes binds the ?types=… query string for /stocks/{ticker}/holdings.
+        // The defined PositionChangeType members are New=1, Increased=2, Reduced=3,
+        // Unchanged=4, SoldOut=5. The contract a caller relies on is "the returned set
+        // contains only defined enum members" — the result is rendered as filter chips,
+        // round-tripped into toggle URLs (string.Join(",", next)) and used to gate
+        // bucket counts, so a garbage value pollutes every downstream use of the set.
+        //
+        // The risk this catches: Enum.TryParse accepts numeric forms by default, so
+        // ?types=999 succeeds and produces (PositionChangeType)999 with no matching
+        // name. An unrecognised name like ?types=foo correctly yields null (no filter
+        // applied) — the numeric form should follow the same rejection path. The fix
+        // is a single Enum.IsDefined gate on the parsed value.
+        var method = typeof(StocksController).GetMethod(
+            "ParsePositionTypes",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (HashSet<PositionChangeType>)method.Invoke(null, ["999"]);
+
+        result
+            .Should()
+            .BeNull(
+                "a numeric value with no matching enum member should be rejected the same as an unrecognised name"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Lane A finding: `StocksController.ParsePositionTypes` (binds `?types=…` on `/stocks/{ticker}/holdings`) accepts numeric input that does not correspond to a defined `PositionChangeType` — `Enum.TryParse<PositionChangeType>("999", true, …)` succeeds and produces `(PositionChangeType)999`.
- An unrecognised name like `?types=foo` correctly yields `null` (no filter); the numeric form should follow the same rejection path. The fix is a one-line `Enum.IsDefined` gate.
- Filed as GH-2123. Low-severity (the user must hand-craft the URL) but the polluted set is round-tripped into toggle URLs by `_HoldingsTab.cshtml` via `string.Join(",", next)`.

## Code changes

- `tests/Equibles.UnitTests/Web/StocksControllerParsePositionTypesUndefinedNumericTests.cs` — single `[Fact(Skip = ...)]` reflecting into the private static `ParsePositionTypes`, asserting `"999"` yields `null`. Skipped — see GH-2123.