### PR TITLE
refactor(views): extract <date-option> tag helper; collapse 5 duplicated date-option blocks across 4 views

### DIFF
--- a/src/Equibles.Web/TagHelpers/DateOptionTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/DateOptionTagHelper.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.Web.TagHelpers;
+
+[HtmlTargetElement("date-option", TagStructure = TagStructure.WithoutEndTag)]
+public class DateOptionTagHelper : TagHelper
+{
+    [HtmlAttributeName("date")]
+    public DateOnly Date { get; set; }
+
+    [HtmlAttributeName("selected")]
+    public bool Selected { get; set; }
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        output.TagName = "option";
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.Attributes.SetAttribute("value", Date.ToString("yyyy-MM-dd"));
+        if (Selected)
+            output.Attributes.SetAttribute("selected", "selected");
+        output.Content.SetContent(Date.ToString("MMM dd, yyyy"));
+    }
+}

--- a/src/Equibles.Web/Views/HoldingsActivity/_QuarterDateOptions.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/_QuarterDateOptions.cshtml
@@ -8,10 +8,5 @@
     }
 }
 @foreach (var date in Model.AvailableDates) {
-    var isSelected = !Model.IsCombinedSelected && date == Model.SelectedDate;
-    if (isSelected) {
-        <option value="@date.ToString("yyyy-MM-dd")" selected>@date.ToString("MMM dd, yyyy")</option>
-    } else {
-        <option value="@date.ToString("yyyy-MM-dd")">@date.ToString("MMM dd, yyyy")</option>
-    }
+    <date-option date="@date" selected="@(!Model.IsCombinedSelected && date == Model.SelectedDate)" />
 }

--- a/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
+++ b/src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml
@@ -36,8 +36,7 @@
                         <legend class="fieldset-legend">Report quarter</legend>
                         <select name="date" class="select select-bordered w-full">
                             @foreach (var date in Model.AvailableDates) {
-                                var isSelected = date == Model.SelectedDate;
-                                <option value="@date.ToString("yyyy-MM-dd")" selected="@(isSelected ? "selected" : null)">@date.ToString("MMM dd, yyyy")</option>
+                                <date-option date="@date" selected="@(date == Model.SelectedDate)" />
                             }
                         </select>
                     </fieldset>
@@ -45,8 +44,7 @@
                         <legend class="fieldset-legend">Comparison quarter</legend>
                         <select name="compareDate" class="select select-bordered w-full">
                             @foreach (var date in Model.AvailableDates) {
-                                var isSelected = date == Model.ComparisonDate;
-                                <option value="@date.ToString("yyyy-MM-dd")" selected="@(isSelected ? "selected" : null)">@date.ToString("MMM dd, yyyy")</option>
+                                <date-option date="@date" selected="@(date == Model.ComparisonDate)" />
                             }
                         </select>
                     </fieldset>

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -139,12 +139,7 @@
                                 onchange="window.location.href='?activityDate=' + this.value">
                                 @foreach (var date in Model.AvailableReportDates) {
                                     if (date == Model.AvailableReportDates[^1]) { continue; }
-                                    var isSelected = date == Model.ActivityDate;
-                                    if (isSelected) {
-                                        <option value="@date.ToString("yyyy-MM-dd")" selected>@date.ToString("MMM dd, yyyy")</option>
-                                    } else {
-                                        <option value="@date.ToString("yyyy-MM-dd")">@date.ToString("MMM dd, yyyy")</option>
-                                    }
+                                    <date-option date="@date" selected="@(date == Model.ActivityDate)" />
                                 }
                             </select>
                         </div>

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -56,12 +56,7 @@
                         }
                     }
                     @foreach (var date in Model.AvailableDates) {
-                        var isSelected = !Model.IsCombinedView && date == Model.SelectedDate;
-                        if (isSelected) {
-                            <option value="@date.ToString("yyyy-MM-dd")" selected>@date.ToString("MMM dd, yyyy")</option>
-                        } else {
-                            <option value="@date.ToString("yyyy-MM-dd")">@date.ToString("MMM dd, yyyy")</option>
-                        }
+                        <date-option date="@date" selected="@(!Model.IsCombinedView && date == Model.SelectedDate)" />
                     }
                 </select>
             </div>


### PR DESCRIPTION
## Summary

- Repeated `<option value="yyyy-MM-dd" [selected]>MMM dd, yyyy</option>` markup appeared in 4 view files (5 selector loops, 8 lines of if/else and ternary boilerplate).
- Extracted a single `DateOptionTagHelper` (`<date-option date="..." selected="..." />`) that emits the same `<option>` element — same value, conditional `selected="selected"`, same display text.
- Each consumer now writes one line inside the `foreach` instead of a 4-line if/else block (or a ternary `selected="..."` expression).

## Code changes

- `src/Equibles.Web/TagHelpers/DateOptionTagHelper.cs` — new tag helper.
- `src/Equibles.Web/Views/HoldingsActivity/_QuarterDateOptions.cshtml` — collapse if/else into `<date-option>`.
- `src/Equibles.Web/Views/HoldingsScreener/Screener.cshtml` — collapse two date selectors (report quarter + comparison quarter) into `<date-option>`.
- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml` — collapse if/else into `<date-option>`.
- `src/Equibles.Web/Views/Profiles/Institution.cshtml` — collapse if/else into `<date-option>`.