### PR TITLE
feat(holdings): add daily AUM snapshot safety-net worker and first-boot backfill

### DIFF
--- a/src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs
+++ b/src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs
@@ -1,0 +1,118 @@
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.HostedService;
+
+/// <summary>
+/// Daily safety-net for the per-quarter AUM and sector-allocation snapshots
+/// that power /holdings/stats and /holdings/trends.
+///
+/// The event-driven path (<see cref="Consumers.Filings13FImportedConsumer"/>)
+/// keeps snapshots current on every 13F import. This worker is the second
+/// line of defence — it rebuilds every quarter once a day so a message lost
+/// to a transient bus failure, or a snapshot row missed during a bulk
+/// historical replay, gets reconciled within 24h.
+///
+/// On first boot (snapshot tables empty but the holdings table is not), the
+/// worker performs a one-off backfill of every existing quarter with an
+/// extended <c>CommandTimeout</c> for the initial pass — afterwards the
+/// per-quarter work is small enough that the default timeout is fine.
+/// </summary>
+public class AumSnapshotRebuildWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly HoldingsAggregateRefreshService _refreshService;
+    private readonly ILogger<AumSnapshotRebuildWorker> _logger;
+
+    // Exposed as virtual seams so tests can collapse the waits without
+    // changing production behaviour.
+    protected virtual TimeSpan StartupDelay => TimeSpan.FromMinutes(5);
+    protected virtual TimeSpan SleepInterval => TimeSpan.FromHours(24);
+    protected virtual TimeSpan BackfillCommandTimeout => TimeSpan.FromMinutes(30);
+
+    public AumSnapshotRebuildWorker(
+        IServiceScopeFactory scopeFactory,
+        HoldingsAggregateRefreshService refreshService,
+        ILogger<AumSnapshotRebuildWorker> logger
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _refreshService = refreshService;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (StartupDelay > TimeSpan.Zero)
+        {
+            try
+            {
+                await Task.Delay(StartupDelay, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+
+        await TryBackfillIfEmpty(stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                _logger.LogInformation("Running daily AUM snapshot safety-net rebuild");
+                await _refreshService.RebuildAllAsync(stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "AUM snapshot safety-net rebuild failed; will retry next cycle"
+                );
+            }
+
+            try
+            {
+                await Task.Delay(SleepInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
+    private async Task TryBackfillIfEmpty(CancellationToken cancellationToken)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+
+        var snapshotsExist = await dbContext
+            .Set<AumQuarterlySnapshot>()
+            .AnyAsync(cancellationToken);
+        if (snapshotsExist)
+        {
+            return;
+        }
+
+        var hasHoldings = await dbContext.Set<InstitutionalHolding>().AnyAsync(cancellationToken);
+        if (!hasHoldings)
+        {
+            return;
+        }
+
+        _logger.LogInformation(
+            "AUM snapshot tables are empty but holdings exist — running one-off backfill with {Timeout}s command timeout",
+            BackfillCommandTimeout.TotalSeconds
+        );
+
+        await _refreshService.RebuildAllAsync(BackfillCommandTimeout, cancellationToken);
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Holdings.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ public static class ServiceCollectionExtensions
 
         services.AddHostedService<HoldingsScraperWorker>();
         services.AddHostedService<Holdings13FRealtimeWorker>();
+        services.AddHostedService<AumSnapshotRebuildWorker>();
 
         return services;
     }

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -42,18 +42,37 @@ public class HoldingsAggregateRefreshService
         _logger = logger;
     }
 
-    public async Task RebuildQuarterAsync(DateOnly reportDate, CancellationToken cancellationToken)
+    public Task RebuildQuarterAsync(DateOnly reportDate, CancellationToken cancellationToken) =>
+        RebuildQuarterAsync(reportDate, commandTimeout: null, cancellationToken);
+
+    public async Task RebuildQuarterAsync(
+        DateOnly reportDate,
+        TimeSpan? commandTimeout,
+        CancellationToken cancellationToken
+    )
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
-        await RebuildQuarterInScope(scope.ServiceProvider, reportDate, cancellationToken);
+        await RebuildQuarterInScope(
+            scope.ServiceProvider,
+            reportDate,
+            commandTimeout,
+            cancellationToken
+        );
     }
 
-    public async Task RebuildAllAsync(CancellationToken cancellationToken)
+    public Task RebuildAllAsync(CancellationToken cancellationToken) =>
+        RebuildAllAsync(commandTimeout: null, cancellationToken);
+
+    public async Task RebuildAllAsync(TimeSpan? commandTimeout, CancellationToken cancellationToken)
     {
         List<DateOnly> reportDates;
         await using (var scope = _scopeFactory.CreateAsyncScope())
         {
             var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+            if (commandTimeout is not null)
+            {
+                dbContext.Database.SetCommandTimeout(commandTimeout.Value);
+            }
             reportDates = await dbContext
                 .Set<InstitutionalHolding>()
                 .Select(h => h.ReportDate)
@@ -71,17 +90,27 @@ public class HoldingsAggregateRefreshService
         {
             cancellationToken.ThrowIfCancellationRequested();
             await using var scope = _scopeFactory.CreateAsyncScope();
-            await RebuildQuarterInScope(scope.ServiceProvider, reportDate, cancellationToken);
+            await RebuildQuarterInScope(
+                scope.ServiceProvider,
+                reportDate,
+                commandTimeout,
+                cancellationToken
+            );
         }
     }
 
     private async Task RebuildQuarterInScope(
         IServiceProvider services,
         DateOnly reportDate,
+        TimeSpan? commandTimeout,
         CancellationToken cancellationToken
     )
     {
         var dbContext = services.GetRequiredService<EquiblesFinancialDbContext>();
+        if (commandTimeout is not null)
+        {
+            dbContext.Database.SetCommandTimeout(commandTimeout.Value);
+        }
         var aumRepo = services.GetRequiredService<AumQuarterlySnapshotRepository>();
         var sectorRepo = services.GetRequiredService<SectorQuarterlySnapshotRepository>();
 

--- a/tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs
@@ -1,0 +1,199 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Contract: <see cref="AumSnapshotRebuildWorker"/> backfills every quarter
+/// on first boot when the snapshot tables are empty, and on subsequent ticks
+/// re-runs the rebuild as a safety net.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class AumSnapshotRebuildWorkerTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<Equibles.Data.EquiblesFinancialDbContext> _contexts = [];
+
+    public AumSnapshotRebuildWorkerTests(ParadeDbFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Equibles.Data.EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private static readonly DateOnly Q3 = new(2024, 9, 30);
+    private static readonly DateOnly Q4 = new(2024, 12, 31);
+
+    private IServiceScopeFactory ScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var scope = Substitute.For<IServiceScope>();
+                var provider = Substitute.For<IServiceProvider>();
+                provider.GetService(typeof(Equibles.Data.EquiblesFinancialDbContext)).Returns(ctx);
+                provider
+                    .GetService(typeof(AumQuarterlySnapshotRepository))
+                    .Returns(_ => new AumQuarterlySnapshotRepository(ctx));
+                provider
+                    .GetService(typeof(SectorQuarterlySnapshotRepository))
+                    .Returns(_ => new SectorQuarterlySnapshotRepository(ctx));
+                scope.ServiceProvider.Returns(provider);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    // BackgroundService subclass that collapses both delays so the test can
+    // poke ExecuteAsync without waiting 5 minutes for the startup gate and
+    // 24 hours for the next cycle.
+    private sealed class InstantTickWorker : AumSnapshotRebuildWorker
+    {
+        public InstantTickWorker(
+            IServiceScopeFactory scopeFactory,
+            HoldingsAggregateRefreshService refreshService
+        )
+            : base(scopeFactory, refreshService, NullLogger<AumSnapshotRebuildWorker>.Instance) { }
+
+        protected override TimeSpan StartupDelay => TimeSpan.Zero;
+        protected override TimeSpan SleepInterval => TimeSpan.FromMilliseconds(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptySnapshotsButHoldingsExist_BackfillsEveryQuarter()
+    {
+        await SeedTwoQuarters();
+
+        var scopeFactory = ScopeFactory();
+        var refreshService = new HoldingsAggregateRefreshService(
+            scopeFactory,
+            NullLogger<HoldingsAggregateRefreshService>.Instance
+        );
+        var worker = new InstantTickWorker(scopeFactory, refreshService);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        // Run one cycle: the backfill, then one safety-net pass. Cancel after
+        // a brief delay so the loop exits.
+        var run = worker.StartAsync(cts.Token);
+        await Task.Delay(TimeSpan.FromMilliseconds(500), cts.Token);
+        await cts.CancelAsync();
+        try
+        {
+            await run;
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected — the loop exited via the stoppingToken.
+        }
+
+        await using var read = FreshContext();
+        var snapshots = await read.Set<AumQuarterlySnapshot>()
+            .OrderBy(s => s.ReportDate)
+            .ToListAsync();
+
+        snapshots.Should().HaveCount(2);
+        snapshots[0].ReportDate.Should().Be(Q3);
+        snapshots[0].TotalValue.Should().Be(100_000);
+        snapshots[1].ReportDate.Should().Be(Q4);
+        snapshots[1].TotalValue.Should().Be(200_000);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoHoldings_DoesNotCreatePhantomSnapshotRows()
+    {
+        // No holdings seeded — the worker should not invent rows out of nothing.
+        var scopeFactory = ScopeFactory();
+        var refreshService = new HoldingsAggregateRefreshService(
+            scopeFactory,
+            NullLogger<HoldingsAggregateRefreshService>.Instance
+        );
+        var worker = new InstantTickWorker(scopeFactory, refreshService);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var run = worker.StartAsync(cts.Token);
+        await Task.Delay(TimeSpan.FromMilliseconds(300), cts.Token);
+        await cts.CancelAsync();
+        try
+        {
+            await run;
+        }
+        catch (OperationCanceledException) { }
+
+        await using var read = FreshContext();
+        (await read.Set<AumQuarterlySnapshot>().AnyAsync()).Should().BeFalse();
+    }
+
+    private async Task SeedTwoQuarters()
+    {
+        await using var seed = FreshContext();
+        var tech = new Sector { Name = "Technology" };
+        seed.Add(tech);
+        await seed.SaveChangesAsync();
+        var industry = new Industry { Name = "Software", SectorId = tech.Id };
+        seed.Add(industry);
+        await seed.SaveChangesAsync();
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple",
+            Cik = "C0000320193",
+            IndustryId = industry.Id,
+        };
+        seed.Add(aapl);
+        var holder = new InstitutionalHolder { Cik = "H001", Name = "Holder H001" };
+        seed.Add(holder);
+        await seed.SaveChangesAsync();
+        seed.AddRange(
+            MakeHolding(aapl, holder, Q3, 100_000, "acc-q3"),
+            MakeHolding(aapl, holder, Q4, 200_000, "acc-q4")
+        );
+        await seed.SaveChangesAsync();
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long value,
+        string accession
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = value / 100,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = accession,
+            Cusip =
+                $"{stock.Ticker[..Math.Min(4, stock.Ticker.Length)]}{stock.Id.GetHashCode():X8}"[
+                    ..9
+                ],
+        };
+}


### PR DESCRIPTION
## Summary

- Slice 4 of 5 for #2458 — adds the second line of defence for the per-quarter snapshots. The consumer from slice 3 already keeps them current on every import; this worker reconciles anything missed (transient bus failure, bulk replay) within 24h, and also performs the first-boot backfill so deployments come up with snapshots already populated.
- Per-quarter rebuilds use the existing `[Index(ReportDate)]` btree slice. Only the first-boot pass uses an extended `CommandTimeout`, propagated to the per-quarter scopes via a new overload on the refresh service.

## Code changes

- `src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs` — new `BackgroundService` with a 5-minute startup delay (so it doesn't compete with the scrapers for the cold-start window) and a 24-hour cycle. On each cycle, it (1) checks once whether the snapshot tables are empty and the holdings table is not, and if so runs `RebuildAllAsync` with a 30-minute `CommandTimeout`; (2) runs the daily `RebuildAllAsync` safety-net. Both `StartupDelay` / `SleepInterval` / `BackfillCommandTimeout` are exposed as `virtual` seams so tests can collapse them deterministically.
- `src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs` — adds optional `TimeSpan? commandTimeout` overloads for both `RebuildQuarterAsync` and `RebuildAllAsync`. When set, each per-quarter scope applies the timeout before running its aggregate query.
- `src/Equibles.Holdings.HostedService/Extensions/ServiceCollectionExtensions.cs` — registers the worker as a hosted service in `AddHoldingsWorker()`.
- `tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs` — two ParadeDB-backed tests: empty snapshot tables + seeded holdings produces one row per quarter on first boot; no holdings produces no phantom rows. A test-only subclass collapses the 5-minute / 24-hour timers down to zero / 1 ms so the loop spins immediately.

Refs #2458