### PR TITLE
fix(sec): push chunk search filters into the BM25 index (#2157)

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260527222748_ReindexChunkBm25TickerRawTokenizer.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260527222748_ReindexChunkBm25TickerRawTokenizer.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260527222748_ReindexChunkBm25TickerRawTokenizer")]
+    partial class ReindexChunkBm25TickerRawTokenizer
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260527222748_ReindexChunkBm25TickerRawTokenizer.cs
+++ b/src/Equibles.Migrations/Migrations/20260527222748_ReindexChunkBm25TickerRawTokenizer.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class ReindexChunkBm25TickerRawTokenizer : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Chunk_Id_Content_DocumentType_DocumentId_Ticker_ReportingDa~",
+                table: "Chunk"
+            );
+
+            migrationBuilder
+                .CreateIndex(
+                    name: "IX_Chunk_Id_Content_DocumentType_DocumentId_Ticker_ReportingDa~",
+                    table: "Chunk",
+                    columns: new[]
+                    {
+                        "Id",
+                        "Content",
+                        "DocumentType",
+                        "DocumentId",
+                        "Ticker",
+                        "ReportingDate",
+                    }
+                )
+                .Annotation("Npgsql:IndexMethod", "bm25")
+                .Annotation("Npgsql:StorageParameter:key_field", "Id")
+                .Annotation(
+                    "Npgsql:StorageParameter:text_fields",
+                    "{\"Ticker\":{\"tokenizer\":{\"type\":\"raw\"},\"fast\":true}}"
+                );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Chunk_Id_Content_DocumentType_DocumentId_Ticker_ReportingDa~",
+                table: "Chunk"
+            );
+
+            migrationBuilder
+                .CreateIndex(
+                    name: "IX_Chunk_Id_Content_DocumentType_DocumentId_Ticker_ReportingDa~",
+                    table: "Chunk",
+                    columns: new[]
+                    {
+                        "Id",
+                        "Content",
+                        "DocumentType",
+                        "DocumentId",
+                        "Ticker",
+                        "ReportingDate",
+                    }
+                )
+                .Annotation("Npgsql:IndexMethod", "bm25")
+                .Annotation("Npgsql:StorageParameter:key_field", "Id");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/Chunks/Chunk.cs
+++ b/src/Equibles.Sec.Data/Models/Chunks/Chunk.cs
@@ -50,7 +50,15 @@ public class Chunk
     /// Denormalized from <see cref="Document"/>.<see cref="Documents.Document.CommonStock"/>.<see cref="CommonStocks.CommonStock.Ticker"/>.
     /// Stored on the chunk so Tantivy can filter by ticker without SQL joins.
     /// </summary>
+    /// <remarks>
+    /// Indexed with the <c>raw</c> tokenizer so the whole symbol is a single token.
+    /// The default tokenizer splits on dash/slash, which would shatter class-share
+    /// tickers (e.g. <c>BRK-B</c> → <c>brk</c>/<c>b</c>) and make an exact term filter
+    /// impossible. <c>Fast = true</c> stores it columnar so the filter can be pushed
+    /// into the BM25 index instead of post-filtering scored chunks on the heap (#2157).
+    /// </remarks>
     [MaxLength(20)]
+    [Bm25Text(Tokenizer = Bm25Tokenizer.Raw, Fast = true)]
     public string Ticker { get; set; }
 
     /// <summary>

