### PR TITLE
refactor(web-views): extract SignPrefix<T> extension; collapse 8 inline sign-prefix ternaries

### DIFF
--- a/src/Equibles.Web/Extensions/SignPrefixExtensions.cs
+++ b/src/Equibles.Web/Extensions/SignPrefixExtensions.cs
@@ -1,0 +1,12 @@
+using System.Numerics;
+
+namespace Equibles.Web.Extensions;
+
+public static class SignPrefixExtensions
+{
+    public static string SignPrefix<T>(this T value)
+        where T : INumber<T> => value > T.Zero ? "+" : string.Empty;
+
+    public static string SignPrefix<T>(this T? value)
+        where T : struct, INumber<T> => value.HasValue ? value.Value.SignPrefix() : string.Empty;
+}

--- a/src/Equibles.Web/Views/Cftc/Show.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Show.cshtml
@@ -121,7 +121,7 @@
                                     <td class="text-right tabular-nums hidden lg:table-cell">
                                         @if (report.ChangeOpenInterest.HasValue) {
                                             <span class="@(report.ChangeOpenInterest.Value.SignCss("text-base-content/50"))">
-                                                @(report.ChangeOpenInterest.Value > 0 ? "+" : "")@report.ChangeOpenInterest.Value.ToString("N0")
+                                                @report.ChangeOpenInterest.Value.SignPrefix()@report.ChangeOpenInterest.Value.ToString("N0")
                                             </span>
                                         } else {
                                             <span class="text-base-content/30">&mdash;</span>

--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -73,7 +73,7 @@
                         <div class="text-lg font-bold tabular-nums">@Model.LatestValue.Value.ToString("N2")</div>
                         @if (changePct.HasValue) {
                             <div class="text-xs tabular-nums @(changePct.Value.SignCss("text-base-content/50"))">
-                                @(changePct.Value > 0 ? "+" : "")@changePct.Value.ToString("N2")%
+                                @changePct.Value.SignPrefix()@changePct.Value.ToString("N2")%
                             </div>
                         }
                     </div>
@@ -140,7 +140,7 @@
                                     </td>
                                     <td class="text-right text-sm tabular-nums hidden sm:table-cell @(pctChange.SignCss("text-base-content/50"))">
                                         @if (pctChange.HasValue) {
-                                            @(pctChange.Value > 0 ? "+" : "")@pctChange.Value.ToString("N2")<text>%</text>
+                                            @pctChange.Value.SignPrefix()@pctChange.Value.ToString("N2")<text>%</text>
                                         }
                                     </td>
                                 </tr>

--- a/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
@@ -81,7 +81,7 @@
                                         <td><a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@p.Ticker" class="link link-hover font-mono">@p.Ticker</a></td>
                                         <td class="max-w-xs truncate">@p.Name</td>
                                         <td class="text-right font-mono @scoreCss">@p.ConvictionScore.ToString("F1")</td>
-                                        <td class="text-right font-mono hidden md:table-cell @p.NetConvictionPct.SignCss()">@(p.NetConvictionPct > 0 ? "+" : "")@p.NetConvictionPct.ToString("F1")%</td>
+                                        <td class="text-right font-mono hidden md:table-cell @p.NetConvictionPct.SignCss()">@p.NetConvictionPct.SignPrefix()@p.NetConvictionPct.ToString("F1")%</td>
                                         <td class="text-right font-mono hidden md:table-cell">@p.RetentionPct.ToString("F1")%</td>
                                         <td class="text-right font-mono hidden lg:table-cell">@p.UniversePct.ToString("F2")%</td>
                                         <td class="text-right font-mono">@p.CurrentFilerCount.ToString("N0")</td>

--- a/src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml
@@ -59,7 +59,7 @@
                                         @snap.FilerCount.ToString("N0")
                                         @if (filerDelta.HasValue && filerDelta.Value != 0) {
                                             <span class="text-xs @(filerDelta.Value > 0 ? "text-success" : "text-error")">
-                                                @(filerDelta.Value > 0 ? "+" : "")@filerDelta.Value.ToString("N0")
+                                                @filerDelta.Value.SignPrefix()@filerDelta.Value.ToString("N0")
                                             </span>
                                         }
                                     </td>

--- a/src/Equibles.Web/Views/Market/Index.cshtml
+++ b/src/Equibles.Web/Views/Market/Index.cshtml
@@ -94,7 +94,7 @@
                             <div class="text-lg font-bold tabular-nums">@Model.Vix.LatestClose?.ToString("N2")</div>
                             @if (vixChange.HasValue) {
                                 <div class="text-xs tabular-nums @(vixChange.Value > 0 ? "text-error" : vixChange.Value < 0 ? "text-success" : "text-base-content/50")">
-                                    @(vixChange.Value > 0 ? "+" : "")@vixChange.Value.ToString("N2")
+                                    @vixChange.Value.SignPrefix()@vixChange.Value.ToString("N2")
                                 </div>
                             }
                         </div>

--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -51,7 +51,7 @@
                     <div class="text-lg font-bold tabular-nums">@Model.LatestClose.Value.ToString("N2")</div>
                     @if (vixChange.HasValue) {
                         <div class="text-xs tabular-nums @(vixChange.Value > 0 ? "text-error" : vixChange.Value < 0 ? "text-success" : "text-base-content/50")">
-                            @(vixChange.Value > 0 ? "+" : "")@vixChange.Value.ToString("N2")
+                            @vixChange.Value.SignPrefix()@vixChange.Value.ToString("N2")
                         </div>
                     }
                 </div>

--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -114,9 +114,7 @@
                                 <td class="text-right font-mono"><compactable-number value="@h.Shares" /></td>
                                 <td class="text-right font-mono hidden md:table-cell">
                                     @if (changePercent.HasValue) {
-                                        var css = changePercent.Value.SignCss();
-                                        var sign = changePercent.Value > 0 ? "+" : "";
-                                        <span class="@css">@sign@changePercent.Value.ToString("F1")%</span>
+                                        <span class="@changePercent.Value.SignCss()">@changePercent.Value.SignPrefix()@changePercent.Value.ToString("F1")%</span>
                                     } else {
                                         <span>—</span>
                                     }

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -30,8 +30,7 @@
     static string FormatPct(double? pct)
     {
         if (pct == null) return "—";
-        var sign = pct > 0 ? "+" : "";
-        return $"{sign}{pct:F1}%";
+        return $"{pct.SignPrefix()}{pct:F1}%";
     }
 
     static string FormatQuarter(DateOnly? date) =>


### PR DESCRIPTION
## Summary

- Extract `SignPrefix<T>()` extension method that mirrors the existing `SignCss<T>` pattern — returns `"+"` for positive values, empty string otherwise.
- Collapse 8 inline `value > 0 ? "+" : ""` ternaries across 7 views into `value.SignPrefix()` calls; also drop the local `var sign = …` block in `ShowHolder.cshtml` and the equivalent line inside `_HoldingsTab.cshtml`'s `FormatPct` helper.
- Byte-equivalent output at every call site.

## Code changes

- `src/Equibles.Web/Extensions/SignPrefixExtensions.cs` — new file; two `INumber<T>` overloads (value and nullable struct) returning `"+"` when strictly positive.
- `src/Equibles.Web/Views/EconomicData/Show.cshtml` — 2 inline ternaries replaced.
- `src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml` — 1 inline ternary replaced.
- `src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml` — 1 inline ternary replaced.
- `src/Equibles.Web/Views/Market/Index.cshtml` — 1 inline ternary replaced.
- `src/Equibles.Web/Views/Market/Vix.cshtml` — 1 inline ternary replaced.
- `src/Equibles.Web/Views/Cftc/Show.cshtml` — 1 inline ternary replaced.
- `src/Equibles.Web/Views/Stocks/ShowHolder.cshtml` — dropped intermediate `var sign`/`var css` block; now a single inline `<span>`.
- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml` — `FormatPct` helper now interpolates `pct.SignPrefix()` directly.