### PR TITLE
test(sec): pin InsiderTradingFilingProcessor.ParseBool null-safe path returns false

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseBoolNullTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseBoolNullTests.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InsiderTradingFilingProcessorParseBoolNullTests
+{
+    // Sibling to ParseBoolLowercaseTrueTests and ParseBoolWhitespacePaddedTests
+    // (the two existing positive arms). The null-safe-fallback path —
+    // `value?.Trim() is ...` — is unpinned. The `?.` null-conditional short-
+    // circuits a null `value` to `null`, and pattern-matching against the
+    // string literals returns false. The body relies on that elision
+    // entirely; a refactor that dropped the `?.` (e.g. inlined the Trim
+    // call: `value.Trim() is ...`) would NRE on any null upstream input.
+    //
+    // Null is production-real here: ParseBool is invoked on
+    // `ownerRelationship?.Element(...)?.Value` chains. Every missing
+    // `isDirector` / `isOfficer` / `isTenPercentOwner` element flows
+    // through as null. SEC Form 4 omits these elements for officers whose
+    // role doesn't apply (a 10% owner who isn't an officer or director
+    // has only `isTenPercentOwner = true`; the other two elements are
+    // absent). Dropping the `?.` would crash the parser on every such
+    // filing and lose every 10%-owner-only insider's transactions.
+    //
+    // The risks this pin uniquely catches and the two existing siblings
+    // cannot:
+    //   • Drop the `?.` — would NRE on null; siblings pass non-null.
+    //   • Inversion (`return value?.Trim() is not (...)`) — siblings
+    //     would FAIL (positive cases) but the inversion regression also
+    //     causes null → true, the assertion here catches it.
+    //   • A "tighten" refactor that adds `?? string.Empty` would pass
+    //     this pin (null → "" → no match → false) without exposing a
+    //     defensive shift in convention.
+    //
+    // Pin: ParseBool(null) returns false.
+    [Fact]
+    public void ParseBool_NullInput_ReturnsFalseWithoutThrowing()
+    {
+        var method = typeof(InsiderTradingFilingProcessor).GetMethod(
+            "ParseBool",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        bool result = false;
+        var act = () => result = (bool)method.Invoke(null, [null]);
+
+        act.Should().NotThrow();
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the null-safe-fallback path of `InsiderTradingFilingProcessor.ParseBool`. The two existing siblings (`ParseBoolLowercaseTrueTests`, `ParseBoolWhitespacePaddedTests`) cover positive arms with non-null inputs; the `value?.Trim() is ...` null-conditional short-circuit was unpinned.
- Null is production-real: ParseBool is invoked on `ownerRelationship?.Element(...)?.Value` chains. SEC Form 4 omits `isDirector` / `isOfficer` / `isTenPercentOwner` elements when the role doesn't apply (e.g. a 10%-owner-only insider has only `isTenPercentOwner = true`; the other two flow through as null). A refactor that drops the `?.` (`value.Trim() is ...`) would NRE on every such filing and lose every 10%-owner-only insider's transactions.
- Asserts both no-throw AND the false result — catches both the dropped `?.` regression and any inversion regression.

## Code changes

- `tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseBoolNullTests.cs` — new unit test. Reflection-invokes the private static `ParseBool(null)`, asserts no throw and result is `false`.