### PR TITLE
refactor(holdings-repo): add GetReportDatesByStock/Holder and drop inline copies

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -75,7 +75,7 @@ public class InstitutionalHoldingsTools
 
                 var (targetDate, found) = await TryResolveLatestReportDate(
                     reportDate,
-                    GetReportDatesByStock(stock)
+                    _holdingRepository.GetReportDatesByStock(stock)
                 );
                 if (!found)
                     return $"No institutional holdings data available for {ticker}.";
@@ -161,7 +161,7 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var reportDates = await GetReportDatesByStock(stock).Take(maxPeriods).ToListAsync();
+                var reportDates = await _holdingRepository.GetReportDatesByStock(stock).Take(maxPeriods).ToListAsync();
 
                 if (reportDates.Count == 0)
                     return $"No institutional holdings history available for {ticker}.";
@@ -233,7 +233,7 @@ public class InstitutionalHoldingsTools
 
                 var (targetDate, found) = await TryResolveLatestReportDate(
                     reportDate,
-                    GetReportDatesByHolder(holder)
+                    _holdingRepository.GetReportDatesByHolder(holder)
                 );
                 if (!found)
                     return $"No holdings data for {holder.Name}.";
@@ -339,7 +339,7 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var reportDates = await GetReportDatesByStock(stock).ToListAsync();
+                var reportDates = await _holdingRepository.GetReportDatesByStock(stock).ToListAsync();
 
                 var targetDate = TryParseReportDate(reportDate, out var parsed)
                     ? parsed
@@ -942,7 +942,7 @@ public class InstitutionalHoldingsTools
                 if (holderError != null)
                     return holderError;
 
-                var reportDates = await GetReportDatesByHolder(holder).ToListAsync();
+                var reportDates = await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync();
                 if (reportDates.Count < 2)
                     return $"{holder.Name} has fewer than two reported quarters — no diff available.";
 
@@ -1103,7 +1103,7 @@ public class InstitutionalHoldingsTools
     {
         var perHolder = new List<List<DateOnly>>(holders.Count);
         foreach (var holder in holders)
-            perHolder.Add(await GetReportDatesByHolder(holder).ToListAsync());
+            perHolder.Add(await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync());
 
         return perHolder
             .Skip(1)
@@ -1329,26 +1329,12 @@ public class InstitutionalHoldingsTools
         if (holderError != null)
             return (null, null, default, holderError);
 
-        var reportDates = await GetReportDatesByHolder(holder).ToListAsync();
+        var reportDates = await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync();
         if (reportDates.Count == 0)
             return (holder, null, default, $"No 13F holdings reported by {holder.Name}.");
 
         return (holder, reportDates, ResolveReportDate(reportDate, reportDates), null);
     }
-
-    private IQueryable<DateOnly> GetReportDatesByHolder(InstitutionalHolder holder) =>
-        _holdingRepository
-            .GetHistoryByHolder(holder)
-            .Select(h => h.ReportDate)
-            .Distinct()
-            .OrderByDescending(d => d);
-
-    private IQueryable<DateOnly> GetReportDatesByStock(CommonStock stock) =>
-        _holdingRepository
-            .GetHistoryByStock(stock)
-            .Select(h => h.ReportDate)
-            .Distinct()
-            .OrderByDescending(d => d);
 
     private static bool TryParseReportDate(string input, out DateOnly result)
     {

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -59,6 +59,18 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         return GetAll().Select(h => h.ReportDate).Distinct().OrderByDescending(d => d);
     }
 
