### PR TITLE
fix(sec): make daily-index 403 handling resilient, not fatal

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
@@ -180,7 +180,25 @@ public class Realtime13FIngestionService
             cancellationToken.ThrowIfCancellationRequested();
 
             var date = today.AddDays(-offset);
-            var indexEntries = await _edgarClient.GetDailyIndex(date, cancellationToken);
+
+            // One day's fetch failing (a transient error, or SEC throttling that
+            // outlasts the client's retries) must not abort the whole sweep and
+            // lose every other day. Log it and move on — the next cycle re-sweeps
+            // this date.
+            List<EdgarDailyIndexEntry> indexEntries;
+            try
+            {
+                indexEntries = await _edgarClient.GetDailyIndex(date, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to fetch the {Date:yyyy-MM-dd} daily index; skipping this day",
+                    date
+                );
+                continue;
+            }
 
             // The client already filters to 13F-HR / 13F-HR/A; only guard
             // against a malformed row with no accession number here.

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -435,26 +435,38 @@ public class SecEdgarClient : ISecEdgarClient
         var url =
             $"{FilesBaseUrl}/Archives/edgar/daily-index/{date.Year}/QTR{quarter}/master.{date.ToString("yyyyMMdd", System.Globalization.CultureInfo.InvariantCulture)}.idx";
 
-        using var response = await SendWithRetryAsync(url, cancellationToken);
-
-        // No index file for that day → nothing to ingest, skip it rather than
-        // failing the whole real-time sweep. Weekends/holidays can 404, and SEC
-        // returns 403 (Forbidden) for not-yet-published index files (today or a
-        // future date, before SEC posts it). Both mean "no index for this date".
-        //
-        // A 403 on a PAST date is different: that index always exists, so a
-        // Forbidden there is SEC's rate-limit throttle page surviving
-        // SendWithRetryAsync's retries — NOT a missing index. Swallowing it as
-        // empty silently drops that day's filings (this is exactly how large
-        // filers went missing during a long catch-up sweep). Let
-        // EnsureSuccessStatusCode surface it instead.
+        // A 403 on a PAST date is never a missing index (those always exist) —
+        // it's SEC throttling, so retry it as transient. For today/future dates a
+        // 403 means the index isn't published yet, so don't retry those.
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var isPastDate = date < today;
+        using var response = await SendWithRetryAsync(
+            url,
+            HttpCompletionOption.ResponseContentRead,
+            cancellationToken,
+            retryForbidden: isPastDate
+        );
+
+        // Weekend/holiday 404, or a 403 for a not-yet-published index (today or a
+        // future date), both mean "no index for this date" — skip it.
         if (
             response.StatusCode == HttpStatusCode.NotFound
-            || (response.StatusCode == HttpStatusCode.Forbidden && date >= today)
+            || (response.StatusCode == HttpStatusCode.Forbidden && !isPastDate)
         )
         {
             _logger.LogInformation("No daily index published for {Date:yyyy-MM-dd}", date);
+            return [];
+        }
+
+        // A past-date 403 that survived the retries is SEC still throttling.
+        // Skip this one day with a visible warning rather than failing the whole
+        // sweep or silently dropping its filings — the next cycle re-sweeps it.
+        if (response.StatusCode == HttpStatusCode.Forbidden)
+        {
+            _logger.LogWarning(
+                "SEC throttling persisted for the {Date:yyyy-MM-dd} daily index; skipping this day, will retry next cycle",
+                date
+            );
             return [];
         }
 
