### PR TITLE
refactor(mcp-tools): extract MarkdownTable.Start helper; collapse 14 inline title/header/separator boilerplates across 8 MCP tool files

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Text;
 using Equibles.Cboe.Data.Models;
 using Equibles.Cboe.Repositories;
 using Equibles.Core.Extensions;
@@ -7,6 +6,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -68,11 +68,11 @@ public class CboeTools
                 if (records.Count == 0)
                     return $"No put/call ratio data found for {ratioType.NameForHumans()} in the specified date range.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"CBOE {ratioType.NameForHumans()} Put/Call Ratios:");
-                result.AppendLine();
-                result.AppendLine("| Date | Call Volume | Put Volume | Total | P/C Ratio |");
-                result.AppendLine("|------|-----------|----------|-------|-----------|");
+                var result = MarkdownTable.Start(
+                    $"CBOE {ratioType.NameForHumans()} Put/Call Ratios:",
+                    "| Date | Call Volume | Put Volume | Total | P/C Ratio |",
+                    "|------|-----------|----------|-------|-----------|"
+                );
 
                 foreach (var r in records.OrderBy(r => r.Date))
                 {
@@ -123,11 +123,11 @@ public class CboeTools
                 if (records.Count == 0)
                     return "No VIX data found in the specified date range.";
 
-                var result = new StringBuilder();
-                result.AppendLine("CBOE Volatility Index (VIX):");
-                result.AppendLine();
-                result.AppendLine("| Date | Open | High | Low | Close |");
-                result.AppendLine("|------|------|------|-----|-------|");
+                var result = MarkdownTable.Start(
+                    "CBOE Volatility Index (VIX):",
+                    "| Date | Open | High | Low | Close |",
+                    "|------|------|------|-----|-------|"
+                );
 
                 foreach (var v in records.OrderBy(v => v.Date))
                 {

--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Text;
 using Equibles.Cftc.Data.Models;
 using Equibles.Cftc.Repositories;
 using Equibles.Core.Extensions;
@@ -7,6 +6,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -74,15 +74,9 @@ public class CftcTools
                 if (reports.Count == 0)
                     return $"No COT reports found for {contract.MarketName} ({contract.MarketCode}) in the specified date range.";
 
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"{contract.MarketName} ({contract.MarketCode}) — {contract.Category.NameForHumans()}"
-                );
-                result.AppendLine();
-                result.AppendLine(
-                    "| Date | Open Interest | Comm Long | Comm Short | Non-Comm Long | Non-Comm Short | Non-Comm Spread |"
-                );
-                result.AppendLine(
+                var result = MarkdownTable.Start(
+                    $"{contract.MarketName} ({contract.MarketCode}) — {contract.Category.NameForHumans()}",
+                    "| Date | Open Interest | Comm Long | Comm Short | Non-Comm Long | Non-Comm Short | Non-Comm Spread |",
                     "|------|--------------|-----------|------------|---------------|----------------|-----------------|"
                 );
 
@@ -140,11 +134,11 @@ public class CftcTools
                     .GetLatestPerContract()
                     .ToDictionaryAsync(r => r.CftcContractId);
 
-                var result = new StringBuilder();
-                result.AppendLine("Latest COT Positioning:");
-                result.AppendLine();
-                result.AppendLine("| Market | Date | Open Interest | Comm Net | Non-Comm Net |");
-                result.AppendLine("|--------|------|--------------|----------|--------------|");
+                var result = MarkdownTable.Start(
+                    "Latest COT Positioning:",
+                    "| Market | Date | Open Interest | Comm Net | Non-Comm Net |",
+                    "|--------|------|--------------|----------|--------------|"
+                );
 
                 CftcContractCategory? currentCategory = null;
 
@@ -204,11 +198,11 @@ public class CftcTools
                 if (contracts.Count == 0)
                     return $"No contracts found matching '{query}'.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"CFTC contracts matching '{query}':");
-                result.AppendLine();
-                result.AppendLine("| Market Code | Name | Category |");
-                result.AppendLine("|-------------|------|----------|");
+                var result = MarkdownTable.Start(
+                    $"CFTC contracts matching '{query}':",
+                    "| Market Code | Name | Category |",
+                    "|-------------|------|----------|"
+                );
 
                 foreach (var c in contracts)
                 {

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Text;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Congress.Data.Models;
@@ -9,6 +8,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -78,11 +78,11 @@ public class CongressTools
                 if (trades.Count == 0)
                     return $"No congressional trades found for {stock.Ticker} in the specified date range.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"Congressional trades for {stock.Ticker} ({stock.Name}):");
-                result.AppendLine();
-                result.AppendLine("| Date | Member | Position | Type | Amount Range | Owner |");
-                result.AppendLine("|------|--------|----------|------|-------------|-------|");
+                var result = MarkdownTable.Start(
+                    $"Congressional trades for {stock.Ticker} ({stock.Name}):",
+                    "| Date | Member | Position | Type | Amount Range | Owner |",
+                    "|------|--------|----------|------|-------------|-------|"
+                );
 
                 foreach (var t in trades)
                 {
@@ -145,11 +145,11 @@ public class CongressTools
                 if (trades.Count == 0)
                     return $"No trades found for {member.Name} ({member.Position.NameForHumans()}) in the specified date range.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"Trades by {member.Name} ({member.Position.NameForHumans()}):");
-                result.AppendLine();
-                result.AppendLine("| Date | Ticker | Type | Amount Range | Asset | Owner |");
-                result.AppendLine("|------|--------|------|-------------|-------|-------|");
+                var result = MarkdownTable.Start(
+                    $"Trades by {member.Name} ({member.Position.NameForHumans()}):",
+                    "| Date | Ticker | Type | Amount Range | Asset | Owner |",
+                    "|------|--------|------|-------------|-------|-------|"
+                );
 
                 foreach (var t in trades)
                 {
@@ -189,11 +189,11 @@ public class CongressTools
                 if (members.Count == 0)
                     return $"No congress members found matching '{query}'.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"Congress members matching '{query}':");
-                result.AppendLine();
-                result.AppendLine("| Name | Position |");
-                result.AppendLine("|------|----------|");
+                var result = MarkdownTable.Start(
+                    $"Congress members matching '{query}':",
+                    "| Name | Position |",
+                    "|------|----------|"
+                );
 
                 foreach (var m in members)
                 {

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using System.Globalization;
-using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
@@ -9,6 +8,7 @@ using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Finra.Repositories;
 using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -76,11 +76,11 @@ public class ShortDataTools
                 if (records.Count == 0)
                     return $"No short volume data found for {stock.Ticker} in the specified date range.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"Daily short volume for {stock.Ticker} ({stock.Name}):");
-                result.AppendLine();
-                result.AppendLine("| Date | Short Volume | Exempt | Total Volume | Short % |");
-                result.AppendLine("|------|-------------|--------|-------------|---------|");
+                var result = MarkdownTable.Start(
+                    $"Daily short volume for {stock.Ticker} ({stock.Name}):",
+                    "| Date | Short Volume | Exempt | Total Volume | Short % |",
+                    "|------|-------------|--------|-------------|---------|"
+                );
 
                 foreach (var r in records.OrderBy(r => r.Date))
                 {
@@ -137,13 +137,9 @@ public class ShortDataTools
                 if (records.Count == 0)
                     return $"No short interest data found for {stock.Ticker} in the specified date range.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"Short interest for {stock.Ticker} ({stock.Name}):");
-                result.AppendLine();
-                result.AppendLine(
-                    "| Settlement Date | Short Position | Change | Avg Daily Volume | Days to Cover |"
-                );
-                result.AppendLine(
+                var result = MarkdownTable.Start(
+                    $"Short interest for {stock.Ticker} ({stock.Name}):",
+                    "| Settlement Date | Short Position | Change | Avg Daily Volume | Days to Cover |",
                     "|----------------|---------------|--------|-----------------|---------------|"
                 );
 
@@ -201,15 +197,9 @@ public class ShortDataTools
                 if (records.Count == 0)
                     return $"No short interest data found for settlement date {latestDate:yyyy-MM-dd} with days to cover >= {minDaysToCover}.";
 
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"Short interest snapshot — settlement date {latestDate:yyyy-MM-dd}:"
-                );
-                result.AppendLine();
-                result.AppendLine(
-                    "| Ticker | Short Position | Change | Avg Daily Volume | Days to Cover |"
-                );
-                result.AppendLine(
+                var result = MarkdownTable.Start(
+                    $"Short interest snapshot — settlement date {latestDate:yyyy-MM-dd}:",
+                    "| Ticker | Short Position | Change | Avg Daily Volume | Days to Cover |",
                     "|--------|---------------|--------|-----------------|---------------|"
                 );
 

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -6,6 +6,7 @@ using Equibles.Errors.Data.Models;
 using Equibles.Fred.Data.Models;
 using Equibles.Fred.Repositories;
 using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -133,11 +134,11 @@ public class FredTools
                     .GetLatestPerSeries()
                     .ToDictionaryAsync(o => o.FredSeriesId);
 
-                var result = new StringBuilder();
-                result.AppendLine("Latest Economic Indicators:");
-                result.AppendLine();
-                result.AppendLine("| Series | Title | Latest Date | Value | Units |");
-                result.AppendLine("|--------|-------|-------------|-------|-------|");
+                var result = MarkdownTable.Start(
+                    "Latest Economic Indicators:",
+                    "| Series | Title | Latest Date | Value | Units |",
+                    "|--------|-------|-------------|-------|-------|"
+                );
 
                 var currentCategory = (FredSeriesCategory?)null;
 
@@ -191,11 +192,11 @@ public class FredTools
                 if (series.Count == 0)
                     return $"No series found matching '{query}'.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"Economic indicators matching '{query}':");
-                result.AppendLine();
-                result.AppendLine("| Series ID | Title | Category | Frequency | Units |");
-                result.AppendLine("|-----------|-------|----------|-----------|-------|");
+                var result = MarkdownTable.Start(
+                    $"Economic indicators matching '{query}':",
+                    "| Series ID | Title | Category | Frequency | Units |",
+                    "|-----------|-------|----------|-----------|-------|"
+                );
 
                 foreach (var s in series)
                 {

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -10,6 +10,7 @@ using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Models;
 using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -183,13 +184,11 @@ public class InstitutionalHoldingsTools
         List<DateOnly> reportDates
     )
     {
-        var result = new StringBuilder();
-        result.AppendLine($"Institutional ownership history for {stock.Name} ({ticker}):");
-        result.AppendLine();
-        result.AppendLine(
-            "| Report Date | Institutions | Total Shares | Total Value ($M) | Change |"
+        var result = MarkdownTable.Start(
+            $"Institutional ownership history for {stock.Name} ({ticker}):",
+            "| Report Date | Institutions | Total Shares | Total Value ($M) | Change |",
+            "|------------|-------------|-------------|-----------------|--------|"
         );
-        result.AppendLine("|------------|-------------|-------------|-----------------|--------|");
 
         long previousShares = 0;
         foreach (var date in reportDates.OrderBy(d => d))
@@ -264,13 +263,11 @@ public class InstitutionalHoldingsTools
         List<InstitutionalHolding> holdings
     )
     {
-        var result = new StringBuilder();
-        result.AppendLine(
-            $"Portfolio of {holder.Name} (CIK: {holder.Cik}) as of {targetDate:yyyy-MM-dd}:"
+        var result = MarkdownTable.Start(
+            $"Portfolio of {holder.Name} (CIK: {holder.Cik}) as of {targetDate:yyyy-MM-dd}:",
+            "| # | Ticker | Company | Shares | Value ($M) |",
+            "|---|--------|---------|--------|-----------|"
         );
-        result.AppendLine();
-        result.AppendLine("| # | Ticker | Company | Shares | Value ($M) |");
-        result.AppendLine("|---|--------|---------|--------|-----------|");
 
         for (var i = 0; i < holdings.Count; i++)
         {
@@ -304,11 +301,11 @@ public class InstitutionalHoldingsTools
                 if (holders.Count == 0)
                     return $"No institutions found matching '{query}'.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"Institutions matching '{query}':");
-                result.AppendLine();
-                result.AppendLine("| Institution | CIK | City | State/Country |");
-                result.AppendLine("|------------|-----|------|--------------|");
+                var result = MarkdownTable.Start(
+                    $"Institutions matching '{query}':",
+                    "| Institution | CIK | City | State/Country |",
+                    "|------------|-----|------|--------------|"
+                );
 
                 foreach (var h in holders)
                 {

--- a/src/Equibles.Mcp/Helpers/MarkdownTable.cs
+++ b/src/Equibles.Mcp/Helpers/MarkdownTable.cs
@@ -1,0 +1,16 @@
+using System.Text;
+
+namespace Equibles.Mcp.Helpers;
+
+public static class MarkdownTable
+{
+    public static StringBuilder Start(string title, string headerRow, string separatorRow)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(title);
+        sb.AppendLine();
+        sb.AppendLine(headerRow);
+        sb.AppendLine(separatorRow);
+        return sb;
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -9,6 +9,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Models;
@@ -305,11 +306,11 @@ public class FinancialFactsTools
         List<string> skipped
     )
     {
-        var result = new StringBuilder();
-        result.AppendLine($"{concept} — {fiscalYear} {period.NameForHumans()} peer comparison:");
-        result.AppendLine();
-        result.AppendLine("| Ticker | Company | Value | Unit | Form | Filed |");
-        result.AppendLine("|--------|---------|------:|------|------|-------|");
+        var result = MarkdownTable.Start(
+            $"{concept} — {fiscalYear} {period.NameForHumans()} peer comparison:",
+            "| Ticker | Company | Value | Unit | Form | Filed |",
+            "|--------|---------|------:|------|------|-------|"
+        );
         foreach (var (ticker, name, fact) in rows)
         {
             result.AppendLine(

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -1,11 +1,11 @@
 using System.ComponentModel;
-using System.Text;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -69,11 +69,11 @@ public class FailToDeliverTools
                 if (records.Count == 0)
                     return $"No FTD data found for {stock.Ticker} in the specified date range.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"Fails-to-deliver for {stock.Ticker} ({stock.Name}):");
-                result.AppendLine();
-                result.AppendLine("| Settlement Date | Quantity | Price | Value |");
-                result.AppendLine("|----------------|---------|-------|-------|");
+                var result = MarkdownTable.Start(
+                    $"Fails-to-deliver for {stock.Ticker} ({stock.Name}):",
+                    "| Settlement Date | Quantity | Price | Value |",
+                    "|----------------|---------|-------|-------|"
+                );
 
                 foreach (var f in records.OrderBy(f => f.SettlementDate))
                 {


### PR DESCRIPTION
## Summary

- Same `new StringBuilder()` + title + blank + header + separator boilerplate was inlined at the top of dozens of MCP tools across modules. Each module re-implemented the same 4-line preamble before formatting rows.
- Extracted `MarkdownTable.Start(title, headerRow, separatorRow)` to `Equibles.Mcp/Helpers/MarkdownTable.cs` (the foundation MCP project all `*.Mcp` modules already reference) and routed 14 sites across 8 files through it.
- Behavior-preserving: the helper performs the identical four `AppendLine` calls in the same order with the same arguments. All 3,665 affected unit + integration tests stay green.

## Code changes

- `src/Equibles.Mcp/Helpers/MarkdownTable.cs` — new shared helper.
- `src/Equibles.Cboe.Mcp/Tools/CboeTools.cs` — 2 sites (`GetPutCallRatios`, `GetVixHistory`).
- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs` — 3 sites (`GetCftcPositioning`, `GetLatestCftcData`, `SearchCftcMarkets`).
- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — 3 sites (`GetShortVolume`, `GetShortInterest`, `GetShortInterestSnapshot`).
- `src/Equibles.Fred.Mcp/Tools/FredTools.cs` — 2 sites (`GetLatestEconomicData`, `SearchEconomicIndicators`).
- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — 3 sites (`GetCongressionalTrades`, `GetMemberTrades`, `SearchCongressMembers`).
- `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs` — 1 site (`GetFailsToDeliver`).
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — 1 site (peer-comparison renderer).
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — 3 sites (`GetOwnershipHistory`, `RenderInstitutionPortfolio`, `SearchInstitutions`).