### PR TITLE
feat(web): segmented stock section navbar, metrics on Technicals tab

### DIFF
--- a/src/Equibles.Web/Views/Stocks/Show.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Show.cshtml
@@ -88,8 +88,32 @@
             _ => null
         };
     }
-    @if (hasAnyMetric) {
-        <!-- Key Metrics -->
+    @{
+        // Each "tab" is a full-page navigation, not an in-page tabpanel — so
+        // ARIA tab/tablist roles would mislead assistive tech (they expect
+        // arrow-key panel switching). Render as a <nav> landmark with normal
+        // links and mark the active one via aria-current="page". Items sit
+        // flush in a bordered, segmented bar.
+        string TabBtnClass(string id) =>
+            "btn btn-ghost rounded-none border-y-0 border-r-0 border-l border-base-300 first:border-l-0 font-medium "
+            + (activeTab == id ? "btn-neutral" : "");
+        string TabAriaCurrent(string id) => activeTab == id ? "page" : null;
+    }
+    <!-- Section navbar -->
+    <nav class="flex flex-wrap rounded-lg border border-base-300 bg-base-100 shadow-sm overflow-hidden mb-6" aria-label="@(stock.Ticker) sections">
+        <a class="@TabBtnClass("price")" aria-current="@TabAriaCurrent("price")" asp-action="Price" asp-route-ticker="@stock.Ticker">Technicals</a>
+        <a class="@TabBtnClass("holdings")" aria-current="@TabAriaCurrent("holdings")" asp-action="Holdings" asp-route-ticker="@stock.Ticker">Institutional Holders</a>
+        <a class="@TabBtnClass("short-volume")" aria-current="@TabAriaCurrent("short-volume")" asp-action="ShortVolume" asp-route-ticker="@stock.Ticker">Short Volume</a>
+        <a class="@TabBtnClass("short-interest")" aria-current="@TabAriaCurrent("short-interest")" asp-action="ShortInterest" asp-route-ticker="@stock.Ticker">Short Interest</a>
+        <a class="@TabBtnClass("ftd")" aria-current="@TabAriaCurrent("ftd")" asp-action="Ftd" asp-route-ticker="@stock.Ticker">Fails to Deliver</a>
+        <a class="@TabBtnClass("financials")" aria-current="@TabAriaCurrent("financials")" asp-action="Financials" asp-route-ticker="@stock.Ticker">Financials</a>
+        <a class="@TabBtnClass("documents")" aria-current="@TabAriaCurrent("documents")" asp-action="Documents" asp-route-ticker="@stock.Ticker">SEC Filings</a>
+        <a class="@TabBtnClass("insider-trading")" aria-current="@TabAriaCurrent("insider-trading")" asp-action="InsiderTrading" asp-route-ticker="@stock.Ticker">Insider Trades</a>
+        <a class="@TabBtnClass("congressional-trades")" aria-current="@TabAriaCurrent("congressional-trades")" asp-action="CongressionalTrades" asp-route-ticker="@stock.Ticker">Congressional Trades</a>
+    </nav>
+
+    @if (activeTab == "price" && hasAnyMetric) {
+        <!-- Key Metrics (Technicals tab only) -->
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-6">
             @if (km.LatestClose.HasValue) {
                 <div class="card bg-base-100 shadow-sm">
@@ -141,28 +165,6 @@
             }
         </div>
     }
-
-    @{
-        // Each "tab" is a full-page navigation, not an in-page tabpanel — so
-        // ARIA tab/tablist roles would mislead assistive tech (they expect
-        // arrow-key panel switching). Render as a <nav> landmark with normal
-        // links and mark the active one via aria-current="page".
-        string TabBtnClass(string id) =>
-            "btn btn-sm " + (activeTab == id ? "btn-primary" : "btn-ghost border border-base-300");
-        string TabAriaCurrent(string id) => activeTab == id ? "page" : null;
-    }
-    <!-- Tabs -->
-    <nav class="flex flex-wrap gap-2 mb-6" aria-label="@(stock.Ticker) sections">
-        <a class="@TabBtnClass("price")" aria-current="@TabAriaCurrent("price")" asp-action="Price" asp-route-ticker="@stock.Ticker">Price History</a>
-        <a class="@TabBtnClass("holdings")" aria-current="@TabAriaCurrent("holdings")" asp-action="Holdings" asp-route-ticker="@stock.Ticker">Institutional Holders</a>
-        <a class="@TabBtnClass("short-volume")" aria-current="@TabAriaCurrent("short-volume")" asp-action="ShortVolume" asp-route-ticker="@stock.Ticker">Short Volume</a>
-        <a class="@TabBtnClass("short-interest")" aria-current="@TabAriaCurrent("short-interest")" asp-action="ShortInterest" asp-route-ticker="@stock.Ticker">Short Interest</a>
-        <a class="@TabBtnClass("ftd")" aria-current="@TabAriaCurrent("ftd")" asp-action="Ftd" asp-route-ticker="@stock.Ticker">Fails to Deliver</a>
-        <a class="@TabBtnClass("financials")" aria-current="@TabAriaCurrent("financials")" asp-action="Financials" asp-route-ticker="@stock.Ticker">Financials</a>
-        <a class="@TabBtnClass("documents")" aria-current="@TabAriaCurrent("documents")" asp-action="Documents" asp-route-ticker="@stock.Ticker">SEC Filings</a>
-        <a class="@TabBtnClass("insider-trading")" aria-current="@TabAriaCurrent("insider-trading")" asp-action="InsiderTrading" asp-route-ticker="@stock.Ticker">Insider Trades</a>
-        <a class="@TabBtnClass("congressional-trades")" aria-current="@TabAriaCurrent("congressional-trades")" asp-action="CongressionalTrades" asp-route-ticker="@stock.Ticker">Congressional Trades</a>
-    </nav>
 
     <!-- Tab Content (server-rendered) -->
     <div>


### PR DESCRIPTION
## Summary

- Replace the wrapping pill-button section menu on the stock detail page with a modern segmented navbar: a single bordered, rounded bar with flush items, thin dividers, and the active section filled dark. Sits directly below the stock header.
- Rename the first section "Price History" → "Technicals" (display label only; action/route unchanged) and scope the Key Metrics cards to that tab, moving them below the navbar.

## Code changes

- `src/Equibles.Web/Views/Stocks/Show.cshtml` — Restyle the `<nav>` section links into a flush, bordered segmented bar via the `TabBtnClass` helper (`btn-ghost` items with left-border dividers, `btn-neutral` for the active item, `aria-current="page"` preserved). Key Metrics block moved below the navbar and gated on `activeTab == "price"`. First section relabeled "Technicals".