### PR TITLE
test(web): pin VersionCheckService.NormalizeVersion trims surrounding whitespace before v-prefix strip

### DIFF
--- a/tests/Equibles.UnitTests/Web/VersionCheckServiceNormalizeVersionWhitespaceTests.cs
+++ b/tests/Equibles.UnitTests/Web/VersionCheckServiceNormalizeVersionWhitespaceTests.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+public class VersionCheckServiceNormalizeVersionWhitespaceTests
+{
+    // Sibling to the existing NormalizeVersion pins (SemVerPreReleaseTag,
+    // SemVerBuildMetadataTag, NullInput, UppercaseVPrefix). None of them
+    // exercises the leading `value.Trim()` step at the top of the method.
+    //
+    // The Trim step is load-bearing in production: an
+    // `AssemblyInformationalVersionAttribute` can legitimately carry
+    // padding when a CI build script emits the version literal via env
+    // var interpolation with a stray newline or trailing space
+    // (`-p:InformationalVersion="${{ secrets.VERSION }}"` where the
+    // secret was set with a trailing newline — a common gotcha in
+    // GitHub Actions). Without Trim, `" v1.2.3 ".StartsWith('v')` is
+    // FALSE (starts with space), the v-prefix strip silently no-ops,
+    // and `Version.TryParse(" v1.2.3 ")` returns false — `IsNewer`
+    // then returns false for every version comparison and the update
+    // banner is permanently hidden with no log signal.
+    //
+    // The risks this pin uniquely catches:
+    //   • Drop Trim — a "simplify" cleanup that inlines the v-prefix
+    //     strip directly on the raw value. Pin assertion is the
+    //     `Version.TryParse` promise that the existing siblings also
+    //     use, so the regression mode is consistent across the family.
+    //   • Reorder steps so Trim happens AFTER v-strip — the v-prefix
+    //     check would no-op on padded input (same failure mode).
+    //
+    // Pin: feed a tag with both leading AND trailing whitespace, the
+    // canonical pre-release v-prefix shape; assert the result parses
+    // to the expected core Version. The whitespace must be on BOTH
+    // sides to catch a `TrimEnd()`-only or `TrimStart()`-only
+    // narrowing regression.
+    [Fact]
+    public void NormalizeVersion_LeadingAndTrailingWhitespace_ProducesAVersionParseableCoreVersion()
+    {
+        var method = typeof(VersionCheckService).GetMethod(
+            "NormalizeVersion",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var normalized = (string)method.Invoke(null, ["  v1.2.3  "]);
+
+        Version.TryParse(normalized, out var parsed).Should().BeTrue();
+        parsed.Should().Be(new Version(1, 2, 3));
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the leading `value.Trim()` step in `VersionCheckService.NormalizeVersion`. The existing sibling pins (SemVerPreReleaseTag, SemVerBuildMetadataTag, NullInput, UppercaseVPrefix) all feed inputs without padding — none exercises this branch.
- Padding is production-real: an `AssemblyInformationalVersionAttribute` can legitimately carry trailing whitespace when a CI build script emits the version via env-var interpolation with a stray newline (a common GitHub Actions gotcha when a secret was set with a trailing newline). Without `Trim`, `" v1.2.3 ".StartsWith('v')` is false, the v-prefix strip silently no-ops, `Version.TryParse(" v1.2.3 ")` returns false, and `IsNewer` returns false for every comparison — the update banner stays permanently hidden with no log signal.
- The whitespace is supplied on BOTH sides so a `TrimEnd`-only or `TrimStart`-only narrowing regression also fails the assertion.

## Code changes

- `tests/Equibles.UnitTests/Web/VersionCheckServiceNormalizeVersionWhitespaceTests.cs` — new unit test. Reflection-invokes the private static `NormalizeVersion` with `"  v1.2.3  "`, asserts the result parses to `new Version(1, 2, 3)` via `Version.TryParse`. Same assertion shape as the existing SemVer pre-release / build-metadata siblings so the family stays consistent.