### PR TITLE
refactor(holdings-views): extract quarter date option markup into _QuarterDateOptions partial

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -17,21 +17,7 @@
                 <label for="activity-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
                 <select id="activity-date" class="select select-bordered select-sm"
                     onchange="var v=this.value; window.location.href = v==='combined' ? 'Activity?combined=true' : 'Activity?date=' + v">
-                    @if (Model.IsCombinedAvailable) {
-                        if (Model.IsCombinedSelected) {
-                            <option value="combined" selected>Current Combined</option>
-                        } else {
-                            <option value="combined">Current Combined</option>
-                        }
-                    }
-                    @foreach (var date in Model.AvailableDates) {
-                        var isSelected = !Model.IsCombinedSelected && date == Model.SelectedDate;
-                        if (isSelected) {
-                            <option value="@date.ToString("yyyy-MM-dd")" selected>@date.ToString("MMM dd, yyyy")</option>
-                        } else {
-                            <option value="@date.ToString("yyyy-MM-dd")">@date.ToString("MMM dd, yyyy")</option>
-                        }
-                    }
+                    <partial name="_QuarterDateOptions" model="Model" />
                 </select>
             </div>
             @if (Model.PreviousDate.HasValue) {

--- a/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
@@ -44,21 +44,7 @@
                     <span class="label-text text-sm mb-1">Report Date</span>
                     <select name="date" id="dd-date-select" class="select select-bordered" aria-label="Report date"
                         onchange="document.getElementById('dd-combined-flag').value = this.value==='combined' ? 'true' : ''; if(this.value==='combined') this.name=''; else this.name='date';">
-                        @if (Model.IsCombinedAvailable) {
-                            if (Model.IsCombinedSelected) {
-                                <option value="combined" selected>Current Combined</option>
-                            } else {
-                                <option value="combined">Current Combined</option>
-                            }
-                        }
-                        @foreach (var d in Model.AvailableDates) {
-                            var isSelected = !Model.IsCombinedSelected && d == Model.SelectedDate;
-                            if (isSelected) {
-                                <option value="@d.ToString("yyyy-MM-dd")" selected>@d.ToString("MMM dd, yyyy")</option>
-                            } else {
-                                <option value="@d.ToString("yyyy-MM-dd")">@d.ToString("MMM dd, yyyy")</option>
-                            }
-                        }
+                        <partial name="_QuarterDateOptions" model="Model" />
                     </select>
                 </label>
                 <label class="form-control">

--- a/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
@@ -31,21 +31,7 @@
                     <label for="heatmap-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
                     <select id="heatmap-date" class="select select-bordered select-sm"
                         onchange="var v=this.value; window.location.href = v==='combined' ? 'HeatMap?combined=true' : 'HeatMap?date=' + v">
-                        @if (Model.IsCombinedAvailable) {
-                            if (Model.IsCombinedSelected) {
-                                <option value="combined" selected>Current Combined</option>
-                            } else {
-                                <option value="combined">Current Combined</option>
-                            }
-                        }
-                        @foreach (var d in Model.AvailableDates) {
-                            var sel = !Model.IsCombinedSelected && d == Model.SelectedDate;
-                            if (sel) {
-                                <option value="@d.ToString("yyyy-MM-dd")" selected>@d.ToString("MMM dd, yyyy")</option>
-                            } else {
-                                <option value="@d.ToString("yyyy-MM-dd")">@d.ToString("MMM dd, yyyy")</option>
-                            }
-                        }
+                        <partial name="_QuarterDateOptions" model="Model" />
                     </select>
                 </div>
                 <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Stocks:</span> <strong>@Model.Points.Count.ToString("N0")</strong></div>

--- a/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
@@ -25,21 +25,7 @@
                 }
                 <select id="most-held-date" class="select select-bordered select-sm"
                     onchange="var v=this.value; window.location.href = v==='combined' ? 'MostHeld?combined=true&sort=@Model.Sort' : 'MostHeld?date=' + v + '&sort=@Model.Sort'">
-                    @if (Model.IsCombinedAvailable) {
-                        if (Model.IsCombinedSelected) {
-                            <option value="combined" selected>Current Combined</option>
-                        } else {
-                            <option value="combined">Current Combined</option>
-                        }
-                    }
-                    @foreach (var date in Model.AvailableDates) {
-                        var isSelected = !Model.IsCombinedSelected && date == Model.SelectedDate;
-                        if (isSelected) {
-                            <option value="@date.ToString("yyyy-MM-dd")" selected>@date.ToString("MMM dd, yyyy")</option>
-                        } else {
-                            <option value="@date.ToString("yyyy-MM-dd")">@date.ToString("MMM dd, yyyy")</option>
-                        }
-                    }
+                    <partial name="_QuarterDateOptions" model="Model" />
                 </select>
             </div>
             <div class="flex items-center gap-2 shrink-0">

--- a/src/Equibles.Web/Views/HoldingsActivity/_QuarterDateOptions.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/_QuarterDateOptions.cshtml
@@ -1,0 +1,17 @@
+@using Equibles.Web.ViewModels.Holdings
+@model QuarterlySelectionViewModel
+@if (Model.IsCombinedAvailable) {
+    if (Model.IsCombinedSelected) {
+        <option value="combined" selected>Current Combined</option>
+    } else {
+        <option value="combined">Current Combined</option>
+    }
+}
+@foreach (var date in Model.AvailableDates) {
+    var isSelected = !Model.IsCombinedSelected && date == Model.SelectedDate;
+    if (isSelected) {
+        <option value="@date.ToString("yyyy-MM-dd")" selected>@date.ToString("MMM dd, yyyy")</option>
+    } else {
+        <option value="@date.ToString("yyyy-MM-dd")">@date.ToString("MMM dd, yyyy")</option>
+    }
+}


### PR DESCRIPTION
## Summary

- The `Activity`, `DoubleDown`, `MostHeld`, and `HeatMap` views each duplicated 11 lines of `<option>` markup for the 13F report-date selector (Current Combined + each `AvailableDate`, with the right one preselected).
- Extracted that markup into a single `_QuarterDateOptions.cshtml` partial bound to `QuarterlySelectionViewModel`. Each view now renders one `<partial>` reference inside its existing `<select>`.

## Code changes

- `src/Equibles.Web/Views/HoldingsActivity/_QuarterDateOptions.cshtml` — new partial; renders the combined `<option>` (when available) and one `<option>` per `AvailableDate` with the right one marked `selected`.
- `src/Equibles.Web/Views/HoldingsActivity/{Activity,DoubleDown,MostHeld,HeatMap}.cshtml` — replaced the duplicated 11-line block with `<partial name="_QuarterDateOptions" model="Model" />`. Hosting `<select>` and its `onchange` handler stay per page since they differ.