### PR TITLE
refactor(views): extract _CompactToggle shared partial; collapse 3 duplicated markup blocks

### DIFF
--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -233,11 +233,7 @@
 
     <div class="flex items-center justify-between mb-3">
         <h2 class="text-xl font-semibold m-0">Recent holdings</h2>
-        <label class="flex items-center gap-1.5 cursor-pointer" title="Toggle compact numbers (1M, 1B)">
-            <span class="text-xs text-base-content/60">Compact</span>
-            <input type="checkbox" class="toggle toggle-xs toggle-primary btn-compact-toggle"
-                   onchange="toggleCompactNumbers()" />
-        </label>
+        <partial name="_CompactToggle" />
     </div>
     @if (Model.Holdings.Count == 0) {
         <div class="text-base-content/60 py-8">No reported holdings.</div>

--- a/src/Equibles.Web/Views/Shared/_CompactToggle.cshtml
+++ b/src/Equibles.Web/Views/Shared/_CompactToggle.cshtml
@@ -1,0 +1,5 @@
+<label class="flex items-center gap-1.5 cursor-pointer" title="Toggle compact numbers (1M, 1B)">
+    <span class="text-xs text-base-content/60">Compact</span>
+    <input type="checkbox" class="toggle toggle-xs toggle-primary btn-compact-toggle"
+           onchange="toggleCompactNumbers()" />
+</label>

--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -68,11 +68,7 @@
 
         <div class="flex items-center justify-between mb-3">
             <h2 class="text-lg font-semibold m-0">Holdings in @stock.Ticker</h2>
-            <label class="flex items-center gap-1.5 cursor-pointer" title="Toggle compact numbers (1M, 1B)">
-                <span class="text-xs text-base-content/60">Compact</span>
-                <input type="checkbox" class="toggle toggle-xs toggle-primary btn-compact-toggle"
-                       onchange="toggleCompactNumbers()" />
-            </label>
+            <partial name="_CompactToggle" />
         </div>
 
         <!-- Position Over Time Chart -->

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -69,11 +69,7 @@
             <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Value:</span> <strong><compactable-number value="@Model.TotalValue" prefix="$" /></strong></div>
             <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Total Shares:</span> <strong><compactable-number value="@Model.TotalShares" /></strong></div>
             <div class="flex items-center gap-2 ml-auto">
-                <label class="flex items-center gap-1.5 cursor-pointer" title="Toggle compact numbers (1M, 1B)">
-                    <span class="text-xs text-base-content/60">Compact</span>
-                    <input type="checkbox" class="toggle toggle-xs toggle-primary btn-compact-toggle"
-                           onchange="toggleCompactNumbers()" />
-                </label>
+                <partial name="_CompactToggle" />
                 @if (!Model.IsCombinedView) {
                     <a class="btn btn-outline btn-sm"
                        asp-controller="HoldingsExport" asp-action="Holders"


### PR DESCRIPTION
## Summary

- Three views rendered the same 4-line "Compact" toggle markup (label + DaisyUI toggle wired to `toggleCompactNumbers()`). Extracted into a shared partial.
- Same pattern as the existing `_Pager` / `_EmptyStateCard` / `_MetricCard` extractions: static markup, no model.

## Code changes

- `src/Equibles.Web/Views/Shared/_CompactToggle.cshtml` — new file containing the `<label>` + `<input class="…btn-compact-toggle" onchange="toggleCompactNumbers()" />` markup.
- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml`, `Views/Stocks/ShowHolder.cshtml`, `Views/Profiles/Institution.cshtml` — replaced the 4-line inline markup with `<partial name="_CompactToggle" />`.

Behavior is preserved: Razor inlines the partial's markup at each call site, producing identical DOM. No model, no parameters, no JS contract change.