### PR TITLE
test(web): pin StocksController.ShowDocument unknown-id 404 guard

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentNotFoundTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentNotFoundTests.cs
@@ -1,0 +1,47 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Equibles.Web.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Sibling to StocksControllerShowDocumentCrossTickerTests (which pins the
+/// stock-vs-ticker mismatch NotFound). ShowDocument's first guard
+/// `if (document == null) return NotFound();` catches an unknown document id
+/// before the ticker comparison can NRE on `document.CommonStock.Ticker`.
+/// A refactor dropping this guard (or reordering it after the ticker check)
+/// would NRE on every stale or harvested URL that points at a deleted filing —
+/// the document viewer route is publicly enumerable. Pin the NotFound.
+/// </summary>
+public class StocksControllerShowDocumentNotFoundTests
+{
+    [Fact]
+    public async Task ShowDocument_UnknownDocumentId_ReturnsNotFoundWithoutThrowing()
+    {
+        using var ctx = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new MediaModuleConfiguration(),
+            new SecTestModuleConfiguration()
+        );
+
+        var sut = new StocksController(
+            new CommonStockRepository(ctx),
+            institutionalHolderRepository: null!,
+            institutionalHoldingRepository: null!,
+            new DocumentRepository(ctx),
+            stockTabService: null!,
+            Substitute.For<ILogger<StocksController>>()
+        );
+
+        var result = await sut.ShowDocument("AAPL", Guid.NewGuid());
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+}


### PR DESCRIPTION
## Summary

- Sibling to `StocksControllerShowDocumentCrossTickerTests` (which pins the stock-vs-ticker mismatch NotFound). `ShowDocument`'s first guard — `if (document == null) return NotFound();` — catches an unknown document id before the ticker comparison can NRE on `document.CommonStock.Ticker`.
- A refactor dropping the guard or reordering it after the ticker check would NRE on every stale or harvested URL that points at a deleted filing — the document viewer route is publicly enumerable. Pin the NotFound.

## Code changes

- `tests/Equibles.IntegrationTests/Web/StocksControllerShowDocumentNotFoundTests.cs` — new integration test. Builds the controller against an in-memory `EquiblesDbContext` with no documents, calls `ShowDocument("AAPL", Guid.NewGuid())`, and asserts the result is `NotFoundResult`.