### PR TITLE
test(sec): pin SecDocumentHtmlNormalizer.ExtractInnerContent missing-open-tag null guard

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerExtractInnerContentMissingOpenTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerExtractInnerContentMissingOpenTests.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentHtmlNormalizerExtractInnerContentMissingOpenTests
+{
+    // Sibling to ExtractInnerContentMissingCloseTests. The MissingClose pin
+    // exercises the close-tag arm of the two early-return null guards:
+    //   if (openIdx == -1) return null;
+    //   ...
+    //   if (closeIdx == -1) return null;
+    // The MissingOpen arm is unpinned. A refactor that drops the
+    // `openIdx == -1` guard would compile cleanly, pass the close-arm
+    // sibling, and silently produce bogus content for blocks that
+    // contain ONLY the close tag (the rare but real SGML corruption case
+    // SEC's older filings produce when an upstream FILER's text editor
+    // truncated their XBRL envelope mid-write). The downstream HTML
+    // normalizer would then ingest arbitrary header text as if it were
+    // XBRL body, polluting the persisted document.
+    //
+    // Pin: a block with the CLOSE tag but no OPEN tag returns null,
+    // not partial content. A regression that drops the open-arm guard
+    // would compute `contentStart = -1 + openTagLen = openTagLen - 1`,
+    // find the closeTag, and return `block.Substring(closeIdx - 5)` —
+    // arbitrary header text. The null assertion fails on that path.
+    [Fact]
+    public void ExtractInnerContent_CloseTagPresentButNoOpenTag_ReturnsNullNotPartialContent()
+    {
+        var method = typeof(SecDocumentHtmlNormalizer).GetMethod(
+            "ExtractInnerContent",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (string)
+            method.Invoke(null, ["junk header data ending in </XBRL> trailing", "XBRL"]);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the open-tag null guard in `SecDocumentHtmlNormalizer.ExtractInnerContent`. The existing sibling `MissingClose` pin exercises the close-tag arm; the open-tag arm of the two early-return null guards was unpinned.
- A refactor that drops the `openIdx == -1` check would compile cleanly, pass the close-arm sibling, and silently produce bogus content for blocks that contain ONLY the close tag — the rare but real SGML corruption case SEC's older filings produce when an upstream filer's text editor truncated the XBRL envelope mid-write. The downstream HTML normalizer would then ingest arbitrary header text as if it were XBRL body.
- A regression that drops the open-arm guard would compute `contentStart = -1 + openTagLen`, find the close tag, and return `block.Substring(closeIdx - 5)` — arbitrary header text. The `null` assertion fails on that path.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerExtractInnerContentMissingOpenTests.cs` — new unit test. Reflection-invokes the private static `ExtractInnerContent("junk header data ending in </XBRL> trailing", "XBRL")` and asserts the result is `null`.