### PR TITLE
feat(search): redirect exact ticker submissions to the stock page

### DIFF
--- a/src/Equibles.Web/Controllers/SearchController.cs
+++ b/src/Equibles.Web/Controllers/SearchController.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Repositories;
 using Equibles.Search;
 using Equibles.Search.Abstractions;
 using Equibles.Web.Controllers.Abstract;
@@ -16,11 +17,17 @@ public class SearchController : BaseController
     private const int MaxPerProviderFocused = 50;
 
     private readonly SearchAggregator _searchAggregator;
+    private readonly CommonStockRepository _commonStockRepository;
 
-    public SearchController(SearchAggregator searchAggregator, ILogger<SearchController> logger)
+    public SearchController(
+        SearchAggregator searchAggregator,
+        CommonStockRepository commonStockRepository,
+        ILogger<SearchController> logger
+    )
         : base(logger)
     {
         _searchAggregator = searchAggregator;
+        _commonStockRepository = commonStockRepository;
     }
 
     [HttpGet]
@@ -32,8 +39,28 @@ public class SearchController : BaseController
         DateOnly? dateTo
     )
     {
+        // When the user submits a query that is an exact ticker, skip the results page and go
+        // straight to that stock. Only on the unfiltered overview — a category-filtered search
+        // (e.g. "Filings") is an explicit request to stay on the results page.
+        if (string.IsNullOrWhiteSpace(category))
+        {
+            var stock = await ResolveExactTicker(q);
+            if (stock != null)
+                return RedirectToAction("Show", "Stocks", new { ticker = stock.Ticker });
+        }
+
         ViewData["Title"] = "Search";
         return View(await BuildViewModel(q, category, sort, dateFrom, dateTo));
+    }
+
+    // Resolves a query to a stock only on an exact (case-insensitive) ticker match — primary or
+    // secondary. Returns null for company-name or partial queries so they fall through to search.
+    private async Task<Equibles.CommonStocks.Data.Models.CommonStock> ResolveExactTicker(string q)
+    {
+        if (string.IsNullOrWhiteSpace(q))
+            return null;
+
+        return await _commonStockRepository.GetByTicker(q.Trim().ToUpperInvariant());
     }
 
     // Results-only fragment for instant (as-you-type) search. instant-search.js fetches this

--- a/tests/Equibles.IntegrationTests/Web/SearchControllerExactTickerRedirectTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/SearchControllerExactTickerRedirectTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Covers the exact-ticker shortcut on the global search: submitting a query that
+/// is an exact ticker (case-insensitive, primary or secondary) on the unfiltered
+/// overview redirects straight to the stock page instead of rendering results. A
+/// company-name / partial query, or a query with a category filter applied, still
+/// renders the results page.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class SearchControllerExactTickerRedirectTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public SearchControllerExactTickerRedirectTests(WebHostFixture fixture) => _fixture = fixture;
+
+    private async Task SeedStock()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "GXA",
+                    Name = "Globex Alpha Corp",
+                    SecondaryTickers = ["GXA.B"],
+                    MarketCapitalization = 1_000_000_000d,
+                }
+            );
+            await Task.CompletedTask;
+        });
+    }
+
+    // Dedicated non-redirecting client so the 302 itself is observable (the shared
+    // fixture client auto-follows redirects).
+    private HttpClient CreateNonRedirectingClient() =>
+        new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
+        {
+            BaseAddress = _fixture.Client.BaseAddress,
+        };
+
+    [Fact]
+    public async Task Index_ExactTicker_RedirectsToStockPage()
+    {
+        await SeedStock();
+        using var client = CreateNonRedirectingClient();
+
+        var response = await client.GetAsync("/Search?q=GXA");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location.ToString().ToLowerInvariant().Should().Contain("/stocks/gxa");
+    }
+
+    [Fact]
+    public async Task Index_ExactTickerLowercase_RedirectsToStockPage()
+    {
+        await SeedStock();
+        using var client = CreateNonRedirectingClient();
+
+        var response = await client.GetAsync("/Search?q=gxa");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location.ToString().ToLowerInvariant().Should().Contain("/stocks/gxa");
+    }
+
+    [Fact]
+    public async Task Index_ExactSecondaryTicker_RedirectsToPrimaryStockPage()
+    {
+        await SeedStock();
+        using var client = CreateNonRedirectingClient();
+
+        var response = await client.GetAsync("/Search?q=GXA.B");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location.ToString().ToLowerInvariant().Should().Contain("/stocks/gxa");
+    }
+
+    [Fact]
+    public async Task Index_CompanyNameQuery_RendersSearchPage()
+    {
+        await SeedStock();
+        using var client = CreateNonRedirectingClient();
+
+        var response = await client.GetAsync("/Search?q=Globex");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Globex Alpha Corp");
+    }
+
+    [Fact]
+    public async Task Index_ExactTickerWithCategoryFilter_DoesNotRedirect()
+    {
+        await SeedStock();
+        using var client = CreateNonRedirectingClient();
+
+        var response = await client.GetAsync("/Search?q=GXA&category=Stocks");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}


### PR DESCRIPTION
## Summary

- Submitting a global search query that exactly matches a ticker now jumps straight to that stock's page instead of showing the search results page.
- Applies on the unfiltered overview only — company-name/partial queries and category-filtered searches still render results, and the as-you-type fragment is unchanged.

## Code changes

- `src/Equibles.Web/Controllers/SearchController.cs` — `Index` now resolves the query against `CommonStockRepository.GetByTicker` (case-insensitive, primary or secondary ticker) when no category filter is active; on a match it redirects to `Stocks/Show` for that stock. Injected `CommonStockRepository` for the read.
- `tests/Equibles.IntegrationTests/Web/SearchControllerExactTickerRedirectTests.cs` — integration tests covering exact ticker, lowercase input, secondary→primary ticker, company-name query (no redirect), and category-filtered search (no redirect).