### PR TITLE
refactor(mcp-tools): wire 4 remaining inline ticker-resolve sites through ResolveByTicker

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Congress.Data.Models;
 using Equibles.Congress.Repositories;
 using Equibles.Core.Extensions;
@@ -55,11 +56,9 @@ public class CongressTools
         return _runner.Execute(
             async () =>
             {
-                var stock = await _commonStockRepository.GetByTicker(
-                    McpToolExecutor.NormalizeTicker(ticker)
-                );
-                if (stock == null)
-                    return McpToolExecutor.StockNotFound(ticker);
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
 
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
@@ -80,11 +81,9 @@ public class FinancialFactsTools
                 if (string.IsNullOrWhiteSpace(concept))
                     return $"A concept is required. {SupportedAliasesNote()}";
 
-                var stock = await _commonStockRepository.GetByTicker(
-                    McpToolExecutor.NormalizeTicker(ticker)
-                );
-                if (stock == null)
-                    return McpToolExecutor.StockNotFound(ticker);
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
 
                 if (!FinancialConceptAliases.TryResolve(concept, out var conceptRefs))
                     return $"Unknown concept '{concept}'. {SupportedAliasesNote()}";

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
@@ -69,11 +70,9 @@ public class FinancialStatementTools
                 if (string.IsNullOrWhiteSpace(ticker))
                     return "A ticker symbol is required.";
 
-                var stock = await _commonStockRepository.GetByTicker(
-                    McpToolExecutor.NormalizeTicker(ticker)
-                );
-                if (stock == null)
-                    return McpToolExecutor.StockNotFound(ticker);
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
 
                 if (!TryParseStatement(statement, out var statementType))
                     return $"Unknown statement '{statement}'. Use 'income', 'balance', or 'cashflow'.";

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -48,11 +49,9 @@ public class FailToDeliverTools
         return _runner.Execute(
             async () =>
             {
-                var stock = await _commonStockRepository.GetByTicker(
-                    McpToolExecutor.NormalizeTicker(ticker)
-                );
-                if (stock == null)
-                    return McpToolExecutor.StockNotFound(ticker);
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
 
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,


### PR DESCRIPTION
## Summary

- Following on from #2553, four more MCP tool files (`FailToDeliverTools`, `FinancialStatementTools`, `FinancialFactsTools`, `CongressTools`) still inlined the same 5-line pattern: `GetByTicker(NormalizeTicker(...))` + null-check + `return StockNotFound(ticker)`.
- Each call site now uses the shared `CommonStockRepository.ResolveByTicker` extension. Same normalization, same lookup, same error string — wire output is unchanged.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs`, `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs`, `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs`, `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — replaced the 5-line inline pattern with the 3-line tuple-destructuring call to `_commonStockRepository.ResolveByTicker(ticker)`; added the matching `using` for the extension namespace.