### PR TITLE
test(web): pin VersionCheckService.Refresh attaches Bearer auth header when GitHubToken configured

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/VersionCheckServiceRefreshGitHubTokenTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/VersionCheckServiceRefreshGitHubTokenTests.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Equibles.Web.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Contract: when `GitHubToken` is configured, the background refresh's outgoing
+/// request to api.github.com must carry `Authorization: Bearer <token>`. The
+/// token exists to lift the anonymous-IP rate limit (60/h → 5000/h); a refactor
+/// that quietly drops or mis-schemes the header re-introduces the original
+/// problem under a name nobody is looking at, and the failure mode (banner
+/// silently stops updating) is the kind of bug that lives in production for
+/// months before anyone notices.
+/// </summary>
+public class VersionCheckServiceRefreshGitHubTokenTests
+{
+    private class HeaderCapturingHandler : HttpMessageHandler
+    {
+        private readonly string _json;
+        public AuthenticationHeaderValue LastAuthorization { get; private set; }
+        public int Calls { get; private set; }
+
+        public HeaderCapturingHandler(string json)
+        {
+            _json = json;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            Calls++;
+            LastAuthorization = request.Headers.Authorization;
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_json, Encoding.UTF8, "application/json"),
+                }
+            );
+        }
+    }
+
+    [Fact]
+    public async Task Refresh_GitHubTokenConfigured_AttachesBearerAuthorizationHeader()
+    {
+        const string token = "ghp_TEST_TOKEN_VALUE_0123456789";
+
+        var handler = new HeaderCapturingHandler("{\"tag_name\":\"v1.1.1\"}");
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory
+            .CreateClient(Arg.Any<string>())
+            .Returns(_ => new HttpClient(handler, disposeHandler: false));
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string>
+                {
+                    ["CheckForUpdates"] = "true",
+                    ["GitHubToken"] = token,
+                }
+            )
+            .Build();
+
+        var sut = new VersionCheckService(
+            factory,
+            configuration,
+            Substitute.For<ILogger<VersionCheckService>>()
+        );
+
+        sut.Get();
+
+        for (var i = 0; i < 100 && handler.Calls == 0; i++)
+        {
+            await Task.Delay(20);
+        }
+
+        handler.Calls.Should().BeGreaterThan(0, "the background refresh must hit the stub");
+        handler.LastAuthorization.Should().NotBeNull();
+        handler.LastAuthorization!.Scheme.Should().Be("Bearer");
+        handler.LastAuthorization.Parameter.Should().Be(token);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the `GitHubToken` arm of `VersionCheckService.Refresh`. The token exists to lift GitHub's anonymous-IP rate limit (60/h → 5000/h); a refactor that silently drops the header, mis-schemes it (Basic vs Bearer), or attaches it to the wrong message re-introduces the original throttle without surfacing a failure — the banner just quietly stops detecting updates.
- Previously zero-hit: lines 109-112 of `VersionCheckService.cs` (the entire `if (!string.IsNullOrEmpty(token))` arm).

## Code changes

- `tests/Equibles.IntegrationTests/Web/VersionCheckServiceRefreshGitHubTokenTests.cs` — new integration test. Configures `GitHubToken`, stubs `IHttpClientFactory` with a header-capturing `HttpMessageHandler`, calls `Get()` to trigger the background refresh, polls until the stub records a call, and asserts the request's `Authorization` header is `Bearer <token>`.