### PR TITLE
refactor(views): extract _InsiderLink shared partial; route 3 anchors through it

### DIFF
--- a/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
+++ b/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
@@ -42,8 +42,7 @@
                                     @foreach (var row in Model.TopBuys) {
                                         <tr>
                                             <td class="max-w-[150px] truncate">
-                                                <a asp-controller="Profiles" asp-action="Insider" asp-route-ownerCik="@row.OwnerCik"
-                                                   class="link link-primary text-sm">@row.OwnerName</a>
+                                                <partial name="_InsiderLink" model='(OwnerCik: row.OwnerCik, OwnerName: row.OwnerName, Class: "link link-primary text-sm")' />
                                             </td>
                                             <td>
                                                 <partial name="_StockLink" model='(Ticker: row.Ticker, Class: "font-mono link link-primary")' />
@@ -83,8 +82,7 @@
                                     @foreach (var row in Model.TopSells) {
                                         <tr>
                                             <td class="max-w-[150px] truncate">
-                                                <a asp-controller="Profiles" asp-action="Insider" asp-route-ownerCik="@row.OwnerCik"
-                                                   class="link link-primary text-sm">@row.OwnerName</a>
+                                                <partial name="_InsiderLink" model='(OwnerCik: row.OwnerCik, OwnerName: row.OwnerName, Class: "link link-primary text-sm")' />
                                             </td>
                                             <td>
                                                 <partial name="_StockLink" model='(Ticker: row.Ticker, Class: "font-mono link link-primary")' />
@@ -128,8 +126,7 @@
                                 @foreach (var row in Model.BiggestTransactions) {
                                     <tr>
                                         <td class="max-w-[150px] truncate">
-                                            <a asp-controller="Profiles" asp-action="Insider" asp-route-ownerCik="@row.OwnerCik"
-                                               class="link link-primary text-sm">@row.OwnerName</a>
+                                            <partial name="_InsiderLink" model='(OwnerCik: row.OwnerCik, OwnerName: row.OwnerName, Class: "link link-primary text-sm")' />
                                         </td>
                                         <td>
                                             <partial name="_StockLink" model='(Ticker: row.Ticker, Class: "font-mono link link-primary")' />

--- a/src/Equibles.Web/Views/Shared/_InsiderLink.cshtml
+++ b/src/Equibles.Web/Views/Shared/_InsiderLink.cshtml
@@ -1,0 +1,3 @@
+@model (string OwnerCik, string OwnerName, string Class)
+<a asp-controller="Profiles" asp-action="Insider" asp-route-ownerCik="@Model.OwnerCik"
+   class="@Model.Class">@Model.OwnerName</a>


### PR DESCRIPTION
## Summary

- The `<a asp-controller="Profiles" asp-action="Insider" asp-route-ownerCik="@row.OwnerCik" class="link link-primary text-sm">@row.OwnerName</a>` markup appeared 3 times in `Views/InsiderActivity/Dashboard.cshtml` (Top Buys, Top Sells, Biggest Transactions tables) — all byte-identical except for the surrounding cell indentation.
- Adds `Views/Shared/_InsiderLink.cshtml` — a 3-line partial taking `(string OwnerCik, string OwnerName, string Class)` — and routes every site through it. Completes the entity-link partial trio with `_StockLink` (#2579) and `_InstitutionLink` (#2580).
- Behavior-preserving: same `<a>` tag handled by the same built-in `AnchorTagHelper`, producing the same `href`, the same `class` attribute, and the same inner owner-name text. Centralizes "how to link to an insider profile" so a future route change is one edit.

## Code changes

- `src/Equibles.Web/Views/Shared/_InsiderLink.cshtml` — **new** 3-line partial that renders `<a asp-controller="Profiles" asp-action="Insider" asp-route-ownerCik="@Model.OwnerCik" class="@Model.Class">@Model.OwnerName</a>`.
- `src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml` — replaces the 3 hand-rolled insider-profile `<a>` blocks (Top Buys cell, Top Sells cell, Biggest Transactions cell) with `<partial name="_InsiderLink" …>`.