### PR TITLE
refactor(views): parameterise _ChartCard margin; route 3 stock-tab chart cards through the shared partial

### DIFF
--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -97,7 +97,7 @@
         </div>
 
         <!-- Chart -->
-        <partial name="_ChartCard" model='($"{Model.Title} ({Model.Units})", "economy-chart", "Economic series history chart", "h-[320px]")' />
+        <partial name="_ChartCard" model='($"{Model.Title} ({Model.Units})", "economy-chart", "Economic series history chart", "h-[320px]", "mb-6")' />
     }
 
     <!-- Observations Table -->

--- a/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
@@ -32,7 +32,7 @@
         </div>
 
         <!-- Bubble Chart -->
-        <partial name="_ChartCard" model='("Conviction Score vs. Filer Count", "heatmap-chart", "13F conviction heat map bubble chart", "h-[500px]")' />
+        <partial name="_ChartCard" model='("Conviction Score vs. Filer Count", "heatmap-chart", "13F conviction heat map bubble chart", "h-[500px]", "mb-6")' />
 
         <!-- Score breakdown legend -->
         <div class="card bg-base-100 shadow-sm mb-6">

--- a/src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml
@@ -18,14 +18,14 @@
         <partial name="_EmptyStateCard" model='(IconName: "chart-bar", Heading: "No 13F data yet", Message: "Once at least one quarter of 13F filings has been ingested, the trend charts appear here.")' />
     } else {
         <!-- AUM Over Time -->
-        <partial name="_ChartCard" model='("Total Assets Under Management", "aum-chart", "Total AUM trend chart", "h-[320px]")' />
+        <partial name="_ChartCard" model='("Total Assets Under Management", "aum-chart", "Total AUM trend chart", "h-[320px]", "mb-6")' />
 
         <!-- Filer & Position Count Over Time -->
-        <partial name="_ChartCard" model='("Filers and Positions", "filer-chart", "Filer and position count trend chart", "h-[320px]")' />
+        <partial name="_ChartCard" model='("Filers and Positions", "filer-chart", "Filer and position count trend chart", "h-[320px]", "mb-6")' />
 
         <!-- Sector Allocation Over Time -->
         @if (Model.SectorAllocations.Count > 0) {
-            <partial name="_ChartCard" model='("Sector Allocation", "sector-chart", "Sector allocation trend chart", "h-[400px]")' />
+            <partial name="_ChartCard" model='("Sector Allocation", "sector-chart", "Sector allocation trend chart", "h-[400px]", "mb-6")' />
         }
     }
 </div>

--- a/src/Equibles.Web/Views/Shared/_ChartCard.cshtml
+++ b/src/Equibles.Web/Views/Shared/_ChartCard.cshtml
@@ -1,5 +1,5 @@
-@model (string Title, string ChartId, string AriaLabel, string HeightClass)
-<div class="card bg-base-100 shadow-sm mb-6">
+@model (string Title, string ChartId, string AriaLabel, string HeightClass, string MarginClass)
+<div class="card bg-base-100 shadow-sm @Model.MarginClass">
     <div class="card-body p-4 lg:p-6">
         <h2 class="font-semibold text-sm mb-3">@Model.Title</h2>
         <div class="@Model.HeightClass">

--- a/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
@@ -4,14 +4,7 @@
     <partial name="_EmptyStateCard" model='(IconName: "exclamation-triangle", Heading: "No Fails to Deliver Data", Message: "No fails-to-deliver data is available for this stock yet.")' />
 } else {
     <!-- Chart -->
-    <div class="card bg-base-100 shadow-sm mb-4">
-        <div class="card-body p-4 lg:p-6">
-            <h2 class="font-semibold text-sm mb-3">Fails to Deliver History</h2>
-            <div class="h-[200px]">
-                <canvas id="ftd-chart" role="img" aria-label="Fails-to-deliver history"></canvas>
-            </div>
-        </div>
-    </div>
+    <partial name="_ChartCard" model='("Fails to Deliver History", "ftd-chart", "Fails-to-deliver history", "h-[200px]", "mb-4")' />
 
     <!-- Table -->
     <div class="card bg-base-100 shadow-sm">

--- a/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
@@ -4,14 +4,7 @@
     <partial name="_EmptyStateCard" model='(IconName: "chart-bar", Heading: "No Short Interest Data", Message: "No short interest data is available for this stock yet.")' />
 } else {
     <!-- Chart -->
-    <div class="card bg-base-100 shadow-sm mb-4">
-        <div class="card-body p-4 lg:p-6">
-            <h2 class="font-semibold text-sm mb-3">Short Interest History</h2>
-            <div class="h-[200px]">
-                <canvas id="short-interest-chart" role="img" aria-label="Short interest history"></canvas>
-            </div>
-        </div>
-    </div>
+    <partial name="_ChartCard" model='("Short Interest History", "short-interest-chart", "Short interest history", "h-[200px]", "mb-4")' />
 
     <!-- Table -->
     <div class="card bg-base-100 shadow-sm">

--- a/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
@@ -4,14 +4,7 @@
     <partial name="_EmptyStateCard" model='(IconName: "arrow-trending-down", Heading: "No Short Volume Data", Message: "No daily short volume data is available for this stock yet.")' />
 } else {
     <!-- Chart -->
-    <div class="card bg-base-100 shadow-sm mb-4">
-        <div class="card-body p-4 lg:p-6">
-            <h2 class="font-semibold text-sm mb-3">Short Volume (Last 90 Days)</h2>
-            <div class="h-[200px]">
-                <canvas id="short-volume-chart" role="img" aria-label="Daily short volume history"></canvas>
-            </div>
-        </div>
-    </div>
+    <partial name="_ChartCard" model='("Short Volume (Last 90 Days)", "short-volume-chart", "Daily short volume history", "h-[200px]", "mb-4")' />
 
     <!-- Table -->
     <div class="card bg-base-100 shadow-sm">


### PR DESCRIPTION
## Summary

- Three stock-detail tabs (`_ShortInterestTab`, `_ShortVolumeTab`, `_FtdTab`) had their own inline copy of the DaisyUI chart-card markup — same shape as the existing `_ChartCard` shared partial but with `mb-4` instead of the partial's hardcoded `mb-6`.
- Added `MarginClass` as a fifth tuple element on `_ChartCard`'s model. The 5 existing callers now pass `"mb-6"` explicitly (same render as before); the 3 new tab callers pass `"mb-4"` (same render as their previous inline markup).

## Code changes

- `src/Equibles.Web/Views/Shared/_ChartCard.cshtml` — model is now `(string Title, string ChartId, string AriaLabel, string HeightClass, string MarginClass)`; the hardcoded `mb-6` was replaced with `@Model.MarginClass`.
- `src/Equibles.Web/Views/EconomicData/Show.cshtml`, `Views/HoldingsActivity/HeatMap.cshtml`, `Views/HoldingsActivity/Trends.cshtml` — 5 existing call sites now pass `"mb-6"` as the explicit fifth argument.
- `src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml`, `Views/Stocks/_ShortVolumeTab.cshtml`, `Views/Stocks/_FtdTab.cshtml` — 3 inline 9-line chart-card blocks replaced with a single `<partial name="_ChartCard" model=... />` call, passing `"mb-4"`.

Behavior is preserved: every render emits exactly the same `<div class="card bg-base-100 shadow-sm {mb-N}">…</div>` markup it did before — existing sites keep `mb-6`, new sites keep `mb-4`.