### PR TITLE
test(sec): add skipped repro for GH-2239 — ParseTransactionCode W symmetric arm

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCodeWInheritanceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCodeWInheritanceTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Symmetric half of the I/W swap pinned in GH-2239
+/// (InsiderTradingFilingProcessorParseTransactionCodeIDiscretionaryTests). Per
+/// the SEC Form 4 General Instructions Item 8 transaction-code table, "W"
+/// denotes an Acquisition or disposition by will or the laws of descent and
+/// distribution — i.e. an inheritance — *not* a discretionary trade. Pinning
+/// only the I→Discretionary direction would let a half-fix (e.g. swapping I's
+/// arm in isolation) pass while still misclassifying every actual will/descent
+/// transfer. This is the second regression net the fix in GH-2239 must clear.
+/// </summary>
+public class InsiderTradingFilingProcessorParseTransactionCodeWInheritanceTests
+{
+    private static readonly MethodInfo ParseTransactionCodeMethod =
+        typeof(InsiderTradingFilingProcessor).GetMethod(
+            "ParseTransactionCode",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    [Fact(Skip = "GH-2239 — SEC Form 4 codes I and W are swapped in ParseTransactionCode mapping")]
+    public void ParseTransactionCode_CodeW_ReturnsInheritance()
+    {
+        var result = (TransactionCode)ParseTransactionCodeMethod.Invoke(null, ["W"]);
+
+        result.Should().Be(TransactionCode.Inheritance);
+    }
+}


### PR DESCRIPTION
## Summary

- Symmetric half of the `I`/`W` swap pinned by GH-2239 (and PR #2240 covering the `I` direction). Per the SEC Form 4 General Instructions Item 8, code `W` denotes an acquisition or disposition by will or laws of descent and distribution (inheritance) — but the production parser maps it to `TransactionCode.Discretionary`. The PR #2240 sibling pinned the `I → Discretionary` direction; this one pins `W → Inheritance`.
- Both pins together make the swap a two-sided regression net: a half-fix that only swaps one arm would still fail one of the two tests.
- Test is skipped — see GH-2239. Un-skip both this and the `I` test in the same PR that swaps the two arms back to spec.

## Code changes

- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCodeWInheritanceTests.cs` — new test, skipped — see GH-2239. Reflection-invokes the private static `ParseTransactionCode` with input `"W"` and asserts the result is `TransactionCode.Inheritance` (matching the SEC Form 4 spec).