### PR TITLE
refactor(profiles): add InstitutionPickerViewModel.For factory; shorten 3 views

### DIFF
--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionPickerViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionPickerViewModel.cs
@@ -11,4 +11,20 @@ public class InstitutionPickerViewModel
     public List<DateOnly> CommonReportDates { get; set; } = [];
     public DateOnly? SelectedDate { get; set; }
     public string SubmitLabel { get; set; } = "Compare";
+
+    public static InstitutionPickerViewModel For(
+        MultiInstitutionViewModel source,
+        int minPicks,
+        int maxPicks,
+        string submitLabel
+    ) =>
+        new()
+        {
+            Picks = source.InitialPicks,
+            MinPicks = minPicks,
+            MaxPicks = maxPicks,
+            CommonReportDates = source.CommonReportDates,
+            SelectedDate = source.SelectedDate,
+            SubmitLabel = submitLabel,
+        };
 }

--- a/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
@@ -4,15 +4,11 @@
 @{
     ViewData["Title"] = "Combined portfolio";
 
-    var pickerVm = new InstitutionPickerViewModel
-    {
-        Picks = Model.InitialPicks,
-        MinPicks = InstitutionCombinedViewModel.MinCiks,
-        MaxPicks = InstitutionCombinedViewModel.MaxCiks,
-        CommonReportDates = Model.CommonReportDates,
-        SelectedDate = Model.SelectedDate,
-        SubmitLabel = "Combine",
-    };
+    var pickerVm = InstitutionPickerViewModel.For(
+        Model,
+        InstitutionCombinedViewModel.MinCiks,
+        InstitutionCombinedViewModel.MaxCiks,
+        "Combine");
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">

--- a/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
@@ -4,15 +4,11 @@
 @{
     ViewData["Title"] = "Compare institutions";
 
-    var pickerVm = new InstitutionPickerViewModel
-    {
-        Picks = Model.InitialPicks,
-        MinPicks = InstitutionCompareViewModel.MinCiks,
-        MaxPicks = InstitutionCompareViewModel.MaxCiks,
-        CommonReportDates = Model.CommonReportDates,
-        SelectedDate = Model.SelectedDate,
-        SubmitLabel = "Compare",
-    };
+    var pickerVm = InstitutionPickerViewModel.For(
+        Model,
+        InstitutionCompareViewModel.MinCiks,
+        InstitutionCompareViewModel.MaxCiks,
+        "Compare");
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">

--- a/src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml
+++ b/src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml
@@ -5,15 +5,11 @@
     ViewData["Title"] = "Overlap Matrix";
     ViewData["Description"] = "Pairwise overlap of institutional 13F holdings — count of shared tickers between each pair.";
 
-    var pickerVm = new InstitutionPickerViewModel
-    {
-        Picks = Model.InitialPicks,
-        MinPicks = InstitutionOverlapMatrixViewModel.MinCiks,
-        MaxPicks = InstitutionOverlapMatrixViewModel.MaxCiks,
-        CommonReportDates = Model.CommonReportDates,
-        SelectedDate = Model.SelectedDate,
-        SubmitLabel = "Compare",
-    };
+    var pickerVm = InstitutionPickerViewModel.For(
+        Model,
+        InstitutionOverlapMatrixViewModel.MinCiks,
+        InstitutionOverlapMatrixViewModel.MaxCiks,
+        "Compare");
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">


### PR DESCRIPTION
## Summary

- Three Profiles pages backed by `MultiInstitutionViewModel` (CompareInstitutions, CombinedInstitutions, OverlapMatrix) each opened with a nine-line `new InstitutionPickerViewModel { ... }` initializer that copied the same five fields from the page model and varied only in the per-view min/max constants and submit label.
- Add an `InstitutionPickerViewModel.For(MultiInstitutionViewModel source, int minPicks, int maxPicks, string submitLabel)` static factory and replace each view's nine-line block with a single factory call.

## Code changes

- `src/Equibles.Web/ViewModels/Profiles/InstitutionPickerViewModel.cs` — add the `For` static factory.
- `src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml`, `CombinedInstitutions.cshtml`, `OverlapMatrix.cshtml` — replace the inline initializer with a single `InstitutionPickerViewModel.For(...)` call.