### PR TITLE
fix(holdings): make snapshot rebuild race-free and guard first-boot backfill

### DIFF
--- a/src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs
+++ b/src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs
@@ -15,10 +15,11 @@ namespace Equibles.Holdings.HostedService;
 /// to a transient bus failure, or a snapshot row missed during a bulk
 /// historical replay, gets reconciled within 24h.
 ///
-/// On first boot (snapshot tables empty but the holdings table is not), the
-/// worker performs a one-off backfill of every existing quarter with an
-/// extended <c>CommandTimeout</c> for the initial pass — afterwards the
-/// per-quarter work is small enough that the default timeout is fine.
+/// On boot, the worker runs a one-off backfill with an extended
+/// <c>CommandTimeout</c> whenever the snapshot tables don't yet cover every
+/// quarter present in the holdings table. The naive "snapshot tables empty"
+/// gate this replaced lost the backfill whenever the realtime consumer beat
+/// the worker to inserting the first row.
 /// </summary>
 public class AumSnapshotRebuildWorker : BackgroundService
 {
@@ -57,7 +58,25 @@ public class AumSnapshotRebuildWorker : BackgroundService
             }
         }
 
-        await TryBackfillIfEmpty(stoppingToken);
+        // A throw out of TryBackfillIfNeeded propagates out of ExecuteAsync —
+        // BackgroundService treats that as fatal and shuts the worker down
+        // for the process lifetime. Catch everything except cancellation so a
+        // transient DB hiccup at boot time doesn't kill the safety-net.
+        try
+        {
+            await TryBackfillIfNeeded(stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "AUM snapshot first-boot backfill failed; daily safety-net will retry full rebuild on each cycle"
+            );
+        }
 
         while (!stoppingToken.IsCancellationRequested)
         {
@@ -89,27 +108,33 @@ public class AumSnapshotRebuildWorker : BackgroundService
         }
     }
 
-    private async Task TryBackfillIfEmpty(CancellationToken cancellationToken)
+    private async Task TryBackfillIfNeeded(CancellationToken cancellationToken)
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
 
-        var snapshotsExist = await dbContext
-            .Set<AumQuarterlySnapshot>()
-            .AnyAsync(cancellationToken);
-        if (snapshotsExist)
+        var holdingQuarters = await dbContext
+            .Set<InstitutionalHolding>()
+            .Select(h => h.ReportDate)
+            .Distinct()
+            .CountAsync(cancellationToken);
+        if (holdingQuarters == 0)
         {
             return;
         }
 
-        var hasHoldings = await dbContext.Set<InstitutionalHolding>().AnyAsync(cancellationToken);
-        if (!hasHoldings)
+        var snapshotQuarters = await dbContext
+            .Set<AumQuarterlySnapshot>()
+            .CountAsync(cancellationToken);
+        if (snapshotQuarters >= holdingQuarters)
         {
             return;
         }
 
         _logger.LogInformation(
-            "AUM snapshot tables are empty but holdings exist — running one-off backfill with {Timeout}s command timeout",
+            "AUM snapshot coverage incomplete ({Snapshots}/{Holdings} quarters) — running backfill with {Timeout}s command timeout",
+            snapshotQuarters,
+            holdingQuarters,
             BackfillCommandTimeout.TotalSeconds
         );
 

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -3,7 +3,7 @@ using Equibles.CommonStocks.Data.Models.Taxonomies;
 using Equibles.Core.AutoWiring;
 using Equibles.Data;
 using Equibles.Holdings.Data.Models;
-using Equibles.Holdings.Repositories;
+using FlexLabs.EntityFrameworkCore.Upsert;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Holdings.HostedService.Services;
@@ -24,8 +24,16 @@ namespace Equibles.Holdings.HostedService.Services;
 ///     by the event-driven path on each 13F import.</item>
 ///   <item><c>RebuildAllAsync</c> — enumerates distinct ReportDate values and
 ///     rebuilds each in its own DbContext scope; called by the daily
-///     safety-net job and the one-time first-boot backfill.</item>
+///     safety-net job and the one-time first-boot backfill. Each quarter is
+///     wrapped in its own try/catch so a single bad quarter (e.g. a unique-
+///     key collision from a parallel consumer rebuild) doesn't abort the
+///     whole pass.</item>
 /// </list>
+///
+/// Writes go through FlexLabs <c>UpsertRange</c> (single <c>INSERT … ON
+/// CONFLICT</c>) and <c>ExecuteDeleteAsync</c> (single <c>DELETE</c>) so the
+/// consumer and the safety-net worker can rebuild the same ReportDate
+/// concurrently without a TOCTOU race between "load existing → mutate → save".
 /// </summary>
 [Service]
 public class HoldingsAggregateRefreshService
