### PR TITLE
refactor(economic-data-show-view): collapse 5 duplicated _MetricCard tiles into a foreach

### DIFF
--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -79,20 +79,17 @@
                     </div>
                 </div>
             }
-            @if (Model.Mean.HasValue) {
-                <partial name="_MetricCard" model='(Label: "Mean", Value: Model.Mean.Value.ToString("N2"))' />
+            @{
+                var stats = new (string Label, decimal? Value)[] {
+                    ("Mean", Model.Mean),
+                    ("Median", Model.Median),
+                    ("Std Dev", Model.StdDev),
+                    ("Min", Model.Min),
+                    ("Max", Model.Max),
+                };
             }
-            @if (Model.Median.HasValue) {
-                <partial name="_MetricCard" model='(Label: "Median", Value: Model.Median.Value.ToString("N2"))' />
-            }
-            @if (Model.StdDev.HasValue) {
-                <partial name="_MetricCard" model='(Label: "Std Dev", Value: Model.StdDev.Value.ToString("N2"))' />
-            }
-            @if (Model.Min.HasValue) {
-                <partial name="_MetricCard" model='(Label: "Min", Value: Model.Min.Value.ToString("N2"))' />
-            }
-            @if (Model.Max.HasValue) {
-                <partial name="_MetricCard" model='(Label: "Max", Value: Model.Max.Value.ToString("N2"))' />
+            @foreach (var stat in stats.Where(s => s.Value.HasValue)) {
+                <partial name="_MetricCard" model='(Label: stat.Label, Value: stat.Value.Value.ToString("N2"))' />
             }
         </div>
 


### PR DESCRIPTION
## Summary

- The Statistics grid in `Views/EconomicData/Show.cshtml` rendered five near-identical `_MetricCard` tiles (Mean, Median, Std Dev, Min, Max), each wrapped in its own `@if (Model.X.HasValue)` block with the same `.ToString("N2")` formatter.
- Collapses those five 3-line conditional blocks into one inline `(Label, decimal?)[]` array + a single `@foreach` over the `HasValue` entries — same labels, same order, same format, same `_MetricCard` partial.
- Mirrors #2574 (PutCallRatio view); behavior-preserving — every surviving tile still renders byte-identical HTML and nullable stats are still skipped via the same `HasValue` predicate.

## Code changes

- `src/Equibles.Web/Views/EconomicData/Show.cshtml` — replaces the 5 hand-rolled `@if + <partial>` blocks (lines 82-96) with a 5-element tuple array and a `foreach` that filters on `Value.HasValue` and renders the same `_MetricCard` partial. The custom "Latest" card with the change% delta above the loop is untouched.