### PR TITLE
refactor(web-views): extract Html.Json<T>; collapse 40 inline JsonSerializer.Serialize sites

### DIFF
--- a/src/Equibles.Web/Extensions/HtmlExtensions.cs
+++ b/src/Equibles.Web/Extensions/HtmlExtensions.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace Equibles.Web.Extensions;
+
+public static class HtmlExtensions
+{
+    // Generic so the compile-time T matches what the inline call sites used,
+    // keeping the JSON output byte-identical to the prior
+    // @Html.Raw(JsonSerializer.Serialize(...)) pattern.
+    public static IHtmlContent Json<T>(this IHtmlHelper html, T value) =>
+        new HtmlString(JsonSerializer.Serialize(value));
+}

--- a/src/Equibles.Web/Views/Cftc/Show.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Show.cshtml
@@ -146,9 +146,9 @@
             const ctx = document.getElementById('cftc-chart');
             if (!ctx || typeof Chart === 'undefined') return;
 
-            const labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chronological.Select(r => r.ReportDate.ToString("yyyy-MM-dd")).ToList()));
-            const commNet = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chronological.Select(r => r.CommLong - r.CommShort).ToList()));
-            const nonCommNet = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chronological.Select(r => r.NonCommLong - r.NonCommShort).ToList()));
+            const labels = @Html.Json(chronological.Select(r => r.ReportDate.ToString("yyyy-MM-dd")).ToList());
+            const commNet = @Html.Json(chronological.Select(r => r.CommLong - r.CommShort).ToList());
+            const nonCommNet = @Html.Json(chronological.Select(r => r.NonCommLong - r.NonCommShort).ToList());
 
             new Chart(ctx, {
                 type: 'line',

--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -159,12 +159,12 @@
             const ctx = document.getElementById('economy-chart');
             if (!ctx || typeof Chart === 'undefined') return;
 
-            const labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chronological.Select(o => o.Date.ToString("yyyy-MM-dd")).ToList()));
-            const values = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chronological.Select(o => o.Value).ToList()));
-            const sma20 = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Sma20));
-            const sma50 = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Sma50));
+            const labels = @Html.Json(chronological.Select(o => o.Date.ToString("yyyy-MM-dd")).ToList());
+            const values = @Html.Json(chronological.Select(o => o.Value).ToList());
+            const sma20 = @Html.Json(Model.Sma20);
+            const sma50 = @Html.Json(Model.Sma50);
 
