### PR TITLE
test(sec): pin FinancialFactsImportService.TryMapFiscalPeriod FY token maps to FullYear

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapFiscalPeriodFyTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapFiscalPeriodFyTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Sibling to <see cref="FinancialFactsImportServiceTryMapFiscalPeriodUnknownTests"/>.
+/// The Unknown pin protects the default arm; the discriminating arms (FY,
+/// Q1–Q4) are unpinned. <c>FY</c> is asymmetric: it maps to
+/// <c>SecFiscalPeriod.FullYear</c>, not <c>FY</c> or <c>Annual</c>, and is the
+/// FIRST switch arm (the most likely casualty of a copy-paste-and-edit
+/// insertion). A silent break of FY→FullYear (e.g. arm body retyped to Q1)
+/// would classify every annual financial fact as Q1, corrupting the entire
+/// FullYear column of the SEC Company Facts ingestion.
+/// </summary>
+public class FinancialFactsImportServiceTryMapFiscalPeriodFyTests
+{
+    [Fact]
+    public void TryMapFiscalPeriod_FyToken_ReturnsTrueWithFullYearOut()
+    {
+        var method = typeof(FinancialFactsImportService).GetMethod(
+            "TryMapFiscalPeriod",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var args = new object[] { "FY", default(SecFiscalPeriod) };
+
+        var resolved = (bool)method.Invoke(null, args);
+
+        resolved.Should().BeTrue();
+        args[1].Should().Be(SecFiscalPeriod.FullYear);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the FY arm of `FinancialFactsImportService.TryMapFiscalPeriod` — the SEC Company Facts `fp` token "FY" maps to `SecFiscalPeriod.FullYear`. Sibling to the existing Unknown-arm pin; the discriminating arms (FY, Q1–Q4) were unpinned.
- FY is asymmetric (maps to `FullYear`, not `FY` or `Annual`) and is the first switch case — the most likely casualty of a copy-paste-and-edit insertion. A silent break (arm body retyped to `Q1`) would classify every annual financial fact as Q1, corrupting the FullYear column of SEC ingestion.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceTryMapFiscalPeriodFyTests.cs` — new test. Reflection-invokes the private static `TryMapFiscalPeriod` with input `"FY"` and asserts the out parameter is `SecFiscalPeriod.FullYear` and the boolean return is true.