### PR TITLE
test(worker): pin BaseScraperWorker.FormatInterval renders 5-min interval as "5m"

### DIFF
--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerFormatIntervalMinutesTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerFormatIntervalMinutesTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Equibles.Worker;
+
+namespace Equibles.UnitTests.Worker;
+
+public class BaseScraperWorkerFormatIntervalMinutesTests
+{
+    // FormatInterval picks the most relevant unit by descending order: hours
+    // first, then minutes, then seconds. The minutes arm is the middle range
+    // (1 min ≤ interval < 1 hour) — the band every operator sees in the
+    // worker's "next run in Nm" startup log. A copy-paste swap of the
+    // minutes and seconds bodies would silently render a 5-minute sleep as
+    // "300s" — operationally usable but a regression from the deliberate
+    // unit picker. Pin the minutes branch on a value plainly inside the
+    // band so any reorder of the return statements is loud.
+    [Fact]
+    public void FormatInterval_FiveMinuteInterval_RendersInMinutesUnit()
+    {
+        var method = typeof(BaseScraperWorker).GetMethod(
+            "FormatInterval",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (string)method.Invoke(null, [TimeSpan.FromMinutes(5)]);
+
+        result.Should().Be("5m");
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the minutes branch of `BaseScraperWorker.FormatInterval` — the "next run in Nm" log seen by every operator in the worker startup output.
- Catches a copy-paste swap of the minutes and seconds return statements that would silently render a 5-minute sleep as "300s".

## Code changes

- `tests/Equibles.UnitTests/Worker/BaseScraperWorkerFormatIntervalMinutesTests.cs` — reflection-invoked test asserting `FormatInterval(TimeSpan.FromMinutes(5))` returns `"5m"`.