### PR TITLE
test(holdings): pin ParseLong null-tolerant null-conditional contract

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseLongNullToleranceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseLongNullToleranceTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Filing13FXmlParserParseLongNullToleranceTests
+{
+    // Filing13FXmlParser.ParseLong reads free-text numerics from the 13F
+    // info-table XML (Shares, Value, voting-share triplets). The body uses
+    // the null-conditional `raw?.Replace(",", "")` so callers can pass the
+    // result of `Value(child)` (which returns null for an absent element)
+    // without an upstream null-check — important because the info-table
+    // schema makes most numeric fields optional and the parser is hit row-
+    // by-row across the entire filing. A refactor that dropped the `?.` to
+    // an unconditional `raw.Replace(...)` would compile cleanly and NRE on
+    // the first absent element, aborting the import of the whole filing.
+    [Fact]
+    public void ParseLong_NullInput_ReturnsZeroWithoutThrowing()
+    {
+        var method = typeof(Filing13FXmlParser).GetMethod(
+            "ParseLong",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        long parsed = 0;
+        var act = () => parsed = (long)method.Invoke(null, [null]);
+
+        act.Should().NotThrow();
+        parsed.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin `Filing13FXmlParser.ParseLong`'s null-conditional `raw?.Replace(",", "")` so absent `Value(child)` results don't NRE — the 13F info-table schema makes most numeric fields optional, and ParseLong is hit row-by-row.
- Catches a refactor that drops the `?.` (a plausible "simplification") which would compile cleanly and abort the whole filing import on the first missing numeric.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseLongNullToleranceTests.cs` — reflection-invoked test asserting `ParseLong(null)` returns 0 without throwing.