### PR TITLE
feat(holdings): add HoldingsAggregateRefreshService for per-quarter snapshots

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -1,0 +1,245 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Core.AutoWiring;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Recomputes the per-quarter AUM and sector-allocation snapshots that power
+/// /holdings/stats and /holdings/trends.
+///
+/// The live multi-distinct GROUP BY on InstitutionalHoldings cannot finish
+/// inside the 30s Npgsql command timeout at production scale (~5-15M rows per
+/// quarter * ~100 quarters). This service filters by a single ReportDate
+/// first, so the existing <c>[Index(ReportDate)]</c> btree narrows the scan
+/// to one quarter's slice and the multi-distinct only ever sees that slice.
+///
+/// Two entry points:
+/// <list type="bullet">
+///   <item><c>RebuildQuarterAsync</c> — single quarter, bounded work; called
+///     by the event-driven path on each 13F import.</item>
+///   <item><c>RebuildAllAsync</c> — enumerates distinct ReportDate values and
+///     rebuilds each in its own DbContext scope; called by the daily
+///     safety-net job and the one-time first-boot backfill.</item>
+/// </list>
+/// </summary>
+[Service]
+public class HoldingsAggregateRefreshService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<HoldingsAggregateRefreshService> _logger;
+
+    public HoldingsAggregateRefreshService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<HoldingsAggregateRefreshService> logger
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task RebuildQuarterAsync(DateOnly reportDate, CancellationToken cancellationToken)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        await RebuildQuarterInScope(scope.ServiceProvider, reportDate, cancellationToken);
+    }
+
+    public async Task RebuildAllAsync(CancellationToken cancellationToken)
+    {
+        List<DateOnly> reportDates;
+        await using (var scope = _scopeFactory.CreateAsyncScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+            reportDates = await dbContext
+                .Set<InstitutionalHolding>()
+                .Select(h => h.ReportDate)
+                .Distinct()
+                .OrderBy(d => d)
+                .ToListAsync(cancellationToken);
+        }
+
+        _logger.LogInformation(
+            "Rebuilding holdings aggregate snapshots for {Count} quarter(s)",
+            reportDates.Count
+        );
+
+        foreach (var reportDate in reportDates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            await RebuildQuarterInScope(scope.ServiceProvider, reportDate, cancellationToken);
+        }
+    }
+
+    private async Task RebuildQuarterInScope(
+        IServiceProvider services,
+        DateOnly reportDate,
+        CancellationToken cancellationToken
+    )
+    {
+        var dbContext = services.GetRequiredService<EquiblesFinancialDbContext>();
+        var aumRepo = services.GetRequiredService<AumQuarterlySnapshotRepository>();
+        var sectorRepo = services.GetRequiredService<SectorQuarterlySnapshotRepository>();
+
+        await UpsertAumSnapshot(dbContext, aumRepo, reportDate, cancellationToken);
+        await UpsertSectorSnapshots(dbContext, sectorRepo, reportDate, cancellationToken);
+    }
+
+    private async Task UpsertAumSnapshot(
+        EquiblesFinancialDbContext dbContext,
+        AumQuarterlySnapshotRepository aumRepo,
+        DateOnly reportDate,
+        CancellationToken cancellationToken
+    )
+    {
+        // Filtering by ReportDate first narrows the scan via the existing
+        // [Index(ReportDate)] btree, so the multi-distinct aggregate only
+        // touches one quarter's slice. GroupBy on the same column then folds
+        // to a single output row.
+        var aggregate = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h => h.ReportDate == reportDate)
+            .GroupBy(h => h.ReportDate)
+            .Select(g => new
+            {
+                TotalValue = g.Sum(h => h.Value),
+                FilerCount = g.Select(h => h.InstitutionalHolderId).Distinct().Count(),
+                PositionCount = g.Count(),
+                StockCount = g.Select(h => h.CommonStockId).Distinct().Count(),
+                FilingCount = g.Select(h => h.AccessionNumber).Distinct().Count(),
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        var existing = await aumRepo
+            .GetAll()
+            .FirstOrDefaultAsync(s => s.ReportDate == reportDate, cancellationToken);
+
+        if (aggregate is null)
+        {
+            // Quarter exists only in the snapshot table now (e.g. all holdings
+            // for it were deleted). Drop the stale row so /stats and /trends
+            // don't keep reporting phantom AUM for a now-empty quarter.
+            if (existing is not null)
+            {
+                aumRepo.Delete(existing);
+                await aumRepo.SaveChanges();
+            }
+            return;
+        }
+
+        if (existing is null)
+        {
+            aumRepo.Add(
+                new AumQuarterlySnapshot
+                {
+                    ReportDate = reportDate,
+                    TotalValue = aggregate.TotalValue,
+                    FilerCount = aggregate.FilerCount,
+                    PositionCount = aggregate.PositionCount,
+                    StockCount = aggregate.StockCount,
+                    FilingCount = aggregate.FilingCount,
+                    ComputedAt = DateTime.UtcNow,
+                }
+            );
+        }
+        else
+        {
+            existing.TotalValue = aggregate.TotalValue;
+            existing.FilerCount = aggregate.FilerCount;
+            existing.PositionCount = aggregate.PositionCount;
+            existing.StockCount = aggregate.StockCount;
+            existing.FilingCount = aggregate.FilingCount;
+            existing.ComputedAt = DateTime.UtcNow;
+        }
+
+        await aumRepo.SaveChanges();
+    }
+
+    private async Task UpsertSectorSnapshots(
+        EquiblesFinancialDbContext dbContext,
+        SectorQuarterlySnapshotRepository sectorRepo,
+        DateOnly reportDate,
+        CancellationToken cancellationToken
+    )
+    {
+        // Same quarter-bounded shape: filter holdings first, then join the
+        // stock/industry/sector taxonomy. The aggregate produces one row per
+        // (ReportDate, SectorId).
+        var rows = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h => h.ReportDate == reportDate)
+            .Join(
+                dbContext.Set<CommonStock>(),
+                h => h.CommonStockId,
+                s => s.Id,
+                (h, s) => new { h.Value, s.IndustryId }
+            )
+            .Join(
+                dbContext.Set<Industry>(),
+                x => x.IndustryId,
+                i => i.Id,
+                (x, i) => new { x.Value, i.SectorId }
+            )
+            .Where(x => x.SectorId != null)
+            .GroupBy(x => x.SectorId!.Value)
+            .Select(g => new { SectorId = g.Key, TotalValue = g.Sum(x => x.Value) })
+            .Join(
+                dbContext.Set<Sector>(),
+                a => a.SectorId,
+                s => s.Id,
+                (a, s) =>
+                    new
+                    {
+                        a.SectorId,
+                        SectorName = s.Name,
+                        a.TotalValue,
+                    }
+            )
+            .ToListAsync(cancellationToken);
+
+        var existing = await sectorRepo
+            .GetAll()
+            .Where(s => s.ReportDate == reportDate)
+            .ToListAsync(cancellationToken);
+
+        var existingBySector = existing.ToDictionary(s => s.SectorId);
+        var seen = new HashSet<Guid>();
+
+        foreach (var row in rows)
+        {
+            seen.Add(row.SectorId);
+            if (existingBySector.TryGetValue(row.SectorId, out var current))
+            {
+                current.SectorName = row.SectorName;
+                current.TotalValue = row.TotalValue;
+                current.ComputedAt = DateTime.UtcNow;
+            }
+            else
+            {
+                sectorRepo.Add(
+                    new SectorQuarterlySnapshot
+                    {
+                        ReportDate = reportDate,
+                        SectorId = row.SectorId,
+                        SectorName = row.SectorName,
+                        TotalValue = row.TotalValue,
+                        ComputedAt = DateTime.UtcNow,
+                    }
+                );
+            }
+        }
+
+        // Sectors that no longer have positions for this quarter — drop them
+        // so /trends doesn't render a chart line for an empty allocation.
+        foreach (var stale in existing.Where(s => !seen.Contains(s.SectorId)))
+        {
+            sectorRepo.Delete(stale);
+        }
+
+        await sectorRepo.SaveChanges();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceTests.cs
@@ -1,0 +1,298 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Contract for <see cref="HoldingsAggregateRefreshService"/>: after
+/// <c>RebuildQuarterAsync</c>, the per-quarter AUM and sector snapshot rows
+/// match what the live multi-distinct aggregate over the same holdings would
+/// have produced — distinct filer/stock/filing counts, sector value totals,
+/// and stale-sector clean-up.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsAggregateRefreshServiceTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<Equibles.Data.EquiblesFinancialDbContext> _contexts = [];
+
+    public HoldingsAggregateRefreshServiceTests(ParadeDbFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Equibles.Data.EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private static readonly DateOnly Q4 = new(2024, 12, 31);
+    private static readonly DateOnly Q3 = new(2024, 9, 30);
+
+    private HoldingsAggregateRefreshService BuildService()
+    {
+        // The service creates a fresh scope per call, so the substitute hands
+        // back a scope whose ServiceProvider resolves a fresh DbContext + the
+        // two snapshot repositories — exactly what the production scope would
+        // do under MassTransit / the worker host.
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(_ => CreateScopeFromFixture());
+        return new HoldingsAggregateRefreshService(
+            scopeFactory,
+            NullLogger<HoldingsAggregateRefreshService>.Instance
+        );
+    }
+
+    private IServiceScope CreateScopeFromFixture()
+    {
+        var ctx = FreshContext();
+        var scope = Substitute.For<IServiceScope>();
+        var provider = Substitute.For<IServiceProvider>();
+        provider.GetService(typeof(Equibles.Data.EquiblesFinancialDbContext)).Returns(ctx);
+        provider
+            .GetService(typeof(AumQuarterlySnapshotRepository))
+            .Returns(_ => new AumQuarterlySnapshotRepository(ctx));
+        provider
+            .GetService(typeof(SectorQuarterlySnapshotRepository))
+            .Returns(_ => new SectorQuarterlySnapshotRepository(ctx));
+        scope.ServiceProvider.Returns(provider);
+        return scope;
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_OneFilerTwoPositionsOneFiling_FilerAndFilingCountAreOne()
+    {
+        // Same edge case the legacy HoldingsStatsSeededTests pins: a single
+        // holder filed once and holds two stocks. The distinct counts must
+        // collapse to one filer / one filing, not two.
+        await using var seed = FreshContext();
+        var tech = await SeedSector(seed, "Technology");
+        var industry = await SeedIndustry(seed, "Software", tech.Id);
+        var aapl = await SeedStock(seed, "AAPL", industry.Id);
+        var msft = await SeedStock(seed, "MSFT", industry.Id);
+        var holder = await SeedHolder(seed, "H001");
+        seed.AddRange(
+            MakeHolding(aapl, holder, Q4, 100_000, "acc-q4"),
+            MakeHolding(msft, holder, Q4, 200_000, "acc-q4")
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(Q4, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var aum = await read.Set<AumQuarterlySnapshot>().SingleAsync(s => s.ReportDate == Q4);
+        aum.TotalValue.Should().Be(300_000);
+        aum.FilerCount.Should().Be(1, "one holder with two positions is still one filer");
+        aum.PositionCount.Should().Be(2);
+        aum.StockCount.Should().Be(2);
+        aum.FilingCount.Should()
+            .Be(1, "two positions filed under one accession is still one filing");
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_ProducesOneSectorRowPerSector_WithSummedValue()
+    {
+        await using var seed = FreshContext();
+        var tech = await SeedSector(seed, "Technology");
+        var energy = await SeedSector(seed, "Energy");
+        var techIndustry = await SeedIndustry(seed, "Software", tech.Id);
+        var energyIndustry = await SeedIndustry(seed, "Oil & Gas", energy.Id);
+        var aapl = await SeedStock(seed, "AAPL", techIndustry.Id);
+        var msft = await SeedStock(seed, "MSFT", techIndustry.Id);
+        var xom = await SeedStock(seed, "XOM", energyIndustry.Id);
+        var holder = await SeedHolder(seed, "H001");
+        seed.AddRange(
+            MakeHolding(aapl, holder, Q4, 500_000, "acc-q4"),
+            MakeHolding(msft, holder, Q4, 400_000, "acc-q4"),
+            MakeHolding(xom, holder, Q4, 200_000, "acc-q4")
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(Q4, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var rows = await read.Set<SectorQuarterlySnapshot>()
+            .Where(s => s.ReportDate == Q4)
+            .OrderByDescending(s => s.TotalValue)
+            .ToListAsync();
+
+        rows.Should().HaveCount(2);
+        rows[0].SectorName.Should().Be("Technology");
+        rows[0].TotalValue.Should().Be(900_000);
+        rows[1].SectorName.Should().Be("Energy");
+        rows[1].TotalValue.Should().Be(200_000);
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_StaleSectorRow_GetsRemoved()
+    {
+        Guid xomId;
+
+        // First pass: tech and energy both have positions.
+        await using (var seed = FreshContext())
+        {
+            var tech = await SeedSector(seed, "Technology");
+            var energy = await SeedSector(seed, "Energy");
+            var techIndustry = await SeedIndustry(seed, "Software", tech.Id);
+            var energyIndustry = await SeedIndustry(seed, "Oil & Gas", energy.Id);
+            var aapl = await SeedStock(seed, "AAPL", techIndustry.Id);
+            var xom = await SeedStock(seed, "XOM", energyIndustry.Id);
+            xomId = xom.Id;
+            var holder = await SeedHolder(seed, "H001");
+            seed.AddRange(
+                MakeHolding(aapl, holder, Q4, 500_000, "acc-q4"),
+                MakeHolding(xom, holder, Q4, 200_000, "acc-q4")
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        await BuildService().RebuildQuarterAsync(Q4, CancellationToken.None);
+
+        // Remove the energy position, leaving only tech for Q4.
+        await using (var ctx = FreshContext())
+        {
+            var energyHolding = await ctx.Set<InstitutionalHolding>()
+                .SingleAsync(h => h.CommonStockId == xomId);
+            ctx.Remove(energyHolding);
+            await ctx.SaveChangesAsync();
+        }
+
+        await BuildService().RebuildQuarterAsync(Q4, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var rows = await read.Set<SectorQuarterlySnapshot>()
+            .Where(s => s.ReportDate == Q4)
+            .ToListAsync();
+
+        rows.Should().ContainSingle(r => r.SectorName == "Technology");
+        rows.Should()
+            .NotContain(
+                r => r.SectorName == "Energy",
+                "the now-empty sector must be removed on rebuild"
+            );
+    }
+
+    [Fact]
+    public async Task RebuildAllAsync_RebuildsEveryDistinctReportDate()
+    {
+        await using var seed = FreshContext();
+        var tech = await SeedSector(seed, "Technology");
+        var industry = await SeedIndustry(seed, "Software", tech.Id);
+        var aapl = await SeedStock(seed, "AAPL", industry.Id);
+        var holder = await SeedHolder(seed, "H001");
+        seed.AddRange(
+            MakeHolding(aapl, holder, Q3, 100_000, "acc-q3"),
+            MakeHolding(aapl, holder, Q4, 200_000, "acc-q4")
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildAllAsync(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var aum = await read.Set<AumQuarterlySnapshot>()
+            .OrderByDescending(s => s.ReportDate)
+            .ToListAsync();
+
+        aum.Should().HaveCount(2);
+        aum[0].ReportDate.Should().Be(Q4);
+        aum[0].TotalValue.Should().Be(200_000);
+        aum[1].ReportDate.Should().Be(Q3);
+        aum[1].TotalValue.Should().Be(100_000);
+    }
+
+    private static async Task<Sector> SeedSector(
+        Equibles.Data.EquiblesFinancialDbContext ctx,
+        string name
+    )
+    {
+        var sector = new Sector { Name = name };
+        ctx.Add(sector);
+        await ctx.SaveChangesAsync();
+        return sector;
+    }
+
+    private static async Task<Industry> SeedIndustry(
+        Equibles.Data.EquiblesFinancialDbContext ctx,
+        string name,
+        Guid sectorId
+    )
+    {
+        var industry = new Industry { Name = name, SectorId = sectorId };
+        ctx.Add(industry);
+        await ctx.SaveChangesAsync();
+        return industry;
+    }
+
+    private static async Task<CommonStock> SeedStock(
+        Equibles.Data.EquiblesFinancialDbContext ctx,
+        string ticker,
+        Guid industryId
+    )
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Corp.",
+            Cik = $"C{Guid.NewGuid().GetHashCode() & int.MaxValue:D8}",
+            IndustryId = industryId,
+        };
+        ctx.Add(stock);
+        await ctx.SaveChangesAsync();
+        return stock;
+    }
+
+    private static async Task<InstitutionalHolder> SeedHolder(
+        Equibles.Data.EquiblesFinancialDbContext ctx,
+        string cik
+    )
+    {
+        var holder = new InstitutionalHolder { Cik = cik, Name = $"Holder {cik}" };
+        ctx.Add(holder);
+        await ctx.SaveChangesAsync();
+        return holder;
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long value,
+        string accession
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = value / 100,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = accession,
+            // CUSIP column is varchar(9). Derive a deterministic 9-char value
+            // from the stock+holder pair so the holding-row unique key
+            // (CommonStock, Holder, ReportDate, ShareType, OptionType,
+            // FilingType) stays disambiguated across the test seeds.
+            Cusip =
+                $"{stock.Ticker[..Math.Min(4, stock.Ticker.Length)]}{stock.Id.GetHashCode():X8}"[
+                    ..9
+                ],
+        };
+}


### PR DESCRIPTION
## Summary

- Slice 2 of 5 for #2458 — implements the per-quarter aggregate refresh path that slices 3 and 4 will invoke. No call sites yet; existing `/holdings/stats` and `/holdings/trends` still run the live multi-distinct query.
- Filters `InstitutionalHoldings` on `ReportDate` first so the existing index narrows the scan and the multi-distinct aggregate only ever sees one quarter's slice — bounded work, not table-scale.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs` — `[Service]`, two entry points:
  - `RebuildQuarterAsync(DateOnly, CancellationToken)` — single-quarter rebuild (event-driven path).
  - `RebuildAllAsync(CancellationToken)` — enumerates distinct `ReportDate` values, rebuilds each in its own DbContext scope to keep change-tracking bounded (daily safety-net + first-boot backfill).
  - Quarter-scoped AUM aggregate: filter on `ReportDate`, then `GroupBy(ReportDate)` and project the five `AumSnapshot`-shaped aggregates.
  - Quarter-scoped sector aggregate: same filter, joined to `CommonStock` → `Industry` → `Sector`, grouped by `SectorId`.
  - Upserts to `AumQuarterlySnapshot` / `SectorQuarterlySnapshot`; removes a stale sector row when its allocation drops to zero on rebuild; removes the AUM row entirely when the quarter has no holdings left.
- `tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceTests.cs` — four ParadeDB-backed tests:
  - One filer + two positions under one accession produces FilerCount=1, FilingCount=1 (the distinct-collapse edge case the legacy `HoldingsStatsSeededTests` already pins).
  - Sector totals sum per sector and exclude unclassified stocks.
  - Stale sector row is removed when its positions disappear on rebuild.
  - `RebuildAllAsync` rebuilds every distinct `ReportDate` in the table.

Refs #2458