### PR TITLE
test(sec): pin InsiderTradingFilingProcessor.ParseOwnershipNature explicit "D" returns Direct

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseOwnershipNatureDirectTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseOwnershipNatureDirectTests.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using System.Xml.Linq;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InsiderTradingFilingProcessorParseOwnershipNatureDirectTests
+{
+    // Third sibling in the ParseOwnershipNature family (after Absent and
+    // Indirect). The existing siblings cover:
+    //   • Absent element → Direct (fallback arm of the ternary)
+    //   • Explicit "I" value → Indirect (truthy arm)
+    // The Indirect sibling's comment explicitly flags this gap: "A future
+    // iteration could add the explicit 'D' → Direct sibling to round out
+    // the case matrix."
+    //
+    // The risk this pin uniquely catches and that the other two siblings
+    // cannot:
+    //   • Case-sensitivity regression — `value?.ToUpperInvariant() == "I"`.
+    //     The Indirect sibling passes (uppercase "I" still maps to
+    //     Indirect). The Absent sibling passes (no value at all → Direct).
+    //     But lowercase "d" or any non-"I" value would still flow through
+    //     the case-insensitive ToUpperInvariant comparison... hmm, that's
+    //     not quite right. Let me restate:
+    //   • The Absent sibling fires the fallback because the element is
+    //     missing. The Direct case here fires the fallback because the
+    //     value is explicitly "D" and the comparison `"D" == "I"` is
+    //     false. These are STRUCTURALLY DISTINCT — a regression that
+    //     skipped the equality check entirely (`return Direct;` for any
+    //     present element) would pass both Absent and Direct but
+    //     break Indirect. A regression that always returned Indirect
+    //     when the element is present (`return present ? Indirect :
+    //     Direct;`) would pass Absent and Indirect but break this Direct
+    //     pin. The three-pin matrix closes both gaps.
+    //
+    // Construction: minimal transactionElement carrying
+    // `<ownershipNature><directOrIndirectOwnership><value>D</value></...>`
+    // — the SEC Form 4 standard encoding for direct ownership.
+    [Fact]
+    public void ParseOwnershipNature_OwnershipNatureValueD_ReturnsDirect()
+    {
+        var method = typeof(InsiderTradingFilingProcessor).GetMethod(
+            "ParseOwnershipNature",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var transactionElement = new XElement(
+            "nonDerivativeTransaction",
+            new XElement(
+                "ownershipNature",
+                new XElement("directOrIndirectOwnership", new XElement("value", "D"))
+            )
+        );
+
+        var result = (OwnershipNature)method!.Invoke(null, [transactionElement]);
+
+        result.Should().Be(OwnershipNature.Direct);
+    }
+}


### PR DESCRIPTION
## Summary

- Third sibling in the `ParseOwnershipNature` family. The existing Absent sibling covers the fallback arm (no element → Direct) and the Indirect sibling covers the truthy arm ("I" → Indirect). The Indirect sibling's comment explicitly flagged this as the gap: "A future iteration could add the explicit 'D' → Direct sibling to round out the case matrix."
- The three-pin matrix closes both single-branch regressions:
  - "Always Direct when element present" — passes Absent + Direct, fails Indirect.
  - "Always Indirect when element present" — passes Absent + Indirect, fails Direct.
- Construction: minimal transactionElement carrying `<ownershipNature><directOrIndirectOwnership><value>D</value></...>` — the SEC Form 4 standard encoding for direct ownership.

## Code changes

- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseOwnershipNatureDirectTests.cs` — new unit test. Reflection-invokes the private static `ParseOwnershipNature(XElement)` with a transaction element whose `directOrIndirectOwnership/value` is "D"; asserts `OwnershipNature.Direct`.