### PR TITLE
refactor(profiles): extract MultiInstitutionViewModel base for picker state

### DIFF
--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionCombinedViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionCombinedViewModel.cs
@@ -2,17 +2,9 @@ using Equibles.Holdings.Repositories.Models;
 
 namespace Equibles.Web.ViewModels.Profiles;
 
-public class InstitutionCombinedViewModel
+public class InstitutionCombinedViewModel : MultiInstitutionViewModel
 {
-    public List<string> RequestedCiks { get; set; } = [];
-    public List<string> MissingCiks { get; set; } = [];
-    public List<DateOnly> CommonReportDates { get; set; } = [];
-    public DateOnly? SelectedDate { get; set; }
     public FundOverlapResult Overlap { get; set; }
-
-    // Resolved name + CIK pairs for chip rendering on first paint; see
-    // [InstitutionOverlapMatrixViewModel.InitialPicks] for the same contract.
-    public List<InstitutionPick> InitialPicks { get; set; } = [];
 
     // Pre-computed per-row consensus count (number of funds with Value > 0 in the row's
     // slices). Ranking sort key — populated alongside Overlap by the controller.

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionCompareViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionCompareViewModel.cs
@@ -2,17 +2,9 @@ using Equibles.Holdings.Repositories.Models;
 
 namespace Equibles.Web.ViewModels.Profiles;
 
-public class InstitutionCompareViewModel
+public class InstitutionCompareViewModel : MultiInstitutionViewModel
 {
-    public List<string> RequestedCiks { get; set; } = [];
-    public List<string> MissingCiks { get; set; } = [];
-    public List<DateOnly> CommonReportDates { get; set; } = [];
-    public DateOnly? SelectedDate { get; set; }
     public FundOverlapResult Overlap { get; set; }
-
-    // Resolved name + CIK pairs for chip rendering on first paint; see
-    // [InstitutionOverlapMatrixViewModel.InitialPicks] for the same contract.
-    public List<InstitutionPick> InitialPicks { get; set; } = [];
 
     public const int MaxCiks = 4;
     public const int MinCiks = 2;

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionOverlapMatrixViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionOverlapMatrixViewModel.cs
@@ -2,19 +2,10 @@ using Equibles.Holdings.Repositories.Models;
 
 namespace Equibles.Web.ViewModels.Profiles;
 
-public class InstitutionOverlapMatrixViewModel
+public class InstitutionOverlapMatrixViewModel : MultiInstitutionViewModel
 {
     public const int MaxCiks = 10;
     public const int MinCiks = 2;
 
-    public List<string> RequestedCiks { get; set; } = [];
-    public List<string> MissingCiks { get; set; } = [];
-    public List<DateOnly> CommonReportDates { get; set; } = [];
-    public DateOnly? SelectedDate { get; set; }
     public PairwiseOverlapMatrix Matrix { get; set; }
-
-    // Resolved name + CIK pairs for the chips the picker renders on first load — one
-    // entry per requested CIK, with Name == null when the CIK is missing from the
-    // database. Driven server-side so the chips look complete even before JS boots.
-    public List<InstitutionPick> InitialPicks { get; set; } = [];
 }

--- a/src/Equibles.Web/ViewModels/Profiles/MultiInstitutionViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/MultiInstitutionViewModel.cs
@@ -1,0 +1,14 @@
+namespace Equibles.Web.ViewModels.Profiles;
+
+public abstract class MultiInstitutionViewModel
+{
+    public List<string> RequestedCiks { get; set; } = [];
+    public List<string> MissingCiks { get; set; } = [];
+    public List<DateOnly> CommonReportDates { get; set; } = [];
+    public DateOnly? SelectedDate { get; set; }
+
+    // Resolved name + CIK pairs for the chips the picker renders on first load — one
+    // entry per requested CIK, with Name == null when the CIK is missing from the
+    // database. Driven server-side so the chips look complete even before JS boots.
+    public List<InstitutionPick> InitialPicks { get; set; } = [];
+}


### PR DESCRIPTION
## Summary

- Hoist the five duplicated picker-state properties (`RequestedCiks`, `MissingCiks`, `CommonReportDates`, `SelectedDate`, `InitialPicks`) plus the shared `InitialPicks` documentation comment out of `InstitutionCompareViewModel`, `InstitutionOverlapMatrixViewModel`, and `InstitutionCombinedViewModel` into a new `MultiInstitutionViewModel` abstract base class.
- View-specific properties (`Overlap`, `Matrix`, `FundsHoldingByStock`) and per-view `MaxCiks` / `MinCiks` constants stay on each subclass — the constants intentionally differ across views (4, 10, 25).

## Code changes

- `src/Equibles.Web/ViewModels/Profiles/MultiInstitutionViewModel.cs` — new abstract base class with the five shared picker-state properties.
- `src/Equibles.Web/ViewModels/Profiles/InstitutionCompareViewModel.cs`, `InstitutionOverlapMatrixViewModel.cs`, `InstitutionCombinedViewModel.cs` — inherit from `MultiInstitutionViewModel`; remove the duplicated property declarations and now-redundant `InitialPicks` comment block.