### PR TITLE
refactor(views): extract shared _EmptyStateCard partial across 15 views

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
@@ -26,15 +26,7 @@
     </div>
 
     @if (Model.AvailableDates.Count < 2) {
-        <div class="card bg-base-100 shadow-sm">
-            <div class="card-body items-center text-center py-12">
-                <div class="text-base-content/30 mb-3">
-                    <icon name="arrow-trending-up" size="12" />
-                </div>
-                <h2 class="text-base-content/60 mb-2">Not enough data</h2>
-                <p class="text-base-content/40 text-sm">The double-down report needs at least two quarters of 13F data.</p>
-            </div>
-        </div>
+        <partial name="_EmptyStateCard" model='(IconName: "arrow-trending-up", Heading: "Not enough data", Message: "The double-down report needs at least two quarters of 13F data.")' />
     } else {
         <!-- Controls -->
         <form method="get" class="mb-6">

--- a/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
@@ -15,15 +15,7 @@
     </div>
 
     @if (Model.AvailableDates.Count < 2) {
-        <div class="card bg-base-100 shadow-sm">
-            <div class="card-body items-center text-center py-12">
-                <div class="text-base-content/30 mb-3">
-                    <icon name="fire" size="12" />
-                </div>
-                <h2 class="text-base-content/60 mb-2">Not enough data</h2>
-                <p class="text-base-content/40 text-sm">At least two quarters of 13F filings are required for the heat map.</p>
-            </div>
-        </div>
+        <partial name="_EmptyStateCard" model='(IconName: "fire", Heading: "Not enough data", Message: "At least two quarters of 13F filings are required for the heat map.")' />
     } else {
         <div class="mb-4 text-sm">
             <div class="flex flex-wrap items-center gap-x-5 gap-y-2">

--- a/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
+++ b/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
@@ -15,15 +15,7 @@
     </div>
 
     @if (Model.TopBuys.Count == 0 && Model.TopSells.Count == 0) {
-        <div class="card bg-base-100 shadow-sm">
-            <div class="card-body items-center text-center py-12">
-                <div class="text-base-content/30 mb-3">
-                    <icon name="user-group" size="12" />
-                </div>
-                <h2 class="text-base-content/60 mb-2">No insider transactions yet</h2>
-                <p class="text-base-content/40 text-sm">Once Form 4 filings have been ingested, the insider dashboard appears here.</p>
-            </div>
-        </div>
+        <partial name="_EmptyStateCard" model='(IconName: "user-group", Heading: "No insider transactions yet", Message: "Once Form 4 filings have been ingested, the insider dashboard appears here.")' />
     } else {
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
             <!-- Top Buys -->

--- a/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
@@ -23,15 +23,7 @@
     <partial name="_InstitutionPicker" model="pickerVm" />
 
     @if (Model.RequestedCiks.Count < InstitutionCombinedViewModel.MinCiks) {
-        <div class="card bg-base-100 shadow-sm">
-            <div class="card-body items-center text-center py-12">
-                <div class="text-base-content/30 mb-3">
-                    <icon name="user-group" size="12" />
-                </div>
-                <h2 class="text-base-content/60 mb-2">Pick at least @InstitutionCombinedViewModel.MinCiks institutions</h2>
-                <p class="text-base-content/40 text-sm">Search by name or CIK above to pool them into one combined portfolio.</p>
-            </div>
-        </div>
+        <partial name="_EmptyStateCard" model='(IconName: "user-group", Heading: $"Pick at least {InstitutionCombinedViewModel.MinCiks} institutions", Message: "Search by name or CIK above to pool them into one combined portfolio.")' />
     } else if (Model.MissingCiks.Count > 0 && Model.Overlap == null) {
         <div class="alert alert-warning" data-testid="combined-missing-ciks">
             <icon name="exclamation-triangle" size="5" />

--- a/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
@@ -22,15 +22,7 @@
     <partial name="_InstitutionPicker" model="pickerVm" />
 
     @if (Model.RequestedCiks.Count < InstitutionCompareViewModel.MinCiks) {
-        <div class="card bg-base-100 shadow-sm">
-            <div class="card-body items-center text-center py-12">
-                <div class="text-base-content/30 mb-3">
-                    <icon name="user-group" size="12" />
-                </div>
-                <h2 class="text-base-content/60 mb-2">Pick at least @InstitutionCompareViewModel.MinCiks institutions</h2>
-                <p class="text-base-content/40 text-sm">Search by name or CIK above to see a side-by-side 13F overlap.</p>
-            </div>
-        </div>
+        <partial name="_EmptyStateCard" model='(IconName: "user-group", Heading: $"Pick at least {InstitutionCompareViewModel.MinCiks} institutions", Message: "Search by name or CIK above to see a side-by-side 13F overlap.")' />
     } else if (Model.MissingCiks.Count > 0 && Model.Overlap == null) {
         <div class="alert alert-warning" data-testid="compare-missing-ciks">
             <icon name="exclamation-triangle" size="5" />

--- a/src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml
+++ b/src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml
@@ -30,22 +30,10 @@
     }
 
     @if (Model.RequestedCiks.Count < InstitutionOverlapMatrixViewModel.MinCiks) {
-        <div class="card bg-base-100 shadow-sm">
-            <div class="card-body items-center text-center py-12">
-                <div class="text-base-content/30 mb-3">
-                    <icon name="table-cells" size="12" />
-                </div>
-                <h2 class="text-base-content/60 mb-2">Pick at least @InstitutionOverlapMatrixViewModel.MinCiks institutions</h2>
-                <p class="text-base-content/40 text-sm">Search by name or CIK above to see how their 13F portfolios overlap.</p>
-            </div>
-        </div>
+        <partial name="_EmptyStateCard" model='(IconName: "table-cells", Heading: $"Pick at least {InstitutionOverlapMatrixViewModel.MinCiks} institutions", Message: "Search by name or CIK above to see how their 13F portfolios overlap.")' />
     } else if (Model.CommonReportDates.Count == 0 && Model.MissingCiks.Count < Model.RequestedCiks.Count) {
-        <div class="card bg-base-100 shadow-sm">
-            <div class="card-body items-center text-center py-12">
-                <h2 class="text-base-content/60 mb-2">No common report dates</h2>
-                <p class="text-base-content/40 text-sm">The selected institutions don't share any 13F reporting quarter.</p>
-            </div>
-        </div>
+        var noDatesModel = (IconName: "", Heading: "No common report dates", Message: "The selected institutions don't share any 13F reporting quarter.");
+        <partial name="_EmptyStateCard" model="noDatesModel" />
     } else if (Model.Matrix != null) {
         var n = Model.Matrix.Funds.Count;
         var maxOverlap = 0;

--- a/src/Equibles.Web/Views/Shared/_EmptyStateCard.cshtml
+++ b/src/Equibles.Web/Views/Shared/_EmptyStateCard.cshtml
@@ -1,0 +1,12 @@
+@model (string IconName, string Heading, string Message)
+<div class="card bg-base-100 shadow-sm">
+    <div class="card-body items-center text-center py-12">
+        @if (!string.IsNullOrEmpty(Model.IconName)) {
+            <div class="text-base-content/30 mb-3">
+                <icon name="@Model.IconName" size="12" />
+            </div>
+        }
+        <h2 class="text-base-content/60 mb-2">@Model.Heading</h2>
+        <p class="text-base-content/40 text-sm">@Model.Message</p>
+    </div>
+</div>

--- a/src/Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml
@@ -2,15 +2,7 @@
 @model Equibles.Web.ViewModels.Stocks.CongressionalTradesTabViewModel
 
 @if (Model.Trades.Count == 0) {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="card-body items-center text-center py-12">
-            <div class="text-base-content/30 mb-3">
-                <icon name="building-library" size="12" />
-            </div>
-            <h2 class="text-base-content/60 mb-2">No Congressional Trades</h2>
-            <p class="text-base-content/40 text-sm">No congressional trading data is available for this stock yet.</p>
-        </div>
-    </div>
+    <partial name="_EmptyStateCard" model='(IconName: "building-library", Heading: "No Congressional Trades", Message: "No congressional trading data is available for this stock yet.")' />
 } else {
     <div class="card bg-base-100 shadow-sm">
         <div class="overflow-x-auto">

--- a/src/Equibles.Web/Views/Stocks/_DocumentsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_DocumentsTab.cshtml
@@ -2,15 +2,7 @@
 @model Equibles.Web.ViewModels.Stocks.DocumentsTabViewModel
 
 @if (Model.Documents.Count == 0) {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="card-body items-center text-center py-12">
-            <div class="text-base-content/30 mb-3">
-                <icon name="document-text" size="12" />
-            </div>
-            <h2 class="text-base-content/60 mb-2">No Documents Available</h2>
-            <p class="text-base-content/40 text-sm">No SEC filings or earnings transcripts are available for this stock yet.</p>
-        </div>
-    </div>
+    <partial name="_EmptyStateCard" model='(IconName: "document-text", Heading: "No Documents Available", Message: "No SEC filings or earnings transcripts are available for this stock yet.")' />
 } else {
     <div class="card bg-base-100 shadow-sm">
         <div class="overflow-x-auto">

--- a/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
@@ -3,15 +3,7 @@
 @model Equibles.Web.ViewModels.Stocks.FinancialsTabViewModel
 
 @if (!Model.HasData) {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="card-body items-center text-center py-12">
-            <div class="text-base-content/30 mb-3">
-                <icon name="document-text" size="12" />
-            </div>
-            <h2 class="text-base-content/60 mb-2">No Financial Data</h2>
-            <p class="text-base-content/40 text-sm">No structured financial facts have been ingested for this stock yet.</p>
-        </div>
-    </div>
+    <partial name="_EmptyStateCard" model='(IconName: "document-text", Heading: "No Financial Data", Message: "No structured financial facts have been ingested for this stock yet.")' />
 } else {
     @* Reuse the single Token definition from FinancialsPeriodOption rather than
        rebuilding the "year-period" string here, so the format lives in one place. *@

--- a/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
@@ -1,15 +1,7 @@
 @model Equibles.Web.ViewModels.Stocks.FtdTabViewModel
 
 @if (Model.FailsToDeliver.Count == 0) {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="card-body items-center text-center py-12">
-            <div class="text-base-content/30 mb-3">
-                <icon name="exclamation-triangle" size="12" />
-            </div>
-            <h2 class="text-base-content/60 mb-2">No Fails to Deliver Data</h2>
-            <p class="text-base-content/40 text-sm">No fails-to-deliver data is available for this stock yet.</p>
-        </div>
-    </div>
+    <partial name="_EmptyStateCard" model='(IconName: "exclamation-triangle", Heading: "No Fails to Deliver Data", Message: "No fails-to-deliver data is available for this stock yet.")' />
 } else {
     <!-- Chart -->
     <div class="card bg-base-100 shadow-sm mb-4">

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -43,15 +43,7 @@
 }
 
 @if (Model.AvailableDates.Count == 0) {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="card-body items-center text-center py-12">
-            <div class="text-base-content/30 mb-3">
-                <icon name="building-office" size="12" />
-            </div>
-            <h2 class="text-base-content/60 mb-2">No Holdings Data</h2>
-            <p class="text-base-content/40 text-sm">No institutional holdings data is available for this stock yet.</p>
-        </div>
-    </div>
+    <partial name="_EmptyStateCard" model='(IconName: "building-office", Heading: "No Holdings Data", Message: "No institutional holdings data is available for this stock yet.")' />
 } else {
     <!-- Date Selector + Stats -->
     <div class="mb-4 text-sm">

--- a/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
@@ -2,15 +2,7 @@
 @model Equibles.Web.ViewModels.Stocks.InsiderTradingTabViewModel
 
 @if (Model.Transactions.Count == 0) {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="card-body items-center text-center py-12">
-            <div class="text-base-content/30 mb-3">
-                <icon name="user" size="12" />
-            </div>
-            <h2 class="text-base-content/60 mb-2">No Insider Trading Data</h2>
-            <p class="text-base-content/40 text-sm">No insider transactions are available for this stock yet.</p>
-        </div>
-    </div>
+    <partial name="_EmptyStateCard" model='(IconName: "user", Heading: "No Insider Trading Data", Message: "No insider transactions are available for this stock yet.")' />
 } else {
     <div class="card bg-base-100 shadow-sm">
         <div class="overflow-x-auto">

--- a/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
@@ -1,15 +1,7 @@
 @model Equibles.Web.ViewModels.Stocks.PriceTabViewModel
 
 @if (Model.Prices.Count == 0) {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="card-body items-center text-center py-12">
-            <div class="text-base-content/30 mb-3">
-                <icon name="chart-bar" size="12" />
-            </div>
-            <h2 class="text-base-content/60 mb-2">No Price Data</h2>
-            <p class="text-base-content/40 text-sm">No daily price data is available for this stock yet. Data syncs automatically from Yahoo Finance.</p>
-        </div>
-    </div>
+    <partial name="_EmptyStateCard" model='(IconName: "chart-bar", Heading: "No Price Data", Message: "No daily price data is available for this stock yet. Data syncs automatically from Yahoo Finance.")' />
 } else {
     <!-- Period selector -->
     <div class="flex flex-wrap gap-2 mb-4">

--- a/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
@@ -1,15 +1,7 @@
 @model Equibles.Web.ViewModels.Stocks.ShortInterestTabViewModel
 
 @if (Model.ShortInterests.Count == 0) {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="card-body items-center text-center py-12">
-            <div class="text-base-content/30 mb-3">
-                <icon name="chart-bar" size="12" />
-            </div>
-            <h2 class="text-base-content/60 mb-2">No Short Interest Data</h2>
-            <p class="text-base-content/40 text-sm">No short interest data is available for this stock yet.</p>
-        </div>
-    </div>
+    <partial name="_EmptyStateCard" model='(IconName: "chart-bar", Heading: "No Short Interest Data", Message: "No short interest data is available for this stock yet.")' />
 } else {
     <!-- Chart -->
     <div class="card bg-base-100 shadow-sm mb-4">

--- a/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
@@ -1,15 +1,7 @@
 @model Equibles.Web.ViewModels.Stocks.ShortVolumeTabViewModel
 
 @if (Model.ShortVolumes.Count == 0) {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="card-body items-center text-center py-12">
-            <div class="text-base-content/30 mb-3">
-                <icon name="arrow-trending-down" size="12" />
-            </div>
-            <h2 class="text-base-content/60 mb-2">No Short Volume Data</h2>
-            <p class="text-base-content/40 text-sm">No daily short volume data is available for this stock yet.</p>
-        </div>
-    </div>
+    <partial name="_EmptyStateCard" model='(IconName: "arrow-trending-down", Heading: "No Short Volume Data", Message: "No daily short volume data is available for this stock yet.")' />
 } else {
     <!-- Chart -->
     <div class="card bg-base-100 shadow-sm mb-4">


### PR DESCRIPTION
## Summary

- Fifteen views (8 Stocks tabs, 2 HoldingsActivity reports, 3 Profiles pages, 1 InsiderActivity dashboard) inlined the same 8-line empty-state card markup (`card > card-body items-center text-center py-12 > optional icon + h2 + p`), varying only by icon, heading, and message.
- Extracted a single `_EmptyStateCard.cshtml` partial in `Views/Shared/` taking a `(IconName, Heading, Message)` tuple model. Every consumer now renders one `<partial>` reference. Output HTML is byte-for-byte equivalent; the icon block is suppressed when `IconName` is empty (the one icon-less site in `OverlapMatrix.cshtml`).

## Code changes

- `src/Equibles.Web/Views/Shared/_EmptyStateCard.cshtml` — new shared partial; emits the same wrapper/inner divs, optional icon container, h2, and p as the original inline markup.
- `src/Equibles.Web/Views/Stocks/_DocumentsTab.cshtml`, `_FtdTab.cshtml`, `_ShortVolumeTab.cshtml`, `_PriceTab.cshtml`, `_HoldingsTab.cshtml`, `_InsiderTradingTab.cshtml`, `_FinancialsTab.cshtml`, `_CongressionalTradesTab.cshtml`, `_ShortInterestTab.cshtml` — replaced the 8-line empty-state block with a `<partial>` call.
- `src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml`, `HeatMap.cshtml` — same.
- `src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml`, `CompareInstitutions.cshtml`, `OverlapMatrix.cshtml` — same; OverlapMatrix has two sites (icon-less variant uses empty `IconName`).
- `src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml` — same.