### PR TITLE
feat(web): typeahead institution picker on overlap matrix page

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
@@ -24,6 +24,25 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
         return GetAll().Where(h => EF.Functions.ILike(h.Name, $"%{search}%"));
     }
 
+    // Typeahead variant: matches a CIK prefix as well as a name substring so the
+    // picker can resolve either "berk" or "0001067" to the same row. The user's
+    // input is escaped first so '%' / '_' / '\\' in the query don't behave as LIKE
+    // wildcards (e.g. "50%" would otherwise match every name).
+    public IQueryable<InstitutionalHolder> SearchNameOrCik(string search)
+    {
+        var escaped = EscapeLikePattern(search);
+        var namePattern = $"%{escaped}%";
+        var cikPrefix = $"{escaped}%";
+        return GetAll()
+            .Where(h =>
+                EF.Functions.ILike(h.Name, namePattern, "\\")
+                || EF.Functions.ILike(h.Cik, cikPrefix, "\\")
+            );
+    }
+
+    private static string EscapeLikePattern(string input) =>
+        input.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
+
     public IQueryable<InstitutionalHolder> GetUnclassified()
     {
         return GetAll()

--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -78,7 +78,7 @@ public class InstitutionsController : BaseController
             aggByHolder,
             h => h.Id,
             a => a.HolderId,
-            (h, ags) => new { h, agg = ags.FirstOrDefault() }
+            (h, aggs) => new { h, agg = aggs.FirstOrDefault() }
         );
 
         var ordered = sort switch
@@ -124,5 +124,38 @@ public class InstitutionsController : BaseController
         };
 
         return View(viewModel);
+    }
+
+    // JSON typeahead endpoint backing the institution picker (overlap/compare/combined
+    // pages). Returns a small top-N projection — no aggregates, just enough to render
+    // a chip with name + city/state hint.
+    [HttpGet("~/institutions/search")]
+    public async Task<IActionResult> Search(string q, int limit = 20)
+    {
+        if (string.IsNullOrWhiteSpace(q) || q.Trim().Length < 2)
+        {
+            return Json(Array.Empty<object>());
+        }
+        if (limit < 1)
+            limit = 1;
+        if (limit > 50)
+            limit = 50;
+
+        // Lowercase property names pin the wire contract — the JS picker reads
+        // row.cik/row.name/etc. without depending on the host's JSON casing policy.
+        var rows = await _holderRepository
+            .SearchNameOrCik(q.Trim())
+            .OrderBy(h => h.Name)
+            .Take(limit)
+            .Select(h => new
+            {
+                cik = h.Cik,
+                name = h.Name,
+                city = h.City,
+                stateOrCountry = h.StateOrCountry,
+            })
+            .ToListAsync();
+
+        return Json(rows);
     }
 }

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -239,6 +239,10 @@ public class ProfilesController : BaseController
         [FromQuery(Name = "date")] DateOnly? date = null
     )
     {
+        // The picker submits one ?ciks=A&ciks=B per chip — the default ASP.NET
+        // string[] binding shape. The Split is kept for the legacy comma/space
+        // shape (?ciks=A,B) that bookmarks and InstitutionsOverlapMatrixSeededTests
+        // still use.
         var splitCiks = (ciks ?? [])
             .SelectMany(c => c.Split([',', ' '], StringSplitOptions.RemoveEmptyEntries))
             .ToArray();
@@ -265,6 +269,7 @@ public class ProfilesController : BaseController
                 viewModel.Matrix = FundOverlapCalculator.ComputePairwiseOverlap(loaded.Overlap);
         }
 
+        viewModel.InitialPicks = await ResolvePicks(distinctCiks);
         return View(viewModel);
     }
 
