### PR TITLE
refactor(views): extract <breadcrumbs> tag helper; collapse 7 duplicated breadcrumb wrappers

### DIFF
--- a/src/Equibles.Web/TagHelpers/BreadcrumbsTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/BreadcrumbsTagHelper.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.Web.TagHelpers;
+
+[HtmlTargetElement("breadcrumbs")]
+public class BreadcrumbsTagHelper : TagHelper
+{
+    [HtmlAttributeName("class")]
+    public string CssClass { get; set; }
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var inner = await output.GetChildContentAsync();
+
+        output.TagName = "div";
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.Attributes.Clear();
+        var cssClass = string.IsNullOrWhiteSpace(CssClass)
+            ? "breadcrumbs text-sm text-base-content/60"
+            : $"breadcrumbs text-sm text-base-content/60 {CssClass}";
+        output.Attributes.SetAttribute("class", cssClass);
+        output.Content.SetHtmlContent("<ul>");
+        output.Content.AppendHtml(inner);
+        output.Content.AppendHtml("</ul>");
+    }
+}

--- a/src/Equibles.Web/Views/Cftc/Show.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Show.cshtml
@@ -15,14 +15,12 @@
 
 <div class="max-w-6xl mx-auto px-6 py-8">
     <!-- Breadcrumb -->
-    <div class="breadcrumbs text-sm text-base-content/60 mb-2">
-        <ul>
-            <li><a asp-controller="Cftc" asp-action="Index">Futures</a></li>
-            <li>
-                <span class="font-semibold text-base-content">@Model.MarketCode</span>
-            </li>
-        </ul>
-    </div>
+    <breadcrumbs class="mb-2">
+        <li><a asp-controller="Cftc" asp-action="Index">Futures</a></li>
+        <li>
+            <span class="font-semibold text-base-content">@Model.MarketCode</span>
+        </li>
+    </breadcrumbs>
 
     <!-- Contract Header -->
     <div class="card bg-base-100 shadow-sm mb-6">

--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -10,14 +10,12 @@
 
 <div class="max-w-6xl mx-auto px-6 py-8">
     <!-- Breadcrumb -->
-    <div class="breadcrumbs text-sm text-base-content/60 mb-2">
-        <ul>
-            <li><a asp-controller="EconomicData" asp-action="Index">Economic Data</a></li>
-            <li>
-                <span class="font-semibold text-base-content">@Model.SeriesId</span>
-            </li>
-        </ul>
-    </div>
+    <breadcrumbs class="mb-2">
+        <li><a asp-controller="EconomicData" asp-action="Index">Economic Data</a></li>
+        <li>
+            <span class="font-semibold text-base-content">@Model.SeriesId</span>
+        </li>
+    </breadcrumbs>
 
     <!-- Series Header -->
     <div class="card bg-base-100 shadow-sm mb-6">

--- a/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
+++ b/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
@@ -16,15 +16,13 @@
 
 <div class="max-w-6xl mx-auto px-6 py-8">
     <!-- Breadcrumb -->
-    <div class="breadcrumbs text-sm text-base-content/60 mb-2">
-        <ul>
-            <li><a asp-controller="Market" asp-action="Index">Market</a></li>
-            <li><span class="text-base-content/60">Put/Call Ratio</span></li>
-            <li>
-                <span class="font-semibold text-base-content">@Model.DisplayName</span>
-            </li>
-        </ul>
-    </div>
+    <breadcrumbs class="mb-2">
+        <li><a asp-controller="Market" asp-action="Index">Market</a></li>
+        <li><span class="text-base-content/60">Put/Call Ratio</span></li>
+        <li>
+            <span class="font-semibold text-base-content">@Model.DisplayName</span>
+        </li>
+    </breadcrumbs>
 
     <!-- Header -->
     <div class="card bg-base-100 shadow-sm mb-6">

--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -16,14 +16,12 @@
 
 <div class="max-w-6xl mx-auto px-6 py-8">
     <!-- Breadcrumb -->
-    <div class="breadcrumbs text-sm text-base-content/60 mb-2">
-        <ul>
-            <li><a asp-controller="Market" asp-action="Index">Market</a></li>
-            <li>
-                <span class="font-semibold text-base-content">VIX</span>
-            </li>
-        </ul>
-    </div>
+    <breadcrumbs class="mb-2">
+        <li><a asp-controller="Market" asp-action="Index">Market</a></li>
+        <li>
+            <span class="font-semibold text-base-content">VIX</span>
+        </li>
+    </breadcrumbs>
 
     <!-- Header -->
     <div class="card bg-base-100 shadow-sm mb-6">

