### PR TITLE
refactor(web-js): extract row-click navigation into shared module

### DIFF
--- a/src/Equibles.Web/Views/Cftc/Index.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Index.cshtml
@@ -74,15 +74,3 @@
         }
     </div>
 </div>
-
-@section Scripts {
-    <script>
-    // Make table rows clickable to navigate to the contract detail page
-    document.querySelectorAll('.cftc-row').forEach(function(row) {
-        row.addEventListener('click', function(e) {
-            if (e.target.closest('a')) return; // let native link clicks through
-            window.location.href = this.dataset.href;
-        });
-    });
-    </script>
-}

--- a/src/Equibles.Web/Views/EconomicData/Index.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Index.cshtml
@@ -82,15 +82,3 @@
         }
     </div>
 </div>
-
-@section Scripts {
-    <script>
-    // Make table rows clickable to navigate to the series detail page
-    document.querySelectorAll('.economy-row').forEach(function(row) {
-        row.addEventListener('click', function(e) {
-            if (e.target.closest('a')) return; // let native link clicks through
-            window.location.href = this.dataset.href;
-        });
-    });
-    </script>
-}

--- a/src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml
@@ -69,15 +69,3 @@
 
     <partial name="_Pager" model='(Model.Page, Model.TotalPages, "LatestFilings", "Filings pagination", "filings-pager", (IDictionary<string, string>)null)' />
 </div>
-
-@section Scripts {
-    <script>
-    // Row-click navigation
-    document.querySelectorAll('.filing-row').forEach(function(row) {
-        row.addEventListener('click', function(e) {
-            if (e.target.closest('a')) return;
-            window.location.href = this.dataset.href;
-        });
-    });
-    </script>
-}

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -107,16 +107,3 @@
 
     <partial name="_Pager" model='(Model.Page, Model.TotalPages, "Index", "Institutions pagination", "institutions-pager", (IDictionary<string, string>)filterRoute)' />
 </div>
-
-@section Scripts {
-    <script>
-    // Row-click navigation: same UX as the Stocks index — clicking anywhere on
-    // a row (other than an inner link) navigates to the institution profile.
-    document.querySelectorAll('.institution-row').forEach(function(row) {
-        row.addEventListener('click', function(e) {
-            if (e.target.closest('a')) return; // let native link clicks through
-            window.location.href = this.dataset.href;
-        });
-    });
-    </script>
-}

--- a/src/Equibles.Web/Views/Market/Index.cshtml
+++ b/src/Equibles.Web/Views/Market/Index.cshtml
@@ -120,15 +120,3 @@
         </div>
     </div>
 </div>
-
-@section Scripts {
-    <script>
-    // Make table rows clickable to navigate to the detail page
-    document.querySelectorAll('.market-row').forEach(function(row) {
-        row.addEventListener('click', function(e) {
-            if (e.target.closest('a')) return; // let native link clicks through
-            window.location.href = this.dataset.href;
-        });
-    });
-    </script>
-}

--- a/src/Equibles.Web/Views/Stocks/Index.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Index.cshtml
@@ -99,15 +99,3 @@
 
     <partial name="_Pager" model='(Model.Page, Model.TotalPages, "Index", "Stocks pagination", (string)null, (IDictionary<string, string>)filterRoute)' />
 </div>
-
-@section Scripts {
-    <script>
-    // Make table rows clickable to navigate to the stock detail page
-    document.querySelectorAll('.stock-row').forEach(function(row) {
-        row.addEventListener('click', function(e) {
-            if (e.target.closest('a')) return; // let native link clicks through
-            window.location.href = this.dataset.href;
-        });
-    });
-    </script>
-}

--- a/src/Equibles.Web/src/index.js
+++ b/src/Equibles.Web/src/index.js
@@ -26,3 +26,4 @@ import './js/search-clear';
 import './js/copy-button';
 import './js/compact-numbers';
 import './js/institution-picker';
+import './js/row-click-navigation';

--- a/src/Equibles.Web/src/js/row-click-navigation.js
+++ b/src/Equibles.Web/src/js/row-click-navigation.js
@@ -1,0 +1,9 @@
+// Row-click navigation — any element with `data-href` becomes clickable; clicks on
+// inner <a> pass through so native link semantics (middle-click, modifier keys, etc.)
+// stay intact. Uses event delegation so dynamically-added rows are covered too.
+document.addEventListener('click', function (e) {
+    const row = e.target.closest('[data-href]');
+    if (!row) return;
+    if (e.target.closest('a')) return;
+    window.location.href = row.dataset.href;
+});


### PR DESCRIPTION
## Summary

- Six views (`Stocks/Index`, `Institutions/Index`, `EconomicData/Index`, `HoldingsActivity/LatestFilings`, `Market/Index`, `Cftc/Index`) each inlined a ~10-line `@section Scripts` block that queried per-view CSS classes (`.stock-row`, `.market-row`, etc.) and attached a click listener navigating to `dataset.href` while passing through inner `<a>` clicks.
- Replaced all six with one event-delegated handler in `src/js/row-click-navigation.js` (imported from `src/index.js`) targeting any element with `[data-href]`. Identical UX, plus dynamically-added rows now work for free. Per-view CSS classes stay in the markup since they may serve styling.

## Code changes

- `src/Equibles.Web/src/js/row-click-navigation.js` — new shared module; one delegated `click` listener on `document` walks up to the closest `[data-href]` ancestor and navigates unless the click target is inside an `<a>`.
- `src/Equibles.Web/src/index.js` — imports the new module alongside the existing `loader`, `messages`, `modals`, etc.
- `src/Equibles.Web/Views/Stocks/Index.cshtml`, `Institutions/Index.cshtml`, `EconomicData/Index.cshtml`, `HoldingsActivity/LatestFilings.cshtml`, `Market/Index.cshtml`, `Cftc/Index.cshtml` — removed the now-redundant `@section Scripts {…}` block.