@@ -567,7 +579,8 @@ public class SecEdgarClient : ISecEdgarClient
     private async Task<HttpResponseMessage> SendWithRetryAsync(
         string url,
         HttpCompletionOption completionOption,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken = default,
+        bool retryForbidden = false
     )
     {
         for (var attempt = 0; attempt <= MaxRetries; attempt++)
@@ -633,13 +646,15 @@ public class SecEdgarClient : ISecEdgarClient
             // a 403 (not a 429), so a burst that trips the rolling-window limit
             // arrives as a Forbidden carrying that HTML body. Back off and retry
             // it like a 429 — otherwise callers that read 403 as "no resource"
-            // (e.g. GetDailyIndex) silently discard real data. A genuine 403 (a
-            // not-yet-published index, an access-restricted path) has a different
-            // body and falls through to the caller unchanged.
+            // silently discard real data. Callers that know a 403 can only mean
+            // throttling (retryForbidden: e.g. a past-dated daily index, which
+            // always exists) retry every Forbidden; otherwise we retry only when
+            // the body is the recognizable throttle page, leaving a genuine 403
+            // (not-yet-published index, access-restricted path) to fall through.
             if (response.StatusCode == HttpStatusCode.Forbidden && attempt < MaxRetries)
             {
                 var body = await response.Content.ReadAsStringAsync(cancellationToken);
-                if (IsRateLimitThresholdPage(body))
+                if (retryForbidden || IsRateLimitThresholdPage(body))
                 {
                     var delay = GetRetryDelay(response, attempt);
 

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientGetDailyIndexThrottleRetryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientGetDailyIndexThrottleRetryTests.cs
@@ -7,76 +7,106 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Equibles.UnitTests.Sec;
 
 /// <summary>
-/// Pins GetDailyIndex's throttle-retry path: a 403 "Request Rate Threshold
-/// Exceeded" page on a PAST date (whose index always exists) is retried and the
-/// recovered master index parsed — not swallowed as "no index". A regression
-/// returning empty on that 403 silently drops the day's filings during a sweep,
-/// which is how large filers went missing (GH-2222).
+/// Pins GetDailyIndex's 403 handling (GH-2222). A daily index for a PAST date
+/// always exists, so a 403 there is SEC throttling — it must be retried
+/// regardless of the response body, and if throttling persists the day is
+/// skipped (logged) rather than crashing the whole sweep. For today/future
+/// dates a 403 means "not yet published" and must not be retried.
 /// </summary>
 public class SecEdgarClientGetDailyIndexThrottleRetryTests
 {
-    [Fact]
-    public async Task GetDailyIndex_ThrottlePageThenSuccess_RetriesAndParses()
+    private const string MasterIndexBody =
+        "CIK|Company Name|Form Type|Date Filed|File Name\n"
+        + "933478|VANGUARD FIDUCIARY TRUST CO|13F-HR|20200102|edgar/data/933478/0000933478-20-000004.txt\n";
+
+    private static SecEdgarClient BuildClient(HttpMessageHandler handler)
     {
-        var threshold =
-            "<html><head><title>SEC.gov | Request Rate Threshold Exceeded</title></head></html>";
-        var master =
-            "CIK|Company Name|Form Type|Date Filed|File Name\n"
-            + "933478|VANGUARD FIDUCIARY TRUST CO|13F-HR|20200102|edgar/data/933478/0000933478-20-000004.txt\n";
-        var handler = new ThrottleThenOkHandler(threshold, master);
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(
                 new Dictionary<string, string> { ["Sec:ContactEmail"] = "test@example.com" }
             )
             .Build();
-        var sut = new SecEdgarClient(
+        return new SecEdgarClient(
             new HttpClient(handler),
             NullLogger<SecEdgarClient>.Instance,
             config
         );
+    }
 
-        // A past date: its daily index always exists, so the 403 must be treated
-        // as a throttle to retry, never as "no index for this day".
+    [Fact]
+    public async Task GetDailyIndex_PastDateForbiddenThenSuccess_RetriesRegardlessOfBodyAndParses()
+    {
+        // Empty 403 body — proves the retry is driven by the past-date rule, not
+        // by recognizing the throttle page (real throttle 403s can be body-less).
+        var handler = new SequencedHandler(() => Forbidden(body: ""), () => Ok(MasterIndexBody));
+        var sut = BuildClient(handler);
+
         var result = await sut.GetDailyIndex(new DateOnly(2020, 1, 2));
 
-        // Two calls prove the 403 drove a retry that then succeeded and parsed.
         handler.CallCount.Should().Be(2);
         result.Should().ContainSingle();
         result[0].AccessionNumber.Should().Be("0000933478-20-000004");
     }
 
-    private sealed class ThrottleThenOkHandler : HttpMessageHandler
+    [Fact]
+    public async Task GetDailyIndex_PastDateThrottlePersists_ReturnsEmptyWithoutThrowing()
     {
-        private readonly string _throttleBody;
-        private readonly string _okBody;
+        // Every attempt is throttled. The day must be skipped (empty), never
+        // surfaced as the unhandled 403 that aborted the whole realtime sweep.
+        var handler = new SequencedHandler(() => Forbidden(body: ""));
+        var sut = BuildClient(handler);
+
+        var result = await sut.GetDailyIndex(new DateOnly(2020, 1, 2));
+
+        result.Should().BeEmpty();
+        handler.CallCount.Should().BeGreaterThan(1); // retried before giving up
+    }
+
+    [Fact]
+    public async Task GetDailyIndex_FutureDateForbidden_ReturnsEmptyWithoutRetry()
+    {
+        // A future date's index isn't published yet: 403 means "no index", not
+        // throttling, so it must not be retried.
+        var handler = new SequencedHandler(() => Forbidden(body: ""));
+        var sut = BuildClient(handler);
+
+        var result = await sut.GetDailyIndex(new DateOnly(2099, 1, 1));
+
+        result.Should().BeEmpty();
+        handler.CallCount.Should().Be(1);
+    }
+
+    private static HttpResponseMessage Ok(string body) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(body) };
+
+    private static HttpResponseMessage Forbidden(string body)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent(body),
+        };
+        // Retry-After: 0 keeps retrying tests fast and avoids a real backoff pause.
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.Zero);
+        return response;
+    }
+
+    private sealed class SequencedHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpResponseMessage>[] _responses;
         public int CallCount { get; private set; }
 
-        public ThrottleThenOkHandler(string throttleBody, string okBody)
-        {
-            _throttleBody = throttleBody;
-            _okBody = okBody;
-        }
+        public SequencedHandler(params Func<HttpResponseMessage>[] responses) =>
+            _responses = responses;
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken
         )
         {
+            // Repeat the last configured response once the sequence is exhausted.
+            var factory = _responses[Math.Min(CallCount, _responses.Length - 1)];
             CallCount++;
-            if (CallCount == 1)
-            {
-                var throttled = new HttpResponseMessage(HttpStatusCode.Forbidden)
-                {
-                    Content = new StringContent(_throttleBody),
-                };
-                // Retry-After: 0 keeps the test fast and avoids pausing the shared rate limiter.
-                throttled.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.Zero);
-                return Task.FromResult(throttled);
-            }
-
-            return Task.FromResult(
-                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_okBody) }
-            );
+            return Task.FromResult(factory());
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2224 (GH-2222). That fix had two flaws that surfaced on the first production sweep:

