### PR TITLE
refactor(controllers): add IQueryable<T>.Page extension; collapse 5 inline Skip/Take paginators

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -106,9 +106,8 @@ public class HoldingsActivityController : BaseController
         var query = _holdingRepository.GetRecentFilings().OrderByDescending(f => f.ImportedAt);
 
         var totalCount = await query.CountAsync();
-        var skip = (page - 1) * LatestFilingsViewModel.PageSize;
 
-        var filings = await query.Skip(skip).Take(LatestFilingsViewModel.PageSize).ToListAsync();
+        var filings = await query.Page(page, LatestFilingsViewModel.PageSize).ToListAsync();
 
         return View(
             new LatestFilingsViewModel
@@ -177,10 +176,8 @@ public class HoldingsActivityController : BaseController
             );
 
         viewModel.TotalCount = await query.CountAsync();
-        var skip = (viewModel.Page - 1) * DoubleDownViewModel.PageSize;
         viewModel.Positions = await query
-            .Skip(skip)
-            .Take(DoubleDownViewModel.PageSize)
+            .Page(viewModel.Page, DoubleDownViewModel.PageSize)
             .ToListAsync();
 
         return View(viewModel);
@@ -251,7 +248,6 @@ public class HoldingsActivityController : BaseController
         viewModel.TotalUniverseFilers = await _holdingRepository
             .GetUniqueFilerIds(selectedDate, priorForRepo, viewModel.IsCombinedSelected)
             .CountAsync();
-        var skip = (viewModel.Page - 1) * HoldingsMostHeldViewModel.PageSize;
 
         var orderedQuery = normalizedSort switch
         {
@@ -267,8 +263,7 @@ public class HoldingsActivityController : BaseController
         };
 
         var pageRows = await orderedQuery
-            .Skip(skip)
-            .Take(HoldingsMostHeldViewModel.PageSize)
+            .Page(viewModel.Page, HoldingsMostHeldViewModel.PageSize)
             .ToListAsync();
 
         var stockIds = pageRows.Select(r => r.CommonStockId).ToList();

--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -2,6 +2,7 @@ using Equibles.Data;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Extensions;
 using Equibles.Web.ViewModels.Institutions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -97,8 +98,7 @@ public class InstitutionsController : BaseController
         var totalCount = await ordered.CountAsync();
 
         var pageRows = await ordered
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
+            .Page(page, pageSize)
             .Select(x => new InstitutionListItemViewModel
             {
                 Id = x.h.Id,

--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -79,8 +79,7 @@ public class StocksController : BaseController
 
         var stocks = await query
             .Include(s => s.Industry)
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
+            .Page(page, pageSize)
             .Select(s => new StockListItemViewModel
             {
                 Ticker = s.Ticker,

--- a/src/Equibles.Web/Extensions/Pagination.cs
+++ b/src/Equibles.Web/Extensions/Pagination.cs
@@ -5,4 +5,7 @@ public static class Pagination
     // Ceiling division with a floor of 1 — pages never collapse to 0 even on empty datasets.
     public static int PageCount(int totalCount, int pageSize) =>
         Math.Max(1, (totalCount + pageSize - 1) / pageSize);
+
+    public static IQueryable<T> Page<T>(this IQueryable<T> source, int page, int pageSize) =>
+        source.Skip((page - 1) * pageSize).Take(pageSize);
 }


### PR DESCRIPTION
## Summary

- Add `IQueryable<T>.Page(int page, int pageSize)` extension to `Equibles.Web.Extensions.Pagination` that wraps the existing `Skip((page - 1) * pageSize).Take(pageSize)` chain.
- Collapse 5 inline paginators across 3 controllers — `StocksController`, `InstitutionsController`, and `HoldingsActivityController` (LatestFilings / DoubleDown / MostHeld) — into the new extension.
- Pure syntactic substitution: the extension is a one-line delegation, so each site composes the same `IQueryable<T>` and emits the same EF SQL.

## Code changes

- `src/Equibles.Web/Extensions/Pagination.cs` — add the `Page<T>` extension method alongside the existing `PageCount`.
- `src/Equibles.Web/Controllers/StocksController.cs` — replace inline `Skip((page - 1) * pageSize).Take(pageSize)` with `Page(page, pageSize)`.
- `src/Equibles.Web/Controllers/InstitutionsController.cs` — same swap; adds the `Equibles.Web.Extensions` using directive.
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — three sites swapped (LatestFilings, DoubleDown, MostHeld); drops the per-action `var skip = …` locals.