### PR TITLE
test(web): pin ProfileFormatting.JoinLocation both-sides-empty case

### DIFF
--- a/tests/Equibles.UnitTests/Web/ProfileFormattingJoinLocationBothEmptyTests.cs
+++ b/tests/Equibles.UnitTests/Web/ProfileFormattingJoinLocationBothEmptyTests.cs
@@ -1,0 +1,38 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class ProfileFormattingJoinLocationBothEmptyTests
+{
+    // Sibling to ProfileFormattingJoinLocationWhitespaceTests, which only
+    // pins the *one-sided* fallback (`city, whitespace` → `city`). The
+    // existing pin leaves the both-sides-empty case unpinned — which is
+    // production-real on freshly-scraped institutional holders whose
+    // EDGAR profile rows landed with neither City nor State populated
+    // (a common shape for foreign filers and shell entities).
+    //
+    // Contract derived from the class doc ("Small presentation helpers
+    // shared by the entity profile pages") and the method name
+    // `JoinLocation` — the helper must NOT emit a stray ", " or a
+    // leading-comma artifact when BOTH inputs are missing. The implementation
+    // uses `IsNullOrWhiteSpace` on BOTH parts via the same Where filter; a
+    // refactor that "harmonised" the predicate to filter only
+    // `stateOrCountry` (under the assumption that the upstream guarantees
+    // `city` is always present) would compile, pass the existing
+    // one-sided sibling pin (`city = "San Francisco"`), and silently
+    // emit `"  , "` for a both-empty row — visible on the profile page
+    // as a stray-comma typo.
+    //
+    // Pin both parameters as whitespace-only. The assertion is the empty
+    // string — anything else (null, ", ", " , ") indicates the filter
+    // dropped or got asymmetric. This catches both the
+    // IsNullOrWhiteSpace → IsNullOrEmpty regression AND the
+    // "only-filter-stateOrCountry" regression in one assertion.
+    [Fact]
+    public void JoinLocation_BothCityAndStateOrCountryWhitespace_ReturnsEmptyString()
+    {
+        var result = ProfileFormatting.JoinLocation("  ", "\t");
+
+        result.Should().Be(string.Empty);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin `ProfileFormatting.JoinLocation` to return `string.Empty` when BOTH `city` and `stateOrCountry` are whitespace-only. The existing sibling `ProfileFormattingJoinLocationWhitespaceTests` covers the one-sided fallback (`city, whitespace` → `city`); the both-sides-empty case stayed unpinned and is production-real on freshly-scraped institutional holders whose EDGAR profile rows landed with neither field populated (a common shape for foreign filers and shell entities).
- The implementation filters via `IsNullOrWhiteSpace` on BOTH parts. A refactor that "harmonised" the predicate to filter only `stateOrCountry` (under the false assumption that the upstream guarantees a non-empty `city`) would compile cleanly, pass the existing one-sided pin, and silently emit `"  , "` for a both-empty row — visible on the profile page as a stray-comma typo.
- Asserting `string.Empty` catches both the `IsNullOrWhiteSpace → IsNullOrEmpty` regression AND the "only-filter-stateOrCountry" regression in a single assertion.

## Code changes

- `tests/Equibles.UnitTests/Web/ProfileFormattingJoinLocationBothEmptyTests.cs` — new unit test. Calls `ProfileFormatting.JoinLocation("  ", "\t")` (two distinct whitespace shapes to also catch a regression that special-cases only ASCII space) and asserts the result is `string.Empty`.