### PR TITLE
test(holdings): fix realtime-ingestion test assertions for RealtimeIngestionResult shape

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/Holdings13FRealtimeWorkerDoWorkTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Holdings13FRealtimeWorkerDoWorkTests.cs
@@ -101,6 +101,8 @@ public class Holdings13FRealtimeWorkerDoWorkTests : IAsyncLifetime
                 sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
                 sp.GetService(typeof(ProcessedDataSetRepository))
                     .Returns(new ProcessedDataSetRepository(ctx));
+                sp.GetService(typeof(RealtimeSweepStateRepository))
+                    .Returns(new RealtimeSweepStateRepository(ctx));
                 var importService = new HoldingsImportService(
                     scopeFactory,
                     Substitute.For<ILogger<HoldingsImportService>>(),

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionWindowDedupTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionWindowDedupTests.cs
@@ -211,7 +211,9 @@ public class HoldingsRealtimeIngestionWindowDedupTests : IAsyncLifetime
             CancellationToken.None
         );
 
-        imported.Should().Be(1, "the re-listed accession must be collapsed to one filing");
+        imported
+            .FilingsImported.Should()
+            .Be(1, "the re-listed accession must be collapsed to one filing");
 
         // Parsed once, not once per window day.
         await edgar

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionZeroHoldingsSkipTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionZeroHoldingsSkipTests.cs
@@ -168,7 +168,7 @@ public class HoldingsRealtimeIngestionZeroHoldingsSkipTests : IAsyncLifetime
             CancellationToken.None
         );
 
-        count.Should().Be(0);
+        count.FilingsImported.Should().Be(0);
 
         using var verify = FreshContext();
         (await verify.Set<InstitutionalHolding>().AnyAsync()).Should().BeFalse();

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13FIngestionCrashSafetyTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13FIngestionCrashSafetyTests.cs
@@ -230,7 +230,7 @@ public class Realtime13FIngestionCrashSafetyTests : IAsyncLifetime
             CancellationToken.None
         );
 
-        imported.Should().Be(1);
+        imported.FilingsImported.Should().Be(1);
 
         using var verify = FreshContext();
         var holdings = await verify


### PR DESCRIPTION
## Summary

Four Holdings realtime-ingestion integration tests were red on `main`. `Realtime13FIngestionService.IngestRecentFilings` was refactored to return `RealtimeIngestionResult { EarliestFailedDate, FilingsImported }` instead of an `int` filing count, and `Holdings13FRealtimeWorker.DoWork` now resolves `RealtimeSweepStateRepository` from the scope — the test surfaces weren't updated to match. Pure test-only fix; no production behavior change.

## Code changes

- `Realtime13FIngestionCrashSafetyTests`, `HoldingsRealtimeIngestionZeroHoldingsSkipTests`, `HoldingsRealtimeIngestionWindowDedupTests` — assertion changed from `result.Should().Be(N)` to `result.FilingsImported.Should().Be(N)`.
- `Holdings13FRealtimeWorkerDoWorkTests` — registered `RealtimeSweepStateRepository(ctx)` in the stubbed `IServiceProvider` alongside `ProcessedDataSetRepository`, fixing `InvalidOperationException: No service for type 'RealtimeSweepStateRepository' has been registered`.

## Test plan

- [x] All 4 previously-red tests pass locally
- [x] Full Holdings folder regression — 130/130 pass
- [x] csharpier check + codespell pass via pre-commit