### PR TITLE
test(data): repair ServiceCollectionExtensionsTests after #2258 ModuleConfigurationSet switch

### DIFF
--- a/tests/Equibles.IntegrationTests/Data/DataLayerTests.cs
+++ b/tests/Equibles.IntegrationTests/Data/DataLayerTests.cs
@@ -63,7 +63,7 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddEquiblesDbContext_RegistersModuleConfigurationsAsSingletons()
+    public void AddEquiblesDbContext_RegistersModuleConfigurationSet_AsSingletonWithAllModules()
     {
         var services = new ServiceCollection();
 
@@ -77,12 +77,16 @@ public class ServiceCollectionExtensionsTests
             }
         );
 
-        var moduleDescriptors = services
-            .Where(d => d.ServiceType == typeof(IModuleConfiguration))
-            .ToList();
+        var descriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(ModuleConfigurationSet<EquiblesFinancialDbContext>)
+        );
 
-        moduleDescriptors.Should().HaveCount(3);
-        moduleDescriptors.Should().OnlyContain(d => d.Lifetime == ServiceLifetime.Singleton);
+        descriptor.Should().NotBeNull();
+        descriptor!.Lifetime.Should().Be(ServiceLifetime.Singleton);
+
+        var set =
+            (ModuleConfigurationSet<EquiblesFinancialDbContext>)descriptor.ImplementationInstance!;
+        set.Modules.Should().HaveCount(3);
     }
 
     [Fact]
@@ -102,13 +106,12 @@ public class ServiceCollectionExtensionsTests
             }
         );
 
-        var moduleDescriptors = services
-            .Where(d => d.ServiceType == typeof(IModuleConfiguration))
-            .ToList();
-
-        var moduleTypes = moduleDescriptors
-            .Select(d => d.ImplementationInstance!.GetType())
-            .ToList();
+        var descriptor = services.Single(d =>
+            d.ServiceType == typeof(ModuleConfigurationSet<EquiblesFinancialDbContext>)
+        );
+        var set =
+            (ModuleConfigurationSet<EquiblesFinancialDbContext>)descriptor.ImplementationInstance!;
+        var moduleTypes = set.Modules.Select(m => m.GetType()).ToList();
 
         moduleTypes.Should().Contain(typeof(CommonStocksModuleConfiguration));
         moduleTypes.Should().Contain(typeof(HoldingsModuleConfiguration));


### PR DESCRIPTION
## Summary

Two integration tests in `tests/Equibles.IntegrationTests/Data/DataLayerTests.cs` (`AddEquiblesDbContext_RegistersModuleConfigurationsAsSingletons` and `AddEquiblesDbContext_WithMultipleModules_RegistersAllModuleConfigurations`) broke when #2258 merged and have been red on `main` ever since. They probed `services.Where(d => d.ServiceType == typeof(IModuleConfiguration))`, but `AddEquiblesDbContext<TContext>` no longer registers each module as a singleton `IModuleConfiguration` — it now registers a single `ModuleConfigurationSet<TContext>` holding the module list. The tests are rewritten to assert against the real new surface, preserving the original intent (singleton lifetime, all expected module types present, `CommonStocks` deduplicated when added transitively by `Holdings` and `Congress`).

## Code changes

- **`tests/Equibles.IntegrationTests/Data/DataLayerTests.cs`** — `AddEquiblesDbContext_RegistersModuleConfigurationsAsSingletons` renamed to `AddEquiblesDbContext_RegistersModuleConfigurationSet_AsSingletonWithAllModules` and now finds the `ModuleConfigurationSet<EquiblesFinancialDbContext>` descriptor, asserts it's a singleton, and verifies `set.Modules.Count == 3`. `AddEquiblesDbContext_WithMultipleModules_RegistersAllModuleConfigurations` keeps its name and intent — pulls the set out of the service collection, enumerates `set.Modules` and asserts each expected `IModuleConfiguration` type is present and `CommonStocks` appears exactly once.

## Test plan

- [x] `dotnet build tests/Equibles.IntegrationTests` — clean (0 errors)
- [x] `dotnet test ... --filter "FullyQualifiedName~Data.ServiceCollectionExtensionsTests"` — 4/4 pass
- [x] `dotnet test ... --filter "FullyQualifiedName~Data"` (full Data folder regression) — 64/64 pass
- [x] csharpier check + codespell — pass via pre-commit