### PR TITLE
fix(holdings): pin BuildHoldingKey reportDate to InvariantCulture

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO.Compression;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
@@ -854,7 +855,7 @@ public class HoldingsImportService
         OptionType? optionType,
         FilingType filingType
     ) =>
-        $"{commonStockId}|{institutionalHolderId}|{reportDate}|{(int)shareType}|{optionType?.ToString() ?? ""}|{(int)filingType}";
+        $"{commonStockId}|{institutionalHolderId}|{reportDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}|{(int)shareType}|{optionType?.ToString() ?? ""}|{(int)filingType}";
 
     private static string BuildHoldingKey(InstitutionalHolding h) =>
         BuildHoldingKey(

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildHoldingKeyCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildHoldingKeyCultureInvarianceTests.cs
@@ -44,9 +44,7 @@ public class HoldingsImportServiceBuildHoldingKeyCultureInvarianceTests
     // Invariant-culture key for the same inputs. Failure manifests as
     // the date-segment separator/order swap (".12.31.2024." vs
     // ".12/31/2024.").
-    [Fact(
-        Skip = "GH-2594 — BuildHoldingKey's reportDate segment renders host-locale short-date pattern (de-DE 31.12.2024 vs Invariant 12/31/2024); dedup-key forks by culture"
-    )]
+    [Fact]
     public void BuildHoldingKey_UnderNonInvariantCulture_RendersReportDateSegmentCultureInvariantly()
     {
         var method = typeof(HoldingsImportService).GetMethod(


### PR DESCRIPTION
## Summary

- Fixes #2594: `HoldingsImportService.BuildHoldingKey` interpolated `DateOnly` via its default `ToString()`, which renders the thread `CurrentCulture`'s short-date pattern (de-DE → `31.12.2024`, Invariant → `12/31/2024`). The dedup key therefore forked by host locale, silently missing every `entriesByKey` match and duplicating institutional holdings rows whenever the runtime culture differed from the one that populated the dict.
- Pin the `reportDate` segment to `"yyyy-MM-dd"` / `CultureInfo.InvariantCulture` — matches the convention threaded through `BaseScraperWorker.FormatInterval` (#2426) and `FactMarkdown.Value`.
- Drop `Skip` on the regression test scaffolded in #2595 so it now runs and pins the contract.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — add `using System.Globalization;`; change the `BuildHoldingKey` interpolation to render `reportDate` as `ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)`.
- `tests/Equibles.UnitTests/Holdings/HoldingsImportServiceBuildHoldingKeyCultureInvarianceTests.cs` — remove `Skip = "..."` so the de-DE vs Invariant key-equality assertion runs every commit.