### PR TITLE
test(web): pin IsNewer fails closed when latest version is unparseable

### DIFF
--- a/tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerUnparseableLatestTests.cs
+++ b/tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerUnparseableLatestTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+public class VersionCheckServiceIsNewerUnparseableLatestTests
+{
+    [Fact]
+    public void IsNewer_UnparseableLatestVersion_ReturnsFalseFailingClosed()
+    {
+        // Sibling to IsNewerUnparseable, which pins the FIRST arm of the
+        // OR (`!Version.TryParse(NormalizeVersion(current), …)`). The
+        // SECOND arm — `!Version.TryParse(latest, …)` — is unpinned. A
+        // refactor that drops the latest TryParse and uses Version.Parse
+        // directly (or that only guards the current side under "the
+        // GitHub release tag is always a valid version") would compile,
+        // pass the existing pin, and throw FormatException up the request
+        // path the first time GitHub returns a malformed `tag_name`
+        // (release notes editors occasionally hand-edit tags into
+        // non-version strings like "v1.0-beta-readme-update"). Pin the
+        // fail-closed contract on the latest side.
+        var method = typeof(VersionCheckService).GetMethod(
+            "IsNewer",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (bool)method!.Invoke(null, ["1.2.3", "not a version"]);
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial sibling to `IsNewerUnparseable` (which pins the FIRST arm of the parse-failure OR). The SECOND arm — unparseable `latest` from a GitHub release tag — is unpinned.
- A refactor swapping `TryParse` for `Parse` on the latest side (or only guarding the current side under "GitHub tags are always valid versions") would throw `FormatException` up the request path the first time a release tag is hand-edited into a non-version form.

## Code changes

- `tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerUnparseableLatestTests.cs` — `IsNewer("1.2.3", "not a version")` → expects `false` (fail closed, no throw).