### PR TITLE
refactor(mcp): extract repeated error-reporter lambda into ErrorManager.AsMcpErrorReporter() extension

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -4,6 +4,7 @@ using Equibles.Cboe.Data.Models;
 using Equibles.Cboe.Repositories;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Microsoft.EntityFrameworkCore;
@@ -28,11 +29,7 @@ public class CboeTools
     {
         _putCallRepository = putCallRepository;
         _vixRepository = vixRepository;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetPutCallRatios")]

--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -4,6 +4,7 @@ using Equibles.Cftc.Data.Models;
 using Equibles.Cftc.Repositories;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Microsoft.EntityFrameworkCore;
@@ -28,11 +29,7 @@ public class CftcTools
     {
         _contractRepository = contractRepository;
         _reportRepository = reportRepository;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetCftcPositioning")]

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -5,6 +5,7 @@ using Equibles.Congress.Data.Models;
 using Equibles.Congress.Repositories;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Microsoft.EntityFrameworkCore;
@@ -32,11 +33,7 @@ public class CongressTools
         _tradeRepository = tradeRepository;
         _memberRepository = memberRepository;
         _commonStockRepository = commonStockRepository;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetCongressionalTrades")]

--- a/src/Equibles.Errors.BusinessLogic/Extensions/ErrorManagerExtensions.cs
+++ b/src/Equibles.Errors.BusinessLogic/Extensions/ErrorManagerExtensions.cs
@@ -1,0 +1,10 @@
+using Equibles.Errors.Data.Models;
+
+namespace Equibles.Errors.BusinessLogic.Extensions;
+
+public static class ErrorManagerExtensions
+{
+    public static Func<string, string, string, string, Task> AsMcpErrorReporter(
+        this ErrorManager errorManager
+    ) => (tool, msg, stack, ctx) => errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx);
+}

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Finra.Repositories;
 using Equibles.Mcp;
@@ -32,11 +33,7 @@ public class ShortDataTools
         _shortVolumeRepository = shortVolumeRepository;
         _shortInterestRepository = shortInterestRepository;
         _commonStockRepository = commonStockRepository;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetShortVolume")]

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Fred.Data.Models;
 using Equibles.Fred.Repositories;
@@ -27,11 +28,7 @@ public class FredTools
     {
         _seriesRepository = seriesRepository;
         _observationRepository = observationRepository;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetEconomicIndicator")]

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
@@ -51,11 +52,7 @@ public class InstitutionalHoldingsTools
         _holdingRepository = holdingRepository;
         _holderRepository = holderRepository;
         _commonStockRepository = commonStockRepository;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetTopHolders")]
@@ -1289,7 +1286,9 @@ public class InstitutionalHoldingsTools
 
     private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
     {
-        var stock = await _commonStockRepository.GetByTicker(McpToolExecutor.NormalizeTicker(ticker));
+        var stock = await _commonStockRepository.GetByTicker(
+            McpToolExecutor.NormalizeTicker(ticker)
+        );
         if (stock == null)
             return (null, McpToolExecutor.StockNotFound(ticker));
         return (stock, null);

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
@@ -32,11 +33,7 @@ public class InsiderTradingTools
         _transactionRepository = transactionRepository;
         _ownerRepository = ownerRepository;
         _commonStockRepository = commonStockRepository;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetInsiderTransactions")]
@@ -222,7 +219,9 @@ public class InsiderTradingTools
 
     private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
     {
-        var stock = await _commonStockRepository.GetByTicker(McpToolExecutor.NormalizeTicker(ticker));
+        var stock = await _commonStockRepository.GetByTicker(
+            McpToolExecutor.NormalizeTicker(ticker)
+        );
         if (stock == null)
             return (null, McpToolExecutor.StockNotFound(ticker));
         return (stock, null);

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -5,6 +5,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Sec.Data.Models;
@@ -41,11 +42,7 @@ public class FinancialFactsTools
         _financialFactRepository = financialFactRepository;
         _financialConceptRepository = financialConceptRepository;
         _commonStockRepository = commonStockRepository;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetFinancialFact")]

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -4,6 +4,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Sec.FinancialFacts.Data.Enums;
@@ -36,11 +37,7 @@ public class FinancialStatementTools
         _financialFactRepository = financialFactRepository;
         _financialConceptRepository = financialConceptRepository;
         _commonStockRepository = commonStockRepository;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetFinancialStatement")]

--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Sec.Data.Models;
@@ -24,11 +25,7 @@ public class DocumentTextTools
     )
     {
         _documentRepository = documentRepository;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "SearchDocumentKeyword")]

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Sec.Repositories;
@@ -27,11 +28,7 @@ public class FailToDeliverTools
     {
         _ftdRepository = ftdRepository;
         _commonStockRepository = commonStockRepository;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetFailsToDeliver")]

--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Sec.BusinessLogic.Search;
@@ -31,11 +32,7 @@ public class RagSearchTools
     {
         _ragManager = ragManager;
         _secDocumentService = secDocumentService;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "SearchDocuments")]

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
 using Equibles.Yahoo.Data.Models;
@@ -29,11 +30,7 @@ public class StockPriceTools
     {
         _priceRepository = priceRepository;
         _commonStockRepository = commonStockRepository;
-        _runner = new McpToolRunner(
-            logger,
-            (tool, msg, stack, ctx) =>
-                errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)
-        );
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
     [McpServerTool(Name = "GetStockPrices")]


### PR DESCRIPTION
## Summary

- 13 MCP tool constructors inlined the same 4-line lambda — `(tool, msg, stack, ctx) => errorManager.Create(ErrorSource.McpTool, tool, msg, stack, ctx)` — to build the error-report callback passed to `McpToolRunner`.
- Consolidated into a single `errorManager.AsMcpErrorReporter()` extension method on `ErrorManager`. Each MCP tool constructor's 5-line `_runner = new McpToolRunner(...)` block now collapses to one line.
- Net -25 lines (+42 / -67) across 14 files.

## Code changes

- `src/Equibles.Errors.BusinessLogic/Extensions/ErrorManagerExtensions.cs` — new extension class containing `AsMcpErrorReporter()`. Returns the exact same `Func<string, string, string, string, Task>` shape with `ErrorSource.McpTool` baked in.
- 13 MCP tool files (Cboe, Cftc, Congress, Finra, Fred, Holdings, InsiderTrading, Sec/FailToDeliver, Sec/RagSearch, Sec/DocumentText, SecFinancialFacts/FinancialFacts, SecFinancialFacts/FinancialStatement, Yahoo/StockPrice) — added `using Equibles.Errors.BusinessLogic.Extensions;` and swapped the inline lambda for the extension call.

## Verification

- `dotnet build Equibles.sln -c Release` — 0 errors.
- `dotnet csharpier format` on changed files — clean.
- `dotnet test tests/Equibles.UnitTests` — 2168/2168 passing.
- `dotnet test tests/Equibles.IntegrationTests --filter "FullyQualifiedName~Equibles.IntegrationTests.Mcp"` — 253/253 passing.

## Behavior preservation

- The extension method's body is the byte-identical lambda the callers previously inlined. `errorManager` is captured via closure on the extension's `this` parameter — identical to the previous closure on the constructor's `errorManager` parameter.
- No new project references introduced: the extension lives in `Equibles.Errors.BusinessLogic` (already a dep of every MCP tool); its return type is `System.Func`; it uses `ErrorSource.McpTool` from `Equibles.Errors.Data` (also already a dep).