### PR TITLE
refactor(repositories): extract LatestValue extension to collapse 10 date-projection duplicates

### DIFF
--- a/src/Equibles.Cboe.Repositories/CboePutCallRatioRepository.cs
+++ b/src/Equibles.Cboe.Repositories/CboePutCallRatioRepository.cs
@@ -1,5 +1,6 @@
 using Equibles.Cboe.Data.Models;
 using Equibles.Data;
+using Equibles.Data.Extensions;
 
 namespace Equibles.Cboe.Repositories;
 
@@ -24,11 +25,7 @@ public class CboePutCallRatioRepository : BaseRepository<CboePutCallRatio>
 
     public IQueryable<DateOnly> GetLatestDate(CboePutCallRatioType type)
     {
-        return GetAll()
-            .Where(r => r.RatioType == type)
-            .Select(r => r.Date)
-            .OrderByDescending(d => d)
-            .Take(1);
+        return GetAll().Where(r => r.RatioType == type).LatestValue(r => r.Date);
     }
 
     public IQueryable<CboePutCallRatio> GetLatestPerType()

--- a/src/Equibles.Cboe.Repositories/CboeVixDailyRepository.cs
+++ b/src/Equibles.Cboe.Repositories/CboeVixDailyRepository.cs
@@ -1,5 +1,6 @@
 using Equibles.Cboe.Data.Models;
 using Equibles.Data;
+using Equibles.Data.Extensions;
 
 namespace Equibles.Cboe.Repositories;
 
@@ -15,6 +16,6 @@ public class CboeVixDailyRepository : BaseRepository<CboeVixDaily>
 
     public IQueryable<DateOnly> GetLatestDate()
     {
-        return GetAll().Select(v => v.Date).OrderByDescending(d => d).Take(1);
+        return GetAll().LatestValue(v => v.Date);
     }
 }

--- a/src/Equibles.Cftc.Repositories/CftcPositionReportRepository.cs
+++ b/src/Equibles.Cftc.Repositories/CftcPositionReportRepository.cs
@@ -1,5 +1,6 @@
 using Equibles.Cftc.Data.Models;
 using Equibles.Data;
+using Equibles.Data.Extensions;
 
 namespace Equibles.Cftc.Repositories;
 
@@ -29,11 +30,7 @@ public class CftcPositionReportRepository : BaseRepository<CftcPositionReport>
 
     public IQueryable<DateOnly> GetLatestDate(CftcContract contract)
     {
-        return GetAll()
-            .Where(r => r.CftcContractId == contract.Id)
-            .Select(r => r.ReportDate)
-            .OrderByDescending(d => d)
-            .Take(1);
+        return GetAll().Where(r => r.CftcContractId == contract.Id).LatestValue(r => r.ReportDate);
     }
 
     public IQueryable<CftcPositionReport> GetLatestPerContract()
@@ -45,6 +42,6 @@ public class CftcPositionReportRepository : BaseRepository<CftcPositionReport>
 
     public IQueryable<DateOnly> GetGlobalLatestDate()
     {
-        return GetAll().Select(r => r.ReportDate).OrderByDescending(d => d).Take(1);
+        return GetAll().LatestValue(r => r.ReportDate);
     }
 }

--- a/src/Equibles.Data/Extensions/QueryableLatestExtensions.cs
+++ b/src/Equibles.Data/Extensions/QueryableLatestExtensions.cs
@@ -1,0 +1,26 @@
+using System.Linq.Expressions;
+
+namespace Equibles.Data.Extensions;
+
+public static class QueryableLatestExtensions
+{
+    /// <summary>
+    /// Projects the source to <paramref name="selector"/> and returns the single
+    /// highest value as an <see cref="IQueryable{TKey}"/> (ORDER BY ... DESC LIMIT 1).
+    /// Set <paramref name="distinct"/> when the underlying rows can repeat the
+    /// projected value and the caller wants a unique-by-projection comparison.
+    /// </summary>
+    public static IQueryable<TKey> LatestValue<TSource, TKey>(
+        this IQueryable<TSource> source,
+        Expression<Func<TSource, TKey>> selector,
+        bool distinct = false
+    )
+    {
+        var projected = source.Select(selector);
+        if (distinct)
+        {
+            projected = projected.Distinct();
+        }
+        return projected.OrderByDescending(k => k).Take(1);
+    }
+}

--- a/src/Equibles.Finra.Repositories/DailyShortVolumeRepository.cs
+++ b/src/Equibles.Finra.Repositories/DailyShortVolumeRepository.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
+using Equibles.Data.Extensions;
 using Equibles.Finra.Data.Models;
 
 namespace Equibles.Finra.Repositories;
@@ -21,7 +22,7 @@ public class DailyShortVolumeRepository : BaseRepository<DailyShortVolume>
 
     public IQueryable<DateOnly> GetLatestDate()
     {
-        return GetAll().Select(d => d.Date).Distinct().OrderByDescending(d => d).Take(1);
+        return GetAll().LatestValue(d => d.Date, distinct: true);
     }
 
     public IQueryable<DailyShortVolume> GetByDate(DateOnly date)

--- a/src/Equibles.Finra.Repositories/ShortInterestRepository.cs
+++ b/src/Equibles.Finra.Repositories/ShortInterestRepository.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
+using Equibles.Data.Extensions;
 using Equibles.Finra.Data.Models;
 
 namespace Equibles.Finra.Repositories;
