### PR TITLE
refactor(views): extract _Pager shared partial; collapse 4 duplicated pagination blocks

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
@@ -107,49 +107,6 @@
             </div>
         </div>
 
-        <!-- Pagination -->
-        @if (Model.TotalPages > 1) {
-            <nav class="flex justify-center mt-6" aria-label="Double-down pagination" data-testid="double-down-pager">
-                <div class="join">
-                    @if (Model.Page > 1) {
-                        <a asp-action="DoubleDown" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page - 1)"
-                           class="join-item btn btn-sm" aria-label="Go to previous page">Previous</a>
-                    }
-
-                    @{
-                        var startPage = Math.Max(1, Model.Page - 2);
-                        var endPage = Math.Min(Model.TotalPages, Model.Page + 2);
-                    }
-
-                    @if (startPage > 1) {
-                        <a asp-action="DoubleDown" asp-all-route-data="filterRoute" asp-route-page="1"
-                           class="join-item btn btn-sm" aria-label="Go to page 1">1</a>
-                        @if (startPage > 2) {
-                            <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
-                        }
-                    }
-
-                    @for (var i = startPage; i <= endPage; i++) {
-                        <a asp-action="DoubleDown" asp-all-route-data="filterRoute" asp-route-page="@i"
-                           class="join-item btn btn-sm @(i == Model.Page ? "btn-active" : "")"
-                           aria-label="Go to page @i"
-                           aria-current="@(i == Model.Page ? "page" : null)">@i</a>
-                    }
-
-                    @if (endPage < Model.TotalPages) {
-                        @if (endPage < Model.TotalPages - 1) {
-                            <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
-                        }
-                        <a asp-action="DoubleDown" asp-all-route-data="filterRoute" asp-route-page="@Model.TotalPages"
-                           class="join-item btn btn-sm" aria-label="Go to page @Model.TotalPages">@Model.TotalPages</a>
-                    }
-
-                    @if (Model.Page < Model.TotalPages) {
-                        <a asp-action="DoubleDown" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page + 1)"
-                           class="join-item btn btn-sm" aria-label="Go to next page">Next</a>
-                    }
-                </div>
-            </nav>
-        }
+        <partial name="_Pager" model='(Model.Page, Model.TotalPages, "DoubleDown", "Double-down pagination", "double-down-pager", (IDictionary<string, string>)filterRoute)' />
     }
 </div>

--- a/src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml
@@ -67,50 +67,7 @@
         </div>
     </div>
 
