### PR TITLE
style(cboe): reformat with pinned csharpier to unbreak main

### DIFF
--- a/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
+++ b/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
@@ -75,8 +75,7 @@ public class CboeImportService
         // Drive the catch-up cursor from the LEAST advanced type so a type that
         // briefly stopped reporting (or a fresh DB) gets backfilled too.
         var earliestKnown = latestPerType.Values.Min();
-        var start =
-            earliestKnown == default ? DailyPageMinDate : earliestKnown.AddDays(1);
+        var start = earliestKnown == default ? DailyPageMinDate : earliestKnown.AddDays(1);
         var today = _today();
         if (start > today)
         {

--- a/src/Equibles.Integrations.Cboe/CboeClient.cs
+++ b/src/Equibles.Integrations.Cboe/CboeClient.cs
@@ -21,23 +21,26 @@ public class CboeClient : ICboeClient
         "https://cdn.cboe.com/api/global/us_indices/daily_prices/VIX_History.csv";
     private const int MaxRetries = 3;
 
-    private static readonly (CboePutCallProductType Product, string RatioKey, string VolumeKey)[]
-        ProductMappings =
-        [
-            (CboePutCallProductType.Total, "TOTAL PUT/CALL RATIO", "SUM OF ALL PRODUCTS"),
-            (CboePutCallProductType.Equity, "EQUITY PUT/CALL RATIO", "EQUITY OPTIONS"),
-            (CboePutCallProductType.Index, "INDEX PUT/CALL RATIO", "INDEX OPTIONS"),
-            (
-                CboePutCallProductType.Vix,
-                "CBOE VOLATILITY INDEX (VIX) PUT/CALL RATIO",
-                "CBOE VOLATILITY INDEX (VIX)"
-            ),
-            (
-                CboePutCallProductType.Etp,
-                "EXCHANGE TRADED PRODUCTS PUT/CALL RATIO",
-                "EXCHANGE TRADED PRODUCTS"
-            ),
-        ];
+    private static readonly (
+        CboePutCallProductType Product,
+        string RatioKey,
+        string VolumeKey
+    )[] ProductMappings =
+    [
+        (CboePutCallProductType.Total, "TOTAL PUT/CALL RATIO", "SUM OF ALL PRODUCTS"),
+        (CboePutCallProductType.Equity, "EQUITY PUT/CALL RATIO", "EQUITY OPTIONS"),
+        (CboePutCallProductType.Index, "INDEX PUT/CALL RATIO", "INDEX OPTIONS"),
+        (
+            CboePutCallProductType.Vix,
+            "CBOE VOLATILITY INDEX (VIX) PUT/CALL RATIO",
+            "CBOE VOLATILITY INDEX (VIX)"
+        ),
+        (
+            CboePutCallProductType.Etp,
+            "EXCHANGE TRADED PRODUCTS PUT/CALL RATIO",
+            "EXCHANGE TRADED PRODUCTS"
+        ),
+    ];
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<CboeClient> _logger;
@@ -50,9 +53,9 @@ public class CboeClient : ICboeClient
         _rateLimiter = rateLimiter;
     }
 
-    public async Task<Dictionary<CboePutCallProductType, CboePutCallRecord>> DownloadDailyPutCallRatios(
-        DateOnly date
-    )
+    public async Task<
+        Dictionary<CboePutCallProductType, CboePutCallRecord>
+    > DownloadDailyPutCallRatios(DateOnly date)
     {
         var url = $"{DailyStatsUrl}?dt={date:yyyy-MM-dd}";
         _logger.LogDebug("Downloading CBOE daily put/call ratios for {Date}", date);

--- a/tests/Equibles.IntegrationTests/Cboe/CboeImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Cboe/CboeImportServiceFullPipelineTests.cs
@@ -159,18 +159,16 @@ public class CboeImportServiceFullPipelineTests : IAsyncLifetime
             );
         client
             .DownloadVixHistory()
-            .Returns(
-                [
-                    new CboeVixRecord
-                    {
-                        Date = today,
-                        Open = 14.20m,
-                        High = 15.30m,
-                        Low = 13.80m,
-                        Close = 14.95m,
-                    },
-                ]
-            );
+            .Returns([
+                new CboeVixRecord
+                {
+                    Date = today,
+                    Open = 14.20m,
+                    High = 15.30m,
+                    Low = 13.80m,
+                    Close = 14.95m,
+                },
+            ]);
 
         var sut = CreateSut(CreateScopeFactory(), client, today);
 
@@ -231,18 +229,16 @@ public class CboeImportServiceFullPipelineTests : IAsyncLifetime
         var client = EmptyClient();
         client
             .DownloadVixHistory()
-            .Returns(
-                [
-                    new CboeVixRecord
-                    {
-                        Date = new DateOnly(2026, 4, 1), // older than stored → filtered out
-                        Open = 1m,
-                        High = 1m,
-                        Low = 1m,
-                        Close = 1m,
-                    },
-                ]
-            );
+            .Returns([
+                new CboeVixRecord
+                {
+                    Date = new DateOnly(2026, 4, 1), // older than stored → filtered out
+                    Open = 1m,
+                    High = 1m,
+                    Low = 1m,
+                    Close = 1m,
+                },
+            ]);
 
         var sut = CreateSut(CreateScopeFactory(), client, new DateOnly(2026, 4, 10));
 
@@ -283,12 +279,7 @@ public class CboeImportServiceFullPipelineTests : IAsyncLifetime
             Substitute.For<ILogger<ErrorReporter>>()
         );
 
-        var sut = CreateSut(
-            CreateScopeFactory(),
-            client,
-            new DateOnly(2026, 4, 10),
-            errorReporter
-        );
+        var sut = CreateSut(CreateScopeFactory(), client, new DateOnly(2026, 4, 10), errorReporter);
 
         await sut.Import(CancellationToken.None);
 

--- a/tests/Equibles.UnitTests/Cboe/CboeClientRealPageCassetteTests.cs
+++ b/tests/Equibles.UnitTests/Cboe/CboeClientRealPageCassetteTests.cs
@@ -32,9 +32,7 @@ public class CboeClientRealPageCassetteTests
 
         var result = await sut.DownloadDailyPutCallRatios(date);
 
-        result
-            .Should()
-            .HaveCount(5, "the captured page covers all five product types");
+        result.Should().HaveCount(5, "the captured page covers all five product types");
 
         // The cassette is for 2020-06-15. Ratios are the values rendered on
         // the live page at capture time; if CBOE retroactively edits a day's


### PR DESCRIPTION
## Summary

- Main's lint job has been red since PR #2526 because four Cboe files were authored against an older csharpier and don't match the repo-pinned `1.2.6`.
- Reformat with the pinned tool; no behaviour change.

## Code changes

- `src/Equibles.Integrations.Cboe/CboeClient.cs` — csharpier reformat.
- `src/Equibles.Cboe.HostedService/Services/CboeImportService.cs` — csharpier reformat.
- `tests/Equibles.UnitTests/Cboe/CboeClientRealPageCassetteTests.cs` — csharpier reformat.
- `tests/Equibles.IntegrationTests/Cboe/CboeImportServiceFullPipelineTests.cs` — csharpier reformat.