### PR TITLE
test(holdings): pin Holdings13FRealtimeWorker.ComputeWindowStart zero lookback clamps to today

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerComputeWindowStartZeroLookbackTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerComputeWindowStartZeroLookbackTests.cs
@@ -1,0 +1,29 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Sibling to <see cref="Holdings13FRealtimeWorkerComputeWindowStartTests"/>.
+/// The cold-start arm normalises a zero (or smaller) <c>firstRunLookbackDays</c>
+/// via <c>Math.Max(firstRunLookbackDays, 1) - 1</c> so the window degenerates to
+/// today alone, never to tomorrow. Without the floor, a misconfigured option
+/// passing 0 would compute <c>today.AddDays(-(0 - 1)) = today.AddDays(1)</c> —
+/// a future-dated window start that scans nothing and silently skips the very
+/// day the operator wanted swept. Pin the lower bound at today on the
+/// equals-zero input.
+/// </summary>
+public class Holdings13FRealtimeWorkerComputeWindowStartZeroLookbackTests
+{
+    [Fact]
+    public void ComputeWindowStart_NoWatermarkZeroFirstRunLookback_ClampsToTodayNotTomorrow()
+    {
+        var result = Holdings13FRealtimeWorker.ComputeWindowStart(
+            today: new DateOnly(2026, 5, 27),
+            watermark: null,
+            trailingDays: 14,
+            firstRunLookbackDays: 0
+        );
+
+        result.Should().Be(new DateOnly(2026, 5, 27));
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `Math.Max(firstRunLookbackDays, 1) - 1` floor in `Holdings13FRealtimeWorker.ComputeWindowStart`'s no-watermark arm. Sibling to the existing cold-start pin (which only exercises `firstRunLookbackDays: 10`); the zero-lookback edge has no dedicated pin.
- Without the floor, a misconfigured option passing 0 computes `today.AddDays(-(0 - 1)) = today.AddDays(1)` — a future-dated window start that scans nothing and silently skips the very day the operator wanted swept. The floor is the only line keeping the cold-start sweep on this side of today.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerComputeWindowStartZeroLookbackTests.cs` — new test. Calls `ComputeWindowStart(today=2026-05-27, watermark=null, trailingDays=14, firstRunLookbackDays=0)` and asserts the result is today, not tomorrow.