### PR TITLE
test(sec): pin StandaloneXbrlParser skips facts missing contextRef attribute

### DIFF
--- a/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserContextRefAttributeAbsentTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserContextRefAttributeAbsentTests.cs
@@ -1,0 +1,40 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Adversarial sibling to <c>Parse_ContextRefMissing_SkipsFact</c>, whose XML
+/// fixture actually exercises a *dangling* contextRef (`contextRef="DoesNotExist"`
+/// — attribute present, value unmatched by the contexts map). The truly absent
+/// case — a numeric fact element with no <c>contextRef</c> attribute at all —
+/// trips a different guard: the early <c>string.IsNullOrEmpty(contextRef)</c>
+/// check before the contexts-map lookup. Without that first guard, the absent
+/// attribute coerces to <c>null</c>, and <c>Dictionary&lt;string,_&gt;.TryGetValue(null,…)</c>
+/// throws <see cref="ArgumentNullException"/> — the parser would crash instead
+/// of silently skipping the malformed fact. The contract derived from the
+/// function name <c>TryParseFact</c> is "drop, never throw" on any fact whose
+/// referential integrity can't be resolved.
+/// </summary>
+public class StandaloneXbrlParserContextRefAttributeAbsentTests
+{
+    [Fact]
+    public void Parse_FactWithNoContextRefAttribute_SkipsFactWithoutThrowing()
+    {
+        var xml =
+            "<xbrli:xbrl "
+            + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+            + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2018-01-31\">"
+            + "<xbrli:context id=\"C1\">"
+            + "<xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "<xbrli:period><xbrli:instant>2020-01-01</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + "<us-gaap:Revenues unitRef=\"u\">100</us-gaap:Revenues>"
+            + "</xbrli:xbrl>";
+
+        var act = () => new StandaloneXbrlParser().Parse(xml);
+
+        var facts = act.Should().NotThrow().Subject;
+        facts.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the early `string.IsNullOrEmpty(contextRef)` guard in `StandaloneXbrlParser.TryParseFact`. The existing `Parse_ContextRefMissing_SkipsFact` actually exercises a *dangling* contextRef (`contextRef="DoesNotExist"`) — the value is present but unmatched by the contexts map, tripping the second guard (`contexts.TryGetValue` miss). The truly absent case — fact element with no `contextRef` attribute — is unpinned and trips a different code path.
- Without that first guard, the absent attribute coerces to null and `Dictionary<string,_>.TryGetValue(null,…)` throws `ArgumentNullException`. `Parse()` doesn't wrap `TryParseFact` in a try/catch, so the exception would propagate and crash the parser instead of silently skipping the malformed fact.

## Code changes

- `tests/Equibles.UnitTests/Sec/StandaloneXbrlParserContextRefAttributeAbsentTests.cs` — new test. Feeds an XBRL document containing a `<us-gaap:Revenues>` fact with no `contextRef` attribute, asserts the parser returns an empty list without throwing.