### PR TITLE
refactor(views): extract repeated DaisyUI metric-card markup into shared _MetricCard partial

### DIFF
--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -80,44 +80,19 @@
                 </div>
             }
             @if (Model.Mean.HasValue) {
-                <div class="card bg-base-100 shadow-sm">
-                    <div class="card-body p-3">
-                        <div class="text-xs text-base-content/50 uppercase tracking-wider">Mean</div>
-                        <div class="text-lg font-bold tabular-nums">@Model.Mean.Value.ToString("N2")</div>
-                    </div>
-                </div>
+                <partial name="_MetricCard" model='(Label: "Mean", Value: Model.Mean.Value.ToString("N2"))' />
             }
             @if (Model.Median.HasValue) {
-                <div class="card bg-base-100 shadow-sm">
-                    <div class="card-body p-3">
-                        <div class="text-xs text-base-content/50 uppercase tracking-wider">Median</div>
-                        <div class="text-lg font-bold tabular-nums">@Model.Median.Value.ToString("N2")</div>
-                    </div>
-                </div>
+                <partial name="_MetricCard" model='(Label: "Median", Value: Model.Median.Value.ToString("N2"))' />
             }
             @if (Model.StdDev.HasValue) {
-                <div class="card bg-base-100 shadow-sm">
-                    <div class="card-body p-3">
-                        <div class="text-xs text-base-content/50 uppercase tracking-wider">Std Dev</div>
-                        <div class="text-lg font-bold tabular-nums">@Model.StdDev.Value.ToString("N2")</div>
-                    </div>
-                </div>
+                <partial name="_MetricCard" model='(Label: "Std Dev", Value: Model.StdDev.Value.ToString("N2"))' />
             }
             @if (Model.Min.HasValue) {
-                <div class="card bg-base-100 shadow-sm">
-                    <div class="card-body p-3">
-                        <div class="text-xs text-base-content/50 uppercase tracking-wider">Min</div>
-                        <div class="text-lg font-bold tabular-nums">@Model.Min.Value.ToString("N2")</div>
-                    </div>
-                </div>
+                <partial name="_MetricCard" model='(Label: "Min", Value: Model.Min.Value.ToString("N2"))' />
             }
             @if (Model.Max.HasValue) {
-                <div class="card bg-base-100 shadow-sm">
-                    <div class="card-body p-3">
-                        <div class="text-xs text-base-content/50 uppercase tracking-wider">Max</div>
-                        <div class="text-lg font-bold tabular-nums">@Model.Max.Value.ToString("N2")</div>
-                    </div>
-                </div>
+                <partial name="_MetricCard" model='(Label: "Max", Value: Model.Max.Value.ToString("N2"))' />
             }
         </div>
 

--- a/src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml
@@ -23,42 +23,12 @@
             <span class="text-xs text-base-content/50">@Model.Latest.ReportDate.ToString("MMM dd, yyyy")</span>
         </div>
         <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-8">
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Filers</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Latest.FilerCount.ToString("N0")</div>
-                </div>
-            </div>
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Filings</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Latest.FilingCount.ToString("N0")</div>
-                </div>
-            </div>
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Stocks</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Latest.StockCount.ToString("N0")</div>
-                </div>
-            </div>
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Positions</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Latest.PositionCount.ToString("N0")</div>
-                </div>
-            </div>
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Avg Pos/Filer</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Latest.AvgPositionsPerFiler.ToString("F1")</div>
-                </div>
-            </div>
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Total AUM</div>
-                    <div class="text-lg font-bold tabular-nums">$@((Model.Latest.TotalValue / 1_000_000_000m).ToString("N1"))B</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Filers", Value: Model.Latest.FilerCount.ToString("N0"))' />
+            <partial name="_MetricCard" model='(Label: "Filings", Value: Model.Latest.FilingCount.ToString("N0"))' />
+            <partial name="_MetricCard" model='(Label: "Stocks", Value: Model.Latest.StockCount.ToString("N0"))' />
+            <partial name="_MetricCard" model='(Label: "Positions", Value: Model.Latest.PositionCount.ToString("N0"))' />
+            <partial name="_MetricCard" model='(Label: "Avg Pos/Filer", Value: Model.Latest.AvgPositionsPerFiler.ToString("F1"))' />
+            <partial name="_MetricCard" model='(Label: "Total AUM", Value: "$" + (Model.Latest.TotalValue / 1_000_000_000m).ToString("N1") + "B")' />
         </div>
 
         <!-- Historical Table -->

