### PR TITLE
fix(sec): pass existing parent ticker as 4th LogWarning arg in BuildSecondaryCikToParent

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -640,7 +640,8 @@ public class CompanySyncService : ICompanySyncService
                             + "keeping {ExistingParent}. Manual cleanup required.",
                         subCik,
                         secondaryCikToParent[subCik].Ticker,
-                        stock.Ticker
+                        stock.Ticker,
+                        secondaryCikToParent[subCik].Ticker
                     );
                 }
             }

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentTests.cs
@@ -25,9 +25,7 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class CompanySyncServiceBuildSecondaryCikToParentTests
 {
-    [Fact(
-        Skip = "GH-2606 — log template has 4 placeholder occurrences but only 3 args; LogWarning throws FormatException on duplicate subsidiary CIK"
-    )]
+    [Fact]
     public void BuildSecondaryCikToParent_DuplicateSubsidiaryCik_WarningRendersExistingTickerAtEveryPlaceholderSite()
     {
         var capturing = new CapturingLogger();


### PR DESCRIPTION
## Summary

- Fixes #2606: `CompanySyncService.BuildSecondaryCikToParent` was throwing `System.FormatException` whenever it hit the exact data anomaly its XML doc says it was "built defensively to survive" (the same subsidiary CIK attached to two parents). The `LogWarning` template at `CompanySyncService.cs:638-644` uses the named placeholder `{ExistingParent}` twice — once in the parents-conflict parenthetical, once in "keeping {ExistingParent}." — but only three arguments were passed. `LogValuesFormatter` raised `Index (zero based) must be greater than or equal to zero and less than the size of the argument list.` and aborted the build of the secondary-CIK map. The compiler already flagged the site with CA2017.
- Minimal fix: pass the existing parent's ticker as the fourth argument so both `{ExistingParent}` occurrences resolve.
- Drop `Skip` on the regression test scaffolded in #2607 so it now runs and pins the contract.

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — add `secondaryCikToParent[subCik].Ticker` as the fourth argument to the `LogWarning` call.
- `tests/Equibles.UnitTests/Sec/CompanySyncServiceBuildSecondaryCikToParentTests.cs` — remove `Skip = "..."` so the duplicate-subsidiary-CIK warning-substitution assertion runs every commit.