@@ -22,7 +23,7 @@ public class ShortInterestRepository : BaseRepository<ShortInterest>
 
     public IQueryable<DateOnly> GetLatestSettlementDate()
     {
-        return GetAll().Select(s => s.SettlementDate).Distinct().OrderByDescending(d => d).Take(1);
+        return GetAll().LatestValue(s => s.SettlementDate, distinct: true);
     }
 
     public IQueryable<ShortInterest> GetBySettlementDate(DateOnly settlementDate)

--- a/src/Equibles.Fred.Repositories/FredObservationRepository.cs
+++ b/src/Equibles.Fred.Repositories/FredObservationRepository.cs
@@ -1,4 +1,5 @@
 using Equibles.Data;
+using Equibles.Data.Extensions;
 using Equibles.Fred.Data.Models;
 
 namespace Equibles.Fred.Repositories;
@@ -25,11 +26,7 @@ public class FredObservationRepository : BaseRepository<FredObservation>
 
     public IQueryable<DateOnly> GetLatestDate(FredSeries series)
     {
-        return GetAll()
-            .Where(o => o.FredSeriesId == series.Id)
-            .Select(o => o.Date)
-            .OrderByDescending(d => d)
-            .Take(1);
+        return GetAll().Where(o => o.FredSeriesId == series.Id).LatestValue(o => o.Date);
     }
 
     public IQueryable<FredObservation> GetLatestPerSeries()

--- a/src/Equibles.Sec.Repositories/FailToDeliverRepository.cs
+++ b/src/Equibles.Sec.Repositories/FailToDeliverRepository.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
+using Equibles.Data.Extensions;
 using Equibles.Sec.Data.Models;
 
 namespace Equibles.Sec.Repositories;
@@ -16,6 +17,6 @@ public class FailToDeliverRepository : BaseRepository<FailToDeliver>
 
     public IQueryable<DateOnly> GetLatestDate()
     {
-        return GetAll().Select(f => f.SettlementDate).Distinct().OrderByDescending(d => d).Take(1);
+        return GetAll().LatestValue(f => f.SettlementDate, distinct: true);
     }
 }

--- a/src/Equibles.Yahoo.Repositories/DailyStockPriceRepository.cs
+++ b/src/Equibles.Yahoo.Repositories/DailyStockPriceRepository.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
+using Equibles.Data.Extensions;
 using Equibles.Yahoo.Data.Models;
 
 namespace Equibles.Yahoo.Repositories;
@@ -38,15 +39,11 @@ public class DailyStockPriceRepository : BaseRepository<DailyStockPrice>
 
     public IQueryable<DateOnly> GetLatestDate(CommonStock stock)
     {
-        return GetAll()
-            .Where(p => p.CommonStockId == stock.Id)
-            .Select(p => p.Date)
-            .OrderByDescending(d => d)
-            .Take(1);
+        return GetAll().Where(p => p.CommonStockId == stock.Id).LatestValue(p => p.Date);
     }
 
     public IQueryable<DateOnly> GetLatestDateAcrossAllStocks()
     {
-        return GetAll().Select(p => p.Date).Distinct().OrderByDescending(d => d).Take(1);
+        return GetAll().LatestValue(p => p.Date, distinct: true);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `IQueryable<T>.LatestValue(selector, distinct)` in `Equibles.Data.Extensions`, which encapsulates the repeated `.Select(...).Distinct?().OrderByDescending(d => d).Take(1)` pipeline that 8 repositories had hand-rolled 10 times.
- Each call site collapses to a single line that names the intent ("latest value of this projection") instead of forcing the reader to reassemble the pipeline mentally.
- Behavior-preserving: the extension composes the identical operators in the identical order, so EF Core translates to byte-identical SQL. Build, unit suite (2140), and integration suite (1525) all green; csharpier clean on the changed files.

## Code changes

- `src/Equibles.Data/Extensions/QueryableLatestExtensions.cs` — new file. Single static extension `LatestValue<TSource, TKey>` with an optional `distinct` flag for the 4 call sites that previously inserted `.Distinct()` between the projection and ordering.
- `src/Equibles.Cboe.Repositories/CboeVixDailyRepository.cs` — `GetLatestDate` switched to `LatestValue(v => v.Date)`.
- `src/Equibles.Cboe.Repositories/CboePutCallRatioRepository.cs` — `GetLatestDate(type)` switched to `.Where(...).LatestValue(r => r.Date)`.
- `src/Equibles.Cftc.Repositories/CftcPositionReportRepository.cs` — both `GetLatestDate(contract)` and `GetGlobalLatestDate` switched to `LatestValue(r => r.ReportDate)` (one filtered, one not).
- `src/Equibles.Fred.Repositories/FredObservationRepository.cs` — `GetLatestDate(series)` switched to `.Where(...).LatestValue(o => o.Date)`.
- `src/Equibles.Yahoo.Repositories/DailyStockPriceRepository.cs` — both `GetLatestDate(stock)` (filtered, no distinct) and `GetLatestDateAcrossAllStocks` (no filter, distinct) switched.
- `src/Equibles.Sec.Repositories/FailToDeliverRepository.cs` — `GetLatestDate` switched to `LatestValue(f => f.SettlementDate, distinct: true)`.
- `src/Equibles.Finra.Repositories/ShortInterestRepository.cs` — `GetLatestSettlementDate` switched (distinct).
- `src/Equibles.Finra.Repositories/DailyShortVolumeRepository.cs` — `GetLatestDate` switched (distinct).