### PR TITLE
test(sec): pin FactMarkdown.Cell null-tolerant short-circuit returns empty string

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownCellNullTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownCellNullTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FactMarkdownCellNullTests
+{
+    // Cell() runs on every Markdown table cell the FinancialFacts MCP tools
+    // render, and the production callers feed it nullable strings — notably
+    // `fact.Form?.DisplayName` (FinancialStatementTools.cs:187) where the
+    // null-conditional propagates null when Form is absent. The leading
+    // `value == null ? "" : …` short-circuit is the load-bearing safety —
+    // a refactor that "simplified" Cell to `value.Replace(…)` (dropping
+    // the null arm) would compile cleanly and NRE every time an MCP tool
+    // rendered a row where any nullable field was actually null, aborting
+    // the response mid-table for the LLM consumer.
+    [Fact]
+    public void Cell_NullInput_ReturnsEmptyStringWithoutThrowing()
+    {
+        string result = "not-empty";
+        var act = () => result = FactMarkdown.Cell(null);
+
+        act.Should().NotThrow();
+        result.Should().Be(string.Empty);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the `value == null` short-circuit in `FactMarkdown.Cell` — production callers pipe nullable fields like `fact.Form?.DisplayName` through it, so the null arm protects every MCP-rendered row.
- Catches a refactor that drops the null check, which would NRE every time a table cell received a propagated-null value and abort the LLM response mid-row.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownCellNullTests.cs` — asserts `Cell(null)` returns `string.Empty` without throwing.