### PR TITLE
refactor(views): extract _InstitutionLink shared partial; route 5 anchors through it

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
@@ -77,8 +77,7 @@
                             @foreach (var pos in Model.Positions) {
                                 <tr class="hover">
                                     <td class="max-w-[200px]">
-                                        <a asp-action="Institution" asp-controller="Profiles" asp-route-cik="@pos.FilerCik"
-                                           class="font-semibold link link-primary truncate block">@pos.FilerName</a>
+                                        <partial name="_InstitutionLink" model='(Cik: pos.FilerCik, Name: pos.FilerName, Class: "font-semibold link link-primary truncate block")' />
                                         <span class="text-xs text-base-content/50 font-mono">@pos.FilerCik</span>
                                     </td>
                                     <td>

--- a/src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml
@@ -36,8 +36,7 @@
                             data-href="@Url.Action("Institution", "Profiles", new { cik = filing.FilerCik })">
                             <td class="max-w-xs">
                                 <div class="flex items-center gap-2">
-                                    <a asp-action="Institution" asp-controller="Profiles" asp-route-cik="@filing.FilerCik"
-                                       class="font-semibold link link-primary truncate">@filing.FilerName</a>
+                                    <partial name="_InstitutionLink" model='(Cik: filing.FilerCik, Name: filing.FilerName, Class: "font-semibold link link-primary truncate")' />
                                     @if (filing.IsNewFiler) {
                                         <span class="badge badge-info badge-xs whitespace-nowrap" title="First 13F filing for this CIK">New</span>
                                     }

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -78,8 +78,7 @@
                         <tr class="hover cursor-pointer institution-row"
                             data-href="@Url.Action("Institution", "Profiles", new { cik = inst.Cik })">
                             <td class="max-w-xs">
-                                <a asp-action="Institution" asp-controller="Profiles" asp-route-cik="@inst.Cik"
-                                   class="font-semibold link link-primary">@inst.Name</a>
+                                <partial name="_InstitutionLink" model='(Cik: inst.Cik, Name: inst.Name, Class: "font-semibold link link-primary")' />
                             </td>
                             <td class="hidden md:table-cell font-mono text-sm text-base-content/60">@inst.Cik</td>
                             <td class="hidden lg:table-cell text-sm text-base-content/60">@(string.IsNullOrEmpty(location) ? "—" : location)</td>

--- a/src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml
+++ b/src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml
@@ -66,8 +66,7 @@
                             @for (var i = 0; i < n; i++) {
                                 <tr>
                                     <th scope="row" class="text-xs max-w-[150px] truncate font-semibold" title="@Model.Matrix.Funds[i].HolderName">
-                                        <a asp-action="Institution" asp-controller="Profiles" asp-route-cik="@Model.Matrix.Funds[i].HolderCik"
-                                           class="link link-primary">@Model.Matrix.Funds[i].HolderName</a>
+                                        <partial name="_InstitutionLink" model='(Cik: Model.Matrix.Funds[i].HolderCik, Name: Model.Matrix.Funds[i].HolderName, Class: "link link-primary")' />
                                     </th>
                                     @for (var j = 0; j < n; j++) {
                                         var count = Model.Matrix.SharedTickerCounts[i][j];
@@ -111,8 +110,7 @@
                             @foreach (var fund in Model.Matrix.Funds) {
                                 <tr>
                                     <td>
-                                        <a asp-action="Institution" asp-controller="Profiles" asp-route-cik="@fund.HolderCik"
-                                           class="link link-primary font-semibold">@fund.HolderName</a>
+                                        <partial name="_InstitutionLink" model='(Cik: fund.HolderCik, Name: fund.HolderName, Class: "link link-primary font-semibold")' />
                                     </td>
                                     <td class="hidden md:table-cell font-mono text-sm text-base-content/60">@fund.HolderCik</td>
                                     <td class="text-right font-mono">@fund.PositionCount.ToString("N0")</td>

--- a/src/Equibles.Web/Views/Shared/_InstitutionLink.cshtml
+++ b/src/Equibles.Web/Views/Shared/_InstitutionLink.cshtml
@@ -1,0 +1,3 @@
+@model (string Cik, string Name, string Class)
+<a asp-controller="Profiles" asp-action="Institution" asp-route-cik="@Model.Cik"
+   class="@Model.Class">@Model.Name</a>


### PR DESCRIPTION
## Summary

- The `<a asp-action="Institution" asp-controller="Profiles" asp-route-cik="@X.Cik" class="…">@X.Name</a>` markup appeared 5 times across 4 views (institutions index, holdings-activity double-down/latest-filings, overlap matrix row + column header), each one differing only in the class string and the cik/name source expressions.
- Adds `Views/Shared/_InstitutionLink.cshtml` — a 3-line partial taking `(string Cik, string Name, string Class)` — and routes every existing site through it. Direct mirror of `_StockLink` (#2579).
- Behavior-preserving: the partial emits the same `<a>` tag handled by the same built-in `AnchorTagHelper`, producing the same `href`, the same `class` attribute, and the same inner holder name text. Centralizes "how to link to an institution" so a future route change is one edit.

## Code changes

- `src/Equibles.Web/Views/Shared/_InstitutionLink.cshtml` — **new** 3-line partial that renders `<a asp-controller="Profiles" asp-action="Institution" asp-route-cik="@Model.Cik" class="@Model.Class">@Model.Name</a>`.
- `src/Equibles.Web/Views/Institutions/Index.cshtml` — replaces the row-level institution link with `<partial name="_InstitutionLink" …>`.
- `src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml` — 1 site (filer name in the double-down board).
- `src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml` — 1 site (filer name in the latest-filings board).
- `src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml` — 2 sites (matrix row-header link + summary-table fund link).