### PR TITLE
refactor(vix-view): collapse 5 duplicated _MetricCard stat tiles into a data-driven foreach

### DIFF
--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -57,20 +57,17 @@
                 </div>
             </div>
         }
-        @if (Model.Mean.HasValue) {
-            <partial name="_MetricCard" model='(Label: "Mean", Value: Model.Mean.Value.ToString("N2"))' />
+        @{
+            var stats = new (string Label, decimal? Value)[] {
+                ("Mean", Model.Mean),
+                ("Median", Model.Median),
+                ("Min", Model.Min),
+                ("Max", Model.Max),
+                ("Std Dev", Model.StdDev),
+            };
         }
-        @if (Model.Median.HasValue) {
-            <partial name="_MetricCard" model='(Label: "Median", Value: Model.Median.Value.ToString("N2"))' />
-        }
-        @if (Model.Min.HasValue) {
-            <partial name="_MetricCard" model='(Label: "Min", Value: Model.Min.Value.ToString("N2"))' />
-        }
-        @if (Model.Max.HasValue) {
-            <partial name="_MetricCard" model='(Label: "Max", Value: Model.Max.Value.ToString("N2"))' />
-        }
-        @if (Model.StdDev.HasValue) {
-            <partial name="_MetricCard" model='(Label: "Std Dev", Value: Model.StdDev.Value.ToString("N2"))' />
+        @foreach (var stat in stats.Where(s => s.Value.HasValue)) {
+            <partial name="_MetricCard" model='(Label: stat.Label, Value: stat.Value.Value.ToString("N2"))' />
         }
     </div>
 


### PR DESCRIPTION
## Summary

- `Views/Market/Vix.cshtml` had five `@if (Model.X.HasValue) { <partial name="_MetricCard" … /> }` blocks for Mean / Median / Min / Max / Std Dev. Collapsed them into one tuple array + a single `@foreach`, matching the data-driven pattern that PR #2574 just established for the sibling `PutCallRatio.cshtml`.

## Code changes

- `src/Equibles.Web/Views/Market/Vix.cshtml` — replaced the five `@if` + inline `_MetricCard` blocks with a `(string Label, decimal? Value)[]` array and a `.Where(s => s.Value.HasValue)` foreach. Render order is unchanged (Mean, Median, Min, Max, Std Dev).

Behavior is preserved: every iteration emits the same `<partial name="_MetricCard">` call with the same Label / Value the inline `@if` block did; the `HasValue` filter preserves the conditional gate.