### PR TITLE
test(web): pin CsvExportService.EscapeField combined comma+double-quote escaping

### DIFF
--- a/tests/Equibles.UnitTests/Web/CsvExportServiceEscapeFieldCombinedTests.cs
+++ b/tests/Equibles.UnitTests/Web/CsvExportServiceEscapeFieldCombinedTests.cs
@@ -1,0 +1,38 @@
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+public class CsvExportServiceEscapeFieldCombinedTests
+{
+    // EscapeField's sibling pins each isolate a single special character:
+    // ContainsComma → wraps; ContainsDoubleQuote → doubles + wraps;
+    // ContainsNewline → wraps; ContainsCarriageReturn → wraps. Each pin
+    // exercises one branch of the IndexOfAny(['"', ',', '\n', '\r'])
+    // detection and one shape of escaping.
+    //
+    // The interesting risk lives in the *combination*: a field that
+    // contains BOTH a double-quote AND a delimiter (comma / newline / CR).
+    // The two escaping rules layer:
+    //   1. Inner quotes must be doubled ("" -> """")
+    //   2. The whole field is then wrapped in outer quotes
+    //
+    // A refactor that handled each special character as an independent
+    // branch (e.g. an if-else cascade rather than the current "doubled +
+    // wrapped" pipeline) would compile, pass every sibling pin (each
+    // isolates one character), and silently emit invalid CSV for any
+    // field that combines them — every quoted free-form string with
+    // an embedded comma. Excel / pandas / RFC-4180 parsers would
+    // misalign columns starting at that field.
+    //
+    // Pin: a field that combines both forces the full pipeline. The
+    // expected output is byte-exact per RFC-4180:
+    //   input  : He said, "hi"
+    //   output : "He said, ""hi"""
+    [Fact]
+    public void EscapeField_ContainsBothCommaAndDoubleQuote_DoublesInnerQuotesAndWrapsWholeField()
+    {
+        var result = CsvExportService.EscapeField("He said, \"hi\"");
+
+        result.Should().Be("\"He said, \"\"hi\"\"\"");
+    }
+}


### PR DESCRIPTION
## Summary

- Pin `CsvExportService.EscapeField`'s combined-special-character path. Existing sibling pins isolate one special character at a time (`,` / `"` / `\n` / `\r`) — none exercises the case that exposes the layering bug: a field containing BOTH a quote AND a delimiter, where the inner quotes must be doubled AND the whole field must be wrapped in outer quotes.
- A refactor that handled each special character as an independent if-else branch (e.g. "if has comma: wrap; if has quote: double; if has newline: wrap") would compile, pass every sibling pin (each isolates one character), and silently emit invalid CSV for any quoted free-form string with an embedded comma. Excel / pandas / RFC-4180 parsers would misalign columns starting at that field.
- Byte-exact assertion: input `He said, "hi"` → output `"He said, ""hi"""` per RFC-4180.

## Code changes

- `tests/Equibles.UnitTests/Web/CsvExportServiceEscapeFieldCombinedTests.cs` — new unit test. Calls `EscapeField` with a string containing both a comma and a double-quote, asserts the exact escaped output matches the RFC-4180 canonical form.