### PR TITLE
test(sec): pin IsItalicSpan matches CSS with spaced colon form

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItalicSpanSpacedColonTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItalicSpanSpacedColonTests.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class HeadingConversionStepIsItalicSpanSpacedColonTests
+{
+    [Fact]
+    public void IsItalicSpan_InlineStyleFontStyleItalicWithSpaceAfterColon_ReturnsTrue()
+    {
+        // Sibling to IsItalicSpanTests (compact `font-style:italic`) and to
+        // the just-added IsBoldSpan spaced-colon pin (#2372). ContainsCssDeclaration
+        // handles both `property:value` and `property: value` because SEC
+        // EDGAR ships both forms across filers. A refactor dropping the
+        // spaced arm would compile, pass the compact-form pin, and silently
+        // miss every italic-span heading from filings that emit the spaced
+        // form — h4 promotion would skip them and the rendered markdown
+        // would lose its sub-heading anchors.
+        var span = new HtmlParser()
+            .ParseDocument(
+                "<html><body><span style=\"font-style: italic\">Heading</span></body></html>"
+            )
+            .QuerySelector("span")!;
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "IsItalicSpan",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var step = new HeadingConversionStep();
+
+        var result = (bool)method!.Invoke(step, [span])!;
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial sibling to the IsItalicSpan compact-form pin and to the just-added IsBoldSpan spaced-colon pin (#2372). Both inline-style probes now defend both compact and spaced colon forms.
- A refactor dropping the spaced arm would compile, pass the compact pin, and silently miss h4 promotion on italic-span filings that emit the spaced form — losing sub-heading anchors.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItalicSpanSpacedColonTests.cs` — `style="font-style: italic"` (space after `:`). Expects `IsItalicSpan` → `true`.