+    // Latest dates first — see GetAvailableReportDates for the ordering contract.
+    public IQueryable<DateOnly> GetReportDatesByStock(CommonStock stock)
+    {
+        return GetHistoryByStock(stock).Select(h => h.ReportDate).Distinct().OrderByDescending(d => d);
+    }
+
+    // Latest dates first — see GetAvailableReportDates for the ordering contract.
+    public IQueryable<DateOnly> GetReportDatesByHolder(InstitutionalHolder holder)
+    {
+        return GetHistoryByHolder(holder).Select(h => h.ReportDate).Distinct().OrderByDescending(d => d);
+    }
+
     public IQueryable<InstitutionalHolding> GetByAccessionNumber(string accessionNumber)
     {
         return GetAll().Where(h => h.AccessionNumber == accessionNumber);

--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -106,7 +106,7 @@ public class HoldingsExportController : BaseController
         if (holder == null)
             return NotFound();
 
-        var reportDates = await LoadReportDates(_holdingRepository.GetHistoryByHolder(holder));
+        var reportDates = await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync();
         if (reportDates.Count == 0)
             return NotFound();
 
@@ -251,9 +251,6 @@ public class HoldingsExportController : BaseController
 
     private static DateOnly ResolveSelectedDate(DateOnly? requested, List<DateOnly> available) =>
         requested.HasValue && available.Contains(requested.Value) ? requested.Value : available[0];
-
-    private static Task<List<DateOnly>> LoadReportDates(IQueryable<InstitutionalHolding> query) =>
-        query.Select(h => h.ReportDate).Distinct().OrderByDescending(d => d).ToListAsync();
 
     private static string[] ActivityRow(
         string board,

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -70,7 +70,9 @@ public class ProfilesController : BaseController
 
         // Header strip + industry allocation — pulled with extra per-quarter
         // materializations so the existing recent-rows list keeps its top-50 shape.
-        var distinctDates = await LoadReportDatesByHolder(holder);
+        var distinctDates = await _institutionalHoldingRepository
+            .GetReportDatesByHolder(holder)
+            .ToListAsync();
         var (summary, industryAllocation) = await BuildSummaryAndAllocation(holder, distinctDates);
         var (quarterlyActivity, activityResolved, activityPrior) = await BuildQuarterlyActivity(
             holder,
@@ -440,7 +442,9 @@ public class ProfilesController : BaseController
         var perHolderDates = new List<List<DateOnly>>();
         foreach (var holder in holders)
         {
-            var dates = await LoadReportDatesByHolder(holder);
+            var dates = await _institutionalHoldingRepository
+                .GetReportDatesByHolder(holder)
+                .ToListAsync();
             perHolderDates.Add(dates);
         }
         return perHolderDates
@@ -465,14 +469,6 @@ public class ProfilesController : BaseController
         }
         return perFund;
     }
-
-    private Task<List<DateOnly>> LoadReportDatesByHolder(InstitutionalHolder holder) =>
-        _institutionalHoldingRepository
-            .GetHistoryByHolder(holder)
-            .Select(h => h.ReportDate)
-            .Distinct()
-            .OrderByDescending(d => d)
-            .ToListAsync();
 
     private Task<List<InstitutionalHolding>> LoadHoldingsByHolderWithStock(
         InstitutionalHolder holder,

--- a/src/Equibles.Web/Services/HoldingsBacktestService.cs
+++ b/src/Equibles.Web/Services/HoldingsBacktestService.cs
@@ -80,11 +80,10 @@ public class HoldingsBacktestService
         viewModel.BenchmarkName = benchmarkStock.Name;
 
         var reportDates = await _holdingRepository
-            .GetHistoryByHolder(holder)
-            .Select(h => h.ReportDate)
-            .Distinct()
-            .OrderBy(d => d)
+            .GetReportDatesByHolder(holder)
             .ToListAsync();
+        // GetReportDatesByHolder returns latest first; backtest iterates earliest first.
+        reportDates.Reverse();
         if (reportDates.Count == 0)
         {
             viewModel.Result.Reason = "Holder has no 13F snapshots on file.";

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -63,10 +63,7 @@ public class StockTabService
     public async Task<HoldingsTabViewModel> LoadHoldingsTab(CommonStock stock, DateOnly? date)
     {
         var reportDates = await _institutionalHoldingRepository
-            .GetHistoryByStock(stock)
-            .Select(h => h.ReportDate)
-            .Distinct()
-            .OrderByDescending(d => d)
+            .GetReportDatesByStock(stock)
             .ToListAsync();
 
         var isCombinedAvailable =
@@ -177,10 +174,7 @@ public class StockTabService
     public async Task<HoldingsTabViewModel> LoadHoldingsCombinedTab(CommonStock stock)
     {
         var reportDates = await _institutionalHoldingRepository
-            .GetHistoryByStock(stock)
-            .Select(h => h.ReportDate)
-            .Distinct()
-            .OrderByDescending(d => d)
+            .GetReportDatesByStock(stock)
             .ToListAsync();
 
         if (reportDates.Count < 2)


### PR DESCRIPTION
## Summary

- Six call sites — `StockTabService`, `HoldingsBacktestService`, `ProfilesController`, `HoldingsExportController`, and two private helpers on `InstitutionalHoldingsTools` — each rebuilt the same `GetHistoryBy*(x).Select(h => h.ReportDate).Distinct().OrderByDescending(d => d)` query inline. Promote the query to two dedicated methods on `InstitutionalHoldingRepository` (mirroring the existing `GetAvailableReportDates` helper) and route every caller through them.
- `HoldingsBacktestService` iterates earliest-first, so it reverses the now-descending list in place to preserve identical observable ordering.

## Code changes

- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — add `GetReportDatesByStock(CommonStock)` and `GetReportDatesByHolder(InstitutionalHolder)`.
- `src/Equibles.Web/Services/StockTabService.cs` — replace inline distinct-report-date query with `GetReportDatesByStock`.
- `src/Equibles.Web/Services/HoldingsBacktestService.cs` — use `GetReportDatesByHolder` then `List<T>.Reverse()` to keep the earliest-first iteration.
- `src/Equibles.Web/Controllers/ProfilesController.cs` — drop the `LoadReportDatesByHolder` private helper; call `GetReportDatesByHolder` directly at both sites.
- `src/Equibles.Web/Controllers/HoldingsExportController.cs` — drop the `LoadReportDates` private helper; call `GetReportDatesByHolder` directly.
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — drop the two private `GetReportDatesByHolder`/`GetReportDatesByStock` helpers; route all seven call sites through the repository.