### PR TITLE
fix(common-stocks): publish StockCusipChanged via root bus

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/CommonStockManager.cs
@@ -11,25 +11,28 @@ namespace Equibles.CommonStocks.BusinessLogic;
 public class CommonStockManager
 {
     private readonly CommonStockRepository _commonStockRepository;
-    private readonly IPublishEndpoint _publishEndpoint;
+    private readonly IBus _bus;
 
-    public CommonStockManager(
-        CommonStockRepository commonStockRepository,
-        IPublishEndpoint publishEndpoint
-    )
+    public CommonStockManager(CommonStockRepository commonStockRepository, IBus bus)
     {
         _commonStockRepository = commonStockRepository;
-        _publishEndpoint = publishEndpoint;
+        _bus = bus;
     }
 
     /// <summary>
     /// Sets a stock's CUSIP. When the value actually changes, publishes
     /// <see cref="StockCusipChanged"/> after SaveChanges so the Holdings module can
     /// backfill quarterly 13F data sets that were processed while this stock
-    /// was still unresolvable. A no-op change publishes nothing. OSS has no
-    /// transactional outbox, so the event is published only once the write has
-    /// committed (the consumer is idempotent, so an undelivered event after a
-    /// crash is recovered on the next resolve).
+    /// was still unresolvable. A no-op change publishes nothing.
+    /// <para>
+    /// This is a financial-domain event, so it publishes via the root
+    /// <see cref="IBus"/> rather than the scoped <c>IPublishEndpoint</c>. A host
+    /// that enables a bus outbox on a different context (e.g. the commercial
+    /// customer database) would otherwise capture this publish into that context
+    /// and never deliver it, since this flow only saves the financial context.
+    /// Delivery is at-least-once; the consumer is idempotent, so a publish lost to
+    /// a crash is recovered on the next resolve.
+    /// </para>
     /// </summary>
     public async Task SetCusip(CommonStock commonStock, string cusip)
     {
@@ -45,8 +48,8 @@ public class CommonStockManager
 
         await _commonStockRepository.SaveChanges();
 
-        // Publish after SaveChanges (no outbox in OSS — consumer is idempotent).
-        await _publishEndpoint.Publish(
+        // Publish via the root bus (bypasses any bus outbox) after the write commits.
+        await _bus.Publish(
             new StockCusipChanged(commonStock.Id, commonStock.Ticker, previousCusip, cusip)
         );
     }

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerCreateWhitespaceTickerTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerCreateWhitespaceTickerTests.cs
@@ -16,10 +16,7 @@ public class CommonStockManagerCreateWhitespaceTickerTests
     public CommonStockManagerCreateWhitespaceTickerTests()
     {
         var context = TestDbContextFactory.Create(new CommonStocksModuleConfiguration());
-        _sut = new CommonStockManager(
-            new CommonStockRepository(context),
-            Substitute.For<IPublishEndpoint>()
-        );
+        _sut = new CommonStockManager(new CommonStockRepository(context), Substitute.For<IBus>());
     }
 
     // Contract: "Ticker is required". Ticker is also the globally-unique key

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerSetCusipCaseInsensitiveTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerSetCusipCaseInsensitiveTests.cs
@@ -19,7 +19,7 @@ namespace Equibles.IntegrationTests.CommonStocks;
 public class CommonStockManagerSetCusipCaseInsensitiveTests
 {
     private readonly CommonStockManager _sut;
-    private readonly IPublishEndpoint _publishEndpoint = Substitute.For<IPublishEndpoint>();
+    private readonly IBus _publishEndpoint = Substitute.For<IBus>();
     private readonly CommonStockRepository _repository;
 
     public CommonStockManagerSetCusipCaseInsensitiveTests()

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerSetCusipTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerSetCusipTests.cs
@@ -12,7 +12,7 @@ namespace Equibles.IntegrationTests.CommonStocks;
 public class CommonStockManagerSetCusipTests
 {
     private readonly CommonStockManager _sut;
-    private readonly IPublishEndpoint _publishEndpoint = Substitute.For<IPublishEndpoint>();
+    private readonly IBus _publishEndpoint = Substitute.For<IBus>();
     private readonly CommonStockRepository _repository;
 
     public CommonStockManagerSetCusipTests()

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockManagerTests.cs
@@ -18,7 +18,7 @@ public class CommonStockManagerTests
     {
         var context = TestDbContextFactory.Create(new CommonStocksModuleConfiguration());
         _repository = new CommonStockRepository(context);
-        _sut = new CommonStockManager(_repository, Substitute.For<IPublishEndpoint>());
+        _sut = new CommonStockManager(_repository, Substitute.For<IBus>());
     }
 
     private static CommonStock MakeStock(

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceActiveTickerCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceActiveTickerCollisionTests.cs
@@ -81,10 +81,7 @@ public class CompanySyncServiceActiveTickerCollisionTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceCreateNewStockCatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceCreateNewStockCatchTests.cs
@@ -55,10 +55,7 @@ public class CompanySyncServiceCreateNewStockCatchTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceDispatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceDispatchTests.cs
@@ -38,10 +38,7 @@ public class CompanySyncServiceDispatchTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceOrchestrationSkipTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceOrchestrationSkipTests.cs
@@ -83,10 +83,7 @@ public class CompanySyncServiceOrchestrationSkipTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCatchTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteCatchTests.cs
@@ -68,10 +68,7 @@ public class CompanySyncServiceReplaceObsoleteCatchTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteHolderNullTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteHolderNullTests.cs
@@ -72,10 +72,7 @@ public class CompanySyncServiceReplaceObsoleteHolderNullTests : ParadeDbMcpTestB
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceReplaceObsoleteTests.cs
@@ -72,10 +72,7 @@ public class CompanySyncServiceReplaceObsoleteTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceResolveCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceResolveCollisionTests.cs
@@ -104,10 +104,7 @@ public class CompanySyncServiceResolveCollisionTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTests.cs
@@ -63,10 +63,7 @@ public class CompanySyncServiceTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTickerFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceTickerFilterTests.cs
@@ -62,10 +62,7 @@ public class CompanySyncServiceTickerFilterTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingCollisionTests.cs
@@ -45,10 +45,7 @@ public class CompanySyncServiceUpdateExistingCollisionTests : ParadeDbMcpTestBas
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingRollbackTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingRollbackTests.cs
@@ -70,10 +70,7 @@ public class CompanySyncServiceUpdateExistingRollbackTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CompanySyncServiceUpdateExistingTests.cs
@@ -68,10 +68,7 @@ public class CompanySyncServiceUpdateExistingTests : ParadeDbMcpTestBase
             (typeof(CommonStockRepository), new CommonStockRepository(DbContext)),
             (
                 typeof(CommonStockManager),
-                new CommonStockManager(
-                    new CommonStockRepository(DbContext),
-                    Substitute.For<IPublishEndpoint>()
-                )
+                new CommonStockManager(new CommonStockRepository(DbContext), Substitute.For<IBus>())
             ),
             (typeof(EquiblesFinancialDbContext), DbContext)
         );

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceFullPipelineTests.cs
@@ -86,7 +86,7 @@ public class FtdImportServiceFullPipelineTests : IAsyncLifetime
                     .Returns(
                         new CommonStockManager(
                             new CommonStockRepository(ctx),
-                            Substitute.For<IPublishEndpoint>()
+                            Substitute.For<IBus>()
                         )
                     );
                 sp.GetService(typeof(FailToDeliverRepository))

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceMissingCommonStockTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceMissingCommonStockTests.cs
@@ -75,7 +75,7 @@ public class FtdImportServiceMissingCommonStockTests : IAsyncLifetime
                     .Returns(
                         new CommonStockManager(
                             new CommonStockRepository(ctx),
-                            Substitute.For<IPublishEndpoint>()
+                            Substitute.For<IBus>()
                         )
                     );
                 sp.GetService(typeof(FailToDeliverRepository))

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsPublishesEventTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsPublishesEventTests.cs
@@ -70,7 +70,7 @@ public class FtdImportServiceSeedCusipsPublishesEventTests : IAsyncLifetime
             await seed.SaveChangesAsync();
         }
 
-        var publishEndpoint = Substitute.For<IPublishEndpoint>();
+        var publishEndpoint = Substitute.For<IBus>();
         var scopeFactory = Substitute.For<IServiceScopeFactory>();
         scopeFactory
             .CreateScope()

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerCreateNegativeMarketCapTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerCreateNegativeMarketCapTests.cs
@@ -30,7 +30,7 @@ public class CommonStockManagerCreateNegativeMarketCapTests
         // negative — the validator should reject it before persist.
         var db = NewDb();
         var repo = Substitute.For<CommonStockRepository>(db);
-        var sut = new CommonStockManager(repo, Substitute.For<IPublishEndpoint>());
+        var sut = new CommonStockManager(repo, Substitute.For<IBus>());
         var stock = new CommonStock
         {
             Ticker = "TEST",

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerCreateNegativeSharesTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerCreateNegativeSharesTests.cs
@@ -30,7 +30,7 @@ public class CommonStockManagerCreateNegativeSharesTests
         // must never be negative — the validator should reject it before persist.
         var db = NewDb();
         var repo = Substitute.For<CommonStockRepository>(db);
-        var sut = new CommonStockManager(repo, Substitute.For<IPublishEndpoint>());
+        var sut = new CommonStockManager(repo, Substitute.For<IBus>());
         var stock = new CommonStock
         {
             Ticker = "TEST",

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetCusipNoopTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetCusipNoopTests.cs
@@ -33,7 +33,7 @@ public class CommonStockManagerSetCusipNoopTests
     {
         var db = NewDb();
         var repo = Substitute.For<CommonStockRepository>(db);
-        var publishEndpoint = Substitute.For<IPublishEndpoint>();
+        var publishEndpoint = Substitute.For<IBus>();
         var sut = new CommonStockManager(repo, publishEndpoint);
         var stock = new CommonStock
         {

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetCusipTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetCusipTests.cs
@@ -31,7 +31,7 @@ public class CommonStockManagerSetCusipTests
     {
         var db = NewDb();
         var repo = Substitute.For<CommonStockRepository>(db);
-        var publishEndpoint = Substitute.For<IPublishEndpoint>();
+        var publishEndpoint = Substitute.For<IBus>();
         var sut = new CommonStockManager(repo, publishEndpoint);
         var stock = new CommonStock
         {

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetFiscalYearEndInvalidDayForMonthTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetFiscalYearEndInvalidDayForMonthTests.cs
@@ -27,7 +27,7 @@ public class CommonStockManagerSetFiscalYearEndInvalidDayForMonthTests
             new IModuleConfiguration[] { new CommonStocksModuleConfiguration() }
         );
         var repository = Substitute.For<CommonStockRepository>(db);
-        var sut = new CommonStockManager(repository, Substitute.For<IPublishEndpoint>());
+        var sut = new CommonStockManager(repository, Substitute.For<IBus>());
         var stock = new CommonStock();
 
         var act = () => sut.SetFiscalYearEnd(stock, 2, 31);

--- a/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetFiscalYearEndTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/CommonStockManagerSetFiscalYearEndTests.cs
@@ -31,7 +31,7 @@ public class CommonStockManagerSetFiscalYearEndTests
     }
 
     private static CommonStockManager NewManager(CommonStockRepository repository) =>
-        new(repository, Substitute.For<IPublishEndpoint>());
+        new(repository, Substitute.For<IBus>());
 
     [Fact]
     public async Task SetFiscalYearEnd_PreviouslyUndetected_PersistsMonthAndDay()

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingBranchATests.cs
@@ -78,10 +78,7 @@ public class CompanySyncServiceUpdateExistingBranchATests
         Set("CommonStockRepository", new CommonStockRepository(db));
         Set(
             "CommonStockManager",
-            new CommonStockManager(
-                new CommonStockRepository(db),
-                Substitute.For<IPublishEndpoint>()
-            )
+            new CommonStockManager(new CommonStockRepository(db), Substitute.For<IBus>())
         );
         Set("DbContext", db);
         return s;

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperDeferredRetryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperDeferredRetryTests.cs
@@ -105,9 +105,9 @@ public class DocumentScraperDeferredRetryTests
         services.AddScoped<CommonStockRepository>();
         services.AddScoped<DocumentRepository>();
         // DocumentScraper resolves CommonStockManager per scope to persist the
-        // SEC-sourced fiscal year-end; IPublishEndpoint is an unrelated ctor
+        // SEC-sourced fiscal year-end; IBus is an unrelated ctor
         // dep (SetCusip outbox event) the fiscal-year path never uses.
-        services.AddSingleton(Substitute.For<IPublishEndpoint>());
+        services.AddSingleton(Substitute.For<IBus>());
         services.AddScoped<CommonStockManager>();
         services.AddSingleton(secEdgar);
         services.AddSingleton(persistence);

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperProcessCompanyScopeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperProcessCompanyScopeTests.cs
@@ -66,9 +66,9 @@ public class DocumentScraperProcessCompanyScopeTests
         services.AddScoped<CommonStockRepository>();
         services.AddScoped<DocumentRepository>();
         // DocumentScraper resolves CommonStockManager per scope to persist the
-        // SEC-sourced fiscal year-end; IPublishEndpoint is an unrelated ctor
+        // SEC-sourced fiscal year-end; IBus is an unrelated ctor
         // dep (SetCusip outbox event) the fiscal-year path never uses.
-        services.AddSingleton(Substitute.For<IPublishEndpoint>());
+        services.AddSingleton(Substitute.For<IBus>());
         services.AddScoped<CommonStockManager>();
         services.AddSingleton(_secEdgarClient);
         services.AddSingleton(_persistence);

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
@@ -613,10 +613,10 @@ public class DocumentScraperTests
             services.AddScoped<CommonStockRepository>();
             services.AddScoped<DocumentRepository>();
             // DocumentScraper now resolves CommonStockManager per scope to
-            // persist the SEC-sourced fiscal year-end. IPublishEndpoint is an
+            // persist the SEC-sourced fiscal year-end. IBus is an
             // unrelated CommonStockManager ctor dep (SetCusip outbox event);
             // substituted because fiscal-year detection never publishes.
-            services.AddSingleton(Substitute.For<IPublishEndpoint>());
+            services.AddSingleton(Substitute.For<IBus>());
             services.AddScoped<CommonStockManager>();
             services.AddSingleton(SecEdgarClient);
             services.AddSingleton(Normalizer);

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperUpdateFiscalYearEndErrorIsolationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperUpdateFiscalYearEndErrorIsolationTests.cs
@@ -70,7 +70,7 @@ public class DocumentScraperUpdateFiscalYearEndErrorIsolationTests
         services.AddSingleton(dbContext);
         services.AddScoped<CommonStockRepository>();
         services.AddScoped<DocumentRepository>();
-        services.AddSingleton(Substitute.For<IPublishEndpoint>());
+        services.AddSingleton(Substitute.For<IBus>());
         services.AddScoped<CommonStockManager>();
         services.AddSingleton(secEdgarClient);
         services.AddSingleton(Substitute.For<IDocumentPersistenceService>());


### PR DESCRIPTION
## Summary

`CommonStockManager.SetCusip` published `StockCusipChanged` through the scoped `IPublishEndpoint`. When a host enables a MassTransit bus outbox on a *different* `DbContext` (the commercial deployment puts the outbox on its customer database), the scoped publish is captured into that context and only delivered when that context's `SaveChanges` runs — but this flow saves the financial context, so the event would be silently dropped.

## Code changes

- `CommonStockManager` now injects the root `IBus` and publishes after `SaveChanges`. The root bus bypasses any bus outbox, so the event is always delivered directly. Delivery is at-least-once and `StockCusipChangedConsumer` is idempotent, so a publish lost to a crash is recovered on the next CUSIP resolve.
- Tests that constructed `CommonStockManager` updated to substitute `IBus`.