### PR TITLE
refactor(web): lowercase kebab-case URLs for stock and 13F pages

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -100,7 +100,7 @@ public class HoldingsActivityController : BaseController
         return View(viewModel);
     }
 
-    [HttpGet("~/holdings/filings")]
+    [HttpGet("~/holdings/latest-13f-filings")]
     public async Task<IActionResult> LatestFilings(int page = 1)
     {
         if (page < 1)
@@ -123,7 +123,7 @@ public class HoldingsActivityController : BaseController
         );
     }
 
-    [HttpGet("~/holdings/stats")]
+    [HttpGet("~/holdings/13f-statistics")]
     public async Task<IActionResult> Stats()
     {
         // Reads the per-quarter snapshot table that the worker rebuilds on
@@ -138,7 +138,7 @@ public class HoldingsActivityController : BaseController
         return View(new StatsDashboardViewModel { Snapshots = snapshots });
     }
 
-    [HttpGet("~/holdings/double-down")]
+    [HttpGet("~/holdings/double-down-report")]
     public async Task<IActionResult> DoubleDown(
         DateOnly? date,
         double? minPct,
@@ -192,7 +192,7 @@ public class HoldingsActivityController : BaseController
         return View(viewModel);
     }
 
-    [HttpGet("~/holdings/trends")]
+    [HttpGet("~/holdings/13f-trends")]
     public async Task<IActionResult> Trends()
     {
         // Same snapshot-table reads as /holdings/stats; the legacy live
@@ -217,7 +217,7 @@ public class HoldingsActivityController : BaseController
         );
     }
 
-    [HttpGet("~/Holdings/MostHeld")]
+    [HttpGet("~/holdings/most-held")]
     public async Task<IActionResult> MostHeld(
         DateOnly? date,
         string sort,
@@ -341,7 +341,7 @@ public class HoldingsActivityController : BaseController
         };
     }
 
-    [HttpGet("~/holdings/heatmap")]
+    [HttpGet("~/holdings/conviction-heat-map")]
     public async Task<IActionResult> HeatMap(DateOnly? date, bool combined = false)
     {
         var reportDates = await LoadAvailableReportDates();

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -234,7 +234,7 @@ public class ProfilesController : BaseController
         return View(viewModel);
     }
 
-    [HttpGet("~/institutions/overlap")]
+    [HttpGet("~/institutions/overlap-matrix")]
     public async Task<IActionResult> OverlapMatrix(
         [FromQuery(Name = "ciks")] string[] ciks = null,
         [FromQuery(Name = "date")] DateOnly? date = null

--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -136,7 +136,7 @@ public class StocksController : BaseController
             }
         );
 
-    [HttpGet("~/stocks/{ticker}/shortvolume")]
+    [HttpGet("~/stocks/{ticker}/short-volume")]
     public Task<IActionResult> ShortVolume(string ticker) =>
         ShowStockTab(
             ticker,
@@ -144,7 +144,7 @@ public class StocksController : BaseController
             async s => await _stockTabService.LoadShortVolumeTab(s)
         );
 
-    [HttpGet("~/stocks/{ticker}/shortinterest")]
+    [HttpGet("~/stocks/{ticker}/short-interest")]
     public Task<IActionResult> ShortInterest(string ticker) =>
         ShowStockTab(
             ticker,
@@ -173,7 +173,7 @@ public class StocksController : BaseController
     public Task<IActionResult> Documents(string ticker) =>
         ShowStockTab(ticker, "documents", async s => await _stockTabService.LoadDocumentsTab(s));
 
-    [HttpGet("~/stocks/{ticker}/insidertrading")]
+    [HttpGet("~/stocks/{ticker}/insider-trading")]
     public Task<IActionResult> InsiderTrading(string ticker) =>
         ShowStockTab(
             ticker,
@@ -181,7 +181,7 @@ public class StocksController : BaseController
             async s => await _stockTabService.LoadInsiderTradingTab(s)
         );
 
-    [HttpGet("~/stocks/{ticker}/congressionaltrades")]
+    [HttpGet("~/stocks/{ticker}/congressional-trades")]
     public Task<IActionResult> CongressionalTrades(string ticker) =>
         ShowStockTab(
             ticker,

--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.AspNetCore.Rewrite;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
 using Serilog;
@@ -228,6 +229,7 @@ public partial class Program
                 },
             }
         );
