### PR TITLE
perf(insider-trading): keyset pagination in price backfill manager

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
@@ -69,14 +69,21 @@ public class InsiderTransactionPriceBackfillManager
 
         _dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
 
-        // Skip/Take pagination is safe here because IsPriceValid is the only
-        // mutated column — row ordering by Id is stable across batches.
-        while (result.Processed < result.Total)
+        // Keyset (cursor) pagination on Id. Postgres OFFSET scans and
+        // discards N rows before returning the M for that batch, so a
+        // Skip(N).Take(M) loop is O(N²) — the last batch in a 3M-row table
+        // is thousands of times slower than the first. Filtering by
+        // `Id > lastSeenId` instead lets the index seek straight to the
+        // next page, keeping every batch roughly the same speed and the
+        // whole pass O(N). Npgsql translates `Guid > Guid` to PostgreSQL's
+        // native `uuid > uuid` comparison.
+        var lastSeenId = Guid.Empty;
+        while (true)
         {
             var batch = await _transactionRepository
                 .GetAll()
+                .Where(t => t.Id > lastSeenId)
                 .OrderBy(t => t.Id)
-                .Skip(result.Processed)
                 .Take(BatchSize)
                 .ToListAsync();
 
@@ -109,6 +116,7 @@ public class InsiderTransactionPriceBackfillManager
 
             await _transactionRepository.SaveChanges();
             result.Processed += batch.Count;
+            lastSeenId = batch[^1].Id;
 
             _logger.LogInformation(
                 "Insider price backfill: processed {Processed}/{Total}, invalid={Invalid}",


### PR DESCRIPTION
## Summary

The price-validity backfill manager used `Skip(N).Take(M)` pagination. Postgres scans and discards N rows on every OFFSET, which makes the loop O(N²) — the last batch in a 3M-row table is thousands of times slower than the first.

An operator-triggered run was reporting ETA 2h+ at 29% with visible per-batch slowdown as the cursor advanced:

```
894000 / 3099051   ~2h 8m · 29%
```

Swap to keyset (cursor) pagination on `Id`:

```csharp
var lastSeenId = Guid.Empty;
while (true) {
    var batch = await _transactionRepository
        .GetAll()
        .Where(t => t.Id > lastSeenId)
        .OrderBy(t => t.Id)
        .Take(BatchSize)
        .ToListAsync();
    if (batch.Count == 0) break;
    // ... validate ...
    lastSeenId = batch[^1].Id;
}
```

Npgsql translates `Guid > Guid` to PostgreSQL's native `uuid > uuid`, which uses the primary-key index for a seek on every batch. Total cost drops to O(N); each batch costs the same regardless of position.

## Code changes

- `Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs` — replaced `Skip/Take` with the keyset loop above. Cursor advances by `lastSeenId = batch[^1].Id` after each save. Comment block updated to explain the choice.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors).
- [x] `dotnet csharpier format` clean.
- [ ] After merge + commercial deploy: click the "Recompute price validity" button on the backoffice `/Home` page. Whole pass should complete in minutes, not hours, with a flat per-batch rate.