@@ -86,15 +94,45 @@ public class HoldingsAggregateRefreshService
             reportDates.Count
         );
 
+        var failed = 0;
         foreach (var reportDate in reportDates)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await using var scope = _scopeFactory.CreateAsyncScope();
-            await RebuildQuarterInScope(
-                scope.ServiceProvider,
-                reportDate,
-                commandTimeout,
-                cancellationToken
+            try
+            {
+                await using var scope = _scopeFactory.CreateAsyncScope();
+                await RebuildQuarterInScope(
+                    scope.ServiceProvider,
+                    reportDate,
+                    commandTimeout,
+                    cancellationToken
+                );
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Defence in depth on top of the race-free upsert path. If one
+                // quarter throws (transient DB failure, schema drift, etc.),
+                // log and keep going — the rest of the snapshot table is still
+                // worth refreshing this cycle.
+                failed++;
+                _logger.LogError(
+                    ex,
+                    "Failed to rebuild holdings aggregate snapshot for {ReportDate}; continuing with remaining quarters",
+                    reportDate
+                );
+            }
+        }
+
+        if (failed > 0)
+        {
+            _logger.LogWarning(
+                "Holdings aggregate snapshot rebuild finished with {Failed}/{Total} quarter(s) failed",
+                failed,
+                reportDates.Count
             );
         }
     }
@@ -111,16 +149,13 @@ public class HoldingsAggregateRefreshService
         {
             dbContext.Database.SetCommandTimeout(commandTimeout.Value);
         }
-        var aumRepo = services.GetRequiredService<AumQuarterlySnapshotRepository>();
-        var sectorRepo = services.GetRequiredService<SectorQuarterlySnapshotRepository>();
 
-        await UpsertAumSnapshot(dbContext, aumRepo, reportDate, cancellationToken);
-        await UpsertSectorSnapshots(dbContext, sectorRepo, reportDate, cancellationToken);
+        await UpsertAumSnapshot(dbContext, reportDate, cancellationToken);
+        await UpsertSectorSnapshots(dbContext, reportDate, cancellationToken);
     }
 
-    private async Task UpsertAumSnapshot(
+    private static async Task UpsertAumSnapshot(
         EquiblesFinancialDbContext dbContext,
-        AumQuarterlySnapshotRepository aumRepo,
         DateOnly reportDate,
         CancellationToken cancellationToken
     )
@@ -143,54 +178,52 @@ public class HoldingsAggregateRefreshService
             })
             .FirstOrDefaultAsync(cancellationToken);
 
-        var existing = await aumRepo
-            .GetAll()
-            .FirstOrDefaultAsync(s => s.ReportDate == reportDate, cancellationToken);
-
         if (aggregate is null)
         {
             // Quarter exists only in the snapshot table now (e.g. all holdings
             // for it were deleted). Drop the stale row so /stats and /trends
             // don't keep reporting phantom AUM for a now-empty quarter.
-            if (existing is not null)
-            {
-                aumRepo.Delete(existing);
-                await aumRepo.SaveChanges();
-            }
+            await dbContext
+                .Set<AumQuarterlySnapshot>()
+                .Where(s => s.ReportDate == reportDate)
+                .ExecuteDeleteAsync(cancellationToken);
             return;
         }
 
-        if (existing is null)
+        var snapshot = new AumQuarterlySnapshot
         {
-            aumRepo.Add(
-                new AumQuarterlySnapshot
-                {
-                    ReportDate = reportDate,
-                    TotalValue = aggregate.TotalValue,
-                    FilerCount = aggregate.FilerCount,
-                    PositionCount = aggregate.PositionCount,
-                    StockCount = aggregate.StockCount,
-                    FilingCount = aggregate.FilingCount,
-                    ComputedAt = DateTime.UtcNow,
-                }
-            );
-        }
-        else
-        {
-            existing.TotalValue = aggregate.TotalValue;
-            existing.FilerCount = aggregate.FilerCount;
-            existing.PositionCount = aggregate.PositionCount;
-            existing.StockCount = aggregate.StockCount;
-            existing.FilingCount = aggregate.FilingCount;
-            existing.ComputedAt = DateTime.UtcNow;
-        }
+            ReportDate = reportDate,
+            TotalValue = aggregate.TotalValue,
+            FilerCount = aggregate.FilerCount,
+            PositionCount = aggregate.PositionCount,
+            StockCount = aggregate.StockCount,
+            FilingCount = aggregate.FilingCount,
+            ComputedAt = DateTime.UtcNow,
+        };
 