--- a/src/Equibles.Sec.Repositories/ChunkRepository.cs
+++ b/src/Equibles.Sec.Repositories/ChunkRepository.cs
@@ -29,18 +29,37 @@ public class ChunkRepository : BaseRepository<Chunk>
         CancellationToken cancellationToken = default
     )
     {
-        var query = DbContext
-            .Set<Chunk>()
-            .Where(c => EF.Functions.Parse(c.Id, searchText, lenient: true, conjunctionMode: true));
+        // Compose the text match and the ticker/document/type filters into one BM25
+        // boolean query so ParadeDB resolves the filters INSIDE the index (with_index).
+        // Layering them as SQL .Where(...) predicates instead made Postgres score every
+        // text match first and post-filter the result on the heap (heap_filter) — for a
+        // high-coverage ticker that scored set is enormous and blew the 5s budget (#2157).
+        var clauses = new List<ParadeDbJsonQuery>
+        {
+            ParadeDbJsonQuery.Parse(searchText, lenient: true, conjunctionMode: true),
+        };
 
+        // Ticker (raw tokenizer) and DocumentType (single-token enum values) are stored
+        // lowercased; Term is an exact, untokenized match, so the filter value must be
+        // lowercased to line up with the indexed token. DocumentId is a UUID and matches
+        // as-is.
         if (ticker != null)
-            query = query.Where(c => c.Ticker == ticker);
+            clauses.Add(ParadeDbJsonQuery.Term(nameof(Chunk.Ticker), ticker.ToLowerInvariant()));
 
         if (documentId.HasValue)
-            query = query.Where(c => c.DocumentId == documentId.Value);
+            clauses.Add(ParadeDbJsonQuery.Term(nameof(Chunk.DocumentId), documentId.Value));
 
         if (documentType != null)
-            query = query.Where(c => c.DocumentType == documentType);
+            clauses.Add(
+                ParadeDbJsonQuery.Term(
+                    nameof(Chunk.DocumentType),
+                    documentType.Value.ToLowerInvariant()
+                )
+            );
+
+        var searchQuery = ParadeDbJsonQuery.Boolean(b => b.Must(clauses.ToArray())).ToJson();
+
+        var query = DbContext.Set<Chunk>().Where(c => EF.Functions.JsonSearch(c.Id, searchQuery));
 
         if (startDate.HasValue)
         {

--- a/tests/Equibles.IntegrationTests/Sec/ChunkRepositoryHybridSearchTickerFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/ChunkRepositoryHybridSearchTickerFilterTests.cs
@@ -1,0 +1,203 @@
+using System.Data.Common;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.Data.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Data.Models.Chunks;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit.Abstractions;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Pins the fix for #2157: <see cref="ChunkRepository.HybridSearch"/> must push the
+/// ticker filter INTO the BM25 index (a Tantivy <c>term</c> inside the <c>@@@</c>
+/// query) rather than post-filtering scored chunks with a SQL
+/// <c>WHERE "Ticker" = ...</c> predicate. The SQL form compiles to a ParadeDB
+/// <c>heap_filter</c> that scores every text match before filtering — for a
+/// high-coverage ticker that scored set is enormous and blows the 5s budget.
+///
+/// Two guarantees are pinned here:
+/// 1. <see cref="HybridSearch_WithSeparatorTicker_StillMatchesViaRawTokenizer"/> —
+///    correctness for class-share tickers (e.g. <c>BRK-B</c>). The default tokenizer
+///    splits on dash/slash, so an exact term filter only works because the column is
+///    indexed with the <c>raw</c> tokenizer.
+/// 2. <see cref="HybridSearch_TickerFilter_IsPushedIntoTheBm25Query_NotASqlHeapFilter"/> —
+///    the filter rides inside the single <c>@@@ ...::jsonb</c> predicate and never
+///    reappears as a standalone SQL column comparison.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class ChunkRepositoryHybridSearchTickerFilterTests : ParadeDbMcpTestBase
+{
+    private readonly ITestOutputHelper _output;
+
+    public ChunkRepositoryHybridSearchTickerFilterTests(
+        ParadeDbFixture fixture,
+        ITestOutputHelper output
+    )
+        : base(fixture)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task HybridSearch_WithTickerFilter_ReturnsOnlyChunksForThatTicker()
+    {
+        var apple = SeedStock("AAPL", "Apple Inc.", "0000320193");
+        var microsoft = SeedStock("MSFT", "Microsoft Corp.", "0000789019");
+        SeedChunk(SeedDocument(apple), "Services revenue grew substantially this quarter.", "AAPL");
+        SeedChunk(SeedDocument(microsoft), "Services revenue rose across the cloud unit.", "MSFT");
+        await DbContext.SaveChangesAsync();
+
+        var sut = new ChunkRepository(DbContext);
+
+        var results = await sut.HybridSearch("services revenue", maxResults: 10, ticker: "AAPL");
+
+        results.Should().NotBeEmpty();
+        results.Should().AllSatisfy(c => c.Ticker.Should().Be("AAPL"));
+    }
+
+    [Fact]
+    public async Task HybridSearch_WithSeparatorTicker_StillMatchesViaRawTokenizer()
+    {
+        // The default BM25 tokenizer splits "BRK-B" into "brk"/"b", which would make a
+        // single exact term filter impossible. The raw tokenizer keeps it as one token.
+        var berkshire = SeedStock("BRK-B", "Berkshire Hathaway Inc.", "0001067983");
+        var apple = SeedStock("AAPL", "Apple Inc.", "0000320193");
+        SeedChunk(SeedDocument(berkshire), "Insurance services revenue increased.", "BRK-B");
+        SeedChunk(SeedDocument(apple), "Services revenue grew this quarter.", "AAPL");
+        await DbContext.SaveChangesAsync();
+
+        var sut = new ChunkRepository(DbContext);
+
+        var results = await sut.HybridSearch("services revenue", maxResults: 10, ticker: "BRK-B");
+
+        results.Should().NotBeEmpty("the raw tokenizer must let a class-share ticker match");
+        results.Should().AllSatisfy(c => c.Ticker.Should().Be("BRK-B"));
+    }
+
+    [Fact]
+    public async Task HybridSearch_TickerFilter_IsPushedIntoTheBm25Query_NotASqlHeapFilter()
+    {
+        var apple = SeedStock("AAPL", "Apple Inc.", "0000320193");
+        SeedChunk(SeedDocument(apple), "Services revenue grew substantially this quarter.", "AAPL");
+        await DbContext.SaveChangesAsync();
+
+        var interceptor = new CapturingCommandInterceptor();
+        await using var instrumentedContext = Fixture.CreateDbContext(builder =>
+            builder.AddInterceptors(interceptor)
+        );
+        var sut = new ChunkRepository(instrumentedContext);
+
+        await sut.HybridSearch("services revenue", maxResults: 10, ticker: "AAPL");
+
+        var sql = interceptor.GetChunkSelectCommandText();
+        _output.WriteLine(sql);
+
+        sql.Should().NotBeNull();
+        sql.Should().Contain("@@@", "the filter must ride inside the BM25 search operator");
+        sql.Should().Contain("jsonb", "the boolean query is passed as a ::jsonb predicate");
+        sql.Should()
+            .NotContain(
+                "\"Ticker\" =",
+                "the ticker filter must live inside the BM25 query, not a SQL heap-filter predicate that re-introduces #2157"
+            );
+    }
+
+    private CommonStock SeedStock(string ticker, string name, string cik)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = name,
+            Cik = cik,
+        };
+        DbContext.Add(stock);
+        return stock;
+    }
+
+    private Document SeedDocument(CommonStock stock)
+    {
+        var fileContent = new FileContent { Bytes = "placeholder"u8.ToArray() };
+        var file = new File
+        {
+            Name = "filing",
+            Extension = "txt",
+            ContentType = "text/plain",
+            Size = fileContent.Bytes.Length,
+            FileContent = fileContent,
+        };
+        fileContent.FileId = file.Id;
+        DbContext.Add(file);
+
+        var document = new Document
+        {
+            CommonStock = stock,
+            CommonStockId = stock.Id,
+            Content = file,
+            ContentId = file.Id,
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2026, 1, 15),
+            ReportingForDate = new DateOnly(2025, 12, 31),
+            LineCount = 1,
+        };
+        DbContext.Add(document);
+        return document;
+    }
+
+    private void SeedChunk(Document document, string content, string ticker)
+    {
+        DbContext.Add(
+            new Chunk
+            {
+                Document = document,
+                DocumentId = document.Id,
+                Index = 0,
+                StartPosition = 0,
+                EndPosition = content.Length,
+                StartLineNumber = 1,
+                Content = content,
+                DocumentType = document.DocumentType,
+                Ticker = ticker,
+                ReportingDate = DateTime.SpecifyKind(
+                    document.ReportingDate.ToDateTime(TimeOnly.MinValue),
+                    DateTimeKind.Utc
+                ),
+            }
+        );
+    }
+
+    private sealed class CapturingCommandInterceptor : DbCommandInterceptor
+    {
+        private readonly List<string> _commands = new();
+
+        public string GetChunkSelectCommandText() =>
+            _commands.LastOrDefault(c =>
+                c.StartsWith("SELECT", StringComparison.Ordinal)
+                && c.Contains("\"Chunk\"", StringComparison.Ordinal)
+            );
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result
+        )
+        {
+            _commands.Add(command.CommandText);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _commands.Add(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`SearchCompanyDocuments` and `SearchDocument` consistently timed out at the 5s budget on production. Confirmed root cause against ParadeDB (Testcontainers + `EXPLAIN`): `ChunkRepository.HybridSearch` layered the ticker/document/type filters as SQL `WHERE` predicates on top of the BM25 `Parse` match. ParadeDB compiled those into a **`heap_filter`** — it scored *every* text match first, then filtered on the heap. For a high-coverage ticker the scored set is enormous and blows the 5s ceiling. `SearchDocuments` (no filter) was unaffected, matching the report.

Verified on live data: the production `Chunk` table holds **~20.05M rows**, and **90,300** of them carry dash/slash tickers (`BRK-B`, `BF-A`, `MOG-A`, preferred `-P*` shares, …) — so the filter cannot rely on the default tokenizer.

## Code changes

- **`ChunkRepository.HybridSearch`** — the text match and the ticker/document/type filters now compose into a single `ParadeDbJsonQuery.Boolean(Must(...))` pushed through `JsonSearch`. `EXPLAIN` confirms this flips the plan from `heap_filter` to `with_index`: ParadeDB resolves the filter inside the index and returns only matching chunks top-K. DocumentId (UUID) matches as-is; Ticker/DocumentType are lowercased to line up with the indexed token.
- **`Chunk.Ticker`** — indexed with the `raw` tokenizer (`Fast = true`). The default tokenizer splits on dash/slash (`BRK-B` → `brk`/`b`), which would make an exact term filter impossible for class-share tickers. Raw keeps the whole symbol as one token.
- **Migration `ReindexChunkBm25TickerRawTokenizer`** — EF-generated drop/recreate of the chunk BM25 index with the raw-tokenizer storage parameter (no custom SQL).
- **Tests** — `ChunkRepositoryHybridSearchTickerFilterTests`: ticker scoping, a `BRK-B` raw-tokenizer correctness test, and a guard that fails if the ticker filter ever regresses to a SQL heap-filter predicate.

## Deploy note

The migration **rebuilds the BM25 index over the entire `Chunk` table (~20M rows)** on startup. Company search is degraded until the rebuild completes (runs under the existing 1-hour migration timeout). Schedule the deploy accordingly.

Closes #2157