### PR TITLE
test(sec): pin GetWrappedValue happy-path nested walk with sidecar guard

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorGetWrappedValueHappyPathNestedTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorGetWrappedValueHappyPathNestedTests.cs
@@ -1,0 +1,64 @@
+using System.Reflection;
+using System.Xml.Linq;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InsiderTradingFilingProcessorGetWrappedValueHappyPathNestedTests
+{
+    // Adversarial sibling to GetWrappedValue_PathMissingMidWalk_ReturnsNullWithoutThrowing.
+    // The null-tolerance pin covers the failure path; nothing pins the
+    // happy path — walk a nested path, then read the inner <value>.
+    // The doc-comment is explicit: "Walk the path then read the inner
+    // <value>." Two refactor risks slip past the null-path pin alone:
+    //   (1) returning `element?.Value` instead of `element?.Element("value")?.Value`
+    //       — concatenates ALL descendant text, so a sidecar element next
+    //       to <value> contaminates the result.
+    //   (2) walking only path[0] instead of every path[] entry — would
+    //       still return null on the existing pin but read the wrong
+    //       element when the first hop has a direct <value> child.
+    //
+    // The construction deliberately includes a SIDECAR sibling element
+    // ("transactionPricePerShare") inside the inner wrapper. If a
+    // refactor switched to `.Value` (concatenated descendant text), the
+    // sidecar's text ("0.00") would bleed into the result. Asserting the
+    // exact "1500" string catches both regression classes from one pin.
+    [Fact]
+    public void GetWrappedValue_NestedPathWithSidecarSibling_ReturnsInnerValueTextOnly()
+    {
+        var method = typeof(InsiderTradingFilingProcessor).GetMethod(
+            "GetWrappedValue",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        // <nonDerivativeTransaction>
+        //   <transactionAmounts>
+        //     <transactionShares>
+        //       <transactionPricePerShare>0.00</transactionPricePerShare>  ← sidecar
+        //       <value>1500</value>
+        //     </transactionShares>
+        //   </transactionAmounts>
+        // </nonDerivativeTransaction>
+        var parent = new XElement(
+            "nonDerivativeTransaction",
+            new XElement(
+                "transactionAmounts",
+                new XElement(
+                    "transactionShares",
+                    new XElement("transactionPricePerShare", "0.00"),
+                    new XElement("value", "1500")
+                )
+            )
+        );
+        var pathArg = new[] { "transactionAmounts", "transactionShares" };
+
+        var result = (string)method!.Invoke(null, [parent, pathArg]);
+
+        result
+            .Should()
+            .Be(
+                "1500",
+                "the contract is to walk the full path and read the inner <value>'s text only; a sidecar sibling must not bleed into the result"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- `GetWrappedValue` in `InsiderTradingFilingProcessor` is the path-walker every Form 4 field traversal flows through (`transactionAmounts/transactionShares`, `transactionCoding/transactionCode`, etc.). The existing pin (`GetWrappedValue_PathMissingMidWalk_ReturnsNullWithoutThrowing`) covers the null-tolerant failure path; the happy path — walk a nested path and read the inner `<value>` — is unpinned.
- This pin walks a two-step path into a wrapper that contains a sidecar sibling element next to the inner `<value>`. Asserting the exact text `"1500"` catches two refactor classes the null-path pin misses:
  - returning `element?.Value` instead of `element?.Element("value")?.Value` — concatenates ALL descendant text, so the sidecar's `"0.00"` would bleed into the result;
  - walking only `path[0]` instead of every `path[]` entry.

## Code changes

- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorGetWrappedValueHappyPathNestedTests.cs` — new file. One `[Fact]` reflection-invoking the private static `GetWrappedValue` with a constructed `XElement` carrying `<transactionAmounts><transactionShares><transactionPricePerShare>0.00</transactionPricePerShare><value>1500</value></transactionShares></transactionAmounts>`. Asserts the result is exactly `"1500"`.