### PR TITLE
test(web): pin FlashMessage convenience-helper title plumbing through QueueOfType

### DIFF
--- a/tests/Equibles.UnitTests/Web/FlashMessageTitlePlumbingTests.cs
+++ b/tests/Equibles.UnitTests/Web/FlashMessageTitlePlumbingTests.cs
@@ -1,0 +1,57 @@
+using Equibles.Web.FlashMessage;
+using Equibles.Web.FlashMessage.Contracts;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Web;
+
+public class FlashMessageTitlePlumbingTests
+{
+    // The four FlashMessage convenience helpers (Success / Error / Info /
+    // Warning) all accept an optional `title` parameter and forward it
+    // through the shared private QueueOfType helper:
+    //   QueueOfType(type, message, title, isHtml) =>
+    //       Queue(new FlashMessageModel { Message=msg, Title=title, ... });
+    //
+    // Every existing sibling pin in this file passes a single positional
+    // argument (`sut.Error("Something broke")`) — the `title` parameter
+    // defaults to null in those calls, so its plumbing through QueueOfType
+    // is unreachable from any current test. A "harmonize all helpers to
+    // null titles" cleanup that dropped the `Title = title` line in
+    // QueueOfType would compile, pass every existing Error/Warning/Info/
+    // Success pin, and silently strip the title from every flash message
+    // emitted by a controller that uses the title overload (the
+    // _FlashMessages.cshtml partial renders the title as a bold heading
+    // above the message — losing it doesn't 500, it just produces a
+    // titleless toast that's still readable).
+    //
+    // Pin: pass an explicit non-null title via `sut.Error(message, title)`,
+    // capture the serialized payload, round-trip through the real
+    // JsonFlashMessageSerializer, assert the deserialised model carries
+    // the exact title. Distinguishes from the existing Error sibling
+    // because that pin asserts `Type` only and uses the default-null
+    // title — a regression that drops the Title assignment would still
+    // pass the Type pin.
+    [Fact]
+    public void Error_TitleArgumentSupplied_PlumbsThroughQueueOfTypeIntoFlashMessageModel()
+    {
+        var serializer = new JsonFlashMessageSerializer();
+        string captured = null;
+        var tempData = Substitute.For<ITempDataDictionary>();
+        tempData
+            .WhenForAnyArgs(t => t[FlashMessage.KeyName] = default)
+            .Do(callInfo => captured = (string)callInfo.Arg<object>());
+        var factory = Substitute.For<ITempDataDictionaryFactory>();
+        factory.GetTempData(Arg.Any<HttpContext>()).Returns(tempData);
+        var sut = new FlashMessage(factory, Substitute.For<IHttpContextAccessor>(), serializer);
+
+        sut.Error("Could not save", "Form submission failed");
+
+        captured.Should().NotBeNull();
+        var roundTripped = serializer.Deserialize(captured);
+        roundTripped.Should().ContainSingle();
+        roundTripped[0].Title.Should().Be("Form submission failed");
+        roundTripped[0].Message.Should().Be("Could not save");
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the `title` parameter flow through the FlashMessage convenience helpers (`Success` / `Error` / `Info` / `Warning` → `QueueOfType` → `FlashMessageModel.Title`). Every existing sibling pin invokes a helper with a single positional argument, so the `title` parameter defaults to null and its plumbing is unreachable.
- A "harmonize all helpers to null titles" refactor that drops `Title = title` from `QueueOfType` would compile, pass every existing Error/Warning/Info/Success pin, and silently strip the title from every flash message emitted by a controller that uses the title overload — the `_FlashMessages.cshtml` partial would render a titleless toast instead of failing loudly.
- Round-trips through the real `JsonFlashMessageSerializer` to assert the title survives both the `QueueOfType` plumbing and the cookie-store serialization in one shot.

## Code changes

- `tests/Equibles.UnitTests/Web/FlashMessageTitlePlumbingTests.cs` — new unit test. Calls `sut.Error("Could not save", "Form submission failed")`, captures the serialized TempData payload, round-trips through `JsonFlashMessageSerializer`, asserts both `Title` and `Message` arrive intact on the deserialised model.