### PR TITLE
test(congress): pin IsTransactionTable requires asset column alongside date

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsTransactionTableMissingAssetTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsTransactionTableMissingAssetTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperIsTransactionTableMissingAssetTests
+{
+    // IsTransactionTable gates the entire ParseTransactionTable iterator —
+    // when it returns false the parser yields nothing. The contract is that
+    // a table qualifies ONLY when it has BOTH a date-like column AND an
+    // asset/ticker/description column (the body literally returns
+    // `hasDate && hasAsset`). Pin the AND-ing on a date-only header set: a
+    // refactor that flipped `&&` to `||` (a single-character typo) would
+    // silently accept malformed tables that contain only a date column,
+    // routing the next step (ParseTransactionRow) into a column-index
+    // lookup against absent columns — producing rows with empty tickers
+    // that pollute the congressional-trade stream.
+    [Fact]
+    public void IsTransactionTable_DateColumnOnlyNoAsset_ReturnsFalse()
+    {
+        var method = typeof(DisclosureParsingHelper).GetMethod(
+            "IsTransactionTable",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var headers = new List<string> { "transaction date", "owner", "amount" };
+
+        var result = (bool)method.Invoke(null, [headers]);
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the `&&`-conjunction in `DisclosureParsingHelper.IsTransactionTable` — a date column alone does not qualify a table as a transaction table.
- Catches a one-character refactor (`&&` → `||`) that would silently accept malformed tables and let `ParseTransactionRow` look up absent columns, polluting the congressional-trade stream with empty-ticker rows.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsTransactionTableMissingAssetTests.cs` — reflection-invoked test asserting `IsTransactionTable(["transaction date", "owner", "amount"])` returns `false`.