-        await aumRepo.SaveChanges();
+        // Single INSERT … ON CONFLICT (ReportDate) DO UPDATE …
+        // Race-free against a parallel rebuild for the same quarter.
+        await dbContext
+            .Set<AumQuarterlySnapshot>()
+            .UpsertRange(snapshot)
+            .On(s => s.ReportDate)
+            .WhenMatched(
+                (_, incoming) =>
+                    new AumQuarterlySnapshot
+                    {
+                        TotalValue = incoming.TotalValue,
+                        FilerCount = incoming.FilerCount,
+                        PositionCount = incoming.PositionCount,
+                        StockCount = incoming.StockCount,
+                        FilingCount = incoming.FilingCount,
+                        ComputedAt = incoming.ComputedAt,
+                    }
+            )
+            .RunAsync(cancellationToken);
     }
 
-    private async Task UpsertSectorSnapshots(
+    private static async Task UpsertSectorSnapshots(
         EquiblesFinancialDbContext dbContext,
-        SectorQuarterlySnapshotRepository sectorRepo,
         DateOnly reportDate,
         CancellationToken cancellationToken
     )
@@ -230,45 +263,47 @@ public class HoldingsAggregateRefreshService
             )
             .ToListAsync(cancellationToken);
 
-        var existing = await sectorRepo
-            .GetAll()
-            .Where(s => s.ReportDate == reportDate)
-            .ToListAsync(cancellationToken);
+        var computedAt = DateTime.UtcNow;
+        var snapshots = rows.Select(r => new SectorQuarterlySnapshot
+            {
+                ReportDate = reportDate,
+                SectorId = r.SectorId,
+                SectorName = r.SectorName,
+                TotalValue = r.TotalValue,
+                ComputedAt = computedAt,
+            })
+            .ToList();
 
-        var existingBySector = existing.ToDictionary(s => s.SectorId);
-        var seen = new HashSet<Guid>();
-
-        foreach (var row in rows)
+        if (snapshots.Count > 0)
         {
-            seen.Add(row.SectorId);
-            if (existingBySector.TryGetValue(row.SectorId, out var current))
-            {
-                current.SectorName = row.SectorName;
-                current.TotalValue = row.TotalValue;
-                current.ComputedAt = DateTime.UtcNow;
-            }
-            else
-            {
-                sectorRepo.Add(
-                    new SectorQuarterlySnapshot
-                    {
-                        ReportDate = reportDate,
-                        SectorId = row.SectorId,
-                        SectorName = row.SectorName,
-                        TotalValue = row.TotalValue,
-                        ComputedAt = DateTime.UtcNow,
-                    }
-                );
-            }
+            // Single INSERT … ON CONFLICT (ReportDate, SectorId) DO UPDATE …
+            // for the whole batch. Race-free against a parallel rebuild.
+            await dbContext
+                .Set<SectorQuarterlySnapshot>()
+                .UpsertRange(snapshots)
+                .On(s => new { s.ReportDate, s.SectorId })
+                .WhenMatched(
+                    (_, incoming) =>
+                        new SectorQuarterlySnapshot
+                        {
+                            SectorName = incoming.SectorName,
+                            TotalValue = incoming.TotalValue,
+                            ComputedAt = incoming.ComputedAt,
+                        }
+                )
+                .RunAsync(cancellationToken);
         }
 
         // Sectors that no longer have positions for this quarter — drop them
-        // so /trends doesn't render a chart line for an empty allocation.
-        foreach (var stale in existing.Where(s => !seen.Contains(s.SectorId)))
-        {
-            sectorRepo.Delete(stale);
-        }
-
-        await sectorRepo.SaveChanges();
+        // so /trends doesn't render a chart line for an empty allocation. A
+        // single DELETE … WHERE … NOT IN (…) removes the race window that the
+        // previous load-then-delete had. When `snapshots` is empty (the
+        // quarter has no remaining sector exposure), this collapses to
+        // "delete every sector row for this quarter".
+        var currentSectorIds = snapshots.Select(s => s.SectorId).ToList();
+        await dbContext
+            .Set<SectorQuarterlySnapshot>()
+            .Where(s => s.ReportDate == reportDate && !currentSectorIds.Contains(s.SectorId))
+            .ExecuteDeleteAsync(cancellationToken);
     }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs
