### PR TITLE
test(holdings): pin OrderedInfoTableCandidates uppercase .XML inclusion

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Realtime13FIngestionServiceOrderedInfoTableCandidatesUppercaseExtensionTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13FIngestionServiceOrderedInfoTableCandidatesUppercaseExtensionTests.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Realtime13FIngestionServiceOrderedInfoTableCandidatesUppercaseExtensionTests
+{
+    // Adversarial Lane A. The XML doc on OrderedInfoTableCandidates calls
+    // out SEC's inconsistent naming (`infotable.xml`,
+    // `form13fInfoTable.xml`, `<accession>.xml`) — i.e. case varies. The
+    // existing PrimaryDocUppercase test pins case-insensitive EXCLUSION of
+    // the cover page, but a regression of the `EndsWith(".xml", IgnoreCase)`
+    // guard to plain `Ordinal` would still pass that test (uppercase
+    // `PRIMARY_DOC.XML` would be filtered out for the wrong reason — failing
+    // the EndsWith). It would silently DROP every non-primary uppercase
+    // `.XML` artifact and the caller would get an empty candidate list →
+    // realtime ingestion stops finding info tables on filings that ship
+    // uppercase extensions.
+    [Fact]
+    public void OrderedInfoTableCandidates_UppercaseXmlExtensionOnInfoTable_StillIncludedAndYieldedFirst()
+    {
+        List<string> artifacts = ["rendering.XML", "form13fInfoTable.XML"];
+
+        var method = typeof(Realtime13FIngestionService).GetMethod(
+            "OrderedInfoTableCandidates",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var result = ((IEnumerable<string>)method.Invoke(null, [artifacts])).ToList();
+
+        // Both .XML files must survive the extension filter, and the
+        // table-looking name must still be yielded first per the doc.
+        result.Should().Equal("form13fInfoTable.XML", "rendering.XML");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins case-insensitive INCLUSION of uppercase `.XML` extensions in `Realtime13FIngestionService.OrderedInfoTableCandidates` — the dual of the existing PrimaryDocUppercase test, which only pins exclusion of `PRIMARY_DOC.XML`.
- A regression of the `EndsWith(".xml", IgnoreCase)` guard to plain `Ordinal` would still pass PrimaryDocUppercase (cover page filtered out for the wrong reason) but would silently DROP every non-primary uppercase `.XML` artifact — real-time ingestion would stop finding info tables on filings that ship uppercase extensions, matching SEC's documented inconsistent naming.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Realtime13FIngestionServiceOrderedInfoTableCandidatesUppercaseExtensionTests.cs` — new unit test invoking the private static helper via reflection with `["rendering.XML", "form13fInfoTable.XML"]`. Asserts both files survive the extension filter and the table-looking name (`form13fInfoTable.XML`) is yielded first per the doc.