### PR TITLE
refactor(stocks-vm): extract StockTabViewModel base for shared Ticker

### DIFF
--- a/src/Equibles.Web/ViewModels/Stocks/CongressionalTradesTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/CongressionalTradesTabViewModel.cs
@@ -2,8 +2,7 @@ using Equibles.Congress.Data.Models;
 
 namespace Equibles.Web.ViewModels.Stocks;
 
-public class CongressionalTradesTabViewModel
+public class CongressionalTradesTabViewModel : StockTabViewModel
 {
     public List<CongressionalTrade> Trades { get; set; } = [];
-    public string Ticker { get; set; }
 }

--- a/src/Equibles.Web/ViewModels/Stocks/DocumentsTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/DocumentsTabViewModel.cs
@@ -2,8 +2,7 @@ using Equibles.Sec.Data.Models;
 
 namespace Equibles.Web.ViewModels.Stocks;
 
-public class DocumentsTabViewModel
+public class DocumentsTabViewModel : StockTabViewModel
 {
     public List<Document> Documents { get; set; } = [];
-    public string Ticker { get; set; }
 }

--- a/src/Equibles.Web/ViewModels/Stocks/FinancialsTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/FinancialsTabViewModel.cs
@@ -2,10 +2,8 @@ using Equibles.Sec.FinancialFacts.Data.Enums;
 
 namespace Equibles.Web.ViewModels.Stocks;
 
-public class FinancialsTabViewModel
+public class FinancialsTabViewModel : StockTabViewModel
 {
-    public string Ticker { get; set; }
-
     public FinancialStatementType StatementType { get; set; }
 
     public List<FinancialsPeriodOption> AvailablePeriods { get; set; } = [];

--- a/src/Equibles.Web/ViewModels/Stocks/FtdTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/FtdTabViewModel.cs
@@ -2,8 +2,7 @@ using Equibles.Sec.Data.Models;
 
 namespace Equibles.Web.ViewModels.Stocks;
 
-public class FtdTabViewModel
+public class FtdTabViewModel : StockTabViewModel
 {
     public List<FailToDeliver> FailsToDeliver { get; set; } = [];
-    public string Ticker { get; set; }
 }

--- a/src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/HoldingsTabViewModel.cs
@@ -1,10 +1,9 @@
 namespace Equibles.Web.ViewModels.Stocks;
 
-public class HoldingsTabViewModel
+public class HoldingsTabViewModel : StockTabViewModel
 {
     public List<DateOnly> AvailableDates { get; set; } = [];
     public DateOnly SelectedDate { get; set; }
-    public string Ticker { get; set; }
     public long TotalValue { get; set; }
     public long TotalShares { get; set; }
     public int HolderCount { get; set; }

--- a/src/Equibles.Web/ViewModels/Stocks/InsiderTradingTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/InsiderTradingTabViewModel.cs
@@ -2,8 +2,7 @@ using Equibles.InsiderTrading.Data.Models;
 
 namespace Equibles.Web.ViewModels.Stocks;
 
-public class InsiderTradingTabViewModel
+public class InsiderTradingTabViewModel : StockTabViewModel
 {
     public List<InsiderTransaction> Transactions { get; set; } = [];
-    public string Ticker { get; set; }
 }

--- a/src/Equibles.Web/ViewModels/Stocks/PriceTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/PriceTabViewModel.cs
@@ -2,9 +2,8 @@ using Equibles.Yahoo.Data.Models;
 
 namespace Equibles.Web.ViewModels.Stocks;
 
-public class PriceTabViewModel
+public class PriceTabViewModel : StockTabViewModel
 {
-    public string Ticker { get; set; }
     public List<DailyStockPrice> Prices { get; set; } = [];
 
     // Pre-computed indicator series (same length as Prices, null-padded at start)

--- a/src/Equibles.Web/ViewModels/Stocks/ShortInterestTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/ShortInterestTabViewModel.cs
@@ -2,8 +2,7 @@ using Equibles.Finra.Data.Models;
 
 namespace Equibles.Web.ViewModels.Stocks;
 
-public class ShortInterestTabViewModel
+public class ShortInterestTabViewModel : StockTabViewModel
 {
     public List<ShortInterest> ShortInterests { get; set; } = [];
-    public string Ticker { get; set; }
 }

--- a/src/Equibles.Web/ViewModels/Stocks/ShortVolumeTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/ShortVolumeTabViewModel.cs
@@ -2,8 +2,7 @@ using Equibles.Finra.Data.Models;
 
 namespace Equibles.Web.ViewModels.Stocks;
 
-public class ShortVolumeTabViewModel
+public class ShortVolumeTabViewModel : StockTabViewModel
 {
     public List<DailyShortVolume> ShortVolumes { get; set; } = [];
-    public string Ticker { get; set; }
 }

--- a/src/Equibles.Web/ViewModels/Stocks/StockTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/StockTabViewModel.cs
@@ -1,0 +1,6 @@
+namespace Equibles.Web.ViewModels.Stocks;
+
+public abstract class StockTabViewModel
+{
+    public string Ticker { get; set; }
+}


### PR DESCRIPTION
## Summary

- Nine stock-tab view models (Congressional, Documents, Financials, Ftd, Holdings, InsiderTrading, Price, ShortInterest, ShortVolume) each redeclared `public string Ticker { get; set; }`. Lift the property into a new `StockTabViewModel` abstract base class so the "every tab carries the stock ticker" contract is captured in one place.
- `DocumentViewModel` and `StockListItemViewModel` also expose a `Ticker` but are not tab view models, so they stay independent.

## Code changes

- `src/Equibles.Web/ViewModels/Stocks/StockTabViewModel.cs` — new abstract base class with the shared `Ticker` property.
- `src/Equibles.Web/ViewModels/Stocks/CongressionalTradesTabViewModel.cs`, `DocumentsTabViewModel.cs`, `FinancialsTabViewModel.cs`, `FtdTabViewModel.cs`, `HoldingsTabViewModel.cs`, `InsiderTradingTabViewModel.cs`, `PriceTabViewModel.cs`, `ShortInterestTabViewModel.cs`, `ShortVolumeTabViewModel.cs` — inherit from `StockTabViewModel`; remove the duplicated `Ticker` property.