### PR TITLE
test(sec): pin NormalizeCompanyName.LIV English-word case alongside MIX

### DIFF
--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameRomanNumeralFalsePositiveTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameRomanNumeralFalsePositiveTests.cs
@@ -27,4 +27,15 @@ public class CompanySyncServiceNormalizeCompanyNameRomanNumeralFalsePositiveTest
 
         result.Should().Be("Quick Mix Corp");
     }
+
+    // LIV decomposes as L (50) + IV (4) = 54, so the Roman regex matches it
+    // even though it is a common English name/word. Covers the L/X regex group
+    // — distinct from MIX, which exercises the leading-M group.
+    [Fact]
+    public void AllCapsName_LivIsEnglishWord_NotRomanNumeral54()
+    {
+        var result = Normalize("LIV INDUSTRIES CORP");
+
+        result.Should().Be("Liv Industries Corp");
+    }
 }


### PR DESCRIPTION
## Summary

- LIV decomposes as L (50) + IV (4) = 54, so the Roman numeral regex in `NormalizeCompanyName` matches it the same way it matched MIX before #2130.
- The existing regression test only pins MIX (which exercises the leading-M regex group); this PR adds a sibling test that pins LIV, exercising the L/X group instead.
- Strengthens the contract assertion that the helper does not treat common English words as numerals.

## Code changes

- `tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameRomanNumeralFalsePositiveTests.cs` — added `AllCapsName_LivIsEnglishWord_NotRomanNumeral54` asserting `"LIV INDUSTRIES CORP"` titles to `"Liv Industries Corp"`.