### PR TITLE
refactor(web): share the institution picker across overlap/compare/combined

### DIFF
--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -230,6 +230,7 @@ public class ProfilesController : BaseController
             viewModel.Overlap = loaded.Overlap;
         }
 
+        viewModel.InitialPicks = await ResolvePicks(distinctCiks);
         return View(viewModel);
     }
 
@@ -320,6 +321,7 @@ public class ProfilesController : BaseController
             }
         }
 
+        viewModel.InitialPicks = await ResolvePicks(distinctCiks);
         return View(viewModel);
     }
 
@@ -508,8 +510,7 @@ public class ProfilesController : BaseController
                 .ToListAsync()
         ).ToDictionary(x => x.Cik, x => x.Name, StringComparer.OrdinalIgnoreCase);
 
-        return ciks
-            .Select(cik => new InstitutionPick
+        return ciks.Select(cik => new InstitutionPick
             {
                 Cik = cik,
                 Name = byCik.GetValueOrDefault(cik),

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionCombinedViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionCombinedViewModel.cs
@@ -10,6 +10,10 @@ public class InstitutionCombinedViewModel
     public DateOnly? SelectedDate { get; set; }
     public FundOverlapResult Overlap { get; set; }
 
+    // Resolved name + CIK pairs for chip rendering on first paint; see
+    // [InstitutionOverlapMatrixViewModel.InitialPicks] for the same contract.
+    public List<InstitutionPick> InitialPicks { get; set; } = [];
+
     // Pre-computed per-row consensus count (number of funds with Value > 0 in the row's
     // slices). Ranking sort key — populated alongside Overlap by the controller.
     public Dictionary<Guid, int> FundsHoldingByStock { get; set; } = [];

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionCompareViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionCompareViewModel.cs
@@ -10,6 +10,10 @@ public class InstitutionCompareViewModel
     public DateOnly? SelectedDate { get; set; }
     public FundOverlapResult Overlap { get; set; }
 
+    // Resolved name + CIK pairs for chip rendering on first paint; see
+    // [InstitutionOverlapMatrixViewModel.InitialPicks] for the same contract.
+    public List<InstitutionPick> InitialPicks { get; set; } = [];
+
     public const int MaxCiks = 4;
     public const int MinCiks = 2;
 }

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionPickerViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionPickerViewModel.cs
@@ -1,0 +1,14 @@
+namespace Equibles.Web.ViewModels.Profiles;
+
+// Shared shape for the institution-picker partial used by the overlap / compare /
+// combined pages. Each host page builds one of these from its own view model and
+// hands it to _InstitutionPicker.cshtml.
+public class InstitutionPickerViewModel
+{
+    public List<InstitutionPick> Picks { get; set; } = [];
+    public int MinPicks { get; set; }
+    public int MaxPicks { get; set; }
+    public List<DateOnly> CommonReportDates { get; set; } = [];
+    public DateOnly? SelectedDate { get; set; }
+    public string SubmitLabel { get; set; } = "Compare";
+}

--- a/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
@@ -1,26 +1,39 @@
-@model Equibles.Web.ViewModels.Profiles.InstitutionCombinedViewModel
+@using Equibles.Web.ViewModels.Profiles
+@model InstitutionCombinedViewModel
 
 @{
     ViewData["Title"] = "Combined portfolio";
+
+    var pickerVm = new InstitutionPickerViewModel
+    {
+        Picks = Model.InitialPicks,
+        MinPicks = InstitutionCombinedViewModel.MinCiks,
+        MaxPicks = InstitutionCombinedViewModel.MaxCiks,
+        CommonReportDates = Model.CommonReportDates,
+        SelectedDate = Model.SelectedDate,
+        SubmitLabel = "Combine",
+    };
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
     <div class="mb-8">
         <h1 class="text-3xl font-bold mb-2">Combined portfolio</h1>
         <p class="text-base-content/60">
-            Pool 2–25 funds into a single combined portfolio. Pass CIKs via <code>?ciks=…&amp;ciks=…</code>.
+            Pool @InstitutionCombinedViewModel.MinCiks–@InstitutionCombinedViewModel.MaxCiks funds into a single combined portfolio.
             Consensus picks (held by the most funds) appear at the top.
         </p>
     </div>
 
-    @if (Model.RequestedCiks.Count < Equibles.Web.ViewModels.Profiles.InstitutionCombinedViewModel.MinCiks) {
+    <partial name="_InstitutionPicker" model="pickerVm" />
+
+    @if (Model.RequestedCiks.Count < InstitutionCombinedViewModel.MinCiks) {
         <div class="card bg-base-100 shadow-sm">
             <div class="card-body items-center text-center py-12">
                 <div class="text-base-content/30 mb-3">
                     <icon name="user-group" size="12" />
                 </div>
-                <h2 class="text-base-content/60 mb-2">Pass at least two CIKs to combine</h2>
-                <p class="text-base-content/40 text-sm">Example: <code>/Institutions/Combined?ciks=0001067983&amp;ciks=0001336528&amp;ciks=0001603466</code></p>
+                <h2 class="text-base-content/60 mb-2">Pick at least @InstitutionCombinedViewModel.MinCiks institutions</h2>
+                <p class="text-base-content/40 text-sm">Search by name or CIK above to pool them into one combined portfolio.</p>
             </div>
         </div>
     } else if (Model.MissingCiks.Count > 0 && Model.Overlap == null) {

--- a/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
@@ -1,25 +1,38 @@
-@model Equibles.Web.ViewModels.Profiles.InstitutionCompareViewModel
+@using Equibles.Web.ViewModels.Profiles
+@model InstitutionCompareViewModel
 
 @{
     ViewData["Title"] = "Compare institutions";
+
+    var pickerVm = new InstitutionPickerViewModel
+    {
+        Picks = Model.InitialPicks,
+        MinPicks = InstitutionCompareViewModel.MinCiks,
+        MaxPicks = InstitutionCompareViewModel.MaxCiks,
+        CommonReportDates = Model.CommonReportDates,
+        SelectedDate = Model.SelectedDate,
+        SubmitLabel = "Compare",
+    };
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
     <div class="mb-8">
         <h1 class="text-3xl font-bold mb-2">Compare institutions</h1>
         <p class="text-base-content/60">
-            Side-by-side 13F portfolio overlap. Pass 2–4 CIKs via <code>?ciks=…&amp;ciks=…</code>.
+            Side-by-side 13F portfolio overlap of @InstitutionCompareViewModel.MinCiks–@InstitutionCompareViewModel.MaxCiks selected funds.
         </p>
     </div>
 
-    @if (Model.RequestedCiks.Count < Equibles.Web.ViewModels.Profiles.InstitutionCompareViewModel.MinCiks) {
+    <partial name="_InstitutionPicker" model="pickerVm" />
+
+    @if (Model.RequestedCiks.Count < InstitutionCompareViewModel.MinCiks) {
         <div class="card bg-base-100 shadow-sm">
             <div class="card-body items-center text-center py-12">
                 <div class="text-base-content/30 mb-3">
                     <icon name="user-group" size="12" />
                 </div>
-                <h2 class="text-base-content/60 mb-2">Pass at least two CIKs to compare</h2>
-                <p class="text-base-content/40 text-sm">Example: <code>/Institutions/Compare?ciks=0001067983&amp;ciks=0001603466</code></p>
+                <h2 class="text-base-content/60 mb-2">Pick at least @InstitutionCompareViewModel.MinCiks institutions</h2>
+                <p class="text-base-content/40 text-sm">Search by name or CIK above to see a side-by-side 13F overlap.</p>
             </div>
         </div>
     } else if (Model.MissingCiks.Count > 0 && Model.Overlap == null) {

--- a/src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml
+++ b/src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml
@@ -4,6 +4,16 @@
 @{
     ViewData["Title"] = "Overlap Matrix";
     ViewData["Description"] = "Pairwise overlap of institutional 13F holdings — count of shared tickers between each pair.";
+
+    var pickerVm = new InstitutionPickerViewModel
+    {
+        Picks = Model.InitialPicks,
+        MinPicks = InstitutionOverlapMatrixViewModel.MinCiks,
+        MaxPicks = InstitutionOverlapMatrixViewModel.MaxCiks,
+        CommonReportDates = Model.CommonReportDates,
+        SelectedDate = Model.SelectedDate,
+        SubmitLabel = "Compare",
+    };
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
@@ -14,91 +24,7 @@
         </p>
     </div>
 
-    <!-- Institution picker — typeahead chips replace the raw CIK textbox. The hidden
-         `ciks` input is what posts to the controller; the visible search input drives
-         the autocomplete dropdown. If JS is disabled, the picker still renders the
-         chips read-only and the user can edit the hidden field via the fallback
-         textarea below. -->
-    <form method="get" class="mb-6" data-institution-picker-form>
-        <div class="flex flex-col gap-3">
-            <div class="flex flex-wrap gap-3 items-end">
-                <div class="form-control flex-1 min-w-[300px]"
-                     data-institution-picker
-                     data-search-url="@Url.Action("Search", "Institutions")"
-                     data-min-picks="@InstitutionOverlapMatrixViewModel.MinCiks"
-                     data-max-picks="@InstitutionOverlapMatrixViewModel.MaxCiks">
-                    <span class="label-text text-sm mb-1">
-                        Institutions (@InstitutionOverlapMatrixViewModel.MinCiks–@InstitutionOverlapMatrixViewModel.MaxCiks)
-                    </span>
-
-                    <!-- Chip container + visible text input. The whole row looks like a
-                         single DaisyUI .input so it blends with the rest of the form.
-                         Each chip carries its own <input name="ciks"> so the form submits
-                         repeated keys (?ciks=A&ciks=B&ciks=C), which is what ASP.NET's
-                         default string[] model binding expects. -->
-                    <div class="input input-bordered h-auto min-h-[3rem] py-2 flex flex-wrap gap-2 items-center cursor-text"
-                         data-institution-picker-box>
-                        <div class="flex flex-wrap gap-1.5 items-center" data-institution-picker-chips>
-                            @foreach (var pick in Model.InitialPicks) {
-                                var isMissing = string.IsNullOrEmpty(pick.Name);
-                                <span class="badge badge-lg gap-1 @(isMissing ? "badge-warning" : "badge-primary") badge-soft"
-                                      data-institution-chip
-                                      data-cik="@pick.Cik">
-                                    <input type="hidden" name="ciks" value="@pick.Cik" />
-                                    <span class="font-medium">
-                                        @(isMissing ? "(name unknown)" : pick.Name)
-                                    </span>
-                                    <span class="text-xs opacity-70 font-mono">@pick.Cik</span>
-                                    <button type="button"
-                                            class="btn btn-ghost btn-xs btn-circle"
-                                            aria-label="Remove @(isMissing ? pick.Cik : pick.Name)"
-                                            data-institution-chip-remove>
-                                        <icon name="x-mark" size="3" />
-                                    </button>
-                                </span>
-                            }
-                        </div>
-                        <input type="text"
-                               class="flex-1 min-w-[140px] bg-transparent border-0 focus:outline-none focus:ring-0 p-0"
-                               placeholder="@(Model.InitialPicks.Count == 0 ? "Type an institution name or CIK..." : "Add another...")"
-                               aria-label="Search institutions to add"
-                               autocomplete="off"
-                               data-institution-picker-search />
-                    </div>
-
-                    <!-- Autocomplete results dropdown, positioned absolutely by the JS. -->
-                    <div class="relative">
-                        <ul class="menu bg-base-100 rounded-box shadow-lg border border-base-300 absolute left-0 right-0 top-1 z-30 max-h-72 overflow-y-auto hidden"
-                            role="listbox"
-                            aria-label="Institution suggestions"
-                            data-institution-picker-results></ul>
-                    </div>
-
-                    <span class="label-text-alt text-xs text-base-content/50 mt-1"
-                          data-institution-picker-hint>
-                        Type at least 2 characters. Pick @InstitutionOverlapMatrixViewModel.MinCiks–@InstitutionOverlapMatrixViewModel.MaxCiks institutions.
-                    </span>
-                </div>
-
-                @if (Model.CommonReportDates.Count > 0) {
-                    <label class="form-control">
-                        <span class="label-text text-sm mb-1">Report Date</span>
-                        <select name="date" class="select select-bordered" aria-label="Report date">
-                            @foreach (var d in Model.CommonReportDates) {
-                                var isSelected = Model.SelectedDate.HasValue && d == Model.SelectedDate.Value;
-                                if (isSelected) {
-                                    <option value="@d.ToString("yyyy-MM-dd")" selected>@d.ToString("MMM dd, yyyy")</option>
-                                } else {
-                                    <option value="@d.ToString("yyyy-MM-dd")">@d.ToString("MMM dd, yyyy")</option>
-                                }
-                            }
-                        </select>
-                    </label>
-                }
-                <button type="submit" class="btn btn-primary">Compare</button>
-            </div>
-        </div>
-    </form>
+    <partial name="_InstitutionPicker" model="pickerVm" />
 
     @if (Model.MissingCiks.Count > 0) {
         <div class="alert alert-warning mb-4">

--- a/src/Equibles.Web/Views/Profiles/_InstitutionPicker.cshtml
+++ b/src/Equibles.Web/Views/Profiles/_InstitutionPicker.cshtml
@@ -1,0 +1,84 @@
+@model Equibles.Web.ViewModels.Profiles.InstitutionPickerViewModel
+
+@*
+    Institution picker block — shared between /institutions/overlap, /institutions/compare
+    and /institutions/combined. Renders the chip strip + visible search input as a single
+    GET form posting back to the current URL. Each chip emits one <input name="ciks">,
+    so the form submits ?ciks=A&ciks=B which ASP.NET's string[] model binding accepts
+    directly. JS picker (src/js/institution-picker.js) hooks into the [data-institution-picker]
+    container for typeahead behaviour; without JS the chips still render and the form
+    still submits.
+*@
+
+<form method="get" class="mb-6" data-institution-picker-form>
+    <div class="flex flex-wrap gap-3 items-end">
+        <div class="form-control flex-1 min-w-[300px]"
+             data-institution-picker
+             data-search-url="@Url.Action("Search", "Institutions")"
+             data-min-picks="@Model.MinPicks"
+             data-max-picks="@Model.MaxPicks">
+            <span class="label-text text-sm mb-1">
+                Institutions (@Model.MinPicks–@Model.MaxPicks)
+            </span>
+
+            <div class="input input-bordered h-auto min-h-[3rem] py-2 flex flex-wrap gap-2 items-center cursor-text"
+                 data-institution-picker-box>
+                <div class="flex flex-wrap gap-1.5 items-center" data-institution-picker-chips>
+                    @foreach (var pick in Model.Picks) {
+                        var isMissing = string.IsNullOrEmpty(pick.Name);
+                        <span class="badge badge-lg gap-1 @(isMissing ? "badge-warning" : "badge-primary") badge-soft"
+                              data-institution-chip
+                              data-cik="@pick.Cik">
+                            <input type="hidden" name="ciks" value="@pick.Cik" />
+                            <span class="font-medium">
+                                @(isMissing ? "(name unknown)" : pick.Name)
+                            </span>
+                            <span class="text-xs opacity-70 font-mono">@pick.Cik</span>
+                            <button type="button"
+                                    class="btn btn-ghost btn-xs btn-circle"
+                                    aria-label="Remove @(isMissing ? pick.Cik : pick.Name)"
+                                    data-institution-chip-remove>
+                                <icon name="x-mark" size="3" />
+                            </button>
+                        </span>
+                    }
+                </div>
+                <input type="text"
+                       class="flex-1 min-w-[140px] bg-transparent border-0 focus:outline-none focus:ring-0 p-0"
+                       placeholder="@(Model.Picks.Count == 0 ? "Type an institution name or CIK..." : "Add another...")"
+                       aria-label="Search institutions to add"
+                       autocomplete="off"
+                       data-institution-picker-search />
+            </div>
+
+            <div class="relative">
+                <ul class="menu bg-base-100 rounded-box shadow-lg border border-base-300 absolute left-0 right-0 top-1 z-30 max-h-72 overflow-y-auto hidden"
+                    role="listbox"
+                    aria-label="Institution suggestions"
+                    data-institution-picker-results></ul>
+            </div>
+
+            <span class="label-text-alt text-xs text-base-content/50 mt-1"
+                  data-institution-picker-hint>
+                Type at least 2 characters. Pick @Model.MinPicks–@Model.MaxPicks institutions.
+            </span>
+        </div>
+
+        @if (Model.CommonReportDates.Count > 0) {
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">Report date</span>
+                <select name="date" class="select select-bordered" aria-label="Report date">
+                    @foreach (var d in Model.CommonReportDates) {
+                        var isSelected = Model.SelectedDate.HasValue && d == Model.SelectedDate.Value;
+                        if (isSelected) {
+                            <option value="@d.ToString("yyyy-MM-dd")" selected>@d.ToString("MMM dd, yyyy")</option>
+                        } else {
+                            <option value="@d.ToString("yyyy-MM-dd")">@d.ToString("MMM dd, yyyy")</option>
+                        }
+                    }
+                </select>
+            </label>
+        }
+        <button type="submit" class="btn btn-primary">@Model.SubmitLabel</button>
+    </div>
+</form>

--- a/tests/Equibles.IntegrationTests/Web/ProfilesCombinedInstitutionsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesCombinedInstitutionsTests.cs
@@ -27,7 +27,7 @@ public class ProfilesCombinedInstitutionsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync();
-        html.Should().Contain("Pass at least two CIKs");
+        html.Should().Contain("Pick at least 2 institutions");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Web/ProfilesCompareInstitutionsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ProfilesCompareInstitutionsTests.cs
@@ -27,7 +27,7 @@ public class ProfilesCompareInstitutionsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync();
-        html.Should().Contain("Pass at least two CIKs");
+        html.Should().Contain("Pick at least 2 institutions");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- The typeahead chip picker added to `/institutions/overlap` in #2524 is now used on `/institutions/compare` and `/institutions/combined` as well — all three pages render the same shared partial instead of relying on the user to hand-craft the `?ciks=` query string.
- Extracts the inline picker markup into a shared `_InstitutionPicker.cshtml` partial driven by a new `InstitutionPickerViewModel`.
- Replaces the "Pass CIKs via `?ciks=…`" empty-state on compare/combined with the actual picker form plus a matching empty-state hint.

## Code changes

- `src/Equibles.Web/Views/Profiles/_InstitutionPicker.cshtml` (new) — the chip strip + visible search input + dropdown + optional report-date selector + submit button. Hosted views build an `InstitutionPickerViewModel` in `@{ }` and drop the partial in.
- `src/Equibles.Web/ViewModels/Profiles/InstitutionPickerViewModel.cs` (new) — `Picks`, `MinPicks`, `MaxPicks`, `CommonReportDates`, `SelectedDate`, `SubmitLabel`.
- `src/Equibles.Web/ViewModels/Profiles/InstitutionCompareViewModel.cs` and `InstitutionCombinedViewModel.cs` — add `InitialPicks` (same shape as overlap's).
- `src/Equibles.Web/Controllers/ProfilesController.cs` — `CompareInstitutions` and `CombinedInstitutions` now call the existing `ResolvePicks` helper to fill `InitialPicks` before returning the view.
- `src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml`, `CompareInstitutions.cshtml`, `CombinedInstitutions.cshtml` — replace the inline / no-form blocks with `<partial name="_InstitutionPicker" model="pickerVm" />`. Empty-state copy on compare/combined updated to match the picker UX.
- `tests/Equibles.IntegrationTests/Web/ProfilesCompareInstitutionsTests.cs` and `ProfilesCombinedInstitutionsTests.cs` — update the no-CIKs assertion from the old "Pass at least two CIKs" prompt to the new "Pick at least 2 institutions" copy.