### PR TITLE
fix(holdings): floor 13F realtime lookback at the current filing season

### DIFF
--- a/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
+++ b/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
@@ -94,7 +94,7 @@ public class Holdings13FRealtimeWorker : BaseScraperWorker
     {
         var allFileNames = HoldingsDataSetClient.GetDataSetFileNames(startDate);
         if (allFileNames.Count == 0)
-            return MinLookbackDays;
+            return EffectiveMinLookback(today, MinLookbackDays);
 
         await using var scope = ScopeFactory.CreateAsyncScope();
         var repo = scope.ServiceProvider.GetRequiredService<ProcessedDataSetRepository>();
@@ -123,11 +123,39 @@ public class Holdings13FRealtimeWorker : BaseScraperWorker
         }
 
         if (!latestEndDate.HasValue)
-            return MinLookbackDays;
+            return EffectiveMinLookback(today, MinLookbackDays);
 
         // Sweep from the day after the last bulk data set's coverage ends
         var gap = today.DayNumber - latestEndDate.Value.DayNumber;
-        return Math.Max(gap, MinLookbackDays);
+        return Math.Max(gap, EffectiveMinLookback(today, MinLookbackDays));
+    }
+
+    /// <summary>
+    /// The lookback floor. When no processed bulk data set is available to
+    /// measure from (fresh deploy, reset volume, or the startup race against
+    /// <see cref="HoldingsScraperWorker"/>'s backfill), a flat 7-day window
+    /// would skip a whole filing season's worth of submissions: 13F filers
+    /// have 45 days after a quarter end to submit, so a window narrower than
+    /// the gap to the latest completed quarter end misses on-time filings.
+    /// Flooring at that gap keeps the current season covered regardless of
+    /// tracking state, and makes the backfill race harmless.
+    /// </summary>
+    internal static int EffectiveMinLookback(DateOnly today, int minLookbackDays) =>
+        Math.Max(minLookbackDays, today.DayNumber - LatestQuarterEnd(today).DayNumber);
+
+    /// <summary>
+    /// The end of the calendar quarter immediately preceding the one that
+    /// contains <paramref name="today"/> — the latest 13F reporting period
+    /// whose 45-day filing window is open (filings only appear after a period
+    /// ends). Dates in Jan–Mar return the previous year's 31 Dec.
+    /// </summary>
+    internal static DateOnly LatestQuarterEnd(DateOnly today)
+    {
+        const int monthsPerQuarter = 3;
+        var endMonth = (today.Month - 1) / monthsPerQuarter * monthsPerQuarter; // 0, 3, 6, 9
+        return endMonth == 0
+            ? new DateOnly(today.Year - 1, 12, 31)
+            : new DateOnly(today.Year, endMonth, DateTime.DaysInMonth(today.Year, endMonth));
     }
 
     /// <summary>

