### PR TITLE
test(holdings): pin EscapeLikePattern Replace-chain ordering

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHolderRepositoryEscapeLikePatternTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHolderRepositoryEscapeLikePatternTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using Equibles.Holdings.Repositories;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Adversarial Lane A. <c>EscapeLikePattern</c> guards <c>SearchNameOrCik</c>
+/// against LIKE-injection: a user typing "50%" must match the literal three
+/// characters, never every name. The order of the three <c>.Replace</c> calls
+/// is load-bearing: backslash MUST be escaped FIRST, so the backslashes
+/// synthesised by the subsequent <c>%</c> / <c>_</c> escapes don't get
+/// double-escaped on a second pass. A refactor that reorders the chain
+/// (or uses a regex with the wrong alternation order) would silently emit
+/// <c>\\\%</c> instead of <c>\%</c> — the LIKE engine then sees an escaped
+/// backslash followed by a literal <c>%</c> wildcard, and the typeahead
+/// returns every row again.
+/// </summary>
+public class InstitutionalHolderRepositoryEscapeLikePatternTests
+{
+    [Fact]
+    public void EscapeLikePattern_MixedBackslashPercentUnderscore_EscapesEachExactlyOnce()
+    {
+        // Input mixes all three LIKE specials so the test exercises the
+        // ordering invariant: input is "a\b%c_d", expected "a\\b\%c\_d".
+        const string input = "a\\b%c_d";
+
+        var method = typeof(InstitutionalHolderRepository).GetMethod(
+            "EscapeLikePattern",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (string)method.Invoke(null, [input]);
+
+        result
+            .Should()
+            .Be(
+                "a\\\\b\\%c\\_d",
+                "reordering the Replace chain would double-escape the backslashes synthesised by the % and _ escapes"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the Replace-chain ordering invariant in `InstitutionalHolderRepository.EscapeLikePattern`. The user-input escaper guards `SearchNameOrCik` against LIKE-injection so a typeahead of "50%" matches the literal three characters instead of every row.
- Backslash MUST be escaped FIRST. If the chain is reordered (or replaced with a regex whose alternation order differs), the backslashes synthesised by the subsequent `%` / `_` escapes get double-escaped — the LIKE engine then sees an escaped backslash followed by a literal `%` wildcard, and the typeahead silently returns every name again.

## Code changes

- `tests/Equibles.UnitTests/Holdings/InstitutionalHolderRepositoryEscapeLikePatternTests.cs` — new unit test invoking the private static `EscapeLikePattern` via reflection with the input `"a\b%c_d"` (mixes all three LIKE specials) and asserting the result is `"a\\b\%c\_d"` — each special escaped exactly once, no double-escaping of synthesised backslashes.