### PR TITLE
fix(finra-mcp): thread InvariantCulture through ShortDataTools.FormatSignedChange

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
@@ -237,7 +238,9 @@ public class ShortDataTools
     }
 
     private static string FormatSignedChange(long change) =>
-        change >= 0 ? $"+{change:N0}" : change.ToString("N0");
+        change >= 0
+            ? $"+{change.ToString("N0", CultureInfo.InvariantCulture)}"
+            : change.ToString("N0", CultureInfo.InvariantCulture);
 
     private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
     {

--- a/tests/Equibles.UnitTests/Mcp/ShortDataToolsFormatSignedChangeCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/ShortDataToolsFormatSignedChangeCultureInvarianceTests.cs
@@ -34,9 +34,7 @@ public class ShortDataToolsFormatSignedChangeCultureInvarianceTests
     // static, restore in finally. Expected: "+1,234,567" with
     // ASCII commas. Failure manifests as the comma-vs-dot
     // separator mismatch.
-    [Fact(
-        Skip = "GH-2444 — FormatSignedChange renders N0 thousand separator with host CurrentCulture instead of invariant"
-    )]
+    [Fact]
     public void FormatSignedChange_PositiveValueUnderNonInvariantCulture_RendersWithInvariantCommaThousandSeparator()
     {
         var method = typeof(ShortDataTools).GetMethod(


### PR DESCRIPTION
## Summary

- `ShortDataTools.FormatSignedChange` rendered the `N0` thousand separator with the thread's `CurrentCulture`, so under de-DE it produced `"+1.234.567"` and under fr-FR `"+1 234 567"` — forking MCP output by deploy locale and breaking the repo's culture-invariant formatter convention (cf. `FactMarkdown.Value`).
- Same root cause as #2426 (`BaseScraperWorker.FormatInterval`): an interpolated `:N0` without an explicit `IFormatProvider`.
- Pass `CultureInfo.InvariantCulture` to both `ToString("N0")` sites and un-Skip the existing regression test (which now reproduces `"+1.234.567"` on unfixed code, passes on the fix).

Closes #2444

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — add `System.Globalization` using; rewrite `FormatSignedChange` to thread `CultureInfo.InvariantCulture` through both `ToString("N0")` branches.
- `tests/Equibles.UnitTests/Mcp/ShortDataToolsFormatSignedChangeCultureInvarianceTests.cs` — drop `Skip = "..."` from the existing repro under de-DE.