### PR TITLE
test(holdings): pin IsYes recognizes lowercase 'true' as truthy

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsYesTrueArmTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsYesTrueArmTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceIsYesTrueArmTests
+{
+    [Fact]
+    public void IsYes_LowercaseTrue_ReturnsTrueViaCaseInsensitiveMatch()
+    {
+        // Sibling to IsYesYArmTests and IsYesExactOneMatchTests. Those pin
+        // the "Y" canonical arm and the "1" strict-equality arm respectively.
+        // IsYes's four-arm OR also recognises "yes" and "true" as truthy
+        // (case-insensitive), to handle XBRL-cover-page payloads that
+        // occasionally emit a boolean-style string. The "true" arm is
+        // unpinned. A refactor that "tightens" the predicate to only the
+        // canonical SEC encodings (`Y` / `1`) would compile, pass both
+        // existing pins, and misclassify every cover page whose authoring
+        // tool serialized the bool as the word "true" — silently dropping
+        // those into the non-confidential bucket. Pin the LOWERCASE
+        // "true" so the case-insensitive comparison is also exercised
+        // (uppercase or "True" would still match an Ordinal `Equals`).
+        var method = typeof(HoldingsImportService).GetMethod(
+            "IsYes",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (bool)method!.Invoke(null, ["true"]);
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial sibling to the existing "Y" arm and "1" strict-equality pins. IsYes also accepts "yes" and "true" (case-insensitive) for XBRL cover-page payloads that serialize booleans as words.
- A refactor "tightening" the predicate to only the canonical SEC encodings (`Y` / `1`) would compile, pass both existing pins, and silently misclassify every cover page emitting "true"/"yes" as non-confidential.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsYesTrueArmTests.cs` — `IsYes("true")` → expects `true`. Lowercase chosen so a refactor swapping `OrdinalIgnoreCase` for `Ordinal` also surfaces here.