@@ -485,4 +490,30 @@ public class ProfilesController : BaseController
             .Select(c => c.Trim())
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
+
+    // Resolves the picker chips for first render — preserves the order the user
+    // submitted CIKs in, and leaves Name == null for CIKs that aren't in the DB so
+    // the view can flag them as missing. Case-insensitive comparer matches
+    // NormalizeCiks above; otherwise a lowercase `?ciks=cik123` in the URL would
+    // miss the row stored as "CIK123" and render as "(name unknown)".
+    private async Task<List<InstitutionPick>> ResolvePicks(List<string> ciks)
+    {
+        if (ciks.Count == 0)
+            return [];
+
+        var byCik = (
+            await _institutionalHolderRepository
+                .GetByCiks(ciks)
+                .Select(h => new { h.Cik, h.Name })
+                .ToListAsync()
+        ).ToDictionary(x => x.Cik, x => x.Name, StringComparer.OrdinalIgnoreCase);
+
+        return ciks
+            .Select(cik => new InstitutionPick
+            {
+                Cik = cik,
+                Name = byCik.GetValueOrDefault(cik),
+            })
+            .ToList();
+    }
 }

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionOverlapMatrixViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionOverlapMatrixViewModel.cs
@@ -12,4 +12,9 @@ public class InstitutionOverlapMatrixViewModel
     public List<DateOnly> CommonReportDates { get; set; } = [];
     public DateOnly? SelectedDate { get; set; }
     public PairwiseOverlapMatrix Matrix { get; set; }
+
+    // Resolved name + CIK pairs for the chips the picker renders on first load — one
+    // entry per requested CIK, with Name == null when the CIK is missing from the
+    // database. Driven server-side so the chips look complete even before JS boots.
+    public List<InstitutionPick> InitialPicks { get; set; } = [];
 }

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionPick.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionPick.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Web.ViewModels.Profiles;
+
+// One pre-selected institution chip rendered on first load of the overlap / compare /
+// combined pages. Server-side rendering keeps the chip strip complete even before the
+// picker JS module boots, and lets the view show "(name unknown)" for missing CIKs.
+public class InstitutionPick
+{
+    public string Cik { get; set; }
+    public string Name { get; set; }
+}

--- a/src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml
+++ b/src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml
@@ -14,32 +14,89 @@
         </p>
     </div>
 
