### PR TITLE
fix(cftc): look up COT CSV columns by the headers cftc.gov actually ships

### DIFF
--- a/src/Equibles.Integrations.Cftc/CftcClient.cs
+++ b/src/Equibles.Integrations.Cftc/CftcClient.cs
@@ -137,7 +137,7 @@ public class CftcClient : ICftcClient
 
         for (var i = 0; i < headers.Length; i++)
         {
-            var header = headers[i].Trim().Trim('"');
+            var header = headers[i].Trim().Trim('"').Trim();
             index[header] = i;
         }
 
@@ -151,33 +151,33 @@ public class CftcClient : ICftcClient
 
         return new CftcReportRecord
         {
-            MarketAndExchangeName = Get("Market_and_Exchange_Names"),
-            ReportDate = Get("Report_Date_as_YYYY-MM-DD") ?? Get("As_of_Date_In_Form_YYMMDD"),
-            ContractMarketCode = Get("CFTC_Contract_Market_Code"),
-            OpenInterest = ParseLong(Get("Open_Interest_All")),
-            NonCommLong = ParseLong(Get("NonComm_Positions_Long_All")),
-            NonCommShort = ParseLong(Get("NonComm_Positions_Short_All")),
-            NonCommSpreads = ParseLong(Get("NonComm_Positions_Spread_All")),
-            CommLong = ParseLong(Get("Comm_Positions_Long_All")),
-            CommShort = ParseLong(Get("Comm_Positions_Short_All")),
-            TotalRptLong = ParseLong(Get("Tot_Rpt_Positions_Long_All")),
-            TotalRptShort = ParseLong(Get("Tot_Rpt_Positions_Short_All")),
-            NonRptLong = ParseLong(Get("NonRpt_Positions_Long_All")),
-            NonRptShort = ParseLong(Get("NonRpt_Positions_Short_All")),
-            ChangeOpenInterest = ParseLong(Get("Change_in_Open_Interest_All")),
-            ChangeNonCommLong = ParseLong(Get("Change_in_NonComm_Long_All")),
-            ChangeNonCommShort = ParseLong(Get("Change_in_NonComm_Short_All")),
-            ChangeCommLong = ParseLong(Get("Change_in_Comm_Long_All")),
-            ChangeCommShort = ParseLong(Get("Change_in_Comm_Short_All")),
-            PctNonCommLong = ParseDecimal(Get("Pct_of_OI_NonComm_Long_All")),
-            PctNonCommShort = ParseDecimal(Get("Pct_of_OI_NonComm_Short_All")),
-            PctCommLong = ParseDecimal(Get("Pct_of_OI_Comm_Long_All")),
-            PctCommShort = ParseDecimal(Get("Pct_of_OI_Comm_Short_All")),
-            TradersTotal = ParseInt(Get("Traders_Tot_All")),
-            TradersNonCommLong = ParseInt(Get("Traders_NonComm_Long_All")),
-            TradersNonCommShort = ParseInt(Get("Traders_NonComm_Short_All")),
-            TradersCommLong = ParseInt(Get("Traders_Comm_Long_All")),
-            TradersCommShort = ParseInt(Get("Traders_Comm_Short_All")),
+            MarketAndExchangeName = Get("Market and Exchange Names"),
+            ReportDate = Get("As of Date in Form YYYY-MM-DD") ?? Get("As of Date in Form YYMMDD"),
+            ContractMarketCode = Get("CFTC Contract Market Code"),
+            OpenInterest = ParseLong(Get("Open Interest (All)")),
+            NonCommLong = ParseLong(Get("Noncommercial Positions-Long (All)")),
+            NonCommShort = ParseLong(Get("Noncommercial Positions-Short (All)")),
+            NonCommSpreads = ParseLong(Get("Noncommercial Positions-Spreading (All)")),
+            CommLong = ParseLong(Get("Commercial Positions-Long (All)")),
+            CommShort = ParseLong(Get("Commercial Positions-Short (All)")),
+            TotalRptLong = ParseLong(Get("Total Reportable Positions-Long (All)")),
+            TotalRptShort = ParseLong(Get("Total Reportable Positions-Short (All)")),
+            NonRptLong = ParseLong(Get("Nonreportable Positions-Long (All)")),
+            NonRptShort = ParseLong(Get("Nonreportable Positions-Short (All)")),
+            ChangeOpenInterest = ParseLong(Get("Change in Open Interest (All)")),
+            ChangeNonCommLong = ParseLong(Get("Change in Noncommercial-Long (All)")),
+            ChangeNonCommShort = ParseLong(Get("Change in Noncommercial-Short (All)")),
+            ChangeCommLong = ParseLong(Get("Change in Commercial-Long (All)")),
+            ChangeCommShort = ParseLong(Get("Change in Commercial-Short (All)")),
+            PctNonCommLong = ParseDecimal(Get("% of OI-Noncommercial-Long (All)")),
+            PctNonCommShort = ParseDecimal(Get("% of OI-Noncommercial-Short (All)")),
+            PctCommLong = ParseDecimal(Get("% of OI-Commercial-Long (All)")),
+            PctCommShort = ParseDecimal(Get("% of OI-Commercial-Short (All)")),
+            TradersTotal = ParseInt(Get("Traders-Total (All)")),
+            TradersNonCommLong = ParseInt(Get("Traders-Noncommercial-Long (All)")),
+            TradersNonCommShort = ParseInt(Get("Traders-Noncommercial-Short (All)")),
+            TradersCommLong = ParseInt(Get("Traders-Commercial-Long (All)")),
+            TradersCommShort = ParseInt(Get("Traders-Commercial-Short (All)")),
         };
     }
 

