### PR TITLE
refactor(web): extract QuarterlySelectionViewModel base and ApplyDateSelection helper

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -38,11 +38,7 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count == 0)
             return View(viewModel);
 
-        var dateSelection = ResolveCombinedDateSelection(date, combined, reportDates);
-        viewModel.IsCombinedAvailable = dateSelection.IsCombinedAvailable;
-        viewModel.IsCombinedSelected = dateSelection.IsCombinedSelected;
-        viewModel.SelectedDate = dateSelection.SelectedDate;
-        viewModel.PreviousDate = dateSelection.PreviousDate;
+        ApplyDateSelection(viewModel, date, combined);
 
         if (!viewModel.PreviousDate.HasValue)
             return View(viewModel);
@@ -160,11 +156,7 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count < 2)
             return View(viewModel);
 
-        var dateSelection = ResolveCombinedDateSelection(date, combined, reportDates);
-        viewModel.IsCombinedAvailable = dateSelection.IsCombinedAvailable;
-        viewModel.IsCombinedSelected = dateSelection.IsCombinedSelected;
-        viewModel.SelectedDate = dateSelection.SelectedDate;
-        viewModel.PreviousDate = dateSelection.PreviousDate;
+        ApplyDateSelection(viewModel, date, combined);
 
         if (!viewModel.PreviousDate.HasValue)
             return View(viewModel);
@@ -242,11 +234,7 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count == 0)
             return View(viewModel);
 
-        var dateSelection = ResolveCombinedDateSelection(date, combined, reportDates);
-        viewModel.IsCombinedAvailable = dateSelection.IsCombinedAvailable;
-        viewModel.IsCombinedSelected = dateSelection.IsCombinedSelected;
-        viewModel.SelectedDate = dateSelection.SelectedDate;
-        viewModel.PreviousDate = dateSelection.PreviousDate;
+        ApplyDateSelection(viewModel, date, combined);
 
         var selectedDate = viewModel.SelectedDate;
         var priorForRepo = viewModel.PreviousDate ?? selectedDate;
@@ -350,11 +338,7 @@ public class HoldingsActivityController : BaseController
         if (reportDates.Count < 2)
             return View(viewModel);
 
-        var dateSelection = ResolveCombinedDateSelection(date, combined, reportDates);
-        viewModel.IsCombinedAvailable = dateSelection.IsCombinedAvailable;
-        viewModel.IsCombinedSelected = dateSelection.IsCombinedSelected;
-        viewModel.SelectedDate = dateSelection.SelectedDate;
-        viewModel.PreviousDate = dateSelection.PreviousDate;
+        ApplyDateSelection(viewModel, date, combined);
 
         if (!viewModel.PreviousDate.HasValue)
             return View(viewModel);
@@ -450,6 +434,19 @@ public class HoldingsActivityController : BaseController
                 Name = s.Name,
             })
             .ToDictionaryAsync(s => s.Id);
