### PR TITLE
fix(sec): exclude short English words from Roman numeral matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   out as 39M shares instead of 1.43B). The import now flushes at the
   accession boundary, which SEC guarantees is contiguous in both the
   bulk INFOTABLE and the realtime archive.
+- `CompanySyncService.NormalizeCompanyName` no longer treats short English
+  words like MIX, DIV, LIV, MIL, and CIV as Roman numerals. The regex still
+  matches them (MIX = 1009, DIV = 504, LIV = 54), but tokens shorter than
+  four characters must now consist only of I/V/X to be kept uppercase, so
+  "QUICK MIX CORP" titles to "Quick Mix Corp" while "FUND III" and
+  "FUND XVI LP" stay as-is.
 
 ## [1.1.1] — 2026-05-22
 

--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -576,6 +576,26 @@ public class CompanySyncService : ICompanySyncService
         RegexOptions.IgnoreCase | RegexOptions.Compiled
     );
 
+    // Short tokens that match the regex but use L/C/D/M are almost always English
+    // words (MIX=1009, DIV=504, LIV=54, MIL=1051, CIV=104) — exclude them by
+    // requiring tokens shorter than 4 characters to use only I/V/X.
+    private static bool IsRomanNumeral(string token)
+    {
+        if (!RomanNumeralPattern.IsMatch(token))
+            return false;
+
+        if (token.Length >= 4)
+            return true;
+
+        foreach (var c in token)
+        {
+            var u = char.ToUpperInvariant(c);
+            if (u != 'I' && u != 'V' && u != 'X')
+                return false;
+        }
+        return true;
+    }
+
     private static string NormalizeCompanyName(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
@@ -592,10 +612,7 @@ public class CompanySyncService : ICompanySyncService
             var stripped = words[i].TrimStart('(').TrimEnd('.', ',', ';', ')');
             if (
                 stripped.Length > 0
-                && (
-                    UpperCaseAbbreviations.Contains(stripped)
-                    || RomanNumeralPattern.IsMatch(stripped)
-                )
+                && (UpperCaseAbbreviations.Contains(stripped) || IsRomanNumeral(stripped))
             )
             {
                 words[i] = words[i].ToUpperInvariant();

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameRomanNumeralFalsePositiveTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameRomanNumeralFalsePositiveTests.cs
@@ -20,7 +20,7 @@ public class CompanySyncServiceNormalizeCompanyNameRomanNumeralFalsePositiveTest
 
     private static string Normalize(string name) => (string)NormalizeMethod.Invoke(null, [name]);
 
-    [Fact(Skip = "GH-2104 — Roman numeral regex matches English words like MIX (1009)")]
+    [Fact]
     public void AllCapsName_MixIsEnglishWord_NotRomanNumeral1009()
     {
         var result = Normalize("QUICK MIX CORP");


### PR DESCRIPTION
## Summary

- `NormalizeCompanyName` left short English words like MIX, DIV, LIV uppercase because the Roman numeral regex matches them as 1009, 504, 54.
- Tokens shorter than four characters must now contain only I/V/X to be treated as numerals — so `"QUICK MIX CORP"` titles to `"Quick Mix Corp"` while real short numerals (I, II, III, IV, V, VI, VII, IX, X, XI, XV, XX, …) and longer Roman numerals (XVI, XXV, VIII) still stay uppercase.
- Closes #2104.

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — added `IsRomanNumeral` helper that wraps `RomanNumeralPattern.IsMatch` and additionally requires tokens of length < 4 to use only I/V/X; `NormalizeCompanyName` now calls the helper instead of the raw regex.
- `tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameRomanNumeralFalsePositiveTests.cs` — removed `Skip = ...` so the regression test (`"QUICK MIX CORP"` → `"Quick Mix Corp"`) runs.
- `CHANGELOG.md` — Unreleased / Fixed entry.