### PR TITLE
test(congress): pin IsTransactionTable returns false when date column is missing

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsTransactionTableMissingDateTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsTransactionTableMissingDateTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperIsTransactionTableMissingDateTests
+{
+    [Fact]
+    public void IsTransactionTable_AssetColumnOnlyNoDate_ReturnsFalse()
+    {
+        // Sibling to IsTransactionTableMissingAsset. Both `hasDate` and
+        // `hasAsset` must be true (`hasDate && hasAsset`). Existing pin
+        // covers `hasDate=true, hasAsset=false → false`; this isolates
+        // the inverse `hasDate=false, hasAsset=true → false`. A refactor
+        // that loosens the gate to a single condition (e.g. only checking
+        // hasAsset because "the date is always there") would compile,
+        // pass the MissingAsset pin, and start picking up MEMBER-LIST or
+        // ASSET-PORTFOLIO summary tables on the disclosure page — every
+        // such "table" would feed empty rows downstream. Pin date-only
+        // absence: asset-only headers must NOT qualify.
+        var method = typeof(DisclosureParsingHelper).GetMethod(
+            "IsTransactionTable",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var headers = new List<string> { "owner", "asset name", "amount" };
+
+        var result = (bool)method!.Invoke(null, [headers]);
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial sibling to `IsTransactionTableMissingAsset`. Both conditions of `hasDate && hasAsset` now have individual pins.
- A refactor loosening the gate to a single check (e.g. only `hasAsset`) would compile, pass the existing pin, and start picking up MEMBER-LIST or ASSET-PORTFOLIO summary tables — every such "table" feeds empty rows downstream.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsTransactionTableMissingDateTests.cs` — headers with `asset name` + `owner` + `amount`, no date. Expects `false`.