### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.2.0] — 2026-05-26
+
+### Added
+
 - Confidential treatment flag — 13F cover pages' `confidentialTreatmentRequestedFlag`
   is now parsed and stored on `InstitutionalHolder`. The institution profile page
   shows a warning banner when the flag is set, and `GetInstitutionSummary` MCP tool
@@ -503,7 +511,8 @@ First tagged release.
 - Background worker — scrapers and document processor.
 - Docker Compose stack (ParadeDB + web + MCP + worker), with an optional vector-embedding profile.
 
-[Unreleased]: https://github.com/daniel3303/Equibles/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/daniel3303/Equibles/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/daniel3303/Equibles/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/daniel3303/Equibles/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/daniel3303/Equibles/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/daniel3303/Equibles/releases/tag/v1.0.0

--- a/src/Equibles.Web/Equibles.Web.csproj
+++ b/src/Equibles.Web/Equibles.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <!-- Running version surfaced by the update-notification banner. Bump on each release to match the git tag. -->
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Cuts the v1.2.0 release: minor bump over v1.1.1 covering ~28 features and ~56 fixes accumulated on `main` since 2026-05-22.
- Highlights since v1.1.1: 13F conviction heat map / stats / trends / double-down / institution overlap / latest filings / insider dashboard / fund-classification / confidential-treatment flag / fiscal-calendar correctness fixes / Roman-numeral normalization carve-out / many SEC parser robustness fixes / cold-start retry classifier.

## Code changes

- `CHANGELOG.md` — renames `## [Unreleased]` to `## [1.2.0] — 2026-05-26`, inserts a fresh empty `## [Unreleased]` block, and updates the compare-link footer (new `[1.2.0]` link, re-points `[Unreleased]` to `v1.2.0...HEAD`).
- `src/Equibles.Web/Equibles.Web.csproj` — bumps `<Version>` from `1.1.1` to `1.2.0` (this is the version surfaced by the in-app update-notification banner).