### PR TITLE
test(sec): pin ParseInvariantDateOr honors caller-supplied fallback on parse failure

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientParseInvariantDateOrUnparseableTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientParseInvariantDateOrUnparseableTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Equibles.Integrations.Sec;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecEdgarClientParseInvariantDateOrUnparseableTests
+{
+    // ParseInvariantDateOr's contract is `parsed ?? fallback` — the caller
+    // names the sentinel to use when SEC sends an unparseable date string
+    // (truncated payload, blank cell, Hebrew/Hijri-formatted edge cases).
+    // The fallback is what's actually written to the filing row, so the
+    // honored value matters: callers commonly pass the filing's already-
+    // known date (PeriodOfReport) so a parse failure doesn't poison the
+    // record with DateOnly.MinValue. A refactor that returned
+    // `default(DateOnly)` (= MinValue) for the failure arm — independent
+    // of the fallback arg — would silently overwrite every recovery
+    // path's intended sentinel with 0001-01-01.
+    [Fact]
+    public void ParseInvariantDateOr_UnparseableText_ReturnsTheSuppliedFallbackNotMinValue()
+    {
+        var method = typeof(SecEdgarClient).GetMethod(
+            "ParseInvariantDateOr",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var fallback = new DateOnly(2024, 6, 30);
+
+        var result = (DateOnly)method.Invoke(null, ["not-a-date", fallback]);
+
+        result.Should().Be(fallback);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin `SecEdgarClient.ParseInvariantDateOr`'s `parsed ?? fallback` contract — callers pass the filing's already-known date (e.g. `PeriodOfReport`) so a malformed SEC date string doesn't poison the row.
- Catches a refactor that returned `default(DateOnly)` (= `MinValue`) on parse failure instead of the supplied fallback — would silently overwrite every recovery path's intended sentinel with `0001-01-01`.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecEdgarClientParseInvariantDateOrUnparseableTests.cs` — reflection-invoked test asserting `ParseInvariantDateOr("not-a-date", new DateOnly(2024, 6, 30))` returns `2024-06-30`.