### PR TITLE
test(sec): pin HighlightKeyword case-insensitive match preserves source casing

### DIFF
--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsHighlightKeywordCaseInsensitiveTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsHighlightKeywordCaseInsensitiveTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Equibles.Sec.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class DocumentTextToolsHighlightKeywordCaseInsensitiveTests
+{
+    [Fact]
+    public void HighlightKeyword_LowercaseKeywordMatchesUppercaseLine_WrapsOriginalCasing()
+    {
+        // HighlightKeyword's IndexOf uses StringComparison.OrdinalIgnoreCase
+        // (DocumentTextTools.cs:181) so an LLM submitting a lowercase keyword
+        // (the natural default — most LLM tool calls don't preserve casing)
+        // still finds the uppercase or mixed-case occurrences in the source
+        // SEC filing. A refactor that drops the StringComparison argument
+        // would silently fall back to the default Ordinal (case-sensitive)
+        // and the keyword highlighter would miss every case-mismatched hit.
+        // The wrapping must preserve the line's ORIGINAL casing — the **
+        // markers go around the SOURCE substring, not the search query.
+        // Existing pins cover no-match and the empty-keyword DoS guard; this
+        // closes the case-insensitivity contract.
+        var method = typeof(DocumentTextTools).GetMethod(
+            "HighlightKeyword",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (string)method!.Invoke(null, ["The COMPANY filed quarterly", "company"]);
+
+        result.Should().Be("The **COMPANY** filed quarterly");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial pin of `HighlightKeyword`'s `StringComparison.OrdinalIgnoreCase`. Existing pins cover the no-match arm and the empty-keyword DoS guard; the case-insensitivity contract is unpinned.
- An LLM tool call routinely sends a lowercase keyword (`company`) while SEC filings are mixed-case (`COMPANY`). Dropping the comparison argument silently falls back to Ordinal (case-sensitive) and the highlighter misses every case-mismatched hit. The wrapped substring must also preserve the SOURCE casing, not the query.

## Code changes

- `tests/Equibles.UnitTests/Sec/DocumentTextToolsHighlightKeywordCaseInsensitiveTests.cs` — `HighlightKeyword("The COMPANY filed quarterly", "company")` → expects `"The **COMPANY** filed quarterly"`.