### PR TITLE
test(sec): pin BuildArchiveUrl strips CIK zeros and accession dashes

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientBuildArchiveUrlUnpaddedCikTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientBuildArchiveUrlUnpaddedCikTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Equibles.Integrations.Sec;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecEdgarClientBuildArchiveUrlUnpaddedCikTests
+{
+    // BuildArchiveUrl carries an explicit operational contract in its
+    // inline comment: "Per-file URL uses unpadded CIK and the accession
+    // number with dashes removed. Padded CIK works too but triggers a 301
+    // redirect; skip the extra hop." Pin both: CIK stripped of leading
+    // zeros AND accession dashes removed. A refactor that aligned this
+    // helper with the sibling GetDocumentUrl (which uses FormatCik to
+    // pad) would compile cleanly and still resolve via SEC's 301
+    // redirect — but every artifact fetch would double its round-trip,
+    // halving the SEC scraper's rate-limit budget at peak.
+    [Fact]
+    public void BuildArchiveUrl_PaddedCikAndDashedAccession_StripsZerosAndDashes()
+    {
+        var method = typeof(SecEdgarClient).GetMethod(
+            "BuildArchiveUrl",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var url = (string)
+            method.Invoke(null, ["0000320193", "0000320193-25-000001", "primary_doc.xml"]);
+
+        url.Should().Contain("/data/320193/");
+        url.Should().Contain("/000032019325000001/");
+        url.Should().NotContain("/0000320193/");
+        url.Should().NotContain("0000320193-25-000001");
+    }
+}


### PR DESCRIPTION
## Summary

- Pin `SecEdgarClient.BuildArchiveUrl`'s documented contract — strip leading zeros from CIK + drop dashes from accession — so per-file artifact fetches skip SEC's 301 redirect.
- Catches a refactor that aligned BuildArchiveUrl with the padding `GetDocumentUrl` sibling: the URL would still resolve via 301, but every artifact fetch would double its round-trip and halve the scraper's rate-limit budget.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecEdgarClientBuildArchiveUrlUnpaddedCikTests.cs` — reflection-invoked test asserting padded CIK `0000320193` + dashed accession `0000320193-25-000001` produce a URL containing `/data/320193/` and `/000032019325000001/` (and neither the padded CIK nor the dashed accession).