### PR TITLE
test(holdings): pin IsNewHoldingsAmendment case-insensitive AmendmentType match

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsNewHoldingsAmendmentCaseInsensitiveTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsNewHoldingsAmendmentCaseInsensitiveTests.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceIsNewHoldingsAmendmentCaseInsensitiveTests
+{
+    private static readonly MethodInfo IsNewHoldingsAmendmentMethod =
+        typeof(HoldingsImportService).GetMethod(
+            "IsNewHoldingsAmendment",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // Contract: amendments whose cover-page AmendmentType is "NEW HOLDINGS"
+    // merge into existing positions without deleting them; "RESTATEMENT" and
+    // legacy/blank values delete-and-replace. The match uses
+    // StringComparison.OrdinalIgnoreCase — SEC EDGAR has emitted the field in
+    // mixed case across submission generators ("new holdings", "NEW HOLDINGS",
+    // "New Holdings"). A refactor to strict ordinal comparison would route the
+    // lowercase variant through the RESTATEMENT branch and wipe out a manager's
+    // entire prior 13F snapshot on every additive amendment — quiet, large data
+    // loss the existing happy-path test wouldn't catch (it uses the canonical
+    // upper-case form).
+    [Fact]
+    public void IsNewHoldingsAmendment_LowercaseAmendmentType_ReturnsTrue()
+    {
+        var accession = "0000950123-24-006477";
+        var context = new ImportContext
+        {
+            CoverPages = new Dictionary<string, CoverPageRow>
+            {
+                [accession] = new()
+                {
+                    AccessionNumber = accession,
+                    IsAmendment = "Y",
+                    AmendmentType = "new holdings",
+                },
+            },
+        };
+
+        var result = (bool)IsNewHoldingsAmendmentMethod.Invoke(null, [accession, context]);
+
+        result
+            .Should()
+            .BeTrue(
+                "AmendmentType comparison must be case-insensitive so additive amendments are never demoted to RESTATEMENT"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the case-insensitive `AmendmentType` comparison in `HoldingsImportService.IsNewHoldingsAmendment`. The match uses `StringComparison.OrdinalIgnoreCase` because SEC EDGAR has emitted the field in mixed case across submission generators (`"new holdings"`, `"NEW HOLDINGS"`, `"New Holdings"`).
- A refactor to strict ordinal comparison would route the lowercase variant through the RESTATEMENT branch and wipe out a manager's entire prior 13F snapshot on every additive amendment — quiet, large data loss the existing happy-path tests (which use the canonical upper-case form) wouldn't catch.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsNewHoldingsAmendmentCaseInsensitiveTests.cs` — new unit test. Reflectively invokes the private static helper with a cover-page whose `AmendmentType` is `"new holdings"` (lowercase) and asserts the result is `true`.