-    <!-- CIK Input Form -->
-    <form method="get" class="mb-6">
-        <div class="flex flex-wrap gap-3 items-end">
-            <label class="form-control flex-1 min-w-[300px]">
-                <span class="label-text text-sm mb-1">CIKs (comma or space-separated, @InstitutionOverlapMatrixViewModel.MinCiks–@InstitutionOverlapMatrixViewModel.MaxCiks)</span>
-                <input type="text" name="ciks" value="@string.Join(", ", Model.RequestedCiks)"
-                       class="input input-bordered w-full"
-                       placeholder="e.g. 0001067983, 0001603466, 0001350694"
-                       aria-label="Institutional holder CIKs" />
-            </label>
-            @if (Model.CommonReportDates.Count > 0) {
-                <label class="form-control">
-                    <span class="label-text text-sm mb-1">Report Date</span>
-                    <select name="date" class="select select-bordered" aria-label="Report date">
-                        @foreach (var d in Model.CommonReportDates) {
-                            var isSelected = Model.SelectedDate.HasValue && d == Model.SelectedDate.Value;
-                            if (isSelected) {
-                                <option value="@d.ToString("yyyy-MM-dd")" selected>@d.ToString("MMM dd, yyyy")</option>
-                            } else {
-                                <option value="@d.ToString("yyyy-MM-dd")">@d.ToString("MMM dd, yyyy")</option>
+    <!-- Institution picker — typeahead chips replace the raw CIK textbox. The hidden
+         `ciks` input is what posts to the controller; the visible search input drives
+         the autocomplete dropdown. If JS is disabled, the picker still renders the
+         chips read-only and the user can edit the hidden field via the fallback
+         textarea below. -->
+    <form method="get" class="mb-6" data-institution-picker-form>
+        <div class="flex flex-col gap-3">
+            <div class="flex flex-wrap gap-3 items-end">
+                <div class="form-control flex-1 min-w-[300px]"
+                     data-institution-picker
+                     data-search-url="@Url.Action("Search", "Institutions")"
+                     data-min-picks="@InstitutionOverlapMatrixViewModel.MinCiks"
+                     data-max-picks="@InstitutionOverlapMatrixViewModel.MaxCiks">
+                    <span class="label-text text-sm mb-1">
+                        Institutions (@InstitutionOverlapMatrixViewModel.MinCiks–@InstitutionOverlapMatrixViewModel.MaxCiks)
+                    </span>
+
+                    <!-- Chip container + visible text input. The whole row looks like a
+                         single DaisyUI .input so it blends with the rest of the form.
+                         Each chip carries its own <input name="ciks"> so the form submits
+                         repeated keys (?ciks=A&ciks=B&ciks=C), which is what ASP.NET's
+                         default string[] model binding expects. -->
+                    <div class="input input-bordered h-auto min-h-[3rem] py-2 flex flex-wrap gap-2 items-center cursor-text"
+                         data-institution-picker-box>
+                        <div class="flex flex-wrap gap-1.5 items-center" data-institution-picker-chips>
+                            @foreach (var pick in Model.InitialPicks) {
+                                var isMissing = string.IsNullOrEmpty(pick.Name);
+                                <span class="badge badge-lg gap-1 @(isMissing ? "badge-warning" : "badge-primary") badge-soft"
+                                      data-institution-chip
+                                      data-cik="@pick.Cik">
+                                    <input type="hidden" name="ciks" value="@pick.Cik" />
+                                    <span class="font-medium">
+                                        @(isMissing ? "(name unknown)" : pick.Name)
+                                    </span>
+                                    <span class="text-xs opacity-70 font-mono">@pick.Cik</span>
+                                    <button type="button"
+                                            class="btn btn-ghost btn-xs btn-circle"
+                                            aria-label="Remove @(isMissing ? pick.Cik : pick.Name)"
+                                            data-institution-chip-remove>
+                                        <icon name="x-mark" size="3" />
+                                    </button>
+                                </span>
                             }
-                        }
-                    </select>
-                </label>
-            }
-            <button type="submit" class="btn btn-primary">Compare</button>
+                        </div>
+                        <input type="text"
+                               class="flex-1 min-w-[140px] bg-transparent border-0 focus:outline-none focus:ring-0 p-0"
+                               placeholder="@(Model.InitialPicks.Count == 0 ? "Type an institution name or CIK..." : "Add another...")"
+                               aria-label="Search institutions to add"
+                               autocomplete="off"
+                               data-institution-picker-search />
+                    </div>
+
+                    <!-- Autocomplete results dropdown, positioned absolutely by the JS. -->
+                    <div class="relative">
+                        <ul class="menu bg-base-100 rounded-box shadow-lg border border-base-300 absolute left-0 right-0 top-1 z-30 max-h-72 overflow-y-auto hidden"
+                            role="listbox"
+                            aria-label="Institution suggestions"
+                            data-institution-picker-results></ul>
+                    </div>
+
+                    <span class="label-text-alt text-xs text-base-content/50 mt-1"
+                          data-institution-picker-hint>
+                        Type at least 2 characters. Pick @InstitutionOverlapMatrixViewModel.MinCiks–@InstitutionOverlapMatrixViewModel.MaxCiks institutions.
+                    </span>
+                </div>
+
+                @if (Model.CommonReportDates.Count > 0) {
+                    <label class="form-control">
+                        <span class="label-text text-sm mb-1">Report Date</span>
+                        <select name="date" class="select select-bordered" aria-label="Report date">
+                            @foreach (var d in Model.CommonReportDates) {
+                                var isSelected = Model.SelectedDate.HasValue && d == Model.SelectedDate.Value;
+                                if (isSelected) {
+                                    <option value="@d.ToString("yyyy-MM-dd")" selected>@d.ToString("MMM dd, yyyy")</option>
+                                } else {
+                                    <option value="@d.ToString("yyyy-MM-dd")">@d.ToString("MMM dd, yyyy")</option>
+                                }
+                            }
+                        </select>
+                    </label>
+                }
+                <button type="submit" class="btn btn-primary">Compare</button>
+            </div>
         </div>
     </form>
 
@@ -56,8 +113,8 @@
                 <div class="text-base-content/30 mb-3">
                     <icon name="table-cells" size="12" />
                 </div>
-                <h2 class="text-base-content/60 mb-2">Enter at least @InstitutionOverlapMatrixViewModel.MinCiks CIKs</h2>
-                <p class="text-base-content/40 text-sm">Paste institutional holder CIKs above to see how their 13F portfolios overlap.</p>
+                <h2 class="text-base-content/60 mb-2">Pick at least @InstitutionOverlapMatrixViewModel.MinCiks institutions</h2>
+                <p class="text-base-content/40 text-sm">Search by name or CIK above to see how their 13F portfolios overlap.</p>
             </div>
         </div>
     } else if (Model.CommonReportDates.Count == 0 && Model.MissingCiks.Count < Model.RequestedCiks.Count) {

--- a/src/Equibles.Web/src/index.js
+++ b/src/Equibles.Web/src/index.js
@@ -25,3 +25,4 @@ import './js/global-search-shortcut';
 import './js/search-clear';
 import './js/copy-button';
 import './js/compact-numbers';
+import './js/institution-picker';

--- a/src/Equibles.Web/src/js/institution-picker.js
+++ b/src/Equibles.Web/src/js/institution-picker.js
@@ -1,0 +1,298 @@
+// Institution picker — turns the chip strip + search input in [data-institution-picker]
+// into a typeahead multi-picker. The server pre-renders chips for any CIKs already in
+// the URL; this module wires up search, chip add/remove, and keyboard navigation.
+//
+// Each chip owns its own <input type="hidden" name="ciks" value="<cik>">, so removing
+// the chip removes the input and the form posts `?ciks=A&ciks=B&ciks=C` — the shape
+// ASP.NET's default `string[]` model binding expects without any custom splitting.
+//
+// Backend contract: GET data-search-url?q=...&limit=20 returns
+//   [{ cik, name, city, stateOrCountry }, ...]
+// The controller's projection uses lowercase property names directly — the picker
+// reads them without depending on the host's JSON serializer casing policy.
+
+(() => {
+    if (!window.fetch || !window.AbortController) return;
+    // Bundler injects the script at the bottom of <body>, but be defensive: if the
+    // module ever loads earlier, defer until the picker markup is in the DOM.
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', boot, { once: true });
+    } else {
+        boot();
+    }
+
+    function boot() {
+        const pickers = document.querySelectorAll('[data-institution-picker]');
+        pickers.forEach(initPicker);
+    }
+
+    function initPicker(root) {
+        const searchUrl = root.dataset.searchUrl;
+        const minPicks = parseInt(root.dataset.minPicks || '0', 10);
+        const maxPicks = parseInt(root.dataset.maxPicks || '99', 10);
+        const box = root.querySelector('[data-institution-picker-box]');
+        const chipsHost = root.querySelector('[data-institution-picker-chips]');
+        const input = root.querySelector('[data-institution-picker-search]');
+        const results = root.querySelector('[data-institution-picker-results]');
+        const hint = root.querySelector('[data-institution-picker-hint]');
+        if (!searchUrl || !box || !chipsHost || !input || !results) return;
+
+        // Wire delete buttons on chips the server rendered.
+        chipsHost.querySelectorAll('[data-institution-chip]').forEach(wireChipRemove);
+
+        // Clicking anywhere in the chip box focuses the input — feels like one wide field.
+        box.addEventListener('click', (event) => {
+            if (event.target.closest('[data-institution-chip-remove]')) return;
+            if (event.target.closest('[data-institution-chip]')) return;
+            input.focus();
+        });
+
+        let timer;
+        let controller;
+        let activeIndex = -1;
+
+        input.addEventListener('input', () => {
+            clearTimeout(timer);
+            timer = setTimeout(fetchSuggestions, 180);
+        });
+
+        input.addEventListener('keydown', (event) => {
+            // Backspace on empty input removes the last chip — classic chip-input behaviour.
+            if (event.key === 'Backspace' && input.value === '') {
+                const chips = chipsHost.querySelectorAll('[data-institution-chip]');
+                const last = chips[chips.length - 1];
+                if (last) {
+                    removeChip(last);
+                    event.preventDefault();
+                }
+                return;
+            }
+            // Enter with non-empty input should ALWAYS pick — never let the browser
+            // submit the form mid-typeahead. If the dropdown is still loading, swallow
+            // the keystroke too; we don't want to lose what the user typed.
+            if (event.key === 'Enter' && input.value.trim() !== '') {
+                event.preventDefault();
+                const options = Array.from(results.querySelectorAll('[data-pick-option]'));
+                const target = activeIndex >= 0 ? options[activeIndex] : options[0];
+                if (target) selectOption(target);
+                return;
+            }
+            const visible = !results.classList.contains('hidden');
+            if (!visible) return;
+            const options = Array.from(results.querySelectorAll('[data-pick-option]'));
+            if (options.length === 0) return;
+
+            if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                activeIndex = (activeIndex + 1) % options.length;
+                highlight(options);
+            } else if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                activeIndex = (activeIndex - 1 + options.length) % options.length;
+                highlight(options);
+            } else if (event.key === 'Escape') {
+                hideResults();
+            }
+        });
+
+        // Close the dropdown when focus leaves the picker, but let the user finish
+        // clicking a result first (focusout fires before the click handler).
+        document.addEventListener('click', (event) => {
+            if (!root.contains(event.target)) hideResults();
+        });
+
+        async function fetchSuggestions() {
+            const q = input.value.trim();
+            if (q.length < 2) {
+                hideResults();
+                return;
+            }
+            if (atMaxPicks()) {
+                results.innerHTML = '';
+                renderMessage(`You can compare at most ${maxPicks} institutions.`);
+                showResults();
+                return;
+            }
+            if (controller) controller.abort();
+            controller = new AbortController();
+            try {
+                const response = await fetch(
+                    `${searchUrl}?q=${encodeURIComponent(q)}&limit=20`,
+                    { signal: controller.signal, headers: { Accept: 'application/json' } }
+                );
+                if (!response.ok) {
+                    hideResults();
+                    return;
+                }
+                const rows = await response.json();
+                renderResults(rows, q);
+            } catch (error) {
+                if (error.name !== 'AbortError') console.error('[institution-picker]', error);
+            }
+        }
+
+        function renderResults(rows, query) {
+            const picked = new Set(currentCiks());
+            const available = rows.filter((row) => !picked.has(row.cik));
+            results.innerHTML = '';
+            activeIndex = -1;
+
+            if (available.length === 0) {
+                renderMessage(`No matches for "${query}"`);
+                showResults();
+                return;
+            }
+
+            available.forEach((row, index) => {
+                const location = [row.city, row.stateOrCountry].filter(Boolean).join(', ');
+                const li = document.createElement('li');
+                li.setAttribute('data-pick-option', '');
+                li.setAttribute('role', 'option');
+                li.dataset.cik = row.cik || '';
+                li.dataset.name = row.name || '';
+                li.innerHTML = `
+                    <button type="button" class="flex flex-col items-start gap-0.5 w-full text-left">
+                        <span class="font-medium">${escapeHtml(row.name || '(unnamed)')}</span>
+                        <span class="text-xs opacity-60 font-mono">
+                            ${escapeHtml(row.cik || '')}${location ? ` · ${escapeHtml(location)}` : ''}
+                        </span>
+                    </button>`;
+                li.addEventListener('mouseenter', () => {
+                    activeIndex = index;
+                    highlight(Array.from(results.querySelectorAll('[data-pick-option]')));
+                });
+                // mousedown fires before the document-level click that would hide the
+                // dropdown, so the pick lands reliably.
+                li.addEventListener('mousedown', (event) => {
+                    event.preventDefault();
+                    selectOption(li);
+                });
+                results.appendChild(li);
+            });
+            showResults();
+        }
+
+        function renderMessage(text) {
+            const li = document.createElement('li');
+            li.className = 'menu-disabled';
+            li.innerHTML = `<span class="text-sm text-base-content/60">${escapeHtml(text)}</span>`;
+            results.appendChild(li);
+        }
+
+        function highlight(options) {
+            options.forEach((option, index) => {
+                option.classList.toggle('bg-base-200', index === activeIndex);
+            });
+        }
+
+        function selectOption(option) {
+            const cik = option.dataset.cik;
+            const name = option.dataset.name;
+            if (!cik) return;
+            addChip(cik, name);
+            input.value = '';
+            hideResults();
+            input.focus();
+        }
+
+        function addChip(cik, name) {
+            if (currentCiks().includes(cik)) return;
+            if (atMaxPicks()) return;
+            const chip = document.createElement('span');
+            chip.className = 'badge badge-lg gap-1 badge-primary badge-soft';
+            chip.setAttribute('data-institution-chip', '');
+            chip.dataset.cik = cik;
+            const displayName = name || '(name unknown)';
+            chip.innerHTML = `
+                <input type="hidden" name="ciks" />
+                <span class="font-medium"></span>
+                <span class="text-xs opacity-70 font-mono"></span>
+                <button type="button" class="btn btn-ghost btn-xs btn-circle"
+                        aria-label="Remove ${escapeAttr(displayName)}"
+                        data-institution-chip-remove>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                         stroke-width="1.5" stroke="currentColor"
+                         class="size-3 inline-block shrink-0">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+                    </svg>
+                </button>`;
+            chip.querySelector('input[name="ciks"]').value = cik;
+            chip.querySelector('.font-medium').textContent = displayName;
+            chip.querySelector('.font-mono').textContent = cik;
+            chipsHost.appendChild(chip);
+            wireChipRemove(chip);
+            updateHint();
+            updateInputPlaceholder();
+        }
+
+        function wireChipRemove(chip) {
+            const button = chip.querySelector('[data-institution-chip-remove]');
+            button?.addEventListener('click', (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                removeChip(chip);
+            });
+        }
+
+        function removeChip(chip) {
+            chip.remove();
+            updateHint();
+            updateInputPlaceholder();
+        }
+
+        function currentCiks() {
+            return Array.from(chipsHost.querySelectorAll('[data-institution-chip]'))
+                .map((chip) => chip.dataset.cik)
+                .filter(Boolean);
+        }
+
+        function atMaxPicks() {
+            return currentCiks().length >= maxPicks;
+        }
+
+        function updateInputPlaceholder() {
+            input.placeholder = chipsHost.querySelector('[data-institution-chip]')
+                ? 'Add another...'
+                : 'Type an institution name or CIK...';
+        }
+
+        function updateHint() {
+            if (!hint) return;
+            const count = currentCiks().length;
+            if (count < minPicks) {
+                hint.textContent = `Pick at least ${minPicks} institutions (currently ${count}).`;
+                hint.classList.add('text-warning');
+                hint.classList.remove('text-base-content/50');
+            } else if (count >= maxPicks) {
+                hint.textContent = `Maximum ${maxPicks} institutions reached.`;
+                hint.classList.add('text-warning');
+                hint.classList.remove('text-base-content/50');
+            } else {
+                hint.textContent = `${count} selected. Type to add more (up to ${maxPicks}).`;
+                hint.classList.remove('text-warning');
+                hint.classList.add('text-base-content/50');
+            }
+        }
+
+        function showResults() {
+            results.classList.remove('hidden');
+        }
+
+        function hideResults() {
+            results.classList.add('hidden');
+            activeIndex = -1;
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        function escapeAttr(text) {
+            return String(text).replace(/"/g, '&quot;');
+        }
+
+        updateHint();
+    }
+})();