--- a/src/Equibles.Web/Views/Stocks/Show.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Show.cshtml
@@ -11,15 +11,13 @@
 <div class="max-w-6xl mx-auto px-6 py-8">
     <!-- Breadcrumb -->
     <div class="flex items-center justify-between mb-2">
-        <div class="breadcrumbs text-sm text-base-content/60">
-            <ul>
-                <li><a asp-controller="Stocks" asp-action="Index">Stocks</a></li>
-                <li>
-                    <span class="font-semibold text-base-content">@stock.Ticker</span>
-                    <span class="text-base-content/50 ml-1">@stock.Name</span>
-                </li>
-            </ul>
-        </div>
+        <breadcrumbs>
+            <li><a asp-controller="Stocks" asp-action="Index">Stocks</a></li>
+            <li>
+                <span class="font-semibold text-base-content">@stock.Ticker</span>
+                <span class="text-base-content/50 ml-1">@stock.Name</span>
+            </li>
+        </breadcrumbs>
     </div>
 
     <!-- Stock Header -->

--- a/src/Equibles.Web/Views/Stocks/ShowDocument.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowDocument.cshtml
@@ -10,19 +10,17 @@
 <div class="max-w-6xl mx-auto px-6 py-8">
     <!-- Breadcrumb -->
     <div class="flex items-center justify-between mb-2">
-        <div class="breadcrumbs text-sm text-base-content/60">
-            <ul>
-                <li><a asp-controller="Stocks" asp-action="Index">Stocks</a></li>
-                <li>
-                    <a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@Model.Ticker">
-                        @Model.Ticker
-                    </a>
-                </li>
-                <li>
-                    <span class="font-semibold text-base-content">@doc.DocumentType.DisplayName</span>
-                </li>
-            </ul>
-        </div>
+        <breadcrumbs>
+            <li><a asp-controller="Stocks" asp-action="Index">Stocks</a></li>
+            <li>
+                <a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@Model.Ticker">
+                    @Model.Ticker
+                </a>
+            </li>
+            <li>
+                <span class="font-semibold text-base-content">@doc.DocumentType.DisplayName</span>
+            </li>
+        </breadcrumbs>
     </div>
 
     <!-- Document Header -->

--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -10,13 +10,11 @@
 <div class="max-w-6xl mx-auto px-6 py-8">
     <!-- Breadcrumb -->
     <div class="flex items-center justify-between mb-2">
-        <div class="breadcrumbs text-sm text-base-content/60">
-            <ul>
-                <li><a asp-controller="Stocks" asp-action="Index">Stocks</a></li>
-                <li><a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@stock.Ticker">@stock.Ticker</a></li>
-                <li><span class="font-semibold text-base-content">@holder.Name</span></li>
-            </ul>
-        </div>
+        <breadcrumbs>
+            <li><a asp-controller="Stocks" asp-action="Index">Stocks</a></li>
+            <li><a asp-controller="Stocks" asp-action="Show" asp-route-ticker="@stock.Ticker">@stock.Ticker</a></li>
+            <li><span class="font-semibold text-base-content">@holder.Name</span></li>
+        </breadcrumbs>
     </div>
 
     <!-- Holder Info -->


### PR DESCRIPTION
## Summary

- The same `<div class="breadcrumbs text-sm text-base-content/60"><ul>...</ul></div>` wrapper appeared in 7 view files.
- Extracted a `BreadcrumbsTagHelper` (`<breadcrumbs class="...">`) that emits the wrapping div with the default DaisyUI breadcrumb classes plus an optional extra-class attribute, and wraps inner content in `<ul>`.
- Callers now write only the `<li>` items inside `<breadcrumbs>`; DOM output is identical (same root div + class list, same `<ul>` container, same `<li>` content).

## Code changes

- `src/Equibles.Web/TagHelpers/BreadcrumbsTagHelper.cs` — new tag helper.
- `src/Equibles.Web/Views/Stocks/Show.cshtml` — replace wrapper with `<breadcrumbs>`.
- `src/Equibles.Web/Views/Stocks/ShowDocument.cshtml` — replace wrapper with `<breadcrumbs>`.
- `src/Equibles.Web/Views/Stocks/ShowHolder.cshtml` — replace wrapper with `<breadcrumbs>`.
- `src/Equibles.Web/Views/Market/Vix.cshtml` — replace wrapper with `<breadcrumbs class="mb-2">`.
- `src/Equibles.Web/Views/Market/PutCallRatio.cshtml` — replace wrapper with `<breadcrumbs class="mb-2">`.
- `src/Equibles.Web/Views/EconomicData/Show.cshtml` — replace wrapper with `<breadcrumbs class="mb-2">`.
- `src/Equibles.Web/Views/Cftc/Show.cshtml` — replace wrapper with `<breadcrumbs class="mb-2">`.