### PR TITLE
test(cboe): pin ParseVixCsv skips row when High cell is unparseable

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CboeClientParseVixCsvHighUnparseableTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientParseVixCsvHighUnparseableTests.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using Equibles.Integrations.Cboe;
+using Equibles.Integrations.Cboe.Models;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CboeClientParseVixCsvHighUnparseableTests
+{
+    private static readonly MethodInfo ParseVixCsvMethod = typeof(CboeClient).GetMethod(
+        "ParseVixCsv",
+        BindingFlags.NonPublic | BindingFlags.Static
+    )!;
+
+    [Fact]
+    public void ParseVixCsv_HighFieldUnparseable_SkipsRowDoesNotPersistDefault()
+    {
+        // ParseVixCsv has four independent per-cell skip arms — Open, High,
+        // Low, Close — each `if (!TryDec(i, ...)) continue;` (CboeClient.cs:
+        // 157-164). The existing Culture pin asserts the happy path; the
+        // existing skip pins cover date parsing. The individual numeric arms
+        // are unpinned. A refactor that drops `if (!TryDec(2, out var high))
+        // continue;` (say, "the column is always numeric") would leave `high`
+        // at default `0m` from the out var and silently emit a record whose
+        // High = 0 — corrupting downstream VIX-chart bars where the
+        // intraday high looks like the close went to zero. Pin: a row whose
+        // High column is "BAD" must produce NO record (skipped entirely),
+        // not a record with High = 0.
+        var csv = "DATE,OPEN,HIGH,LOW,CLOSE\n" + "01/02/2004,17.96,BAD,17.54,18.22\n";
+
+        var records = (List<CboeVixRecord>)ParseVixCsvMethod.Invoke(null, [csv])!;
+
+        records.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial pin of one of the four independent per-cell skip arms in `ParseVixCsv` (Open, High, Low, Close). Existing pins cover the date arm and the happy-path culture-mapping; the four OHLC skip arms are unpinned.
- A refactor that drops the High guard would leave `high` at the out-var default `0m` and emit a record with `High = 0`, corrupting downstream VIX charts. Pin one arm so the family-sweep can extend the same shape to the other three later.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CboeClientParseVixCsvHighUnparseableTests.cs` — a row with High = `"BAD"`. Expects `records.Should().BeEmpty()` (skipped, not emitted with High = 0).