### PR TITLE
test(web): pin ProfilesController.Member 404 guard

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/ProfilesControllerMemberNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesControllerMemberNotFoundTests.cs
@@ -1,0 +1,31 @@
+using System.Net;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Sibling to ProfilesControllerInsiderNotFoundTests (PR #2209). The Member
+/// action's `if (member == null) return NotFound();` guard is structurally
+/// distinct: a refactor that swallowed the null-check would NRE on member.Name
+/// for every unknown Guid the public-facing /congress/{id} route receives
+/// (search-crawler 404 sweeps, deep-linked stale URLs, manually-typed Guids).
+/// Pin the explicit NotFound response.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class ProfilesControllerMemberNotFoundTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public ProfilesControllerMemberNotFoundTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetMember_UnknownId_Returns404()
+    {
+        await _fixture.ResetAndSeedAsync();
+
+        var response = await _fixture.Client.GetAsync($"/congress/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}


### PR DESCRIPTION
## Summary

- Sibling to `ProfilesControllerInsiderNotFoundTests` (PR #2209). The Member action's `if (member == null) return NotFound();` guard is structurally distinct.
- A refactor that swallowed the null-check would NRE on `member.Name` for every unknown Guid the public-facing `/congress/{id}` route receives (search-crawler 404 sweeps, deep-linked stale URLs, manually-typed Guids). Pin the explicit `NotFound` response.

## Code changes

- `tests/Equibles.IntegrationTests/Web/ProfilesControllerMemberNotFoundTests.cs` — new integration test in the existing `WebHostCollection`. Resets the DB without seeding any congress member, hits `/congress/{Guid.NewGuid()}`, and asserts the response is `404`.