### PR TITLE
refactor(workers): add IImporter contract + BaseScraperWorker.RunImport helper

### DIFF
--- a/src/Equibles.Cboe.HostedService/CboeScraperWorker.cs
+++ b/src/Equibles.Cboe.HostedService/CboeScraperWorker.cs
@@ -24,10 +24,6 @@ public class CboeScraperWorker : BaseScraperWorker
         SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
     }
 
-    protected override async Task DoWork(CancellationToken stoppingToken)
-    {
-        await using var scope = ScopeFactory.CreateAsyncScope();
-        var importService = scope.ServiceProvider.GetRequiredService<CboeImportService>();
-        await importService.Import(stoppingToken);
-    }
+    protected override Task DoWork(CancellationToken stoppingToken) =>
+        RunImport<CboeImportService>(stoppingToken);
 }

--- a/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
+++ b/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 namespace Equibles.Cboe.HostedService.Services;
 
 [Service]
-public class CboeImportService
+public class CboeImportService : IImporter
 {
     private const int InsertBatchSize = 1000;
 

--- a/src/Equibles.Cftc.HostedService/CftcScraperWorker.cs
+++ b/src/Equibles.Cftc.HostedService/CftcScraperWorker.cs
@@ -24,10 +24,6 @@ public class CftcScraperWorker : BaseScraperWorker
         SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
     }
 
-    protected override async Task DoWork(CancellationToken stoppingToken)
-    {
-        await using var scope = ScopeFactory.CreateAsyncScope();
-        var importService = scope.ServiceProvider.GetRequiredService<CftcImportService>();
-        await importService.Import(stoppingToken);
-    }
+    protected override Task DoWork(CancellationToken stoppingToken) =>
+        RunImport<CftcImportService>(stoppingToken);
 }

--- a/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
+++ b/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Options;
 namespace Equibles.Cftc.HostedService.Services;
 
 [Service]
-public class CftcImportService
+public class CftcImportService : IImporter
 {
     private const int InsertBatchSize = 1000;
     private const int EarliestCftcYear = 1986;

--- a/src/Equibles.Fred.HostedService/FredScraperWorker.cs
+++ b/src/Equibles.Fred.HostedService/FredScraperWorker.cs
@@ -39,10 +39,6 @@ public class FredScraperWorker : BaseScraperWorker
         return true;
     }
 
-    protected override async Task DoWork(CancellationToken stoppingToken)
-    {
-        await using var scope = ScopeFactory.CreateAsyncScope();
-        var importService = scope.ServiceProvider.GetRequiredService<FredImportService>();
-        await importService.Import(stoppingToken);
-    }
+    protected override Task DoWork(CancellationToken stoppingToken) =>
+        RunImport<FredImportService>(stoppingToken);
 }

--- a/src/Equibles.Fred.HostedService/Services/FredImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredImportService.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Options;
 namespace Equibles.Fred.HostedService.Services;
 
 [Service]
-public class FredImportService
+public class FredImportService : IImporter
 {
     private const int InsertBatchSize = 1000;
 

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -96,6 +96,14 @@ public abstract class BaseScraperWorker : BackgroundService
         ErrorReporter = errorReporter;
     }
 
+    protected async Task RunImport<TImporter>(CancellationToken stoppingToken)
+        where TImporter : IImporter
+    {
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var importer = scope.ServiceProvider.GetRequiredService<TImporter>();
+        await importer.Import(stoppingToken);
+    }
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         if (!ValidateConfiguration())

--- a/src/Equibles.Worker/IImporter.cs
+++ b/src/Equibles.Worker/IImporter.cs
@@ -1,0 +1,6 @@
+namespace Equibles.Worker;
+
+public interface IImporter
+{
+    Task Import(CancellationToken cancellationToken);
+}


### PR DESCRIPTION
## Summary

- Three scrape workers (CBOE, CFTC, FRED) had the same 3-line "create scope → resolve import service → call Import" boilerplate. Extracted into a `RunImport<TImporter>` helper on `BaseScraperWorker` and introduced the `IImporter` contract the three services already satisfied by convention.
- Workers that need richer pre-import logic (Yahoo's ticker-map cold-start guard, FINRA's two-import cycle, the SEC family) are left as-is — they don't fit the simple pattern.

## Code changes

- `src/Equibles.Worker/IImporter.cs` — new interface: `Task Import(CancellationToken)`.
- `src/Equibles.Worker/BaseScraperWorker.cs` — added `protected async Task RunImport<TImporter>(CancellationToken) where TImporter : IImporter`. Same 3 operations in the same order as the existing boilerplate.
- `src/Equibles.Cboe.HostedService/Services/CboeImportService.cs`, `src/Equibles.Cftc.HostedService/Services/CftcImportService.cs`, `src/Equibles.Fred.HostedService/Services/FredImportService.cs` — class now declares `: IImporter` (existing `Task Import(CancellationToken)` method already matched the contract).
- `src/Equibles.Cboe.HostedService/CboeScraperWorker.cs`, `src/Equibles.Cftc.HostedService/CftcScraperWorker.cs`, `src/Equibles.Fred.HostedService/FredScraperWorker.cs` — `DoWork` is now a one-line expression-body forwarding to `RunImport<TImporter>(stoppingToken)`.

Behavior is preserved: the helper performs the same three operations in the same order; DI resolves the same concrete type; the `await using` scope lifecycle is identical.