### PR TITLE
test(web): derive VersionCheck CurrentVersion expectation from live assembly

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/VersionCheckServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/VersionCheckServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Reflection;
 using System.Text;
 using Equibles.Web.Models;
 using Equibles.Web.Services;
@@ -119,7 +120,10 @@ public class VersionCheckServiceTests
 
         Assert.True(result.UpdateAvailable);
         Assert.Equal("99.0.0", result.LatestVersion);
-        Assert.Equal("1.1.1", result.CurrentVersion);
+        // Read the live assembly version the same way the production code does,
+        // so this stays correct across version bumps. Hardcoded "1.1.1" broke
+        // when the web project rolled to 1.2.0.
+        Assert.Equal(ExpectedCurrentVersion(), result.CurrentVersion);
         Assert.Equal(
             "https://github.com/daniel3303/Equibles/releases/tag/v99.0.0",
             result.ReleaseUrl
@@ -160,5 +164,28 @@ public class VersionCheckServiceTests
         var result = sut.Get();
 
         Assert.False(result.UpdateAvailable);
+    }
+
+    // Mirrors VersionCheckService.GetCurrentVersion: prefer the assembly's
+    // InformationalVersion (stripped of a leading "v" + pre-release/build
+    // metadata), fall back to AssemblyName.Version. The SUT and the assertion
+    // must read from the same source so a project Version bump can't desync them.
+    private static string ExpectedCurrentVersion()
+    {
+        var assembly = typeof(VersionCheckService).Assembly;
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+        if (!string.IsNullOrEmpty(informational))
+        {
+            var v = informational.Trim();
+            if (v.StartsWith('v') || v.StartsWith('V'))
+            {
+                v = v[1..];
+            }
+            var cut = v.IndexOfAny(['-', '+']);
+            return cut >= 0 ? v[..cut] : v;
+        }
+        return assembly.GetName().Version?.ToString();
     }
 }


### PR DESCRIPTION
## Summary

`VersionCheckServiceTests.Get_NewerReleaseAvailable_ReportsUpdate` was red on \`main\` — it asserted \`Assert.Equal(\"1.1.1\", result.CurrentVersion)\` but \`Equibles.Web.csproj\` had rolled to \`<Version>1.2.0</Version>\`. Hardcoding the version was always going to bit-rot on the next bump.

Replaced the literal with \`ExpectedCurrentVersion()\` that reads the same source of truth \`VersionCheckService.GetCurrentVersion\` reads — \`AssemblyInformationalVersionAttribute\` first (stripped of leading \`v\` and \`-\`/\`+\` suffix the same way \`NormalizeVersion\` does), falling back to \`AssemblyName.Version\`. Now the assertion tracks the assembly across future bumps.

## Code changes

- \`tests/Equibles.IntegrationTests/Web/VersionCheckServiceTests.cs\` — \`using System.Reflection\`, replaced the hardcoded \`\"1.1.1\"\` with \`ExpectedCurrentVersion()\` helper.

## Test plan

- [x] \`Get_NewerReleaseAvailable_ReportsUpdate\` now passes
- [x] Full \`VersionCheckServiceTests\` regression — all 6 tests pass
- [x] csharpier check + codespell pass via pre-commit