### PR TITLE
refactor(web): extract StatsViewModel base with ApplyStats helper

### DIFF
--- a/src/Equibles.Web/Controllers/EconomicDataController.cs
+++ b/src/Equibles.Web/Controllers/EconomicDataController.cs
@@ -105,12 +105,7 @@ public class EconomicDataController : BaseController
             .ToArray();
         if (chronological.Length > 0)
         {
-            var s = ComputeStats(chronological, decimals: 4);
-            viewModel.Mean = s.Mean;
-            viewModel.Min = s.Min;
-            viewModel.Max = s.Max;
-            viewModel.Median = s.Median;
-            viewModel.StdDev = s.StdDev;
+            viewModel.ApplyStats(chronological.ComputeStats(decimals: 4));
             viewModel.LatestValue = observations[0].Value; // observations are desc by date
             if (observations.Count > 1)
                 viewModel.PreviousValue = observations[1].Value;

--- a/src/Equibles.Web/Controllers/MarketController.cs
+++ b/src/Equibles.Web/Controllers/MarketController.cs
@@ -111,12 +111,7 @@ public class MarketController : BaseController
             .ToArray();
         if (values.Length > 0)
         {
-            var s = ComputeStats(values, decimals: 4);
-            viewModel.Mean = s.Mean;
-            viewModel.Median = s.Median;
-            viewModel.Min = s.Min;
-            viewModel.Max = s.Max;
-            viewModel.StdDev = s.StdDev;
+            viewModel.ApplyStats(values.ComputeStats(decimals: 4));
             viewModel.LatestRatio = records.FirstOrDefault()?.PutCallRatio;
             if (records.Count > 1)
                 viewModel.PreviousRatio = records[1].PutCallRatio;
@@ -149,12 +144,7 @@ public class MarketController : BaseController
         var values = records.Select(r => (double)r.Close).ToArray();
         if (values.Length > 0)
         {
-            var s = ComputeStats(values, decimals: 2);
-            viewModel.Mean = s.Mean;
-            viewModel.Median = s.Median;
-            viewModel.Min = s.Min;
-            viewModel.Max = s.Max;
-            viewModel.StdDev = s.StdDev;
+            viewModel.ApplyStats(values.ComputeStats(decimals: 2));
             viewModel.LatestClose = records.FirstOrDefault()?.Close;
             if (records.Count > 1)
                 viewModel.PreviousClose = records[1].Close;

--- a/src/Equibles.Web/ViewModels/EconomicData/EconomySeriesViewModel.cs
+++ b/src/Equibles.Web/ViewModels/EconomicData/EconomySeriesViewModel.cs
@@ -1,8 +1,9 @@
 using Equibles.Fred.Data.Models;
+using Equibles.Web.ViewModels.Shared;
 
 namespace Equibles.Web.ViewModels.EconomicData;
 
-public class EconomySeriesViewModel
+public class EconomySeriesViewModel : StatsViewModel
 {
     public string SeriesId { get; set; }
     public string Title { get; set; }
@@ -13,12 +14,6 @@ public class EconomySeriesViewModel
     public string SeasonalAdjustment { get; set; }
     public List<ObservationItem> Observations { get; set; } = [];
 
-    // Statistics
-    public decimal? Mean { get; set; }
-    public decimal? Median { get; set; }
-    public decimal? Min { get; set; }
-    public decimal? Max { get; set; }
-    public decimal? StdDev { get; set; }
     public decimal? LatestValue { get; set; }
     public decimal? PreviousValue { get; set; }
 

--- a/src/Equibles.Web/ViewModels/Market/PutCallRatioViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Market/PutCallRatioViewModel.cs
@@ -1,19 +1,14 @@
 using Equibles.Cboe.Data.Models;
+using Equibles.Web.ViewModels.Shared;
 
 namespace Equibles.Web.ViewModels.Market;
 
-public class PutCallRatioViewModel
+public class PutCallRatioViewModel : StatsViewModel
 {
     public CboePutCallRatioType Type { get; set; }
     public string DisplayName { get; set; }
     public List<PutCallRatioItem> Records { get; set; } = [];
 
-    // Statistics
-    public decimal? Mean { get; set; }
-    public decimal? Median { get; set; }
-    public decimal? Min { get; set; }
-    public decimal? Max { get; set; }
-    public decimal? StdDev { get; set; }
     public decimal? LatestRatio { get; set; }
     public decimal? PreviousRatio { get; set; }
 }

--- a/src/Equibles.Web/ViewModels/Market/VixViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Market/VixViewModel.cs
@@ -1,15 +1,11 @@
+using Equibles.Web.ViewModels.Shared;
+
 namespace Equibles.Web.ViewModels.Market;
 
-public class VixViewModel
+public class VixViewModel : StatsViewModel
 {
     public List<VixDailyItem> Records { get; set; } = [];
 
-    // Statistics
-    public decimal? Mean { get; set; }
-    public decimal? Median { get; set; }
-    public decimal? Min { get; set; }
-    public decimal? Max { get; set; }
-    public decimal? StdDev { get; set; }
     public decimal? LatestClose { get; set; }
     public decimal? PreviousClose { get; set; }
     public List<decimal?> Sma20 { get; set; } = [];

--- a/src/Equibles.Web/ViewModels/Shared/StatsViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Shared/StatsViewModel.cs
@@ -1,0 +1,21 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.Web.ViewModels.Shared;
+
+public abstract class StatsViewModel
+{
+    public decimal? Mean { get; set; }
+    public decimal? Median { get; set; }
+    public decimal? Min { get; set; }
+    public decimal? Max { get; set; }
+    public decimal? StdDev { get; set; }
+
+    public void ApplyStats(StatsSummary stats)
+    {
+        Mean = stats.Mean;
+        Median = stats.Median;
+        Min = stats.Min;
+        Max = stats.Max;
+        StdDev = stats.StdDev;
+    }
+}


### PR DESCRIPTION
## Summary

- `PutCallRatioViewModel`, `VixViewModel`, and `EconomySeriesViewModel` each redeclared the same five `Mean`/`Median`/`Min`/`Max`/`StdDev` properties, and the three controller actions that populate them duplicated the same five-line "copy `StatsSummary` onto viewmodel" block.
- Lift those properties into a shared `StatsViewModel` abstract base class and add an `ApplyStats(StatsSummary)` instance method so each populating call site becomes one line.
- The local private `ComputeStats` wrapper helpers in both controllers stay in place — a reflection-based unit test pins `MarketController.ComputeStats`, and removing them was out of scope for this PR.

## Code changes

- `src/Equibles.Web/ViewModels/Shared/StatsViewModel.cs` — new abstract base class with the five shared stats properties and the `ApplyStats(StatsSummary)` instance method.
- `src/Equibles.Web/ViewModels/EconomicData/EconomySeriesViewModel.cs`, `src/Equibles.Web/ViewModels/Market/VixViewModel.cs`, `src/Equibles.Web/ViewModels/Market/PutCallRatioViewModel.cs` — inherit from `StatsViewModel`; drop the duplicated stats properties and now-redundant `// Statistics` comment headers.
- `src/Equibles.Web/Controllers/MarketController.cs` (PutCallRatio, Vix) and `src/Equibles.Web/Controllers/EconomicDataController.cs` (Show) — replace the five-line copy block with a single `viewModel.ApplyStats(values.ComputeStats(decimals: N));` call.