### PR TITLE
test(sec): un-skip GetDailyIndex Hijri culture test — GH-1901 fix landed

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDailyIndexCultureTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDailyIndexCultureTests.cs
@@ -15,9 +15,7 @@ namespace Equibles.IntegrationTests.Sec;
 /// </summary>
 public class SecEdgarClientGetDailyIndexCultureTests
 {
-    [Fact(
-        Skip = "GH-1901 — GetDailyIndex builds URL with Hijri date on non-Gregorian culture threads"
-    )]
+    [Fact]
     public async Task GetDailyIndex_HijriCultureThread_RequestsGregorianDateInUrl()
     {
         var prev = CultureInfo.CurrentCulture;


### PR DESCRIPTION
## Summary

The repro test `GetDailyIndex_HijriCultureThread_RequestsGregorianDateInUrl` was marked `Skip` pending the fix for GH-1901. The fix landed in `b047581` (\"fix(sec): use InvariantCulture for date in `GetDailyIndex` URL\") and the issue is closed, but the `Skip` annotation was never removed — leaving a stale skip that hides any future regression of the same shape.

Verified locally: test passes (54 ms) against the current `GetDailyIndex` implementation.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDailyIndexCultureTests.cs` — drop the `Skip = "GH-1901 — ..."` argument from the `[Fact]` so the test runs.

## Test plan

- [x] `dotnet test` filtered to `SecEdgarClientGetDailyIndexCultureTests` — passes locally