### PR TITLE
refactor(views): extract repeated No-13F-data-yet empty-state into shared partial

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -8,15 +8,7 @@
 <h1 class="text-2xl font-bold mb-4">13F Quarterly Activity</h1>
 
 @if (Model.AvailableDates.Count == 0) {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="card-body items-center text-center py-12">
-            <div class="text-base-content/30 mb-3">
-                <icon name="building-office" size="12" />
-            </div>
-            <h2 class="text-base-content/60 mb-2">No 13F data yet</h2>
-            <p class="text-base-content/40 text-sm">Once at least one quarter of 13F filings has been ingested, the market-wide activity boards appear here.</p>
-        </div>
-    </div>
+    <partial name="_No13FDataYet" model='(IconName: "building-office", Message: "Once at least one quarter of 13F filings has been ingested, the market-wide activity boards appear here.")' />
 } else {
     <!-- ReportDate selector + comparison subtitle -->
     <div class="mb-4 text-sm">

--- a/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
@@ -11,15 +11,7 @@
 <h1 class="text-2xl font-bold mb-4">Most-Held Stocks</h1>
 
 @if (Model.AvailableDates.Count == 0) {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="card-body items-center text-center py-12">
-            <div class="text-base-content/30 mb-3">
-                <icon name="building-office" size="12" />
-            </div>
-            <h2 class="text-base-content/60 mb-2">No 13F data yet</h2>
-            <p class="text-base-content/40 text-sm">Once at least one quarter of 13F filings has been ingested, the most-held ranking appears here.</p>
-        </div>
-    </div>
+    <partial name="_No13FDataYet" model='(IconName: "building-office", Message: "Once at least one quarter of 13F filings has been ingested, the most-held ranking appears here.")' />
 } else {
     <!-- ReportDate + sort selector + universe size header. -->
     <div class="mb-4 text-sm">

--- a/src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml
@@ -15,15 +15,7 @@
     </div>
 
     @if (Model.Latest == null) {
-        <div class="card bg-base-100 shadow-sm">
-            <div class="card-body items-center text-center py-12">
-                <div class="text-base-content/30 mb-3">
-                    <icon name="chart-bar" size="12" />
-                </div>
-                <h2 class="text-base-content/60 mb-2">No 13F data yet</h2>
-                <p class="text-base-content/40 text-sm">Once at least one quarter of 13F filings has been ingested, the statistics appear here.</p>
-            </div>
-        </div>
+        <partial name="_No13FDataYet" model='(IconName: "chart-bar", Message: "Once at least one quarter of 13F filings has been ingested, the statistics appear here.")' />
     } else {
         <!-- Latest Quarter Summary Cards -->
         <div class="flex items-baseline gap-2 mb-3">

--- a/src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml
@@ -15,15 +15,7 @@
     </div>
 
     @if (Model.AumSnapshots.Count == 0) {
-        <div class="card bg-base-100 shadow-sm">
-            <div class="card-body items-center text-center py-12">
-                <div class="text-base-content/30 mb-3">
-                    <icon name="chart-bar" size="12" />
-                </div>
-                <h2 class="text-base-content/60 mb-2">No 13F data yet</h2>
-                <p class="text-base-content/40 text-sm">Once at least one quarter of 13F filings has been ingested, the trend charts appear here.</p>
-            </div>
-        </div>
+        <partial name="_No13FDataYet" model='(IconName: "chart-bar", Message: "Once at least one quarter of 13F filings has been ingested, the trend charts appear here.")' />
     } else {
         <!-- AUM Over Time -->
         <div class="card bg-base-100 shadow-sm mb-6">

--- a/src/Equibles.Web/Views/HoldingsActivity/_No13FDataYet.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/_No13FDataYet.cshtml
@@ -1,0 +1,10 @@
+@model (string IconName, string Message)
+<div class="card bg-base-100 shadow-sm">
+    <div class="card-body items-center text-center py-12">
+        <div class="text-base-content/30 mb-3">
+            <icon name="@Model.IconName" size="12" />
+        </div>
+        <h2 class="text-base-content/60 mb-2">No 13F data yet</h2>
+        <p class="text-base-content/40 text-sm">@Model.Message</p>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

- Consolidates the same 12-line "No 13F data yet" empty-state card markup that lived verbatim in 4 `HoldingsActivity/` views into a single folder-local partial.
- The 4 instances varied only by the icon name and the tail message — both are now passed as a tuple model to the partial.
- Net -22 lines of Razor across the 4 views (each empty-state branch goes from 10 markup lines to 1 `<partial>` invocation).

## Code changes

- `src/Equibles.Web/Views/HoldingsActivity/_No13FDataYet.cshtml` — new partial with `@model (string IconName, string Message)`. Renders the exact same DaisyUI card + `<icon>` Tag Helper + `<h2>No 13F data yet</h2>` + `<p>` body that the four callers previously inlined.
- `src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml` — replaces the inline empty-state card with `<partial name="_No13FDataYet" ... />`; passes `chart-bar` icon + the original "statistics appear here" message.
- `src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml` — same swap; `building-office` icon + "most-held ranking appears here" message.
- `src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml` — same swap; `chart-bar` icon + "trend charts appear here" message.
- `src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml` — same swap; `building-office` icon + "market-wide activity boards appear here" message.

## Verification

- `dotnet build Equibles.sln -c Release` — succeeded (0 errors).
- `dotnet csharpier check .` — clean.
- `dotnet test tests/Equibles.UnitTests` — 2168/2168 passing.
- `dotnet test tests/Equibles.IntegrationTests --filter Web` — 286/286 passing, including `HoldingsActivityControllerTests` and `HoldingsActivityControllerMostHeldTests` which assert `html.Should().Contain("No 13F data yet")`.

## Behavior preservation

- The partial emits byte-identical inner markup — same DaisyUI card classes, same `<icon>` Tag Helper invocation, same `<h2>` text. Only surrounding whitespace differs (the partial is independent of each calling view's indent).
- The three Playwright tests in `tests/Equibles.FunctionalTests/Tests/Holdings{Trends,MostHeld,Stats}SeededTests.cs` use `Locator("h2").Filter(new() { HasTextString = "No 13F data yet" })` — text-content matchers that are whitespace-agnostic. The extracted partial still emits the same `<h2>No 13F data yet</h2>` so these locators continue to match.