### PR TITLE
fix(web): use ToUpperInvariant for ticker normalization in StocksController

### DIFF
--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -229,7 +229,7 @@ public class StocksController : BaseController
 
     private async Task<Equibles.CommonStocks.Data.Models.CommonStock> LoadStock(string ticker)
     {
-        return await _commonStockRepository.GetByTicker(ticker.ToUpper());
+        return await _commonStockRepository.GetByTicker(ticker.ToUpperInvariant());
     }
 
     private StockDetailViewModel BuildStockViewModel(
@@ -266,17 +266,17 @@ public class StocksController : BaseController
         {
             Document = document,
             Content = content,
-            Ticker = ticker.ToUpper(),
+            Ticker = ticker.ToUpperInvariant(),
         };
 
-        ViewData["Title"] = $"{document.DocumentType.DisplayName} - {ticker.ToUpper()}";
+        ViewData["Title"] = $"{document.DocumentType.DisplayName} - {ticker.ToUpperInvariant()}";
         return View(viewModel);
     }
 
     [HttpGet("~/stocks/{ticker}/holders/{cik}")]
     public async Task<IActionResult> ShowHolder(string ticker, string cik)
     {
-        var stock = await _commonStockRepository.GetByTicker(ticker.ToUpper());
+        var stock = await _commonStockRepository.GetByTicker(ticker.ToUpperInvariant());
         if (stock == null)
             return NotFound();
 
@@ -286,7 +286,7 @@ public class StocksController : BaseController
 
         var viewModel = await _stockTabService.LoadHolderDetail(stock, holder);
 
-        ViewData["Title"] = $"{holder.Name} - {ticker.ToUpper()}";
+        ViewData["Title"] = $"{holder.Name} - {ticker.ToUpperInvariant()}";
         return View(viewModel);
     }
 }

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerLoadStockTurkishCultureTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerLoadStockTurkishCultureTests.cs
@@ -1,0 +1,86 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Equibles.Web.Controllers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Regression for GH-2591. <c>StocksController.LoadStock</c> calls
+/// <c>ticker.ToUpper()</c>, which routes through the thread CurrentCulture's
+/// <c>TextInfo</c>. In Turkish (tr-TR), lowercase <c>"i"</c> uppercases to
+/// <c>"İ"</c> (U+0130, dotted capital I), not <c>"I"</c>. The other ticker
+/// normalizers in this codebase (<c>SearchController.ResolveExactTicker</c>,
+/// <c>HoldingsExportController.Holders</c>) all use <c>ToUpperInvariant()</c>,
+/// so DB rows are keyed by the invariant uppercase form. A web host running
+/// under <c>tr-TR</c> would therefore 404 every ticker containing a lowercase
+/// <c>i</c> — the repository's <c>GetByTicker("İBM")</c> lookup misses the
+/// row stored as <c>"IBM"</c>.
+/// </summary>
+public class StocksControllerLoadStockTurkishCultureTests
+{
+    [Fact]
+    public async Task LoadStock_TurkishCultureLowercaseI_NormalizesViaInvariantAndFindsRow()
+    {
+        using var ctx = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new MediaModuleConfiguration(),
+            new SecTestModuleConfiguration()
+        );
+
+        var ibm = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "IBM",
+            Name = "International Business Machines",
+            Cik = "0000051143",
+        };
+        ctx.Set<CommonStock>().Add(ibm);
+        await ctx.SaveChangesAsync();
+
+        var sut = new StocksController(
+            new CommonStockRepository(ctx),
+            institutionalHolderRepository: null!,
+            institutionalHoldingRepository: null!,
+            new DocumentRepository(ctx),
+            stockTabService: null!,
+            Substitute.For<ILogger<StocksController>>()
+        );
+
+        var loadStock = typeof(StocksController).GetMethod(
+            "LoadStock",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+        var original = CultureInfo.CurrentCulture;
+        CommonStock resolved;
+        try
+        {
+            // tr-TR maps lowercase 'i' → 'İ' (U+0130) under ToUpper(), but
+            // leaves it as 'I' under ToUpperInvariant(). Row is stored as
+            // primary ticker "IBM"; an "İBM" lookup misses entirely.
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            var task = (Task<CommonStock>)loadStock!.Invoke(sut, ["ibm"]);
+            resolved = await task;
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+
+        resolved
+            .Should()
+            .NotBeNull(
+                "LoadStock must normalize the ticker culture-invariantly so a host running under tr-TR (or any other non-invariant locale where ToUpper differs from ToUpperInvariant) still resolves the row stored as IBM; otherwise every /stocks/<ticker> URL containing a lowercase 'i' 404s in production"
+            );
+        resolved.Ticker.Should().Be("IBM");
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes #2591: `StocksController.LoadStock`, `ShowDocument`, and `ShowHolder` called `ticker.ToUpper()`, which routes through the thread `CurrentCulture`'s `TextInfo`. In Turkish (`tr-TR`), lowercase `i` uppercases to `İ` (U+0130, dotted capital I), not `I`. A web host running under `tr-TR` would therefore 404 every `/stocks/<ticker>` URL containing a lowercase `i`, because the row stored as `IBM` is queried as `İBM`.
- Sibling controllers (`SearchController.ResolveExactTicker`, `HoldingsExportController.Holders`) already normalize with `ToUpperInvariant()`; this brings `StocksController` in line.
- Pin via a new integration regression test that seeds an `IBM` row, switches `CurrentCulture` to `tr-TR`, reflection-invokes `LoadStock("ibm")`, and asserts the row resolves.

## Code changes

- `src/Equibles.Web/Controllers/StocksController.cs` — swap all five `ticker.ToUpper()` call sites (`LoadStock` lookup, `ShowDocument` view-model + title, `ShowHolder` lookup + title) to `ticker.ToUpperInvariant()`.
- `tests/Equibles.IntegrationTests/Web/StocksControllerLoadStockTurkishCultureTests.cs` — new regression test (`TestDbContextFactory` + real `CommonStockRepository`) that fails on pre-fix code and passes on fixed code.