### PR TITLE
test(congress): pin DisclosureParsingHelper.Truncate null-passthrough on zero maxLength

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateNullZeroMaxLengthTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateNullZeroMaxLengthTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperTruncateNullZeroMaxLengthTests
+{
+    // Sibling to the zero-maxLength + negative-maxLength + surrogate-pair pins.
+    // The early-bail body reads `value == null ? value : string.Empty` — null
+    // input survives as null when maxLength <= 0, non-null collapses to "".
+    // Pin the null-passthrough on its own: downstream `Truncate(owner, 64)`
+    // (DisclosureParsingHelper.cs:193) and `Truncate(assetName, 256)`
+    // (line 189) feed the result straight into a DisclosureTransaction whose
+    // OwnerType / AssetName columns distinguish "field absent" (null) from
+    // "field intentionally empty" (""). A refactor that simplified the
+    // conditional to `return string.Empty;` would silently coalesce null to
+    // empty for the maxLength<=0 edge — and any future caller that relied on
+    // the null-vs-empty distinction would silently break.
+    [Fact]
+    public void Truncate_NullValueWithZeroMaxLength_ReturnsNullNotEmpty()
+    {
+        var result = DisclosureParsingHelper.Truncate(null, 0);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the null-passthrough arm of `DisclosureParsingHelper.Truncate(value, 0)` — null in returns null out, distinct from a non-null input collapsing to empty string.
- Catches a refactor that simplifies the early-bail to `return string.Empty;` — would silently coalesce null OwnerType / AssetName columns to empty, breaking any consumer that distinguishes "field absent" from "field intentionally empty".

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperTruncateNullZeroMaxLengthTests.cs` — asserts `Truncate(null, 0)` returns `null`.