### PR TITLE
test(cftc): pin BuildColumnIndex against CFTC's in-quote leading-space header

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CftcClientBuildColumnIndexInQuoteLeadingSpaceTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientBuildColumnIndexInQuoteLeadingSpaceTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using Equibles.Integrations.Cftc;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CftcClientBuildColumnIndexInQuoteLeadingSpaceTests
+{
+    private static readonly MethodInfo BuildColumnIndexMethod = typeof(CftcClient).GetMethod(
+        "BuildColumnIndex",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    // GH-2159 fix added a trailing `.Trim()` after `.Trim('"')` so that
+    // CFTC's in-quote leading-space header (`" Total Reportable
+    // Positions-Long (All)"` in deacot{year}.zip — a known
+    // source-data quirk) normalises to the canonical
+    // `Total Reportable Positions-Long (All)` lookup key. The
+    // existing `BuildColumnIndex_QuotedHeaderName_IndexedWithoutQuotes`
+    // sibling pins quote-stripping on a header with NO in-quote
+    // whitespace, so dropping the final `.Trim()` would re-introduce
+    // the leading-space prefix on the dict key, every `Get(...)`
+    // for that column would miss, and Total-Reportable numeric
+    // fields would silently parse to null on every CFTC import
+    // cycle — the exact failure mode of GH-2159.
+    [Fact]
+    public void BuildColumnIndex_QuotedHeaderWithInQuoteLeadingSpace_IndexedUnderTrimmedCanonicalKey()
+    {
+        var headerLine = "\" Total Reportable Positions-Long (All)\",\"Other Column\"";
+
+        var index = (Dictionary<string, int>)BuildColumnIndexMethod.Invoke(null, [headerLine]);
+
+        index
+            .Should()
+            .ContainKey(
+                "Total Reportable Positions-Long (All)",
+                "CFTC ships this column with an in-quote leading space; BuildColumnIndex must trim after the quote-strip so production lookups by the canonical name resolve"
+            )
+            .WhoseValue.Should()
+            .Be(0);
+        // Negative pin: the un-trimmed key form (with leading space) must NOT
+        // be in the index — a regression that dropped the trailing .Trim()
+        // would re-introduce it here.
+        index.Should().NotContainKey(" Total Reportable Positions-Long (All)");
+    }
+}


### PR DESCRIPTION
## Summary

- GH-2159's fix added a trailing `.Trim()` after `.Trim('"')` in `BuildColumnIndex` so CFTC's in-quote leading-space column (`" Total Reportable Positions-Long (All)"` — a source-data quirk verified against the actual `deacot{year}.zip` header) normalises to the canonical lookup key.
- The existing `BuildColumnIndex_QuotedHeaderName_IndexedWithoutQuotes` sibling exercises only the quote-strip on whitespace-free headers, so dropping the new trailing `.Trim()` would slip past it. The dict key would carry the leading space, every `Get(...)` for that column would miss, and Total-Reportable numerics would silently parse to null on every CFTC import (the GH-2159 failure mode for that one column).

## Code changes

- `tests/Equibles.UnitTests/Integrations/CftcClientBuildColumnIndexInQuoteLeadingSpaceTests.cs` — new file. One `[Fact]` reflection-invoking the private static `BuildColumnIndex` with a header line `"\" Total Reportable Positions-Long (All)\",\"Other Column\""`. Positive pin: the canonical trimmed key `Total Reportable Positions-Long (All)` resolves to index 0. Negative pin: the un-trimmed form (with leading space) is NOT in the dict, so a regression to either `.Trim().Trim('"')` ordering or a partial trim surfaces here.