### PR TITLE
refactor(views): extract _ReportDateSelector shared partial; collapse 3 duplicated date-select blocks

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -13,13 +13,7 @@
     <!-- ReportDate selector + comparison subtitle -->
     <div class="mb-4 text-sm">
         <div class="flex flex-wrap items-center gap-x-5 gap-y-2 mb-1">
-            <div class="flex items-center gap-2 shrink-0">
-                <label for="activity-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
-                <select id="activity-date" class="select select-bordered select-sm"
-                    onchange="var v=this.value; window.location.href = v==='combined' ? 'Activity?combined=true' : 'Activity?date=' + v">
-                    <partial name="_QuarterDateOptions" model="Model" />
-                </select>
-            </div>
+            <partial name="_ReportDateSelector" model='("activity-date", "Activity", "", (Equibles.Web.ViewModels.Holdings.QuarterlySelectionViewModel)Model)' />
             @if (Model.PreviousDate.HasValue) {
                 <div class="text-xs text-base-content/50">vs prior quarter @Model.PreviousDate.Value.ToString("MMM dd, yyyy")</div>
                 <!-- CSV download covers all four boards for the selected ReportDate. -->

--- a/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
@@ -19,13 +19,7 @@
     } else {
         <div class="mb-4 text-sm">
             <div class="flex flex-wrap items-center gap-x-5 gap-y-2">
-                <div class="flex items-center gap-2 shrink-0">
-                    <label for="heatmap-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
-                    <select id="heatmap-date" class="select select-bordered select-sm"
-                        onchange="var v=this.value; window.location.href = v==='combined' ? 'HeatMap?combined=true' : 'HeatMap?date=' + v">
-                        <partial name="_QuarterDateOptions" model="Model" />
-                    </select>
-                </div>
+                <partial name="_ReportDateSelector" model='("heatmap-date", "HeatMap", "", (Equibles.Web.ViewModels.Holdings.QuarterlySelectionViewModel)Model)' />
                 <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">Stocks:</span> <strong>@Model.Points.Count.ToString("N0")</strong></div>
                 <div class="shrink-0 whitespace-nowrap"><span class="text-base-content/60">13F Universe:</span> <strong>@Model.TotalUniverseFilers.ToString("N0") filers</strong></div>
             </div>

--- a/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
@@ -16,18 +16,12 @@
     <!-- ReportDate + sort selector + universe size header. -->
     <div class="mb-4 text-sm">
         <div class="flex flex-wrap items-center gap-x-5 gap-y-2 mb-1">
-            <div class="flex items-center gap-2 shrink-0">
-                <label for="most-held-date" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
-                @{
-                    var mostHeldDateParam = Model.IsCombinedSelected
-                        ? "combined=true"
-                        : "date=" + Model.SelectedDate.ToString("yyyy-MM-dd");
-                }
-                <select id="most-held-date" class="select select-bordered select-sm"
-                    onchange="var v=this.value; window.location.href = v==='combined' ? 'MostHeld?combined=true&sort=@Model.Sort' : 'MostHeld?date=' + v + '&sort=@Model.Sort'">
-                    <partial name="_QuarterDateOptions" model="Model" />
-                </select>
-            </div>
+            @{
+                var mostHeldDateParam = Model.IsCombinedSelected
+                    ? "combined=true"
+                    : "date=" + Model.SelectedDate.ToString("yyyy-MM-dd");
+            }
+            <partial name="_ReportDateSelector" model='("most-held-date", "MostHeld", $"&sort={Model.Sort}", (Equibles.Web.ViewModels.Holdings.QuarterlySelectionViewModel)Model)' />
             <div class="flex items-center gap-2 shrink-0">
                 <label for="most-held-sort" class="text-base-content/60 whitespace-nowrap">Sort by:</label>
                 <select id="most-held-sort" class="select select-bordered select-sm"

--- a/src/Equibles.Web/Views/HoldingsActivity/_ReportDateSelector.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/_ReportDateSelector.cshtml
@@ -1,0 +1,9 @@
+@using Equibles.Web.ViewModels.Holdings
+@model (string Id, string Action, string ExtraQuery, QuarterlySelectionViewModel Quarter)
+<div class="flex items-center gap-2 shrink-0">
+    <label for="@Model.Id" class="text-base-content/60 whitespace-nowrap">Report Date:</label>
+    <select id="@Model.Id" class="select select-bordered select-sm"
+        onchange="var v=this.value; window.location.href = v==='combined' ? '@(Model.Action)?combined=true@Html.Raw(Model.ExtraQuery)' : '@(Model.Action)?date=' + v + '@Html.Raw(Model.ExtraQuery)'">
+        <partial name="_QuarterDateOptions" model="Model.Quarter" />
+    </select>
+</div>


### PR DESCRIPTION
## Summary

- The three HoldingsActivity views (Activity, HeatMap, MostHeld) rendered the same `<div><label/><select onchange=…><partial name="_QuarterDateOptions"/></select></div>` block, varying only by element id, controller action name in the JS URL, and (MostHeld only) an extra `&sort=…` query suffix.
- Extracted the markup into `_ReportDateSelector.cshtml` taking a `(string Id, string Action, string ExtraQuery, QuarterlySelectionViewModel Quarter)` tuple model. Same per-area folder as the existing `_QuarterDateOptions` partial.

## Code changes

- `src/Equibles.Web/Views/HoldingsActivity/_ReportDateSelector.cshtml` — new partial.
- `src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml`, `…/HeatMap.cshtml`, `…/MostHeld.cshtml` — replaced the inline 7-line `<div>/<select>` block with a single `<partial name="_ReportDateSelector" …>` call. MostHeld passes `$"&sort={Model.Sort}"` as the extra query suffix; the other two pass `""`.

Behavior is preserved: the partial emits the exact same HTML — same id, same onchange JS skeleton, same action name and extra-query suffix, same `_QuarterDateOptions` rendering — that each view emitted inline. `@Html.Raw` on the extra-query parameter mirrors the bare-string interpolation the inline `&sort=@Model.Sort` produced.