### PR TITLE
docs(changelog): record dual-context module-system prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 
 - Contributor License Agreement (`CLA.md`) based on Project Harmony HA-CLA-I-ANY 1.0. Contributors must sign via CLA Assistant before pull requests can be merged. Enables Equibles to remain AGPL-3.0 while sharing code with the commercial offering.
+- Optional `configureOptions` callback on `AddEquiblesDbContext<TContext>` (applied after the standard Npgsql + lazy-loading setup) so a host can adjust context-level `DbContextOptions` — e.g. suppress a specific warning — without replacing the registration helper. Default behavior unchanged. PR #2279.
 
 ### Changed
 
+- **Multi-context module system.** Split `EquiblesDbContext` into an abstract `EquiblesDbContextBase` (module iteration, no Postgres extensions) plus a concrete `EquiblesFinancialDbContext` (enables pgvector; ParadeDB stays in the Npgsql options). Renamed `EquiblesDbContext` → `EquiblesFinancialDbContext`. Added `IFinancialModule` / `ICustomerModule` markers so a host can scan for either domain; every OSS module implements `IFinancialModule`. `BaseRepository` is now generic over the context (`BaseRepository<TEntity, TContext>`) with a one-arg shim binding to the financial context, so existing repositories are unchanged. `AddEquiblesDbContext` is generic over the context with a per-context `ModuleConfigurationSet<TContext>` (no shared module list); added the `AddEquiblesFinancialDbContext` convenience overload. Unlocks deployments running a second context (e.g. a customer database) over the same module system. PR #2258.
+- **No transactional outbox in OSS standalone.** `AddMessaging` no longer registers the EF outbox and gains a `configureBus` hook so a host can opt a context into one. OSS consumers must therefore be idempotent (no inbox/dedup ships). `CommonStockManager.SetCusip` now publishes **after** `SaveChanges` to avoid phantom events on rollback. PR #2258.
+
 ### Fixed
+
+- `CommonStockManager.SetCusip` publishes `StockCusipChanged` via the root `IBus` instead of the scoped `IPublishEndpoint`. A commercial host that enables a bus outbox on a different DbContext (the customer database) would otherwise capture this publish into that context and never deliver it — the flow only saves the financial context. Tests updated to substitute `IBus`. PR #2271.
 
 ## [1.2.0] — 2026-05-26
 


### PR DESCRIPTION
## Summary

Populates the `[Unreleased]` section with the three PRs that prepared OSS for a commercial host running a second DbContext alongside the financial one. The user-facing material — especially the *no transactional outbox in OSS standalone* change — was buried in PR commit messages; surfacing it here so OSS standalone adopters can find it.

## Code changes

- `CHANGELOG.md` — `[Unreleased]` now records:
  - **Added** — Optional \`configureOptions\` callback on \`AddEquiblesDbContext<TContext>\` (PR #2279).
  - **Changed** — Multi-context module system: \`EquiblesDbContext\` → \`EquiblesFinancialDbContext\`, \`IFinancialModule\` / \`ICustomerModule\` markers, generic \`BaseRepository<TEntity, TContext>\` (PR #2258). And the breaking outbox change: OSS standalone no longer ships a transactional outbox; consumers must be idempotent; \`CommonStockManager.SetCusip\` now publishes after \`SaveChanges\` (PR #2258).
  - **Fixed** — \`CommonStockManager.SetCusip\` publishes via root \`IBus\` so a commercial host's customer-context outbox doesn't trap a publish whose \`SaveChanges\` fires on the financial context (PR #2271).