--- a/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
+++ b/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
@@ -40,52 +40,22 @@
     </div>
     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
         @if (Model.LatestRatio.HasValue) {
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Latest</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.LatestRatio.Value.ToString("N2")</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Latest", Value: Model.LatestRatio.Value.ToString("N2"))' />
         }
         @if (Model.Mean.HasValue) {
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Mean</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Mean.Value.ToString("N2")</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Mean", Value: Model.Mean.Value.ToString("N2"))' />
         }
         @if (Model.Median.HasValue) {
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Median</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Median.Value.ToString("N2")</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Median", Value: Model.Median.Value.ToString("N2"))' />
         }
         @if (Model.Min.HasValue) {
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Min</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Min.Value.ToString("N2")</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Min", Value: Model.Min.Value.ToString("N2"))' />
         }
         @if (Model.Max.HasValue) {
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Max</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Max.Value.ToString("N2")</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Max", Value: Model.Max.Value.ToString("N2"))' />
         }
         @if (Model.StdDev.HasValue) {
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Std Dev</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.StdDev.Value.ToString("N2")</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Std Dev", Value: Model.StdDev.Value.ToString("N2"))' />
         }
     </div>
 

--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -58,44 +58,19 @@
             </div>
         }
         @if (Model.Mean.HasValue) {
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Mean</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Mean.Value.ToString("N2")</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Mean", Value: Model.Mean.Value.ToString("N2"))' />
         }
         @if (Model.Median.HasValue) {
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Median</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Median.Value.ToString("N2")</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Median", Value: Model.Median.Value.ToString("N2"))' />
         }
         @if (Model.Min.HasValue) {
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Min</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Min.Value.ToString("N2")</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Min", Value: Model.Min.Value.ToString("N2"))' />
         }
         @if (Model.Max.HasValue) {
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Max</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.Max.Value.ToString("N2")</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Max", Value: Model.Max.Value.ToString("N2"))' />
         }
         @if (Model.StdDev.HasValue) {
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Std Dev</div>
-                    <div class="text-lg font-bold tabular-nums">@Model.StdDev.Value.ToString("N2")</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Std Dev", Value: Model.StdDev.Value.ToString("N2"))' />
         }
     </div>
 

--- a/src/Equibles.Web/Views/Shared/_MetricCard.cshtml
+++ b/src/Equibles.Web/Views/Shared/_MetricCard.cshtml
@@ -1,0 +1,7 @@
+@model (string Label, string Value)
+<div class="card bg-base-100 shadow-sm">
+    <div class="card-body p-3">
+        <div class="text-xs text-base-content/50 uppercase tracking-wider">@Model.Label</div>
+        <div class="text-lg font-bold tabular-nums">@Model.Value</div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

- Consolidates the 4-line DaisyUI "metric card" (label + formatted value) markup that appeared 22 times across 4 views into one shared partial in `Views/Shared/`.
- Each instance differed only in the label string and the formatted value expression; everything else (card classes, padding, uppercase label styling, `.text-lg.font-bold.tabular-nums` value div) was byte-identical.
- Net -110 lines of Razor across 4 views, +7 lines for the new partial.
- Variants with **additional inner content** (Vix `LatestClose` with a `vixChange` delta line, EconomicData `Latest` with a `changePct` line) are deliberately left untouched — they have content the simple `(Label, Value)` partial cannot represent without speculative parameters.

## Code changes

- `src/Equibles.Web/Views/Shared/_MetricCard.cshtml` — new partial with `@model (string Label, string Value)`. Emits the exact same card markup the callers previously inlined.
- `src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml` — 6 inlined cards → 6 `<partial>` invocations (Filers, Filings, Stocks, Positions, Avg Pos/Filer, Total AUM).
- `src/Equibles.Web/Views/EconomicData/Show.cshtml` — 5 inlined cards → 5 `<partial>` invocations (Mean, Median, Std Dev, Min, Max). The Latest card retained inline because it has a conditional `changePct` row.
- `src/Equibles.Web/Views/Market/PutCallRatio.cshtml` — 6 inlined cards → 6 `<partial>` invocations (Latest, Mean, Median, Min, Max, Std Dev).
- `src/Equibles.Web/Views/Market/Vix.cshtml` — 5 inlined cards → 5 `<partial>` invocations (Mean, Median, Min, Max, Std Dev). The LatestClose card retained inline because it has a conditional `vixChange` row.

## Verification

- `dotnet build Equibles.sln -c Release` — 0 errors.
- `dotnet csharpier check .` — clean.
- `dotnet test tests/Equibles.UnitTests` — 2168/2168 passing.
- `dotnet test tests/Equibles.IntegrationTests --filter Web` — 286/286 passing.

## Behavior preservation

- The partial emits byte-identical inner markup: same `card bg-base-100 shadow-sm`, same `card-body p-3`, same `text-xs text-base-content/50 uppercase tracking-wider` label, same `text-lg font-bold tabular-nums` value div.
- `HoldingsStatsSeededTests` (Playwright) locates the cards by `.grid .card .card-body` and filters by label text, then locates `.font-bold` — both selectors continue to match because the partial preserves the wrapper grid structure and the value div's classes.
- Value-formatting expressions stay at the call site (`Model.Latest.FilerCount.ToString("N0")`, etc.) so culture and rounding behavior are unchanged.