### PR TITLE
refactor(base-scraper-worker): collapse 4 retrysoon ternaries into one if/else

### DIFF
--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -164,21 +164,35 @@ public abstract class BaseScraperWorker : BackgroundService
                 );
             }
 
-            var interval = _retrySoonRequested ? NotReadyRetryInterval : SleepInterval;
-            Logger.LogInformation(
-                _retrySoonRequested
-                    ? "{Worker} not ready (dependency pending); retrying in {Interval}"
-                    : "{Worker} cycle complete. Sleeping for {Interval}",
-                WorkerName,
-                interval
-            );
-            await PublishActivity(
-                _retrySoonRequested ? ScraperActivitySeverity.Warn : ScraperActivitySeverity.Info,
-                _retrySoonRequested
-                    ? $"not ready, retrying in {FormatInterval(interval)}"
-                    : $"cycle complete, sleeping {FormatInterval(interval)}",
-                stoppingToken
-            );
+            TimeSpan interval;
+            if (_retrySoonRequested)
+            {
+                interval = NotReadyRetryInterval;
+                Logger.LogInformation(
+                    "{Worker} not ready (dependency pending); retrying in {Interval}",
+                    WorkerName,
+                    interval
+                );
+                await PublishActivity(
+                    ScraperActivitySeverity.Warn,
+                    $"not ready, retrying in {FormatInterval(interval)}",
+                    stoppingToken
+                );
+            }
+            else
+            {
+                interval = SleepInterval;
+                Logger.LogInformation(
+                    "{Worker} cycle complete. Sleeping for {Interval}",
+                    WorkerName,
+                    interval
+                );
+                await PublishActivity(
+                    ScraperActivitySeverity.Info,
+                    $"cycle complete, sleeping {FormatInterval(interval)}",
+                    stoppingToken
+                );
+            }
             await WaitForNextCycle(interval, stoppingToken);
         }
     }


### PR DESCRIPTION
## Summary

- `BaseScraperWorker.ExecuteAsync` checked `_retrySoonRequested` 4 times in sequence at the end of each cycle (to pick the interval, the log template, the activity severity, and the activity message). Reading the same boolean four times in the same continuation hurts readability and any future change to one branch has to be threaded through four parallel ternaries.
- Collapses the four parallel ternaries into a single `if (_retrySoonRequested) { … } else { … }` block. Each branch picks its own interval, logs its own message, and publishes its own activity event directly. Behavior-preserving — same interval, same log text (same template + args), same severity, same activity message string.
- The field is mutated only inside the awaited `DoWork` call (which has already completed several lines earlier) and reset only at the top of the next iteration, so reading once vs. four times produces identical results.

## Code changes

- `src/Equibles.Worker/BaseScraperWorker.cs` — replaces the post-`DoWork` 15-line ternary cluster in `ExecuteAsync` with an `if/else` block (one branch per `_retrySoonRequested` value); `WaitForNextCycle` invocation stays unchanged.