### PR TITLE
docs(changelog): add missing Unreleased entries since #2077

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   Corp → Corp., Ltd → Ltd., etc.), higher roman numerals (IV–X), and
   parenthesized abbreviations.
 - Duplicated MCP date-parsing logic extracted into `McpToolExecutor.ParseDateOr`.
+- Repeated "stock not found" MCP responses extracted into
+  `McpToolExecutor.StockNotFound`.
+- SEC MCP `DocumentTextTools` migrated to `McpToolRunner`, matching the
+  Execute / ReportError pattern used by the other MCP tool groups.
 - LIKE metacharacter escaping extracted into shared `LikePattern` helper.
+- Repeated empty-table-row markup extracted into a shared
+  `EmptyTableRowTagHelper`.
+- Screener CSV export migrated to the shared `CsvExportService` instead of
+  hand-rolling its own writer.
 - Vite bundles wrapped in IIFE to prevent global scope collision; `bundle.js`
   loaded as ES module.
 - Chart.js split into a separate bundle loaded only on chart pages.
@@ -99,6 +107,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Fiscal year-end day validated against its month (e.g., day 31 rejected
   for months with fewer days).
 - Filer-universe query narrowed to only gap holders.
+- `ParseTransactionCode` trims input so whitespace-padded SEC transaction
+  codes resolve to the correct `TransactionCode` enum value.
+- `ParseBool` trims input so whitespace-padded SEC boolean strings
+  ("true ", " false") are interpreted correctly.
+- `SafeRound` guards against the `decimal.MaxValue` boundary instead of
+  throwing on rounding overflow.
+- House PTR PDF parser joins multi-line transaction entries so the asset
+  name, ticker/dates, and amount land on a single transaction instead of
+  three partial rows.
 
 ## [1.1.1] — 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - House PTR PDF parser joins multi-line transaction entries so the asset
   name, ticker/dates, and amount land on a single transaction instead of
   three partial rows.
+- 13F-HR import aggregates same-key rows across the whole filing instead
+  of flushing every 1000 unique keys. When a filer split a position
+  across `otherManager` codes the matching rows could fall in different
+  batches; the upsert's `WhenMatched` clause REPLACED the persisted row,
+  so only the last batch's slice survived (Vanguard's Q4 2025 AAPL came
+  out as 39M shares instead of 1.43B). The import now flushes at the
+  accession boundary, which SEC guarantees is contiguous in both the
+  bulk INFOTABLE and the realtime archive.
 
 ## [1.1.1] — 2026-05-22
 


### PR DESCRIPTION
## Summary

Eight entries that landed after the last changelog bump (`54731ea`, PR #2077) were missing from the `Unreleased` section, plus the cross-batch holdings fix from PR #2111 (closes #2110). This PR adds them so the changelog reflects what is actually shipping in the next release.

## Code changes

`CHANGELOG.md` — `Unreleased` section:

**Changed** (added):

- Repeated "stock not found" MCP responses extracted into `McpToolExecutor.StockNotFound`.
- SEC MCP `DocumentTextTools` migrated to `McpToolRunner`, matching the Execute / ReportError pattern used by the other MCP tool groups.
- Repeated empty-table-row markup extracted into a shared `EmptyTableRowTagHelper`.
- Screener CSV export migrated to the shared `CsvExportService` instead of hand-rolling its own writer.

**Fixed** (added):

- `ParseTransactionCode` trims input so whitespace-padded SEC transaction codes resolve to the correct `TransactionCode` enum value.
- `ParseBool` trims input so whitespace-padded SEC boolean strings ("true ", " false") are interpreted correctly.
- `SafeRound` guards against the `decimal.MaxValue` boundary instead of throwing on rounding overflow.
- House PTR PDF parser joins multi-line transaction entries so the asset name, ticker/dates, and amount land on a single transaction instead of three partial rows.
- 13F-HR import aggregates same-key rows across the whole filing instead of flushing every 1000 unique keys (closes #2110 — Vanguard's Q4 2025 AAPL was coming out as 39M shares instead of 1.43B).

## Test plan

- [x] Diff against `54731ea..HEAD` to confirm no user-visible change was missed.
- [x] Markdown lint passes (pre-commit hook).