### PR TITLE
feat(holdings): incremental sweep watermark for the 13F realtime worker

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -43,5 +43,6 @@ public class HoldingsModuleConfiguration : Equibles.Data.IModuleConfiguration
 
         builder.Entity<ProcessedDataSet>();
         builder.Entity<ProcessedFiling>();
+        builder.Entity<RealtimeSweepState>();
     }
 }

--- a/src/Equibles.Holdings.Data/Models/RealtimeSweepState.cs
+++ b/src/Equibles.Holdings.Data/Models/RealtimeSweepState.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.Data.Models;
+
+/// <summary>
+/// Per-worker progress marker for the real-time 13F daily-index sweep, keyed by
+/// worker name. <see cref="SweptThrough"/> is the most recent date the worker
+/// has fully swept; each cycle resumes from it (plus a short trailing
+/// re-sweep), so the worker fetches only new/gap days instead of re-requesting
+/// a whole quarter of daily indexes every run — which is what was triggering
+/// SEC rate-limiting and stalling the sweep.
+/// </summary>
+[Index(nameof(WorkerName), IsUnique = true)]
+public class RealtimeSweepState
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [MaxLength(128)]
+    public string WorkerName { get; set; }
+
+    public DateOnly SweptThrough { get; set; }
+
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
+++ b/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
@@ -1,6 +1,7 @@
 using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
+using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.HostedService.Services;
 using Equibles.Holdings.Repositories;
 using Equibles.Worker;
@@ -22,6 +23,14 @@ public class Holdings13FRealtimeWorker : BaseScraperWorker
     // Minimum lookback so the worker always re-sweeps recent days even when
     // the quarterly data set is up to date (catches late/amended filings).
     protected virtual int MinLookbackDays => 7;
+
+    // Once a watermark exists, every cycle still re-sweeps this many recent days
+    // so late/amended filings (which carry a fresh accession) are picked up even
+    // after the watermark has advanced past their report period.
+    private const int TrailingReSweepDays = 14;
+
+    // Identifies this worker's row in RealtimeSweepState.
+    private const string WorkerStateName = "Holdings13FRealtime";
 
     private readonly WorkerOptions _workerOptions;
     private readonly IConfiguration _configuration;
@@ -61,28 +70,102 @@ public class Holdings13FRealtimeWorker : BaseScraperWorker
         var minReportDate = DateOnly.FromDateTime(startDate);
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
 
-        var lookbackDays = await ComputeLookbackDays(startDate, today);
-
-        Logger.LogInformation(
-            "13F real-time ingestion sweeping {LookbackDays} days of EDGAR daily index",
-            lookbackDays
-        );
-
         await using var scope = ScopeFactory.CreateAsyncScope();
+        var stateRepo = scope.ServiceProvider.GetRequiredService<RealtimeSweepStateRepository>();
         var ingestionService =
             scope.ServiceProvider.GetRequiredService<Realtime13FIngestionService>();
 
