### PR TITLE
docs: add contributor license agreement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Contributor License Agreement (`CLA.md`) based on Project Harmony HA-CLA-I-ANY 1.0. Contributors must sign via CLA Assistant before pull requests can be merged. Enables Equibles to remain AGPL-3.0 while sharing code with the commercial offering.
+
 ### Changed
 
 ### Fixed

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,89 @@
+# Equibles Individual Contributor License Agreement
+
+Thank you for your interest in contributing to Equibles ("We" or "Us").
+
+This contributor agreement ("Agreement") documents the rights granted by contributors to Us. To make this document effective, please sign the Agreement using the CLA assistant bot that comments on your pull request, following the instructions in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+This is a legally binding document, so please read it carefully before agreeing to it. The Agreement may cover more than one software project managed by Us.
+
+## 1. Definitions
+
+"You" means the individual who Submits a Contribution to Us.
+
+"Contribution" means any work of authorship that is Submitted by You to Us in which You own or assert ownership of the Copyright. If You do not own the Copyright in the entire work of authorship, please contact Us before submitting the Contribution.
+
+"Copyright" means all rights protecting works of authorship owned or controlled by You, including copyright, moral and neighboring rights, as appropriate, for the full term of their existence including any extensions by You.
+
+"Material" means the work of authorship which is made available by Us to third parties. When this Agreement covers more than one software project, the Material means the work of authorship to which the Contribution was Submitted. After You Submit the Contribution, it may be included in the Material.
+
+"Submit" means any form of electronic, verbal, or written communication sent to Us or our representatives, including but not limited to electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Us for the purpose of discussing and improving the Material, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+"Submission Date" means the date on which You Submit a Contribution to Us.
+
+"Effective Date" means the date You execute this Agreement or the date You first Submit a Contribution to Us, whichever is earlier.
+
+## 2. Grant of Rights
+
+### 2.1 Copyright License
+
+(a) You retain ownership of the Copyright in Your Contribution and have the same rights to use or license the Contribution which You would have had without entering into the Agreement.
+
+(b) To the maximum extent permitted by the relevant law, You grant to Us a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license under the Copyright covering the Contribution, with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform and distribute the Contribution as part of the Material; provided that this license is conditioned upon compliance with Section 2.3.
+
+### 2.2 Patent License
+
+For patent claims including, without limitation, method, process, and apparatus claims which You own, control or have the right to grant, now or in the future, You grant to Us a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable patent license, with the right to sublicense these rights to multiple tiers of sublicensees, to make, have made, use, sell, offer for sale, import and otherwise transfer the Contribution and the Contribution in combination with the Material (and portions of such combination). This license is granted only to the extent that the exercise of the licensed rights infringes such patent claims; and provided that this license is conditioned upon compliance with Section 2.3.
+
+### 2.3 Outbound License
+
+Based on the grant of rights in Sections 2.1 and 2.2, if We include Your Contribution in a Material, We may license the Contribution under any license, including copyleft, permissive, commercial, or proprietary licenses. As a condition on the exercise of this right, We agree to also license the Contribution under the terms of the license or licenses which We are using for the Material on the Submission Date.
+
+### 2.4 Moral Rights
+
+If moral rights apply to the Contribution, to the maximum extent permitted by law, You waive and agree not to assert such moral rights against Us or our successors in interest, or any of our licensees, either direct or indirect.
+
+### 2.5 Our Rights
+
+You acknowledge that We are not obligated to use Your Contribution as part of the Material and may decide to include any Contribution We consider appropriate.
+
+### 2.6 Reservation of Rights
+
+Any rights not expressly licensed under this section are expressly reserved by You.
+
+## 3. Agreement
+
+You confirm that:
+
+(a) You have the legal authority to enter into this Agreement.
+
+(b) You own the Copyright and patent claims covering the Contribution which are required to grant the rights under Section 2.
+
+(c) The grant of rights under Section 2 does not violate any grant of rights which You have made to third parties, including Your employer. If You are an employee, You have had Your employer approve this Agreement or sign the Entity version of this document. If You are less than eighteen years old, please have Your parents or guardian sign the Agreement.
+
+(d) You have notified Us if You do not own the Copyright in the entire work of authorship Submitted.
+
+## 4. Disclaimer
+
+EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 3, THE CONTRIBUTION IS PROVIDED "AS IS". MORE PARTICULARLY, ALL EXPRESS OR IMPLIED WARRANTIES INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE EXPRESSLY DISCLAIMED BY YOU TO US. TO THE EXTENT THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY IS LIMITED IN DURATION TO THE MINIMUM PERIOD PERMITTED BY LAW.
+
+## 5. Consequential Damage Waiver
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL YOU BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF ANTICIPATED SAVINGS, LOSS OF DATA, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL AND EXEMPLARY DAMAGES ARISING OUT OF THIS AGREEMENT REGARDLESS OF THE LEGAL OR EQUITABLE THEORY (CONTRACT, TORT OR OTHERWISE) UPON WHICH THE CLAIM IS BASED.
+
+## 6. Miscellaneous
+
+6.1 This Agreement will be governed by and construed in accordance with the laws of the State of Delaware, United States of America, excluding its conflicts of law provisions. Under certain circumstances, the governing law in this section might be superseded by the United Nations Convention on Contracts for the International Sale of Goods ("UN Convention") and the parties intend to avoid the application of the UN Convention to this Agreement and, thus, exclude the application of the UN Convention in its entirety to this Agreement.
+
+6.2 This Agreement sets out the entire agreement between You and Us for Your Contributions to Us and overrides all other agreements or understandings.
+
+6.3 If You or We assign the rights or obligations received through this Agreement to a third party, as a condition of the assignment, that third party must agree in writing to abide by all the rights and obligations in the Agreement.
+
+6.4 The failure of either party to require performance by the other party of any provision of this Agreement in one situation shall not affect the right of a party to require such performance at any time in the future. A waiver of performance under a provision in one situation shall not be considered a waiver of the performance of the provision in the future or a waiver of the provision in its entirety.
+
+6.5 If any provision of this Agreement is found void and unenforceable, such provision will be replaced to the extent possible with a provision that comes closest to the meaning of the original provision and which is enforceable. The terms and conditions set forth in this Agreement shall apply notwithstanding any failure of essential purpose of this Agreement or any limited remedy to the maximum extent possible under law.
+
+---
+
+This agreement is derived from the Project Harmony CLA generator: <https://www.harmonyagreements.org/>
+
+Harmony (HA-CLA-I-ANY) Version 1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,12 @@ Create additional projects only when needed:
 
 Domain-specific enums like `DocumentType` and `ErrorSource` use a smart enum pattern. They can be extended by calling their `Register()` method — no need to modify the core packages.
 
