### PR TITLE
fix(ci): unbreak lint + Trends functional test on main

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1289,7 +1289,9 @@ public class InstitutionalHoldingsTools
 
     private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
     {
-        var stock = await _commonStockRepository.GetByTicker(McpToolExecutor.NormalizeTicker(ticker));
+        var stock = await _commonStockRepository.GetByTicker(
+            McpToolExecutor.NormalizeTicker(ticker)
+        );
         if (stock == null)
             return (null, McpToolExecutor.StockNotFound(ticker));
         return (stock, null);

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -222,7 +222,9 @@ public class InsiderTradingTools
 
     private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
     {
-        var stock = await _commonStockRepository.GetByTicker(McpToolExecutor.NormalizeTicker(ticker));
+        var stock = await _commonStockRepository.GetByTicker(
+            McpToolExecutor.NormalizeTicker(ticker)
+        );
         if (stock == null)
             return (null, McpToolExecutor.StockNotFound(ticker));
         return (stock, null);

--- a/src/Equibles.Migrations/Migrations/20260527141506_AddInsiderTransactionPriceValidity.cs
+++ b/src/Equibles.Migrations/Migrations/20260527141506_AddInsiderTransactionPriceValidity.cs
@@ -15,12 +15,14 @@ namespace Equibles.Migrations.Migrations
                 table: "InsiderTransaction",
                 type: "boolean",
                 nullable: false,
-                defaultValue: true);
+                defaultValue: true
+            );
 
             migrationBuilder.CreateIndex(
                 name: "IX_InsiderTransaction_IsPriceValid_TransactionDate",
                 table: "InsiderTransaction",
-                columns: new[] { "IsPriceValid", "TransactionDate" });
+                columns: new[] { "IsPriceValid", "TransactionDate" }
+            );
         }
 
         /// <inheritdoc />
@@ -28,11 +30,10 @@ namespace Equibles.Migrations.Migrations
         {
             migrationBuilder.DropIndex(
                 name: "IX_InsiderTransaction_IsPriceValid_TransactionDate",
-                table: "InsiderTransaction");
+                table: "InsiderTransaction"
+            );
 
-            migrationBuilder.DropColumn(
-                name: "IsPriceValid",
-                table: "InsiderTransaction");
+            migrationBuilder.DropColumn(name: "IsPriceValid", table: "InsiderTransaction");
         }
     }
 }

--- a/tests/Equibles.FunctionalTests/Tests/HoldingsTrendsSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HoldingsTrendsSeededTests.cs
@@ -1,4 +1,3 @@
-using Equibles.CommonStocks.Data.Models;
 using Equibles.FunctionalTests.Fixtures;
 using Equibles.Holdings.Data.Models;
 using FluentAssertions;
