### PR TITLE
test(holdings): pin IsYes "1" arm requires exact match, rejects "10"

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsYesExactOneMatchTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsYesExactOneMatchTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceIsYesExactOneMatchTests
+{
+    // IsYes maps SEC cover-page Y/N text to a bool — used for the
+    // ConfidentialTreatmentRequested flag on 13F holdings. The OR chain
+    // distinguishes between case-insensitive word matches (`Y`, `yes`,
+    // `true`) and a strict equality check on `"1"`. A refactor that
+    // generalised the `"1"` arm into `raw.StartsWith("1")` or
+    // `raw.Contains("1")` — a plausible "simplification" — would silently
+    // flip every numeric SEC payload starting with 1 (e.g. quantities like
+    // "10000") into a confidential-treatment claim, mis-flagging the row
+    // and (worse) hiding the real holding under the suppressed-output path.
+    [Fact]
+    public void IsYes_MultiDigitNumericLeadingOne_ReturnsFalse()
+    {
+        var method = typeof(HoldingsImportService).GetMethod(
+            "IsYes",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (bool)method.Invoke(null, ["10"]);
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the exact `raw == "1"` arm in `HoldingsImportService.IsYes` so SEC numeric payloads starting with 1 (e.g. "10000") never read as a confidential-treatment yes.
- Catches a plausible refactor (`StartsWith("1")` / `Contains("1")`) that would silently flip every multi-digit numeric ConfidentialTreatment field into a suppressed-holding marker.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsYesExactOneMatchTests.cs` — reflection-invoked test asserting `IsYes("10")` returns `false`.