+
+    private static void ApplyDateSelection(
+        QuarterlySelectionViewModel viewModel,
+        DateOnly? date,
+        bool combined
+    )
+    {
+        var selection = ResolveCombinedDateSelection(date, combined, viewModel.AvailableDates);
+        viewModel.IsCombinedAvailable = selection.IsCombinedAvailable;
+        viewModel.IsCombinedSelected = selection.IsCombinedSelected;
+        viewModel.SelectedDate = selection.SelectedDate;
+        viewModel.PreviousDate = selection.PreviousDate;
+    }
 
     private static (
         bool IsCombinedAvailable,

--- a/src/Equibles.Web/ViewModels/Holdings/DoubleDownViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/DoubleDownViewModel.cs
@@ -2,16 +2,11 @@ using Equibles.Holdings.Repositories.Models;
 
 namespace Equibles.Web.ViewModels.Holdings;
 
-public class DoubleDownViewModel
+public class DoubleDownViewModel : QuarterlySelectionViewModel
 {
     public const int PageSize = 100;
     public const double DefaultMinPct = 50.0;
 
-    public List<DateOnly> AvailableDates { get; set; } = [];
-    public DateOnly SelectedDate { get; set; }
-    public DateOnly? PreviousDate { get; set; }
-    public bool IsCombinedAvailable { get; set; }
-    public bool IsCombinedSelected { get; set; }
     public double MinPctIncrease { get; set; } = DefaultMinPct;
 
     public List<DoubleDownPosition> Positions { get; set; } = [];

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsActivityViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsActivityViewModel.cs
@@ -1,13 +1,7 @@
 namespace Equibles.Web.ViewModels.Holdings;
 
-public class HoldingsActivityViewModel
+public class HoldingsActivityViewModel : QuarterlySelectionViewModel
 {
-    public List<DateOnly> AvailableDates { get; set; } = [];
-    public DateOnly SelectedDate { get; set; }
-    public DateOnly? PreviousDate { get; set; }
-    public bool IsCombinedAvailable { get; set; }
-    public bool IsCombinedSelected { get; set; }
-
     public List<HoldingsActivityRow> TopBuys { get; set; } = [];
     public List<HoldingsActivityRow> TopSells { get; set; } = [];
     public List<HoldingsActivityRow> NewPositions { get; set; } = [];

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsHeatMapViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsHeatMapViewModel.cs
@@ -1,12 +1,7 @@
 namespace Equibles.Web.ViewModels.Holdings;
 
-public class HoldingsHeatMapViewModel
+public class HoldingsHeatMapViewModel : QuarterlySelectionViewModel
 {
-    public List<DateOnly> AvailableDates { get; set; } = [];
-    public DateOnly SelectedDate { get; set; }
-    public DateOnly? PreviousDate { get; set; }
-    public bool IsCombinedAvailable { get; set; }
-    public bool IsCombinedSelected { get; set; }
     public List<HeatMapPoint> Points { get; set; } = [];
     public int TotalUniverseFilers { get; set; }
 

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsMostHeldViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsMostHeldViewModel.cs
@@ -1,17 +1,11 @@
 namespace Equibles.Web.ViewModels.Holdings;
 
-public class HoldingsMostHeldViewModel
+public class HoldingsMostHeldViewModel : QuarterlySelectionViewModel
 {
     public const int PageSize = 100;
     public const string SortFilers = "filers";
     public const string SortFilersDelta = "filersDelta";
     public const string SortValue = "value";
-
-    public List<DateOnly> AvailableDates { get; set; } = [];
-    public DateOnly SelectedDate { get; set; }
-    public DateOnly? PreviousDate { get; set; }
-    public bool IsCombinedAvailable { get; set; }
-    public bool IsCombinedSelected { get; set; }
 
     public int TotalUniverseFilers { get; set; }
 

--- a/src/Equibles.Web/ViewModels/Holdings/QuarterlySelectionViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/QuarterlySelectionViewModel.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Web.ViewModels.Holdings;
+
+public abstract class QuarterlySelectionViewModel
+{
+    public List<DateOnly> AvailableDates { get; set; } = [];
+    public DateOnly SelectedDate { get; set; }
+    public DateOnly? PreviousDate { get; set; }
+    public bool IsCombinedAvailable { get; set; }
+    public bool IsCombinedSelected { get; set; }
+}


### PR DESCRIPTION
## Summary

- Lift the five shared date-selection properties (`AvailableDates`, `SelectedDate`, `PreviousDate`, `IsCombinedAvailable`, `IsCombinedSelected`) out of the four holdings activity view models into a new `QuarterlySelectionViewModel` base class.
- Collapse the four near-identical per-action "copy tuple onto view model" blocks in `HoldingsActivityController` into a single `ApplyDateSelection` mutator. The underlying `ResolveCombinedDateSelection` helper is preserved verbatim so the existing reflection-based unit test still pins resolver behavior.

## Code changes

- `src/Equibles.Web/ViewModels/Holdings/QuarterlySelectionViewModel.cs` — new abstract base class holding the five shared date-selection properties.
- `src/Equibles.Web/ViewModels/Holdings/HoldingsActivityViewModel.cs`, `DoubleDownViewModel.cs`, `HoldingsHeatMapViewModel.cs`, `HoldingsMostHeldViewModel.cs` — inherit from `QuarterlySelectionViewModel`; drop the duplicated property declarations.
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — replace four 4-line copy blocks (in `Activity`, `DoubleDown`, `MostHeld`, `HeatMap`) with a single `ApplyDateSelection(viewModel, date, combined)` call; add the new helper which delegates to the unchanged `ResolveCombinedDateSelection` tuple resolver.