### PR TITLE
test(sec): pin FinancialStatementConcepts.For us-gaap-only invariant

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialStatementConceptsForAllDefinedTypesTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialStatementConceptsForAllDefinedTypesTests.cs
@@ -1,0 +1,37 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialStatementConceptsForAllDefinedTypesTests
+{
+    // FinancialStatementConcepts is the single source of truth shared by the
+    // Web Financials tab and the MCP GetFinancialStatement tool (see XML doc
+    // on the class). The docstring promises us-gaap concepts only — a refactor
+    // that copy-pasted an IFRS-Full or DEI row into one of the curated lists
+    // (FactTaxonomy is a 5-member enum, easy to misclick) would silently feed
+    // the wrong taxonomy to SEC's Company Facts lookup, where us-gaap and
+    // ifrs-full live under different keys, and every fact would return null.
+    // Pin the invariant across every defined statement type so a single bad
+    // row fails the build for both consumers.
+    [Fact]
+    public void For_EveryDefinedStatementType_ReturnsNonEmptyUsGaapOnlyCatalog()
+    {
+        foreach (var type in Enum.GetValues<FinancialStatementType>())
+        {
+            var statement = FinancialStatementConcepts.For(type);
+
+            statement
+                .Should()
+                .NotBeEmpty(
+                    $"every defined FinancialStatementType must map to a catalog; {type} returned empty"
+                );
+            statement
+                .Should()
+                .OnlyContain(
+                    line => line.Taxonomy == FactTaxonomy.UsGaap,
+                    $"docstring promises us-gaap concepts only; {type} contains a non-us-gaap row"
+                );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the documented invariant that `FinancialStatementConcepts.For` returns a non-empty, us-gaap-only catalog for every defined `FinancialStatementType`.
- Closes a 0% unit-coverage gap on a class shared by the Web Financials tab and the MCP `GetFinancialStatement` tool — a single copy-paste of an IFRS-Full or DEI row would make every fact lookup silently miss against SEC's Company Facts API.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialStatementConceptsForAllDefinedTypesTests.cs` — new unit test that iterates `Enum.GetValues<FinancialStatementType>()` and asserts each catalog is non-empty and contains only `FactTaxonomy.UsGaap` lines.