### PR TITLE
test(holdings): pin RenderOverlapTable emits explicit diagnostic when no overlap rows

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderOverlapTableEmptyRowsTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderOverlapTableEmptyRowsTests.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class InstitutionalHoldingsToolsRenderOverlapTableEmptyRowsTests
+{
+    // RenderOverlapTable renders the GetFundOverlap LLM-facing report. When
+    // FundOverlapCalculator returns no rows (both funds had no positions on
+    // the selected date, or both reported only options), the renderer must
+    // emit an explicit operator-readable diagnostic — not a bare markdown
+    // table-header skeleton with no rows. The empty diagnostic is what tells
+    // the LLM consumer the absence-of-rows is meaningful rather than missing
+    // data. A refactor that dropped the early return would leave just
+    // "| # | Ticker | Company | ... | Combined ($M) |" with no body, leaving
+    // the consumer to guess whether the call succeeded or returned partial.
+    [Fact]
+    public void RenderOverlapTable_OverlapHasNoRows_EmitsExplicitNoPositionsDiagnostic()
+    {
+        var method = typeof(InstitutionalHoldingsTools).GetMethod(
+            "RenderOverlapTable",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var holder1 = new InstitutionalHolder { Name = "Fund A" };
+        var holder2 = new InstitutionalHolder { Name = "Fund B" };
+        var overlap = new FundOverlapResult
+        {
+            UnionPositionCount = 0,
+            IntersectionPositionCount = 0,
+            JaccardSimilarityPercent = 0.0,
+            DollarWeightedOverlapPercent = 0.0,
+            Rows = new List<FundOverlapRow>(),
+        };
+
+        var rendered = (string)
+            method.Invoke(null, [holder1, holder2, new DateOnly(2024, 9, 30), overlap, 20]);
+
+        rendered.Should().Contain("Neither fund reports any positions for this date.");
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the empty-rows diagnostic in `InstitutionalHoldingsTools.RenderOverlapTable`: when `FundOverlapResult.Rows` is empty, the LLM-facing output must include the explicit "Neither fund reports any positions for this date." marker rather than just a bare table-header skeleton.
- Catches a refactor that drops the early return and leaves the consumer guessing whether the call returned partial or empty data.

## Code changes

- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderOverlapTableEmptyRowsTests.cs` — reflection-invoked test feeding two holders + an empty `FundOverlapResult` and asserting the rendered string contains the no-positions diagnostic.