### PR TITLE
refactor(web-views): extract SignCss<T> extension; collapse 19 inline sign→class ternaries

### DIFF
--- a/src/Equibles.Web/Extensions/SignCssExtensions.cs
+++ b/src/Equibles.Web/Extensions/SignCssExtensions.cs
@@ -1,0 +1,16 @@
+using System.Numerics;
+
+namespace Equibles.Web.Extensions;
+
+public static class SignCssExtensions
+{
+    public static string SignCss<T>(this T value, string neutralClass = "")
+        where T : INumber<T> =>
+        value > T.Zero ? "text-success"
+        : value < T.Zero ? "text-error"
+        : neutralClass;
+
+    public static string SignCss<T>(this T? value, string neutralClass = "")
+        where T : struct, INumber<T> =>
+        value.HasValue ? value.Value.SignCss(neutralClass) : neutralClass;
+}

--- a/src/Equibles.Web/Views/Cftc/Show.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Show.cshtml
@@ -120,7 +120,7 @@
                                     <td class="text-right tabular-nums hidden lg:table-cell">@report.NonCommSpreads.ToString("N0")</td>
                                     <td class="text-right tabular-nums hidden lg:table-cell">
                                         @if (report.ChangeOpenInterest.HasValue) {
-                                            <span class="@(report.ChangeOpenInterest.Value > 0 ? "text-success" : report.ChangeOpenInterest.Value < 0 ? "text-error" : "text-base-content/50")">
+                                            <span class="@(report.ChangeOpenInterest.Value.SignCss("text-base-content/50"))">
                                                 @(report.ChangeOpenInterest.Value > 0 ? "+" : "")@report.ChangeOpenInterest.Value.ToString("N0")
                                             </span>
                                         } else {

--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -72,7 +72,7 @@
                         <div class="text-xs text-base-content/50 uppercase tracking-wider">Latest</div>
                         <div class="text-lg font-bold tabular-nums">@Model.LatestValue.Value.ToString("N2")</div>
                         @if (changePct.HasValue) {
-                            <div class="text-xs tabular-nums @(changePct.Value > 0 ? "text-success" : changePct.Value < 0 ? "text-error" : "text-base-content/50")">
+                            <div class="text-xs tabular-nums @(changePct.Value.SignCss("text-base-content/50"))">
                                 @(changePct.Value > 0 ? "+" : "")@changePct.Value.ToString("N2")%
                             </div>
                         }
@@ -138,7 +138,7 @@
                                             <span class="text-base-content/30">&mdash;</span>
                                         }
                                     </td>
-                                    <td class="text-right text-sm tabular-nums hidden sm:table-cell @(pctChange > 0 ? "text-success" : pctChange < 0 ? "text-error" : "text-base-content/50")">
+                                    <td class="text-right text-sm tabular-nums hidden sm:table-cell @(pctChange.SignCss("text-base-content/50"))">
                                         @if (pctChange.HasValue) {
                                             @(pctChange.Value > 0 ? "+" : "")@pctChange.Value.ToString("N2")<text>%</text>
                                         }