1. **It crashed the whole sweep.** `GetDailyIndex` threw (`EnsureSuccessStatusCode`) on a past-date 403, and `DiscoverEntries` didn't guard per-day — so a single throttled day at startup (heavy 429/403 while every scraper fires at once) aborted the entire 87-day sweep with a fatal error and imported nothing.
2. **It missed body-less throttle 403s.** Retry fired only when the response body matched the SEC threshold page; real throttle 403s can arrive with an empty/odd body and so weren't retried.

## Code changes

- **`SecEdgarClient.cs`**
  - `SendWithRetryAsync` gains `retryForbidden`: when set, **any** 403 is retried like a 429 (body-independent). A past-dated daily index always exists, so a 403 there can only be throttling.
  - `GetDailyIndex` passes `retryForbidden: date < today`. Today/future 403s (not-yet-published) still return empty without retry. A past-date 403 that outlasts the retries now logs a **warning and skips that one day** (next cycle re-sweeps it) instead of throwing.
- **`Realtime13FIngestionService.DiscoverEntries`** wraps each day's fetch in try/catch — one day's failure logs and continues rather than aborting the sweep.
- **Tests** (`SecEdgarClientGetDailyIndexThrottleRetryTests`): past-date 403 (empty body) → retries and parses; persistent past-date throttle → returns empty without throwing; future-date 403 → empty, no retry.