### PR TITLE
test(sec): pin GetDailyIndex Forbidden arm to today so it stops burning the retry budget

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDailyIndexTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDailyIndexTests.cs
@@ -67,6 +67,9 @@ public class SecEdgarClientGetDailyIndexTests
     // daily-index files (e.g. "today" before the index is posted, weekends).
     // GetDailyIndex must treat that as "no index for this day" and return empty
     // — a throw here kills the entire near-real-time 13F sweep every cycle.
+    // The date must be today (or future) for the Forbidden arm: a *past-date*
+    // 403 is treated as SEC throttling and retried up to MaxRetries, so the
+    // stubbed-always-Forbidden handler would hang the retry budget (~18m).
     [Theory]
     [InlineData(HttpStatusCode.Forbidden)]
     [InlineData(HttpStatusCode.NotFound)]
@@ -85,7 +88,7 @@ public class SecEdgarClientGetDailyIndexTests
             config
         );
 
-        var entries = await sut.GetDailyIndex(new DateOnly(2026, 5, 17));
+        var entries = await sut.GetDailyIndex(DateOnly.FromDateTime(DateTime.UtcNow));
 
         entries.Should().BeEmpty();
     }


### PR DESCRIPTION
## Summary

`GetDailyIndex_NoIndexForDate_ReturnsEmptyInsteadOfThrowing(status: Forbidden)` was timing out at 18m30s on every CI run. The test hardcoded `DateOnly(2026, 5, 17)`; once that date passed, `SecEdgarClient.GetDailyIndex` correctly classified it as a past-date 403 and entered the retry path (past-date 403 = SEC throttling, retry up to `MaxRetries`). The always-Forbidden stub then ran the retry budget to exhaustion (~18m) and threw, failing the test.

The test name and intent are about the "no index for this date" branch, which production only takes when `isPastDate == false` (today/future, not yet published). Switched the date to `DateOnly.FromDateTime(DateTime.UtcNow)` so Forbidden hits that branch and returns empty. `NotFound` still works regardless of date. Added a comment so the next reader sees why the date matters.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/SecEdgarClientGetDailyIndexTests.cs` — hardcoded date replaced with `DateOnly.FromDateTime(DateTime.UtcNow)` and a 3-line comment.

## Test plan

- [x] Theory passes for both `Forbidden` and `NotFound` arms in <1s combined (was 18m30s on Forbidden alone)
- [x] csharpier check + codespell pass via pre-commit