-            const seriesLabel = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.SeriesId));
+            const seriesLabel = @Html.Json(Model.SeriesId);
             const datasets = [{
                 label: seriesLabel,
                 data: values,

--- a/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
@@ -99,7 +99,7 @@
         document.addEventListener('DOMContentLoaded', function() {
             if (typeof Chart === 'undefined') return;
 
-            const points = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(
+            const points = @Html.Json(
                 Model.Points.Select(p => new {
                     x = p.CurrentFilerCount,
                     y = p.ConvictionScore,
@@ -111,7 +111,7 @@
                     net = p.NetConvictionPct,
                     ret = p.RetentionPct,
                     univ = p.UniversePct,
-                }).ToList()));
+                }).ToList());
 
             // Score-based color: green for high, yellow for mid, red for low
             function scoreColor(score) {

--- a/src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml
@@ -38,14 +38,14 @@
         document.addEventListener('DOMContentLoaded', function() {
             if (typeof Chart === 'undefined') return;
 
-            const aumLabels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(
-                Model.AumSnapshots.Select(a => a.ReportDate.ToString("yyyy-MM-dd")).ToList()));
-            const aumValues = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(
-                Model.AumSnapshots.Select(a => a.TotalValue / 1_000_000_000m).ToList()));
-            const filerCounts = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(
-                Model.AumSnapshots.Select(a => a.FilerCount).ToList()));
-            const positionCounts = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(
-                Model.AumSnapshots.Select(a => a.PositionCount).ToList()));
+            const aumLabels = @Html.Json(
+                Model.AumSnapshots.Select(a => a.ReportDate.ToString("yyyy-MM-dd")).ToList());
+            const aumValues = @Html.Json(
+                Model.AumSnapshots.Select(a => a.TotalValue / 1_000_000_000m).ToList());
+            const filerCounts = @Html.Json(
+                Model.AumSnapshots.Select(a => a.FilerCount).ToList());
+            const positionCounts = @Html.Json(
+                Model.AumSnapshots.Select(a => a.PositionCount).ToList());
 
             const sharedOptions = {
                 responsive: true,
@@ -149,8 +149,8 @@
                     .ToDictionary(s => (s.ReportDate, s.SectorName ?? "Unknown"), s => s.TotalValue);
 
                 <text>
-                const sectorLabels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(
-                    sectorDates.Select(d => d.ToString("yyyy-MM-dd")).ToList()));
+                const sectorLabels = @Html.Json(
+                    sectorDates.Select(d => d.ToString("yyyy-MM-dd")).ToList());
                 const sectorColors = [
                     'oklch(55% 0.15 250)', 'oklch(65% 0.2 145)', 'oklch(65% 0.15 30)',
                     'oklch(55% 0.2 310)', 'oklch(60% 0.15 80)', 'oklch(50% 0.15 200)',
@@ -167,8 +167,8 @@
                         .ToList();
                     <text>
                     sectorDatasets.push({
-                        label: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(sector)),
-                        data: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(values)),
+                        label: @Html.Json(sector),
+                        data: @Html.Json(values),
                         backgroundColor: sectorColors[@i % sectorColors.length] + ' / 0.6)',
                         borderColor: sectorColors[@i % sectorColors.length],
                         borderWidth: 1,

--- a/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
+++ b/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
@@ -129,8 +129,8 @@
             const ctx = document.getElementById('pcr-chart');
             if (!ctx || typeof Chart === 'undefined') return;
 
-            const labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chronological.Select(r => r.Date.ToString("yyyy-MM-dd")).ToList()));
-            const values = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chronological.Select(r => r.PutCallRatio).ToList()));
+            const labels = @Html.Json(chronological.Select(r => r.Date.ToString("yyyy-MM-dd")).ToList());
+            const values = @Html.Json(chronological.Select(r => r.PutCallRatio).ToList());
 
             new Chart(ctx, {
                 type: 'line',

--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -134,8 +134,8 @@
             const ctx = document.getElementById('vix-chart');
             if (!ctx || typeof Chart === 'undefined') return;
 
-            const labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chronological.Select(r => r.Date.ToString("yyyy-MM-dd")).ToList()));
-            const closes = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chronological.Select(r => r.Close).ToList()));
+            const labels = @Html.Json(chronological.Select(r => r.Date.ToString("yyyy-MM-dd")).ToList());
+            const closes = @Html.Json(chronological.Select(r => r.Close).ToList());
 
             // Compute SMA-20 and SMA-50 from chart data
             function computeSma(data, period) {

--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -146,8 +146,8 @@
                 const ctx = document.getElementById('holder-position-chart');
                 if (!ctx || typeof Chart === 'undefined') return;
 
-                const labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chartHoldings.Select(h => h.ReportDate.ToString("yyyy-MM-dd")).ToList()));
-                const shares = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chartHoldings.Select(h => h.Shares).ToList()));
+                const labels = @Html.Json(chartHoldings.Select(h => h.ReportDate.ToString("yyyy-MM-dd")).ToList());
+                const shares = @Html.Json(chartHoldings.Select(h => h.Shares).ToList());
 
                 new Chart(ctx, {
                     type: 'line',

--- a/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
@@ -39,8 +39,8 @@
         const ctx = document.getElementById('ftd-chart');
         if (!ctx || typeof Chart === 'undefined') return;
 
-        const labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.FailsToDeliver.Select(f => f.SettlementDate.ToString("yyyy-MM-dd")).ToList()));
-        const quantities = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.FailsToDeliver.Select(f => f.Quantity).ToList()));
+        const labels = @Html.Json(Model.FailsToDeliver.Select(f => f.SettlementDate.ToString("yyyy-MM-dd")).ToList());
+        const quantities = @Html.Json(Model.FailsToDeliver.Select(f => f.Quantity).ToList());
 
         new Chart(ctx, {
             type: 'bar',

--- a/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
@@ -98,16 +98,16 @@
         if (typeof Chart === 'undefined') return;
 
         // Serialize all data from server
-        const allLabels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Prices.Select(p => p.Date.ToString("yyyy-MM-dd")).ToList()));
-        const allClose = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Prices.Select(p => (decimal?)p.Close).ToList()));
-        const allVolume = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Prices.Select(p => p.Volume).ToList()));
-        const allSma20 = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Sma20));
-        const allSma50 = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Sma50));
-        const allSma200 = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Sma200));
-        const allRsi = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Rsi14));
-        const allMacdLine = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.MacdLine));
-        const allMacdSignal = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.MacdSignal));
-        const allMacdHist = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.MacdHistogram));
+        const allLabels = @Html.Json(Model.Prices.Select(p => p.Date.ToString("yyyy-MM-dd")).ToList());
+        const allClose = @Html.Json(Model.Prices.Select(p => (decimal?)p.Close).ToList());
+        const allVolume = @Html.Json(Model.Prices.Select(p => p.Volume).ToList());
+        const allSma20 = @Html.Json(Model.Sma20);
+        const allSma50 = @Html.Json(Model.Sma50);
+        const allSma200 = @Html.Json(Model.Sma200);
+        const allRsi = @Html.Json(Model.Rsi14);
+        const allMacdLine = @Html.Json(Model.MacdLine);
+        const allMacdSignal = @Html.Json(Model.MacdSignal);
+        const allMacdHist = @Html.Json(Model.MacdHistogram);
 
         let priceChart, volumeChart, rsiChart, macdChart;
 