--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerEffectiveMinLookbackTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerEffectiveMinLookbackTests.cs
@@ -1,0 +1,38 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins EffectiveMinLookback: the realtime lookback floor never drops below the
+/// gap to the latest completed quarter end, so a fresh/empty ProcessedDataSet
+/// (or the startup backfill race) still covers the current filing season rather
+/// than collapsing to the flat 7-day minimum (GH-2206).
+/// </summary>
+public class Holdings13FRealtimeWorkerEffectiveMinLookbackTests
+{
+    [Fact]
+    public void EffectiveMinLookback_MidSeason_FloorsToQuarterEndGap()
+    {
+        // 2026-05-26 is 56 days after the 2026-03-31 quarter end — the window
+        // must reach back across the whole Q1 2026 filing season, not 7 days.
+        var result = Holdings13FRealtimeWorker.EffectiveMinLookback(
+            new DateOnly(2026, 5, 26),
+            minLookbackDays: 7
+        );
+
+        result.Should().Be(56);
+    }
+
+    [Fact]
+    public void EffectiveMinLookback_JustAfterQuarterEnd_KeepsMinimum()
+    {
+        // 2 days into a new quarter the gap is smaller than the floor, so the
+        // configured minimum still wins.
+        var result = Holdings13FRealtimeWorker.EffectiveMinLookback(
+            new DateOnly(2026, 4, 2),
+            minLookbackDays: 7
+        );
+
+        result.Should().Be(7);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerLatestQuarterEndTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerLatestQuarterEndTests.cs
@@ -1,0 +1,33 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins LatestQuarterEnd: the end of the quarter immediately preceding the one
+/// containing the given date, with the Jan–Mar roll back to the prior year's
+/// 31 Dec. This is the basis of the realtime lookback floor (GH-2206).
+/// </summary>
+public class Holdings13FRealtimeWorkerLatestQuarterEndTests
+{
+    [Theory]
+    [InlineData(2026, 1, 15, 2025, 12, 31)] // Jan → prior-year Dec 31
+    [InlineData(2026, 3, 31, 2025, 12, 31)] // Mar 31 (Q1 not yet a filing season)
+    [InlineData(2026, 4, 1, 2026, 3, 31)] // Apr → Mar 31
+    [InlineData(2026, 5, 26, 2026, 3, 31)] // the Vanguard Q1 2026 case
+    [InlineData(2026, 7, 10, 2026, 6, 30)] // Jul → Jun 30
+    [InlineData(2026, 10, 1, 2026, 9, 30)] // Oct → Sep 30
+    [InlineData(2026, 12, 31, 2026, 9, 30)] // Dec → Sep 30 (Q4 not yet ended)
+    public void LatestQuarterEnd_ReturnsPrecedingQuarterEnd(
+        int year,
+        int month,
+        int day,
+        int expectedYear,
+        int expectedMonth,
+        int expectedDay
+    )
+    {
+        var result = Holdings13FRealtimeWorker.LatestQuarterEnd(new DateOnly(year, month, day));
+
+        result.Should().Be(new DateOnly(expectedYear, expectedMonth, expectedDay));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2206.

`Holdings13FRealtimeWorker.ComputeLookbackDays` sizes the EDGAR daily-index sweep as the gap between today and the coverage end date of the latest **processed** quarterly bulk data set. When it can't determine that end date it returned a flat `MinLookbackDays` (7). That fallback is hit on an empty/reset `ProcessedDataSet`, on first run, and — observed in production — by the startup race where the realtime worker computes its window before `HoldingsScraperWorker.BackfillProcessedDataSets` commits.

A 7-day window skips a whole filing season: 13F filers have 45 days after a quarter end to submit, so on-time filings more than a week old are dropped until the authoritative bulk data set lands (up to ~3 months later). Real-world impact: Vanguard's restructured Q1 2026 13F-HRs (filed 2026-05-08, six newly-separate entities) were never ingested after a 2026-05-26 deploy that logged `sweeping 7 days`.

## Code changes

- **`Holdings13FRealtimeWorker.cs`**
  - Add `LatestQuarterEnd(today)` — the end of the calendar quarter immediately preceding the one containing `today` (the latest 13F reporting period whose filing window is open; Jan–Mar rolls back to the prior 31 Dec).
  - Add `EffectiveMinLookback(today, minLookbackDays)` = `max(minLookbackDays, days since LatestQuarterEnd)`.
  - Use it at all three return paths in `ComputeLookbackDays`. The primary path (gap to the last bulk data set) already exceeds this floor in normal operation, so behavior only changes in the fallback — and the backfill race becomes harmless.
- **Tests** (`tests/Equibles.UnitTests/Holdings/`)
  - `Holdings13FRealtimeWorkerLatestQuarterEndTests` — quarter-boundary and year-rollover cases.
  - `Holdings13FRealtimeWorkerEffectiveMinLookbackTests` — floors to the quarter gap mid-season (2026-05-26 → 56), keeps the minimum just after a quarter boundary.