-        var count = await ingestionService.IngestRecentFilings(
+        var state = await stateRepo.GetByWorker(WorkerStateName).FirstOrDefaultAsync(stoppingToken);
+
+        // Cold start (no watermark) backfills the season via the quarter-floor
+        // lookback; once a watermark exists we only resume from it plus the
+        // trailing re-sweep, so steady-state cycles fetch ~14 days, not ~90.
+        var firstRunLookbackDays = state == null ? await ComputeLookbackDays(startDate, today) : 0;
+        var windowStart = ComputeWindowStart(
+            today,
+            state?.SweptThrough,
+            TrailingReSweepDays,
+            firstRunLookbackDays
+        );
+        var lookbackDays = today.DayNumber - windowStart.DayNumber + 1;
+
+        Logger.LogInformation(
+            "13F real-time ingestion sweeping {LookbackDays} days of EDGAR daily index (from {Start:yyyy-MM-dd})",
+            lookbackDays,
+            windowStart
+        );
+
+        var result = await ingestionService.IngestRecentFilings(
             today,
             lookbackDays,
             minReportDate,
             stoppingToken
         );
 
+        // Advance the watermark only past days that swept cleanly: a throttled or
+        // failed day holds it back so the gap is re-swept next cycle.
+        var newWatermark = ComputeNextWatermark(today, result.EarliestFailedDate);
+        await SaveWatermark(stateRepo, state, newWatermark);
+
         Logger.LogInformation(
-            "13F real-time ingestion cycle complete: {Count} filings processed",
-            count
+            "13F real-time ingestion cycle complete: {Count} filings processed, swept through {Watermark:yyyy-MM-dd}",
+            result.FilingsImported,
+            newWatermark
         );
+    }
+
+    /// <summary>
+    /// The first daily-index date to sweep. With no watermark (cold start) it
+    /// goes back <paramref name="firstRunLookbackDays"/> days. With a watermark
+    /// it resumes from it, but never covers fewer than the trailing re-sweep
+    /// window so recent late/amended filings are always re-checked.
+    /// </summary>
+    internal static DateOnly ComputeWindowStart(
+        DateOnly today,
+        DateOnly? watermark,
+        int trailingDays,
+        int firstRunLookbackDays
+    )
+    {
+        if (!watermark.HasValue)
+            return today.AddDays(-(Math.Max(firstRunLookbackDays, 1) - 1));
+
+        var trailingStart = today.AddDays(-trailingDays);
+        return watermark.Value < trailingStart ? watermark.Value : trailingStart;
+    }
+
+    /// <summary>
+    /// The watermark to persist after a cycle: today when every day swept
+    /// cleanly, otherwise the day before the earliest failed day so it (and
+    /// everything older that was skipped) is re-swept next cycle.
+    /// </summary>
+    internal static DateOnly ComputeNextWatermark(DateOnly today, DateOnly? earliestFailedDate) =>
+        earliestFailedDate.HasValue ? earliestFailedDate.Value.AddDays(-1) : today;
+
+    private static async Task SaveWatermark(
+        RealtimeSweepStateRepository repo,
+        RealtimeSweepState existing,
+        DateOnly sweptThrough
+    )
+    {
+        if (existing == null)
+        {
+            repo.Add(
+                new RealtimeSweepState
+                {
+                    WorkerName = WorkerStateName,
+                    SweptThrough = sweptThrough,
+                    UpdatedAt = DateTime.UtcNow,
+                }
+            );
+        }
+        else
+        {
+            existing.SweptThrough = sweptThrough;
+            existing.UpdatedAt = DateTime.UtcNow;
+        }
+
+        await repo.SaveChanges();
     }
 
     /// <summary>

--- a/src/Equibles.Holdings.HostedService/Models/RealtimeIngestionResult.cs
+++ b/src/Equibles.Holdings.HostedService/Models/RealtimeIngestionResult.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Holdings.HostedService.Models;
+
+/// <summary>
+/// Outcome of a real-time 13F sweep. <see cref="EarliestFailedDate"/> is the
+/// oldest daily-index date that could not be fetched this cycle (SEC throttling
+/// or a transient error), or null if every day in the window swept cleanly —
+/// the worker uses it to hold the sweep watermark back so failed days are
+/// re-swept next cycle.
+/// </summary>
+public record RealtimeIngestionResult(int FilingsImported, DateOnly? EarliestFailedDate);

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
@@ -49,18 +49,22 @@ public class Realtime13FIngestionService
     /// <paramref name="minReportDate"/>. Returns the number of filings handed
     /// to the import pipeline.
     /// </summary>
