### PR TITLE
test(sec): pin GetCurrencyName unknown-code returns raw code as fallback

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepGetCurrencyNameUnknownTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepGetCurrencyNameUnknownTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class CurrencyConsolidationStepGetCurrencyNameUnknownTests
+{
+    // GetCurrencyName feeds the rendered "All values are in {currencyName}."
+    // note inserted after every consolidated table. The body's TryGetValue
+    // fallback returns the raw three-letter code (e.g. "CHF" when the code
+    // isn't in CurrencyMap) — NEVER null — so the rendered sentence still
+    // parses cleanly. A refactor that returned `null` for unknown codes
+    // would render "All values are in ." (or NRE downstream) and silently
+    // break the human-readable currency context on any SEC filing using a
+    // non-allowlisted ISO code (CHF, CAD, AUD, BRL, …).
+    [Fact]
+    public void GetCurrencyName_UnknownCurrencyCode_ReturnsRawCodeAsFallback()
+    {
+        var step = new CurrencyConsolidationStep();
+        var method = typeof(CurrencyConsolidationStep).GetMethod(
+            "GetCurrencyName",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+        var result = (string)method.Invoke(step, ["CHF"]);
+
+        result.Should().Be("CHF");
+    }
+}


### PR DESCRIPTION
## Summary

- Pin `CurrencyConsolidationStep.GetCurrencyName`'s `TryGetValue ?? code` fallback so non-allowlisted ISO codes (CHF, CAD, AUD, BRL, …) render cleanly into the "All values are in …" note instead of producing a malformed sentence or NRE.
- Catches a refactor that returned `null` for unknown codes — would emit "All values are in ." or crash downstream string interpolation.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepGetCurrencyNameUnknownTests.cs` — reflection-invoked test asserting `GetCurrencyName("CHF")` returns `"CHF"`.