### PR TITLE
feat(holdings): add quarterly snapshot tables for 13F aggregates

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -44,5 +44,21 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<ProcessedDataSet>();
         builder.Entity<ProcessedFiling>();
         builder.Entity<RealtimeSweepState>();
+
+        // AumQuarterlySnapshot uses ReportDate as the primary key. The [Key]
+        // attribute can't be paired with [DatabaseGenerated(None)] without EF
+        // also treating it as identity-by-convention on integral types, but the
+        // intent is identical here — DateOnly key, caller-supplied. Configured
+        // via Fluent API to keep the entity declaration attribute-only.
+        builder.Entity<AumQuarterlySnapshot>().HasKey(s => s.ReportDate);
+
+        // SectorQuarterlySnapshot uses a composite (ReportDate, SectorId) key,
+        // which the [Key] attribute cannot express. Reads on /holdings/trends
+        // scan the whole table ordered by ReportDate, then SectorName — the
+        // composite key already covers the ordering by date, so no further
+        // index is needed.
+        builder
+            .Entity<SectorQuarterlySnapshot>()
+            .HasKey(s => new { s.ReportDate, s.SectorId });
     }
 }

--- a/src/Equibles.Holdings.Data/Models/AumQuarterlySnapshot.cs
+++ b/src/Equibles.Holdings.Data/Models/AumQuarterlySnapshot.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Equibles.Holdings.Data.Models;
+
+// Per-quarter materialisation of the AUM aggregates that power /holdings/stats
+// and /holdings/trends. The live multi-distinct GROUP BY over
+// InstitutionalHoldings (~5-15M rows/quarter * 100+ quarters) cannot finish
+// inside the 30s Npgsql command timeout, so the worker rebuilds one row per
+// quarter on each 13F import and the request path scans this small table in
+// quarter order.
+public class AumQuarterlySnapshot
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public DateOnly ReportDate { get; set; }
+
+    public long TotalValue { get; set; }
+
+    public int FilerCount { get; set; }
+
+    public int PositionCount { get; set; }
+
+    public int StockCount { get; set; }
+
+    public int FilingCount { get; set; }
+
+    public DateTime ComputedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Holdings.Data/Models/SectorQuarterlySnapshot.cs
+++ b/src/Equibles.Holdings.Data/Models/SectorQuarterlySnapshot.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Holdings.Data.Models;
+
+// Per-(quarter, sector) materialisation of the sector-allocation aggregates
+// that power /holdings/trends. Same rebuild path as AumQuarterlySnapshot; the
+// composite key keeps the table compact (one row per sector per quarter).
+public class SectorQuarterlySnapshot
+{
+    public DateOnly ReportDate { get; set; }
+
+    public Guid SectorId { get; set; }
+
+    [MaxLength(128)]
+    public string SectorName { get; set; }
+
+    public long TotalValue { get; set; }
+
+    public DateTime ComputedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Holdings.Repositories/AumQuarterlySnapshotRepository.cs
+++ b/src/Equibles.Holdings.Repositories/AumQuarterlySnapshotRepository.cs
@@ -1,0 +1,10 @@
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.Holdings.Repositories;
+
+public class AumQuarterlySnapshotRepository : BaseRepository<AumQuarterlySnapshot>
+{
+    public AumQuarterlySnapshotRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+}

--- a/src/Equibles.Holdings.Repositories/SectorQuarterlySnapshotRepository.cs
+++ b/src/Equibles.Holdings.Repositories/SectorQuarterlySnapshotRepository.cs
@@ -1,0 +1,10 @@
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.Holdings.Repositories;
+
+public class SectorQuarterlySnapshotRepository : BaseRepository<SectorQuarterlySnapshot>
+{
+    public SectorQuarterlySnapshotRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+}

--- a/src/Equibles.Migrations/Migrations/20260527105915_AddQuarterlySnapshots.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260527105915_AddQuarterlySnapshots.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260527105915_AddQuarterlySnapshots")]
+    partial class AddQuarterlySnapshots
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260527105915_AddQuarterlySnapshots.cs
+++ b/src/Equibles.Migrations/Migrations/20260527105915_AddQuarterlySnapshots.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddQuarterlySnapshots : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AumQuarterlySnapshot",
+                columns: table => new
+                {
+                    ReportDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    TotalValue = table.Column<long>(type: "bigint", nullable: false),
+                    FilerCount = table.Column<int>(type: "integer", nullable: false),
+                    PositionCount = table.Column<int>(type: "integer", nullable: false),
+                    StockCount = table.Column<int>(type: "integer", nullable: false),
+                    FilingCount = table.Column<int>(type: "integer", nullable: false),
+                    ComputedAt = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AumQuarterlySnapshot", x => x.ReportDate);
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "SectorQuarterlySnapshot",
+                columns: table => new
+                {
+                    ReportDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    SectorId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SectorName = table.Column<string>(
+                        type: "character varying(128)",
+                        maxLength: 128,
+                        nullable: true
+                    ),
+                    TotalValue = table.Column<long>(type: "bigint", nullable: false),
+                    ComputedAt = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey(
+                        "PK_SectorQuarterlySnapshot",
+                        x => new { x.ReportDate, x.SectorId }
+                    );
+                }
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "AumQuarterlySnapshot");
+
+            migrationBuilder.DropTable(name: "SectorQuarterlySnapshot");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/AumQuarterlySnapshotRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/AumQuarterlySnapshotRepositoryTests.cs
@@ -1,0 +1,89 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Schema contract for <see cref="AumQuarterlySnapshot"/>: ReportDate is the
+/// primary key, all aggregate columns persist, and an upsert by ReportDate
+/// replaces the existing row.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class AumQuarterlySnapshotRepositoryTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<Equibles.Data.EquiblesFinancialDbContext> _contexts = [];
+
+    public AumQuarterlySnapshotRepositoryTests(ParadeDbFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Equibles.Data.EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private static readonly DateOnly Q4 = new(2024, 12, 31);
+    private static readonly DateOnly Q3 = new(2024, 9, 30);
+
+    [Fact]
+    public async Task SnapshotRoundTrip_AllAggregateColumnsPersist()
+    {
+        await using var write = FreshContext();
+        var sut = new AumQuarterlySnapshotRepository(write);
+        sut.Add(
+            new AumQuarterlySnapshot
+            {
+                ReportDate = Q4,
+                TotalValue = 1_500_000_000L,
+                FilerCount = 1234,
+                PositionCount = 5_678_910,
+                StockCount = 7_890,
+                FilingCount = 1500,
+            }
+        );
+        await sut.SaveChanges();
+
+        await using var read = FreshContext();
+        var stored = await new AumQuarterlySnapshotRepository(read)
+            .GetAll()
+            .SingleAsync(s => s.ReportDate == Q4);
+
+        stored.TotalValue.Should().Be(1_500_000_000L);
+        stored.FilerCount.Should().Be(1234);
+        stored.PositionCount.Should().Be(5_678_910);
+        stored.StockCount.Should().Be(7_890);
+        stored.FilingCount.Should().Be(1500);
+    }
+
+    [Fact]
+    public async Task PrimaryKey_IsReportDate_OnePerQuarter()
+    {
+        await using var ctx1 = FreshContext();
+        var sut1 = new AumQuarterlySnapshotRepository(ctx1);
+        sut1.Add(new AumQuarterlySnapshot { ReportDate = Q4, TotalValue = 100L });
+        sut1.Add(new AumQuarterlySnapshot { ReportDate = Q3, TotalValue = 50L });
+        await sut1.SaveChanges();
+
+        await using var read = FreshContext();
+        var all = await new AumQuarterlySnapshotRepository(read)
+            .GetAll()
+            .OrderByDescending(s => s.ReportDate)
+            .ToListAsync();
+
+        all.Should().HaveCount(2);
+        all[0].ReportDate.Should().Be(Q4);
+        all[1].ReportDate.Should().Be(Q3);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/SectorQuarterlySnapshotRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/SectorQuarterlySnapshotRepositoryTests.cs
@@ -1,0 +1,79 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Schema contract for <see cref="SectorQuarterlySnapshot"/>: composite key
+/// (ReportDate, SectorId) allows one row per sector per quarter, all columns
+/// persist, and rows are independently addressable by the composite key.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class SectorQuarterlySnapshotRepositoryTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<Equibles.Data.EquiblesFinancialDbContext> _contexts = [];
+
+    public SectorQuarterlySnapshotRepositoryTests(ParadeDbFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Equibles.Data.EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private static readonly DateOnly Q4 = new(2024, 12, 31);
+
+    [Fact]
+    public async Task CompositeKey_AllowsMultipleSectorsPerQuarter()
+    {
+        var tech = Guid.NewGuid();
+        var energy = Guid.NewGuid();
+
+        await using var write = FreshContext();
+        var sut = new SectorQuarterlySnapshotRepository(write);
+        sut.Add(
+            new SectorQuarterlySnapshot
+            {
+                ReportDate = Q4,
+                SectorId = tech,
+                SectorName = "Technology",
+                TotalValue = 900_000_000L,
+            }
+        );
+        sut.Add(
+            new SectorQuarterlySnapshot
+            {
+                ReportDate = Q4,
+                SectorId = energy,
+                SectorName = "Energy",
+                TotalValue = 200_000_000L,
+            }
+        );
+        await sut.SaveChanges();
+
+        await using var read = FreshContext();
+        var rows = await new SectorQuarterlySnapshotRepository(read)
+            .GetAll()
+            .Where(s => s.ReportDate == Q4)
+            .OrderByDescending(s => s.TotalValue)
+            .ToListAsync();
+
+        rows.Should().HaveCount(2);
+        rows[0].SectorName.Should().Be("Technology");
+        rows[0].TotalValue.Should().Be(900_000_000L);
+        rows[1].SectorName.Should().Be("Energy");
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 1 of 5 for #2458 — adds the storage layer that the next slices will populate and read from. No production code path touches these tables yet.
- New entities, repositories, and migration only; no changes to existing query paths.

## Code changes

- `src/Equibles.Holdings.Data/Models/AumQuarterlySnapshot.cs` — new entity, `ReportDate` primary key, columns mirror `AumSnapshot`'s shape (`TotalValue`, `FilerCount`, `PositionCount`, `StockCount`, `FilingCount`) plus `ComputedAt` for safety-net auditing.
- `src/Equibles.Holdings.Data/Models/SectorQuarterlySnapshot.cs` — new entity, composite key `(ReportDate, SectorId)`, mirrors `SectorAllocationSnapshot` (`SectorName`, `TotalValue`) plus `ComputedAt`.
- `src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs` — registers both entities and configures the keys (composite key isn't expressible via `[Key]`; the single `DateOnly` key uses Fluent API for symmetry).
- `src/Equibles.Holdings.Repositories/{AumQuarterlySnapshotRepository,SectorQuarterlySnapshotRepository}.cs` — thin `BaseRepository<T>` repos, picked up by `AddAllRepositories()`.
- `src/Equibles.Migrations/Migrations/20260527105915_AddQuarterlySnapshots.cs` (+ designer / snapshot updates) — generated migration creating both tables.
- `tests/Equibles.IntegrationTests/Holdings/{AumQuarterlySnapshotRepositoryTests,SectorQuarterlySnapshotRepositoryTests}.cs` — schema-contract tests against ParadeDB: every column persists, the AUM primary key keeps one row per quarter, and the sector composite key allows multiple sectors per quarter.

Refs #2458