### PR TITLE
test(web): pin HoldingsBacktestService.Execute no-13F-snapshots branch

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/HoldingsBacktestServiceNoSnapshotsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsBacktestServiceNoSnapshotsTests.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Contract: when the holder exists and the benchmark stock exists but the holder
+/// has zero 13F snapshots on file, `HoldingsBacktestService.Execute` must short-
+/// circuit and surface a UI-friendly reason ("Holder has no 13F snapshots on
+/// file.") instead of trying to backtest an empty portfolio. The companion
+/// ProfilesInstitutionBacktestTests cover the BenchmarkNotFound and happy paths;
+/// this pin covers the previously unverified empty-holdings branch.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HoldingsBacktestServiceNoSnapshotsTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HoldingsBacktestServiceNoSnapshotsTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetBacktest_HolderHasNo13FSnapshots_RendersNoSnapshotsReason()
+    {
+        var holderCik = "0002000099";
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = Guid.NewGuid(),
+                    Ticker = "SPY",
+                    Name = "SPDR S&P 500 ETF",
+                    Cik = "0000884394",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = Guid.NewGuid(),
+                    Cik = holderCik,
+                    Name = "Empty Portfolio Capital",
+                }
+            );
+            // No InstitutionalHolding rows seeded for this holder — that's the whole point.
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync($"/Institutions/{holderCik}/Backtest");
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, html);
+        html.Should().Contain("data-testid=\"backtest-reason\"");
+        html.Should().Contain("Holder has no 13F snapshots on file.");
+        html.Should().NotContain("data-testid=\"backtest-portfolio-summary\"");
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the previously-unverified branch in `HoldingsBacktestService.Execute` that fires when the holder exists, the benchmark stock exists, but the holder has zero 13F snapshots: the method must short-circuit and surface `"Holder has no 13F snapshots on file."` as the displayed reason rather than attempt to backtest an empty portfolio.
- Companion to `ProfilesInstitutionBacktestTests`, which pins the BenchmarkNotFound alert and the happy path — the empty-holdings branch is structurally distinct from both.

## Code changes

- `tests/Equibles.IntegrationTests/Web/HoldingsBacktestServiceNoSnapshotsTests.cs` — new integration test in the existing `WebHostCollection`. Seeds an `InstitutionalHolder` and the SPY benchmark `CommonStock`, leaves the holdings table empty for this holder, hits `/Institutions/{cik}/Backtest`, and asserts the response renders the `backtest-reason` alert with the no-snapshots message and that no portfolio-summary card is emitted.