### PR TITLE
test(sec): pin IsTransientNetworkError treats SocketException as transient

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientIsTransientNetworkErrorSocketTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientIsTransientNetworkErrorSocketTests.cs
@@ -1,0 +1,33 @@
+using System.Net.Sockets;
+using System.Reflection;
+using Equibles.Integrations.Sec;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecEdgarClientIsTransientNetworkErrorSocketTests
+{
+    // IsTransientNetworkError's WHY-comment names DNS resolution, socket and
+    // TLS handshake failures as the transient set — "retried, never recorded
+    // as dashboard errors". DNS lookup failures surface from HttpClient as
+    // an HttpRequestException wrapping a SocketException. A refactor that
+    // narrowed the inner-exception set (e.g. removed SocketException because
+    // "we already handle Socket-related stuff elsewhere") would silently
+    // demote every transient DNS hiccup to a dashboard-visible error and
+    // bury real defects in operational noise. Pin the SocketException arm.
+    [Fact]
+    public void IsTransientNetworkError_SocketExceptionInner_ReturnsTrue()
+    {
+        var method = typeof(SecEdgarClient).GetMethod(
+            "IsTransientNetworkError",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var wrapped = new HttpRequestException(
+            "DNS failure",
+            new SocketException((int)SocketError.HostNotFound)
+        );
+
+        var result = (bool)method.Invoke(null, [wrapped]);
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the `SocketException` arm of `SecEdgarClient.IsTransientNetworkError` — DNS lookup failures surface from `HttpClient` as `HttpRequestException` wrapping a `SocketException`, and the helper's WHY-comment commits to classifying these as transient ("retried, never recorded as dashboard errors").
- Catches a refactor that narrowed the inner-exception set: removing `SocketException` would route every transient DNS hiccup to the dashboard and bury real defects.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecEdgarClientIsTransientNetworkErrorSocketTests.cs` — reflection-invoked test wrapping a `SocketException(HostNotFound)` inside `HttpRequestException`; asserts `IsTransientNetworkError` returns `true`.