### PR TITLE
fix(sec): restore short Roman numerals (XL, XC, CD, CM) in company-name normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,12 +129,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `PositionChangeType` member (e.g. `?types=999`) is rejected the same
   as an unrecognised name, preventing a polluted filter set from
   round-tripping into rendered toggle URLs on the holdings tab.
-- `CompanySyncService.NormalizeCompanyName` no longer treats short English
-  words like MIX, DIV, LIV, MIL, and CIV as Roman numerals. The regex still
-  matches them (MIX = 1009, DIV = 504, LIV = 54), but tokens shorter than
-  four characters must now consist only of I/V/X to be kept uppercase, so
-  "QUICK MIX CORP" titles to "Quick Mix Corp" while "FUND III" and
-  "FUND XVI LP" stay as-is.
+- `CompanySyncService.NormalizeCompanyName` no longer treats the short English
+  words MIX, DIV, LIV, and CIV as Roman numerals — they decompose as 1009,
+  504, 54, and 104 respectively but aren't numerals in a company-name context.
+  An explicit deny-list rejects exactly those four tokens, so other short
+  numerals that use L/C/D/M (XL=40, XC=90, CD=400, CM=900, XLI=41, XLV=45,
+  MII=1002) keep working alongside the pure-I/V/X cases.
 
 ## [1.1.1] — 2026-05-22
 

--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -576,25 +576,22 @@ public class CompanySyncService : ICompanySyncService
         RegexOptions.IgnoreCase | RegexOptions.Compiled
     );
 
-    // Short tokens that match the regex but use L/C/D/M are almost always English
-    // words (MIX=1009, DIV=504, LIV=54, MIL=1051, CIV=104) — exclude them by
-    // requiring tokens shorter than 4 characters to use only I/V/X.
-    private static bool IsRomanNumeral(string token)
+    // Three-letter English words that happen to satisfy the Roman regex
+    // (MIX=1009, DIV=504, LIV=54, CIV=104). Listing them explicitly keeps
+    // legitimate short numerals like XL (40), XC (90), CD (400), CM (900),
+    // and combos (XLI, XLV, MII) working.
+    private static readonly HashSet<string> RomanNumeralFalsePositives = new(
+        StringComparer.OrdinalIgnoreCase
+    )
     {
-        if (!RomanNumeralPattern.IsMatch(token))
-            return false;
+        "MIX",
+        "DIV",
+        "LIV",
+        "CIV",
+    };
 
-        if (token.Length >= 4)
-            return true;
-
-        foreach (var c in token)
-        {
-            var u = char.ToUpperInvariant(c);
-            if (u != 'I' && u != 'V' && u != 'X')
-                return false;
-        }
-        return true;
-    }
+    private static bool IsRomanNumeral(string token) =>
+        RomanNumeralPattern.IsMatch(token) && !RomanNumeralFalsePositives.Contains(token);
 
     private static string NormalizeCompanyName(string name)
     {

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameRomanNumeralFalseNegativeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameRomanNumeralFalseNegativeTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Contract (from <see cref="CompanySyncServiceNormalizeCompanyNameTests"/>):
+/// real Roman numerals stay uppercase. XL = 40 is a real Roman numeral and
+/// satisfies the regex pattern just like XV (15) or XX (20), so a SEC fund
+/// name like "CAPITAL FUND XL LP" must preserve the XL token.
+/// </summary>
+public class CompanySyncServiceNormalizeCompanyNameRomanNumeralFalseNegativeTests
+{
+    private static readonly MethodInfo NormalizeMethod = typeof(CompanySyncService).GetMethod(
+        "NormalizeCompanyName",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    private static string Normalize(string name) => (string)NormalizeMethod.Invoke(null, [name]);
+
+    [Fact]
+    public void AllCapsName_XlIsRomanNumeral40_StayUpperCase()
+    {
+        var result = Normalize("CAPITAL FUND XL LP");
+
+        result.Should().Be("Capital Fund XL LP");
+    }
+}


### PR DESCRIPTION
## Summary

- #2130 traded MIX/DIV/LIV/CIV false positives for a broader regression: every short Roman numeral using L/C/D/M (XL=40, XC=90, CD=400, CM=900, XLI=41, XLV=45, MII=1002) also got rejected.
- Replace the length-vs-pure-IVX heuristic on `IsRomanNumeral` with an explicit four-token deny-list of the actual English-word collisions, so the regex match wins for every other Roman.
- Closes #2132.

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — drop the length/IVX loop on `IsRomanNumeral`; introduce `RomanNumeralFalsePositives = { MIX, DIV, LIV, CIV }` and reject only those tokens after the regex matches.
- `tests/Equibles.UnitTests/Sec/CompanySyncServiceNormalizeCompanyNameRomanNumeralFalseNegativeTests.cs` — new file pinning that `"CAPITAL FUND XL LP"` titles to `"Capital Fund XL LP"`.
- `CHANGELOG.md` — Unreleased / Fixed entry updated to describe the deny-list approach.