### PR TITLE
refactor(mcp): extract repeated ticker normalization into McpToolExecutor.NormalizeTicker

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -59,7 +59,7 @@ public class CongressTools
             async () =>
             {
                 var stock = await _commonStockRepository.GetByTicker(
-                    ticker.Trim().ToUpperInvariant()
+                    McpToolExecutor.NormalizeTicker(ticker)
                 );
                 if (stock == null)
                     return McpToolExecutor.StockNotFound(ticker);

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -244,7 +244,9 @@ public class ShortDataTools
 
     private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
     {
-        var stock = await _commonStockRepository.GetByTicker(ticker.Trim().ToUpperInvariant());
+        var stock = await _commonStockRepository.GetByTicker(
+            McpToolExecutor.NormalizeTicker(ticker)
+        );
         if (stock == null)
             return (null, McpToolExecutor.StockNotFound(ticker));
         return (stock, null);

--- a/src/Equibles.Mcp/McpToolExecutor.cs
+++ b/src/Equibles.Mcp/McpToolExecutor.cs
@@ -9,6 +9,8 @@ public static class McpToolExecutor
 
     public static string StockNotFound(string ticker) => $"Stock '{ticker}' not found.";
 
+    public static string NormalizeTicker(string ticker) => ticker.Trim().ToUpperInvariant();
+
     public static async Task<string> Execute(
         Func<Task<string>> action,
         ILogger logger,

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -84,7 +84,7 @@ public class FinancialFactsTools
                     return $"A concept is required. {SupportedAliasesNote()}";
 
                 var stock = await _commonStockRepository.GetByTicker(
-                    ticker.Trim().ToUpperInvariant()
+                    McpToolExecutor.NormalizeTicker(ticker)
                 );
                 if (stock == null)
                     return McpToolExecutor.StockNotFound(ticker);

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -73,7 +73,7 @@ public class FinancialStatementTools
                     return "A ticker symbol is required.";
 
                 var stock = await _commonStockRepository.GetByTicker(
-                    ticker.Trim().ToUpperInvariant()
+                    McpToolExecutor.NormalizeTicker(ticker)
                 );
                 if (stock == null)
                     return McpToolExecutor.StockNotFound(ticker);

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -52,7 +52,7 @@ public class FailToDeliverTools
             async () =>
             {
                 var stock = await _commonStockRepository.GetByTicker(
-                    ticker.Trim().ToUpperInvariant()
+                    McpToolExecutor.NormalizeTicker(ticker)
                 );
                 if (stock == null)
                     return McpToolExecutor.StockNotFound(ticker);

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -413,5 +413,5 @@ public class StockPriceTools
         );
 
     private Task<CommonStock> FindStockByTicker(string ticker) =>
-        _commonStockRepository.GetByTicker(ticker.Trim().ToUpperInvariant());
+        _commonStockRepository.GetByTicker(McpToolExecutor.NormalizeTicker(ticker));
 }


### PR DESCRIPTION
## Summary

- Consolidates the repeated `ticker.Trim().ToUpperInvariant()` normalization chain that appears verbatim in 6 MCP tool files across 5 different modules into a single helper on the existing `McpToolExecutor` static class.
- Pure clarity-and-drift-prevention refactor: every callsite now reads `McpToolExecutor.NormalizeTicker(ticker)` and ends up with the exact same string. No behavior change at any callsite — the helper body is the same expression that previously sat inline.
- Adds the helper next to its peers (`ParseDateOr`, `StockNotFound`) so a future MCP tool that needs to normalize a user-supplied ticker has one obvious place to call.

## Code changes

- `src/Equibles.Mcp/McpToolExecutor.cs` — adds `public static string NormalizeTicker(string ticker) => ticker.Trim().ToUpperInvariant();` alongside the existing `ParseDateOr` and `StockNotFound` helpers.
- `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs` — replaces inline chain with `McpToolExecutor.NormalizeTicker(ticker)`.
- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — same swap inside the existing `FindStockByTicker` helper.
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs` — same swap.
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — same swap.
- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — same swap inside `ResolveStockByTicker`.
- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — same swap.

All 6 consumer files already imported `Equibles.Mcp` for their existing `McpToolExecutor.StockNotFound` / `McpToolExecutor.ParseDateOr` calls, so no new `using` directives were needed.

## Verification

- `dotnet build Equibles.sln -c Release` — succeeded (0 errors; pre-existing warnings only, none in changed files).
- `dotnet test tests/Equibles.UnitTests` — 2156/2156 passing.
- `dotnet test tests/Equibles.IntegrationTests --filter "FullyQualifiedName~Equibles.IntegrationTests.Mcp"` — 253/253 passing (covers every MCP tool file touched).
- `csharpier check` ran via pre-commit hook on the changed files — clean.