### PR TITLE
refactor(web): extract ResolveSelectedDateOrFirst date-fallback extension

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -3,6 +3,7 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Extensions;
 using Equibles.Web.Services;
 using Equibles.Web.ViewModels.Stocks;
 using Microsoft.AspNetCore.Mvc;
@@ -110,7 +111,7 @@ public class HoldingsExportController : BaseController
         if (reportDates.Count == 0)
             return NotFound();
 
-        var selectedDate = ResolveSelectedDate(date, reportDates);
+        var selectedDate = reportDates.ResolveSelectedDateOrFirst(date);
 
         var rowsRaw = await _holdingRepository
             .GetByHolder(holder, selectedDate)
@@ -169,7 +170,7 @@ public class HoldingsExportController : BaseController
         if (reportDates.Count < 2)
             return NotFound();
 
-        var selectedDate = ResolveSelectedDate(date, reportDates);
+        var selectedDate = reportDates.ResolveSelectedDateOrFirst(date);
         var selectedIndex = reportDates.IndexOf(selectedDate);
         if (selectedIndex >= reportDates.Count - 1)
             return NotFound();
@@ -247,9 +248,6 @@ public class HoldingsExportController : BaseController
         Response.Headers.CacheControl = "no-store";
         return File(Encoding.UTF8.GetBytes(csv), "text/csv", filename);
     }
-
-    private static DateOnly ResolveSelectedDate(DateOnly? requested, List<DateOnly> available) =>
-        requested.HasValue && available.Contains(requested.Value) ? requested.Value : available[0];
 
     private static string[] ActivityRow(
         string board,

--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -4,6 +4,7 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Models;
 using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Extensions;
 using Equibles.Web.Services;
 using Equibles.Web.ViewModels.Holdings;
 using Microsoft.AspNetCore.Mvc;
@@ -179,8 +180,7 @@ public class HoldingsScreenerController : BaseController
         var reportDates = await _holdingRepository.GetAvailableReportDates().ToListAsync();
         if (reportDates.Count < 2)
             return (reportDates, null, null);
-        var selected =
-            date.HasValue && reportDates.Contains(date.Value) ? date.Value : reportDates[0];
+        var selected = reportDates.ResolveSelectedDateOrFirst(date);
         // The default comparison must track the selected date — picking a fixed
         // reportDates[1] collapses to selected==comparison when selected is the
         // second-latest, and to a *newer* comparison when selected is older.

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -480,7 +480,7 @@ public class ProfilesController : BaseController
             .ToListAsync();
 
     private static DateOnly ResolveSelectedDate(DateOnly? requested, List<DateOnly> available) =>
-        requested.HasValue && available.Contains(requested.Value) ? requested.Value : available[0];
+        available.ResolveSelectedDateOrFirst(requested);
 
     private static List<string> NormalizeCiks(string[] ciks) =>
         (ciks ?? [])

--- a/src/Equibles.Web/Extensions/DateOnlyListExtensions.cs
+++ b/src/Equibles.Web/Extensions/DateOnlyListExtensions.cs
@@ -1,0 +1,13 @@
+namespace Equibles.Web.Extensions;
+
+public static class DateOnlyListExtensions
+{
+    // Returns the requested date when it appears in the list, otherwise the first
+    // entry. Callers pass an already-ordered list (typically latest first) so the
+    // fallback lands on the most recent available date. Throws if the list is
+    // empty — guard against that at the call site.
+    public static DateOnly ResolveSelectedDateOrFirst(
+        this IList<DateOnly> available,
+        DateOnly? requested
+    ) => requested.HasValue && available.Contains(requested.Value) ? requested.Value : available[0];
+}


### PR DESCRIPTION
## Summary

- The same `requested.HasValue && available.Contains(requested.Value) ? requested.Value : available[0]` fallback expression sat inline in three controllers — `ProfilesController.ResolveSelectedDate`, `HoldingsExportController.ResolveSelectedDate`, and `HoldingsScreenerController.ResolveScreenerDates`. Move the expression behind a single `DateOnlyListExtensions.ResolveSelectedDateOrFirst` extension on `IList<DateOnly>`.
- `ProfilesController.ResolveSelectedDate` is preserved as a one-line wrapper that delegates to the extension — a reflection-based unit test pins that method name and signature, so removing it is out of scope.

## Code changes

- `src/Equibles.Web/Extensions/DateOnlyListExtensions.cs` — new extension with `ResolveSelectedDateOrFirst(this IList<DateOnly>, DateOnly?)`.
- `src/Equibles.Web/Controllers/ProfilesController.cs` — private `ResolveSelectedDate` delegates to the extension.
- `src/Equibles.Web/Controllers/HoldingsExportController.cs` — removes the local helper; both call sites now use the extension.
- `src/Equibles.Web/Controllers/HoldingsScreenerController.cs` — inline expression replaced with the extension call.