### PR TITLE
refactor(commonstocks-repo): extract ResolveByTicker extension; collapse MCP duplication

### DIFF
--- a/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
+++ b/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
@@ -1,0 +1,15 @@
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.CommonStocks.Repositories.Extensions;
+
+public static class CommonStockRepositoryExtensions
+{
+    public static async Task<(CommonStock Stock, string Error)> ResolveByTicker(
+        this CommonStockRepository repository,
+        string ticker
+    )
+    {
+        var stock = await repository.GetByTicker(ticker.Trim().ToUpperInvariant());
+        return stock == null ? (null, $"Stock '{ticker}' not found.") : (stock, null);
+    }
+}

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -53,7 +54,7 @@ public class ShortDataTools
         return _runner.Execute(
             async () =>
             {
-                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
 
@@ -114,7 +115,7 @@ public class ShortDataTools
         return _runner.Execute(
             async () =>
             {
-                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
 
@@ -233,13 +234,7 @@ public class ShortDataTools
             ? $"+{change.ToString("N0", CultureInfo.InvariantCulture)}"
             : change.ToString("N0", CultureInfo.InvariantCulture);
 
-    private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
-    {
-        var stock = await _commonStockRepository.GetByTicker(
-            McpToolExecutor.NormalizeTicker(ticker)
-        );
-        if (stock == null)
-            return (null, McpToolExecutor.StockNotFound(ticker));
-        return (stock, null);
-    }
+    // Thin forwarder so existing reflection-based normalization tests still find the method.
+    private Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker) =>
+        _commonStockRepository.ResolveByTicker(ticker);
 }

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -69,7 +70,7 @@ public class InstitutionalHoldingsTools
         return _runner.Execute(
             async () =>
             {
-                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
 
@@ -157,7 +158,7 @@ public class InstitutionalHoldingsTools
         return _runner.Execute(
             async () =>
             {
-                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
 
@@ -338,7 +339,7 @@ public class InstitutionalHoldingsTools
         return _runner.Execute(
             async () =>
             {
-                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
 
@@ -1291,16 +1292,6 @@ public class InstitutionalHoldingsTools
         return (holder, null);
     }
 
-    private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
-    {
-        var stock = await _commonStockRepository.GetByTicker(
-            McpToolExecutor.NormalizeTicker(ticker)
-        );
-        if (stock == null)
-            return (null, McpToolExecutor.StockNotFound(ticker));
-        return (stock, null);
-    }
-
     private Task<List<InstitutionalHolding>> LoadHoldingsByHolderWithStock(
         InstitutionalHolder holder,
         DateOnly reportDate
@@ -1369,4 +1360,8 @@ public class InstitutionalHoldingsTools
         public long Shares { get; set; }
         public long Value { get; set; }
     }
+
+    // Thin forwarder so existing reflection-based normalization tests still find the method.
+    private Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker) =>
+        _commonStockRepository.ResolveByTicker(ticker);
 }

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -48,7 +49,7 @@ public class InsiderTradingTools
         return _runner.Execute(
             async () =>
             {
-                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
 
@@ -108,7 +109,7 @@ public class InsiderTradingTools
         return _runner.Execute(
             async () =>
             {
-                var (stock, stockError) = await ResolveStockByTicker(ticker);
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
 
@@ -217,13 +218,7 @@ public class InsiderTradingTools
         return roles.Count > 0 ? string.Join(", ", roles) : "Insider";
     }
 
-    private async Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker)
-    {
-        var stock = await _commonStockRepository.GetByTicker(
-            McpToolExecutor.NormalizeTicker(ticker)
-        );
-        if (stock == null)
-            return (null, McpToolExecutor.StockNotFound(ticker));
-        return (stock, null);
-    }
+    // Thin forwarder so existing reflection-based normalization tests still find the method.
+    private Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker) =>
+        _commonStockRepository.ResolveByTicker(ticker);
 }


### PR DESCRIPTION
## Summary

- `InstitutionalHoldingsTools`, `ShortDataTools`, and `InsiderTradingTools` each owned an identical 9-line private `ResolveStockByTicker(string ticker)` helper (normalize → look up → tuple-return error or stock).
- Extracted the logic into a new `CommonStockRepository.ResolveByTicker` extension method, so all three tools — and any future MCP tool — can share the same resolution path. Each tool keeps a one-line private forwarder so existing reflection-based normalization integration tests still find the symbol.

## Code changes

- `src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs` — new file; defines the shared extension performing `Trim().ToUpperInvariant()` normalization, `GetByTicker` lookup, and the canonical `Stock 'X' not found.` error tuple.
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs`, `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs`, `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — replaced the 9-line private helper with a one-line forwarder that delegates to the new extension; updated callers to invoke `_commonStockRepository.ResolveByTicker(ticker)` directly.