### PR TITLE
refactor(viewmodels): extract Pagination.PageCount; collapse 4 inline TotalPages formulas

### DIFF
--- a/src/Equibles.Web/Extensions/Pagination.cs
+++ b/src/Equibles.Web/Extensions/Pagination.cs
@@ -1,0 +1,8 @@
+namespace Equibles.Web.Extensions;
+
+public static class Pagination
+{
+    // Ceiling division with a floor of 1 — pages never collapse to 0 even on empty datasets.
+    public static int PageCount(int totalCount, int pageSize) =>
+        Math.Max(1, (totalCount + pageSize - 1) / pageSize);
+}

--- a/src/Equibles.Web/ViewModels/Holdings/DoubleDownViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/DoubleDownViewModel.cs
@@ -1,4 +1,5 @@
 using Equibles.Holdings.Repositories.Models;
+using Equibles.Web.Extensions;
 
 namespace Equibles.Web.ViewModels.Holdings;
 
@@ -12,5 +13,5 @@ public class DoubleDownViewModel : QuarterlySelectionViewModel
     public List<DoubleDownPosition> Positions { get; set; } = [];
     public int Page { get; set; } = 1;
     public int TotalCount { get; set; }
-    public int TotalPages => Math.Max(1, (TotalCount + PageSize - 1) / PageSize);
+    public int TotalPages => Pagination.PageCount(TotalCount, PageSize);
 }

--- a/src/Equibles.Web/ViewModels/Holdings/HoldingsMostHeldViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/HoldingsMostHeldViewModel.cs
@@ -1,3 +1,5 @@
+using Equibles.Web.Extensions;
+
 namespace Equibles.Web.ViewModels.Holdings;
 
 public class HoldingsMostHeldViewModel : QuarterlySelectionViewModel
@@ -17,7 +19,7 @@ public class HoldingsMostHeldViewModel : QuarterlySelectionViewModel
     // 1-based page number; total rows + page count drive the pager footer.
     public int Page { get; set; } = 1;
     public int TotalRows { get; set; }
-    public int TotalPages => Math.Max(1, (TotalRows + PageSize - 1) / PageSize);
+    public int TotalPages => Pagination.PageCount(TotalRows, PageSize);
 
     public List<HoldingsMostHeldRow> Rows { get; set; } = [];
 }

--- a/src/Equibles.Web/ViewModels/Holdings/LatestFilingsViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Holdings/LatestFilingsViewModel.cs
@@ -1,4 +1,5 @@
 using Equibles.Holdings.Repositories.Models;
+using Equibles.Web.Extensions;
 
 namespace Equibles.Web.ViewModels.Holdings;
 
@@ -9,5 +10,5 @@ public class LatestFilingsViewModel
     public List<RecentFiling> Filings { get; set; } = [];
     public int Page { get; set; } = 1;
     public int TotalCount { get; set; }
-    public int TotalPages => Math.Max(1, (TotalCount + PageSize - 1) / PageSize);
+    public int TotalPages => Pagination.PageCount(TotalCount, PageSize);
 }

--- a/src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs
@@ -1,3 +1,5 @@
+using Equibles.Web.Extensions;
+
 namespace Equibles.Web.ViewModels.Institutions;
 
 public class InstitutionBrowserViewModel
@@ -13,5 +15,5 @@ public class InstitutionBrowserViewModel
     public int Page { get; set; } = 1;
     public int PageSize { get; set; } = 50;
     public int TotalCount { get; set; }
-    public int TotalPages => Math.Max(1, (TotalCount + PageSize - 1) / PageSize);
+    public int TotalPages => Pagination.PageCount(TotalCount, PageSize);
 }


### PR DESCRIPTION
## Summary

- `InstitutionBrowserViewModel`, `DoubleDownViewModel`, `LatestFilingsViewModel`, and `HoldingsMostHeldViewModel` each declared `TotalPages` with the same `Math.Max(1, (N + PageSize - 1) / PageSize)` ceiling-division formula.
- Extracted a static `Pagination.PageCount(totalCount, pageSize)` helper in `Web/Extensions` and pointed each ViewModel at it. Same integer arithmetic, same "never below 1" floor for empty datasets.

## Code changes

- `src/Equibles.Web/Extensions/Pagination.cs` — new static helper class with one method `PageCount(int totalCount, int pageSize)`.
- `src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs`, `src/Equibles.Web/ViewModels/Holdings/DoubleDownViewModel.cs`, `src/Equibles.Web/ViewModels/Holdings/LatestFilingsViewModel.cs`, `src/Equibles.Web/ViewModels/Holdings/HoldingsMostHeldViewModel.cs` — `TotalPages` getters call `Pagination.PageCount(...)`; added the matching `using`. The HoldingsMostHeldViewModel variant uses `TotalRows` (its existing property name); the other three use `TotalCount`.