### PR TITLE
test(web): add skipped repro for GH-2614 — VersionCheckService.IsNewer drops v-prefixed latest

### DIFF
--- a/tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerVTaggedLatestTests.cs
+++ b/tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerVTaggedLatestTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+/// <summary>
+/// Adversarial Lane A. IsNewer's documented contract calls out tag formatting
+/// variance verbatim: "Compares Major.Minor.Build only so tag formatting
+/// variance (e.g. 'v1.0.0' vs an assembly '1.0.0.0') can't trigger a spurious
+/// banner." Git tags conventionally carry a leading 'v' (the same docstring
+/// gives "v1.0.0" as the example), so a real GitHub release tag fed in as the
+/// 'latest' argument will be 'v&lt;Major&gt;.&lt;Minor&gt;.&lt;Build&gt;'.
+///
+/// NormalizeVersion is the helper that strips the 'v' prefix — and the same
+/// file's GetCurrentVersion already routes the assembly's
+/// InformationalVersion through it. The contract demands the same treatment
+/// for the comparison input, otherwise a real-world tag like 'v1.1.0' would
+/// fail Version.TryParse, IsNewer would short-circuit to false, and operators
+/// would never see the banner for a legitimate release.
+///
+/// Pin: a bare current ('1.0.0') against a v-tagged latest ('v1.1.0') is a
+/// real bump and must return true. Bug class established by the existing
+/// AssemblyVsTag and Unparseable sibling tests — both pin tag-format
+/// tolerance on one side of the comparison; this pins it on the other.
+/// </summary>
+public class VersionCheckServiceIsNewerVTaggedLatestTests
+{
+    [Fact(
+        Skip = "GH-2614 — IsNewer normalizes current via NormalizeVersion but feeds latest to Version.TryParse raw; v-prefixed GitHub release tags (the exact format the docstring names) parse as false and the in-app update banner never fires"
+    )]
+    public void IsNewer_BareCurrentVsVPrefixedLatest_DetectsBumpDespiteTagPrefix()
+    {
+        var method = typeof(VersionCheckService).GetMethod(
+            "IsNewer",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (bool)method.Invoke(null, ["1.0.0", "v1.1.0"]);
+
+        result
+            .Should()
+            .BeTrue(
+                "'v1.1.0' is the conventional GitHub release-tag format the docstring names verbatim; a real release tag must not be silently dropped as unparseable, otherwise the in-app update banner never fires for v-prefixed tags"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `VersionCheckService.IsNewer` against the in-app update banner silently failing on real GitHub release tags. The docstring names `v1.0.0` as the tag format the comparator must tolerate, but the implementation only runs `current` through `NormalizeVersion` — `latest` goes raw into `Version.TryParse` and a `v`-prefixed real-world tag (e.g. `v1.1.0`) fails to parse, short-circuiting the method to `false`.
- Test is `[Fact(Skip = "GH-2614 — …")]` because the assertion is the documented behavior, which the code doesn't currently honor.
- Un-skip alongside the fix on the linked issue (one-line change: normalize `latest` too).

## Code changes

- `tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerVTaggedLatestTests.cs` — new file; one reflection-invoked `[Fact(Skip = "GH-2614 — …")]` calling `IsNewer("1.0.0", "v1.1.0")` and asserting `true`. Currently fails (returns `false`); skipped — see GH-2614.