### PR TITLE
fix(infra): survive cold start on fresh DB volume (closes #2134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Cold-start race on a fresh DB volume — the compose healthcheck now forces a
+  TCP probe instead of a Unix-socket probe, so it only flips healthy after
+  ParadeDB's init phase finishes and the real TCP listener is up. The web
+  host also retries `Database.MigrateAsync` on transient connection failures.
 - `FiscalPeriodResolver.Resolve` guarded against year-underflow on `AddYears(-1)`.
 - `FiscalPeriodResolver.CreateSafe` guarded against year overflow past 9999.
 - `FiscalCalendar.GetPeriod` guarded against fiscal year overflow past 9999.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,15 @@ services:
     volumes:
       - db-data:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      # -h localhost forces a TCP probe. Without it, pg_isready hits the Unix
+      # socket and reports healthy during ParadeDB's init phase — before the
+      # init script shuts Postgres down and restarts it on TCP. Apps connect
+      # over TCP, so this matches reality.
+      test: ["CMD-SHELL", "pg_isready -h localhost -U postgres -d equibles"]
       interval: 5s
       timeout: 5s
       retries: 5
+      start_period: 30s
 
   mcp:
     build:

--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Net.Sockets;
 using Equibles.Core.AutoWiring;
 using Equibles.Data;
 using Equibles.Data.Extensions;
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using Serilog;
 using Serilog.Events;
 
@@ -149,9 +151,45 @@ public partial class Program
         // Extended timeout for index rebuilds.
         using var scope = app.Services.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesDbContext>();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
         dbContext.Database.SetCommandTimeout(TimeSpan.FromHours(1));
-        await dbContext.Database.MigrateAsync();
+
+        // ParadeDB's init script briefly accepts connections on the Unix
+        // socket while the TCP listener is still down, which can release us
+        // a few seconds before Postgres is reachable. Retry transient
+        // connection failures; non-connection errors fail fast.
+        const int maxAttempts = 30;
+        var delay = TimeSpan.FromSeconds(2);
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                await dbContext.Database.MigrateAsync();
+                return;
+            }
+            catch (Exception ex) when (attempt < maxAttempts && IsTransientConnectionFailure(ex))
+            {
+                logger.LogWarning(
+                    ex,
+                    "Database not reachable yet (attempt {Attempt}/{MaxAttempts}); retrying in {Delay}s.",
+                    attempt,
+                    maxAttempts,
+                    delay.TotalSeconds
+                );
+                await Task.Delay(delay);
+            }
+        }
     }
+
+    private static bool IsTransientConnectionFailure(Exception ex) =>
+        ex switch
+        {
+            // TCP refused / unreachable while ParadeDB is restarting.
+            NpgsqlException { InnerException: SocketException } => true,
+            // "cannot_connect_now" — server is in startup.
+            PostgresException { SqlState: "57P03" } => true,
+            _ => false,
+        };
 
     public static void ConfigurePipeline(WebApplication app)
     {


### PR DESCRIPTION
## Summary

- Closes #2134.
- Fixes the cold-start race where the `db` healthcheck (`pg_isready -U postgres`) flips healthy during ParadeDB's init phase (Unix socket only), releasing `web` before the TCP listener is up. Web's un-retried `Database.MigrateAsync` then crashes with `Connection refused`, the container zombies (PID 1 alive, Kestrel never starts), and `mcp` + `worker` never start because they depend on web's health.

## Code changes

- `docker-compose.yml` — switch the `db` healthcheck to a TCP probe: `pg_isready -h localhost -U postgres -d equibles`, with `start_period: 30s`. Matches what apps actually connect over.
- `src/Equibles.Web/Program.cs` — wrap `Database.MigrateAsync` in a retry loop (30 attempts × 2s) that retries transient connection failures (`NpgsqlException` with inner `SocketException`, or `PostgresException 57P03 cannot_connect_now`) and fails fast on schema errors. Defence in depth against any future init-phase quirk.
- `CHANGELOG.md` — Unreleased / Fixed entry.

## Test plan

- [x] `docker compose down -v && docker compose up -d` on a fresh volume — db reaches healthy only after the real TCP listener is up; web migrates cleanly on the first attempt; worker + mcp both start without intervention; no ERR/WRN/FTL across all four containers.
- [x] `dotnet build src/Equibles.Web/Equibles.Web.csproj -c Release` clean.
- [x] csharpier check clean.