+## Contributor License Agreement
+
+In order for Us to accept patches and other contributions from you, you need to sign our [Contributor License Agreement](CLA.md) (the "**CLA**"). The CLA grants Us the rights needed to maintain Equibles as an open-source project under AGPL-3.0 while also distributing it under separate terms in our commercial offering. You retain ownership of your contributions.
+
+Equibles uses [CLA Assistant](https://cla-assistant.io) to track contributor CLA status. When you open a pull request, CLA Assistant will post a comment indicating whether you have signed the CLA. If you have not, you must sign before we can merge your contribution. Signing is a one-time process, valid for all future contributions, and takes under a minute via your GitHub account.
+
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [AGPL-3.0](LICENSE) license.
+Equibles is released under the [AGPL-3.0](LICENSE) license. By signing the [CLA](CLA.md), you grant Us the rights described in the agreement; you continue to own the copyright in your contributions.

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Without the embedding profile, BM25 full-text search via ParadeDB still works ou
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, project architecture, and how to extend the platform.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, project architecture, and how to extend the platform. Contributors must sign the [Contributor License Agreement](CLA.md) — this is handled automatically by a bot when you open a pull request.
 
 ## License
 


### PR DESCRIPTION
## Summary

Add a Contributor License Agreement so future PRs can be accepted under terms that work for both the AGPL-3.0 OSS repo and the commercial offering that consumes these NuGet packages. Without a CLA, contributions are AGPL-only and can't be relicensed for the commercial repo.

Template: **Project Harmony HA-CLA-I-ANY Version 1.0** — the "ANY" outbound-license variant, designed exactly for dual-licensed projects (used by ParadeDB, Canonical projects, MongoDB-style setups). Governing law: Delaware, USA.

Contributors **retain copyright** in their contributions and grant Equibles a perpetual, royalty-free license with the right to sublicense — including under commercial terms. This is the standard pattern for OSS-with-commercial-counterpart projects.

## Code changes

- `CLA.md` — full CLA text at the repo root.
- `CONTRIBUTING.md` — new "Contributor License Agreement" section explaining what contributors are signing and why; License section updated to reflect that contributors retain copyright.
- `README.md` — Contributing section links to the CLA.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## One-time setup required after merge

Enforcement happens via **CLA Assistant** — a free GitHub App that posts a comment on every new PR and blocks merge until the author signs. Steps:

1. Go to <https://cla-assistant.io> and sign in with GitHub.
2. Click **Configure CLA**, pick the `daniel3303/Equibles` repository.
3. For the CLA source, paste the contents of `CLA.md` from this PR into a **public GitHub Gist** (CLA Assistant reads from a Gist, not a repo file) and point CLA Assistant at the Gist URL.
4. (Optional) In **Settings → Branches → Branch protection rules** for `main`, add the `license/cla` check from CLA Assistant as a required status check — that way PRs can't be merged until the contributor signs.

After step 2 is done, the next PR you (or anyone) open will get a CLA Assistant comment. Existing committers don't need to retroactively sign for past contributions — the CLA only governs work merged after enforcement starts.

## Verification

- [x] `CLA.md` text reviewed against the Harmony template; placeholders adjusted to "Equibles" and Delaware law.
- [x] `dotnet build` not applicable — docs-only change.
- [x] markdownlint passes (pre-commit hooks).
- [x] codespell passes (pre-commit hooks).