### PR TITLE
refactor(views): extract <stat-tile> tag helper; collapse 12 duplicated DaisyUI stat blocks across 3 Profiles views

### DIFF
--- a/src/Equibles.Web/TagHelpers/StatTileTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/StatTileTagHelper.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.Web.TagHelpers;
+
+[HtmlTargetElement("stat-tile")]
+public class StatTileTagHelper : TagHelper
+{
+    [HtmlAttributeName("title")]
+    public string Title { get; set; }
+
+    // Maps to the outer div's native `title` attribute (browser tooltip);
+    // a separate attribute name avoids colliding with the inner stat-title label.
+    [HtmlAttributeName("tooltip")]
+    public string Tooltip { get; set; }
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var inner = await output.GetChildContentAsync();
+
+        output.TagName = "div";
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.Attributes.Clear();
+        output.Attributes.SetAttribute("class", "stat");
+        if (!string.IsNullOrEmpty(Tooltip))
+            output.Attributes.SetAttribute("title", Tooltip);
+
+        output.Content.AppendHtml("<div class=\"stat-title\">");
+        output.Content.Append(Title);
+        output.Content.AppendHtml("</div>");
+        output.Content.AppendHtml("<div class=\"stat-value text-2xl font-mono\">");
+        output.Content.AppendHtml(inner);
+        output.Content.AppendHtml("</div>");
+    }
+}

--- a/src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml
@@ -63,18 +63,9 @@
                     <div class="card-body p-4">
                         <h2 class="text-base font-medium mb-2">@row.Label</h2>
                         <div class="stats stats-vertical sm:stats-horizontal shadow-sm bg-base-200 w-full">
-                            <div class="stat">
-                                <div class="stat-title">Total return</div>
-                                <div class="stat-value text-2xl font-mono">@row.Summary.TotalReturnPercent.ToString("F2")%</div>
-                            </div>
-                            <div class="stat">
-                                <div class="stat-title">CAGR</div>
-                                <div class="stat-value text-2xl font-mono">@row.Summary.CagrPercent.ToString("F2")%</div>
-                            </div>
-                            <div class="stat">
-                                <div class="stat-title">Max drawdown</div>
-                                <div class="stat-value text-2xl font-mono">@row.Summary.MaxDrawdownPercent.ToString("F2")%</div>
-                            </div>
+                            <stat-tile title="Total return">@row.Summary.TotalReturnPercent.ToString("F2")%</stat-tile>
+                            <stat-tile title="CAGR">@row.Summary.CagrPercent.ToString("F2")%</stat-tile>
+                            <stat-tile title="Max drawdown">@row.Summary.MaxDrawdownPercent.ToString("F2")%</stat-tile>
                         </div>
                     </div>
                 </div>

--- a/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
@@ -45,22 +45,10 @@
                     }
                 </div>
                 <div class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200 w-full">
-                    <div class="stat">
-                        <div class="stat-title">Union positions</div>
-                        <div class="stat-value text-2xl font-mono">@overlap.UnionPositionCount.ToString("N0")</div>
-                    </div>
-                    <div class="stat">
-                        <div class="stat-title">Shared positions</div>
-                        <div class="stat-value text-2xl font-mono">@overlap.IntersectionPositionCount.ToString("N0")</div>
-                    </div>
-                    <div class="stat" title="|A ∩ B| / |A ∪ B|">
-                        <div class="stat-title">Jaccard similarity</div>
-                        <div class="stat-value text-2xl font-mono">@overlap.JaccardSimilarityPercent.ToString("F1")%</div>
-                    </div>
-                    <div class="stat" title="Σ min(value)/Σ max(value) across shared stocks">
-                        <div class="stat-title">$-weighted overlap</div>
-                        <div class="stat-value text-2xl font-mono">@overlap.DollarWeightedOverlapPercent.ToString("F1")%</div>
-                    </div>
+                    <stat-tile title="Union positions">@overlap.UnionPositionCount.ToString("N0")</stat-tile>
+                    <stat-tile title="Shared positions">@overlap.IntersectionPositionCount.ToString("N0")</stat-tile>
+                    <stat-tile title="Jaccard similarity" tooltip="|A ∩ B| / |A ∪ B|">@overlap.JaccardSimilarityPercent.ToString("F1")%</stat-tile>
+                    <stat-tile title="$-weighted overlap" tooltip="Σ min(value)/Σ max(value) across shared stocks">@overlap.DollarWeightedOverlapPercent.ToString("F1")%</stat-tile>
                 </div>
             </div>
         </div>

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -57,26 +57,11 @@
                     <span class="badge badge-ghost">Quarters reported: @Model.Summary.QuartersReported</span>
                 </div>
                 <div class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200 w-full">
