### PR TITLE
test(sec): pin IsBoldSpan matches CSS with spaced colon form

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsBoldSpanSpacedColonTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsBoldSpanSpacedColonTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class HeadingConversionStepIsBoldSpanSpacedColonTests
+{
+    [Fact]
+    public void IsBoldSpan_InlineStyleFontWeightBoldWithSpaceAfterColon_ReturnsTrue()
+    {
+        // Sibling to IsBoldSpanTests (compact `font-weight:bold`). The
+        // ContainsCssDeclaration helper explicitly handles both compact
+        // and spaced forms (HeadingConversionStep.cs:179-184) because SEC
+        // EDGAR emits CSS both ways across filers. A refactor that drops
+        // the `source.Contains($"{property}: {value}")` second arm of the
+        // OR (perhaps assuming the upstream serializer normalises spacing)
+        // would compile, pass the existing compact-form pin, and silently
+        // miss every bold-span heading from filings that ship with the
+        // spaced form — h3 promotion would skip them and the rendered
+        // markdown would lose its section anchors.
+        var span = new HtmlParser()
+            .ParseDocument(
+                "<html><body><span style=\"font-weight: bold\">Section</span></body></html>"
+            )
+            .QuerySelector("span")!;
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "IsBoldSpan",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var step = new HeadingConversionStep();
+
+        var result = (bool)method!.Invoke(step, [span])!;
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial sibling to the existing IsBoldSpan compact-form pin (`font-weight:bold`). `ContainsCssDeclaration` handles both compact and spaced forms because SEC EDGAR ships CSS both ways across filers.
- A refactor dropping the `source.Contains($"{property}: {value}")` second arm would compile, pass the compact pin, and silently miss every bold-span heading from filings with the spaced form — h3 promotion would skip them, breaking section anchors in the rendered markdown.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsBoldSpanSpacedColonTests.cs` — `style="font-weight: bold"` (note the space after `:`). Expects `IsBoldSpan` → `true`.