### PR TITLE
feat(holdings): publish Filings13FImported per affected quarter and refresh snapshots

### DIFF
--- a/src/Equibles.Holdings.HostedService/Consumers/Filings13FImportedConsumer.cs
+++ b/src/Equibles.Holdings.HostedService/Consumers/Filings13FImportedConsumer.cs
@@ -1,0 +1,42 @@
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Messaging.Attributes;
+using Equibles.Messaging.Contracts.Holdings;
+using MassTransit;
+
+namespace Equibles.Holdings.HostedService.Consumers;
+
+/// <summary>
+/// Rebuilds the per-quarter AUM and sector-allocation snapshots for the
+/// affected ReportDate after a successful 13F import. Idempotent — re-running
+/// for the same quarter just recomputes the same row. The daily safety-net
+/// worker is the second line of defence if a message is lost to a transient
+/// bus failure.
+/// </summary>
+[Consumer]
+public class Filings13FImportedConsumer : IConsumer<Filings13FImported>
+{
+    private readonly HoldingsAggregateRefreshService _refreshService;
+    private readonly ILogger<Filings13FImportedConsumer> _logger;
+
+    public Filings13FImportedConsumer(
+        HoldingsAggregateRefreshService refreshService,
+        ILogger<Filings13FImportedConsumer> logger
+    )
+    {
+        _refreshService = refreshService;
+        _logger = logger;
+    }
+
+    public async Task Consume(ConsumeContext<Filings13FImported> context)
+    {
+        var reportDate = context.Message.ReportDate;
+
+        _logger.LogInformation(
+            "Rebuilding holdings aggregate snapshots for {ReportDate} ({FilingCount} filing(s))",
+            reportDate,
+            context.Message.FilingCount
+        );
+
+        await _refreshService.RebuildQuarterAsync(reportDate, context.CancellationToken);
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -9,7 +9,9 @@ using Equibles.Errors.Data.Models;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.HostedService.Models;
 using Equibles.Holdings.Repositories;
+using Equibles.Messaging.Contracts.Holdings;
 using FlexLabs.EntityFrameworkCore.Upsert;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using static Equibles.Holdings.HostedService.Services.HoldingsParsingHelper;
@@ -23,18 +25,21 @@ public class HoldingsImportService
     private readonly ILogger<HoldingsImportService> _logger;
     private readonly WorkerOptions _workerOptions;
     private readonly IStockPriceProvider _stockPriceProvider;
+    private readonly IBus _bus;
 
     public HoldingsImportService(
         IServiceScopeFactory scopeFactory,
         ILogger<HoldingsImportService> logger,
         IOptions<WorkerOptions> workerOptions,
-        IStockPriceProvider stockPriceProvider
+        IStockPriceProvider stockPriceProvider,
+        IBus bus
     )
     {
         _scopeFactory = scopeFactory;
         _logger = logger;
         _workerOptions = workerOptions.Value;
         _stockPriceProvider = stockPriceProvider;
+        _bus = bus;
     }
 
     public async Task<ImportResult> ImportDataSet(
@@ -74,7 +79,43 @@ public class HoldingsImportService
         await UpsertInstitutionalHolders(context, cancellationToken);
         await HandleAmendments(context, cancellationToken);
         await StreamAndInsertHoldings(context, cancellationToken);
+        await PublishAffectedQuartersAsync(context, cancellationToken);
         return new ImportResult(submissionCount, IsComplete: true);
+    }
+
+    // Bulk data sets routinely import many quarters at once, so group submissions
+    // by ReportDate and publish one Filings13FImported per distinct quarter. The
+    // consumer rebuilds the per-quarter AUM + sector snapshots; the work is
+    // bounded per event, and deduplicating here keeps the import path from
+    // stampeding the consumer with one event per filing.
+    private async Task PublishAffectedQuartersAsync(
+        ImportContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        var byQuarter = new Dictionary<DateOnly, int>();
+        foreach (var submission in context.Submissions.Values)
+        {
+            if (TryParseDateOnly(submission.PeriodOfReport, out var reportDate))
+            {
+                byQuarter[reportDate] = byQuarter.GetValueOrDefault(reportDate) + 1;
+            }
+        }
+
+        if (byQuarter.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var (reportDate, count) in byQuarter)
+        {
+            await _bus.Publish(new Filings13FImported(reportDate, count), cancellationToken);
+        }
+
+        _logger.LogInformation(
+            "Published Filings13FImported for {Quarters} distinct quarter(s)",
+            byQuarter.Count
+        );
     }
 
     /// <summary>

--- a/src/Equibles.Messaging/Contracts/Holdings/Filings13FImported.cs
+++ b/src/Equibles.Messaging/Contracts/Holdings/Filings13FImported.cs
@@ -1,0 +1,6 @@
+namespace Equibles.Messaging.Contracts.Holdings;
+
+// Raised after a successful 13F import for each distinct ReportDate that
+// received new filings. Triggers a per-quarter rebuild of the AUM and
+// sector-allocation snapshots that power /holdings/stats and /holdings/trends.
+public record Filings13FImported(DateOnly ReportDate, int FilingCount);

--- a/tests/Equibles.IntegrationTests/Holdings/Filings13FImportedConsumerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Filings13FImportedConsumerTests.cs
@@ -1,0 +1,156 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Consumers;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging.Contracts.Holdings;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Contract: consuming a <see cref="Filings13FImported"/> event rebuilds the
+/// per-quarter AUM snapshot row for the message's <c>ReportDate</c>.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class Filings13FImportedConsumerTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<Equibles.Data.EquiblesFinancialDbContext> _contexts = [];
+
+    public Filings13FImportedConsumerTests(ParadeDbFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Equibles.Data.EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private static readonly DateOnly Q4 = new(2024, 12, 31);
+
+    private HoldingsAggregateRefreshService BuildRefreshService()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(_ => CreateScopeFromFixture());
+        return new HoldingsAggregateRefreshService(
+            scopeFactory,
+            NullLogger<HoldingsAggregateRefreshService>.Instance
+        );
+    }
+
+    private IServiceScope CreateScopeFromFixture()
+    {
+        var ctx = FreshContext();
+        var scope = Substitute.For<IServiceScope>();
+        var provider = Substitute.For<IServiceProvider>();
+        provider.GetService(typeof(Equibles.Data.EquiblesFinancialDbContext)).Returns(ctx);
+        provider
+            .GetService(typeof(AumQuarterlySnapshotRepository))
+            .Returns(_ => new AumQuarterlySnapshotRepository(ctx));
+        provider
+            .GetService(typeof(SectorQuarterlySnapshotRepository))
+            .Returns(_ => new SectorQuarterlySnapshotRepository(ctx));
+        scope.ServiceProvider.Returns(provider);
+        return scope;
+    }
+
+    private static ConsumeContext<Filings13FImported> Context(Filings13FImported message)
+    {
+        var ctx = Substitute.For<ConsumeContext<Filings13FImported>>();
+        ctx.Message.Returns(message);
+        ctx.CancellationToken.Returns(CancellationToken.None);
+        return ctx;
+    }
+
+    [Fact]
+    public async Task Consume_PublishedQuarter_WritesSnapshotRowForThatQuarter()
+    {
+        // Seed two holdings in Q4 — one filer, two stocks, one accession.
+        await using (var seed = FreshContext())
+        {
+            var tech = new Sector { Name = "Technology" };
+            seed.Add(tech);
+            await seed.SaveChangesAsync();
+            var industry = new Industry { Name = "Software", SectorId = tech.Id };
+            seed.Add(industry);
+            await seed.SaveChangesAsync();
+            var aapl = new CommonStock
+            {
+                Ticker = "AAPL",
+                Name = "Apple",
+                Cik = "C0000320193",
+                IndustryId = industry.Id,
+            };
+            var msft = new CommonStock
+            {
+                Ticker = "MSFT",
+                Name = "Microsoft",
+                Cik = "C0000789019",
+                IndustryId = industry.Id,
+            };
+            seed.AddRange(aapl, msft);
+            var holder = new InstitutionalHolder { Cik = "H001", Name = "Holder H001" };
+            seed.Add(holder);
+            await seed.SaveChangesAsync();
+            seed.AddRange(
+                MakeHolding(aapl, holder, Q4, 100_000, "acc-q4"),
+                MakeHolding(msft, holder, Q4, 200_000, "acc-q4")
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var sut = new Filings13FImportedConsumer(
+            BuildRefreshService(),
+            NullLogger<Filings13FImportedConsumer>.Instance
+        );
+
+        await sut.Consume(Context(new Filings13FImported(Q4, FilingCount: 1)));
+
+        await using var read = FreshContext();
+        var aum = await read.Set<AumQuarterlySnapshot>().SingleAsync(s => s.ReportDate == Q4);
+        aum.TotalValue.Should().Be(300_000);
+        aum.FilerCount.Should().Be(1);
+        aum.PositionCount.Should().Be(2);
+        aum.FilingCount.Should().Be(1);
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long value,
+        string accession
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = value / 100,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = accession,
+            Cusip =
+                $"{stock.Ticker[..Math.Min(4, stock.Ticker.Length)]}{stock.Id.GetHashCode():X8}"[
+                    ..9
+                ],
+        };
+}

--- a/tests/Equibles.IntegrationTests/Holdings/Holdings13FRealtimeWorkerDoWorkTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Holdings13FRealtimeWorkerDoWorkTests.cs
@@ -107,7 +107,8 @@ public class Holdings13FRealtimeWorkerDoWorkTests : IAsyncLifetime
                     scopeFactory,
                     Substitute.For<ILogger<HoldingsImportService>>(),
                     Options.Create(new WorkerOptions()),
-                    Substitute.For<IStockPriceProvider>()
+                    Substitute.For<IStockPriceProvider>(),
+                    Substitute.For<MassTransit.IBus>()
                 );
                 var ingestion = new Realtime13FIngestionService(
                     edgarClient,

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceAmendmentReconciliationTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceAmendmentReconciliationTests.cs
@@ -86,7 +86,8 @@ public class HoldingsImportServiceAmendmentReconciliationTests : IAsyncLifetime
             CreateScopeFactory(),
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            priceProvider
+            priceProvider,
+            Substitute.For<MassTransit.IBus>()
         );
 
     private static ZipArchive BuildArchive(params (string Name, string Body)[] entries)

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceBatchFlushAggregationTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceBatchFlushAggregationTests.cs
@@ -91,7 +91,8 @@ public class HoldingsImportServiceBatchFlushAggregationTests : IAsyncLifetime
             CreateScopeFactory(),
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            priceProvider
+            priceProvider,
+            Substitute.For<MassTransit.IBus>()
         );
 
     private static ZipArchive BuildArchive(params (string Name, string Body)[] entries)

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
@@ -98,7 +98,8 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
             CreateScopeFactory(),
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            priceProvider
+            priceProvider,
+            Substitute.For<MassTransit.IBus>()
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServicePublishesFilingsImportedTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServicePublishesFilingsImportedTests.cs
@@ -1,0 +1,238 @@
+using System.IO.Compression;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Messaging.Contracts.Holdings;
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Contract: after a successful 13F import, <see cref="HoldingsImportService"/>
+/// publishes one <see cref="Filings13FImported"/> per distinct <c>ReportDate</c>
+/// that received filings — deduplicating the per-filing volume so the consumer
+/// rebuilds one snapshot per quarter, not one per filing.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsImportServicePublishesFilingsImportedTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public HoldingsImportServicePublishesFilingsImportedTests(ParadeDbFixture fixture) =>
+        _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(InstitutionalHolderRepository))
+                    .Returns(new InstitutionalHolderRepository(ctx));
+                sp.GetService(typeof(InstitutionalHoldingRepository))
+                    .Returns(new InstitutionalHoldingRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    private static ZipArchive BuildArchive(params (string Name, string Body)[] entries)
+    {
+        var buffer = new MemoryStream();
+        using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, body) in entries)
+            {
+                var entry = writer.CreateEntry(name);
+                using var stream = entry.Open();
+                var bytes = Encoding.UTF8.GetBytes(body);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+        buffer.Position = 0;
+        return new ZipArchive(buffer, ZipArchiveMode.Read);
+    }
+
+    private static IStockPriceProvider PriceProviderReturning(
+        Dictionary<(Guid, DateOnly), decimal> prices
+    )
+    {
+        var provider = Substitute.For<IStockPriceProvider>();
+        provider
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult(prices));
+        return provider;
+    }
+
+    [Fact]
+    public async Task ImportDataSet_TwoFilingsInSameQuarter_PublishesOneEventForThatQuarter()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+            Cusip = "037833100",
+        };
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        var reportDate = new DateOnly(2024, 9, 30);
+        var submission =
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+            + "13F-HR\tACC-A\t2024-10-15\t2024-09-30\t0001000001\n"
+            + "13F-HR\tACC-B\t2024-10-16\t2024-09-30\t0001000002\n";
+        var coverPage =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+            + "ACC-A\tN\tFilerA\tNY\tNY\t028-1\t1\n"
+            + "ACC-B\tN\tFilerB\tNY\tNY\t028-2\t2\n";
+        var infoTable =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n"
+            + "ACC-A\t037833100\t100\tSH\t\tSOLE\t100\t0\t0\tCOM\t\n"
+            + "ACC-B\t037833100\t200\tSH\t\tSOLE\t200\t0\t0\tCOM\t\n";
+
+        using var archive = BuildArchive(
+            ("SUBMISSION.tsv", submission),
+            ("COVERPAGE.tsv", coverPage),
+            ("INFOTABLE.tsv", infoTable)
+        );
+
+        var bus = Substitute.For<IBus>();
+        var sut = new HoldingsImportService(
+            CreateScopeFactory(),
+            NullLogger<HoldingsImportService>.Instance,
+            Options.Create(new WorkerOptions()),
+            PriceProviderReturning(
+                new Dictionary<(Guid, DateOnly), decimal> { [(stock.Id, reportDate)] = 150m }
+            ),
+            bus
+        );
+
+        var result = await sut.ImportDataSet(
+            archive,
+            new DateOnly(2024, 1, 1),
+            CancellationToken.None
+        );
+        result.IsComplete.Should().BeTrue();
+
+        await bus.Received(1)
+            .Publish(
+                Arg.Is<Filings13FImported>(e => e.ReportDate == reportDate && e.FilingCount == 2),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task ImportDataSet_FilingsAcrossTwoQuarters_PublishesOneEventPerQuarter()
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+            Cusip = "037833100",
+        };
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().Add(stock);
+            await seed.SaveChangesAsync();
+        }
+
+        var q3 = new DateOnly(2024, 9, 30);
+        var q4 = new DateOnly(2024, 12, 31);
+        var submission =
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+            + "13F-HR\tACC-Q3\t2024-10-15\t2024-09-30\t0001000003\n"
+            + "13F-HR\tACC-Q4\t2025-02-10\t2024-12-31\t0001000004\n";
+        var coverPage =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+            + "ACC-Q3\tN\tFilerA\tNY\tNY\t028-3\t3\n"
+            + "ACC-Q4\tN\tFilerB\tNY\tNY\t028-4\t4\n";
+        var infoTable =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n"
+            + "ACC-Q3\t037833100\t100\tSH\t\tSOLE\t100\t0\t0\tCOM\t\n"
+            + "ACC-Q4\t037833100\t200\tSH\t\tSOLE\t200\t0\t0\tCOM\t\n";
+
+        using var archive = BuildArchive(
+            ("SUBMISSION.tsv", submission),
+            ("COVERPAGE.tsv", coverPage),
+            ("INFOTABLE.tsv", infoTable)
+        );
+
+        var bus = Substitute.For<IBus>();
+        var sut = new HoldingsImportService(
+            CreateScopeFactory(),
+            NullLogger<HoldingsImportService>.Instance,
+            Options.Create(new WorkerOptions()),
+            PriceProviderReturning(
+                new Dictionary<(Guid, DateOnly), decimal>
+                {
+                    [(stock.Id, q3)] = 150m,
+                    [(stock.Id, q4)] = 160m,
+                }
+            ),
+            bus
+        );
+
+        var result = await sut.ImportDataSet(
+            archive,
+            new DateOnly(2024, 1, 1),
+            CancellationToken.None
+        );
+        result.IsComplete.Should().BeTrue();
+
+        await bus.Received(1)
+            .Publish(
+                Arg.Is<Filings13FImported>(e => e.ReportDate == q3),
+                Arg.Any<CancellationToken>()
+            );
+        await bus.Received(1)
+            .Publish(
+                Arg.Is<Filings13FImported>(e => e.ReportDate == q4),
+                Arg.Any<CancellationToken>()
+            );
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceReducingAmendmentTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceReducingAmendmentTests.cs
@@ -85,7 +85,8 @@ public class HoldingsImportServiceReducingAmendmentTests : IAsyncLifetime
             CreateScopeFactory(),
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            priceProvider
+            priceProvider,
+            Substitute.For<MassTransit.IBus>()
         );
 
     private static ZipArchive BuildArchive(params (string Name, string Body)[] entries)

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceTests.cs
@@ -183,7 +183,8 @@ public class HoldingsImportServiceTests
             ScopeFactoryFor(db),
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            Substitute.For<IStockPriceProvider>()
+            Substitute.For<IStockPriceProvider>(),
+            Substitute.For<MassTransit.IBus>()
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionRevertGuardTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionRevertGuardTests.cs
@@ -197,7 +197,8 @@ public class HoldingsRealtimeIngestionRevertGuardTests : IAsyncLifetime
             scopeFactory,
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            prices
+            prices,
+            Substitute.For<MassTransit.IBus>()
         );
         var ingestion = new Realtime13FIngestionService(
             edgar,

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionWindowDedupTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionWindowDedupTests.cs
@@ -189,7 +189,8 @@ public class HoldingsRealtimeIngestionWindowDedupTests : IAsyncLifetime
             scopeFactory,
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            prices
+            prices,
+            Substitute.For<MassTransit.IBus>()
         );
         var ingestion = new Realtime13FIngestionService(
             edgar,

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionZeroHoldingsSkipTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsRealtimeIngestionZeroHoldingsSkipTests.cs
@@ -150,7 +150,8 @@ public class HoldingsRealtimeIngestionZeroHoldingsSkipTests : IAsyncLifetime
             scopeFactory,
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            prices
+            prices,
+            Substitute.For<MassTransit.IBus>()
         );
         var ingestion = new Realtime13FIngestionService(
             edgar,

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkCycleTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerDoWorkCycleTests.cs
@@ -77,7 +77,8 @@ public class HoldingsScraperWorkerDoWorkCycleTests : ParadeDbMcpTestBase
             Substitute.For<IServiceScopeFactory>(),
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            Substitute.For<IStockPriceProvider>()
+            Substitute.For<IStockPriceProvider>(),
+            Substitute.For<MassTransit.IBus>()
         );
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerMarkProcessedFailTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerMarkProcessedFailTests.cs
@@ -74,7 +74,8 @@ public class HoldingsScraperWorkerMarkProcessedFailTests : ParadeDbMcpTestBase
             sf,
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            Substitute.For<IStockPriceProvider>()
+            Substitute.For<IStockPriceProvider>(),
+            Substitute.For<MassTransit.IBus>()
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRetryArmsTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerRetryArmsTests.cs
@@ -75,7 +75,8 @@ public class HoldingsScraperWorkerRetryArmsTests : ParadeDbMcpTestBase
             Substitute.For<IServiceScopeFactory>(),
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            Substitute.For<IStockPriceProvider>()
+            Substitute.For<IStockPriceProvider>(),
+            Substitute.For<MassTransit.IBus>()
         );
 
     private FastRetryWorker BuildWorker(Exception downloadException)

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerTryProcessDataSetTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerTryProcessDataSetTests.cs
@@ -108,7 +108,8 @@ public class HoldingsScraperWorkerTryProcessDataSetTests : ParadeDbMcpTestBase
             scopeFactory,
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            Substitute.For<IStockPriceProvider>()
+            Substitute.For<IStockPriceProvider>(),
+            Substitute.For<MassTransit.IBus>()
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13FIngestionCrashSafetyTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13FIngestionCrashSafetyTests.cs
@@ -195,7 +195,8 @@ public class Realtime13FIngestionCrashSafetyTests : IAsyncLifetime
             scopeFactory,
             Substitute.For<ILogger<HoldingsImportService>>(),
             Options.Create(new WorkerOptions()),
