### PR TITLE
test(sec): pin FtdImportService.IsRecentFtdFile rejects out-of-range month

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceIsRecentFtdFileInvalidMonthTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceIsRecentFtdFileInvalidMonthTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Symmetric sibling to <see cref="FtdImportServiceIsRecentFtdFileYearZeroTests"/>.
+/// That pin covers the <c>year &gt;= 1</c> lower-bound gate; this one pins the
+/// <c>month is &gt;= 1 and &lt;= 12</c> gate on the upper side. Without the gate,
+/// a filename like <c>cnsfails202613a.zip</c> would fall through to
+/// <c>new DateOnly(2026, 13, 1)</c>, whose constructor throws
+/// <see cref="ArgumentOutOfRangeException"/> and crashes the FTD scrape cycle
+/// instead of being silently rejected. The contract derived from the function
+/// name + doc-comment is "validates and returns a bool, never throws".
+/// </summary>
+public class FtdImportServiceIsRecentFtdFileInvalidMonthTests
+{
+    [Fact]
+    public void IsRecentFtdFile_MonthGreaterThanTwelve_ReturnsFalseWithoutThrowing()
+    {
+        var act = () => FtdImportService.IsRecentFtdFile("cnsfails202613a.zip");
+
+        var result = act.Should().NotThrow().Subject;
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Symmetric sibling to `FtdImportServiceIsRecentFtdFileYearZeroTests`. That pin covers the `year >= 1` lower-bound gate; this one pins the `month is >= 1 and <= 12` gate on the upper side.
- Without the gate, a filename like `cnsfails202613a.zip` falls through to `new DateOnly(2026, 13, 1)`, whose constructor throws `ArgumentOutOfRangeException` and crashes the FTD scrape cycle instead of being silently rejected. Contract derived from the function name + doc-comment: validates and returns a bool, never throws.

## Code changes

- `tests/Equibles.UnitTests/Sec/FtdImportServiceIsRecentFtdFileInvalidMonthTests.cs` — new test. Calls `IsRecentFtdFile("cnsfails202613a.zip")` and asserts it returns false without throwing.