### PR TITLE
refactor(economicdata): inline ComputeSma to existing StatisticsExtensions.ComputeSma

### DIFF
--- a/src/Equibles.Web/Controllers/EconomicDataController.cs
+++ b/src/Equibles.Web/Controllers/EconomicDataController.cs
@@ -115,21 +115,14 @@ public class EconomicDataController : BaseController
             if (observations.Count > 1)
                 viewModel.PreviousValue = observations[1].Value;
 
-            viewModel.Sma20 = ComputeSma(chronological, 20);
-            viewModel.Sma50 = ComputeSma(chronological, 50);
+            viewModel.Sma20 = chronological.ComputeSma(20, 4);
+            viewModel.Sma50 = chronological.ComputeSma(50, 4);
         }
 
         ViewData["Title"] = $"{series.SeriesId} — {series.Title}";
         ViewData["Description"] =
             $"{series.Title} ({series.SeriesId}) — {series.Units}. FRED economic data.";
         return View(viewModel);
-    }
-
-    private static List<decimal?> ComputeSma(double[] values, int period)
-    {
-        var sma = values.MovingAverage(period);
-        return sma.Select((v, i) => i < period - 1 ? (decimal?)null : (decimal?)Math.Round(v, 4))
-            .ToList();
     }
 
     private static StatsSummary ComputeStats(double[] values, int decimals) =>


### PR DESCRIPTION
## Summary

- `EconomicDataController` carried a 6-line private `ComputeSma(double[] values, int period)` helper that reimplemented `StatisticsExtensions.ComputeSma(this double[], int period, int digits)` with `digits` baked to 4.
- Replaced the 2 callers with the shared extension (`chronological.ComputeSma(20, 4)` / `.ComputeSma(50, 4)`) and removed the redundant private helper. Reinvented-wheel cleanup — the canonical impl already lived next door in `Equibles.Web/Extensions/StatisticsExtensions.cs`.
- Single-file change. Net -7 lines.

## Code changes

- `src/Equibles.Web/Controllers/EconomicDataController.cs` — `Sma20` / `Sma50` assignments now call the shared `ComputeSma(period, 4)` extension; the private `ComputeSma(double[], int)` method is deleted.

## Verification

- `dotnet build Equibles.sln -c Release` — 0 errors.
- `dotnet csharpier format` on `EconomicDataController.cs` — clean.
- `dotnet test tests/Equibles.UnitTests` — 2168/2168 passing. The reflection-coupled `EconomicDataControllerExpandFrequency*Tests` continue to find `ExpandFrequency` (untouched).
- `dotnet test tests/Equibles.IntegrationTests --filter Web` — 286/286 passing.

## Behavior preservation

- The extension's body is `values.MovingAverage(period).Select((v, i) => i < period - 1 ? null : (decimal?)Math.Round(v, digits)).ToList()` — the deleted controller helper was the same expression with `digits` literal `4`. Calling the extension with `digits: 4` produces an identical `List<decimal?>`.
- No reflection test pins the private `ComputeSma` on `EconomicDataController` (the existing reflection-coupled tests on this controller all target `ExpandFrequency`).