### PR TITLE
refactor(web-views): add InverseSignCss<T> overload; collapse 3 inverse sign→class ternaries

### DIFF
--- a/src/Equibles.Web/Extensions/SignCssExtensions.cs
+++ b/src/Equibles.Web/Extensions/SignCssExtensions.cs
@@ -13,4 +13,14 @@ public static class SignCssExtensions
     public static string SignCss<T>(this T? value, string neutralClass = "")
         where T : struct, INumber<T> =>
         value.HasValue ? value.Value.SignCss(neutralClass) : neutralClass;
+
+    public static string InverseSignCss<T>(this T value, string neutralClass = "")
+        where T : INumber<T> =>
+        value > T.Zero ? "text-error"
+        : value < T.Zero ? "text-success"
+        : neutralClass;
+
+    public static string InverseSignCss<T>(this T? value, string neutralClass = "")
+        where T : struct, INumber<T> =>
+        value.HasValue ? value.Value.InverseSignCss(neutralClass) : neutralClass;
 }

--- a/src/Equibles.Web/Views/Market/Index.cshtml
+++ b/src/Equibles.Web/Views/Market/Index.cshtml
@@ -93,7 +93,7 @@
                             <div class="text-xs text-base-content/50 uppercase tracking-wider">Latest Close</div>
                             <div class="text-lg font-bold tabular-nums">@Model.Vix.LatestClose?.ToString("N2")</div>
                             @if (vixChange.HasValue) {
-                                <div class="text-xs tabular-nums @(vixChange.Value > 0 ? "text-error" : vixChange.Value < 0 ? "text-success" : "text-base-content/50")">
+                                <div class="text-xs tabular-nums @(vixChange.Value.InverseSignCss("text-base-content/50"))">
                                     @(vixChange.Value > 0 ? "+" : "")@vixChange.Value.ToString("N2")
                                 </div>
                             }

--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -50,7 +50,7 @@
                     <div class="text-xs text-base-content/50 uppercase tracking-wider">Latest Close</div>
                     <div class="text-lg font-bold tabular-nums">@Model.LatestClose.Value.ToString("N2")</div>
                     @if (vixChange.HasValue) {
-                        <div class="text-xs tabular-nums @(vixChange.Value > 0 ? "text-error" : vixChange.Value < 0 ? "text-success" : "text-base-content/50")">
+                        <div class="text-xs tabular-nums @(vixChange.Value.InverseSignCss("text-base-content/50"))">
                             @(vixChange.Value > 0 ? "+" : "")@vixChange.Value.ToString("N2")
                         </div>
                     }

--- a/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
@@ -33,7 +33,7 @@
                             <td>@si.SettlementDate.ToString("yyyy-MM-dd")</td>
                             <td class="text-right font-mono"><compactable-number value="@si.CurrentShortPosition" /></td>
                             <td class="text-right font-mono"><compactable-number value="@si.PreviousShortPosition" /></td>
-                            <td class="text-right font-mono @(si.ChangeInShortPosition > 0 ? "text-error" : si.ChangeInShortPosition < 0 ? "text-success" : "")">
+                            <td class="text-right font-mono @si.ChangeInShortPosition.InverseSignCss()">
                                 <compactable-number value="@si.ChangeInShortPosition" sign />
                             </td>
                             <td class="text-right font-mono hidden md:table-cell">


### PR DESCRIPTION
## Summary

- Follow-up to #2563: covers the three sites where a *rising* value is bad news (VIX up = risk-on stress, short-interest growth = bearish), so the color mapping inverts.
- Adds `InverseSignCss<T>` overloads to the existing `SignCssExtensions` helper using the same `INumber<T>` + nullable-struct pattern just established.

## Code changes

- `src/Equibles.Web/Extensions/SignCssExtensions.cs` — added two overloads of `InverseSignCss<T>` (one on `T : INumber<T>`, one on `T? where T : struct, INumber<T>`). Returns `text-error` for positive, `text-success` for negative, and the supplied neutral class otherwise.
- `src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml` — replaced inline inverse ternary with `si.ChangeInShortPosition.InverseSignCss()`.
- `src/Equibles.Web/Views/Market/Index.cshtml`, `Views/Market/Vix.cshtml` — replaced inline inverse ternaries with `vixChange.Value.InverseSignCss("text-base-content/50")`.

Behavior is preserved: each replacement returns the same string for every input. After this PR, every sign-based CSS color decision in views routes through `SignCss` / `InverseSignCss`.