### PR TITLE
test(cboe): pin CboeClient.ParseDecimal whitespace short-circuit

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CboeClientParseDecimalWhitespaceTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientParseDecimalWhitespaceTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Equibles.Integrations.Cboe;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CboeClientParseDecimalWhitespaceTests
+{
+    // Sibling to CboeClientParseLongWhitespaceTests. ParseDecimal reads the
+    // PutCallRatio column (and the equity/index/VIX ratio variants). CBOE
+    // occasionally emits a blank cell for thinly-traded sessions; the
+    // `value?.Trim()` + `IsNullOrEmpty` short-circuit collapses those to a
+    // null result instead of letting decimal.TryParse(" ") return its
+    // coincidental false. A refactor that dropped the Trim arm (under the
+    // assumption that decimal.TryParse on whitespace is null-equivalent)
+    // would silently change the meaning of " " from "no data" to "decimal
+    // parse failed" — both currently null today, but the former is the
+    // intended contract and the latter is implementation accident.
+    [Fact]
+    public void ParseDecimal_WhitespaceOnlyInput_ReturnsNullWithoutThrowing()
+    {
+        var method = typeof(CboeClient).GetMethod(
+            "ParseDecimal",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        decimal? parsed = 1m;
+        var act = () => parsed = (decimal?)method.Invoke(null, ["   "]);
+
+        act.Should().NotThrow();
+        parsed.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Sibling to the existing `CboeClientParseLongWhitespaceTests` pin. `ParseDecimal` reads the PutCallRatio column (and the equity/index/VIX ratio variants). CBOE occasionally emits a blank cell for thinly-traded sessions; the `value?.Trim()` + `IsNullOrEmpty` short-circuit collapses those to a null result instead of letting `decimal.TryParse(" ")` return its coincidental false.
- A refactor that dropped the Trim arm (under the assumption that `decimal.TryParse` on whitespace is null-equivalent) would change the meaning of `" "` from "no data" to "decimal parse failed" — both currently null today, but the former is the intended contract and the latter is implementation accident.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CboeClientParseDecimalWhitespaceTests.cs` — new unit test. Reflectively invokes the private static `ParseDecimal` with a whitespace-only input and asserts it returns null without throwing.