### PR TITLE
test(search): pin InsiderOwnerSearchProvider.Project Kind=Insider, ownerCik route, null subtitle on no-role

### DIFF
--- a/tests/Equibles.UnitTests/Search/InsiderOwnerSearchProviderProjectTests.cs
+++ b/tests/Equibles.UnitTests/Search/InsiderOwnerSearchProviderProjectTests.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories.Search;
+using Equibles.Search.Abstractions;
+
+namespace Equibles.UnitTests.Search;
+
+/// <summary>
+/// Pins InsiderOwnerSearchProvider.Project (new global search #885, 0% covered).
+/// The four existing DescribeRole sibling tests pin the role-string fallback chain,
+/// but none of them go through Project itself — so the cross-component wiring
+/// HitUrl's "Insider" arm relies on (Kind + RouteValues["ownerCik"]) has no
+/// producer-side guard. A rename on either side ships a dead link with no
+/// compile-time check. Project is protected → reflection (repo pattern; the
+/// repository dependency is unused by Project).
+///
+/// Adversarial input choice: an owner with OfficerTitle = null AND IsDirector =
+/// false AND IsTenPercentOwner = false — this drives DescribeRole through every
+/// fallback to its only currently-uncovered exit (the `return null;` line). The
+/// Subtitle should be null per the documented contract; a regression treating
+/// it as "" or "Unknown" would compile but break the empty-role rendering.
+/// </summary>
+public class InsiderOwnerSearchProviderProjectTests
+{
+    [Fact]
+    public void Project_NoRoleFlagsSet_SubtitleNullAndWiresInsiderRoute()
+    {
+        var provider = new InsiderOwnerSearchProvider(null);
+        var owner = new InsiderOwner
+        {
+            OwnerCik = "0001316889",
+            Name = "Buffett Warren E",
+            OfficerTitle = null,
+            IsDirector = false,
+            IsTenPercentOwner = false,
+        };
+
+        var project = typeof(InsiderOwnerSearchProvider).GetMethod(
+            "Project",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+
+        var hit = (SearchHit)project.Invoke(provider, [owner])!;
+
+        hit.Subtitle.Should().BeNull();
+        hit.Kind.Should().Be("Insider");
+        hit.RouteValues.Should().ContainKey("ownerCik").WhoseValue.Should().Be("0001316889");
+        hit.Title.Should().Be("Buffett Warren E");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the producer side of the HitUrl/Insider cross-component wiring contract — none of the existing four DescribeRole sibling tests go through Project itself, so until now `Kind="Insider"` and `RouteValues["ownerCik"]` had no producer-side guard.
- Adversarial input choice: OfficerTitle=null, IsDirector=false, IsTenPercentOwner=false drives DescribeRole through every fallback to its `return null;` exit. Subtitle should be null per the contract — a regression turning it into `""` or `"Unknown"` would compile and pass the existing pins.
- Project is protected → invoked via reflection per the repo's established pattern. Fills a 0%-covered surface.

## Code changes

- `tests/Equibles.UnitTests/Search/InsiderOwnerSearchProviderProjectTests.cs` — one Fact via reflection: asserts Title, null Subtitle, Kind="Insider", and the `ownerCik` route value.