### PR TITLE
refactor(mcp): extract repeated start/end ParseDateOr pair into McpToolExecutor.ParseDateRange

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -56,13 +56,10 @@ public class CboeTools
                 if (!Enum.TryParse<CboePutCallRatioType>(type, true, out var ratioType))
                     return $"Invalid type '{type}'. Valid types: Total, Equity, Index, Vix, Etp";
 
-                var start = McpToolExecutor.ParseDateOr(
+                var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
-                );
-                var end = McpToolExecutor.ParseDateOr(
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow)
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
 
                 var records = await _putCallRepository
@@ -114,13 +111,10 @@ public class CboeTools
         return _runner.Execute(
             async () =>
             {
-                var start = McpToolExecutor.ParseDateOr(
+                var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
-                );
-                var end = McpToolExecutor.ParseDateOr(
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow)
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
 
                 var records = await _vixRepository

--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -62,13 +62,10 @@ public class CftcTools
                 if (contract == null)
                     return $"Contract '{marketCode}' not found. Use SearchCftcMarkets to find available contracts.";
 
-                var start = McpToolExecutor.ParseDateOr(
+                var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
-                );
-                var end = McpToolExecutor.ParseDateOr(
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow)
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
 
                 var reports = await _reportRepository

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -64,13 +64,10 @@ public class CongressTools
                 if (stock == null)
                     return McpToolExecutor.StockNotFound(ticker);
 
-                var start = McpToolExecutor.ParseDateOr(
+                var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
-                );
-                var end = McpToolExecutor.ParseDateOr(
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow)
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
 
                 var query = _tradeRepository.GetByStock(stock, start, end);
@@ -132,13 +129,10 @@ public class CongressTools
                 if (member == null)
                     return $"Member '{memberName}' not found. Use SearchCongressMembers to find the exact name.";
 
-                var start = McpToolExecutor.ParseDateOr(
+                var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
-                );
-                var end = McpToolExecutor.ParseDateOr(
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow)
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
 
                 var query = _tradeRepository

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -62,13 +62,10 @@ public class ShortDataTools
 
                 var query = _shortVolumeRepository.GetHistoryByStock(stock);
 
-                var start = McpToolExecutor.ParseDateOr(
+                var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
-                );
-                var end = McpToolExecutor.ParseDateOr(
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow)
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
 
                 query = query.Where(d => d.Date >= start && d.Date <= end);
@@ -126,13 +123,10 @@ public class ShortDataTools
 
                 var query = _shortInterestRepository.GetHistoryByStock(stock);
 
-                var start = McpToolExecutor.ParseDateOr(
+                var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
-                );
-                var end = McpToolExecutor.ParseDateOr(
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow)
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
 
                 query = query.Where(s => s.SettlementDate >= start && s.SettlementDate <= end);

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -59,13 +59,10 @@ public class FredTools
                 if (series == null)
                     return $"Series '{seriesId}' not found. Use SearchEconomicIndicators to find available series.";
 
-                var start = McpToolExecutor.ParseDateOr(
+                var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
-                );
-                var end = McpToolExecutor.ParseDateOr(
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow)
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
 
                 var observations = await _observationRepository

--- a/src/Equibles.Mcp/McpToolExecutor.cs
+++ b/src/Equibles.Mcp/McpToolExecutor.cs
@@ -7,6 +7,16 @@ public static class McpToolExecutor
     public static DateOnly ParseDateOr(string text, DateOnly fallback) =>
         !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
 
+    public static (DateOnly Start, DateOnly End) ParseDateRange(
+        string startText,
+        string endText,
+        DateOnly defaultStart
+    ) =>
+        (
+            ParseDateOr(startText, defaultStart),
+            ParseDateOr(endText, DateOnly.FromDateTime(DateTime.UtcNow))
+        );
+
     public static string StockNotFound(string ticker) => $"Stock '{ticker}' not found.";
 
     public static string NormalizeTicker(string ticker) => ticker.Trim().ToUpperInvariant();

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -57,13 +57,10 @@ public class FailToDeliverTools
                 if (stock == null)
                     return McpToolExecutor.StockNotFound(ticker);
 
-                var start = McpToolExecutor.ParseDateOr(
+                var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
-                );
-                var end = McpToolExecutor.ParseDateOr(
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow)
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
 
                 var records = await _ftdRepository

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -57,13 +57,10 @@ public class StockPriceTools
                 if (stock == null)
                     return McpToolExecutor.StockNotFound(ticker);
 
-                var start = McpToolExecutor.ParseDateOr(
+                var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
-                );
-                var end = McpToolExecutor.ParseDateOr(
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow)
+                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
 
                 var records = await _priceRepository
@@ -355,11 +352,11 @@ public class StockPriceTools
         if (stock == null)
             return (null, null, McpToolExecutor.StockNotFound(ticker));
 
-        var start = McpToolExecutor.ParseDateOr(
+        var (start, end) = McpToolExecutor.ParseDateRange(
             startDate,
+            endDate,
             DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6))
         );
-        var end = McpToolExecutor.ParseDateOr(endDate, DateOnly.FromDateTime(DateTime.UtcNow));
 
         var records = await _priceRepository
             .GetByStock(stock, start, end)


### PR DESCRIPTION
## Summary

- Consolidates 11 verbatim copies of the `start = ParseDateOr(startText, <default>); end = ParseDateOr(endText, today)` pair into a single `McpToolExecutor.ParseDateRange` helper that returns the pair as a `(DateOnly Start, DateOnly End)` tuple.
- Every call site collapses 8 lines to 5 (1 helper call); the call-site `today` literal (`DateOnly.FromDateTime(DateTime.UtcNow)`) is now centralized in the helper.
- Net -20 lines (+32 / -52); 7 MCP tool files touched.

## Code changes

- `src/Equibles.Mcp/McpToolExecutor.cs` — adds `public static (DateOnly Start, DateOnly End) ParseDateRange(string startText, string endText, DateOnly defaultStart)` alongside the existing `ParseDateOr`, `NormalizeTicker`, `StockNotFound` helpers. Body delegates to two `ParseDateOr` calls in the same order as the inline pairs.
- `src/Equibles.Cboe.Mcp/Tools/CboeTools.cs` — 2 swaps (`GetPutCallRatios`, `GetVixHistory`).
- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs` — 1 swap (`GetCftcPositioning`).
- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — 2 swaps (`GetCongressionalTrades`, `GetMemberTrades`).
- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — 2 swaps (`GetShortVolume`, `GetShortInterest`).
- `src/Equibles.Fred.Mcp/Tools/FredTools.cs` — 1 swap (`GetEconomicIndicator`).
- `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs` — 1 swap (`GetFailsToDeliver`).
- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — 2 swaps (`GetStockPrices` and the internal `LoadPriceWindow` helper).

## Verification

- `dotnet build Equibles.sln -c Release` — 0 errors.
- `dotnet csharpier format <changed files>` — applied; build still clean.
- `dotnet test tests/Equibles.UnitTests` — 2168/2168 passing.
- `dotnet test tests/Equibles.IntegrationTests --filter "FullyQualifiedName~Equibles.IntegrationTests.Mcp"` — 253/253 passing (covers every MCP tool file touched).

## Behavior preservation

- The helper body is the literal pair of `ParseDateOr` calls in the same order. For each callsite the resolved `start` and `end` come from the same expressions evaluated in the same sequence.
- Subtle timing note: previously each site read `DateTime.UtcNow` twice (once per `ParseDateOr` call) microseconds apart; the helper still reads `UtcNow` separately for the `end` fallback. Same `DateOnly` (day granularity) every time — no observable behavior shift.