### PR TITLE
fix: csharpier format HoldingsBacktestService

### DIFF
--- a/src/Equibles.Web/Services/HoldingsBacktestService.cs
+++ b/src/Equibles.Web/Services/HoldingsBacktestService.cs
@@ -79,9 +79,7 @@ public class HoldingsBacktestService
         }
         viewModel.BenchmarkName = benchmarkStock.Name;
 
-        var reportDates = await _holdingRepository
-            .GetReportDatesByHolder(holder)
-            .ToListAsync();
+        var reportDates = await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync();
         // GetReportDatesByHolder returns latest first; backtest iterates earliest first.
         reportDates.Reverse();
         if (reportDates.Count == 0)


### PR DESCRIPTION
## Summary

CI lint job failed on main after #2590 with a CSharpier formatting violation in `HoldingsBacktestService.cs:82`. Reformatted the file so the call chain stays on a single line.

## Code changes

- `src/Equibles.Web/Services/HoldingsBacktestService.cs` — collapse the 3-line `_holdingRepository.GetReportDatesByHolder(holder).ToListAsync()` chain onto one line per CSharpier.