### PR TITLE
test(mcp): pin NormalizeTicker against Turkish-I locale trap

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/McpToolExecutorNormalizeTickerTurkishCultureTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpToolExecutorNormalizeTickerTurkishCultureTests.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+using Equibles.Mcp;
+
+namespace Equibles.UnitTests.Mcp;
+
+/// <summary>
+/// Adversarial Lane A. <c>NormalizeTicker</c> uppercases via
+/// <c>ToUpperInvariant()</c> — the Invariant is load-bearing. Under
+/// Turkish locale (<c>tr-TR</c>) the default <c>ToUpper()</c> maps
+/// <c>'i'</c> to <c>'İ'</c> (dotted capital I, U+0130) instead of plain
+/// <c>'I'</c> (U+0049). A regression that dropped the Invariant — for
+/// example "the linter complained about the redundancy, ToUpper is
+/// already invariant for ASCII" — would compile, pass every existing
+/// ASCII-clean test, and silently break ticker lookups for any MCP host
+/// running under a Turkish locale: <c>"ICE"</c> in the URL becomes
+/// <c>"İCE"</c> after normalisation, which doesn't match the SQL
+/// <c>Ticker = 'ICE'</c> stored row → "Stock not found" for a real ticker.
+/// </summary>
+public class McpToolExecutorNormalizeTickerTurkishCultureTests
+{
+    [Fact]
+    public void NormalizeTicker_LowercaseILetterUnderTurkishCulture_UppercasesToAsciiI()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+
+            var result = McpToolExecutor.NormalizeTicker("ice");
+
+            result
+                .Should()
+                .Be(
+                    "ICE",
+                    "ToUpperInvariant must keep 'i' → ASCII 'I' (U+0049); a non-invariant uppercase would produce dotted 'İ' (U+0130) and break ticker lookups"
+                );
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the load-bearing `Invariant` in `McpToolExecutor.NormalizeTicker`'s `ToUpperInvariant()` call. A regression to plain `ToUpper()` would compile, pass every existing ASCII-clean test, and silently break ticker lookups on any MCP host running under Turkish locale (`tr-TR`): `i` → `İ` (U+0130, dotted capital I) instead of `I` (U+0049), so `"ice"` after normalisation no longer matches the `Ticker = 'ICE'` row in SQL — "Stock not found" for a real ticker.

## Code changes

- `tests/Equibles.UnitTests/Mcp/McpToolExecutorNormalizeTickerTurkishCultureTests.cs` — new unit test that switches `CultureInfo.CurrentCulture` to `tr-TR`, calls `NormalizeTicker("ice")`, and asserts the result is exactly `"ICE"` — three plain ASCII bytes, with no dotted Turkish capital.