-    <!-- Pagination -->
-    @if (Model.TotalPages > 1) {
-        <nav class="flex justify-center mt-6" aria-label="Filings pagination" data-testid="filings-pager">
-            <div class="join">
-                @if (Model.Page > 1) {
-                    <a asp-action="LatestFilings" asp-route-page="@(Model.Page - 1)"
-                       class="join-item btn btn-sm" aria-label="Go to previous page">Previous</a>
-                }
-
-                @{
-                    var startPage = Math.Max(1, Model.Page - 2);
-                    var endPage = Math.Min(Model.TotalPages, Model.Page + 2);
-                }
-
-                @if (startPage > 1) {
-                    <a asp-action="LatestFilings" asp-route-page="1"
-                       class="join-item btn btn-sm" aria-label="Go to page 1">1</a>
-                    @if (startPage > 2) {
-                        <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
-                    }
-                }
-
-                @for (var i = startPage; i <= endPage; i++) {
-                    <a asp-action="LatestFilings" asp-route-page="@i"
-                       class="join-item btn btn-sm @(i == Model.Page ? "btn-active" : "")"
-                       aria-label="Go to page @i"
-                       aria-current="@(i == Model.Page ? "page" : null)">@i</a>
-                }
-
-                @if (endPage < Model.TotalPages) {
-                    @if (endPage < Model.TotalPages - 1) {
-                        <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
-                    }
-                    <a asp-action="LatestFilings" asp-route-page="@Model.TotalPages"
-                       class="join-item btn btn-sm" aria-label="Go to page @Model.TotalPages">@Model.TotalPages</a>
-                }
-
-                @if (Model.Page < Model.TotalPages) {
-                    <a asp-action="LatestFilings" asp-route-page="@(Model.Page + 1)"
-                       class="join-item btn btn-sm" aria-label="Go to next page">Next</a>
-                }
-            </div>
-        </nav>
-    }
+    <partial name="_Pager" model='(Model.Page, Model.TotalPages, "LatestFilings", "Filings pagination", "filings-pager", (IDictionary<string, string>)null)' />
 </div>
 
 @section Scripts {

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -105,50 +105,7 @@
         </div>
     </div>
 
-    <!-- Pagination -->
-    @if (Model.TotalPages > 1) {
-        <nav class="flex justify-center mt-6" aria-label="Institutions pagination" data-testid="institutions-pager">
-            <div class="join">
-                @if (Model.Page > 1) {
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page - 1)"
-                       class="join-item btn btn-sm" aria-label="Go to previous page">Previous</a>
-                }
-
-                @{
-                    var startPage = Math.Max(1, Model.Page - 2);
-                    var endPage = Math.Min(Model.TotalPages, Model.Page + 2);
-                }
-
-                @if (startPage > 1) {
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="1"
-                       class="join-item btn btn-sm" aria-label="Go to page 1">1</a>
-                    @if (startPage > 2) {
-                        <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
-                    }
-                }
-
-                @for (var i = startPage; i <= endPage; i++) {
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@i"
-                       class="join-item btn btn-sm @(i == Model.Page ? "btn-active" : "")"
-                       aria-label="Go to page @i"
-                       aria-current="@(i == Model.Page ? "page" : null)">@i</a>
-                }
-
-                @if (endPage < Model.TotalPages) {
-                    @if (endPage < Model.TotalPages - 1) {
-                        <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
-                    }
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@Model.TotalPages"
-                       class="join-item btn btn-sm" aria-label="Go to page @Model.TotalPages">@Model.TotalPages</a>
-                }
-
-                @if (Model.Page < Model.TotalPages) {
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page + 1)"
-                       class="join-item btn btn-sm" aria-label="Go to next page">Next</a>
-                }
-            </div>
-        </nav>
-    }
+    <partial name="_Pager" model='(Model.Page, Model.TotalPages, "Index", "Institutions pagination", "institutions-pager", (IDictionary<string, string>)filterRoute)' />
 </div>
 
 @section Scripts {

--- a/src/Equibles.Web/Views/Shared/_Pager.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Pager.cshtml
@@ -1,0 +1,43 @@
+@model (int Page, int TotalPages, string Action, string AriaLabel, string TestId, IDictionary<string, string> RouteData)
+@if (Model.TotalPages > 1) {
+    var startPage = Math.Max(1, Model.Page - 2);
+    var endPage = Math.Min(Model.TotalPages, Model.Page + 2);
+    var routeData = Model.RouteData ?? new Dictionary<string, string>();
+    var testId = string.IsNullOrEmpty(Model.TestId) ? null : Model.TestId;
+    <nav class="flex justify-center mt-6" aria-label="@Model.AriaLabel" data-testid="@testId">
+        <div class="join">
+            @if (Model.Page > 1) {
+                <a asp-action="@Model.Action" asp-all-route-data="routeData" asp-route-page="@(Model.Page - 1)"
+                   class="join-item btn btn-sm" aria-label="Go to previous page">Previous</a>
+            }
+
+            @if (startPage > 1) {
+                <a asp-action="@Model.Action" asp-all-route-data="routeData" asp-route-page="1"
+                   class="join-item btn btn-sm" aria-label="Go to page 1">1</a>
+                @if (startPage > 2) {
+                    <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
+                }
+            }
+
+            @for (var i = startPage; i <= endPage; i++) {
+                <a asp-action="@Model.Action" asp-all-route-data="routeData" asp-route-page="@i"
+                   class="join-item btn btn-sm @(i == Model.Page ? "btn-active" : "")"
+                   aria-label="Go to page @i"
+                   aria-current="@(i == Model.Page ? "page" : null)">@i</a>
+            }
+
+            @if (endPage < Model.TotalPages) {
+                @if (endPage < Model.TotalPages - 1) {
+                    <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
+                }
+                <a asp-action="@Model.Action" asp-all-route-data="routeData" asp-route-page="@Model.TotalPages"
+                   class="join-item btn btn-sm" aria-label="Go to page @Model.TotalPages">@Model.TotalPages</a>
+            }
+
+            @if (Model.Page < Model.TotalPages) {
+                <a asp-action="@Model.Action" asp-all-route-data="routeData" asp-route-page="@(Model.Page + 1)"
+                   class="join-item btn btn-sm" aria-label="Go to next page">Next</a>
+            }
+        </div>
+    </nav>
+}

--- a/src/Equibles.Web/Views/Stocks/Index.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Index.cshtml
@@ -97,50 +97,7 @@
         </div>
     </div>
 
-    <!-- Pagination -->
-    @if (Model.TotalPages > 1) {
-        <nav class="flex justify-center mt-6" aria-label="Stocks pagination">
-            <div class="join">
-                @if (Model.Page > 1) {
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page - 1)"
-                       class="join-item btn btn-sm" aria-label="Go to previous page">Previous</a>
-                }
-
-                @{
-                    var startPage = Math.Max(1, Model.Page - 2);
-                    var endPage = Math.Min(Model.TotalPages, Model.Page + 2);
-                }
-
-                @if (startPage > 1) {
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="1"
-                       class="join-item btn btn-sm" aria-label="Go to page 1">1</a>
-                    @if (startPage > 2) {
-                        <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
-                    }
-                }
-
-                @for (var i = startPage; i <= endPage; i++) {
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@i"
-                       class="join-item btn btn-sm @(i == Model.Page ? "btn-active" : "")"
-                       aria-label="Go to page @i"
-                       aria-current="@(i == Model.Page ? "page" : null)">@i</a>
-                }
-
-                @if (endPage < Model.TotalPages) {
-                    @if (endPage < Model.TotalPages - 1) {
-                        <span class="join-item btn btn-sm btn-disabled" aria-hidden="true">...</span>
-                    }
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@Model.TotalPages"
-                       class="join-item btn btn-sm" aria-label="Go to page @Model.TotalPages">@Model.TotalPages</a>
-                }
-
-                @if (Model.Page < Model.TotalPages) {
-                    <a asp-action="Index" asp-all-route-data="filterRoute" asp-route-page="@(Model.Page + 1)"
-                       class="join-item btn btn-sm" aria-label="Go to next page">Next</a>
-                }
-            </div>
-        </nav>
-    }
+    <partial name="_Pager" model='(Model.Page, Model.TotalPages, "Index", "Stocks pagination", (string)null, (IDictionary<string, string>)filterRoute)' />
 </div>
 
 @section Scripts {


### PR DESCRIPTION
## Summary

- `Institutions/Index`, `Stocks/Index`, `HoldingsActivity/LatestFilings`, and `HoldingsActivity/DoubleDown` each inlined the same ~40-line "Previous / numbered with ellipses / Next" pager markup, varying only by `asp-action`, `aria-label`, optional `data-testid`, and `asp-all-route-data` source.
- Extracted a single `Views/Shared/_Pager.cshtml` partial taking `(Page, TotalPages, Action, AriaLabel, TestId, RouteData)`. Each call site collapses to a single `<partial>` reference. Output HTML is unchanged — anchors keep the same classes, `aria-current`, `aria-label`, and `asp-route-page` values; `data-testid` is rendered only when non-null so Stocks/Index keeps no attribute.

## Code changes

- `src/Equibles.Web/Views/Shared/_Pager.cshtml` — new shared partial; emits the `<nav class="flex justify-center mt-6"><div class="join">…</div></nav>` block with Previous / leading 1+ellipsis / numbered range / trailing ellipsis+last / Next, mirroring the previously inlined markup.
- `src/Equibles.Web/Views/Institutions/Index.cshtml`, `src/Equibles.Web/Views/Stocks/Index.cshtml`, `src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml`, `src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml` — replaced the inlined ~40-line pager block with a `<partial>` call forwarding the model's page/totalPages plus the per-view action name, aria label, optional testid, and (when applicable) the local `filterRoute` dictionary.