### PR TITLE
refactor(web): extract PreviousFrom date-list extension; collapse 4 inline prior-quarter lookups

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Repositories;
 using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Extensions;
 using Equibles.Web.ViewModels.Holdings;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -464,14 +465,8 @@ public class HoldingsActivityController : BaseController
         List<DateOnly> reportDates
     )
     {
-        var requestedIndex = requested.HasValue ? reportDates.IndexOf(requested.Value) : -1;
-        var selectedIndex = requestedIndex < 0 ? 0 : requestedIndex;
-        var selected = reportDates[selectedIndex];
-        var previous =
-            selectedIndex < reportDates.Count - 1
-                ? reportDates[selectedIndex + 1]
-                : (DateOnly?)null;
-        return (selected, previous);
+        var selected = reportDates.ResolveSelectedDateOrFirst(requested);
+        return (selected, reportDates.PreviousFrom(selected));
     }
 
     private static (string Ticker, string Name) ResolveStockCells(

--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -171,10 +171,8 @@ public class HoldingsExportController : BaseController
             return NotFound();
 
         var selectedDate = reportDates.ResolveSelectedDateOrFirst(date);
-        var selectedIndex = reportDates.IndexOf(selectedDate);
-        if (selectedIndex >= reportDates.Count - 1)
+        if (reportDates.PreviousFrom(selectedDate) is not { } previousDate)
             return NotFound();
-        var previousDate = reportDates[selectedIndex + 1];
 
         // Per-stock buy/sell movers (CSV has no row cap — analysts expect the full set).
         var activity = await _holdingRepository

--- a/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsScreenerController.cs
@@ -184,11 +184,10 @@ public class HoldingsScreenerController : BaseController
         // The default comparison must track the selected date — picking a fixed
         // reportDates[1] collapses to selected==comparison when selected is the
         // second-latest, and to a *newer* comparison when selected is older.
-        var selectedIndex = reportDates.IndexOf(selected);
         DateOnly? comparison =
-            compareDate.HasValue && reportDates.Contains(compareDate.Value) ? compareDate.Value
-            : selectedIndex < reportDates.Count - 1 ? reportDates[selectedIndex + 1]
-            : null;
+            compareDate.HasValue && reportDates.Contains(compareDate.Value)
+                ? compareDate.Value
+                : reportDates.PreviousFrom(selected);
         if (comparison is null)
             return (reportDates, null, null);
         return (reportDates, selected, comparison.Value);

--- a/src/Equibles.Web/Extensions/DateOnlyListExtensions.cs
+++ b/src/Equibles.Web/Extensions/DateOnlyListExtensions.cs
@@ -10,4 +10,12 @@ public static class DateOnlyListExtensions
         this IList<DateOnly> available,
         DateOnly? requested
     ) => requested.HasValue && available.Contains(requested.Value) ? requested.Value : available[0];
+
+    // List is latest-first (descending); returns the quarter immediately older than
+    // `current`, or null when `current` is the oldest entry or not in the list.
+    public static DateOnly? PreviousFrom(this IList<DateOnly> available, DateOnly current)
+    {
+        var index = available.IndexOf(current);
+        return index >= 0 && index < available.Count - 1 ? available[index + 1] : null;
+    }
 }

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -11,6 +11,7 @@ using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Statements;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
+using Equibles.Web.Extensions;
 using Equibles.Web.ViewModels.Stocks;
 using Equibles.Yahoo.Repositories;
 using Microsoft.EntityFrameworkCore;
@@ -89,11 +90,7 @@ public class StockTabService
         // so the in-memory aggregates are cheaper than re-querying.
         var allCurrent = await LoadHoldingsByStockWithHolder(stock, selectedDate);
 
-        var selectedIndex = reportDates.IndexOf(selectedDate);
-        var previousDate =
-            selectedIndex >= 0 && selectedIndex < reportDates.Count - 1
-                ? reportDates[selectedIndex + 1]
-                : (DateOnly?)null;
+        var previousDate = reportDates.PreviousFrom(selectedDate);
         var allPrevious = previousDate.HasValue
             ? await LoadHoldingsByStockWithHolder(stock, previousDate.Value)
             : [];


### PR DESCRIPTION
## Summary

- `HoldingsActivityController`, `HoldingsExportController`, `HoldingsScreenerController`, and `StockTabService` each computed "the quarter immediately older than the selected date" with an inline `selectedIndex = IndexOf(...)` + bounds-check + `[index + 1]` ternary returning `DateOnly?`.
- Added a sibling `IList<DateOnly>.PreviousFrom(DateOnly current)` extension to `Web/Extensions/DateOnlyListExtensions` (next to the existing `ResolveSelectedDateOrFirst`). Each call site now reads `reportDates.PreviousFrom(selectedDate)`; HoldingsExportController also pattern-matches on the nullable return to keep its NotFound early-return.

## Code changes

- `src/Equibles.Web/Extensions/DateOnlyListExtensions.cs` — new `PreviousFrom` extension method returning `DateOnly?` (next index after the matched current, or null when current is the oldest or absent).
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — `ResolveSelectedAndPriorDate` now delegates to `ResolveSelectedDateOrFirst` + `PreviousFrom`; added `using Equibles.Web.Extensions`.
- `src/Equibles.Web/Controllers/HoldingsExportController.cs` — replaced the inline index/bounds-check with `reportDates.PreviousFrom(selectedDate) is not { } previousDate ? NotFound() : …`.
- `src/Equibles.Web/Controllers/HoldingsScreenerController.cs` — replaced the nested ternary with `compareDate fallback ?? reportDates.PreviousFrom(selected)`.
- `src/Equibles.Web/Services/StockTabService.cs` — collapsed the 5-line index-and-ternary block to one `reportDates.PreviousFrom(selectedDate)`; added `using Equibles.Web.Extensions`.