### PR TITLE
refactor(views): extract _StockLink shared partial; route 8 anchors through it

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
@@ -82,8 +82,7 @@
                                         <span class="text-xs text-base-content/50 font-mono">@pos.FilerCik</span>
                                     </td>
                                     <td>
-                                        <a asp-action="Show" asp-controller="Stocks" asp-route-ticker="@pos.Ticker"
-                                           class="link link-primary font-mono">@pos.Ticker</a>
+                                        <partial name="_StockLink" model='(Ticker: pos.Ticker, Class: "link link-primary font-mono")' />
                                         <span class="text-xs text-base-content/50 block truncate max-w-[150px]">@pos.StockName</span>
                                     </td>
                                     <td class="text-right font-mono">@pos.PreviousShares.ToString("N0")</td>

--- a/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
@@ -72,7 +72,7 @@
                                 @foreach (var p in Model.Points.Take(25)) {
                                     var scoreCss = p.ConvictionScore >= 150 ? "text-success" : p.ConvictionScore < 50 ? "text-error" : "";
                                     <tr>
-                                        <td><a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@p.Ticker" class="link link-hover font-mono">@p.Ticker</a></td>
+                                        <td><partial name="_StockLink" model='(Ticker: p.Ticker, Class: "link link-hover font-mono")' /></td>
                                         <td class="max-w-xs truncate">@p.Name</td>
                                         <td class="text-right font-mono @scoreCss">@p.ConvictionScore.ToString("F1")</td>
                                         <td class="text-right font-mono hidden md:table-cell @p.NetConvictionPct.SignCss()">@p.NetConvictionPct.ToStringWithSign("F1")%</td>

--- a/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
+++ b/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
@@ -46,8 +46,7 @@
                                                    class="link link-primary text-sm">@row.OwnerName</a>
                                             </td>
                                             <td>
-                                                <a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@row.Ticker"
-                                                   class="font-mono link link-primary">@row.Ticker</a>
+                                                <partial name="_StockLink" model='(Ticker: row.Ticker, Class: "font-mono link link-primary")' />
                                             </td>
                                             <td class="text-right font-mono text-success"><compactable-number value="@row.Value" prefix="$" /></td>
                                             <td class="text-right text-sm text-base-content/60 hidden md:table-cell">@row.TransactionDate.ToString("MMM dd")</td>
@@ -88,8 +87,7 @@
                                                    class="link link-primary text-sm">@row.OwnerName</a>
                                             </td>
                                             <td>
-                                                <a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@row.Ticker"
-                                                   class="font-mono link link-primary">@row.Ticker</a>
+                                                <partial name="_StockLink" model='(Ticker: row.Ticker, Class: "font-mono link link-primary")' />
                                             </td>
                                             <td class="text-right font-mono text-error"><compactable-number value="@row.Value" prefix="$" /></td>
                                             <td class="text-right text-sm text-base-content/60 hidden md:table-cell">@row.TransactionDate.ToString("MMM dd")</td>
@@ -134,8 +132,7 @@
                                                class="link link-primary text-sm">@row.OwnerName</a>
                                         </td>
                                         <td>
-                                            <a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@row.Ticker"
-                                               class="font-mono link link-primary">@row.Ticker</a>
+                                            <partial name="_StockLink" model='(Ticker: row.Ticker, Class: "font-mono link link-primary")' />
                                         </td>
                                         <td>
                                             <span class="badge @(row.IsAcquisition ? "badge-success" : "badge-error") badge-xs">

--- a/src/Equibles.Web/Views/Profiles/Insider.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Insider.cshtml
@@ -33,8 +33,7 @@
                         @foreach (var trade in Model.Transactions) {
                             <tr>
                                 <td>
-                                    <a asp-action="Show" asp-controller="Stocks" asp-route-ticker="@trade.Ticker"
-                                       class="font-semibold link link-primary">@trade.Ticker</a>
+                                    <partial name="_StockLink" model='(Ticker: trade.Ticker, Class: "font-semibold link link-primary")' />
                                 </td>
                                 <td class="hidden lg:table-cell">@trade.TransactionDate.ToString("yyyy-MM-dd")</td>
                                 <td class="hidden lg:table-cell max-w-xs truncate">@trade.SecurityTitle</td>

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -254,8 +254,7 @@
                         @foreach (var holding in Model.Holdings) {
                             <tr>
                                 <td>
-                                    <a asp-action="Show" asp-controller="Stocks" asp-route-ticker="@holding.Ticker"
-                                       class="font-semibold link link-primary">@holding.Ticker</a>
+                                    <partial name="_StockLink" model='(Ticker: holding.Ticker, Class: "font-semibold link link-primary")' />
                                 </td>
                                 <td class="max-w-xs truncate">@holding.Company</td>
                                 <td class="hidden lg:table-cell">@holding.ReportDate.ToString("yyyy-MM-dd")</td>

--- a/src/Equibles.Web/Views/Profiles/Member.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Member.cshtml
@@ -30,8 +30,7 @@
                         @foreach (var trade in Model.Trades) {
                             <tr>
                                 <td>
-                                    <a asp-action="Show" asp-controller="Stocks" asp-route-ticker="@trade.Ticker"
-                                       class="font-semibold link link-primary">@trade.Ticker</a>
+                                    <partial name="_StockLink" model='(Ticker: trade.Ticker, Class: "font-semibold link link-primary")' />
                                 </td>
                                 <td class="hidden lg:table-cell">@trade.TransactionDate.ToString("yyyy-MM-dd")</td>
                                 <td class="hidden lg:table-cell max-w-xs truncate">@trade.AssetName</td>

--- a/src/Equibles.Web/Views/Shared/_StockLink.cshtml
+++ b/src/Equibles.Web/Views/Shared/_StockLink.cshtml
@@ -1,0 +1,3 @@
+@model (string Ticker, string Class)
+<a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@Model.Ticker"
+   class="@Model.Class">@Model.Ticker</a>

--- a/src/Equibles.Web/Views/Stocks/Index.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Index.cshtml
@@ -77,8 +77,7 @@
                         <tr class="hover cursor-pointer stock-row"
                             data-href="@Url.Action("Show", "Stocks", new { ticker = stock.Ticker })">
                             <td>
-                                <a asp-action="Show" asp-controller="Stocks" asp-route-ticker="@stock.Ticker"
-                                   class="font-semibold link link-primary">@stock.Ticker</a>
+                                <partial name="_StockLink" model='(Ticker: stock.Ticker, Class: "font-semibold link link-primary")' />
                             </td>
                             <td class="max-w-xs truncate">@stock.Name</td>
                             <td class="hidden lg:table-cell font-mono text-sm text-base-content/60">@(stock.Cusip ?? "—")</td>


### PR DESCRIPTION
## Summary

- The `<a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@X.Ticker" class="…">@X.Ticker</a>` markup appeared 8 times across 7 views (insider/holdings/profiles dashboards and the stocks index), each one differing only in the class string and the ticker source expression.
- Adds `Views/Shared/_StockLink.cshtml` — a 3-line partial taking `(string Ticker, string Class)` — and routes every existing site through it. Same idiom as the recent `_MetricCard` / `_ChartCard` / `_EmptyStateCard` / `_Pager` / `_CompactToggle` / `_ReportDateSelector` extractions.
- Behavior-preserving: the partial emits the same `<a>` tag handled by the same built-in `AnchorTagHelper`, producing the same `href`, the same `class` attribute, and the same inner ticker text. Centralizes "how to link to a stock" so a future route change is one edit.

## Code changes

- `src/Equibles.Web/Views/Shared/_StockLink.cshtml` — **new** 3-line partial that renders `<a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@Model.Ticker" class="@Model.Class">@Model.Ticker</a>`.
- `src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml` — replaces 3 hand-rolled `<a>` blocks (Top Buys / Top Sells / Biggest Transactions rows) with `<partial name="_StockLink" …>`.
- `src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml` — 1 site.
- `src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml` — 1 site.
- `src/Equibles.Web/Views/Profiles/Insider.cshtml` — 1 site.
- `src/Equibles.Web/Views/Profiles/Institution.cshtml` — 1 site.
- `src/Equibles.Web/Views/Profiles/Member.cshtml` — 1 site.
- `src/Equibles.Web/Views/Stocks/Index.cshtml` — 1 site.