-            prices
+            prices,
+            Substitute.For<MassTransit.IBus>()
         );
         var ingestion = new Realtime13FIngestionService(
             edgar,

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseOtherManagerRowWhitespaceNameTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceTryParseOtherManagerRowWhitespaceNameTests.cs
@@ -27,7 +27,8 @@ public class HoldingsImportServiceTryParseOtherManagerRowWhitespaceNameTests
             Substitute.For<IServiceScopeFactory>(),
             NullLogger<HoldingsImportService>.Instance,
             Options.Create(new WorkerOptions()),
-            Substitute.For<IStockPriceProvider>()
+            Substitute.For<IStockPriceProvider>(),
+            Substitute.For<MassTransit.IBus>()
         );
         var accession = "0000950123-24-006477";
         var submissions = new Dictionary<string, SubmissionRow>


### PR DESCRIPTION
## Summary

- Slice 3 of 5 for #2458 — wires the producer + consumer that drive the per-quarter snapshot rebuild. After this lands, every successful 13F import triggers an automatic rebuild for the affected `ReportDate`. Controllers still read from the live query in slice 5.
- Single event per distinct quarter, regardless of filing volume — bulk archives that span many filings in one quarter collapse to one consumer rebuild, not one per filing.

## Code changes

- `src/Equibles.Messaging/Contracts/Holdings/Filings13FImported.cs` — new event contract `(DateOnly ReportDate, int FilingCount)`. `FilingCount` is informational; consumer keys on `ReportDate`.
- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — adds an `IBus` dependency and a `PublishAffectedQuartersAsync` step at the end of a successful import. Groups submissions by parsed `ReportDate` and publishes one event per distinct quarter; nothing happens on the structural-failure / no-tracked-stocks early-exit paths.
- `src/Equibles.Holdings.HostedService/Consumers/Filings13FImportedConsumer.cs` — new `[Consumer]`, delegates to `HoldingsAggregateRefreshService.RebuildQuarterAsync`. Idempotent (re-running the same quarter just recomputes the same snapshot row); the daily safety-net worker in slice 4 covers messages lost to a transient bus failure.
- 14 existing test files updated to pass an additional `Substitute.For<IBus>()` into the `HoldingsImportService` constructor — no behaviour change in those tests.
- `tests/Equibles.IntegrationTests/Holdings/Filings13FImportedConsumerTests.cs` — consumes a published event, asserts the per-quarter AUM snapshot row appears with the correct distinct-collapse counts.
- `tests/Equibles.IntegrationTests/Holdings/HoldingsImportServicePublishesFilingsImportedTests.cs` — drives the import pipeline end-to-end with a stubbed `IBus`, asserts (1) two filings in one quarter produce one event with `FilingCount=2` and (2) filings spread across two quarters produce one event per quarter.

Refs #2458