### PR TITLE
refactor(holdings-stats-view): collapse 6 duplicated _MetricCard tiles into a foreach

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml
@@ -23,12 +23,19 @@
             <span class="text-xs text-base-content/50">@Model.Latest.ReportDate.ToString("MMM dd, yyyy")</span>
         </div>
         <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-8">
-            <partial name="_MetricCard" model='(Label: "Filers", Value: Model.Latest.FilerCount.ToString("N0"))' />
-            <partial name="_MetricCard" model='(Label: "Filings", Value: Model.Latest.FilingCount.ToString("N0"))' />
-            <partial name="_MetricCard" model='(Label: "Stocks", Value: Model.Latest.StockCount.ToString("N0"))' />
-            <partial name="_MetricCard" model='(Label: "Positions", Value: Model.Latest.PositionCount.ToString("N0"))' />
-            <partial name="_MetricCard" model='(Label: "Avg Pos/Filer", Value: Model.Latest.AvgPositionsPerFiler.ToString("F1"))' />
-            <partial name="_MetricCard" model='(Label: "Total AUM", Value: "$" + (Model.Latest.TotalValue / 1_000_000_000m).ToString("N1") + "B")' />
+            @{
+                var tiles = new (string Label, string Value)[] {
+                    ("Filers", Model.Latest.FilerCount.ToString("N0")),
+                    ("Filings", Model.Latest.FilingCount.ToString("N0")),
+                    ("Stocks", Model.Latest.StockCount.ToString("N0")),
+                    ("Positions", Model.Latest.PositionCount.ToString("N0")),
+                    ("Avg Pos/Filer", Model.Latest.AvgPositionsPerFiler.ToString("F1")),
+                    ("Total AUM", "$" + (Model.Latest.TotalValue / 1_000_000_000m).ToString("N1") + "B"),
+                };
+            }
+            @foreach (var tile in tiles) {
+                <partial name="_MetricCard" model="tile" />
+            }
         </div>
 
         <!-- Historical Table -->


### PR DESCRIPTION
## Summary

- The "Latest Quarter" grid in `Views/HoldingsActivity/Stats.cshtml` rendered six unconditional `_MetricCard` tiles (Filers, Filings, Stocks, Positions, Avg Pos/Filer, Total AUM) as six near-identical inline `<partial>` lines, each varying only by label and per-tile formatter.
- Collapses those six lines into one inline `(string Label, string Value)[]` array + a single `@foreach` — each tile's pre-formatted value expression carried verbatim into the tuple. Same labels, same order, same partial.
- Mirrors #2574 / #2575 / #2576; behavior-preserving — every tile renders byte-identical HTML, per-tile formatters (`N0`, `F1`, the bespoke `$ + N1 + B` for AUM) are preserved exactly.

## Code changes

- `src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml` — replaces the 6 hand-rolled `<partial name="_MetricCard">` lines (26-31) with a 6-element tuple array and a `foreach` that passes each tuple as the partial's `(Label, Value)` model.