### PR TITLE
test(holdings): pin TryParseCoverPageRow returns false when accession field is absent

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseCoverPageRowMissingAccessionTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseCoverPageRowMissingAccessionTests.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceTryParseCoverPageRowMissingAccessionTests
+{
+    [Fact]
+    public void TryParseCoverPageRow_RowMissingAccessionField_ReturnsFalseWithoutDictionaryLookup()
+    {
+        // Sibling to TryParseCoverPageRowOrphanAccessionTests. The
+        // existing pin defends the `!submissions.ContainsKey(accession)`
+        // arm — accession is known to GetValue but unknown to submissions.
+        // This sibling defends the OR's FIRST arm: `IsNullOrEmpty(accession)
+        // → false`. GetValue returns null when the field is absent from
+        // the row dictionary. A refactor that drops the IsNullOrEmpty
+        // guard ("ContainsKey already handles missing keys") would
+        // short-circuit to `submissions.ContainsKey(null)` — Dictionary
+        // throws ArgumentNullException on a null key. That would crash
+        // the whole cover-page parse pass on the first row missing
+        // ACCESSION_NUMBER, instead of the contractual graceful skip.
+        var method = typeof(HoldingsImportService).GetMethod(
+            "TryParseCoverPageRow",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        // Row has NO ACCESSION_NUMBER field — GetValue returns null.
+        var row = new Dictionary<string, string> { ["FILINGMANAGER_NAME"] = "Some Fund" };
+        var submissions = new Dictionary<string, SubmissionRow>();
+        var args = new object[] { row, submissions, null };
+
+        var resolved = (bool)method!.Invoke(null, args);
+
+        resolved.Should().BeFalse();
+        args[2].Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial sibling to `TryParseCoverPageRowOrphanAccessionTests`. The existing pin covers the second arm (`!submissions.ContainsKey(accession)`); this pins the first arm (`IsNullOrEmpty(accession)`) on the null path.
- A refactor dropping the IsNullOrEmpty guard would short-circuit to `submissions.ContainsKey(null)`, which throws `ArgumentNullException`. The whole cover-page parse pass would crash on the first row missing ACCESSION_NUMBER instead of the contractual graceful skip.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseCoverPageRowMissingAccessionTests.cs` — row dictionary has no `ACCESSION_NUMBER` key (GetValue returns null). Expects `false` and `out` arg `null`.