### PR TITLE
test(cboe): pin ParseVixCsv skips row when Low cell is unparseable

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CboeClientParseVixCsvLowUnparseableTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientParseVixCsvLowUnparseableTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using Equibles.Integrations.Cboe;
+using Equibles.Integrations.Cboe.Models;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CboeClientParseVixCsvLowUnparseableTests
+{
+    private static readonly MethodInfo ParseVixCsvMethod = typeof(CboeClient).GetMethod(
+        "ParseVixCsv",
+        BindingFlags.NonPublic | BindingFlags.Static
+    )!;
+
+    [Fact]
+    public void ParseVixCsv_LowFieldUnparseable_SkipsRowDoesNotPersistDefault()
+    {
+        // Third sibling of the OHLC per-cell skip family. With #2337 (High)
+        // and #2338 (Open), this isolates the Low arm. Dropping the Low
+        // guard would silently emit a record with Low = 0m — making the
+        // intraday range (High - Low) look like a full-day crash to zero,
+        // which downstream max-drawdown analytics and "circuit-breaker"
+        // detectors would flag as a real event.
+        var csv = "DATE,OPEN,HIGH,LOW,CLOSE\n" + "01/02/2004,17.96,18.68,BAD,18.22\n";
+
+        var records = (List<CboeVixRecord>)ParseVixCsvMethod.Invoke(null, [csv])!;
+
+        records.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial sibling to the High (#2337) and Open (#2338) pins. Closes the Low arm of `ParseVixCsv`'s four-arm OHLC per-cell skip family.
- Dropping the Low guard would silently emit `Low = 0m`, making the intraday range look like a full-day crash — drawdown analytics and circuit-breaker detectors would misfire.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CboeClientParseVixCsvLowUnparseableTests.cs` — row with Low = `"BAD"`. Expects empty result.