### PR TITLE
test(web): pin ChangelogController.Index redirect to canonical GitHub URL on missing CHANGELOG.md

### DIFF
--- a/tests/Equibles.UnitTests/Web/ChangelogControllerIndexFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Web/ChangelogControllerIndexFallbackTests.cs
@@ -1,0 +1,55 @@
+using Equibles.Web.Controllers;
+using Equibles.Web.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.UnitTests.Web;
+
+// The collection serialises this test against ChangelogServiceRenderHtmlTests:
+// both manipulate AppContext.BaseDirectory/CHANGELOG.md and would race under
+// xUnit's default per-class parallelism. The CollectionDefinition lives in
+// ChangelogFileCollection.cs in this folder.
+[Collection(ChangelogFileCollection.Name)]
+public class ChangelogControllerIndexFallbackTests
+{
+    // Index's documented contract is a graceful fallback when CHANGELOG.md was
+    // not shipped with the build — redirect to the canonical GitHub copy so
+    // users never hit a broken page. A typo in the URL, a future refactor that
+    // returns 404 instead of redirecting, or a repo rename without test update
+    // would silently degrade that fallback. The redirect URL is hard-coded in
+    // the controller, so the contract is "this exact URL", not a pattern.
+    [Fact]
+    public void Index_ChangelogFileMissing_RedirectsToCanonicalGitHubChangelogUrl()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "CHANGELOG.md");
+        var hadExisting = File.Exists(path);
+        var backup = hadExisting ? File.ReadAllText(path) : null;
+
+        try
+        {
+            if (hadExisting)
+            {
+                File.Delete(path);
+            }
+
+            var controller = new ChangelogController(
+                NullLogger<ChangelogController>.Instance,
+                new ChangelogService()
+            );
+
+            var result = controller.Index();
+
+            var redirect = result.Should().BeOfType<RedirectResult>().Subject;
+            redirect
+                .Url.Should()
+                .Be("https://github.com/daniel3303/Equibles/blob/main/CHANGELOG.md");
+        }
+        finally
+        {
+            if (backup != null)
+            {
+                File.WriteAllText(path, backup);
+            }
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Web/ChangelogFileCollection.cs
+++ b/tests/Equibles.UnitTests/Web/ChangelogFileCollection.cs
@@ -1,0 +1,11 @@
+namespace Equibles.UnitTests.Web;
+
+// Serialises any test that mutates AppContext.BaseDirectory/CHANGELOG.md so
+// the two coexisting backup+restore patterns (write-and-restore in the
+// service test, delete-and-restore in the controller fallback test) don't
+// race under xUnit's default per-class parallelism.
+[CollectionDefinition(Name)]
+public class ChangelogFileCollection
+{
+    public const string Name = "ChangelogFile";
+}

--- a/tests/Equibles.UnitTests/Web/ChangelogServiceRenderHtmlTests.cs
+++ b/tests/Equibles.UnitTests/Web/ChangelogServiceRenderHtmlTests.cs
@@ -13,6 +13,7 @@ namespace Equibles.UnitTests.Web;
 /// the no-raw-HTML contract: a CHANGELOG containing a script tag must come back
 /// escaped, never as a live element.
 /// </summary>
+[Collection(ChangelogFileCollection.Name)]
 public class ChangelogServiceRenderHtmlTests
 {
     [Fact]


### PR DESCRIPTION
## Summary

- Pin the documented fallback contract of `ChangelogController.Index`: when the bundled `CHANGELOG.md` is missing, the action must redirect to the canonical GitHub copy at `https://github.com/daniel3303/Equibles/blob/main/CHANGELOG.md`. The redirect URL is hard-coded in the controller; a typo, repo rename, or a refactor that returns 404 would silently degrade the fallback with no test catching it.
- The fixture deletes `CHANGELOG.md` from `AppContext.BaseDirectory` for the duration of one assertion, then restores the original contents — same backup-and-restore shape the existing `ChangelogServiceRenderHtmlTests` uses.
- An xUnit `[CollectionDefinition]` serialises the new controller test against the existing service test, since both manipulate the same file and xUnit's default per-class parallelism would otherwise race them.

## Code changes

- `tests/Equibles.UnitTests/Web/ChangelogControllerIndexFallbackTests.cs` — new unit test. Deletes `CHANGELOG.md`, instantiates `ChangelogController` with a real `ChangelogService`, asserts `RedirectResult.Url` matches the canonical GitHub URL byte-for-byte, restores the file in `finally`.
- `tests/Equibles.UnitTests/Web/ChangelogFileCollection.cs` — new `[CollectionDefinition("ChangelogFile")]` host. Pure coordination glue; no fixture state.
- `tests/Equibles.UnitTests/Web/ChangelogServiceRenderHtmlTests.cs` — tag with `[Collection(ChangelogFileCollection.Name)]` so the existing service test serialises with the new controller test.