### PR TITLE
test(web): pin StocksController.ParsePositionTypes keeps only defined members

### DIFF
--- a/tests/Equibles.UnitTests/Web/StocksControllerParsePositionTypesMixedValidInvalidTests.cs
+++ b/tests/Equibles.UnitTests/Web/StocksControllerParsePositionTypesMixedValidInvalidTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Equibles.Web.Controllers;
+using Equibles.Web.ViewModels.Stocks;
+
+namespace Equibles.UnitTests.Web;
+
+public class StocksControllerParsePositionTypesMixedValidInvalidTests
+{
+    [Fact]
+    public void ParsePositionTypes_MixedValidAndInvalid_KeepsOnlyDefinedMembersCaseInsensitive()
+    {
+        // Companion to StocksControllerParsePositionTypesUndefinedNumericTests, which
+        // pins the all-invalid path (returns null). This pin covers the surviving-valid
+        // path: when the comma-separated input mixes a defined name ("new", lower-case),
+        // a numeric value with no matching member ("999"), an unrecognised name ("foo")
+        // and another defined name ("Increased"), the parser must drop the two invalid
+        // tokens and return a set containing exactly the two valid members. Anything
+        // looser would leak (PositionChangeType)999 (or a parsed-as-name garbage value)
+        // into the bucket-filter set the UI/CSV exports trust.
+        var method = typeof(StocksController).GetMethod(
+            "ParsePositionTypes",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (HashSet<PositionChangeType>)method.Invoke(null, ["new,999,foo,Increased"]);
+
+        result.Should().NotBeNull();
+        result
+            .Should()
+            .BeEquivalentTo(new[] { PositionChangeType.New, PositionChangeType.Increased });
+    }
+}


### PR DESCRIPTION
## Summary

- Companion to the existing `StocksControllerParsePositionTypesUndefinedNumericTests` (which pins the all-invalid path returning null). This pin covers the surviving-valid path: a comma-separated mix of a defined name in lower case, a numeric value with no matching member, an unrecognised name and another defined name must yield a set containing exactly the two defined members.
- Closes the previously-zero-hit `result.Add(parsed)` line inside the parser; that line is the gate that injects parsed enum values into the bucket-filter set the UI / CSV exports trust, so leaving it unverified meant we could regress to leaking `(PositionChangeType)999` without any test failing.

## Code changes

- `tests/Equibles.UnitTests/Web/StocksControllerParsePositionTypesMixedValidInvalidTests.cs` — new unit test that reflectively invokes the private static `ParsePositionTypes` with the input `"new,999,foo,Increased"` and asserts the returned set equals `{ New, Increased }`.