### PR TITLE
test(holdings): pin HolderQuarterlyActivityCalculator.ClassifyChange Reduced arm

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HolderQuarterlyActivityCalculatorClassifyChangeReducedTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HolderQuarterlyActivityCalculatorClassifyChangeReducedTests.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HolderQuarterlyActivityCalculatorClassifyChangeReducedTests
+{
+    // Sibling to HolderQuarterlyActivityCalculatorClassifyChangeInitiatedTests
+    // (PR #2314). That pins arm 1 (previous=0 → Initiated). This pin covers
+    // the structurally distinct DEFAULT/REDUCED arm — the false branch of
+    // the closing ternary:
+    //   return currentShares > previousShares
+    //       ? StockPositionChangeType.Increased
+    //       : StockPositionChangeType.Reduced;
+    //                              ^ this branch
+    //
+    // The four arms of ClassifyChange and the regressions each pin defends:
+    //   1. previous=0 → Initiated (PR #2314)
+    //   2. current == previous → Unchanged (unpinned)
+    //   3. current > previous → Increased (unpinned)
+    //   4. current < previous → Reduced (this pin)
+    //
+    // The risk this pin uniquely catches:
+    //   • SWAP regression — the closing ternary's two arms swapped:
+    //     `return current > previous ? Reduced : Increased;` (logic flip
+    //     from a careless edit) — would compile, pass the Initiated
+    //     sibling (its input has previous=0 → arm 1 fires before the
+    //     ternary), and INVERT every Increased/Reduced classification.
+    //     The portfolio-activity view's "Increased" and "Reduced"
+    //     sections would visibly swap stocks. Caught by THIS pin
+    //     (its input has current=500 < previous=1000, expects
+    //     Reduced; swap returns Increased, fails).
+    //   • Drop-the-Reduced-default — `return current > previous ?
+    //     Increased : Unchanged;` (someone "tidies" the default to
+    //     Unchanged) — would compile, pass the Initiated sibling, pass
+    //     any future Unchanged sibling for equal inputs, and
+    //     mis-classify every actual reduction as Unchanged. Caught
+    //     here (input has current != previous, expects Reduced;
+    //     this regression returns Unchanged).
+    //
+    // Pin: invoke with current=500, previous=1000 (a clear share-count
+    // reduction). Assert StockPositionChangeType.Reduced. Reflection-
+    // invoke since private static. Pair (Initiated + Reduced) defends
+    // both the FIRST and LAST arms of the classifier; Unchanged and
+    // Increased remain as future sibling targets.
+    [Fact]
+    public void ClassifyChange_CurrentBelowPrevious_ReturnsReduced()
+    {
+        var method = typeof(HolderQuarterlyActivityCalculator).GetMethod(
+            "ClassifyChange",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (StockPositionChangeType)method!.Invoke(null, [500L, 1000L]);
+
+        result.Should().Be(StockPositionChangeType.Reduced);
+    }
+}


### PR DESCRIPTION
## Summary

Sibling to PR #2314 (Initiated arm). Covers the structurally distinct REDUCED arm — the false branch of the closing ternary `current > previous ? Increased : Reduced`.

Catches:
- Closing-ternary swap (`? Reduced : Increased`) — inverts every Increased/Reduced classification across the portfolio-activity view; the two columns visibly swap stocks. Initiated sibling can't see this (its input fires arm 1 before the ternary).
- Drop-the-Reduced-default (`? Increased : Unchanged`) — mis-classifies every reduction as Unchanged.

Input current=500, previous=1000 is a clear reduction. Pair (Initiated + Reduced) defends both the FIRST and LAST arms of the four-arm classifier; Unchanged and Increased remain as future siblings.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HolderQuarterlyActivityCalculatorClassifyChangeReducedTests.cs` — single `[Fact]` reflection-invoking the private static helper.