### PR TITLE
refactor(views): extract repeated DaisyUI chart-card markup into shared _ChartCard partial

### DIFF
--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -97,14 +97,7 @@
         </div>
 
         <!-- Chart -->
-        <div class="card bg-base-100 shadow-sm mb-6">
-            <div class="card-body p-4 lg:p-6">
-                <h2 class="font-semibold text-sm mb-3">@Model.Title (@Model.Units)</h2>
-                <div class="h-[320px]">
-                    <canvas id="economy-chart" role="img" aria-label="Economic series history chart"></canvas>
-                </div>
-            </div>
-        </div>
+        <partial name="_ChartCard" model='($"{Model.Title} ({Model.Units})", "economy-chart", "Economic series history chart", "h-[320px]")' />
     }
 
     <!-- Observations Table -->

--- a/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
@@ -54,14 +54,7 @@
         </div>
 
         <!-- Bubble Chart -->
-        <div class="card bg-base-100 shadow-sm mb-6">
-            <div class="card-body p-4 lg:p-6">
-                <h2 class="font-semibold text-sm mb-3">Conviction Score vs. Filer Count</h2>
-                <div class="h-[500px]">
-                    <canvas id="heatmap-chart" role="img" aria-label="13F conviction heat map bubble chart"></canvas>
-                </div>
-            </div>
-        </div>
+        <partial name="_ChartCard" model='("Conviction Score vs. Filer Count", "heatmap-chart", "13F conviction heat map bubble chart", "h-[500px]")' />
 
         <!-- Score breakdown legend -->
         <div class="card bg-base-100 shadow-sm mb-6">

--- a/src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml
@@ -18,35 +18,14 @@
         <partial name="_No13FDataYet" model='(IconName: "chart-bar", Message: "Once at least one quarter of 13F filings has been ingested, the trend charts appear here.")' />
     } else {
         <!-- AUM Over Time -->
-        <div class="card bg-base-100 shadow-sm mb-6">
-            <div class="card-body p-4 lg:p-6">
-                <h2 class="font-semibold text-sm mb-3">Total Assets Under Management</h2>
-                <div class="h-[320px]">
-                    <canvas id="aum-chart" role="img" aria-label="Total AUM trend chart"></canvas>
-                </div>
-            </div>
-        </div>
+        <partial name="_ChartCard" model='("Total Assets Under Management", "aum-chart", "Total AUM trend chart", "h-[320px]")' />
 
         <!-- Filer & Position Count Over Time -->
-        <div class="card bg-base-100 shadow-sm mb-6">
-            <div class="card-body p-4 lg:p-6">
-                <h2 class="font-semibold text-sm mb-3">Filers and Positions</h2>
-                <div class="h-[320px]">
-                    <canvas id="filer-chart" role="img" aria-label="Filer and position count trend chart"></canvas>
-                </div>
-            </div>
-        </div>
+        <partial name="_ChartCard" model='("Filers and Positions", "filer-chart", "Filer and position count trend chart", "h-[320px]")' />
 
         <!-- Sector Allocation Over Time -->
         @if (Model.SectorAllocations.Count > 0) {
-            <div class="card bg-base-100 shadow-sm mb-6">
-                <div class="card-body p-4 lg:p-6">
-                    <h2 class="font-semibold text-sm mb-3">Sector Allocation</h2>
-                    <div class="h-[400px]">
-                        <canvas id="sector-chart" role="img" aria-label="Sector allocation trend chart"></canvas>
-                    </div>
-                </div>
-            </div>
+            <partial name="_ChartCard" model='("Sector Allocation", "sector-chart", "Sector allocation trend chart", "h-[400px]")' />
         }
     }
 </div>

--- a/src/Equibles.Web/Views/Shared/_ChartCard.cshtml
+++ b/src/Equibles.Web/Views/Shared/_ChartCard.cshtml
@@ -1,0 +1,9 @@
+@model (string Title, string ChartId, string AriaLabel, string HeightClass)
+<div class="card bg-base-100 shadow-sm mb-6">
+    <div class="card-body p-4 lg:p-6">
+        <h2 class="font-semibold text-sm mb-3">@Model.Title</h2>
+        <div class="@Model.HeightClass">
+            <canvas id="@Model.ChartId" role="img" aria-label="@Model.AriaLabel"></canvas>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

- Consolidates 5 instances of the chart-card markup (DaisyUI card wrapper + heading + height-fixed canvas) across 3 views (`EconomicData/Show.cshtml`, `HoldingsActivity/Trends.cshtml` ×3, `HoldingsActivity/HeatMap.cshtml`) into one shared partial.
- Each callsite shrinks from 7-9 lines to 1 `<partial>` invocation. Net -35 lines of Razor.
- `_PriceTab.cshtml` chart variants are deliberately untouched — they use intentional tighter spacing (`pb-2 lg:pb-2`, `mb-2`, `mb-4`) that the partial's `mb-6 + p-4 lg:p-6` baseline doesn't represent.

## Code changes

- `src/Equibles.Web/Views/Shared/_ChartCard.cshtml` — new partial with `@model (string Title, string ChartId, string AriaLabel, string HeightClass)`. Emits the identical card wrapper + h2 + height div + canvas previously inlined at each site.
- `src/Equibles.Web/Views/EconomicData/Show.cshtml` — `economy-chart` block replaced with `<partial name="_ChartCard" ... />`. Title built via `$"{Model.Title} ({Model.Units})"` interpolation to preserve current "`Title (Units)`" rendering.
- `src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml` — 3 chart blocks (`aum-chart`, `filer-chart`, `sector-chart`) replaced.
- `src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml` — `heatmap-chart` block replaced.

## Verification

- `dotnet build Equibles.sln -c Release` — 0 errors.
- `dotnet test tests/Equibles.UnitTests` — 2168/2168 passing.
- `dotnet test tests/Equibles.IntegrationTests --filter Web` — 286/286 passing.

## Behavior preservation

- Partial body is byte-identical to the inlined markup — same DaisyUI classes (`card bg-base-100 shadow-sm mb-6`, `card-body p-4 lg:p-6`), same `h2` styling, same `<canvas>` attributes.
- Functional tests (`HoldingsTrendsSeededTests`, `EconomicDataShowTests`, `HoldingsHeatMapSeededTests`) assert on `#aum-chart`, `#filer-chart`, `#economy-chart`, and `canvas[aria-label='13F conviction heat map bubble chart']` — all preserved by the partial.
- Razor HTML-encodes `@Model.Title` once; previously `@Model.Title (@Model.Units)` encoded the two values separately and concatenated them with literal text — result is identical because `(` and `)` aren't part of the HTML encoding set.