-    public async Task<int> IngestRecentFilings(
+    public async Task<RealtimeIngestionResult> IngestRecentFilings(
         DateOnly today,
         int lookbackDays,
         DateOnly minReportDate,
         CancellationToken cancellationToken
     )
     {
-        var entries = await DiscoverEntries(today, lookbackDays, cancellationToken);
+        var (entries, earliestFailedDate) = await DiscoverEntries(
+            today,
+            lookbackDays,
+            cancellationToken
+        );
         if (entries.Count == 0)
         {
             _logger.LogInformation("No 13F-HR submissions found in daily index window");
-            return 0;
+            return new RealtimeIngestionResult(0, earliestFailedDate);
         }
 
         var alreadyProcessed = await LoadProcessedAccessions(
@@ -115,7 +119,7 @@ public class Realtime13FIngestionService
             totalImported
         );
 
-        return totalImported;
+        return new RealtimeIngestionResult(totalImported, earliestFailedDate);
     }
 
     private async Task<Parsed13FFiling> TryParseAndValidateEntry(
@@ -162,11 +166,10 @@ public class Realtime13FIngestionService
         }
     }
 
-    private async Task<List<EdgarDailyIndexEntry>> DiscoverEntries(
-        DateOnly today,
-        int lookbackDays,
-        CancellationToken cancellationToken
-    )
+    private async Task<(
+        List<EdgarDailyIndexEntry> Entries,
+        DateOnly? EarliestFailedDate
+    )> DiscoverEntries(DateOnly today, int lookbackDays, CancellationToken cancellationToken)
     {
         // Deduplicate by accession across the window: an amendment carries a
         // distinct accession number, so this only collapses the same filing
@@ -174,6 +177,11 @@ public class Realtime13FIngestionService
         var byAccession = new Dictionary<string, EdgarDailyIndexEntry>(
             StringComparer.OrdinalIgnoreCase
         );
+
+        // The oldest day this cycle failed to fetch. Offsets increase (dates run
+        // backwards), so the last failure seen is the earliest date — the worker
+        // holds the sweep watermark back to before it so it is re-swept next time.
+        DateOnly? earliestFailed = null;
 
         for (var offset = 0; offset < lookbackDays; offset++)
         {
@@ -183,8 +191,7 @@ public class Realtime13FIngestionService
 
             // One day's fetch failing (a transient error, or SEC throttling that
             // outlasts the client's retries) must not abort the whole sweep and
-            // lose every other day. Log it and move on — the next cycle re-sweeps
-            // this date.
+            // lose every other day. Log it, remember it, and move on.
             List<EdgarDailyIndexEntry> indexEntries;
             try
             {
@@ -197,6 +204,7 @@ public class Realtime13FIngestionService
                     "Failed to fetch the {Date:yyyy-MM-dd} daily index; skipping this day",
                     date
                 );
+                earliestFailed = date;
                 continue;
             }
 
@@ -209,7 +217,7 @@ public class Realtime13FIngestionService
             }
         }
 
