### PR TITLE
test(holdings): pin IsYes recognizes mixed-case 'Yes' as truthy

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsYesYesArmTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsYesYesArmTests.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceIsYesYesArmTests
+{
+    [Fact]
+    public void IsYes_MixedCaseYes_ReturnsTrueViaCaseInsensitiveMatch()
+    {
+        // Closes the IsYes truthy-arm family alongside the existing YArm
+        // (`Y` canonical), `1` strict-equality, and just-added "true"
+        // (lowercase) pins. The "yes" arm is the third textual alternative
+        // — natural-language XBRL cover pages occasionally emit the full
+        // word. A refactor that drops `Equals("yes", OrdinalIgnoreCase)`
+        // would compile, pass each other sibling, and silently misclassify
+        // any cover page whose authoring tool serialized the bool as the
+        // word "yes" instead of "Y" / "true" / "1". Pin MIXED case ("Yes")
+        // so the case-insensitive comparator is also exercised — a swap to
+        // `Ordinal` Equals would only match "yes" lowercase and fail here.
+        var method = typeof(HoldingsImportService).GetMethod(
+            "IsYes",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (bool)method!.Invoke(null, ["Yes"]);
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Closes the IsYes truthy-arm family. Pins the "yes" arm (sibling to Y, "1", and "true"). Mixed casing ("Yes") also exercises the `OrdinalIgnoreCase` comparator.
- A refactor that drops the `Equals("yes", OrdinalIgnoreCase)` clause would compile, pass every existing sibling, and silently misclassify cover pages serialized as the word "yes".

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsYesYesArmTests.cs` — `IsYes("Yes")` → expects `true`.