### PR TITLE
test(sec): pin TryParseBound treats blank input as absent bound

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsTryParseBoundBlankTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsTryParseBoundBlankTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactsToolsTryParseBoundBlankTests
+{
+    [Fact]
+    public void TryParseBound_BlankInput_ReturnsTrueAndLeavesBoundNull()
+    {
+        // Sibling to the existing NonIsoDate rejection pin. The in-source
+        // comment is explicit: "Accepts an absent bound (null/blank → no
+        // bound) but rejects a non-empty value that is not an ISO yyyy-MM-dd
+        // date". The rejection pin covers "non-empty malformed"; this pins
+        // the structurally-distinct "absent" arm — the LLM omits an
+        // optional bound by passing blank, and the tool must interpret
+        // that as "no filter" (success, null bound), NOT as "parse error".
+        // A refactor that flips IsNullOrWhiteSpace to `return false` (under
+        // "blank means failed parse, surface the error to the LLM") would
+        // compile, pass the rejection pin, and refuse every unbounded
+        // financial-fact query — the dominant use case.
+        var method = typeof(FinancialFactsTools).GetMethod(
+            "TryParseBound",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var args = new object[] { "   ", null };
+        var result = (bool)method!.Invoke(null, args);
+
+        result.Should().BeTrue();
+        ((DateOnly?)args[1]).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial sibling to the NonIsoDate rejection pin. The contract distinguishes "absent" (null/blank → success with null bound) from "non-empty malformed" (false, null bound). The absent arm was unpinned.
- A refactor flipping `IsNullOrWhiteSpace` to `return false` (under "blank means failed parse") would compile, pass the rejection pin, and refuse every unbounded `GetFinancialFact` / `CompareFinancialFact` query — the dominant use case.

## Code changes

- `tests/Equibles.UnitTests/Sec/FinancialFactsToolsTryParseBoundBlankTests.cs` — `TryParseBound("   ", out var b)` → expects `true` and `b == null`.