@@ -23,36 +22,43 @@ public class HoldingsTrendsSeededTests
     [Fact]
     public async Task Trends_WithTwoQuarters_RendersChartCardsAndCreatesChartInstances()
     {
-        // Contract: /holdings/trends renders Chart.js trend charts when AumSnapshots
-        // is non-empty. The view serializes data inline and Chart.js creates instances
-        // on each <canvas> during DOMContentLoaded. Seeding two quarters in reverse
-        // insertion order verifies the controller's OrderBy(ReportDate) produces
-        // chronological labels for the charts.
-        var aaplId = Guid.NewGuid();
+        // Contract: /holdings/trends reads the per-quarter snapshot rows that
+        // HoldingsAggregateRefreshService writes after each 13F import, then
+        // renders Chart.js trend charts when the snapshot list is non-empty.
+        // The view serializes data inline and Chart.js creates instances on
+        // each <canvas> during DOMContentLoaded. Seeding two quarters in
+        // reverse insertion order verifies the controller's OrderBy(ReportDate)
+        // produces chronological labels for the charts. Aggregate-correctness
+        // is covered by HoldingsAggregateRefreshServiceTests at the integration
+        // tier; this test pins the rendered chart given already-aggregated rows.
         var q1 = new DateOnly(2024, 9, 30);
         var q2 = new DateOnly(2024, 12, 31);
 
         await _web.ResetAndSeedAsync(async db =>
         {
+            // Seed Q2 first (reverse chronological insertion) to verify OrderBy works
             db.Add(
-                new CommonStock
+                new AumQuarterlySnapshot
                 {
-                    Id = aaplId,
-                    Ticker = "AAPL",
-                    Name = "Apple Inc.",
-                    Cik = "0000320193",
+                    ReportDate = q2,
+                    TotalValue = 5_000_000_000,
+                    FilerCount = 2,
+                    PositionCount = 2,
+                    StockCount = 1,
+                    FilingCount = 2,
                 }
             );
-
-            var filerA = new InstitutionalHolder { Cik = "F0000001", Name = "Filer A" };
-            var filerB = new InstitutionalHolder { Cik = "F0000002", Name = "Filer B" };
-            db.AddRange(filerA, filerB);
-
-            // Seed Q2 first (reverse chronological insertion) to verify OrderBy works
-            db.Add(MakeHolding(aaplId, filerA.Id, q2, 200, 2_000_000_000));
-            db.Add(MakeHolding(aaplId, filerB.Id, q2, 300, 3_000_000_000));
-            db.Add(MakeHolding(aaplId, filerA.Id, q1, 100, 1_000_000_000));
-
+            db.Add(
+                new AumQuarterlySnapshot
+                {
+                    ReportDate = q1,
+                    TotalValue = 1_000_000_000,
+                    FilerCount = 1,
+                    PositionCount = 1,
+                    StockCount = 1,
+                    FilingCount = 1,
+                }
+            );
             await Task.CompletedTask;
         });
 
@@ -106,23 +112,4 @@ public class HoldingsTrendsSeededTests
         labels![0].Should().Be("2024-09-30");
         labels[1].Should().Be("2024-12-31");
     }
-
-    private static InstitutionalHolding MakeHolding(
-        Guid stockId,
-        Guid holderId,
-        DateOnly reportDate,
-        long shares,
-        long value
-    ) =>
-        new()
-        {
-            CommonStockId = stockId,
-            InstitutionalHolderId = holderId,
-            ReportDate = reportDate,
-            FilingDate = reportDate.AddDays(45),
-            Value = value,
-            Shares = shares,
-            ShareType = ShareType.Shares,
-            InvestmentDiscretion = InvestmentDiscretion.Sole,
-        };
 }


### PR DESCRIPTION
## Summary

CI has been red on main since this morning across both `CI` (lint) and `Functional Tests`. This PR fixes both:

1. **Lint (CSharpier)** — three files merged earlier today were not formatted:
   - `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` and `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — `McpToolExecutor.NormalizeTicker(ticker)` call sites added by #2517 need to be broken across lines.
   - `src/Equibles.Migrations/Migrations/20260527141506_AddInsiderTransactionPriceValidity.cs` — the auto-generated migration from #2511 uses the EF default formatting that CSharpier rewrites.
2. **Functional test** — `HoldingsTrendsSeededTests.Trends_WithTwoQuarters_RendersChartCardsAndCreatesChartInstances` was missed when `/holdings/trends` switched to per-quarter snapshot reads in #2479. It still seeded raw `InstitutionalHolding` rows, so `AumQuarterlySnapshot` came back empty and the page rendered the empty state, failing the very first assertion. Replaced the seed with two `AumQuarterlySnapshot` rows — same shape as `HoldingsStatsSeededTests` already uses.

Verified locally: the trends test now passes against the Testcontainers ParadeDB fixture.

## Code changes

- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — csharpier formatting only.
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — csharpier formatting only.
- `src/Equibles.Migrations/Migrations/20260527141506_AddInsiderTransactionPriceValidity.cs` — csharpier formatting only.
- `tests/Equibles.FunctionalTests/Tests/HoldingsTrendsSeededTests.cs` — rewrite seed to insert two `AumQuarterlySnapshot` rows (Q2 first, Q1 second) so the controller's `OrderBy(ReportDate)` still has something to sort; drop the now-unused `MakeHolding` helper and the `CommonStocks`/`InstitutionalHolder` setup.