### PR TITLE
test(sec): pin FactMarkdown.Value omits dollar prefix for non-USD per-share

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownValuePerShareNonUsdTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownValuePerShareNonUsdTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FactMarkdownValuePerShareNonUsdTests
+{
+    [Fact]
+    public void Value_NonUsdPerSharesUnit_RendersCentsWithoutDollarPrefix()
+    {
+        // Sibling to ValuePerShareUsd. The contract's doc-comment is explicit:
+        // "Only USD is prefixed with '$'; other currencies (EUR/GBP for 20-F /
+        // 40-F filers) are conveyed by the unit column rather than mislabelled
+        // with a dollar sign." A 20-F filer reporting EPS in EUR (e.g. ASML
+        // at €5.23 per share) must render as "5.23" (cents preserved by the
+        // per-share branch), NOT "$5.23" (would falsely imply USD to the LLM).
+        // A refactor that drops the `isUsd ? "$" + number : number` final
+        // ternary and unconditionally prefixes '$' would compile, pass the
+        // USD pin, and silently relabel every foreign-filer EPS as dollars.
+        var result = FactMarkdown.Value(5.23m, "EUR/shares");
+
+        result.Should().Be("5.23");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial sibling to `ValuePerShareUsd`. The contract's doc-comment is explicit: "Only USD is prefixed with '\$'; other currencies are conveyed by the unit column."
- A 20-F filer reporting EPS in EUR (e.g. ASML at €5.23) must render as "5.23", not "\$5.23". A refactor dropping the final `isUsd ? "\$" + number : number` ternary would silently relabel every foreign-filer EPS as dollars in the LLM-readable output.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownValuePerShareNonUsdTests.cs` — `Value(5.23m, "EUR/shares")` → expects `"5.23"`, not `"\$5.23"`.