### PR TITLE
test(sec): pin FinancialConceptAliases Normalize folds '/' to '-' in alias lookup

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSlashSeparatorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSlashSeparatorTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialConceptAliasesTryResolveSlashSeparatorTests
+{
+    // Normalize folds '/' → '-' so callers can use path-style phrasing
+    // ("operating/income") that the MCP LLM consumer would generate when
+    // mirroring a user input like "operating/income". A refactor that
+    // pruned the Replace("/", "-") on the false intuition that "we already
+    // accept dashes" would compile cleanly — every existing test passes —
+    // and only the slash-form queries would silently miss the Map lookup
+    // and return SupportedAliases-only suggestions. Pin the slash arm.
+    [Fact]
+    public void TryResolve_AliasWithForwardSlashSeparator_NormalizesToDashAndResolves()
+    {
+        var success = FinancialConceptAliases.TryResolve("operating/income", out var concepts);
+
+        success.Should().BeTrue();
+        concepts.Should().HaveCount(1);
+        concepts[0].Taxonomy.Should().Be(FactTaxonomy.UsGaap);
+        concepts[0].Tag.Should().Be("OperatingIncomeLoss");
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the `Replace("/", "-")` step in `FinancialConceptAliases.Normalize` so callers can use path-style phrasing (`"operating/income"`) — the MCP LLM consumer routinely mirrors user input verbatim, including slashes.
- Catches a refactor that drops the slash-fold ("we already accept dashes") — every existing test passes, but slash-form queries silently miss the Map lookup.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveSlashSeparatorTests.cs` — asserts `TryResolve("operating/income")` resolves to `us-gaap:OperatingIncomeLoss`.