### PR TITLE
refactor(web-views): extract ToStringWithSign<T> extension; collapse 10 positive-sign-prefix sites

### DIFF
--- a/src/Equibles.Web/Extensions/SignedFormatting.cs
+++ b/src/Equibles.Web/Extensions/SignedFormatting.cs
@@ -1,0 +1,9 @@
+using System.Numerics;
+
+namespace Equibles.Web.Extensions;
+
+public static class SignedFormatting
+{
+    public static string ToStringWithSign<T>(this T value, string format)
+        where T : INumber<T> => (value > T.Zero ? "+" : "") + value.ToString(format, null);
+}

--- a/src/Equibles.Web/Views/Cftc/Show.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Show.cshtml
@@ -121,7 +121,7 @@
                                     <td class="text-right tabular-nums hidden lg:table-cell">
                                         @if (report.ChangeOpenInterest.HasValue) {
                                             <span class="@(report.ChangeOpenInterest.Value.SignCss("text-base-content/50"))">
-                                                @(report.ChangeOpenInterest.Value > 0 ? "+" : "")@report.ChangeOpenInterest.Value.ToString("N0")
+                                                @report.ChangeOpenInterest.Value.ToStringWithSign("N0")
                                             </span>
                                         } else {
                                             <span class="text-base-content/30">&mdash;</span>

--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -73,7 +73,7 @@
                         <div class="text-lg font-bold tabular-nums">@Model.LatestValue.Value.ToString("N2")</div>
                         @if (changePct.HasValue) {
                             <div class="text-xs tabular-nums @(changePct.Value.SignCss("text-base-content/50"))">
-                                @(changePct.Value > 0 ? "+" : "")@changePct.Value.ToString("N2")%
+                                @changePct.Value.ToStringWithSign("N2")%
                             </div>
                         }
                     </div>
@@ -140,7 +140,7 @@
                                     </td>
                                     <td class="text-right text-sm tabular-nums hidden sm:table-cell @(pctChange.SignCss("text-base-content/50"))">
                                         @if (pctChange.HasValue) {
-                                            @(pctChange.Value > 0 ? "+" : "")@pctChange.Value.ToString("N2")<text>%</text>
+                                            @pctChange.Value.ToStringWithSign("N2")<text>%</text>
                                         }
                                     </td>
                                 </tr>

--- a/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
@@ -81,7 +81,7 @@
                                         <td><a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@p.Ticker" class="link link-hover font-mono">@p.Ticker</a></td>
                                         <td class="max-w-xs truncate">@p.Name</td>
                                         <td class="text-right font-mono @scoreCss">@p.ConvictionScore.ToString("F1")</td>
-                                        <td class="text-right font-mono hidden md:table-cell @p.NetConvictionPct.SignCss()">@(p.NetConvictionPct > 0 ? "+" : "")@p.NetConvictionPct.ToString("F1")%</td>
+                                        <td class="text-right font-mono hidden md:table-cell @p.NetConvictionPct.SignCss()">@p.NetConvictionPct.ToStringWithSign("F1")%</td>
                                         <td class="text-right font-mono hidden md:table-cell">@p.RetentionPct.ToString("F1")%</td>
                                         <td class="text-right font-mono hidden lg:table-cell">@p.UniversePct.ToString("F2")%</td>
                                         <td class="text-right font-mono">@p.CurrentFilerCount.ToString("N0")</td>

--- a/src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml
@@ -59,7 +59,7 @@
                                         @snap.FilerCount.ToString("N0")
                                         @if (filerDelta.HasValue && filerDelta.Value != 0) {
                                             <span class="text-xs @(filerDelta.Value > 0 ? "text-success" : "text-error")">
-                                                @(filerDelta.Value > 0 ? "+" : "")@filerDelta.Value.ToString("N0")
+                                                @filerDelta.Value.ToStringWithSign("N0")
                                             </span>
                                         }
                                     </td>

--- a/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
+++ b/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
@@ -150,7 +150,7 @@
                                 @foreach (var row in Model.Rows) {
                                     var deltaFilerCss = row.DeltaFilerCount.SignCss();
                                     var deltaValueCss = row.DeltaValue.SignCss();
-                                    var deltaFilerText = (row.DeltaFilerCount > 0 ? "+" : row.DeltaFilerCount < 0 ? "-" : "") + Math.Abs(row.DeltaFilerCount).ToString("N0");
+                                    var deltaFilerText = row.DeltaFilerCount.ToStringWithSign("N0");
                                     var deltaValueText = (row.DeltaValue > 0 ? "+$" : row.DeltaValue < 0 ? "-$" : "$") + Math.Abs(row.DeltaValue).ToString("N0");
                                     <tr>
                                         <td class="font-mono">

--- a/src/Equibles.Web/Views/Market/Index.cshtml
+++ b/src/Equibles.Web/Views/Market/Index.cshtml
@@ -94,7 +94,7 @@
                             <div class="text-lg font-bold tabular-nums">@Model.Vix.LatestClose?.ToString("N2")</div>
                             @if (vixChange.HasValue) {
                                 <div class="text-xs tabular-nums @(vixChange.Value.InverseSignCss("text-base-content/50"))">
-                                    @(vixChange.Value > 0 ? "+" : "")@vixChange.Value.ToString("N2")
+                                    @vixChange.Value.ToStringWithSign("N2")
                                 </div>
                             }
                         </div>

--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -51,7 +51,7 @@
                     <div class="text-lg font-bold tabular-nums">@Model.LatestClose.Value.ToString("N2")</div>
                     @if (vixChange.HasValue) {
                         <div class="text-xs tabular-nums @(vixChange.Value.InverseSignCss("text-base-content/50"))">
-                            @(vixChange.Value > 0 ? "+" : "")@vixChange.Value.ToString("N2")
+                            @vixChange.Value.ToStringWithSign("N2")
                         </div>
                     }
                 </div>

--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -115,8 +115,7 @@
                                 <td class="text-right font-mono hidden md:table-cell">
                                     @if (changePercent.HasValue) {
                                         var css = changePercent.Value.SignCss();
-                                        var sign = changePercent.Value > 0 ? "+" : "";
-                                        <span class="@css">@sign@changePercent.Value.ToString("F1")%</span>
+                                        <span class="@css">@changePercent.Value.ToStringWithSign("F1")%</span>
                                     } else {
                                         <span>—</span>
                                     }

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -30,8 +30,7 @@
     static string FormatPct(double? pct)
     {
         if (pct == null) return "—";
-        var sign = pct > 0 ? "+" : "";
-        return $"{sign}{pct:F1}%";
+        return pct.Value.ToStringWithSign("F1") + "%";
     }
 
     static string FormatQuarter(DateOnly? date) =>


### PR DESCRIPTION
## Summary

- Extracted the `(value > 0 ? "+" : "") + value.ToString(format)` pattern (10 sites across 8 views + a local helper) into a single generic `ToStringWithSign<T>` extension on `INumber<T>`.
- Negative values still get the leading `-` from `ToString` itself; zero gets no prefix. Current-culture formatting is preserved by passing `null` as the format provider, matching the existing inline calls.

## Code changes

- `src/Equibles.Web/Extensions/SignedFormatting.cs` — new file. Single static extension `ToStringWithSign<T>(this T, string format) where T : INumber<T>` returning `(value > T.Zero ? "+" : "") + value.ToString(format, null)`.
- `src/Equibles.Web/Views/EconomicData/Show.cshtml`, `Views/HoldingsActivity/Stats.cshtml`, `Views/HoldingsActivity/HeatMap.cshtml`, `Views/Market/Vix.cshtml`, `Views/Market/Index.cshtml`, `Views/Cftc/Show.cshtml` — replaced 7 inline `@(x > 0 ? "+" : "")@x.ToString(...)` with `@x.ToStringWithSign(...)`.
- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml` — rewrote the local `FormatPct(double?)` helper to use the extension internally; public contract unchanged (still returns `"—"` for null).
- `src/Equibles.Web/Views/Stocks/ShowHolder.cshtml` — removed the local `var sign = …` line; inlined into the span via the extension.
- `src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml` — collapsed the `(x > 0 ? "+" : x < 0 ? "-" : "") + Math.Abs(x).ToString(…)` count formatter into `x.ToStringWithSign(…)` (equivalent because `ToString` itself renders the leading `-` for negative numbers).

Behavior is preserved: each call site returns the same string for every input. The `+$` / `-$` / `$` currency-prefix formatter for `DeltaValue` in `Screener.cshtml` is intentionally untouched — different shape, separate extraction.