-        return byAccession.Values.ToList();
+        return (byAccession.Values.ToList(), earliestFailed);
     }
 
     private async Task<HashSet<string>> LoadProcessedAccessions(

--- a/src/Equibles.Holdings.Repositories/RealtimeSweepStateRepository.cs
+++ b/src/Equibles.Holdings.Repositories/RealtimeSweepStateRepository.cs
@@ -1,0 +1,15 @@
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.Holdings.Repositories;
+
+public class RealtimeSweepStateRepository : BaseRepository<RealtimeSweepState>
+{
+    public RealtimeSweepStateRepository(EquiblesDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<RealtimeSweepState> GetByWorker(string workerName)
+    {
+        return GetAll().Where(s => s.WorkerName == workerName);
+    }
+}

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -458,18 +458,11 @@ public class SecEdgarClient : ISecEdgarClient
             return [];
         }
 
-        // A past-date 403 that survived the retries is SEC still throttling.
-        // Skip this one day with a visible warning rather than failing the whole
-        // sweep or silently dropping its filings — the next cycle re-sweeps it.
-        if (response.StatusCode == HttpStatusCode.Forbidden)
-        {
-            _logger.LogWarning(
-                "SEC throttling persisted for the {Date:yyyy-MM-dd} daily index; skipping this day, will retry next cycle",
-                date
-            );
-            return [];
-        }
-
+        // A past-date 403 that survived the retries is SEC still throttling: that
+        // index always exists, so this is a real failure to fetch, not "no
+        // filings". Let it throw — the caller (DiscoverEntries) catches it per
+        // day and holds the sweep watermark back so the day is re-swept next
+        // cycle, rather than being silently skipped past.
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
 

--- a/src/Equibles.Migrations/Migrations/20260526235839_AddRealtimeSweepState.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260526235839_AddRealtimeSweepState.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260526235839_AddRealtimeSweepState")]
+    partial class AddRealtimeSweepState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260526235839_AddRealtimeSweepState.cs
+++ b/src/Equibles.Migrations/Migrations/20260526235839_AddRealtimeSweepState.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRealtimeSweepState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RealtimeSweepState",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    WorkerName = table.Column<string>(
+                        type: "character varying(128)",
+                        maxLength: 128,
+                        nullable: false
+                    ),
+                    SweptThrough = table.Column<DateOnly>(type: "date", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RealtimeSweepState", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RealtimeSweepState_WorkerName",
+                table: "RealtimeSweepState",
+                column: "WorkerName",
+                unique: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "RealtimeSweepState");
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerComputeNextWatermarkTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerComputeNextWatermarkTests.cs
@@ -1,0 +1,34 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins ComputeNextWatermark (GH-2241): the watermark advances to today only
+/// when every day swept cleanly; a failed/throttled day holds it back to the
+/// day before the earliest failure so the gap is re-swept next cycle rather
+/// than being silently skipped past.
+/// </summary>
+public class Holdings13FRealtimeWorkerComputeNextWatermarkTests
+{
+    [Fact]
+    public void ComputeNextWatermark_NoFailure_ReturnsToday()
+    {
+        var result = Holdings13FRealtimeWorker.ComputeNextWatermark(
+            new DateOnly(2026, 5, 27),
+            earliestFailedDate: null
+        );
+
+        result.Should().Be(new DateOnly(2026, 5, 27));
+    }
+
+    [Fact]
+    public void ComputeNextWatermark_FailedDay_ReturnsDayBeforeEarliestFailure()
+    {
+        var result = Holdings13FRealtimeWorker.ComputeNextWatermark(
+            new DateOnly(2026, 5, 27),
+            earliestFailedDate: new DateOnly(2026, 5, 20)
+        );
+
+        result.Should().Be(new DateOnly(2026, 5, 19));
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerComputeWindowStartTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerComputeWindowStartTests.cs
@@ -1,0 +1,50 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins ComputeWindowStart, the incremental-sweep window (GH-2241). With a
+/// watermark the sweep resumes from it but never covers fewer than the trailing
+/// re-sweep window (so late/amended filings are still caught); with no watermark
+/// (cold start) it falls back to the quarter-floor lookback.
+/// </summary>
+public class Holdings13FRealtimeWorkerComputeWindowStartTests
+{
+    // today = 2026-05-27, trailing = 14 → trailing window starts 2026-05-13.
+    [Theory]
+    [InlineData(2026, 5, 26, 2026, 5, 13)] // recent watermark → clamp to trailing window
+    [InlineData(2026, 5, 13, 2026, 5, 13)] // watermark == trailing start → trailing start
+    [InlineData(2026, 4, 17, 2026, 4, 17)] // watermark older than trailing → resume at watermark
+    public void ComputeWindowStart_WithWatermark_ResumesButNeverBelowTrailingWindow(
+        int wYear,
+        int wMonth,
+        int wDay,
+        int eYear,
+        int eMonth,
+        int eDay
+    )
+    {
+        var result = Holdings13FRealtimeWorker.ComputeWindowStart(
+            new DateOnly(2026, 5, 27),
+            new DateOnly(wYear, wMonth, wDay),
+            trailingDays: 14,
+            firstRunLookbackDays: 0
+        );
+
+        result.Should().Be(new DateOnly(eYear, eMonth, eDay));
+    }
+
+    [Fact]
+    public void ComputeWindowStart_NoWatermark_GoesBackFirstRunLookbackInclusive()
+    {
+        // Cold start: a 10-day lookback covers today back through today-9 (10 days inclusive).
+        var result = Holdings13FRealtimeWorker.ComputeWindowStart(
+            new DateOnly(2026, 5, 27),
+            watermark: null,
+            trailingDays: 14,
+            firstRunLookbackDays: 10
+        );
+
+        result.Should().Be(new DateOnly(2026, 5, 18));
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientGetDailyIndexThrottleRetryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientGetDailyIndexThrottleRetryTests.cs
@@ -49,16 +49,18 @@ public class SecEdgarClientGetDailyIndexThrottleRetryTests
     }
 
     [Fact]
-    public async Task GetDailyIndex_PastDateThrottlePersists_ReturnsEmptyWithoutThrowing()
+    public async Task GetDailyIndex_PastDateThrottlePersists_ThrowsAfterRetries()
     {
-        // Every attempt is throttled. The day must be skipped (empty), never
-        // surfaced as the unhandled 403 that aborted the whole realtime sweep.
+        // Every attempt is throttled. A past-date index always exists, so a
+        // persistent 403 is a real fetch failure, not "no filings": it must be
+        // retried and then surfaced (the caller catches it per day and holds the
+        // sweep watermark back), never silently returned as empty.
         var handler = new SequencedHandler(() => Forbidden(body: ""));
         var sut = BuildClient(handler);
 
-        var result = await sut.GetDailyIndex(new DateOnly(2020, 1, 2));
+        var act = async () => await sut.GetDailyIndex(new DateOnly(2020, 1, 2));
 
-        result.Should().BeEmpty();
+        await act.Should().ThrowAsync<HttpRequestException>();
         handler.CallCount.Should().BeGreaterThan(1); // retried before giving up
     }
 


### PR DESCRIPTION
## Summary

Closes #2241.

The realtime worker re-fetched a ~90-day window of EDGAR daily indexes **every 6h**. That volume — stacked with the other SEC scrapers sharing the one `SecEdgarClient` limiter — sustained enough load that SEC throttled us (429/403), and the limiter's backoff stalled the sweep (observed: offset 2 of 87 after 8 min, 8 throttle pauses), so freshly-restructured filers (Vanguard's split Q1 2026 entities, filed 2026-05-08) were never reached.

Persist a per-worker watermark and sweep only what's new each cycle. Steady state drops from ~90 to **~14** daily-index fetches/cycle, removing the sustained load that caused the throttling. The full backfill now runs once at cold start, not every 6h.

## How it works
- `windowStart = watermark.HasValue ? earlier(watermark, today − 14d) : today − ComputeLookbackDays()` (cold start keeps the quarter-floor backfill from #2207).
- Always re-sweep the trailing 14 days so late/amended filings (fresh accession) are still caught; `ProcessedFiling` dedups the rest.
- Advance the watermark to `today` only when every day swept cleanly; a throttled/failed day holds it back to `earliestFailed − 1` so the gap is re-swept next cycle (never silently skipped past).

## Code changes
- **`RealtimeSweepState`** entity (Holdings.Data) + `RealtimeSweepStateRepository` + migration `AddRealtimeSweepState` + registration in `HoldingsModuleConfiguration`.
- **`SecEdgarClient.GetDailyIndex`**: a past-date 403 surviving retries now throws (a past index always exists → real fetch failure), replacing the silent-empty return from #2234. `DiscoverEntries` catches it per day and records the earliest failed date.
- **`Realtime13FIngestionService`**: `DiscoverEntries` returns the earliest failed date; `IngestRecentFilings` returns `RealtimeIngestionResult { FilingsImported, EarliestFailedDate }`.
- **`Holdings13FRealtimeWorker`**: loads/computes/persists the watermark; pure `ComputeWindowStart` / `ComputeNextWatermark` helpers.
- **Tests**: window-start (steady / downtime / cold-start) and next-watermark (clean / failed) math; updated the persistent-throttle test to expect the throw.

Builds on #2207, #2224, #2234. Commercial side adds the matching migration after the submodule bump.