### PR TITLE
test(web): cover cold-start retry classifier + retry loop

### DIFF
--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -158,13 +158,26 @@ public partial class Program
         // socket while the TCP listener is still down, which can release us
         // a few seconds before Postgres is reachable. Retry transient
         // connection failures; non-connection errors fail fast.
-        const int maxAttempts = 30;
-        var delay = TimeSpan.FromSeconds(2);
+        await RetryOnTransientConnectionFailure(
+            () => dbContext.Database.MigrateAsync(),
+            logger,
+            maxAttempts: 30,
+            delay: TimeSpan.FromSeconds(2)
+        );
+    }
+
+    public static async Task RetryOnTransientConnectionFailure(
+        Func<Task> operation,
+        Microsoft.Extensions.Logging.ILogger logger,
+        int maxAttempts,
+        TimeSpan delay
+    )
+    {
         for (var attempt = 1; ; attempt++)
         {
             try
             {
-                await dbContext.Database.MigrateAsync();
+                await operation();
                 return;
             }
             catch (Exception ex) when (attempt < maxAttempts && IsTransientConnectionFailure(ex))
@@ -181,7 +194,7 @@ public partial class Program
         }
     }
 
-    private static bool IsTransientConnectionFailure(Exception ex) =>
+    public static bool IsTransientConnectionFailure(Exception ex) =>
         ex switch
         {
             // TCP refused / unreachable while ParadeDB is restarting.

--- a/tests/Equibles.UnitTests/Web/ProgramIsTransientConnectionFailureTests.cs
+++ b/tests/Equibles.UnitTests/Web/ProgramIsTransientConnectionFailureTests.cs
@@ -1,0 +1,68 @@
+using System.Net.Sockets;
+using Equibles.Web;
+using FluentAssertions;
+using Npgsql;
+
+namespace Equibles.UnitTests.Web;
+
+public class ProgramIsTransientConnectionFailureTests
+{
+    [Fact]
+    public void NpgsqlException_WithSocketInner_IsTransient()
+    {
+        var ex = new NpgsqlException("conn refused", new SocketException());
+
+        Program.IsTransientConnectionFailure(ex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void NpgsqlException_WithNonSocketInner_IsNotTransient()
+    {
+        var ex = new NpgsqlException("boom", new InvalidOperationException());
+
+        Program.IsTransientConnectionFailure(ex).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NpgsqlException_WithNoInner_IsNotTransient()
+    {
+        var ex = new NpgsqlException("boom");
+
+        Program.IsTransientConnectionFailure(ex).Should().BeFalse();
+    }
+
+    [Fact]
+    public void PostgresException_CannotConnectNow_IsTransient()
+    {
+        // "57P03" = cannot_connect_now (server in startup).
+        var ex = new PostgresException(
+            messageText: "the database system is starting up",
+            severity: "FATAL",
+            invariantSeverity: "FATAL",
+            sqlState: "57P03"
+        );
+
+        Program.IsTransientConnectionFailure(ex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void PostgresException_OtherSqlState_IsNotTransient()
+    {
+        var ex = new PostgresException(
+            messageText: "duplicate key",
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: "23505"
+        );
+
+        Program.IsTransientConnectionFailure(ex).Should().BeFalse();
+    }
+
+    [Fact]
+    public void UnrelatedException_IsNotTransient()
+    {
+        var ex = new InvalidOperationException("nope");
+
+        Program.IsTransientConnectionFailure(ex).Should().BeFalse();
+    }
+}

--- a/tests/Equibles.UnitTests/Web/ProgramRetryOnTransientConnectionFailureTests.cs
+++ b/tests/Equibles.UnitTests/Web/ProgramRetryOnTransientConnectionFailureTests.cs
@@ -1,0 +1,101 @@
+using System.Net.Sockets;
+using Equibles.Web;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Web;
+
+public class ProgramRetryOnTransientConnectionFailureTests
+{
+    private readonly ILogger _logger = Substitute.For<ILogger>();
+    private static readonly TimeSpan ZeroDelay = TimeSpan.Zero;
+
+    [Fact]
+    public async Task SuccessOnFirstAttempt_InvokesOperationOnce()
+    {
+        var calls = 0;
+        Task Operation()
+        {
+            calls++;
+            return Task.CompletedTask;
+        }
+
+        await Program.RetryOnTransientConnectionFailure(
+            Operation,
+            _logger,
+            maxAttempts: 3,
+            ZeroDelay
+        );
+
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task TransientThenSuccess_RetriesUntilOperationSucceeds()
+    {
+        var calls = 0;
+        Task Operation()
+        {
+            calls++;
+            if (calls < 3)
+                throw new NpgsqlException("refused", new SocketException());
+            return Task.CompletedTask;
+        }
+
+        await Program.RetryOnTransientConnectionFailure(
+            Operation,
+            _logger,
+            maxAttempts: 5,
+            ZeroDelay
+        );
+
+        calls.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task NonTransientException_PropagatesImmediately()
+    {
+        var calls = 0;
+        Task Operation()
+        {
+            calls++;
+            throw new InvalidOperationException("hard failure");
+        }
+
+        var act = () =>
+            Program.RetryOnTransientConnectionFailure(
+                Operation,
+                _logger,
+                maxAttempts: 5,
+                ZeroDelay
+            );
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task TransientFailureOnFinalAttempt_PropagatesException()
+    {
+        var calls = 0;
+        Task Operation()
+        {
+            calls++;
+            throw new NpgsqlException("refused", new SocketException());
+        }
+
+        var act = () =>
+            Program.RetryOnTransientConnectionFailure(
+                Operation,
+                _logger,
+                maxAttempts: 3,
+                ZeroDelay
+            );
+
+        await act.Should().ThrowAsync<NpgsqlException>();
+        // First two attempts are caught by the retry filter; the 3rd one re-throws.
+        calls.Should().Be(3);
+    }
+}


### PR DESCRIPTION
## Summary

- The cold-start retry added in #2135 landed with `codecov/patch` at 22.72% (target 60%) because the new retry loop and `IsTransientConnectionFailure` classifier had no unit tests.
- Extract the retry loop into a `public static RetryOnTransientConnectionFailure(Func<Task>, ILogger, int, TimeSpan)` helper on `Program` so it can be exercised without a live `DbContext`; expose `IsTransientConnectionFailure` as `public static` so it can be tested directly.
- Add 10 unit tests covering both helpers, no production behaviour change.

## Code changes

- `src/Equibles.Web/Program.cs` — `ApplyMigrationsAsync` now calls `RetryOnTransientConnectionFailure` instead of running the retry loop inline. The classifier and the loop are both `public static` (visibility-only); the surrounding migration code is unchanged.
- `tests/Equibles.UnitTests/Web/ProgramIsTransientConnectionFailureTests.cs` — 6 cases: `NpgsqlException` + `SocketException` inner, `NpgsqlException` + non-socket inner, `NpgsqlException` with no inner, `PostgresException` `57P03`, `PostgresException` other SqlState, unrelated exception.
- `tests/Equibles.UnitTests/Web/ProgramRetryOnTransientConnectionFailureTests.cs` — 4 cases: success on first attempt, transient then success, non-transient propagates immediately, transient on every attempt up to the cap propagates.