### PR TITLE
feat(worker): stagger SEC scraper startup so the 13F realtime sweep isn't throttled at deploy

### DIFF
--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -34,6 +34,10 @@ public class HoldingsScraperWorker : BaseScraperWorker
     protected override TimeSpan SleepInterval => TimeSpan.FromHours(24);
     protected override ErrorSource ErrorSource => ErrorSource.HoldingsScraper;
 
+    // Staggered so the SEC scrapers don't drain the shared EDGAR request budget at
+    // deploy time before the time-sensitive 13F real-time sweep (delay 0) runs.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(4);
+
     public HoldingsScraperWorker(
         ILogger<HoldingsScraperWorker> logger,
         IServiceScopeFactory scopeFactory,

--- a/src/Equibles.Sec.FinancialFacts.HostedService/FinancialFactsScraperWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/FinancialFactsScraperWorker.cs
@@ -23,6 +23,10 @@ public class FinancialFactsScraperWorker : BaseScraperWorker
     protected override TimeSpan SleepInterval { get; }
     protected override ErrorSource ErrorSource => ErrorSource.FinancialFactsScraper;
 
+    // Heaviest SEC walker (one request per tracked company) — staggered last so it
+    // doesn't drain the shared EDGAR budget before the 13F real-time sweep runs.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(8);
+
     public FinancialFactsScraperWorker(
         ILogger<FinancialFactsScraperWorker> logger,
         IServiceScopeFactory scopeFactory,

--- a/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
@@ -18,6 +18,10 @@ public class FtdScraperWorker : BaseScraperWorker
     protected override TimeSpan SleepInterval { get; }
     protected override ErrorSource ErrorSource => ErrorSource.FtdScraper;
 
+    // Staggered so the SEC scrapers don't drain the shared EDGAR request budget at
+    // deploy time before the time-sensitive 13F real-time sweep (delay 0) runs.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(6);
+
     public FtdScraperWorker(
         ILogger<FtdScraperWorker> logger,
         IServiceScopeFactory scopeFactory,

--- a/src/Equibles.Sec.HostedService/SecScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/SecScraperWorker.cs
@@ -14,6 +14,10 @@ public class SecScraperWorker : BaseScraperWorker
     protected override TimeSpan SleepInterval => TimeSpan.FromSeconds(15);
     protected override ErrorSource ErrorSource => ErrorSource.DocumentScraper;
 
+    // Staggered so the SEC scrapers don't drain the shared EDGAR request budget at
+    // deploy time before the time-sensitive 13F real-time sweep (delay 0) runs.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(5);
+
     public SecScraperWorker(
         ILogger<SecScraperWorker> logger,
         IServiceScopeFactory scopeFactory,

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -100,6 +100,26 @@ public abstract class BaseScraperWorker : BackgroundService
         if (!ValidateConfiguration())
             return;
 
+        // One-off stagger before the first cycle. Workers sharing a rate-limited
+        // upstream (SEC EDGAR) use this so they don't all fire at deploy time and
+        // exhaust the shared request budget — see the SEC scrapers' StartupDelay.
+        if (StartupDelay > TimeSpan.Zero)
+        {
+            Logger.LogInformation(
+                "{Worker} staggering startup by {Delay}",
+                WorkerName,
+                FormatInterval(StartupDelay)
+            );
+        }
+        try
+        {
+            await DelayStartup(stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            return;
+        }
+
         while (!stoppingToken.IsCancellationRequested)
         {
             Logger.LogInformation("{Worker} running at: {Time}", WorkerName, DateTimeOffset.Now);
@@ -170,6 +190,18 @@ public abstract class BaseScraperWorker : BackgroundService
     /// </summary>
     protected virtual Task WaitForNextCycle(TimeSpan interval, CancellationToken stoppingToken) =>
         Task.Delay(interval, stoppingToken);
+
+    /// <summary>
+    /// One-off delay before the first cycle (default none). Lets workers that
+    /// share a rate-limited upstream be staggered at startup so they don't all
+    /// fire at once — the SEC scrapers set this so the lighter, time-sensitive
+    /// 13F real-time sweep gets the SEC request budget first after a deploy.
+    /// </summary>
+    protected virtual TimeSpan StartupDelay => TimeSpan.Zero;
+
+    /// <summary>Awaits <see cref="StartupDelay"/>; overridable so tests can gate it deterministically.</summary>
+    protected virtual Task DelayStartup(CancellationToken stoppingToken) =>
+        StartupDelay > TimeSpan.Zero ? Task.Delay(StartupDelay, stoppingToken) : Task.CompletedTask;
 
     protected virtual bool ValidateConfiguration() => true;
 

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerStartupDelayTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerStartupDelayTests.cs
@@ -1,0 +1,84 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Worker;
+
+/// <summary>
+/// Pins the startup-stagger added for GH-2241/SEC throttling: a worker with a
+/// non-zero StartupDelay must not run its first DoWork until the delay elapses.
+/// Uses a gate (TaskCompletionSource) in place of a real delay so the test is
+/// deterministic — DoWork cannot run while the gate is open, regardless of
+/// scheduling.
+/// </summary>
+public class BaseScraperWorkerStartupDelayTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WaitsForStartupDelay_BeforeFirstDoWork()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var worker = new GatedStartupWorker(gate);
+        using var cts = new CancellationTokenSource();
+
+        await worker.StartAsync(cts.Token);
+
+        // The startup delay is still pending → DoWork must not have run.
+        await Task.Delay(50);
+        worker.DoWorkCallCount.Should().Be(0);
+
+        // Releasing the gate lets the first cycle proceed.
+        gate.SetResult();
+        await WaitUntilAsync(() => worker.DoWorkCallCount >= 1, TimeSpan.FromSeconds(5));
+        await worker.StopAsync(CancellationToken.None);
+
+        worker.DoWorkCallCount.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+                return;
+            await Task.Delay(10);
+        }
+    }
+
+    private sealed class GatedStartupWorker : BaseScraperWorker
+    {
+        private readonly TaskCompletionSource _gate;
+        private int _doWorkCallCount;
+
+        public int DoWorkCallCount => _doWorkCallCount;
+
+        public GatedStartupWorker(TaskCompletionSource gate)
+            : base(
+                NullLogger.Instance,
+                Substitute.For<IServiceScopeFactory>(),
+                new ErrorReporter(
+                    Substitute.For<IServiceScopeFactory>(),
+                    NullLogger<ErrorReporter>.Instance
+                )
+            ) => _gate = gate;
+
+        protected override string WorkerName => "GatedStartup";
+        protected override TimeSpan SleepInterval => TimeSpan.FromSeconds(30);
+        protected override ErrorSource ErrorSource => ErrorSource.Other;
+
+        // Non-zero so ExecuteAsync takes the stagger path; the real wait is the
+        // gate, keeping the test deterministic.
+        protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(1);
+
+        protected override Task DelayStartup(CancellationToken stoppingToken) => _gate.Task;
+
+        protected override Task DoWork(CancellationToken stoppingToken)
+        {
+            Interlocked.Increment(ref _doWorkCallCount);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2252. Final piece of the Vanguard-ingestion chain (#2207, #2224, #2234, #2244).

All SEC scrapers start simultaneously and share one 4 req/s SEC limiter. At deploy their combined burst trips SEC's rolling-window throttle (56× 429, 27× 403 observed), and the limiter's backoff stalls the 13F realtime sweep — its one-time cold-start backfill couldn't get past day 1, so Vanguard's restructured Q1 2026 entities were never ingested even after the watermark shipped.

## Code changes
- **`BaseScraperWorker`**: overridable `StartupDelay` (default `TimeSpan.Zero`), awaited once before the first cycle via `DelayStartup` (overridable seam for deterministic tests), with a "staggering startup" log and cancellation handling.
- **`Holdings13FRealtimeWorker`**: unchanged → delay 0, so it runs first and its cold-start backfill gets the SEC budget uncontended.
- **Heavy SEC walkers** stagger their first cycle: `HoldingsScraperWorker` 4m, `SecScraperWorker` 5m, `FtdScraperWorker` 6m, `FinancialFactsScraperWorker` 8m.
- **Test**: `BaseScraperWorkerStartupDelayTests` — a gated (TaskCompletionSource) startup delay proves the first `DoWork` doesn't run until the delay elapses; deterministic, no real-clock dependency.

## Verification
- 16 `BaseScraperWorker` tests pass (new + regression); all SEC/Holdings worker projects build clean; csharpier clean.
- Post-deploy (to be confirmed in prod): realtime worker runs first, cold-start backfill completes without throttling and ingests Vanguard, then settles into light ~14-day watermark cycles.