+        app.UseRewriter(BuildLegacyUrlRedirects());
         app.UseRouting();
         app.UseSession();
         app.UseAuthentication();
@@ -235,5 +237,61 @@ public partial class Program
 
         app.MapHealthChecks("/healthz").AllowAnonymous();
         app.MapControllerRoute(name: "default", pattern: "{controller=Home}/{action=Index}/{id?}");
+    }
+
+    // 301 redirects from the old stock/holdings/institution URLs to the new
+    // lowercase kebab-case slugs. Patterns are case-insensitive ((?i)) so both
+    // the old PascalCase and old no-separator variants redirect; the rewriter
+    // preserves the query string and prepends the leading slash automatically.
+    private static RewriteOptions BuildLegacyUrlRedirects()
+    {
+        const int movedPermanently = StatusCodes.Status301MovedPermanently;
+        return new RewriteOptions()
+            // Stock detail tabs (ticker captured in $1)
+            .AddRedirect(
+                "(?i)^stocks/([^/]+)/shortvolume/?$",
+                "stocks/$1/short-volume",
+                movedPermanently
+            )
+            .AddRedirect(
+                "(?i)^stocks/([^/]+)/shortinterest/?$",
+                "stocks/$1/short-interest",
+                movedPermanently
+            )
+            .AddRedirect(
+                "(?i)^stocks/([^/]+)/insidertrading/?$",
+                "stocks/$1/insider-trading",
+                movedPermanently
+            )
+            .AddRedirect(
+                "(?i)^stocks/([^/]+)/congressionaltrades/?$",
+                "stocks/$1/congressional-trades",
+                movedPermanently
+            )
+            // 13F / Holdings activity
+            .AddRedirect("(?i)^holdings/stats/?$", "holdings/13f-statistics", movedPermanently)
+            .AddRedirect(
+                "(?i)^holdings/filings/?$",
+                "holdings/latest-13f-filings",
+                movedPermanently
+            )
+            .AddRedirect("(?i)^holdings/trends/?$", "holdings/13f-trends", movedPermanently)
+            .AddRedirect(
+                "(?i)^holdings/double-down/?$",
+                "holdings/double-down-report",
+                movedPermanently
+            )
+            .AddRedirect(
+                "(?i)^holdings/heatmap/?$",
+                "holdings/conviction-heat-map",
+                movedPermanently
+            )
+            .AddRedirect("(?i)^holdings/mostheld/?$", "holdings/most-held", movedPermanently)
+            // Institution profiles
+            .AddRedirect(
+                "(?i)^institutions/overlap/?$",
+                "institutions/overlap-matrix",
+                movedPermanently
+            );
     }
 }

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -59,7 +59,7 @@
             <div class="flex items-center gap-2 shrink-0">
                 <label for="holdings-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
                 <select id="holdings-date" class="select select-bordered select-sm"
