### PR TITLE
fix(worker): thread InvariantCulture through BaseScraperWorker.FormatInterval

### DIFF
--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Messaging.Contracts.Activity;
@@ -177,10 +178,10 @@ public abstract class BaseScraperWorker : BackgroundService
     private static string FormatInterval(TimeSpan interval)
     {
         if (interval.TotalHours >= 1)
-            return $"{interval.TotalHours:0.#}h";
+            return $"{interval.TotalHours.ToString("0.#", CultureInfo.InvariantCulture)}h";
         if (interval.TotalMinutes >= 1)
-            return $"{interval.TotalMinutes:0.#}m";
-        return $"{interval.TotalSeconds:0}s";
+            return $"{interval.TotalMinutes.ToString("0.#", CultureInfo.InvariantCulture)}m";
+        return $"{interval.TotalSeconds.ToString("0", CultureInfo.InvariantCulture)}s";
     }
 
     /// <summary>

--- a/tests/Equibles.UnitTests/Worker/BaseScraperWorkerFormatIntervalCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Worker/BaseScraperWorkerFormatIntervalCultureInvarianceTests.cs
@@ -40,9 +40,7 @@ public class BaseScraperWorkerFormatIntervalCultureInvarianceTests
     // culture used across the repo's other culture pins (FormBindingFixture
     // names this explicitly). The result MUST be "1.5h" with a literal
     // dot - never "1,5h".
-    [Fact(
-        Skip = "GH-2426 — FormatInterval renders fractional intervals with locale-dependent decimal separator"
-    )]
+    [Fact]
     public void FormatInterval_FractionalHoursUnderNonInvariantCulture_RendersWithInvariantDecimalPoint()
     {
         var method = typeof(BaseScraperWorker).GetMethod(


### PR DESCRIPTION
## Summary

- `BaseScraperWorker.FormatInterval` rendered fractional intervals with the thread's `CurrentCulture`, so under de-DE a 1.5-hour sleep logged as `"1,5h"` instead of `"1.5h"` — forking operator log output by host locale and breaking the repo's culture-invariant log-formatter convention (cf. `FactMarkdown.Value`).
- Same bug class as #2444 (`ShortDataTools.FormatSignedChange`): an interpolated numeric format without an explicit `IFormatProvider`.
- Pass `CultureInfo.InvariantCulture` to each `ToString` site and un-Skip the existing regression test (which reproduces `"1,5h"` on unfixed code, passes on the fix).

Closes #2426

## Code changes

- `src/Equibles.Worker/BaseScraperWorker.cs` — add `System.Globalization` using; rewrite the three `:0.#` / `:0` interpolations in `FormatInterval` to thread `CultureInfo.InvariantCulture`.
- `tests/Equibles.UnitTests/Worker/BaseScraperWorkerFormatIntervalCultureInvarianceTests.cs` — drop `Skip = "..."` from the existing repro under de-DE.