### PR TITLE
refactor(views): extract <status-badge> tag helper; collapse 3 duplicated status-count badge blocks

### DIFF
--- a/src/Equibles.Web/TagHelpers/StatusBadgeTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/StatusBadgeTagHelper.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.Web.TagHelpers;
+
+[HtmlTargetElement("status-badge", TagStructure = TagStructure.WithoutEndTag)]
+public class StatusBadgeTagHelper : TagHelper
+{
+    [ViewContext]
+    [HtmlAttributeNotBound]
+    public ViewContext ViewContext { get; set; }
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        if (ViewContext.ViewData["StatusBadgeCount"] is not int count || count <= 0)
+        {
+            output.SuppressOutput();
+            return;
+        }
+
+        output.TagName = "span";
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.Attributes.SetAttribute("class", "badge badge-warning badge-xs");
+        output.Attributes.SetAttribute("aria-label", $"{count} status alerts");
+        output.Content.SetContent(count.ToString());
+    }
+}

--- a/src/Equibles.Web/Views/Shared/_Footer.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Footer.cshtml
@@ -14,9 +14,7 @@
                 <a asp-controller="Home" asp-action="Connect" class="hover:text-base-content">MCP</a>
                 <a asp-controller="Status" asp-action="Index" class="hover:text-base-content flex items-center gap-1">
                     Status
-                    @if (ViewData["StatusBadgeCount"] is int footerBadge && footerBadge > 0) {
-                        <span class="badge badge-warning badge-xs" aria-label="@footerBadge status alerts">@footerBadge</span>
-                    }
+                    <status-badge />
                 </a>
                 <a href="https://github.com/daniel3303/Equibles" target="_blank" rel="noopener" aria-label="Equibles on GitHub" title="GitHub" class="hover:text-base-content">
                     <svg class="size-5 inline" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>

--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -57,9 +57,7 @@
                     <a asp-action="Connect" asp-controller="Home" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">MCP</a>
                     <a asp-action="Index" asp-controller="Status" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors flex items-center gap-1">
                         Status
-                        @if (ViewData["StatusBadgeCount"] is int badgeCount && badgeCount > 0) {
-                            <span class="badge badge-warning badge-xs" aria-label="@badgeCount status alerts">@badgeCount</span>
-                        }
+                        <status-badge />
                     </a>
                 </nav>
             </div>
@@ -181,9 +179,7 @@
                         <li>
                             <a asp-action="Index" asp-controller="Status" class="flex items-center gap-2">
                                 <icon name="signal" size="4" /> Status
-                                @if (ViewData["StatusBadgeCount"] is int mobileBadge && mobileBadge > 0) {
-                                    <span class="badge badge-warning badge-xs" aria-label="@mobileBadge status alerts">@mobileBadge</span>
-                                }
+                                <status-badge />
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
## Summary

- The same `@if (ViewData["StatusBadgeCount"] is int X && X > 0) { <span class="badge badge-warning badge-xs" aria-label="@X status alerts">@X</span> }` pattern appeared in 3 sites across the footer and the top/mobile navigation in the layout.
- Extracted `StatusBadgeTagHelper` (`<status-badge />`) that reads `ViewContext.ViewData["StatusBadgeCount"]`, applies the same guard, and emits the same span. Suppresses output entirely when the value is missing, non-int, or non-positive.
- DOM output is identical: same span classes, same aria-label, same numeric content.

## Code changes

- `src/Equibles.Web/TagHelpers/StatusBadgeTagHelper.cs` — new tag helper.
- `src/Equibles.Web/Views/Shared/_Footer.cshtml` — replace inline if-and-span with `<status-badge />`.
- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — replace both inline if-and-span blocks (top nav + mobile nav) with `<status-badge />`.