-                    <div class="stat">
-                        <div class="stat-title">Reported AUM</div>
-                        <div class="stat-value text-2xl font-mono"><compactable-number value="@Model.Summary.ReportedAum" prefix="$" /></div>
-                    </div>
-                    <div class="stat">
-                        <div class="stat-title"># Positions</div>
-                        <div class="stat-value text-2xl font-mono"><compactable-number value="@Model.Summary.PositionCount" /></div>
-                    </div>
-                    <div class="stat">
-                        <div class="stat-title">Top 10 concentration</div>
-                        <div class="stat-value text-2xl font-mono">@Model.Summary.Top10ConcentrationPercent.ToString("F1")%</div>
-                    </div>
-                    <div class="stat">
-                        <div class="stat-title">Top 25 concentration</div>
-                        <div class="stat-value text-2xl font-mono">@Model.Summary.Top25ConcentrationPercent.ToString("F1")%</div>
-                    </div>
-                    <div class="stat" title="(Σ |Δ shares × current price proxy|) / (2 × AUM)">
-                        <div class="stat-title">QoQ turnover</div>
-                        <div class="stat-value text-2xl font-mono">@Model.Summary.QoQTurnoverPercent.ToString("F1")%</div>
-                    </div>
+                    <stat-tile title="Reported AUM"><compactable-number value="@Model.Summary.ReportedAum" prefix="$" /></stat-tile>
+                    <stat-tile title="# Positions"><compactable-number value="@Model.Summary.PositionCount" /></stat-tile>
+                    <stat-tile title="Top 10 concentration">@Model.Summary.Top10ConcentrationPercent.ToString("F1")%</stat-tile>
+                    <stat-tile title="Top 25 concentration">@Model.Summary.Top25ConcentrationPercent.ToString("F1")%</stat-tile>
+                    <stat-tile title="QoQ turnover" tooltip="(Σ |Δ shares × current price proxy|) / (2 × AUM)">@Model.Summary.QoQTurnoverPercent.ToString("F1")%</stat-tile>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- The DaisyUI stat tile pattern — `<div class=\"stat\">` + `<div class=\"stat-title\">…</div>` + `<div class=\"stat-value text-2xl font-mono\">…</div>` — was inlined 12 times across `Profiles/Institution`, `Profiles/CompareInstitutions`, and `Profiles/BacktestInstitution`, with the same three-line shape and an optional outer `title` tooltip on a handful.
- Extracted `<stat-tile title=\"…\" [tooltip=\"…\"]>{value}</stat-tile>` into `Equibles.Web/TagHelpers/StatTileTagHelper.cs` following the conventions of the existing `BreadcrumbsTagHelper` / `DateOptionTagHelper`. The helper emits the identical DOM — same outer `div.stat`, same optional `title` attribute, same inner `stat-title` text and `stat-value text-2xl font-mono` value wrapper. Child content (text, `<compactable-number>`, etc.) flows through unchanged.
- Behavior-preserving: the integration tests for these views (e.g. `ProfilesCompareInstitutionsTests` asserting `\"Jaccard similarity\"` in the response) keep passing because the visible labels and values are unchanged. Full local suite (2,140 unit + 1,525 integration) green.

## Code changes

- `src/Equibles.Web/TagHelpers/StatTileTagHelper.cs` — new tag helper rendering the DaisyUI stat tile structure.
- `src/Equibles.Web/Views/Profiles/Institution.cshtml` — 5 stat blocks (Reported AUM, # Positions, Top 10 / Top 25 concentration, QoQ turnover) → `<stat-tile>`.
- `src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml` — 4 stat blocks (Union / Shared positions, Jaccard similarity, \$-weighted overlap) → `<stat-tile>`.
- `src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml` — 3 stat blocks (Total return, CAGR, Max drawdown) → `<stat-tile>`.