### PR TITLE
test(sec): pin InsiderTradingFilingProcessor.SanitizeXml decimal numeric entity preservation

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSanitizeXmlDecimalNumericTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSanitizeXmlDecimalNumericTests.cs
@@ -1,0 +1,40 @@
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InsiderTradingFilingProcessorSanitizeXmlDecimalNumericTests
+{
+    // Sibling to InsiderTradingFilingProcessorSanitizeXmlNumericEntityTests
+    // (which pins the HEX numeric character reference branch `&#x..`).
+    // The negative lookahead in the production regex
+    //   @"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)"
+    // protects SIX kinds of well-formed escapes from double-escaping: five
+    // named entities (amp/lt/gt/quot/apos), HEX numeric (`#x[\da-fA-F]+`),
+    // and DECIMAL numeric (`#\d+`). The HEX arm is pinned by the existing
+    // sibling; the DECIMAL arm is unpinned.
+    //
+    // The risk this pin uniquely catches:
+    //   • A "tidy — only hex in practice" cleanup that drops `#\d+` from
+    //     the negative lookahead would compile cleanly, pass the hex pin
+    //     (`&#x4A;` still recognised), and silently double-escape every
+    //     decimal entity in production filings (`&#65;` → `&amp;#65;`).
+    //     The downstream XML parser would then render the literal text
+    //     `&#65;` in the filing body — every dash, smart quote, and
+    //     non-ASCII glyph emitted as a decimal entity by SEC's older
+    //     XBRL pipelines would appear as raw escape text in the
+    //     insider-transactions view.
+    //   • A regex anchor regression (e.g. requiring the entity to start
+    //     a line) — caught by the inline-position assertion shape.
+    //
+    // Pin: an inline decimal numeric entity (`&#65;` = "A") survives a
+    // round-trip through SanitizeXml unchanged. The literal `&` MUST
+    // NOT become `&amp;` (which would be `&amp;#65;`) — that's the
+    // adversarial signal.
+    [Fact]
+    public void SanitizeXml_DecimalNumericCharacterReference_IsPreservedNotDoubleEscaped()
+    {
+        var result = InsiderTradingFilingProcessor.SanitizeXml("<v>&#65;</v>");
+
+        result.Should().Be("<v>&#65;</v>");
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the DECIMAL numeric character reference arm of `InsiderTradingFilingProcessor.SanitizeXml`. The existing `SanitizeXmlNumericEntityTests` sibling covers the HEX arm (`&#x4A;`); the negative lookahead in the production regex `@"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)"` protects SIX entity shapes — the decimal `#\d+` arm was unpinned.
- A "tidy — only hex in practice" cleanup that drops `#\d+` from the lookahead would compile, pass the hex sibling, and silently double-escape every decimal entity in production filings (`&#65;` → `&amp;#65;`). The downstream XML parser would then render the literal escape text in the insider-transactions view — every dash, smart quote, and non-ASCII glyph emitted as a decimal entity by older SEC XBRL pipelines becomes raw escape text in the UI.
- Asserts round-trip identity: `<v>&#65;</v>` survives `SanitizeXml` unchanged. The literal `&` must NOT become `&amp;` — that's the adversarial signal.

## Code changes

- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSanitizeXmlDecimalNumericTests.cs` — new unit test. Calls `InsiderTradingFilingProcessor.SanitizeXml("<v>&#65;</v>")` (the static internal helper) and asserts the result equals the input unchanged.