### PR TITLE
fix(web): reject undefined numeric input in ParsePositionTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   out as 39M shares instead of 1.43B). The import now flushes at the
   accession boundary, which SEC guarantees is contiguous in both the
   bulk INFOTABLE and the realtime archive.
+- `StocksController.ParsePositionTypes` gates parsed values with
+  `Enum.IsDefined` so numeric query input with no matching
+  `PositionChangeType` member (e.g. `?types=999`) is rejected the same
+  as an unrecognised name, preventing a polluted filter set from
+  round-tripping into rendered toggle URLs on the holdings tab.
 
 ## [1.1.1] — 2026-05-22
 

--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -222,7 +222,10 @@ public class StocksController : BaseController
         var result = new HashSet<PositionChangeType>();
         foreach (var part in types.Split(',', StringSplitOptions.RemoveEmptyEntries))
         {
-            if (Enum.TryParse<PositionChangeType>(part.Trim(), true, out var parsed))
+            if (
+                Enum.TryParse<PositionChangeType>(part.Trim(), true, out var parsed)
+                && Enum.IsDefined(parsed)
+            )
                 result.Add(parsed);
         }
 

--- a/tests/Equibles.UnitTests/Web/StocksControllerParsePositionTypesUndefinedNumericTests.cs
+++ b/tests/Equibles.UnitTests/Web/StocksControllerParsePositionTypesUndefinedNumericTests.cs
@@ -6,9 +6,7 @@ namespace Equibles.UnitTests.Web;
 
 public class StocksControllerParsePositionTypesUndefinedNumericTests
 {
-    [Fact(
-        Skip = "GH-2123 — ParsePositionTypes accepts numeric input with no matching PositionChangeType member"
-    )]
+    [Fact]
     public void ParsePositionTypes_NumericValueWithNoMatchingEnumMember_RejectsToPreventPollutedFilter()
     {
         // ParsePositionTypes binds the ?types=… query string for /stocks/{ticker}/holdings.


### PR DESCRIPTION
## Summary

- `StocksController.ParsePositionTypes` accepted `?types=999` and produced `(PositionChangeType)999` — a value no UI control could create — which then round-tripped through `HoldingsTabViewModel.IsTypeActive` and the `_HoldingsTab.cshtml` toggle URLs. Gate the parsed value with `Enum.IsDefined` so numeric input with no matching member is rejected the same as an unrecognised name. Closes #2123.

## Code changes

- `src/Equibles.Web/Controllers/StocksController.cs` — add `Enum.IsDefined(parsed)` check inside the `Enum.TryParse` branch of `ParsePositionTypes`.
- `tests/Equibles.UnitTests/Web/StocksControllerParsePositionTypesUndefinedNumericTests.cs` — drop the `Skip` argument from the regression test added in #2125.
- `CHANGELOG.md` — Unreleased / Fixed entry.