### PR TITLE
refactor(commonstocks-repo): add GetByIds and drop inline Contains queries

### DIFF
--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -97,6 +97,11 @@ public class CommonStockRepository : BaseRepository<CommonStock>
             );
     }
 
+    public IQueryable<CommonStock> GetByIds(IEnumerable<Guid> ids)
+    {
+        return GetAll().Where(cs => ids.Contains(cs.Id));
+    }
+
     public IQueryable<string> GetAllTickers()
     {
         return GetAll().Select(cs => cs.Ticker);

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -161,7 +161,10 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var reportDates = await _holdingRepository.GetReportDatesByStock(stock).Take(maxPeriods).ToListAsync();
+                var reportDates = await _holdingRepository
+                    .GetReportDatesByStock(stock)
+                    .Take(maxPeriods)
+                    .ToListAsync();
 
                 if (reportDates.Count == 0)
                     return $"No institutional holdings history available for {ticker}.";
@@ -339,7 +342,9 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var reportDates = await _holdingRepository.GetReportDatesByStock(stock).ToListAsync();
+                var reportDates = await _holdingRepository
+                    .GetReportDatesByStock(stock)
+                    .ToListAsync();
 
                 var targetDate = TryParseReportDate(reportDate, out var parsed)
                     ? parsed
@@ -942,7 +947,9 @@ public class InstitutionalHoldingsTools
                 if (holderError != null)
                     return holderError;
 
-                var reportDates = await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync();
+                var reportDates = await _holdingRepository
+                    .GetReportDatesByHolder(holder)
+                    .ToListAsync();
                 if (reportDates.Count < 2)
                     return $"{holder.Name} has fewer than two reported quarters — no diff available.";
 
@@ -1304,10 +1311,7 @@ public class InstitutionalHoldingsTools
             .ToListAsync();
 
     private Task<Dictionary<Guid, CommonStock>> LoadStocksByIds(List<Guid> stockIds) =>
-        _commonStockRepository
-            .GetAll()
-            .Where(s => stockIds.Contains(s.Id))
-            .ToDictionaryAsync(s => s.Id);
+        _commonStockRepository.GetByIds(stockIds).ToDictionaryAsync(s => s.Id);
 
     private static (string Ticker, string Name) ResolveStockCells(
         IDictionary<Guid, CommonStock> stocks,

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -225,11 +225,7 @@ public class FtdImportService
         // stocks alongside the orphan.
         var stockIds = items.Select(i => i.CommonStockId).Distinct().ToHashSet();
         var existingIds = (
-            await stockRepo
-                .GetAll()
-                .Where(s => stockIds.Contains(s.Id))
-                .Select(s => s.Id)
-                .ToListAsync()
+            await stockRepo.GetByIds(stockIds).Select(s => s.Id).ToListAsync()
         ).ToHashSet();
 
         var safeItems = items.Where(i => existingIds.Contains(i.CommonStockId)).ToList();

--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -425,8 +425,7 @@ public class HoldingsActivityController : BaseController
 
     private Task<Dictionary<Guid, StockLabel>> LoadStockLabels(List<Guid> stockIds) =>
         _commonStockRepository
-            .GetAll()
-            .Where(s => stockIds.Contains(s.Id))
+            .GetByIds(stockIds)
             .Select(s => new StockLabel
             {
                 Id = s.Id,

--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -209,8 +209,7 @@ public class HoldingsExportController : BaseController
             .Distinct()
             .ToList();
         var stocks = await _stockRepository
-            .GetAll()
-            .Where(s => stockIds.Contains(s.Id))
+            .GetByIds(stockIds)
             .Select(s => new StockLabel(s.Id, s.Ticker, s.Name))
             .ToDictionaryAsync(s => s.Id);
 


### PR DESCRIPTION
## Summary

- Four call sites — `HoldingsActivityController.LoadStockLabels`, `HoldingsExportController.Activity`, `InstitutionalHoldingsTools.LoadStocksByIds`, and `FtdImportService` — each rebuilt the same `_commonStockRepository.GetAll().Where(s => stockIds.Contains(s.Id))` chain inline. Add `GetByIds(IEnumerable<Guid> ids)` to `CommonStockRepository` (mirroring the existing `GetByCiks` / `GetByTickers` naming convention) and route each caller through it.

## Code changes

- `src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs` — add `GetByIds(IEnumerable<Guid> ids)`.
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — `LoadStockLabels` calls `GetByIds`.
- `src/Equibles.Web/Controllers/HoldingsExportController.cs` — `Activity` action calls `GetByIds`.
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — `LoadStocksByIds` collapses to `GetByIds(...).ToDictionaryAsync(...)`.
- `src/Equibles.Sec.HostedService/Services/FtdImportService.cs` — orphan-Id check uses `GetByIds`.