### PR TITLE
test(holdings): pin HoldingsBacktestCalculator.ComputeMaxDrawdown rising peak updates running max

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorComputeMaxDrawdownRisingPeakTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorComputeMaxDrawdownRisingPeakTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Equibles.Holdings.Repositories;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Sibling to <c>Calculate_MaxDrawdown_CalculatedCorrectly</c>, whose series
+/// (100 → 75 → 100) never exceeds the initial value — every drawdown is
+/// measured against <c>values[0]</c>, so the running-peak update arm
+/// (<c>if (v &gt; peak) peak = v</c>) never fires. A series that *climbs* first
+/// and then drops requires that arm to be present; if a refactor "simplified"
+/// it away the peak would stay frozen at <c>values[0]</c> and every drawdown
+/// in a rising-portfolio backtest would be silently understated. Pin a
+/// 100 → 150 → 75 trajectory so the rising-peak update is exercised in
+/// isolation: the expected 50% drawdown is computable only against the new
+/// peak of 150, not the initial 100 (which would give 25%).
+/// </summary>
+public class HoldingsBacktestCalculatorComputeMaxDrawdownRisingPeakTests
+{
+    [Fact]
+    public void ComputeMaxDrawdown_ValueExceedsInitialThenDropsBelow_DrawdownMeasuredFromNewPeak()
+    {
+        var method = typeof(HoldingsBacktestCalculator).GetMethod(
+            "ComputeMaxDrawdown",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (decimal)method.Invoke(null, [new[] { 100m, 150m, 75m }]);
+
+        result.Should().Be(50m);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the running-peak-update arm (`if (v > peak) peak = v`) of `HoldingsBacktestCalculator.ComputeMaxDrawdown`. The existing `Calculate_MaxDrawdown_CalculatedCorrectly` test exercises a series (100 → 75 → 100) whose values never exceed the initial — every drawdown is measured against `values[0]` and the rising-peak arm never fires.
- A series that climbs first and then drops requires that arm to be present. Without it, peak would stay frozen at `values[0]` and every drawdown in a rising-portfolio backtest would be silently understated. The 100 → 150 → 75 trajectory expects a 50% drawdown (measured against the new peak of 150); a refactor that dropped the rising-peak arm would report only 25% (measured against the initial 100).

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorComputeMaxDrawdownRisingPeakTests.cs` — new test. Reflection-invokes the private static `ComputeMaxDrawdown` on `[100, 150, 75]` and asserts the result is 50%.