--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -71,8 +71,8 @@
                                     </thead>
                                     <tbody>
                                         @foreach (var row in board.Rows) {
-                                            var deltaSharesCss = row.DeltaShares > 0 ? "text-success" : row.DeltaShares < 0 ? "text-error" : "";
-                                            var deltaValueCss = row.DeltaValue > 0 ? "text-success" : row.DeltaValue < 0 ? "text-error" : "";
+                                            var deltaSharesCss = row.DeltaShares.SignCss();
+                                            var deltaValueCss = row.DeltaValue.SignCss();
                                             <tr>
                                                 <td class="font-mono">@row.Ticker</td>
                                                 <td class="max-w-xs truncate">@row.Name</td>

--- a/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
@@ -81,7 +81,7 @@
                                         <td><a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@p.Ticker" class="link link-hover font-mono">@p.Ticker</a></td>
                                         <td class="max-w-xs truncate">@p.Name</td>
                                         <td class="text-right font-mono @scoreCss">@p.ConvictionScore.ToString("F1")</td>
-                                        <td class="text-right font-mono hidden md:table-cell @(p.NetConvictionPct > 0 ? "text-success" : p.NetConvictionPct < 0 ? "text-error" : "")">@(p.NetConvictionPct > 0 ? "+" : "")@p.NetConvictionPct.ToString("F1")%</td>
+                                        <td class="text-right font-mono hidden md:table-cell @p.NetConvictionPct.SignCss()">@(p.NetConvictionPct > 0 ? "+" : "")@p.NetConvictionPct.ToString("F1")%</td>
                                         <td class="text-right font-mono hidden md:table-cell">@p.RetentionPct.ToString("F1")%</td>
                                         <td class="text-right font-mono hidden lg:table-cell">@p.UniversePct.ToString("F2")%</td>
                                         <td class="text-right font-mono">@p.CurrentFilerCount.ToString("N0")</td>

--- a/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
@@ -68,8 +68,8 @@
                         <tbody>
                             @{ var rowNumber = firstRowNumber; }
                             @foreach (var row in Model.Rows) {
-                                var deltaFilersCss = row.DeltaFilerCount > 0 ? "text-success" : row.DeltaFilerCount < 0 ? "text-error" : "";
-                                var deltaValueCss = row.DeltaValue > 0 ? "text-success" : row.DeltaValue < 0 ? "text-error" : "";
+                                var deltaFilersCss = row.DeltaFilerCount.SignCss();
+                                var deltaValueCss = row.DeltaValue.SignCss();
                                 <tr>
                                     <td class="text-right text-base-content/60">@rowNumber.ToString("N0")</td>
                                     <td class="font-mono">@row.Ticker</td>

--- a/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
+++ b/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
@@ -148,8 +148,8 @@
                             </thead>
                             <tbody>
                                 @foreach (var row in Model.Rows) {
-                                    var deltaFilerCss = row.DeltaFilerCount > 0 ? "text-success" : row.DeltaFilerCount < 0 ? "text-error" : "";
-                                    var deltaValueCss = row.DeltaValue > 0 ? "text-success" : row.DeltaValue < 0 ? "text-error" : "";
+                                    var deltaFilerCss = row.DeltaFilerCount.SignCss();
+                                    var deltaValueCss = row.DeltaValue.SignCss();
                                     var deltaFilerText = (row.DeltaFilerCount > 0 ? "+" : row.DeltaFilerCount < 0 ? "-" : "") + Math.Abs(row.DeltaFilerCount).ToString("N0");
                                     var deltaValueText = (row.DeltaValue > 0 ? "+$" : row.DeltaValue < 0 ? "-$" : "$") + Math.Abs(row.DeltaValue).ToString("N0");
                                     <tr>

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -208,8 +208,8 @@
                                         </thead>
                                         <tbody>
                                             @foreach (var row in rows) {
-                                                var deltaSharesCss = row.DeltaShares > 0 ? "text-success" : row.DeltaShares < 0 ? "text-error" : "";
-                                                var deltaValueCss = row.DeltaValue > 0 ? "text-success" : row.DeltaValue < 0 ? "text-error" : "";
+                                                var deltaSharesCss = row.DeltaShares.SignCss();
+                                                var deltaValueCss = row.DeltaValue.SignCss();
                                                 <tr>
                                                     <td class="font-mono">@row.Ticker</td>
                                                     <td class="max-w-xs truncate">@row.Name</td>

--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -114,7 +114,7 @@
                                 <td class="text-right font-mono"><compactable-number value="@h.Shares" /></td>
                                 <td class="text-right font-mono hidden md:table-cell">
                                     @if (changePercent.HasValue) {
-                                        var css = changePercent.Value > 0 ? "text-success" : changePercent.Value < 0 ? "text-error" : "";
+                                        var css = changePercent.Value.SignCss();
                                         var sign = changePercent.Value > 0 ? "+" : "";
                                         <span class="@css">@sign@changePercent.Value.ToString("F1")%</span>
                                     } else {

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -34,9 +34,6 @@
         return $"{sign}{pct:F1}%";
     }
 
-    static string PctCss(double? pct) =>
-        pct > 0 ? "text-success" : pct < 0 ? "text-error" : "";
-
     static string FormatQuarter(DateOnly? date) =>
         date == null ? "—" : $"Q{(date.Value.Month - 1) / 3 + 1} {date.Value.Year}";
 
@@ -180,12 +177,12 @@
                                     </thead>
                                     <tbody>
                                         @foreach (var e in card.Entries) {
-                                            var deltaSharesCss = e.DeltaShares > 0 ? "text-success" : e.DeltaShares < 0 ? "text-error" : "";
-                                            var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
+                                            var deltaSharesCss = e.DeltaShares.SignCss();
+                                            var deltaValueCss = e.DeltaValue.SignCss();
                                             <tr>
                                                 <td class="max-w-xs truncate">@(e.InstitutionalHolder?.Name ?? "Unknown")</td>
                                                 <td class="text-right font-mono @deltaSharesCss"><compactable-number value="@e.DeltaShares" sign /></td>
-                                                <td class="text-right font-mono hidden md:table-cell @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
+                                                <td class="text-right font-mono hidden md:table-cell @e.ChangePercent.SignCss()">@FormatPct(e.ChangePercent)</td>
                                                 <td class="text-right font-mono hidden md:table-cell @deltaValueCss"><compactable-number value="@e.DeltaValue" prefix="$" sign /></td>
                                             </tr>
                                         }
@@ -240,8 +237,8 @@
                         <tbody>
                             @foreach (var x in allHolders) {
                                 var e = x.Entry;
-                                var deltaSharesCss = e.DeltaShares > 0 ? "text-success" : e.DeltaShares < 0 ? "text-error" : "";
-                                var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
+                                var deltaSharesCss = e.DeltaShares.SignCss();
+                                var deltaValueCss = e.DeltaValue.SignCss();
                                 var own = e.OwnershipPercent(Model.SharesOutstanding);
                                 <tr>
                                     <td class="max-w-xs truncate">
@@ -253,7 +250,7 @@
                                     <td class="text-right font-mono whitespace-nowrap"><compactable-number value="@e.CurrentShares" /></td>
                                     @if (!Model.IsCombinedView) {
                                         <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @deltaSharesCss"><compactable-number value="@e.DeltaShares" sign /></td>
-                                        <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
+                                        <td class="text-right font-mono hidden md:table-cell whitespace-nowrap @e.ChangePercent.SignCss()">@FormatPct(e.ChangePercent)</td>
                                     }
                                     <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap">@(own != null ? $"{own:F2}%" : "—")</td>
                                     <td class="text-right font-mono hidden lg:table-cell whitespace-nowrap"><compactable-number value="@e.CurrentValue" prefix="$" /></td>
@@ -316,8 +313,8 @@
                             </thead>
                             <tbody>
                                 @foreach (var e in sorted) {
-                                    var deltaSharesCss = e.DeltaShares > 0 ? "text-success" : e.DeltaShares < 0 ? "text-error" : "";
-                                    var deltaValueCss = e.DeltaValue > 0 ? "text-success" : e.DeltaValue < 0 ? "text-error" : "";
+                                    var deltaSharesCss = e.DeltaShares.SignCss();
+                                    var deltaValueCss = e.DeltaValue.SignCss();
                                     var own = e.OwnershipPercent(Model.SharesOutstanding);
                                     <tr>
                                         <td class="max-w-xs truncate">
@@ -328,7 +325,7 @@
                                         </td>
                                         <td class="text-right font-mono"><compactable-number value="@e.CurrentShares" /></td>
                                         <td class="text-right font-mono hidden md:table-cell @deltaSharesCss"><compactable-number value="@e.DeltaShares" sign /></td>
-                                        <td class="text-right font-mono hidden md:table-cell @PctCss(e.ChangePercent)">@FormatPct(e.ChangePercent)</td>
+                                        <td class="text-right font-mono hidden md:table-cell @e.ChangePercent.SignCss()">@FormatPct(e.ChangePercent)</td>
                                         <td class="text-right font-mono hidden lg:table-cell">@(own != null ? $"{own:F2}%" : "—")</td>
                                         <td class="text-right font-mono hidden lg:table-cell"><compactable-number value="@e.CurrentValue" prefix="$" /></td>
                                         <td class="text-right hidden xl:table-cell text-base-content/60">@FormatQuarter(e.QuarterFirstOwned)</td>

--- a/src/Equibles.Web/Views/_ViewImports.cshtml
+++ b/src/Equibles.Web/Views/_ViewImports.cshtml
@@ -1,4 +1,5 @@
 @using Equibles.Web
+@using Equibles.Web.Extensions
 @using Microsoft.AspNetCore.Http
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, Equibles.Web


### PR DESCRIPTION
## Summary

- Extracted the repeated `value > 0 ? "text-success" : value < 0 ? "text-error" : ""` pattern (19 occurrences across 9 views) into a single generic `SignCss<T>` extension method using `INumber<T>` so it works uniformly for `int`, `decimal`, `double`, and their nullable forms.
- Removed the local `PctCss(double?)` helper in `_HoldingsTab.cshtml` now that the shared extension covers the same role with identical semantics (including nullable→neutral behavior).
- Added `@using Equibles.Web.Extensions` to `_ViewImports.cshtml` so the helper is available across all views.

## Code changes

- `src/Equibles.Web/Extensions/SignCssExtensions.cs` — new file. Two overloads of `SignCss<T>`: one on `T : INumber<T>` and one on `T? where T : struct, INumber<T>`. Each returns `text-success` / `text-error` for positive / negative, and a caller-supplied neutral class (defaulting to `""`) for zero / null.
- `src/Equibles.Web/Views/_ViewImports.cshtml` — added `@using Equibles.Web.Extensions`.
- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml` — deleted the local `PctCss` helper; rewired 3 callers and 6 inline ternaries through `SignCss()`.
- `src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml`, `Views/HoldingsActivity/{Activity,MostHeld,HeatMap}.cshtml`, `Views/Stocks/ShowHolder.cshtml`, `Views/Profiles/Institution.cshtml` — replaced 11 inline ternaries with `value.SignCss()`.
- `src/Equibles.Web/Views/EconomicData/Show.cshtml`, `Views/Cftc/Show.cshtml` — replaced 3 inline ternaries with `value.SignCss("text-base-content/50")` (the neutral-fallback variant).

Behavior is preserved: each replacement evaluates to the exact same string for every input. Inverse-sign sites (Vix, Market index, short-interest tab) and threshold-based sites (HeatMap conviction score) are intentionally untouched — different semantics.