### PR TITLE
test(holdings): pin Holdings13FRealtimeWorker.ParseDataSetEndDate rejects out-of-range quarter

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateQuarterOutOfRangeTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateQuarterOutOfRangeTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Holdings.HostedService;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Symmetric sibling to
+/// <see cref="Holdings13FRealtimeWorkerParseDataSetEndDateYearZeroTests"/>. That
+/// pin protects the old-format <c>year &gt;= 1</c> gate; this one protects the
+/// <c>quarter is &gt;= 1 and &lt;= 4</c> upper-bound gate. Without that gate,
+/// a filename like <c>2023q5_form13f.zip</c> would compute
+/// <c>endMonth = 5 * 3 = 15</c> and fall through to <c>new DateOnly(year, 15, …)</c>,
+/// which throws <see cref="ArgumentOutOfRangeException"/> and crashes the worker
+/// startup instead of being silently rejected as malformed.
+/// </summary>
+public class Holdings13FRealtimeWorkerParseDataSetEndDateQuarterOutOfRangeTests
+{
+    [Fact]
+    public void ParseDataSetEndDate_OldFormatQuarterFive_ReturnsNullInsteadOfThrowing()
+    {
+        var act = () => Holdings13FRealtimeWorker.ParseDataSetEndDate("2023q5_form13f.zip");
+
+        var result = act.Should().NotThrow().Subject;
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Symmetric sibling to the existing YearZero pin. That test protects the old-format `year >= 1` gate; this one protects the `quarter is >= 1 and <= 4` upper-bound gate.
- Without the gate, a filename like `2023q5_form13f.zip` would compute `endMonth = 5 * 3 = 15` and fall through to `new DateOnly(year, 15, …)`, which throws `ArgumentOutOfRangeException` and crashes the worker startup instead of being silently rejected as malformed.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerParseDataSetEndDateQuarterOutOfRangeTests.cs` — new test. Calls `ParseDataSetEndDate("2023q5_form13f.zip")` and asserts the result is null without throwing.