### PR TITLE
refactor(controllers): extract Pagination.ClampPage helper; collapse 5 inline page-clamp sites across 3 controllers

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -100,8 +100,7 @@ public class HoldingsActivityController : BaseController
     [HttpGet("~/holdings/latest-13f-filings")]
     public async Task<IActionResult> LatestFilings(int page = 1)
     {
-        if (page < 1)
-            page = 1;
+        page = Pagination.ClampPage(page);
 
         var query = _holdingRepository.GetRecentFilings().OrderByDescending(f => f.ImportedAt);
 
@@ -151,7 +150,7 @@ public class HoldingsActivityController : BaseController
         {
             AvailableDates = reportDates,
             MinPctIncrease = threshold,
-            Page = Math.Max(1, page),
+            Page = Pagination.ClampPage(page),
         };
         if (reportDates.Count < 2)
             return View(viewModel);
@@ -228,7 +227,7 @@ public class HoldingsActivityController : BaseController
         {
             AvailableDates = reportDates,
             Sort = normalizedSort,
-            Page = Math.Max(1, page),
+            Page = Pagination.ClampPage(page),
         };
         if (reportDates.Count == 0)
             return View(viewModel);

--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -34,10 +34,7 @@ public class InstitutionsController : BaseController
     {
         ViewData["Title"] = "Institutions";
 
-        // page is a client-supplied query value; a non-positive page would emit
-        // Skip((page-1)*pageSize) = a negative OFFSET, which PostgreSQL rejects.
-        if (page < 1)
-            page = 1;
+        page = Pagination.ClampPage(page);
 
         const int pageSize = 50;
 

--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -49,11 +49,7 @@ public class StocksController : BaseController
     {
         ViewData["Title"] = "Stocks";
 
-        // page is a client-supplied query value; a non-positive page would emit
-        // Skip((page-1)*pageSize) = a negative OFFSET, which PostgreSQL rejects
-        // (22023) and surfaces as HTTP 500. Clamp to the first page.
-        if (page < 1)
-            page = 1;
+        page = Pagination.ClampPage(page);
 
         const int pageSize = 50;
         var query = _commonStockRepository.Search(search);

--- a/src/Equibles.Web/Extensions/Pagination.cs
+++ b/src/Equibles.Web/Extensions/Pagination.cs
@@ -6,6 +6,10 @@ public static class Pagination
     public static int PageCount(int totalCount, int pageSize) =>
         Math.Max(1, (totalCount + pageSize - 1) / pageSize);
 
+    // Client-supplied page param: a non-positive value yields a negative OFFSET in
+    // Skip((page-1)*pageSize), which PostgreSQL rejects (22023) and surfaces as HTTP 500.
+    public static int ClampPage(int page) => page < 1 ? 1 : page;
+
     public static IQueryable<T> Page<T>(this IQueryable<T> source, int page, int pageSize) =>
         source.Skip((page - 1) * pageSize).Take(pageSize);
 }


### PR DESCRIPTION
## Summary

- Pull the page-clamp boilerplate out of three controllers into a single `Pagination.ClampPage(int)` helper, alongside the existing `PageCount` / `Page` extensions.
- Collapses two stylistic variants (3× `if (page < 1) page = 1;` with WHY comments + 2× inline `Math.Max(1, page)`) into one call. The WHY explanation (PostgreSQL rejects negative OFFSET → HTTP 500) now lives on the helper, not duplicated across controllers.
- Behavior-preserving: `Math.Max(1, page)` and `page < 1 ? 1 : page` return the same value for every input, identical to the existing `if/page = 1` mutation.

## Code changes

- `src/Equibles.Web/Extensions/Pagination.cs` — add `ClampPage(int page)` static method with the consolidated WHY comment.
- `src/Equibles.Web/Controllers/StocksController.cs` — replace the 3-line WHY comment + if-block in `Index` with `page = Pagination.ClampPage(page);`.
- `src/Equibles.Web/Controllers/InstitutionsController.cs` — same replacement in `Index`.
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — replace the if-block in `LatestFilings` and the two `Math.Max(1, page)` view-model initializers in `DoubleDown` and `MostHeld` with `Pagination.ClampPage(page)`.