### PR TITLE
test(holdings): pin FundOverlapCalculator returns zero overlap for funds with empty holdings

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/FundOverlapCalculatorEmptyHoldingsTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundOverlapCalculatorEmptyHoldingsTests.cs
@@ -1,0 +1,50 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class FundOverlapCalculatorEmptyHoldingsTests
+{
+    private static readonly DateOnly Report = new(2024, 12, 31);
+
+    [Fact]
+    public void Calculate_TwoFundsBothHoldingNothing_ReturnsZeroOverlapNoDivideByZero()
+    {
+        // Existing `NoFunds_ReturnsEmptyResult` short-circuits via `funds.Count == 0`.
+        // This test exercises a different gap: two funds DO exist, but each one
+        // happens to report zero holdings — a real production state for a fund that
+        // wound down or filed an empty 13F. The orchestrator then reaches the
+        // `allStockIds.Count > 0 ? ... : 0` and `dollarWeightedDenominator > 0 ? ... : 0`
+        // ternaries with empty inputs. A refactor that drops either guard would
+        // surface NaN / +∞ (double / 0 → not an exception, but worse: silently
+        // serialized to the API as JSON `NaN`, which is invalid JSON and tanks
+        // the response). The contract pins both ratios at 0 — and crucially that
+        // the orchestrator does not throw on the empty-fund-list traversal.
+        var fundA = new InstitutionalHolder
+        {
+            Id = Guid.NewGuid(),
+            Name = "Fund A",
+            Cik = "C001",
+        };
+        var fundB = new InstitutionalHolder
+        {
+            Id = Guid.NewGuid(),
+            Name = "Fund B",
+            Cik = "C002",
+        };
+
+        var result = FundOverlapCalculator.Calculate(
+            [
+                (fundA, Array.Empty<InstitutionalHolding>()),
+                (fundB, Array.Empty<InstitutionalHolding>()),
+            ],
+            Report
+        );
+
+        result.Funds.Should().HaveCount(2);
+        result.UnionPositionCount.Should().Be(0);
+        result.IntersectionPositionCount.Should().Be(0);
+        result.JaccardSimilarityPercent.Should().Be(0);
+        result.DollarWeightedOverlapPercent.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial pin of the `allStockIds.Count > 0 ? ... : 0` and `dollarWeightedDenominator > 0 ? ... : 0` divide-by-zero guards in `FundOverlapCalculator.Calculate`.
- Existing `NoFunds_ReturnsEmptyResult` short-circuits via `funds.Count == 0`. This case is different: two funds DO exist (so we pass the early-return), but both report empty holdings (a real state for a wound-down or empty-filing fund). Dropping either guard surfaces `double / 0 = NaN`, which serializes to invalid JSON and tanks the API response.

## Code changes

- `tests/Equibles.UnitTests/Holdings/FundOverlapCalculatorEmptyHoldingsTests.cs` — two funds, both with empty holdings; expects Jaccard = 0, DollarWeightedOverlap = 0, UnionPositionCount = 0, IntersectionPositionCount = 0, and `Funds.HaveCount(2)`.