@@ -122,6 +122,62 @@ public class AumSnapshotRebuildWorkerTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ExecuteAsync_PartialSnapshotCoverage_BackfillsMissingQuarters()
+    {
+        // The realtime consumer can beat the worker to inserting a snapshot
+        // row for the current quarter. The naive "snapshot table empty" gate
+        // would skip the historical backfill in that case. With the coverage
+        // check, the worker sees one snapshot covering two holding quarters
+        // and runs the backfill anyway, picking up the missing quarter.
+        await SeedTwoQuarters();
+        await using (var seed = FreshContext())
+        {
+            seed.Add(
+                new AumQuarterlySnapshot
+                {
+                    ReportDate = Q4,
+                    TotalValue = 999_999_999, // sentinel — must get overwritten
+                    FilerCount = 99,
+                    PositionCount = 99,
+                    StockCount = 99,
+                    FilingCount = 99,
+                }
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = ScopeFactory();
+        var refreshService = new HoldingsAggregateRefreshService(
+            scopeFactory,
+            NullLogger<HoldingsAggregateRefreshService>.Instance
+        );
+        var worker = new InstantTickWorker(scopeFactory, refreshService);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var run = worker.StartAsync(cts.Token);
+        await Task.Delay(TimeSpan.FromMilliseconds(500), cts.Token);
+        await cts.CancelAsync();
+        try
+        {
+            await run;
+        }
+        catch (OperationCanceledException) { }
+
+        await using var read = FreshContext();
+        var snapshots = await read.Set<AumQuarterlySnapshot>()
+            .OrderBy(s => s.ReportDate)
+            .ToListAsync();
+
+        snapshots.Should().HaveCount(2);
+        snapshots[0].ReportDate.Should().Be(Q3);
+        snapshots[0].TotalValue.Should().Be(100_000);
+        snapshots[1].ReportDate.Should().Be(Q4);
+        snapshots[1]
+            .TotalValue.Should()
+            .Be(200_000, "the sentinel row must be overwritten by the rebuild");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_NoHoldings_DoesNotCreatePhantomSnapshotRows()
     {
         // No holdings seeded — the worker should not invent rows out of nothing.

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceTests.cs
@@ -189,6 +189,37 @@ public class HoldingsAggregateRefreshServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RebuildQuarterAsync_ConcurrentRebuildsForSameQuarter_BothSucceed()
+    {
+        // The consumer (event-driven path) and the safety-net worker can race
+        // to rebuild the same ReportDate. The write path must be race-free —
+        // load-then-mutate would let both observe "row missing", both insert,
+        // and the second SaveChanges would hit the PK / composite-PK
+        // violation. UpsertRange + ExecuteDelete are single statements so
+        // both calls land cleanly and the final state is consistent.
+        await using var seed = FreshContext();
+        var tech = await SeedSector(seed, "Technology");
+        var industry = await SeedIndustry(seed, "Software", tech.Id);
+        var aapl = await SeedStock(seed, "AAPL", industry.Id);
+        var holder = await SeedHolder(seed, "H001");
+        seed.AddRange(MakeHolding(aapl, holder, Q4, 100_000, "acc-q4"));
+        await seed.SaveChangesAsync();
+
+        var service = BuildService();
+        var first = service.RebuildQuarterAsync(Q4, CancellationToken.None);
+        var second = service.RebuildQuarterAsync(Q4, CancellationToken.None);
+
+        await Task.WhenAll(first, second);
+
+        await using var read = FreshContext();
+        var rows = await read.Set<AumQuarterlySnapshot>()
+            .Where(s => s.ReportDate == Q4)
+            .ToListAsync();
+        rows.Should().ContainSingle();
+        rows[0].TotalValue.Should().Be(100_000);
+    }
+
+    [Fact]
     public async Task RebuildAllAsync_RebuildsEveryDistinctReportDate()
     {
         await using var seed = FreshContext();


### PR DESCRIPTION
## Summary

Follow-up fixes for #2458 surfaced by code review of the merged implementation. Three changes, no behaviour change for the steady-state happy path; closes three runtime-window failure modes.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs` — snapshot writes now go through FlexLabs `UpsertRange` (single `INSERT … ON CONFLICT`) and stale sector rows through `ExecuteDeleteAsync` (single `DELETE`). The previous load-then-mutate path was TOCTOU-racy when the realtime consumer and the daily safety-net rebuilt the same `ReportDate` concurrently — both would observe "row missing", both `Add()`, and the second `SaveChanges` would hit the `(ReportDate)` / `(ReportDate, SectorId)` PK violation. Also wraps each per-quarter call inside `RebuildAllAsync` in its own try/catch, so one bad quarter (transient DB failure, schema drift) doesn't abort the rest of the safety-net pass.
- `src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs` — guards the first-boot backfill with a try/catch. A throw used to propagate out of `ExecuteAsync`, which `BackgroundService` treats as fatal and never reinstates for the process lifetime. Also replaces the "snapshot table empty" gate with a coverage check (`snapshot count < distinct holding quarters`) — the old gate lost the historical backfill whenever the realtime consumer beat the worker to inserting the first row.
- `tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceTests.cs` — adds `RebuildQuarterAsync_ConcurrentRebuildsForSameQuarter_BothSucceed` to pin the race-free contract.
- `tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs` — adds `ExecuteAsync_PartialSnapshotCoverage_BackfillsMissingQuarters` to pin the new coverage-based gate; sentinel-row trick proves the rebuild actually overwrites the partial row.