--- a/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
@@ -51,8 +51,8 @@
         const ctx = document.getElementById('short-interest-chart');
         if (!ctx || typeof Chart === 'undefined') return;
 
-        const labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.ShortInterests.Select(s => s.SettlementDate.ToString("yyyy-MM-dd")).ToList()));
-        const positions = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.ShortInterests.Select(s => s.CurrentShortPosition).ToList()));
+        const labels = @Html.Json(Model.ShortInterests.Select(s => s.SettlementDate.ToString("yyyy-MM-dd")).ToList());
+        const positions = @Html.Json(Model.ShortInterests.Select(s => s.CurrentShortPosition).ToList());
 
         new Chart(ctx, {
             type: 'line',

--- a/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
@@ -42,11 +42,11 @@
         const ctx = document.getElementById('short-volume-chart');
         if (!ctx || typeof Chart === 'undefined') return;
 
-        const labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.ShortVolumes.Select(v => v.Date.ToString("yyyy-MM-dd")).ToList()));
-        const shortVol = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.ShortVolumes.Select(v => v.ShortVolume).ToList()));
-        const totalVol = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.ShortVolumes.Select(v => v.TotalVolume).ToList()));
+        const labels = @Html.Json(Model.ShortVolumes.Select(v => v.Date.ToString("yyyy-MM-dd")).ToList());
+        const shortVol = @Html.Json(Model.ShortVolumes.Select(v => v.ShortVolume).ToList());
+        const totalVol = @Html.Json(Model.ShortVolumes.Select(v => v.TotalVolume).ToList());
         // Short volume as a percentage of total volume, per day
-        const shortPct = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.ShortVolumes.Select(v => v.TotalVolume > 0 ? Math.Round((double)v.ShortVolume / v.TotalVolume * 100, 2) : 0).ToList()));
+        const shortPct = @Html.Json(Model.ShortVolumes.Select(v => v.TotalVolume > 0 ? Math.Round((double)v.ShortVolume / v.TotalVolume * 100, 2) : 0).ToList());
 
         new Chart(ctx, {
             type: 'bar',


### PR DESCRIPTION
## Summary

- 11 chart-rendering views all embedded JS-safe JSON literals via the verbose `@Html.Raw(System.Text.Json.JsonSerializer.Serialize(X))` boilerplate — 40 sites in total, with `_PriceTab` alone carrying 10.
- Adds `Equibles.Web.Extensions.HtmlExtensions.Json<T>(this IHtmlHelper, T)` returning `IHtmlContent`, and routes every call site through it: `@Html.Json(X)`. Same idiom as the existing `SignCss<T>` / `ToStringWithSign<T>` extensions in the project.
- Behavior-preserving: the extension is a generic forwarder so `T` is inferred at the call site exactly as before, hitting the same `JsonSerializer.Serialize<T>(value)` overload with default options; wrapping in `HtmlString` is what `Html.Raw` already does, so Razor renders the JSON without further encoding. Byte-identical output.

## Code changes

- `src/Equibles.Web/Extensions/HtmlExtensions.cs` — **new**, defines `Json<T>(this IHtmlHelper, T)` returning `new HtmlString(JsonSerializer.Serialize(value))`. Already importable in views via the existing `@using Equibles.Web.Extensions` in `_ViewImports.cshtml`.
- `src/Equibles.Web/Views/EconomicData/Show.cshtml` — 5 sites.
- `src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml` — 7 sites (including 4 multi-line forms).
- `src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml` — 1 site.
- `src/Equibles.Web/Views/Stocks/_PriceTab.cshtml` — 10 sites.
- `src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml` — 4 sites.
- `src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml` — 2 sites.
- `src/Equibles.Web/Views/Stocks/_FtdTab.cshtml` — 2 sites.
- `src/Equibles.Web/Views/Stocks/ShowHolder.cshtml` — 2 sites.
- `src/Equibles.Web/Views/Market/Vix.cshtml` — 2 sites.
- `src/Equibles.Web/Views/Market/PutCallRatio.cshtml` — 2 sites.
- `src/Equibles.Web/Views/Cftc/Show.cshtml` — 3 sites.