### PR TITLE
test(holdings): pin IsNewHoldingsAmendment returns false for missing accession

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsNewHoldingsAmendmentMissingAccessionTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsNewHoldingsAmendmentMissingAccessionTests.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceIsNewHoldingsAmendmentMissingAccessionTests
+{
+    [Fact]
+    public void IsNewHoldingsAmendment_AccessionNotInCoverPages_ReturnsFalseWithoutThrowing()
+    {
+        // Sibling to the CaseInsensitive pin. The existing pin defends the
+        // SECOND arm of the `&&` chain (AmendmentType equality semantic).
+        // This pins the FIRST arm — `CoverPages.TryGetValue(accession, ...)`
+        // — on the miss path. A refactor that drops the TryGetValue and
+        // uses the indexer (`var coverPage = context.CoverPages[accession]`
+        // under "the accession always has a cover page") would throw
+        // KeyNotFoundException on every orphan accession (filings whose
+        // cover page row was rejected upstream still appear in the
+        // submission map). The downstream amendment-classification pass
+        // would crash instead of safely falling through to the
+        // delete-and-replace (RESTATEMENT) path. Pin: missing accession
+        // returns false, no throw.
+        var method = typeof(HoldingsImportService).GetMethod(
+            "IsNewHoldingsAmendment",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var accession = "0000950123-24-999999";
+        var context = new ImportContext { CoverPages = new Dictionary<string, CoverPageRow>() };
+
+        var result = (bool)method!.Invoke(null, [accession, context]);
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial sibling to the existing CaseInsensitive pin (which defends the SECOND arm of the `&&` chain). This pins the FIRST arm — `TryGetValue` from `CoverPages`.
- A refactor swapping `TryGetValue` for the indexer would throw `KeyNotFoundException` on every orphan accession; the amendment-classification pass would crash instead of falling through to the delete-and-replace path.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceIsNewHoldingsAmendmentMissingAccessionTests.cs` — empty `CoverPages`, accession not present. Expects `false`, no throw.