### PR TITLE
feat(web): switch global search shortcut from / to Cmd/Ctrl+K

### DIFF
--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -75,9 +75,9 @@
                         <input id="navbar-search-input" type="search" name="q" value="@activeSearchQuery"
                                class="input input-sm input-bordered join-item w-48 xl:w-64"
                                placeholder="Search..." aria-label="Search everything"
-                               aria-keyshortcuts="/" />
+                               aria-keyshortcuts="Control+K Meta+K" />
                         <button type="submit" class="btn btn-sm btn-primary join-item"
-                                aria-label="Search" title="Search">
+                                aria-label="Search" title="Search (Cmd/Ctrl+K)">
                             <icon name="magnifying-glass" size="4" />
                         </button>
                     </div>

--- a/src/Equibles.Web/src/js/global-search-shortcut.js
+++ b/src/Equibles.Web/src/js/global-search-shortcut.js
@@ -1,20 +1,22 @@
-// Global "/" search shortcut — focus the navbar search box from anywhere on the site,
-// so the user can start a search without reaching for the mouse on any page.
+// Global Cmd/Ctrl+K search shortcut — focuses the navbar search box from anywhere
+// on the site, matching the convention used by GitHub / Linear / Vercel and the
+// commercial portal.
 //
-// The /Search page has its own richer keyboard handling (search-keyboard.js, which also
-// owns "/" there and adds result navigation). To avoid two "/" handlers fighting, this
-// module stays out of the way whenever that page's form is present.
+// The /Search page has its own richer keyboard handling (search-keyboard.js, which
+// also owns the shortcut there and adds result navigation). To avoid two handlers
+// fighting, this module stays out of the way whenever that page's form is present.
 
 (() => {
     const input = document.getElementById('navbar-search-input');
     if (!input || document.getElementById('global-search-form')) return;
 
-    // "/" focuses search — unless the user is already typing in a field.
+    // Cmd+K (macOS) / Ctrl+K (other) focuses search from anywhere — including
+    // from inside another input. The modifier keeps the binding unambiguous,
+    // so we don't have to suppress it while the user is typing elsewhere.
     document.addEventListener('keydown', (e) => {
-        if (e.key !== '/') return;
-        const tag = document.activeElement?.tagName;
-        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
-            || document.activeElement?.isContentEditable) return;
+        if (e.key.toLowerCase() !== 'k') return;
+        if (!(e.metaKey || e.ctrlKey)) return;
+        if (e.shiftKey || e.altKey) return;
         e.preventDefault();
         input.focus();
         input.select();

--- a/src/Equibles.Web/src/js/search-keyboard.js
+++ b/src/Equibles.Web/src/js/search-keyboard.js
@@ -1,5 +1,5 @@
 // Search keyboard navigation — makes the search usable without the mouse:
-//   "/"            focus the search box from anywhere on the page
+//   Cmd/Ctrl+K     focus the search box from anywhere on the page
 //   ArrowDown/Up   move a highlight through the rendered result links
 //   Enter          open the highlighted result (falls back to normal submit)
 //   Escape         clear the query
@@ -47,12 +47,12 @@
         if (el.id) input.setAttribute('aria-activedescendant', el.id);
     }
 
-    // "/" focuses search — unless the user is already typing in a field.
+    // Cmd+K (macOS) / Ctrl+K (other) focuses search from anywhere — including
+    // from inside another input. The modifier keeps the binding unambiguous.
     document.addEventListener('keydown', (e) => {
-        if (e.key !== '/') return;
-        const tag = document.activeElement?.tagName;
-        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
-            || document.activeElement?.isContentEditable) return;
+        if (e.key.toLowerCase() !== 'k') return;
+        if (!(e.metaKey || e.ctrlKey)) return;
+        if (e.shiftKey || e.altKey) return;
         e.preventDefault();
         input.focus();
         input.select();


### PR DESCRIPTION
## Summary

- Switches the navbar search shortcut from `/` to `Cmd/Ctrl+K`, matching the commercial portal and the convention used by GitHub / Linear / Vercel.
- The modifier keeps the binding unambiguous, so the new shortcut works from inside another input — no need to suppress it while the user is typing elsewhere.
- Updates the `aria-keyshortcuts` attribute on the navbar search input so screen readers announce the new binding correctly.

## Code changes

- `src/Equibles.Web/src/js/global-search-shortcut.js` — listen for `Cmd+K` / `Ctrl+K` (lowercase-safe), preventDefault, focus + select the navbar input. Bail on Shift/Alt to avoid hijacking other Cmd+K combos.
- `src/Equibles.Web/src/js/search-keyboard.js` — same `Cmd/Ctrl+K` binding on `/Search` (keeps result-navigation keys on the input unchanged).
- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — `aria-keyshortcuts="Control+K Meta+K"`; button title updated to "Search (Cmd/Ctrl+K)".