### PR TITLE
test(sec): add skipped repro for GH-2239 — ParseTransactionCode swaps I and W

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCodeIDiscretionaryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCodeIDiscretionaryTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Adversarial pin against the SEC Form 4 General Instructions transaction-code
+/// table. Existing pins cover P→Purchase, S→Sale, A→Award, Q→Other (default).
+/// This asserts the contract for code "I": per SEC's official Form 4
+/// instructions (Item 8, "Rule 16b-3 Transaction Codes"), "I" denotes a
+/// Discretionary Transaction in accordance with Rule 16b-3(f) — not an
+/// inheritance. Will/inheritance has a separate letter, "W". A wrong mapping
+/// silently misclassifies every 16b-3(f) discretionary trade as inherited
+/// stock in the insider-trading tab and downstream aggregations.
+/// </summary>
+public class InsiderTradingFilingProcessorParseTransactionCodeIDiscretionaryTests
+{
+    private static readonly MethodInfo ParseTransactionCodeMethod =
+        typeof(InsiderTradingFilingProcessor).GetMethod(
+            "ParseTransactionCode",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    [Fact(Skip = "GH-2239 — SEC Form 4 codes I and W are swapped in ParseTransactionCode mapping")]
+    public void ParseTransactionCode_CodeI_ReturnsDiscretionary()
+    {
+        var result = (TransactionCode)ParseTransactionCodeMethod.Invoke(null, ["I"]);
+
+        result.Should().Be(TransactionCode.Discretionary);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an adversarial pin against the SEC Form 4 General Instructions transaction-code table. Per Item 8 of the official Form 4 instructions, code `I` denotes a Rule 16b-3(f) discretionary transaction; `W` denotes an acquisition/disposition by will or descent and distribution. The production parser at `InsiderTradingFilingProcessor.cs:477-478` has these two letters swapped: `I` is mapped to `TransactionCode.Inheritance` and `W` to `TransactionCode.Discretionary`.
- Every Form 4 row carrying code `I` is silently misclassified as inheritance, and every `W` row is misclassified as discretionary — surfacing in the insider-trading tab, per-insider history, and downstream aggregations. The enum values exist distinctly and the view tooltips describe each meaning correctly, so the bug is contained to the parser's letter→enum table.
- Test is committed as skipped — see GH-2239. Un-skip and add the symmetric `W → Inheritance` pin when the swap is corrected.

## Code changes

- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCodeIDiscretionaryTests.cs` — new test, skipped — see GH-2239. Reflection-invokes the private static `ParseTransactionCode` with input `"I"` and asserts the result is `TransactionCode.Discretionary` (matching the SEC Form 4 spec). Fails today with `Expected Discretionary {value: 9}, but found Inheritance {value: 8}`.