### PR TITLE
test(finra-mcp): pin negative branch of FormatSignedChange under de-DE

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/ShortDataToolsFormatSignedChangeCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/ShortDataToolsFormatSignedChangeCultureInvarianceTests.cs
@@ -60,4 +60,40 @@ public class ShortDataToolsFormatSignedChangeCultureInvarianceTests
             CultureInfo.CurrentCulture = original;
         }
     }
+
+    // The negative branch of the ternary takes its own ToString path
+    // (`change.ToString("N0", ...)` rather than the `$"+{...}"`
+    // interpolation), so the culture-invariance contract has to be
+    // pinned on its own. Under de-DE without an explicit
+    // IFormatProvider, N0 renders -1,234,567 as "-1.234.567" — same
+    // bug class GH-2444 fixed on the positive branch. Contract:
+    // negative values render culture-invariantly with US-style
+    // comma thousands and a leading minus sign, regardless of
+    // thread CurrentCulture.
+    [Fact]
+    public void FormatSignedChange_NegativeValueUnderNonInvariantCulture_RendersWithInvariantCommaThousandSeparator()
+    {
+        var method = typeof(ShortDataTools).GetMethod(
+            "FormatSignedChange",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            var result = (string)method!.Invoke(null, [-1_234_567L]);
+
+            result
+                .Should()
+                .Be(
+                    "-1,234,567",
+                    "the negative branch of FormatSignedChange must render culture-invariantly for the same reason as the positive branch (GH-2444); a host-locale-dependent thousand separator forks MCP output by deploy locale"
+                );
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- GH-2444 fixed both branches of `ShortDataTools.FormatSignedChange` (the `change >= 0` positive path and the negative-`ToString("N0", ...)` path), but the existing regression test only exercised the positive branch's `$"+{...}"` interpolation.
- A future revert that touches only the negative branch would slip past — the test pins it now.

## Code changes

- `tests/Equibles.UnitTests/Mcp/ShortDataToolsFormatSignedChangeCultureInvarianceTests.cs` — add `FormatSignedChange_NegativeValueUnderNonInvariantCulture_RendersWithInvariantCommaThousandSeparator`. Same de-DE reflection-invoke pattern as the positive-branch sibling; asserts `-1,234,567L` renders as `"-1,234,567"`, catching a regression to `"-1.234.567"` (de-DE dot thousands).