-                    onchange="var v=this.value; window.location.href = v==='combined' ? 'Holdings?combined=true' : 'Holdings?date=' + v">
+                    onchange="var v=this.value; window.location.href = v==='combined' ? 'holdings?combined=true' : 'holdings?date=' + v">
                     @if (Model.IsCombinedAvailable || Model.IsCombinedView) {
                         if (Model.IsCombinedView) {
                             <option value="combined" selected>Current Combined</option>

--- a/tests/Equibles.FunctionalTests/Tests/HoldingsDoubleDownSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HoldingsDoubleDownSeededTests.cs
@@ -24,7 +24,7 @@ public class HoldingsDoubleDownSeededTests
     [Fact]
     public async Task DoubleDown_WithMixedIncreasesAndThreshold_FiltersAndRanksByConviction()
     {
-        // Contract: /holdings/double-down shows positions where share-count increase ≥
+        // Contract: /holdings/double-down-report shows positions where share-count increase ≥
         // threshold% (default 50%) QoQ, ranked by % increase descending. Positions
         // with no prior shares or below-threshold increase are excluded.
         //
@@ -92,7 +92,7 @@ public class HoldingsDoubleDownSeededTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/holdings/double-down");
+        var response = await page.GotoAsync("/holdings/double-down-report");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/HoldingsHeatMapSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HoldingsHeatMapSeededTests.cs
@@ -23,7 +23,7 @@ public class HoldingsHeatMapSeededTests
     [Fact]
     public async Task HeatMap_WithThreeFilersAcrossTwoQuarters_RendersChartAndTable()
     {
-        // Pins the /holdings/heatmap route — requires ≥2 quarters of data and
+        // Pins the /holdings/conviction-heat-map route — requires ≥2 quarters of data and
         // ≥3 filers per stock to surface in the conviction heat map. Verifies
         // heading, bubble chart canvas, score components legend, and the top
         // scorers table with the seeded ticker.
@@ -58,7 +58,7 @@ public class HoldingsHeatMapSeededTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/holdings/heatmap");
+        var response = await page.GotoAsync("/holdings/conviction-heat-map");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/HoldingsLatestFilingsSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HoldingsLatestFilingsSeededTests.cs
@@ -23,7 +23,7 @@ public class HoldingsLatestFilingsSeededTests
     [Fact]
     public async Task LatestFilings_WithNewAndReturningFilers_RendersCorrectBadges()
     {
-        // Contract: /holdings/filings shows filings ordered by ImportedAt descending.
+        // Contract: /holdings/latest-13f-filings shows filings ordered by ImportedAt descending.
         // A filer with no holdings in a prior quarter gets a "New" badge. Amendment
         // filings get an "A" badge. Position count and total value aggregate multiple
         // holdings per filing.
@@ -132,7 +132,7 @@ public class HoldingsLatestFilingsSeededTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/holdings/filings");
+        var response = await page.GotoAsync("/holdings/latest-13f-filings");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/HoldingsMostHeldSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HoldingsMostHeldSeededTests.cs
@@ -84,7 +84,7 @@ public class HoldingsMostHeldSeededTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/Holdings/MostHeld");
+        var response = await page.GotoAsync("/holdings/most-held");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/HoldingsStatsSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HoldingsStatsSeededTests.cs
@@ -23,7 +23,7 @@ public class HoldingsStatsSeededTests
     [Fact]
     public async Task Stats_WithTwoQuartersOfSnapshots_RendersAggregatesAndFilerDelta()
     {
-        // Contract: /holdings/stats reads the per-quarter snapshot rows that
+        // Contract: /holdings/13f-statistics reads the per-quarter snapshot rows that
         // HoldingsAggregateRefreshService writes after each 13F import. The
         // summary cards show the latest quarter and the history table shows
         // QoQ filer deltas. Aggregate-correctness (distinct filer / stock /
@@ -65,7 +65,7 @@ public class HoldingsStatsSeededTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/holdings/stats");
+        var response = await page.GotoAsync("/holdings/13f-statistics");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/HoldingsTrendsSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HoldingsTrendsSeededTests.cs
@@ -22,7 +22,7 @@ public class HoldingsTrendsSeededTests
     [Fact]
     public async Task Trends_WithTwoQuarters_RendersChartCardsAndCreatesChartInstances()
     {
-        // Contract: /holdings/trends reads the per-quarter snapshot rows that
+        // Contract: /holdings/13f-trends reads the per-quarter snapshot rows that
         // HoldingsAggregateRefreshService writes after each 13F import, then
         // renders Chart.js trend charts when the snapshot list is non-empty.
         // The view serializes data inline and Chart.js creates instances on
@@ -63,7 +63,7 @@ public class HoldingsTrendsSeededTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/holdings/trends");
+        var response = await page.GotoAsync("/holdings/13f-trends");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/InstitutionsOverlapMatrixMaxCiksTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/InstitutionsOverlapMatrixMaxCiksTests.cs
@@ -21,14 +21,14 @@ public class InstitutionsOverlapMatrixMaxCiksTests
     [Fact]
     public async Task OverlapMatrix_MoreThanMaxCiks_Returns400()
     {
-        // Contract: /institutions/overlap rejects requests with more than MaxCiks (10)
+        // Contract: /institutions/overlap-matrix rejects requests with more than MaxCiks (10)
         // distinct CIKs by returning 400 BadRequest. The OverlapMatrix action splits
         // comma-separated CIKs before the check, so a single ciks= param with 11
         // values must trigger the guard.
         var ciks = string.Join(",", Enumerable.Range(1, 11).Select(i => $"000000000{i:D1}"));
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync($"/institutions/overlap?ciks={ciks}");
+        var response = await page.GotoAsync($"/institutions/overlap-matrix?ciks={ciks}");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(400);

--- a/tests/Equibles.FunctionalTests/Tests/InstitutionsOverlapMatrixSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/InstitutionsOverlapMatrixSeededTests.cs
@@ -24,7 +24,7 @@ public class InstitutionsOverlapMatrixSeededTests
     [Fact]
     public async Task OverlapMatrix_TwoFilers_RendersMatrixTableAndFundSummary()
     {
-        // Pins the /institutions/overlap route — seeds two funds with partially
+        // Pins the /institutions/overlap-matrix route — seeds two funds with partially
         // overlapping holdings, verifies the pairwise matrix table renders with
         // shared ticker counts and the fund summary table shows position counts.
         var aaplId = Guid.NewGuid();
@@ -77,7 +77,7 @@ public class InstitutionsOverlapMatrixSeededTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync($"/institutions/overlap?ciks={fundACik},{fundBCik}");
+        var response = await page.GotoAsync($"/institutions/overlap-matrix?ciks={fundACik},{fundBCik}");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/InstitutionsOverlapMatrixSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/InstitutionsOverlapMatrixSeededTests.cs
@@ -77,7 +77,9 @@ public class InstitutionsOverlapMatrixSeededTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync($"/institutions/overlap-matrix?ciks={fundACik},{fundBCik}");
+        var response = await page.GotoAsync(
+            $"/institutions/overlap-matrix?ciks={fundACik},{fundBCik}"
+        );
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/StocksCongressionalTradesSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksCongressionalTradesSeededTests.cs
@@ -97,7 +97,7 @@ public class StocksCongressionalTradesSeededTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/stocks/aapl/congressionaltrades");
+        var response = await page.GotoAsync("/stocks/aapl/congressional-trades");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/StocksCongressionalTradesTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksCongressionalTradesTests.cs
@@ -22,7 +22,7 @@ public class StocksCongressionalTradesTests
     [Fact]
     public async Task CongressionalTrades_GetForSeededStockWithNoTrades_RendersNoCongressionalTradesEmptyState()
     {
-        // /stocks/{ticker}/congressionaltrades goes through LoadStock +
+        // /stocks/{ticker}/congressional-trades goes through LoadStock +
         // StockTabService.LoadCongressionalTradesTab, which queries
         // CongressionalTradeRepository.GetByStock and Includes CongressMember. With no
         // CongressionalTrade rows the view takes the empty-state branch. Pins the explicit
@@ -42,7 +42,7 @@ public class StocksCongressionalTradesTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/stocks/aapl/congressionaltrades");
+        var response = await page.GotoAsync("/stocks/aapl/congressional-trades");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/StocksInsiderTradingSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksInsiderTradingSeededTests.cs
@@ -88,7 +88,7 @@ public class StocksInsiderTradingSeededTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/stocks/aapl/insidertrading");
+        var response = await page.GotoAsync("/stocks/aapl/insider-trading");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/StocksInsiderTradingTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksInsiderTradingTests.cs
@@ -22,7 +22,7 @@ public class StocksInsiderTradingTests
     [Fact]
     public async Task InsiderTrading_GetForSeededStockWithNoTransactions_RendersNoInsiderTradingDataEmptyState()
     {
-        // /stocks/{ticker}/insidertrading goes through LoadStock + StockTabService.LoadInsiderTradingTab,
+        // /stocks/{ticker}/insider-trading goes through LoadStock + StockTabService.LoadInsiderTradingTab,
         // which queries InsiderTransactionRepository.GetByStock and Includes InsiderOwner. With no
         // transactions seeded, Transactions.Count == 0 and the view takes the empty-state branch.
         // Pins the empty-state h3 copy ("No Insider Trading Data") so a refactor that drops the
@@ -41,7 +41,7 @@ public class StocksInsiderTradingTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/stocks/aapl/insidertrading");
+        var response = await page.GotoAsync("/stocks/aapl/insider-trading");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/StocksShortInterestTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksShortInterestTests.cs
@@ -68,7 +68,7 @@ public class StocksShortInterestTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/stocks/aapl/shortinterest");
+        var response = await page.GotoAsync("/stocks/aapl/short-interest");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);
@@ -91,7 +91,7 @@ public class StocksShortInterestTests
     [Fact]
     public async Task ShortInterest_GetForSeededStockWithNoShortInterest_RendersNoShortInterestDataEmptyState()
     {
-        // /stocks/{ticker}/shortinterest runs StockTabService.LoadShortInterestTab against the
+        // /stocks/{ticker}/short-interest runs StockTabService.LoadShortInterestTab against the
         // seeded stock. With no ShortInterest rows, the view takes the explicit empty-state
         // branch ("No Short Interest Data"). Pins both the route + LoadStock lookup AND the
         // empty-state copy — the other test in this file only covers the populated branch.
@@ -109,7 +109,7 @@ public class StocksShortInterestTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/stocks/aapl/shortinterest");
+        var response = await page.GotoAsync("/stocks/aapl/short-interest");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.FunctionalTests/Tests/StocksShortVolumeTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksShortVolumeTests.cs
@@ -67,7 +67,7 @@ public class StocksShortVolumeTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/stocks/aapl/shortvolume");
+        var response = await page.GotoAsync("/stocks/aapl/short-volume");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);
@@ -90,7 +90,7 @@ public class StocksShortVolumeTests
     [Fact]
     public async Task ShortVolume_GetForSeededStockWithNoShortVolume_RendersNoShortVolumeDataEmptyState()
     {
-        // /stocks/{ticker}/shortvolume runs StockTabService.LoadShortVolumeTab against the
+        // /stocks/{ticker}/short-volume runs StockTabService.LoadShortVolumeTab against the
         // seeded stock. With no DailyShortVolume rows, the view takes the explicit empty-state
         // branch ("No Short Volume Data"). Pins both the route + LoadStock lookup AND the
         // empty-state copy — the other test in this file only covers the populated branch.
@@ -108,7 +108,7 @@ public class StocksShortVolumeTests
         });
 
         var page = await _playwright.NewPageAsync(_web.BaseUrl);
-        var response = await page.GotoAsync("/stocks/aapl/shortvolume");
+        var response = await page.GotoAsync("/stocks/aapl/short-volume");
 
         response.Should().NotBeNull();
         response!.Status.Should().Be(200);

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -761,7 +761,7 @@ public class InsiderTradingFilingProcessorTests
         // All three share (insider, security, date, code P, accession, ownership Direct);
         // they differ only in Shares, PricePerShare, and the running SharesOwnedAfter.
         // A dedup key that collapses on the narrow tuple silently drops the 2nd and 3rd
-        // tranches — the user-visible bug on https://equibles.com/stocks/are/insidertrading.
+        // tranches — the user-visible bug on https://equibles.com/stocks/are/insider-trading.
         var multiPurchaseXml = """
             <ownershipDocument>
                 <reportingOwner>

--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerDoubleDownTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerDoubleDownTests.cs
@@ -19,7 +19,7 @@ public class HoldingsActivityControllerDoubleDownTests
     {
         await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
 
-        var response = await _fixture.Client.GetAsync("/holdings/double-down");
+        var response = await _fixture.Client.GetAsync("/holdings/double-down-report");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }

--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerHeatMapNoDatesTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerHeatMapNoDatesTests.cs
@@ -5,7 +5,7 @@ namespace Equibles.IntegrationTests.Web;
 
 /// <summary>
 /// Sibling to HoldingsActivityControllerDoubleDownTests (which pins the no-data
-/// path on /holdings/double-down). The HeatMap action has the same cold-start
+/// path on /holdings/double-down-report). The HeatMap action has the same cold-start
 /// shape — `if (reportDates.Count < 2) return View(viewModel)` — but with its
 /// own controller, route, view, and view model. A refactor that flipped the
 /// guard's `< 2` to `<= 2` (or dropped it entirely) would crash on the
@@ -25,7 +25,7 @@ public class HoldingsActivityControllerHeatMapNoDatesTests
     {
         await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
 
-        var response = await _fixture.Client.GetAsync("/holdings/heatmap");
+        var response = await _fixture.Client.GetAsync("/holdings/conviction-heat-map");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }

--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerLatestFilingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerLatestFilingsTests.cs
@@ -4,7 +4,7 @@ using Equibles.IntegrationTests.Helpers;
 namespace Equibles.IntegrationTests.Web;
 
 /// <summary>
-/// Coverage: exercises the /holdings/filings route with no seeded data and
+/// Coverage: exercises the /holdings/latest-13f-filings route with no seeded data and
 /// a negative page parameter, verifying the page-clamp guard and empty-state
 /// rendering both work without error.
 /// </summary>
@@ -23,7 +23,7 @@ public class HoldingsActivityControllerLatestFilingsTests
         // not throw or return a 500 from a negative Skip value.
         await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
 
-        var response = await _fixture.Client.GetAsync("/holdings/filings?page=-1");
+        var response = await _fixture.Client.GetAsync("/holdings/latest-13f-filings?page=-1");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }

--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerMostHeldFilersDeltaSortTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerMostHeldFilersDeltaSortTests.cs
@@ -70,7 +70,7 @@ public class HoldingsActivityControllerMostHeldFilersDeltaSortTests
             await Task.CompletedTask;
         });
 
-        var response = await _fixture.Client.GetAsync("/Holdings/MostHeld?sort=filersDelta");
+        var response = await _fixture.Client.GetAsync("/holdings/most-held?sort=filersDelta");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync();

--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerMostHeldTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerMostHeldTests.cs
@@ -24,7 +24,7 @@ public class HoldingsActivityControllerMostHeldTests
     {
         await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
 
-        var response = await _fixture.Client.GetAsync("/Holdings/MostHeld");
+        var response = await _fixture.Client.GetAsync("/holdings/most-held");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync();
@@ -62,7 +62,7 @@ public class HoldingsActivityControllerMostHeldTests
             await Task.CompletedTask;
         });
 
-        var response = await _fixture.Client.GetAsync("/Holdings/MostHeld");
+        var response = await _fixture.Client.GetAsync("/holdings/most-held");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync();
@@ -124,7 +124,7 @@ public class HoldingsActivityControllerMostHeldTests
             await Task.CompletedTask;
         });
 
-        var response = await _fixture.Client.GetAsync("/Holdings/MostHeld");
+        var response = await _fixture.Client.GetAsync("/holdings/most-held");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync();

--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerMostHeldValueSortTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerMostHeldValueSortTests.cs
@@ -69,7 +69,7 @@ public class HoldingsActivityControllerMostHeldValueSortTests
             await Task.CompletedTask;
         });
 
-        var response = await _fixture.Client.GetAsync("/Holdings/MostHeld?sort=value");
+        var response = await _fixture.Client.GetAsync("/holdings/most-held?sort=value");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync();

--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerStatsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerStatsTests.cs
@@ -39,7 +39,7 @@ public class HoldingsActivityControllerStatsTests
             await Task.CompletedTask;
         });
 
-        var response = await _fixture.Client.GetAsync("/holdings/stats");
+        var response = await _fixture.Client.GetAsync("/holdings/13f-statistics");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync();

--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerTrendsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerTrendsTests.cs
@@ -4,7 +4,7 @@ using Equibles.IntegrationTests.Helpers;
 namespace Equibles.IntegrationTests.Web;
 
 /// <summary>
-/// Coverage: exercises the /holdings/trends route end-to-end with no seeded
+/// Coverage: exercises the /holdings/13f-trends route end-to-end with no seeded
 /// data, verifying the view renders without error when both AUM and sector
 /// allocation queries return empty results.
 /// </summary>
@@ -20,7 +20,7 @@ public class HoldingsActivityControllerTrendsTests
     {
         await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
 
-        var response = await _fixture.Client.GetAsync("/holdings/trends");
+        var response = await _fixture.Client.GetAsync("/holdings/13f-trends");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }

--- a/tests/Equibles.IntegrationTests/Web/StocksTabsViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksTabsViewRenderingTests.cs
@@ -121,7 +121,7 @@ public class StocksTabsViewRenderingTests
             await Task.CompletedTask;
         });
 
-        var response = await _fixture.Client.GetAsync($"/Stocks/{Ticker}/InsiderTrading");
+        var response = await _fixture.Client.GetAsync($"/stocks/{Ticker}/insider-trading");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var html = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
## Summary

- Renames stock-detail tab, 13F/holdings, and institution overlap page URLs to lowercase kebab-case slugs that match the navigation menu names, so the address bar reflects the page a visitor is on.
- Adds permanent (301) redirects from every old path to the new one, so existing bookmarks, inbound links, and search-engine results keep working.

## URL changes

| Old | New |
|---|---|
| `/stocks/{t}/shortvolume` | `/stocks/{t}/short-volume` |
| `/stocks/{t}/shortinterest` | `/stocks/{t}/short-interest` |
| `/stocks/{t}/insidertrading` | `/stocks/{t}/insider-trading` |
| `/stocks/{t}/congressionaltrades` | `/stocks/{t}/congressional-trades` |
| `/holdings/stats` | `/holdings/13f-statistics` |
| `/holdings/filings` | `/holdings/latest-13f-filings` |
| `/holdings/trends` | `/holdings/13f-trends` |
| `/holdings/double-down` | `/holdings/double-down-report` |
| `/holdings/heatmap` | `/holdings/conviction-heat-map` |
| `/Holdings/MostHeld` | `/holdings/most-held` |
| `/institutions/overlap` | `/institutions/overlap-matrix` |

## Code changes

- `Controllers/StocksController.cs`, `HoldingsActivityController.cs`, `ProfilesController.cs` — updated the `[HttpGet("~/...")]` route literals. In-app links use tag helpers, so they regenerate automatically.
- `Program.cs` — new `BuildLegacyUrlRedirects()` wired via `app.UseRewriter(...)` before routing. Rules are case-insensitive (`(?i)`) so old PascalCase and no-separator variants also redirect; the query string is preserved.
- `Views/Stocks/_HoldingsTab.cshtml` — lowercased the relative date-selector link.
- Integration + functional tests — updated to request the new paths.