--- a/tests/Equibles.IntegrationTests/Cftc/CftcClientDownloadRateLimitedTests.cs
+++ b/tests/Equibles.IntegrationTests/Cftc/CftcClientDownloadRateLimitedTests.cs
@@ -22,8 +22,8 @@ public class CftcClientDownloadRateLimitedTests
     {
         var csv = string.Join(
             "\n",
-            "\"Market_and_Exchange_Names\",\"Report_Date_as_YYYY-MM-DD\","
-                + "\"CFTC_Contract_Market_Code\",\"Open_Interest_All\"",
+            "\"Market and Exchange Names\",\"As of Date in Form YYYY-MM-DD\","
+                + "\"CFTC Contract Market Code\",\"Open Interest (All)\"",
             "\"SILVER - COMMODITY EXCHANGE INC.\",\"2024-12-24\",\"084691\",\"250,000\""
         );
         var zipBytes = BuildZipWith("annual.txt", csv);

--- a/tests/Equibles.IntegrationTests/Cftc/CftcClientDownloadRealCftcHeaderFormatTests.cs
+++ b/tests/Equibles.IntegrationTests/Cftc/CftcClientDownloadRealCftcHeaderFormatTests.cs
@@ -1,0 +1,136 @@
+using System.IO.Compression;
+using System.Net;
+using Equibles.Integrations.Cftc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Cftc;
+
+/// <summary>
+/// Regression pin for GH-2159 — CftcClient.ParseLine was looking up CSV
+/// columns by underscore-style names ("Market_and_Exchange_Names",
+/// "Open_Interest_All", etc.) but the deacot{year}.zip CSVs that
+/// cftc.gov actually ships use space-separated, parenthesised names
+/// ("Market and Exchange Names", "Open Interest (All)", with the
+/// quirky leading space in " Total Reportable Positions-Long (All)").
+/// Every column lookup returned null, every record landed with null
+/// numeric fields, and the downstream persistence dropped every row —
+/// CftcPositionReport stayed at 0 rows indefinitely while the worker
+/// kept logging successful 200 OK downloads.
+///
+/// This pin feeds the actual production header format and asserts the
+/// parser returns a non-empty list with the primary-key fields and at
+/// least one numeric field populated. The existing
+/// CftcClientDownloadTests passes the buggy underscore headers (which
+/// matches the buggy production lookup); it cannot catch this
+/// regression class because both sides agree.
+/// </summary>
+public class CftcClientDownloadRealCftcHeaderFormatTests
+{
+    [Fact]
+    public async Task DownloadYearlyReport_RealCftcHeaderFormat_ReturnsParsedRecord()
+    {
+        // Header verbatim from `cftc.gov/files/dea/history/deacot2024.zip` —
+        // including the leading space in the 14th column (CFTC source-data
+        // quirk) and the (All)/(Old)/(Other) suffix groupings.
+        var header = string.Join(
+            ",",
+            "\"Market and Exchange Names\"",
+            "\"As of Date in Form YYMMDD\"",
+            "\"As of Date in Form YYYY-MM-DD\"",
+            "\"CFTC Contract Market Code\"",
+            "\"CFTC Market Code in Initials\"",
+            "\"CFTC Region Code\"",
+            "\"CFTC Commodity Code\"",
+            "\"Open Interest (All)\"",
+            "\"Noncommercial Positions-Long (All)\"",
+            "\"Noncommercial Positions-Short (All)\"",
+            "\"Noncommercial Positions-Spreading (All)\"",
+            "\"Commercial Positions-Long (All)\"",
+            "\"Commercial Positions-Short (All)\"",
+            "\" Total Reportable Positions-Long (All)\"",
+            "\"Total Reportable Positions-Short (All)\"",
+            "\"Nonreportable Positions-Long (All)\"",
+            "\"Nonreportable Positions-Short (All)\""
+        );
+
+        var dataRow = string.Join(
+            ",",
+            "\"WHEAT-SRW - CHICAGO BOARD OF TRADE\"",
+            "241231",
+            "2024-12-31",
+            "001602",
+            "CBT",
+            "1",
+            "001",
+            "350000",
+            "120000",
+            "80000",
+            "20000",
+            "150000",
+            "200000",
+            "290000",
+            "300000",
+            "60000",
+            "50000"
+        );
+
+        var csv = string.Join("\n", header, dataRow);
+        var zipBytes = BuildZipWith("annual.txt", csv);
+        var handler = new ZipHandler(zipBytes);
+        var sut = new CftcClient(new HttpClient(handler), Substitute.For<ILogger<CftcClient>>());
+
+        var records = await sut.DownloadYearlyReport(2024);
+
+        records.Should().ContainSingle();
+        var record = records[0];
+        record
+            .MarketAndExchangeName.Should()
+            .Be(
+                "WHEAT-SRW - CHICAGO BOARD OF TRADE",
+                "the parser must look up columns by the actual CFTC header strings, not the underscore-style names from the legacy lookup"
+            );
+        record.ContractMarketCode.Should().Be("001602");
+        record.ReportDate.Should().Be("2024-12-31");
+        record
+            .OpenInterest.Should()
+            .Be(
+                350000,
+                "every numeric column was silently parsing to null under the column-name mismatch"
+            );
+        // Pins the leading-space quirk in " Total Reportable Positions-Long (All)".
+        record.TotalRptLong.Should().Be(290000);
+    }
+
+    private static byte[] BuildZipWith(string entryName, string content)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry(entryName);
+            using var writer = new StreamWriter(entry.Open());
+            writer.Write(content);
+        }
+        return stream.ToArray();
+    }
+
+    private sealed class ZipHandler : HttpMessageHandler
+    {
+        private readonly byte[] _zipBytes;
+
+        public ZipHandler(byte[] zipBytes) => _zipBytes = zipBytes;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(_zipBytes),
+                }
+            );
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Cftc/CftcClientDownloadRetryTests.cs
+++ b/tests/Equibles.IntegrationTests/Cftc/CftcClientDownloadRetryTests.cs
@@ -22,8 +22,8 @@ public class CftcClientDownloadRetryTests
     {
         var csv = string.Join(
             "\n",
-            "\"Market_and_Exchange_Names\",\"Report_Date_as_YYYY-MM-DD\","
-                + "\"CFTC_Contract_Market_Code\",\"Open_Interest_All\"",
+            "\"Market and Exchange Names\",\"As of Date in Form YYYY-MM-DD\","
+                + "\"CFTC Contract Market Code\",\"Open Interest (All)\"",
             "\"GOLD - COMMODITY EXCHANGE INC.\",\"2024-12-24\",\"088691\",\"500,000\""
         );
         var zipBytes = BuildZipWith("annual.txt", csv);

--- a/tests/Equibles.IntegrationTests/Cftc/CftcClientDownloadTests.cs
+++ b/tests/Equibles.IntegrationTests/Cftc/CftcClientDownloadTests.cs
@@ -23,8 +23,8 @@ public class CftcClientDownloadTests
         // them would silently null out that column for every row.
         var csv = string.Join(
             "\n",
-            "\"Market_and_Exchange_Names\",\"Report_Date_as_YYYY-MM-DD\","
-                + "\"CFTC_Contract_Market_Code\",\"Open_Interest_All\"",
+            "\"Market and Exchange Names\",\"As of Date in Form YYYY-MM-DD\","
+                + "\"CFTC Contract Market Code\",\"Open Interest (All)\"",
             "\"E-MINI S&P 500 - CHICAGO MERCANTILE EXCHANGE\",\"2024-12-24\",\"13874+\",\"2,500,000\""
         );
 

--- a/tests/Equibles.UnitTests/Integrations/CftcClientTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientTests.cs
@@ -102,7 +102,7 @@ public class CftcClientTests
         // returned record's ReportDate must equal the legacy raw string "250115" —
         // ParseLine reads the value verbatim and leaves date-string format
         // interpretation to the downstream ParseDate helper.
-        var headerLine = "CFTC_Contract_Market_Code,As_of_Date_In_Form_YYMMDD";
+        var headerLine = "CFTC Contract Market Code,As of Date in Form YYMMDD";
         var columnIndex =
             (Dictionary<string, int>)BuildColumnIndexMethod.Invoke(null, [headerLine]);
         var line = "001602,250115";
@@ -187,7 +187,7 @@ public class CftcClientTests
         // for either column. Assertion compares against the modern wire-format
         // string verbatim, which can ONLY hold for `modern ?? legacy` order.
         var headerLine =
-            "CFTC_Contract_Market_Code,Report_Date_as_YYYY-MM-DD,As_of_Date_In_Form_YYMMDD";
+            "CFTC Contract Market Code,As of Date in Form YYYY-MM-DD,As of Date in Form YYMMDD";
         var columnIndex =
             (Dictionary<string, int>)BuildColumnIndexMethod.Invoke(null, [headerLine]);
         var line = "001602,2025-01-15,250115";
@@ -326,7 +326,7 @@ public class CftcClientTests
         // returned value must be null (so `??` would fall through), NOT empty string,
         // NOT whitespace.
         var headerLine =
-            "CFTC_Contract_Market_Code,Report_Date_as_YYYY-MM-DD,As_of_Date_In_Form_YYMMDD";
+            "CFTC Contract Market Code,As of Date in Form YYYY-MM-DD,As of Date in Form YYMMDD";
         var columnIndex =
             (Dictionary<string, int>)BuildColumnIndexMethod.Invoke(null, [headerLine]);
         var fieldsWithBlankModernDate = new[] { "001602", "   ", "250115" };


### PR DESCRIPTION
## Summary

- `CftcClient.ParseLine` was looking up every CSV column by underscore-style names (`"Market_and_Exchange_Names"`, `"Open_Interest_All"`, etc.), but the `deacot{year}.zip` CSVs cftc.gov actually serves use space-separated, parenthesised headers (`"Market and Exchange Names"`, `"Open Interest (All)"`). Every column lookup returned null, every record landed with null numeric fields, and downstream persistence silently dropped every row — `CftcPositionReport` stayed at zero indefinitely while the worker kept logging successful 200 OK downloads.
- Verified by `curl`ing `deacot2024.zip` and inspecting the real header row: `"Market and Exchange Names","As of Date in Form YYMMDD",...,"Open Interest (All)",...`, with a stray leading space inside the quotes for `" Total Reportable Positions-Long (All)"` (CFTC source-data quirk).
- The buggy headers were also baked into three integration tests and two unit tests' fixture CSVs — both sides agreed, which is why CI never surfaced the mismatch.

Closes #2159

## Code changes

- `src/Equibles.Integrations.Cftc/CftcClient.cs` — rewrite the 27 `Get(...)` column-name strings in `ParseLine` to match the real CFTC headers; re-order `BuildColumnIndex` to `.Trim().Trim('"').Trim()` so the leading-space quirk on the Total-Reportable column normalises to the canonical key.
- `tests/Equibles.IntegrationTests/Cftc/CftcClientDownloadRealCftcHeaderFormatTests.cs` — new regression test that feeds the verbatim cftc.gov header format (including the leading-space quirk) and asserts both the primary-key fields and a numeric column populate.
- `tests/Equibles.IntegrationTests/Cftc/CftcClientDownloadTests.cs`, `CftcClientDownloadRateLimitedTests.cs`, `CftcClientDownloadRetryTests.cs` — update the fixture-CSV header rows from the buggy underscore form to the real CFTC headers so the tests now exercise the production contract.
- `tests/Equibles.UnitTests/Integrations/CftcClientTests.cs` — same update for the two `ParseLine_*Date*` fixture headers.