### PR TITLE
test(sec): pin FinancialConceptAliases.TryResolve earnings alias routes to NetIncomeLoss

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveEarningsSynonymTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveEarningsSynonymTests.cs
@@ -1,0 +1,29 @@
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Sibling to <c>FinancialConceptAliasesTryResolveOperatingProfitSynonymTests</c>.
+/// "earnings" is the most semantically loaded synonym in the table — in
+/// everyday finance the word covers EBITDA, EBIT, EPS, and net income; the
+/// alias library makes the explicit contract decision that bare "earnings"
+/// resolves to <c>NetIncomeLoss</c>, not EPS or operating income. A refactor
+/// that re-routed "earnings" to <c>eps-basic</c> (a plausible "earnings per
+/// share" misread) or to <c>operating-income</c> would compile cleanly, pass
+/// every existing synonym pin (each targets a different alias), and silently
+/// change MCP query semantics for every caller asking for "earnings".
+/// </summary>
+public class FinancialConceptAliasesTryResolveEarningsSynonymTests
+{
+    [Fact]
+    public void TryResolve_EarningsAlias_RoutesToNetIncomeLossTag()
+    {
+        var matched = FinancialConceptAliases.TryResolve("earnings", out var concepts);
+
+        matched.Should().BeTrue();
+        var concept = concepts.Should().ContainSingle().Subject;
+        concept.Taxonomy.Should().Be(FactTaxonomy.UsGaap);
+        concept.Tag.Should().Be("NetIncomeLoss");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `earnings` synonym mapping in `FinancialConceptAliases.TryResolve`. Sibling to the existing operating-profit / R&D / slash-separator / null pins.
- "earnings" is the most semantically loaded synonym in the table — in everyday finance the word spans EBITDA, EBIT, EPS, and net income. The alias library makes the explicit contract decision that bare "earnings" → `NetIncomeLoss`. A refactor that rerouted it to `eps-basic` (plausible "earnings per share" misread) or `operating-income` would compile cleanly, pass every existing synonym pin, and silently change MCP query semantics for every caller asking for "earnings".

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialConceptAliasesTryResolveEarningsSynonymTests.cs` — new test. Calls `TryResolve("earnings", out var concepts)` and asserts the resolved concept is `(UsGaap, NetIncomeLoss)`.