### PR TITLE
test(sec): pin SecEdgarClient.GetFilingArtifactNames empty-CIK guard fires before HTTP

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientGetFilingArtifactNamesEmptyCikTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientGetFilingArtifactNamesEmptyCikTests.cs
@@ -1,0 +1,35 @@
+using Equibles.Integrations.Sec;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecEdgarClientGetFilingArtifactNamesEmptyCikTests
+{
+    // GetFilingArtifactNames documents "cik and accessionNumber are required"
+    // as the synchronous precondition before any HTTP traffic. ASP.NET model
+    // binding turns missing route/query parameters into empty strings rather
+    // than null, so the guard must catch IsNullOrEmpty — not just null —
+    // otherwise the scraper would issue requests against a malformed URL
+    // (https://www.sec.gov/Archives/edgar/data//ACC-X/index.json) and waste
+    // its strict SEC rate-limit budget on 404s. A refactor that swapped
+    // `IsNullOrEmpty` for a `?? throw` or a null-only `ArgumentNullException`
+    // would silently let "" through.
+    [Fact]
+    public async Task GetFilingArtifactNames_EmptyCik_ThrowsBeforeAnyHttpCall()
+    {
+        var client = new SecEdgarClient(
+            new HttpClient(),
+            NullLogger<SecEdgarClient>.Instance,
+            new ConfigurationBuilder().Build()
+        );
+
+        var act = async () =>
+            await client.GetFilingArtifactNames(
+                cik: string.Empty,
+                accessionNumber: "0001234567-24-000001"
+            );
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*required*");
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the documented precondition that `GetFilingArtifactNames` rejects an empty CIK with `ArgumentException` before any HTTP traffic — protects SEC's strict rate-limit budget against malformed URLs caused by ASP.NET model-binding turning missing parameters into empty strings.
- Catches a likely refactor (`IsNullOrEmpty` → null-only check) that would silently let `""` through.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecEdgarClientGetFilingArtifactNamesEmptyCikTests.cs` — instantiates `SecEdgarClient` with an unwired `HttpClient`, awaits the call with `cik: ""`, asserts an `ArgumentException` whose message contains "required" — guarantees the guard fires before any HTTP call.