### PR TITLE
refactor(yahoo-mcp): collapse FindStockByTicker into shared ResolveByTicker

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -50,9 +51,9 @@ public class StockPriceTools
         return _runner.Execute(
             async () =>
             {
-                var stock = await FindStockByTicker(ticker);
-                if (stock == null)
-                    return McpToolExecutor.StockNotFound(ticker);
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
 
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
@@ -345,9 +346,9 @@ public class StockPriceTools
         string Error
     )> LoadAscendingPriceWindow(string ticker, string startDate, string endDate)
     {
-        var stock = await FindStockByTicker(ticker);
-        if (stock == null)
-            return (null, null, McpToolExecutor.StockNotFound(ticker));
+        var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+        if (stockError != null)
+            return (null, null, stockError);
 
         var (start, end) = McpToolExecutor.ParseDateRange(
             startDate,
@@ -405,7 +406,4 @@ public class StockPriceTools
             records.Select(p => p.Low).ToList(),
             records.Select(p => p.Close).ToList()
         );
-
-    private Task<CommonStock> FindStockByTicker(string ticker) =>
-        _commonStockRepository.GetByTicker(McpToolExecutor.NormalizeTicker(ticker));
 }


### PR DESCRIPTION
## Summary

- `StockPriceTools` carried its own private `FindStockByTicker` helper plus two call sites that re-emitted `McpToolExecutor.StockNotFound(ticker)`.
- Both call sites and the helper now go through the shared `CommonStockRepository.ResolveByTicker` extension added in #2553 — same normalization, same lookup, same error string.

## Code changes

- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — added the `Equibles.CommonStocks.Repositories.Extensions` import, rewrote the two call sites (a string-returning action and a `(stock, records, error)` 3-tuple helper) to destructure the extension's `(stock, error)` tuple, and removed the now-redundant private `FindStockByTicker` helper.