### PR TITLE
test(sec): pin TryMapFiscalPeriod returns false with default out on unknown token

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapFiscalPeriodUnknownTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapFiscalPeriodUnknownTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactsImportServiceTryMapFiscalPeriodUnknownTests
+{
+    // TryMapFiscalPeriod follows the .NET Try* contract: on any wire value
+    // outside SEC's documented {FY, Q1-Q4} set, return false and leave the
+    // out parameter as default(SecFiscalPeriod). A future addition of an
+    // SEC-side "H1"/"H2" half-year token (or a typo upstream) would otherwise
+    // silently route through the default arm — but a regression that swapped
+    // the default arm's `return false` for `return true` (a classic copy-paste
+    // off-by-one) would compile and silently classify every unknown period as
+    // FullYear (the default enum value), polluting the financial-fact stream.
+    [Fact]
+    public void TryMapFiscalPeriod_UnknownPeriodToken_ReturnsFalseWithDefaultOut()
+    {
+        var method = typeof(FinancialFactsImportService).GetMethod(
+            "TryMapFiscalPeriod",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var args = new object[] { "H1", default(SecFiscalPeriod) };
+
+        var resolved = (bool)method.Invoke(null, args);
+
+        resolved.Should().BeFalse();
+        args[1].Should().Be(default(SecFiscalPeriod));
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the `.NET Try*` contract on `FinancialFactsImportService.TryMapFiscalPeriod`: any wire token outside SEC's `{FY, Q1-Q4}` set must return `false` with the out parameter set to `default(SecFiscalPeriod)`.
- Catches a copy-paste off-by-one in the default arm (`return false` → `return true`) that would silently reclassify every unknown fiscal-period token as `FullYear` and pollute the fact stream.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapFiscalPeriodUnknownTests.cs` — reflection-invoked test with `"H1"` as the input, asserting `false` returned and the out parameter equals `default(SecFiscalPeriod)`.