### PR TITLE
refactor(stocks-show-view): collapse 6 duplicated KeyMetric tiles into a data-driven foreach

### DIFF
--- a/src/Equibles.Web/Views/Stocks/Show.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Show.cshtml
@@ -122,53 +122,21 @@
     </nav>
 
     @if (activeTab == "price" && hasAnyMetric) {
+        var keyMetrics = new List<(string Label, string Value)>();
+        if (km.LatestClose.HasValue) keyMetrics.Add(("Price", $"${km.LatestClose.Value.ToString("N2")}"));
+        if (km.MarketCapitalization > 0) keyMetrics.Add(("Market Cap", $"${FormatMarketCap(km.MarketCapitalization)}"));
+        if (km.PeRatio.HasValue) keyMetrics.Add(("P/E Ratio", km.PeRatio.Value.ToString("N2")));
+        if (km.EpsDiluted.HasValue) keyMetrics.Add(("EPS (Diluted)", $"${km.EpsDiluted.Value.ToString("N2")}"));
+        if (km.High52Week.HasValue) keyMetrics.Add(("52W High", $"${km.High52Week.Value.ToString("N2")}"));
+        if (km.Low52Week.HasValue) keyMetrics.Add(("52W Low", $"${km.Low52Week.Value.ToString("N2")}"));
+
         <!-- Key Metrics (Technicals tab only) -->
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-6">
-            @if (km.LatestClose.HasValue) {
+            @foreach (var tile in keyMetrics) {
                 <div class="card bg-base-100 shadow-sm">
                     <div class="card-body p-3">
-                        <div class="text-xs text-base-content/50 uppercase tracking-wider">Price</div>
-                        <div class="font-mono font-semibold text-lg">$@km.LatestClose.Value.ToString("N2")</div>
-                    </div>
-                </div>
-            }
-            @if (km.MarketCapitalization > 0) {
-                <div class="card bg-base-100 shadow-sm">
-                    <div class="card-body p-3">
-                        <div class="text-xs text-base-content/50 uppercase tracking-wider">Market Cap</div>
-                        <div class="font-mono font-semibold text-lg">$@FormatMarketCap(km.MarketCapitalization)</div>
-                    </div>
-                </div>
-            }
-            @if (km.PeRatio.HasValue) {
-                <div class="card bg-base-100 shadow-sm">
-                    <div class="card-body p-3">
-                        <div class="text-xs text-base-content/50 uppercase tracking-wider">P/E Ratio</div>
-                        <div class="font-mono font-semibold text-lg">@km.PeRatio.Value.ToString("N2")</div>
-                    </div>
-                </div>
-            }
-            @if (km.EpsDiluted.HasValue) {
-                <div class="card bg-base-100 shadow-sm">
-                    <div class="card-body p-3">
-                        <div class="text-xs text-base-content/50 uppercase tracking-wider">EPS (Diluted)</div>
-                        <div class="font-mono font-semibold text-lg">$@km.EpsDiluted.Value.ToString("N2")</div>
-                    </div>
-                </div>
-            }
-            @if (km.High52Week.HasValue) {
-                <div class="card bg-base-100 shadow-sm">
-                    <div class="card-body p-3">
-                        <div class="text-xs text-base-content/50 uppercase tracking-wider">52W High</div>
-                        <div class="font-mono font-semibold text-lg">$@km.High52Week.Value.ToString("N2")</div>
-                    </div>
-                </div>
-            }
-            @if (km.Low52Week.HasValue) {
-                <div class="card bg-base-100 shadow-sm">
-                    <div class="card-body p-3">
-                        <div class="text-xs text-base-content/50 uppercase tracking-wider">52W Low</div>
-                        <div class="font-mono font-semibold text-lg">$@km.Low52Week.Value.ToString("N2")</div>
+                        <div class="text-xs text-base-content/50 uppercase tracking-wider">@tile.Label</div>
+                        <div class="font-mono font-semibold text-lg">@tile.Value</div>
                     </div>
                 </div>
             }


### PR DESCRIPTION
## Summary

- Six near-identical Key Metrics tiles in the Technicals tab (Price, Market Cap, P/E Ratio, EPS Diluted, 52W High, 52W Low) shared the exact same `card → card-body → label + value` markup and styling, differing only in the value formatting and the source property. Collapse them into a list-built `(Label, Value)` collection rendered by a single foreach.
- Inline markup is preserved because the Technicals-tab styling (`font-mono font-semibold text-lg`) intentionally differs from the shared `_MetricCard` partial (`text-lg font-bold tabular-nums`) — switching to `_MetricCard` would change the visual output.
- Behavior-preserving: each existing `@if (km.X.HasValue)` branch maps 1:1 to a `keyMetrics.Add(("Label", $"${km.X.Value:N2}"))` call with the same condition + format string; the foreach renders the same DOM, classes, and dollar-prefixed / unprefixed values per tile. Net `+11 / -43` LOC in a single file.

## Code changes

- `src/Equibles.Web/Views/Stocks/Show.cshtml` — replace the six `@if (km.X.HasValue) { <div class="card ...">...</div> }` blocks with a small list-build (`keyMetrics.Add(...)`) and a single foreach that renders the same card markup.