### PR TITLE
fix(mcp): normalize ticker in Holdings + InsiderTrading ResolveStockByTicker

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1289,7 +1289,7 @@ public class InstitutionalHoldingsTools
 
     private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
     {
-        var stock = await _commonStockRepository.GetByTicker(ticker);
+        var stock = await _commonStockRepository.GetByTicker(McpToolExecutor.NormalizeTicker(ticker));
         if (stock == null)
             return (null, McpToolExecutor.StockNotFound(ticker));
         return (stock, null);

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -222,7 +222,7 @@ public class InsiderTradingTools
 
     private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
     {
-        var stock = await _commonStockRepository.GetByTicker(ticker);
+        var stock = await _commonStockRepository.GetByTicker(McpToolExecutor.NormalizeTicker(ticker));
         if (stock == null)
             return (null, McpToolExecutor.StockNotFound(ticker));
         return (stock, null);

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests : IDisposable
+{
+    // The MCP ticker contract is uniform across modules: client-supplied
+    // tickers must be normalized (Trim + ToUpperInvariant) before the
+    // CommonStocks lookup, so `aapl`, `AAPL `, and `AAPL` all resolve to the
+    // same stock. McpToolExecutor.NormalizeTicker is the canonical helper
+    // (see ShortDataTools.ResolveStockByTicker). Holdings + InsiderTrading
+    // each declare their own ResolveStockByTicker; the helper must call
+    // NormalizeTicker before GetByTicker so the cross-module contract holds.
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly InstitutionalHoldingsTools _tools;
+
+    public InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new HoldingsModuleConfiguration()
+        );
+        _dbContext.Set<CommonStock>().Add(new CommonStock { Ticker = "AAPL", Name = "Apple Inc" });
+        _dbContext.SaveChanges();
+
+        _tools = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(_dbContext),
+            new InstitutionalHolderRepository(_dbContext),
+            new CommonStockRepository(_dbContext),
+            errorManager: null,
+            NullLogger<InstitutionalHoldingsTools>.Instance
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    private async Task<(CommonStock Stock, string Error)> InvokeResolve(string ticker)
+    {
+        var method = typeof(InstitutionalHoldingsTools).GetMethod(
+            "ResolveStockByTicker",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var task = (Task)method!.Invoke(_tools, [ticker])!;
+        await task.ConfigureAwait(false);
+        var resultProp = task.GetType().GetProperty("Result")!;
+        return ((CommonStock Stock, string Error))resultProp.GetValue(task)!;
+    }
+
+    [Theory]
+    [InlineData("aapl")]
+    [InlineData("AAPL ")]
+    [InlineData(" aapl ")]
+    public async Task ResolveStockByTicker_NonNormalizedInput_ResolvesToStoredUppercaseTicker(
+        string input
+    )
+    {
+        var (stock, error) = await InvokeResolve(input);
+
+        error.Should().BeNull();
+        stock.Should().NotBeNull();
+        stock.Ticker.Should().Be("AAPL");
+    }
+}

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTradingToolsResolveStockByTickerNormalizationTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTradingToolsResolveStockByTickerNormalizationTests.cs
@@ -1,0 +1,69 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Mcp.Tools;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.IntegrationTests.InsiderTrading;
+
+public class InsiderTradingToolsResolveStockByTickerNormalizationTests : IDisposable
+{
+    // Counterpart of the Holdings normalization pin — keeps the MCP ticker
+    // contract uniform across modules. See Holdings'
+    // InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests for
+    // the full reasoning.
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly InsiderTradingTools _tools;
+
+    public InsiderTradingToolsResolveStockByTickerNormalizationTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new InsiderTradingModuleConfiguration()
+        );
+        _dbContext.Set<CommonStock>().Add(new CommonStock { Ticker = "AAPL", Name = "Apple Inc" });
+        _dbContext.SaveChanges();
+
+        _tools = new InsiderTradingTools(
+            new InsiderTransactionRepository(_dbContext),
+            new InsiderOwnerRepository(_dbContext),
+            new CommonStockRepository(_dbContext),
+            errorManager: null,
+            NullLogger<InsiderTradingTools>.Instance
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    private async Task<(CommonStock Stock, string Error)> InvokeResolve(string ticker)
+    {
+        var method = typeof(InsiderTradingTools).GetMethod(
+            "ResolveStockByTicker",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var task = (Task)method!.Invoke(_tools, [ticker])!;
+        await task.ConfigureAwait(false);
+        var resultProp = task.GetType().GetProperty("Result")!;
+        return ((CommonStock Stock, string Error))resultProp.GetValue(task)!;
+    }
+
+    [Theory]
+    [InlineData("aapl")]
+    [InlineData("AAPL ")]
+    [InlineData(" aapl ")]
+    public async Task ResolveStockByTicker_NonNormalizedInput_ResolvesToStoredUppercaseTicker(
+        string input
+    )
+    {
+        var (stock, error) = await InvokeResolve(input);
+
+        error.Should().BeNull();
+        stock.Should().NotBeNull();
+        stock.Ticker.Should().Be("AAPL");
+    }
+}


### PR DESCRIPTION
## Summary

- Both `Holdings.Mcp` and `InsiderTrading.Mcp` declared their own `ResolveStockByTicker` helper that passed the raw user-supplied ticker straight to `CommonStockRepository.GetByTicker`, which is case-sensitive against the uppercase-stored `Ticker` column.
- A client calling `GetTopHolders` or `GetInsiderTransactions` with `aapl` or `AAPL ` (trailing space) got `"Stock 'aapl' not found."` even though the Finra equivalent — which already calls `McpToolExecutor.NormalizeTicker` — answered correctly.
- Route both helpers through `McpToolExecutor.NormalizeTicker` so the ticker contract is uniform across MCP modules.

closes #2513

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — `ResolveStockByTicker` now normalizes the ticker before the repository lookup.
- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — same one-line fix.
- `tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingsToolsResolveStockByTickerNormalizationTests.cs` — new regression test, reflection-invokes the private helper against an in-memory DB seeded with `Ticker = "AAPL"` and asserts that `aapl`, `AAPL `, and ` aapl ` all resolve to the same stock.
- `tests/Equibles.IntegrationTests/InsiderTrading/InsiderTradingToolsResolveStockByTickerNormalizationTests.cs` — counterpart pin for the InsiderTrading module.