### PR TITLE
test(errors): pin ErrorManager.Truncate normal-cut arm takes exactly maxLength chars

### DIFF
--- a/tests/Equibles.UnitTests/Errors/ErrorManagerTruncateNoSurrogateAtCutTests.cs
+++ b/tests/Equibles.UnitTests/Errors/ErrorManagerTruncateNoSurrogateAtCutTests.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using Equibles.Errors.BusinessLogic;
+
+namespace Equibles.UnitTests.Errors;
+
+public class ErrorManagerTruncateNoSurrogateAtCutTests
+{
+    // Sibling to ErrorManagerTruncateSurrogatePairTests and TruncateNullTests.
+    // The surrogate sibling pins the step-back arm (when char.IsHighSurrogate
+    // is true at the cut point). The null sibling pins the null guard. Neither
+    // pins the NORMAL truncation path — the common case where the cut point
+    // does NOT split a surrogate pair and the result should be EXACTLY the
+    // first maxLength characters.
+    //
+    // The Truncate ternary:
+    //   var end = char.IsHighSurrogate(value[maxLength - 1]) ? maxLength - 1 : maxLength;
+    // The `: maxLength` arm is what carries every ASCII / BMP truncation in
+    // production (almost every error message and stack trace the worker
+    // generates). A refactor that "added safety" by hard-coding `end =
+    // maxLength - 1` to "always avoid the surrogate risk" would compile
+    // cleanly, pass the surrogate sibling (still steps back), pass the null
+    // sibling (still returns null), and silently shorten EVERY truncated
+    // error message by one character — visible as off-by-one truncation in
+    // the dashboard's recent-errors list, but invisible to the test suite.
+    //
+    // Pin: a pure-ASCII string longer than maxLength produces exactly the
+    // first maxLength characters. The expected result's length is the
+    // adversarial signal — `maxLength - 1` would fail this pin.
+    [Fact]
+    public void Truncate_ValueExceedsMaxLengthWithNoSurrogateAtCut_TakesExactlyMaxLengthCharacters()
+    {
+        var method = typeof(ErrorManager).GetMethod(
+            "Truncate",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (string)method.Invoke(null, ["abcdefghij", 7]);
+
+        result.Should().Be("abcdefg");
+        result.Length.Should().Be(7);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the normal-cut arm of `ErrorManager.Truncate` — the `: maxLength` branch of the surrogate-aware ternary that carries every ASCII / BMP truncation in production (effectively every error message and stack trace the worker stores). The existing surrogate sibling pins the step-back arm; the null sibling pins the null guard; the common-case normal cut was unpinned.
- A "safety" refactor that hard-codes `end = maxLength - 1` (under the false intuition that "always step back avoids the surrogate risk") would compile, pass the surrogate sibling (still steps back), pass the null sibling, and silently shorten EVERY truncated error message by one character — visible as off-by-one truncation in the dashboard's recent-errors list but invisible to the test suite.
- Asserts both the exact content (`"abcdefg"`) AND the length (`7`) of the truncated result, so a `maxLength - 1` regression fails on length and a wrong-substring refactor fails on content.

## Code changes

- `tests/Equibles.UnitTests/Errors/ErrorManagerTruncateNoSurrogateAtCutTests.cs` — new unit test. Reflection-invokes the private static `Truncate("abcdefghij", 7)` and asserts the result equals `"abcdefg"` with length 7.