### PR TITLE
feat(data): add optional context-options hook to AddEquiblesDbContext

### DIFF
--- a/src/Equibles.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Data/Extensions/ServiceCollectionExtensions.cs
@@ -23,7 +23,8 @@ public static class ServiceCollectionExtensions
         Action<NpgsqlDbContextOptionsBuilder> configureNpgsql = null,
         Assembly migrationsAssembly = null,
         string migrationsAssemblyName = null,
-        TimeSpan? commandTimeout = null
+        TimeSpan? commandTimeout = null,
+        Action<DbContextOptionsBuilder> configureOptions = null
     )
         where TContext : EquiblesDbContextBase
     {
@@ -56,6 +57,9 @@ public static class ServiceCollectionExtensions
                     }
                 );
                 options.UseLazyLoadingProxies();
+                // Last, so a host can adjust context-level options (e.g. suppress a
+                // warning) on top of the standard configuration.
+                configureOptions?.Invoke(options);
             }
         );
 
@@ -73,7 +77,8 @@ public static class ServiceCollectionExtensions
         Action<EquiblesModuleBuilder> configureModules,
         Assembly migrationsAssembly = null,
         string migrationsAssemblyName = null,
-        TimeSpan? commandTimeout = null
+        TimeSpan? commandTimeout = null,
+        Action<DbContextOptionsBuilder> configureOptions = null
     )
     {
         return services.AddEquiblesDbContext<EquiblesFinancialDbContext>(
@@ -82,7 +87,8 @@ public static class ServiceCollectionExtensions
             npgsql => npgsql.UseVector().UseParadeDb(),
             migrationsAssembly,
             migrationsAssemblyName,
-            commandTimeout
+            commandTimeout,
+            configureOptions
         );
     }
 


### PR DESCRIPTION
## Summary

Adds an optional `Action<DbContextOptionsBuilder> configureOptions` parameter to `AddEquiblesDbContext<TContext>` (and the `AddEquiblesFinancialDbContext` convenience overload). It runs after the standard Npgsql + lazy-loading setup, so a host can adjust context-level options without replacing the helper.

## Why

A deployment that runs two contexts over two databases can have a context whose model intentionally differs from its migration snapshot during a phased cutover (e.g. tables that exist physically but are scheduled for a later drop). Such a host needs to suppress EF Core's `PendingModelChangesWarning` on `Migrate` for that one context. The hook makes this a one-liner at the call site; default behavior is unchanged.