### PR TITLE
chore: add glama.json for Glama MCP directory metadata

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["daniel3303"]
+}


### PR DESCRIPTION
## Summary

Add `glama.json` so the Glama MCP directory can pick up server metadata and unblock the profile-completion item on the Equibles score page.

## Code changes

- `glama.json` — minimal Glama server manifest declaring `daniel3303` as maintainer, per the `https://glama.ai/mcp/schemas/server.json` schema.