### PR TITLE
fix(sec): retry SEC throttle 403s instead of dropping daily-index days

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -439,10 +439,20 @@ public class SecEdgarClient : ISecEdgarClient
 
         // No index file for that day → nothing to ingest, skip it rather than
         // failing the whole real-time sweep. Weekends/holidays can 404, and SEC
-        // returns 403 (Forbidden) for not-yet-published / future-dated index
-        // files (e.g. "today" before the daily index is posted). Both mean the
-        // same thing here: there is no daily index for this date.
-        if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Forbidden)
+        // returns 403 (Forbidden) for not-yet-published index files (today or a
+        // future date, before SEC posts it). Both mean "no index for this date".
+        //
+        // A 403 on a PAST date is different: that index always exists, so a
+        // Forbidden there is SEC's rate-limit throttle page surviving
+        // SendWithRetryAsync's retries — NOT a missing index. Swallowing it as
+        // empty silently drops that day's filings (this is exactly how large
+        // filers went missing during a long catch-up sweep). Let
+        // EnsureSuccessStatusCode surface it instead.
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        if (
+            response.StatusCode == HttpStatusCode.NotFound
+            || (response.StatusCode == HttpStatusCode.Forbidden && date >= today)
+        )
         {
             _logger.LogInformation("No daily index published for {Date:yyyy-MM-dd}", date);
             return [];
@@ -619,6 +629,35 @@ public class SecEdgarClient : ISecEdgarClient
                 }
             }
 
