### PR TITLE
test(holdings): pin HolderQuarterlyActivityCalculator.ClassifyChange Increased arm

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HolderQuarterlyActivityCalculatorClassifyChangeIncreasedTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HolderQuarterlyActivityCalculatorClassifyChangeIncreasedTests.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HolderQuarterlyActivityCalculatorClassifyChangeIncreasedTests
+{
+    // Third pin in the ClassifyChange family. Initiated (PR #2314) and
+    // Reduced (PR #2315) pin arms 1 and 4. This pin covers arm 3:
+    //   currentShares > previousShares → StockPositionChangeType.Increased
+    //
+    // This is the TRUE branch of the closing ternary:
+    //   return currentShares > previousShares
+    //       ? StockPositionChangeType.Increased
+    //       : StockPositionChangeType.Reduced;
+    //
+    // The Initiated arm (PR #2314) fires when previousShares == 0 BEFORE
+    // the ternary. The Reduced arm (PR #2315) fires when current < previous.
+    // Neither sibling can exclusively prove the Increased branch returns
+    // the correct value — the swap regression `? Reduced : Increased`
+    // fails the Reduced sibling (its current=500 < previous=1000 input
+    // would return Increased instead of Reduced), but a DIFFERENT
+    // regression that only touches the Increased branch (e.g.
+    // `? Unchanged : Reduced`) would pass the Reduced sibling (Reduced
+    // is unchanged) and silently mis-classify every increase as Unchanged.
+    //
+    // The risk this pin uniquely catches:
+    //   • Drop-the-Increased-arm — `? Unchanged : Reduced` — would
+    //     compile, pass Initiated (arm 1 fires first), pass Reduced
+    //     (false-arm unchanged), and mis-classify every share-count
+    //     increase as Unchanged in the portfolio-activity view.
+    //     "Increased" section renders as empty; every actual increase
+    //     hides under "Unchanged".
+    //   • Asymmetric swap — `? Initiated : Reduced` — same issue;
+    //     caught here.
+    //
+    // Pin: invoke with current=1500, previous=1000 (clear share-count
+    // increase, previous nonzero so arm 1 doesn't fire). Assert
+    // StockPositionChangeType.Increased. Reflection-invoke since
+    // private static. The triad (Initiated + Reduced + Increased)
+    // defends three of four arms — Unchanged remains as the final
+    // sibling target.
+    [Fact]
+    public void ClassifyChange_CurrentAbovePrevious_ReturnsIncreased()
+    {
+        var method = typeof(HolderQuarterlyActivityCalculator).GetMethod(
+            "ClassifyChange",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (StockPositionChangeType)method!.Invoke(null, [1500L, 1000L]);
+
+        result.Should().Be(StockPositionChangeType.Increased);
+    }
+}


### PR DESCRIPTION
## Summary

Third pin in the ClassifyChange family. Initiated (#2314) + Reduced (#2315) defended arms 1 and 4; this pin defends arm 3 (the TRUE branch of the closing ternary).

The Reduced sibling can't see asymmetric regressions touching only the Increased branch (e.g. `? Unchanged : Reduced`) — the Reduced side stays unchanged and passes. This pin closes that gap.

Catches:
- Drop-the-Increased-arm (`? Unchanged : Reduced`) — would compile and pass Initiated + Reduced siblings; every share-count increase silently mis-classifies as Unchanged. The "Increased" section of the portfolio-activity view renders as empty.

Input current=1500, previous=1000. Previous nonzero so arm 1 doesn't fire. The triad (Initiated + Reduced + Increased) defends 3 of 4 arms; Unchanged remains as the final sibling.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HolderQuarterlyActivityCalculatorClassifyChangeIncreasedTests.cs` — single `[Fact]` reflection-invoking the private static helper.