### PR TITLE
feat(insider-trading): flag implausible per-share prices via Yahoo cross-check

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -155,6 +155,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Sec.FinancialFacts
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Sec.FinancialFacts.BusinessLogic", "src\Equibles.Sec.FinancialFacts.BusinessLogic\Equibles.Sec.FinancialFacts.BusinessLogic.csproj", "{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.InsiderTrading.BusinessLogic", "src\Equibles.InsiderTrading.BusinessLogic\Equibles.InsiderTrading.BusinessLogic.csproj", "{77F0FC50-E234-49F3-9A43-46253DE68A0F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1053,6 +1055,18 @@ Global
 		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Release|x64.Build.0 = Release|Any CPU
 		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Release|x86.ActiveCfg = Release|Any CPU
 		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796}.Release|x86.Build.0 = Release|Any CPU
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Debug|x64.Build.0 = Debug|Any CPU
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Debug|x86.Build.0 = Debug|Any CPU
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Release|x64.ActiveCfg = Release|Any CPU
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Release|x64.Build.0 = Release|Any CPU
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Release|x86.ActiveCfg = Release|Any CPU
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1132,6 +1146,7 @@ Global
 		{A15FB700-5BF7-4284-B695-FE04E80D258F} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{2E08AC17-1840-4BBE-A914-6133F83BB43B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{77F0FC50-E234-49F3-9A43-46253DE68A0F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.InsiderTrading.BusinessLogic/Equibles.InsiderTrading.BusinessLogic.csproj
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Equibles.InsiderTrading.BusinessLogic.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <InternalsVisibleTo Include="Equibles.UnitTests" />
+    <InternalsVisibleTo Include="Equibles.IntegrationTests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Equibles.Core.AutoWiring" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.InsiderTrading.Repositories\Equibles.InsiderTrading.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Yahoo.Repositories\Equibles.Yahoo.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
@@ -1,0 +1,174 @@
+using Equibles.Core.AutoWiring;
+using Equibles.Data;
+using Equibles.InsiderTrading.BusinessLogic.Models;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.InsiderTrading.BusinessLogic;
+
+/// <summary>
+/// One-off recompute of <see cref="InsiderTransaction.IsPriceValid"/> across
+/// every row. Cross-checks the filer-reported <c>PricePerShare</c> against
+/// the Yahoo unadjusted close on the transaction date (most recent prior
+/// trading day if the transaction date fell on a weekend / holiday) and
+/// flips the flag according to <see cref="InsiderTransactionPriceValidator"/>.
+///
+/// Triggered from the backoffice maintenance dashboard after a parser fix
+/// lands. Idempotent and re-entrant — safe to click again. Iterates in
+/// batches with a progress callback so the UI can show an SSE-driven bar.
+/// </summary>
+[Service]
+public class InsiderTransactionPriceBackfillManager
+{
+    private const int BatchSize = 1000;
+
+    /// <summary>
+    /// How far back to look from the earliest TransactionDate in a batch
+    /// when fetching candidate closes. Long enough to skip the longest
+    /// real holiday run (Thanksgiving week + adjacent weekends ≈ 5
+    /// trading-day gap; 10 calendar days is comfortably above that).
+    /// </summary>
+    private const int CloseLookbackDays = 10;
+
+    private readonly InsiderTransactionRepository _transactionRepository;
+    private readonly DailyStockPriceRepository _dailyStockPriceRepository;
+    private readonly InsiderTransactionPriceValidator _validator;
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly ILogger<InsiderTransactionPriceBackfillManager> _logger;
+
+    public InsiderTransactionPriceBackfillManager(
+        InsiderTransactionRepository transactionRepository,
+        DailyStockPriceRepository dailyStockPriceRepository,
+        InsiderTransactionPriceValidator validator,
+        EquiblesFinancialDbContext dbContext,
+        ILogger<InsiderTransactionPriceBackfillManager> logger
+    )
+    {
+        _transactionRepository = transactionRepository;
+        _dailyStockPriceRepository = dailyStockPriceRepository;
+        _validator = validator;
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<InsiderTransactionPriceBackfillResult> Run(
+        Func<InsiderTransactionPriceBackfillResult, Task> onProgress = null
+    )
+    {
+        var result = new InsiderTransactionPriceBackfillResult
+        {
+            Total = await _transactionRepository.GetAll().CountAsync(),
+        };
+
+        if (result.Total == 0)
+            return result;
+
+        _dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
+
+        // Skip/Take pagination is safe here because IsPriceValid is the only
+        // mutated column — row ordering by Id is stable across batches.
+        while (result.Processed < result.Total)
+        {
+            var batch = await _transactionRepository
+                .GetAll()
+                .OrderBy(t => t.Id)
+                .Skip(result.Processed)
+                .Take(BatchSize)
+                .ToListAsync();
+
+            if (batch.Count == 0)
+                break;
+
+            var closes = await FetchCloses(batch);
+
+            foreach (var transaction in batch)
+            {
+                var key = (transaction.CommonStockId, transaction.TransactionDate);
+                decimal? close = closes.TryGetValue(key, out var value) ? value : null;
+
+                var wasValid = transaction.IsPriceValid;
+                var nowValid = _validator.IsPlausible(
+                    transaction.PricePerShare,
+                    transaction.SecurityTitle,
+                    close
+                );
+
+                if (wasValid != nowValid)
+                {
+                    transaction.IsPriceValid = nowValid;
+                }
+                if (!nowValid)
+                    result.MarkedInvalid++;
+                else
+                    result.MarkedValid++;
+            }
+
+            await _transactionRepository.SaveChanges();
+            result.Processed += batch.Count;
+
+            _logger.LogInformation(
+                "Insider price backfill: processed {Processed}/{Total}, invalid={Invalid}",
+                result.Processed,
+                result.Total,
+                result.MarkedInvalid
+            );
+
+            if (onProgress != null)
+                await onProgress(result);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Fetch one close per distinct (CommonStockId, TransactionDate) — the
+    /// most recent <see cref="DailyStockPrice.Close"/> on or before that
+    /// date. Uses the unadjusted Close, never AdjustedClose: a reverse
+    /// split between the transaction date and today would otherwise shift
+    /// the historical adjusted close away from the raw price the filer
+    /// reported and produce false rejections.
+    /// </summary>
+    private async Task<Dictionary<(Guid, DateOnly), decimal>> FetchCloses(
+        List<InsiderTransaction> batch
+    )
+    {
+        var stockIds = batch.Select(t => t.CommonStockId).Distinct().ToList();
+        var maxDate = batch.Max(t => t.TransactionDate);
+        var minDate = batch.Min(t => t.TransactionDate).AddDays(-CloseLookbackDays);
+
+        var rawPrices = await _dailyStockPriceRepository
+            .GetAll()
+            .Where(p =>
+                stockIds.Contains(p.CommonStockId) && p.Date >= minDate && p.Date <= maxDate
+            )
+            .Select(p => new
+            {
+                p.CommonStockId,
+                p.Date,
+                p.Close,
+            })
+            .ToListAsync();
+
+        var byStock = rawPrices
+            .GroupBy(p => p.CommonStockId)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(p => p.Date).ToList());
+
+        var result = new Dictionary<(Guid, DateOnly), decimal>();
+        foreach (var transaction in batch)
+        {
+            var key = (transaction.CommonStockId, transaction.TransactionDate);
+            if (result.ContainsKey(key))
+                continue;
+            if (!byStock.TryGetValue(transaction.CommonStockId, out var stockPrices))
+                continue;
+            var match = stockPrices.FirstOrDefault(p => p.Date <= transaction.TransactionDate);
+            if (match != null)
+                result[key] = match.Close;
+        }
+        return result;
+    }
+}

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
@@ -1,0 +1,76 @@
+using Equibles.Core.AutoWiring;
+
+namespace Equibles.InsiderTrading.BusinessLogic;
+
+/// <summary>
+/// Decides whether an InsiderTransaction's reported per-share price is
+/// plausible. Catches the recurring filer-error class where a Form 4 filer
+/// types the total transaction value into <c>transactionPricePerShare</c>
+/// (a per-share field), which then explodes the dashboard's Shares × Price
+/// sort into nonsense numbers (trillions, quadrillions).
+///
+/// Stateless and pure — the close price is passed in by the caller. Lookup
+/// is done by callers that have repository access (parser at ingest time;
+/// backfill manager during one-off recomputes).
+/// </summary>
+[Service]
+public class InsiderTransactionPriceValidator
+{
+    /// <summary>
+    /// Reject when the reported per-share price exceeds the unadjusted close
+    /// by more than this multiple. Real intraday spreads vs. close are well
+    /// under 2×; common stocks above $100k/share don't exist outside BRK.A;
+    /// 10× is a generous ceiling that still catches the actual failure mode
+    /// (per-share field containing the total dollar value, which is
+    /// Shares × close = thousands of times the unit price).
+    /// </summary>
+    public const decimal MaxPriceToCloseMultiplier = 10m;
+
+    private static readonly string[] DerivativeTitleKeywords =
+    {
+        "option",
+        "warrant",
+        "right to buy",
+        "right to sell",
+        "convertible",
+    };
+
+    public bool IsPlausible(decimal pricePerShare, string securityTitle, decimal? unadjustedClose)
+    {
+        // Holdings (Form 3 sentinels) and post-transaction-only rows report
+        // 0 price by design — not a real per-share price to validate.
+        if (pricePerShare == 0m)
+            return true;
+
+        // Negative is nonsense but not what we're hunting; leave alone.
+        if (pricePerShare < 0m)
+            return true;
+
+        // Derivative rows carry the derivative instrument's own price, which
+        // can legitimately diverge from the underlying close (e.g. an option
+        // strike or a deeply OTM warrant). The dashboard sort weighs them
+        // equally so they can produce surprising values, but the validation
+        // rule (10× close) doesn't apply.
+        if (IsDerivativeSecurity(securityTitle))
+            return true;
+
+        // No close on file (delisted, brand-new IPO, foreign listing not in
+        // the Yahoo feed). Can't validate — don't penalize.
+        if (!unadjustedClose.HasValue || unadjustedClose.Value <= 0m)
+            return true;
+
+        return pricePerShare <= unadjustedClose.Value * MaxPriceToCloseMultiplier;
+    }
+
+    private static bool IsDerivativeSecurity(string securityTitle)
+    {
+        if (string.IsNullOrWhiteSpace(securityTitle))
+            return false;
+        foreach (var keyword in DerivativeTitleKeywords)
+        {
+            if (securityTitle.Contains(keyword, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderTransactionPriceBackfillResult.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderTransactionPriceBackfillResult.cs
@@ -1,0 +1,16 @@
+namespace Equibles.InsiderTrading.BusinessLogic.Models;
+
+public class InsiderTransactionPriceBackfillResult
+{
+    public int Total { get; set; }
+    public int Processed { get; set; }
+    public int MarkedInvalid { get; set; }
+    public int MarkedValid { get; set; }
+
+    public string Summary =>
+        Total == 0
+            ? "No insider transactions to scan."
+            : $"Scanned {Processed}/{Total} transactions. "
+                + $"Marked invalid: {MarkedInvalid}. "
+                + $"Marked valid: {MarkedValid}.";
+}

--- a/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
+++ b/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
@@ -8,6 +8,14 @@ public class InsiderTradingModuleConfiguration : Equibles.Data.IFinancialModule
     public void ConfigureEntities(ModelBuilder builder)
     {
         builder.Entity<InsiderOwner>();
-        builder.Entity<InsiderTransaction>();
+        builder.Entity<InsiderTransaction>(entity =>
+        {
+            // SQL DEFAULT true so the column add doesn't backfill existing
+            // rows to false (which would hide every old row from the
+            // dashboard until the maintenance backfill runs). The parser
+            // explicitly sets this on new rows, so the default only ever
+            // applies to legacy data and to manually-inserted rows.
+            entity.Property(t => t.IsPriceValid).HasDefaultValue(true);
+        });
     }
 }

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -9,6 +9,7 @@ namespace Equibles.InsiderTrading.Data.Models;
 [Index(nameof(AccessionNumber), nameof(TransactionOrder), IsUnique = true)]
 [Index(nameof(FilingDate))]
 [Index(nameof(TransactionDate))]
+[Index(nameof(IsPriceValid), nameof(TransactionDate))]
 public class InsiderTransaction
 {
     public Guid Id { get; set; } = Guid.NewGuid();
@@ -43,6 +44,16 @@ public class InsiderTransaction
     public int TransactionOrder { get; set; }
 
     public bool IsAmendment { get; set; }
+
+    /// <summary>
+    /// False when the filer typed a bogus value into transactionPricePerShare —
+    /// most commonly the total transaction value instead of the per-share price.
+    /// Detected by cross-checking against the Yahoo unadjusted close on
+    /// TransactionDate. Dashboards filter on this so a single fat-fingered Form 4
+    /// doesn't drown out every other row when sorted by Shares × PricePerShare.
+    /// Default true — only rows we positively reject are flipped to false.
+    /// </summary>
+    public bool IsPriceValid { get; set; } = true;
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Migrations/Migrations/20260527141506_AddInsiderTransactionPriceValidity.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260527141506_AddInsiderTransactionPriceValidity.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260527141506_AddInsiderTransactionPriceValidity")]
+    partial class AddInsiderTransactionPriceValidity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260527141506_AddInsiderTransactionPriceValidity.cs
+++ b/src/Equibles.Migrations/Migrations/20260527141506_AddInsiderTransactionPriceValidity.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInsiderTransactionPriceValidity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPriceValid",
+                table: "InsiderTransaction",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderTransaction_IsPriceValid_TransactionDate",
+                table: "InsiderTransaction",
+                columns: new[] { "IsPriceValid", "TransactionDate" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_IsPriceValid_TransactionDate",
+                table: "InsiderTransaction");
+
+            migrationBuilder.DropColumn(
+                name: "IsPriceValid",
+                table: "InsiderTransaction");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Equibles.Sec.HostedService.csproj
+++ b/src/Equibles.Sec.HostedService/Equibles.Sec.HostedService.csproj
@@ -19,6 +19,8 @@
     <ProjectReference Include="..\Equibles.Integrations.Sec\Equibles.Integrations.Sec.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.BusinessLogic\Equibles.CommonStocks.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.InsiderTrading.Repositories\Equibles.InsiderTrading.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.InsiderTrading.BusinessLogic\Equibles.InsiderTrading.BusinessLogic.csproj" />
+    <ProjectReference Include="..\Equibles.Yahoo.Repositories\Equibles.Yahoo.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Media.BusinessLogic\Equibles.Media.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Worker\Equibles.Worker.csproj" />

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -4,12 +4,14 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
+using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Contracts;
+using Equibles.Yahoo.Repositories;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Sec.HostedService.Services;
@@ -51,6 +53,10 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         var ownerRepository = scope.ServiceProvider.GetRequiredService<InsiderOwnerRepository>();
         var transactionRepository =
             scope.ServiceProvider.GetRequiredService<InsiderTransactionRepository>();
+        var dailyStockPriceRepository =
+            scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
+        var priceValidator =
+            scope.ServiceProvider.GetRequiredService<InsiderTransactionPriceValidator>();
 
         var existing = await transactionRepository
             .GetByAccessionNumber(filing.AccessionNumber)
@@ -93,6 +99,13 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             );
             return true;
         }
+
+        await ApplyPriceValidity(
+            transactions,
+            companyId,
+            dailyStockPriceRepository,
+            priceValidator
+        );
 
         // No in-memory dedup needed: every parsed row got a unique TransactionOrder from its
         // XML position, so the (AccessionNumber, TransactionOrder) unique index can't collide
@@ -329,6 +342,49 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             }
         );
         await transactionRepository.SaveChanges();
+    }
+
+    // Filer-reported transactionPricePerShare is unvalidated by EDGAR — some
+    // filings dump the total transaction value (or a placeholder like the
+    // share count) into that field, which then explodes the dashboard's
+    // Shares × Price sort. Cross-check against Yahoo's unadjusted close on
+    // the TransactionDate (most recent prior trading day for weekends/
+    // holidays) and flip the flag accordingly. If the Yahoo feed hasn't
+    // caught up yet for a freshly-filed transaction date, leave the default
+    // (true) — the backoffice backfill button re-evaluates everything once
+    // the close is available.
+    private static async Task ApplyPriceValidity(
+        List<InsiderTransaction> transactions,
+        Guid companyId,
+        DailyStockPriceRepository dailyStockPriceRepository,
+        InsiderTransactionPriceValidator priceValidator
+    )
+    {
+        if (transactions.Count == 0)
+            return;
+
+        var minDate = transactions.Min(t => t.TransactionDate).AddDays(-10);
+        var maxDate = transactions.Max(t => t.TransactionDate);
+
+        var prices = await dailyStockPriceRepository
+            .GetAll()
+            .Where(p => p.CommonStockId == companyId && p.Date >= minDate && p.Date <= maxDate)
+            .Select(p => new { p.Date, p.Close })
+            .OrderByDescending(p => p.Date)
+            .ToListAsync();
+
+        foreach (var transaction in transactions)
+        {
+            var close = prices
+                .Where(p => p.Date <= transaction.TransactionDate)
+                .Select(p => (decimal?)p.Close)
+                .FirstOrDefault();
+            transaction.IsPriceValid = priceValidator.IsPlausible(
+                transaction.PricePerShare,
+                transaction.SecurityTitle,
+                close
+            );
+        }
     }
 
     private InsiderTransaction ParseTransaction(

--- a/src/Equibles.Web/Controllers/InsiderActivityController.cs
+++ b/src/Equibles.Web/Controllers/InsiderActivityController.cs
@@ -27,6 +27,7 @@ public class InsiderActivityController : BaseController
 
         var topBuys = await _transactionRepository
             .GetRecentByType(TransactionCode.Purchase, since)
+            .Where(t => t.IsPriceValid)
             .OrderByDescending(t => t.Shares * t.PricePerShare)
             .Take(InsiderDashboardViewModel.RowCap)
             .Select(t => new InsiderDashboardRow
@@ -45,6 +46,7 @@ public class InsiderActivityController : BaseController
 
         var topSells = await _transactionRepository
             .GetRecentByType(TransactionCode.Sale, since)
+            .Where(t => t.IsPriceValid)
             .OrderByDescending(t => t.Shares * t.PricePerShare)
             .Take(InsiderDashboardViewModel.RowCap)
             .Select(t => new InsiderDashboardRow
@@ -63,6 +65,7 @@ public class InsiderActivityController : BaseController
 
         var biggest = await _transactionRepository
             .GetRecent(since)
+            .Where(t => t.IsPriceValid)
             .OrderByDescending(t => t.Shares * t.PricePerShare)
             .Take(InsiderDashboardViewModel.RowCap)
             .Select(t => new InsiderDashboardRow

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -104,6 +104,7 @@ builder.Services.AutoWireServicesFrom<Equibles.Errors.BusinessLogic.ErrorManager
 builder.Services.AutoWireServicesFrom<Equibles.CommonStocks.BusinessLogic.CommonStockManager>();
 builder.Services.AutoWireServicesFrom<Equibles.Media.BusinessLogic.FileManager>();
 builder.Services.AutoWireServicesFrom<Equibles.Sec.BusinessLogic.SecDocumentHtmlNormalizer>();
+builder.Services.AutoWireServicesFrom<Equibles.InsiderTrading.BusinessLogic.InsiderTransactionPriceValidator>();
 
 // Register worker services and all scrapers
 builder.Services.AddWorkerServices();

--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -45,6 +45,7 @@
     <ProjectReference Include="..\..\src\Equibles.Media.BusinessLogic\Equibles.Media.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Congress.HostedService\Equibles.Congress.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.InsiderTrading.Repositories\Equibles.InsiderTrading.Repositories.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.InsiderTrading.BusinessLogic\Equibles.InsiderTrading.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Sec.Repositories\Equibles.Sec.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Fred.HostedService\Equibles.Fred.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Fred.Repositories\Equibles.Fred.Repositories.csproj" />

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs
@@ -1,0 +1,122 @@
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderTransactionPriceValidatorTests
+{
+    private readonly InsiderTransactionPriceValidator _validator = new();
+
+    // Form 3 holdings and post-transaction-only rows pass through the parser
+    // with PricePerShare = 0 by design. They aren't a real per-share price
+    // to validate; dropping them off the dashboard would be wrong.
+    [Fact]
+    public void IsPlausible_ZeroPriceWithNullClose_ReturnsTrue()
+    {
+        var result = _validator.IsPlausible(0m, "Common Stock", null);
+
+        result.Should().BeTrue();
+    }
+
+    // Derivative rows carry the option / warrant price, not the underlying
+    // close — strike prices well above market are normal. The 10× ceiling
+    // doesn't apply, otherwise legitimate deep-OTM derivative grants would
+    // be hidden from the dashboard.
+    [Theory]
+    [InlineData("Stock Option (Right to Buy)")]
+    [InlineData("Warrant")]
+    [InlineData("Convertible Preferred")]
+    public void IsPlausible_DerivativeSecurityTitle_ReturnsTrue(string securityTitle)
+    {
+        // 1000× a $50 close — would be rejected if treated as common stock.
+        var result = _validator.IsPlausible(50_000m, securityTitle, 50m);
+
+        result.Should().BeTrue();
+    }
+
+    // No Yahoo data on file (delisted ticker, brand-new IPO not yet ingested,
+    // foreign listing). Can't validate — must not flip valid rows to invalid
+    // just because the price feed hasn't caught up.
+    [Fact]
+    public void IsPlausible_CommonStockWithNullClose_ReturnsTrue()
+    {
+        var result = _validator.IsPlausible(0.24m, "Common Stock", null);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPlausible_PriceUnderTenTimesClose_ReturnsTrue()
+    {
+        // Real-world spread on a single execution: typically <2× the close.
+        // 5× the close is comfortably under the 10× ceiling.
+        var result = _validator.IsPlausible(1.20m, "Common Stock", 0.24m);
+
+        result.Should().BeTrue();
+    }
+
+    // The bug this whole feature exists to catch — Synchron/REEMF reported
+    // PricePerShare = $24,035,774.40 on a $0.24 stock, because the filer
+    // typed the total transaction value into the per-share field.
+    [Fact]
+    public void IsPlausible_TotalValueInPriceField_ReturnsFalse()
+    {
+        var result = _validator.IsPlausible(
+            pricePerShare: 24_035_774.40m,
+            securityTitle: "Common Stock",
+            unadjustedClose: 0.24m
+        );
+
+        result.Should().BeFalse();
+    }
+
+    // Magnetar/CRWV: stored per-share values in the $11M range against an
+    // actual close in the $20s. Same failure mode, different filer.
+    [Fact]
+    public void IsPlausible_MagnetarStylePrice_ReturnsFalse()
+    {
+        var result = _validator.IsPlausible(
+            pricePerShare: 11_000_689.50m,
+            securityTitle: "Common Stock",
+            unadjustedClose: 20.50m
+        );
+
+        result.Should().BeFalse();
+    }
+
+    // The boundary itself — exactly 10× must pass (≤, not <), so a one-cent
+    // tweak in the production constant changes behavior here and is caught.
+    [Fact]
+    public void IsPlausible_PriceAtExactlyTenTimesClose_ReturnsTrue()
+    {
+        var result = _validator.IsPlausible(100m, "Common Stock", 10m);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPlausible_PriceJustAboveTenTimesClose_ReturnsFalse()
+    {
+        var result = _validator.IsPlausible(100.01m, "Common Stock", 10m);
+
+        result.Should().BeFalse();
+    }
+
+    // Negative prices aren't the bug we're hunting — could surface from a
+    // future amender's bizarre entry, but rejecting them would hide the row
+    // and obscure the real data quality issue.
+    [Fact]
+    public void IsPlausible_NegativePrice_ReturnsTrue()
+    {
+        var result = _validator.IsPlausible(-5m, "Common Stock", 10m);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPlausible_ZeroOrNegativeClose_ReturnsTrue()
+    {
+        var result = _validator.IsPlausible(100m, "Common Stock", 0m);
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Some Form 4 filers type the total transaction value into `transactionPricePerShare` instead of the unit price. EDGAR doesn't validate the magnitude, so the bad number lands in our DB and the insider dashboard's `Shares × PricePerShare` sort explodes into billions/trillions — a single fat-fingered filing drowns out every other row.

Real examples currently visible on `/insider-trading/dashboard`:

| Filing | Stored PricePerShare | Real per-share price | Shares × stored = displayed |
|---|---|---|---|
| Synchron / REEMF / 2026-03-10 | $24,035,774.40 | ~$0.24 | $2.4 quadrillion |
| Aljomaih Automotive / XOS / 2026-05-11 | $1,500,000.00 | ~$5 | $2.25 trillion |
| Magnetar / CRWV / 2026-04-15 | $11,000,689.50 | ~$118 | $5.9 trillion |

Adds an `IsPriceValid` flag, cross-checks against the Yahoo unadjusted close at ingest, and filters the dashboard on the flag. A maintenance backfill manager re-evaluates every row in batches so historical data gets cleaned up once the price feed has caught up.

## Code changes

- `Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs` — added `bool IsPriceValid` (default `true`) + `[Index(IsPriceValid, TransactionDate)]` to keep the dashboard's recent-date sort fast.
- `Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs` — Fluent `HasDefaultValue(true)` so the column add doesn't backfill existing rows to false (which would hide every row until maintenance runs).
- `Equibles.InsiderTrading.BusinessLogic/` (new project):
  - `InsiderTransactionPriceValidator` — pure plausibility check. Holdings (price 0) → valid; derivative title → skip; no Yahoo close → can't validate, leave alone; otherwise reject when `Price > Close × 10`.
  - `InsiderTransactionPriceBackfillManager` — one-off recompute. `Skip/Take` batches of 1000, single close lookup per batch (distinct stock × date pairs), progress callback compatible with SSE streaming.
  - `Models/InsiderTransactionPriceBackfillResult` — result/progress DTO with `Summary`.
- `Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs` — looks up the close on `TransactionDate` (most recent prior trading day for weekends/holidays), calls the validator on every parsed row, sets `IsPriceValid` before save.
- `Equibles.Sec.HostedService.csproj` — added `ProjectReference`s to the new BusinessLogic project + `Yahoo.Repositories`.
- `Equibles.Web/Controllers/InsiderActivityController.cs` — `.Where(t => t.IsPriceValid)` on TopBuys / TopSells / BiggestTransactions.
- `Equibles.Worker.Host/Program.cs` — `AutoWireServicesFrom<InsiderTransactionPriceValidator>()`.
- `Equibles.Migrations/Migrations/20260527141506_AddInsiderTransactionPriceValidity.cs` — adds the column with `defaultValue: true` and the supporting index.
- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs` — 12 tests across holdings, derivatives, missing close, boundary at 10×, and the two real-world bug cases (Synchron/REEMF, Magnetar/CRWV).

## Design notes

- **Unadjusted close, not AdjustedClose.** A reverse split between the transaction date and today shifts the adjusted historical close away from the raw price the filer reported, producing false rejections.
- **Default true.** Existing rows on migrate stay visible until the maintenance pass recomputes — we don't want to wipe the whole dashboard until backfill catches up.
- **Derivative titles excluded.** Option strikes / warrant exercise prices legitimately exceed the underlying close.

## Test plan

- [x] `dotnet vstest tests/Equibles.UnitTests/bin/Debug/net10.0/Equibles.UnitTests.dll --testcasefilter:"FullyQualifiedName~InsiderTransactionPriceValidatorTests"` — 12 passed.
- [x] `dotnet build` clean on the touched projects (Sec.HostedService, Web, Worker.Host, Migrations, UnitTests).
- [x] `dotnet csharpier format` ran clean.
- [ ] After merge: bump the commercial submodule pointer and run the maintenance backfill from the backoffice to clean up the live dashboard.