### PR TITLE
test(web): pin IsNewer detects Build (patch) bump as update

### DIFF
--- a/tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerBuildBumpTests.cs
+++ b/tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerBuildBumpTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+public class VersionCheckServiceIsNewerBuildBumpTests
+{
+    [Fact]
+    public void IsNewer_BuildSegmentBumpOnly_DetectsAsUpdate()
+    {
+        // Existing pins cover the failure arms (unparseable current/latest)
+        // and the Minor bump path (AssemblyVsTag). The Build (patch) bump
+        // path is unpinned — the dominant cadence of a maintenance release
+        // (e.g. 1.0.0 → 1.0.1) is not exercised by any pin. A refactor that
+        // narrowed ToCore to `new(Major, Minor, 0)` (e.g. "tags only track
+        // Major.Minor") would compile, pass AssemblyVsTag (the Minor bump
+        // still beats the prior Minor), and silently swallow every Build
+        // bump — operators would never see a banner for patch releases.
+        // The contract: same Major.Minor with a higher Build is an update.
+        var method = typeof(VersionCheckService).GetMethod(
+            "IsNewer",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (bool)method!.Invoke(null, ["1.0.0", "1.0.1"]);
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial pin of the Build (patch-release) bump arm. Existing pins cover the failure arms and the Minor bump path; Build bumps are unpinned.
- A refactor narrowing `ToCore` to `new(Major, Minor, 0)` ("tags only track Major.Minor") would compile, pass the Minor bump pin, and silently swallow every maintenance release — operators would never see a banner for `1.0.0 → 1.0.1`.

## Code changes

- `tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerBuildBumpTests.cs` — `IsNewer("1.0.0", "1.0.1")` → expects `true`.