### PR TITLE
refactor(market-pcr-view): collapse 6 duplicated _MetricCard tiles into a data-driven foreach

### DIFF
--- a/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
+++ b/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
@@ -39,23 +39,18 @@
         <span class="text-xs text-base-content/50">@Model.Records.Count observations</span>
     </div>
     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
-        @if (Model.LatestRatio.HasValue) {
-            <partial name="_MetricCard" model='(Label: "Latest", Value: Model.LatestRatio.Value.ToString("N2"))' />
+        @{
+            var stats = new (string Label, decimal? Value)[] {
+                ("Latest", Model.LatestRatio),
+                ("Mean", Model.Mean),
+                ("Median", Model.Median),
+                ("Min", Model.Min),
+                ("Max", Model.Max),
+                ("Std Dev", Model.StdDev),
+            };
         }
-        @if (Model.Mean.HasValue) {
-            <partial name="_MetricCard" model='(Label: "Mean", Value: Model.Mean.Value.ToString("N2"))' />
-        }
-        @if (Model.Median.HasValue) {
-            <partial name="_MetricCard" model='(Label: "Median", Value: Model.Median.Value.ToString("N2"))' />
-        }
-        @if (Model.Min.HasValue) {
-            <partial name="_MetricCard" model='(Label: "Min", Value: Model.Min.Value.ToString("N2"))' />
-        }
-        @if (Model.Max.HasValue) {
-            <partial name="_MetricCard" model='(Label: "Max", Value: Model.Max.Value.ToString("N2"))' />
-        }
-        @if (Model.StdDev.HasValue) {
-            <partial name="_MetricCard" model='(Label: "Std Dev", Value: Model.StdDev.Value.ToString("N2"))' />
+        @foreach (var stat in stats.Where(s => s.Value.HasValue)) {
+            <partial name="_MetricCard" model='(Label: stat.Label, Value: stat.Value.Value.ToString("N2"))' />
         }
     </div>
 


### PR DESCRIPTION
## Summary

- The Statistics grid in `Views/Market/PutCallRatio.cshtml` rendered six near-identical `_MetricCard` tiles (Latest, Mean, Median, Min, Max, Std Dev), each wrapped in its own `@if (Model.X.HasValue)` block with the same `.ToString("N2")` formatter.
- Collapses those six 3-line conditional blocks into one inline `(Label, decimal?)[]` array + a single `@foreach` over the `HasValue` entries — same labels, same order, same format, same `_MetricCard` partial.
- Behavior-preserving: every surviving tile still renders byte-identical HTML; nullable stats are still skipped via the same `HasValue` predicate.

## Code changes

- `src/Equibles.Web/Views/Market/PutCallRatio.cshtml` — replaces the 6 hand-rolled `@if + <partial>` blocks (lines 42-59) with a 6-element tuple array and a `foreach` that filters on `Value.HasValue` and renders the same `_MetricCard` partial.