### PR TITLE
refactor(stocks-show-view): collapse 9 duplicated section-tab links into a data-driven foreach

### DIFF
--- a/src/Equibles.Web/Views/Stocks/Show.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Show.cshtml
@@ -100,17 +100,25 @@
             + (activeTab == id ? "btn-neutral" : "btn-ghost bg-base-100 border border-base-300");
         string TabAriaCurrent(string id) => activeTab == id ? "page" : null;
     }
+    @{
+        var sectionTabs = new (string Key, string Action, string Label)[]
+        {
+            ("price", "Price", "Technicals"),
+            ("holdings", "Holdings", "Institutional Holders"),
+            ("short-volume", "ShortVolume", "Short Volume"),
+            ("short-interest", "ShortInterest", "Short Interest"),
+            ("ftd", "Ftd", "Fails to Deliver"),
+            ("financials", "Financials", "Financials"),
+            ("documents", "Documents", "SEC Filings"),
+            ("insider-trading", "InsiderTrading", "Insider Trades"),
+            ("congressional-trades", "CongressionalTrades", "Congressional Trades"),
+        };
+    }
     <!-- Section navbar -->
     <nav class="flex flex-wrap gap-2 mb-6" aria-label="@(stock.Ticker) sections">
-        <a class="@TabBtnClass("price")" aria-current="@TabAriaCurrent("price")" asp-action="Price" asp-route-ticker="@stock.Ticker">Technicals</a>
-        <a class="@TabBtnClass("holdings")" aria-current="@TabAriaCurrent("holdings")" asp-action="Holdings" asp-route-ticker="@stock.Ticker">Institutional Holders</a>
-        <a class="@TabBtnClass("short-volume")" aria-current="@TabAriaCurrent("short-volume")" asp-action="ShortVolume" asp-route-ticker="@stock.Ticker">Short Volume</a>
-        <a class="@TabBtnClass("short-interest")" aria-current="@TabAriaCurrent("short-interest")" asp-action="ShortInterest" asp-route-ticker="@stock.Ticker">Short Interest</a>
-        <a class="@TabBtnClass("ftd")" aria-current="@TabAriaCurrent("ftd")" asp-action="Ftd" asp-route-ticker="@stock.Ticker">Fails to Deliver</a>
-        <a class="@TabBtnClass("financials")" aria-current="@TabAriaCurrent("financials")" asp-action="Financials" asp-route-ticker="@stock.Ticker">Financials</a>
-        <a class="@TabBtnClass("documents")" aria-current="@TabAriaCurrent("documents")" asp-action="Documents" asp-route-ticker="@stock.Ticker">SEC Filings</a>
-        <a class="@TabBtnClass("insider-trading")" aria-current="@TabAriaCurrent("insider-trading")" asp-action="InsiderTrading" asp-route-ticker="@stock.Ticker">Insider Trades</a>
-        <a class="@TabBtnClass("congressional-trades")" aria-current="@TabAriaCurrent("congressional-trades")" asp-action="CongressionalTrades" asp-route-ticker="@stock.Ticker">Congressional Trades</a>
+        @foreach (var tab in sectionTabs) {
+            <a class="@TabBtnClass(tab.Key)" aria-current="@TabAriaCurrent(tab.Key)" asp-action="@tab.Action" asp-route-ticker="@stock.Ticker">@tab.Label</a>
+        }
     </nav>
 
     @if (activeTab == "price" && hasAnyMetric) {


### PR DESCRIPTION
## Summary

- The section navbar in `Views/Stocks/Show.cshtml` had 9 near-identical `<a class="@TabBtnClass(...)" ...>` anchors that only varied in `(key, action, label)`.
- Drive them from a local `(Key, Action, Label)` tuple array and render with a single `@foreach`. `asp-action` accepts a variable identically to a literal, so each link still resolves to the same route at render time.
- Same data-driven Razor pattern PRs #2568 (Screener fieldsets) and #2571 (Status data tiles) used.

## Code changes

- `src/Equibles.Web/Views/Stocks/Show.cshtml` — replace 9 repeated tab-nav anchors with a single `@foreach` over a typed `(Key, Action, Label)` tuple array.