### PR DESCRIPTION
## Summary

- Replaces the raw comma-separated CIK textbox on `/institutions/overlap` with a chip-based typeahead picker that suggests institutions by name or CIK as the user types.
- Adds a `GET /institutions/search` JSON endpoint backing the picker, with LIKE-wildcard escaping so `%`/`_`/`\` in the input don't fan out.
- Form submits the idiomatic ASP.NET `?ciks=A&ciks=B` shape via one hidden `<input name="ciks">` per chip; the legacy `?ciks=A,B` shape is preserved so existing bookmarks and the seeded functional test keep working.

## Code changes

- `src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs` — new `SearchNameOrCik(query)` with `\`-escaped LIKE patterns matching name substring OR CIK prefix.
- `src/Equibles.Web/Controllers/InstitutionsController.cs` — new `GET ~/institutions/search?q=&limit=` action returning lowercase JSON rows (`cik`, `name`, `city`, `stateOrCountry`) so the picker doesn't depend on the host's JSON casing policy. Drive-by: rename `ags` → `aggs` to clear a codespell false-positive.
- `src/Equibles.Web/Controllers/ProfilesController.cs` — `OverlapMatrix` now populates `viewModel.InitialPicks` via a new `ResolvePicks` helper (case-insensitive CIK lookup). Existing split-on-`,`/` ` branch kept and documented for legacy URL shape.
- `src/Equibles.Web/ViewModels/Profiles/InstitutionOverlapMatrixViewModel.cs` + new `InstitutionPick.cs` — pre-resolved chip data for first-paint server rendering.
- `src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml` — replaces the textbox with a chip box + visible search input + absolutely-positioned suggestions dropdown. Updated empty-state copy to match the new UX.
- `src/Equibles.Web/src/js/institution-picker.js` (new) — vanilla JS module: debounced fetch, Arrow/Enter/Escape/Backspace keyboard handling, mouse picking, dedup of already-picked rows, min/max enforcement, DOMContentLoaded guard, `(name unknown)` fallback for missing CIKs. Each chip carries its own hidden `<input name="ciks">` so removing the chip removes the input.
- `src/Equibles.Web/src/index.js` — imports the new module.