### PR TITLE
test(sec): pin FactArgs.TryParsePeriod Q2 maps to SecFiscalPeriod.Q2

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodQ2Tests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodQ2Tests.cs
@@ -1,0 +1,23 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FactArgsTryParsePeriodQ2Tests
+{
+    // Pins the Q2 switch arm of FactArgs.TryParsePeriod — the last untested
+    // quarter discriminator (Q1, Q3, Q4 already have sibling pins). The
+    // canonical SEC `fp` value for the second quarter is "Q2"; a copy-paste
+    // regression that swapped this case to map "Q2" to Q1 or Q3 would
+    // compile cleanly and silently misalign every CompareFinancialFact /
+    // GetFinancialFact call that names the second quarter — symptoms would
+    // surface only at the fact-comparison level, far from the typo.
+    [Fact]
+    public void TryParsePeriod_Q2_ReturnsTrueAndQ2()
+    {
+        var success = FactArgs.TryParsePeriod("Q2", out var period);
+
+        success.Should().BeTrue();
+        period.Should().Be(SecFiscalPeriod.Q2);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the Q2 arm of `FactArgs.TryParsePeriod` — the last untested quarter discriminator (Q1/Q3/Q4 already have sibling pins).
- Catches a copy-paste regression mapping `"Q2"` to the wrong period; the symptom would only surface downstream at fact-comparison time.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactArgsTryParsePeriodQ2Tests.cs` — asserts `TryParsePeriod("Q2")` returns true with `period == SecFiscalPeriod.Q2`.