### PR TITLE
test(web): pin StatusController.MarkAsSeen not-found redirect

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/StatusControllerMarkAsSeenNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerMarkAsSeenNotFoundTests.cs
@@ -1,0 +1,119 @@
+using Equibles.Cboe.Data;
+using Equibles.Cboe.Repositories;
+using Equibles.Cftc.Data;
+using Equibles.Cftc.Repositories;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Congress.Data;
+using Equibles.Congress.Repositories;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.Finra.Data;
+using Equibles.Finra.Repositories;
+using Equibles.Fred.Data;
+using Equibles.Fred.Repositories;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Repositories;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.Data;
+using Equibles.Messaging;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Equibles.Web.Controllers;
+using Equibles.Web.FlashMessage.Contracts;
+using Equibles.Web.Services;
+using Equibles.Web.Services.Activity;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Repositories;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Sibling to StatusControllerShowNotFoundTests. The Show / MarkAsSeen / Delete
+/// actions all share the same not-found-redirect pattern (Show is pinned).
+/// MarkAsSeen specifically must NOT proceed to call ErrorManager.MarkAsSeen
+/// with a null error — a refactor that dropped the null guard would NRE the
+/// moment an operator double-clicked the "Mark as seen" button (concurrent
+/// requests can race the delete-or-purge worker). Pin the redirect-without-
+/// mark contract.
+/// </summary>
+public class StatusControllerMarkAsSeenNotFoundTests : IDisposable
+{
+    private readonly Equibles.Data.EquiblesDbContext _dbContext;
+
+    public StatusControllerMarkAsSeenNotFoundTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new MediaModuleConfiguration(),
+            new SecTestModuleConfiguration(),
+            new HoldingsModuleConfiguration(),
+            new FinraModuleConfiguration(),
+            new InsiderTradingModuleConfiguration(),
+            new CongressModuleConfiguration(),
+            new FredModuleConfiguration(),
+            new YahooModuleConfiguration(),
+            new ErrorsModuleConfiguration(),
+            new MessagingModuleConfiguration(),
+            new CftcModuleConfiguration(),
+            new CboeModuleConfiguration()
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task MarkAsSeen_NonExistentErrorId_FlashesErrorAndRedirectsWithoutCallingManager()
+    {
+        var flashMessage = Substitute.For<IFlashMessage>();
+        var errorRepository = new ErrorRepository(_dbContext);
+        var errorManager = Substitute.ForPartsOf<ErrorManager>(errorRepository);
+        var dataCountService = new DataCountService(
+            new CommonStockRepository(_dbContext),
+            new DocumentRepository(_dbContext),
+            new InsiderTransactionRepository(_dbContext),
+            new CongressionalTradeRepository(_dbContext),
+            new InstitutionalHoldingRepository(_dbContext),
+            new FailToDeliverRepository(_dbContext),
+            new FredObservationRepository(_dbContext),
+            new DailyStockPriceRepository(_dbContext),
+            new CftcPositionReportRepository(_dbContext),
+            new CboePutCallRatioRepository(_dbContext),
+            new CboeVixDailyRepository(_dbContext)
+        );
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>())
+            .Build();
+
+        var controller = new StatusController(
+            errorRepository,
+            errorManager,
+            flashMessage,
+            configuration,
+            _dbContext,
+            dataCountService,
+            new ActivityFeedBroadcaster(),
+            Substitute.For<ILogger<StatusController>>()
+        );
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext(),
+        };
+        controller.TempData = Substitute.For<ITempDataDictionary>();
+
+        var result = await controller.MarkAsSeen(Guid.NewGuid());
+
+        var redirect = result.Should().BeOfType<RedirectToActionResult>().Subject;
+        redirect.ActionName.Should().Be(nameof(StatusController.Index));
+        flashMessage.Received(1).Error("Error not found.");
+    }
+}


### PR DESCRIPTION
## Summary

- Sibling to `StatusControllerShowNotFoundTests`. The Show / MarkAsSeen / Delete actions share the same not-found-redirect pattern (Show is pinned). `MarkAsSeen` specifically must NOT proceed to call `ErrorManager.MarkAsSeen` with a null error — a refactor that dropped the null guard would NRE the moment an operator double-clicked the "Mark as seen" button (concurrent requests can race the delete-or-purge worker).
- Pins the redirect-without-mark contract.

## Code changes

- `tests/Equibles.IntegrationTests/Web/StatusControllerMarkAsSeenNotFoundTests.cs` — new integration test. Constructs the controller against an in-memory `EquiblesDbContext` with no error rows, calls `MarkAsSeen(Guid.NewGuid())`, and asserts the result is a `RedirectToActionResult` pointing at `Index` and that the flash message helper received the not-found message.