### PR TITLE
test(holdings): pin Holdings13FRealtimeWorker.WorkerName literal

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerWorkerNameTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerWorkerNameTests.cs
@@ -1,0 +1,74 @@
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Holdings.HostedService;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Holdings13FRealtimeWorkerWorkerNameTests
+{
+    // Tenth WorkerName pin in the natural-extension family (CBOE, Holdings,
+    // SEC filing, FTD, Document processor, FRED, Yahoo price, FINRA,
+    // Congressional trade, and now 13F real-time ingestion). WorkerName
+    // flows into BaseScraperWorker's structured log scope and shows up in
+    // every Serilog line the worker emits — on-call greps
+    // `data/worker/logs/log<date>.txt` for "13F real-time ingestion" when
+    // institutional-holdings flow stalls before quarter-end reconciliation.
+    //
+    // The literal is deliberately distinct from sibling
+    // `HoldingsScraperWorker` (the quarterly bulk-import worker, name
+    // "Holdings scraper") even though both share `ErrorSource.HoldingsScraper`
+    // for issue-tracker routing. The asymmetry is intentional:
+    //   • ErrorSource is system-wide and short (one queue per data
+    //     domain) — so both 13F paths converge on `HoldingsScraper`.
+    //   • WorkerName is operator-facing and descriptive (one stream per
+    //     worker) — so the two paths must NOT share the log name.
+    //
+    // The risk: a "consistency" refactor that aligns WorkerName with the
+    // shared ErrorSource (e.g. naming this worker "Holdings scraper" or
+    // "13F holdings scraper") would compile, pass every existing pin,
+    // and silently merge two operationally distinct log streams. On-call
+    // tailing for "13F real-time ingestion" during a quarter-end
+    // disclosure burst would see no output even while the worker is
+    // running; the bulk-import dashboard would simultaneously fill with
+    // unrelated real-time noise.
+    //
+    // Pin the exact literal so the rename is loud, not silent.
+    [Fact]
+    public void WorkerName_Is13FRealtimeIngestion()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>())
+            .Build();
+        var sut = new TestableHoldings13FRealtimeWorker(
+            Substitute.For<ILogger<Holdings13FRealtimeWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions()),
+            config
+        );
+
+        sut.InvokeWorkerName().Should().Be("13F real-time ingestion");
+    }
+
+    private sealed class TestableHoldings13FRealtimeWorker : Holdings13FRealtimeWorker
+    {
+        public TestableHoldings13FRealtimeWorker(
+            ILogger<Holdings13FRealtimeWorker> logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            IOptions<WorkerOptions> workerOptions,
+            IConfiguration configuration
+        )
+            : base(logger, scopeFactory, errorReporter, workerOptions, configuration) { }
+
+        public string InvokeWorkerName() => WorkerName;
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the operator-facing log identifier `"13F real-time ingestion"` for `Holdings13FRealtimeWorker.WorkerName`. The existing `Holdings13FRealtimeWorkerTests` covers only `ValidateConfiguration` for the whitespace-email case; the WorkerName / SleepInterval / ErrorSource triple has been unpinned since the worker was introduced.
- `Holdings13FRealtimeWorker` shares `ErrorSource.HoldingsScraper` with the quarterly `HoldingsScraperWorker` (one issue-tracker queue for the data domain) but is operationally distinct: the real-time worker logs to a separate Serilog stream that on-call greps by exact WorkerName during a quarter-end disclosure burst. A "consistency" refactor that aligned WorkerName with the shared ErrorSource (e.g. naming this worker `"Holdings scraper"`) would compile cleanly and silently merge the two log streams, hiding real-time ingestion stalls behind bulk-import noise.
- Tenth and final WorkerName pin in the natural-extension family already covering CBOE / Holdings / SEC filing / FTD / Document processor / FRED / Yahoo price / FINRA / Congressional trade.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Holdings13FRealtimeWorkerWorkerNameTests.cs` — new unit test. Builds a `TestableHoldings13FRealtimeWorker` (private subclass exposing the protected `WorkerName`) with an empty in-memory `IConfiguration` and NSubstitute stubs for the other constructor dependencies. Asserts the WorkerName equals the exact literal `"13F real-time ingestion"`.