### PR TITLE
test(insider-trading): fix InsiderTradingFilingProcessor tests broken on main

### DIFF
--- a/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
+++ b/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
@@ -40,6 +40,7 @@
     <ProjectReference Include="..\..\src\Equibles.Holdings.Data\Equibles.Holdings.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Holdings.HostedService\Equibles.Holdings.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.InsiderTrading.Data\Equibles.InsiderTrading.Data.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.InsiderTrading.BusinessLogic\Equibles.InsiderTrading.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Congress.Data\Equibles.Congress.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Fred.Data\Equibles.Fred.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Errors.Data\Equibles.Errors.Data.csproj" />

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorMalformedOwnershipXmlTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorMalformedOwnershipXmlTests.cs
@@ -3,6 +3,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
 using Equibles.Errors.Repositories;
+using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.Integrations.Sec.Contracts;
@@ -11,6 +12,8 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Repositories;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 
@@ -35,7 +38,8 @@ public class InsiderTradingFilingProcessorMalformedOwnershipXmlTests
         var dbContext = TestDbContextFactory.Create(
             new InsiderTradingModuleConfiguration(),
             new CommonStocksModuleConfiguration(),
-            new ErrorsModuleConfiguration()
+            new ErrorsModuleConfiguration(),
+            new YahooModuleConfiguration()
         );
 
         var errorRepo = new ErrorRepository(dbContext);
@@ -44,7 +48,9 @@ public class InsiderTradingFilingProcessorMalformedOwnershipXmlTests
             (typeof(ISecEdgarClient), secClient),
             (typeof(InsiderOwnerRepository), new InsiderOwnerRepository(dbContext)),
             (typeof(InsiderTransactionRepository), new InsiderTransactionRepository(dbContext)),
-            (typeof(ErrorManager), new ErrorManager(new ErrorRepository(dbContext)))
+            (typeof(ErrorManager), new ErrorManager(new ErrorRepository(dbContext))),
+            (typeof(DailyStockPriceRepository), new DailyStockPriceRepository(dbContext)),
+            (typeof(InsiderTransactionPriceValidator), new InsiderTransactionPriceValidator())
         );
         var processor = new InsiderTradingFilingProcessor(
             scopeFactory,

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -3,6 +3,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data;
 using Equibles.Errors.Repositories;
+using Equibles.InsiderTrading.BusinessLogic;
 using Equibles.InsiderTrading.Data;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
@@ -12,6 +13,8 @@ using Equibles.IntegrationTests.Helpers;
 using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -89,8 +92,8 @@ public class InsiderTradingFilingProcessorTests
     [InlineData("F", TransactionCode.TaxPayment)]
     [InlineData("E", TransactionCode.Expiration)]
     [InlineData("G", TransactionCode.Gift)]
-    [InlineData("I", TransactionCode.Inheritance)]
-    [InlineData("W", TransactionCode.Discretionary)]
+    [InlineData("I", TransactionCode.Discretionary)]
+    [InlineData("W", TransactionCode.Inheritance)]
     public void ParseTransactionCode_ValidCode_ReturnsCorrectEnum(
         string code,
         TransactionCode expected
@@ -301,20 +304,25 @@ public class InsiderTradingFilingProcessorTests
         var dbContext = TestDbContextFactory.Create(
             new InsiderTradingModuleConfiguration(),
             new CommonStocksModuleConfiguration(),
-            new ErrorsModuleConfiguration()
+            new ErrorsModuleConfiguration(),
+            new YahooModuleConfiguration()
         );
 
         var ownerRepo = new InsiderOwnerRepository(dbContext);
         var txRepo = new InsiderTransactionRepository(dbContext);
         var errorRepo = new ErrorRepository(dbContext);
         var errorManager = new ErrorManager(errorRepo);
+        var dailyStockPriceRepo = new DailyStockPriceRepository(dbContext);
+        var priceValidator = new InsiderTransactionPriceValidator();
         var secClient = Substitute.For<ISecEdgarClient>();
 
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(ISecEdgarClient), secClient),
             (typeof(InsiderOwnerRepository), ownerRepo),
             (typeof(InsiderTransactionRepository), txRepo),
-            (typeof(ErrorManager), errorManager)
+            (typeof(ErrorManager), errorManager),
+            (typeof(DailyStockPriceRepository), dailyStockPriceRepo),
+            (typeof(InsiderTransactionPriceValidator), priceValidator)
         );
 
         var errorReporter = new ErrorReporter(


### PR DESCRIPTION
## Summary

- `main` has been red for many commits: 22 integration tests in `InsiderTradingFilingProcessorTests` / `InsiderTradingFilingProcessorMalformedOwnershipXmlTests` fail. Both causes are stale test code lagging production, unrelated to any recent feature.
- Two distinct issues fixed so the suite matches the current processor.

## Code changes

- `tests/.../Sec/InsiderTradingFilingProcessorTests.cs` — correct the `ParseTransactionCode` `[InlineData]`: SEC Form 4 code "I" is a discretionary transaction and "W" is acquisition/disposition by will or the laws of descent (inheritance). The parser was already fixed to this mapping; the test still had them swapped. Also register `DailyStockPriceRepository` + `InsiderTransactionPriceValidator` in the scope substitute and add `YahooModuleConfiguration` to the test DbContext.
- `tests/.../Sec/InsiderTradingFilingProcessorMalformedOwnershipXmlTests.cs` — same fixture fix (the processor resolves both new dependencies at the top of `Process`, before parsing).
- `tests/.../Equibles.IntegrationTests.csproj` — add a project reference to `Equibles.InsiderTrading.BusinessLogic` so the validator type is available.