### PR TITLE
test(sec): pin FactMarkdown.Value renders bare 'shares' as grouped whole

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownValueBareSharesTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownValueBareSharesTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FactMarkdownValueBareSharesTests
+{
+    [Fact]
+    public void Value_BareSharesUnit_RendersGroupedWholeWithoutCurrencyPrefix()
+    {
+        // FactMarkdown.Value's `isWholeMagnitude` test is three-way:
+        //   isUsd || string.Equals(u, "shares", OrdinalIgnoreCase) || IsBareCurrency(u)
+        // Existing pins cover the USD and bare-currency (EUR) arms; "shares"
+        // — the canonical SharesOutstanding/SharesIssued unit on every common-
+        // stock fact — is the middle arm and unpinned. A refactor that
+        // narrows the predicate to "is a currency" (dropping the equals-shares
+        // disjunct) would silently route 1,000,000,000 shares through the
+        // dimensionless "0.############" branch and render as "1000000000",
+        // losing thousand separators that are the whole point of N0 for
+        // human / LLM readability. Also asserts no "$" prefix — bare shares
+        // are NOT a currency.
+        var result = FactMarkdown.Value(1_234_567_890m, "shares");
+
+        result.Should().Be("1,234,567,890");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial pin of the middle arm of `isWholeMagnitude`'s 3-disjunct predicate: `isUsd || equals("shares") || IsBareCurrency`. Existing pins cover USD (#bareusd) and bare-currency (#barecurrency); "shares" — the canonical SharesOutstanding unit — was unpinned.
- A refactor narrowing the predicate to "is a currency" would silently route share-count facts through the dimensionless `0.############` branch and render `1000000000` instead of `1,000,000,000`, losing thousand separators meant for human / LLM readability.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownValueBareSharesTests.cs` — `Value(1_234_567_890m, "shares")` → expects `"1,234,567,890"` (no `$` prefix).