+            // SEC serves its "Request Rate Threshold Exceeded" throttle page with
+            // a 403 (not a 429), so a burst that trips the rolling-window limit
+            // arrives as a Forbidden carrying that HTML body. Back off and retry
+            // it like a 429 — otherwise callers that read 403 as "no resource"
+            // (e.g. GetDailyIndex) silently discard real data. A genuine 403 (a
+            // not-yet-published index, an access-restricted path) has a different
+            // body and falls through to the caller unchanged.
+            if (response.StatusCode == HttpStatusCode.Forbidden && attempt < MaxRetries)
+            {
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+                if (IsRateLimitThresholdPage(body))
+                {
+                    var delay = GetRetryDelay(response, attempt);
+
+                    _logger.LogWarning(
+                        "SEC EDGAR throttled (403 threshold page) for {Url}, pausing for {Delay}s (attempt {Attempt}/{Max})",
+                        url,
+                        delay.TotalSeconds,
+                        attempt + 1,
+                        MaxRetries
+                    );
+
+                    RateLimiter.PauseFor(delay);
+                    response.Dispose();
+                    await Task.Delay(delay, cancellationToken);
+                    continue;
+                }
+            }
+
             if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
             {
                 var delay = GetRetryDelay(response, attempt);
@@ -675,6 +714,13 @@ public class SecEdgarClient : ISecEdgarClient
     // not defects — they are retried, never recorded as dashboard errors.
     private static bool IsTransientNetworkError(HttpRequestException exception) =>
         exception.InnerException is SocketException or IOException or AuthenticationException;
+
+    // SEC's rate-limit response is an HTML page titled "Request Rate Threshold
+    // Exceeded" served with a 403 (not a 429). Detect it by body so throttling
+    // can be backed off and retried rather than mistaken for a missing resource.
+    private static bool IsRateLimitThresholdPage(string body) =>
+        !string.IsNullOrEmpty(body)
+        && body.Contains("Request Rate Threshold Exceeded", StringComparison.OrdinalIgnoreCase);
 
     private static List<CompanyInfo> ParseCompaniesFromResponse(CompanyTickersResponse response)
     {

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientGetDailyIndexThrottleRetryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientGetDailyIndexThrottleRetryTests.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Equibles.Integrations.Sec;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins GetDailyIndex's throttle-retry path: a 403 "Request Rate Threshold
+/// Exceeded" page on a PAST date (whose index always exists) is retried and the
+/// recovered master index parsed — not swallowed as "no index". A regression
+/// returning empty on that 403 silently drops the day's filings during a sweep,
+/// which is how large filers went missing (GH-2222).
+/// </summary>
+public class SecEdgarClientGetDailyIndexThrottleRetryTests
+{
+    [Fact]
+    public async Task GetDailyIndex_ThrottlePageThenSuccess_RetriesAndParses()
+    {
+        var threshold =
+            "<html><head><title>SEC.gov | Request Rate Threshold Exceeded</title></head></html>";
+        var master =
+            "CIK|Company Name|Form Type|Date Filed|File Name\n"
+            + "933478|VANGUARD FIDUCIARY TRUST CO|13F-HR|20200102|edgar/data/933478/0000933478-20-000004.txt\n";
+        var handler = new ThrottleThenOkHandler(threshold, master);
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string> { ["Sec:ContactEmail"] = "test@example.com" }
+            )
+            .Build();
+        var sut = new SecEdgarClient(
+            new HttpClient(handler),
+            NullLogger<SecEdgarClient>.Instance,
+            config
+        );
+
+        // A past date: its daily index always exists, so the 403 must be treated
+        // as a throttle to retry, never as "no index for this day".
+        var result = await sut.GetDailyIndex(new DateOnly(2020, 1, 2));
+
+        // Two calls prove the 403 drove a retry that then succeeded and parsed.
+        handler.CallCount.Should().Be(2);
+        result.Should().ContainSingle();
+        result[0].AccessionNumber.Should().Be("0000933478-20-000004");
+    }
+
+    private sealed class ThrottleThenOkHandler : HttpMessageHandler
+    {
+        private readonly string _throttleBody;
+        private readonly string _okBody;
+        public int CallCount { get; private set; }
+
+        public ThrottleThenOkHandler(string throttleBody, string okBody)
+        {
+            _throttleBody = throttleBody;
+            _okBody = okBody;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            CallCount++;
+            if (CallCount == 1)
+            {
+                var throttled = new HttpResponseMessage(HttpStatusCode.Forbidden)
+                {
+                    Content = new StringContent(_throttleBody),
+                };
+                // Retry-After: 0 keeps the test fast and avoids pausing the shared rate limiter.
+                throttled.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.Zero);
+                return Task.FromResult(throttled);
+            }
+
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_okBody) }
+            );
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientIsRateLimitThresholdPageTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientIsRateLimitThresholdPageTests.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using Equibles.Integrations.Sec;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins IsRateLimitThresholdPage — the discriminator that lets SendWithRetryAsync
+/// tell SEC's 403 throttle page ("Request Rate Threshold Exceeded") apart from a
+/// genuine Forbidden. Broaden it and real 403s would be retried forever; narrow
+/// it and the worker resumes silently dropping throttled daily-index days
+/// (GH-2222).
+/// </summary>
+public class SecEdgarClientIsRateLimitThresholdPageTests
+{
+    private static bool Invoke(string body)
+    {
+        var method = typeof(SecEdgarClient).GetMethod(
+            "IsRateLimitThresholdPage",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        return (bool)method.Invoke(null, [body]);
+    }
+
+    [Fact]
+    public void IsRateLimitThresholdPage_ThrottlePageBody_ReturnsTrue()
+    {
+        var body =
+            "<html><head><title>SEC.gov | Request Rate Threshold Exceeded</title></head></html>";
+
+        Invoke(body).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRateLimitThresholdPage_NormalMasterIndexBody_ReturnsFalse()
+    {
+        var body =
+            "CIK|Company Name|Form Type|Date Filed|File Name\n"
+            + "933478|VANGUARD FIDUCIARY TRUST CO|13F-HR|20260508|edgar/data/933478/0000933478-26-000004.txt";
+
+        Invoke(body).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2222.

SEC serves its **"Request Rate Threshold Exceeded"** page with HTTP **403** — the same status as a not-yet-published daily index. `GetDailyIndex` treated any 403 as "no index for this day" and `SendWithRetryAsync` didn't retry 403s, so a throttled burst silently discarded those days' filings. The #2206/#2207 lookback fix widened the realtime sweep to ~87 days; that longer burst tripped SEC throttling, and the swallowed 403s dropped the busy filing-season days — e.g. Vanguard's six separately-filing Q1 2026 entities (13F-HRs filed 2026-05-08) were fetched but never ingested.

## Code changes

- **`SecEdgarClient.cs`**
  - `SendWithRetryAsync`: new 403 branch — if the body is the SEC threshold page (`IsRateLimitThresholdPage`), back off and retry like a 429; a genuine 403 falls through unchanged.
  - `IsRateLimitThresholdPage(body)` — detects the throttle page by its `Request Rate Threshold Exceeded` marker.
  - `GetDailyIndex`: only treat a 403 as "no index" for **today/future** dates (not-yet-published). A 403 on a **past** date — whose index always exists — now surfaces via `EnsureSuccessStatusCode` instead of returning empty.
- **Tests** (`tests/Equibles.UnitTests/Sec/`)
  - `SecEdgarClientIsRateLimitThresholdPageTests` — pins the discriminator (throttle page → true, normal master index → false).
  - `SecEdgarClientGetDailyIndexThrottleRetryTests` — a 403 throttle page on a past date is retried and the recovered master index parsed (fake handler, `Retry-After: 0`).

## Follow-up (not in this PR)
Deploy-time concurrency across SEC scrapers can exceed SEC's limit at the source; a process-wide shared rate limiter or staggered startup would reduce throttling. This fix makes the sweep self-correct regardless.