### PR TITLE
fix(web): normalize latest version arg in IsNewer to handle v-prefixed tags

### DIFF
--- a/src/Equibles.Web/Services/VersionCheckService.cs
+++ b/src/Equibles.Web/Services/VersionCheckService.cs
@@ -159,7 +159,7 @@ public class VersionCheckService
     {
         if (
             !Version.TryParse(NormalizeVersion(current), out var currentVersion)
-            || !Version.TryParse(latest, out var latestVersion)
+            || !Version.TryParse(NormalizeVersion(latest), out var latestVersion)
         )
         {
             return false;

--- a/tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerVTaggedLatestTests.cs
+++ b/tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerVTaggedLatestTests.cs
@@ -25,9 +25,7 @@ namespace Equibles.UnitTests.Web;
 /// </summary>
 public class VersionCheckServiceIsNewerVTaggedLatestTests
 {
-    [Fact(
-        Skip = "GH-2614 — IsNewer normalizes current via NormalizeVersion but feeds latest to Version.TryParse raw; v-prefixed GitHub release tags (the exact format the docstring names) parse as false and the in-app update banner never fires"
-    )]
+    [Fact]
     public void IsNewer_BareCurrentVsVPrefixedLatest_DetectsBumpDespiteTagPrefix()
     {
         var method = typeof(VersionCheckService).GetMethod(


### PR DESCRIPTION
## Summary

- Fixes #2614: `VersionCheckService.IsNewer`'s docstring says it compares Major.Minor.Build only "so tag formatting variance (e.g. 'v1.0.0' vs an assembly '1.0.0.0') can't trigger a spurious banner". The implementation passed `current` through `NormalizeVersion` (which strips a leading `v`/`V`) but fed `latest` straight to `Version.TryParse` — yet `latest` is the GitHub-release side where the `v`-prefix convention always shows up. Every `v`-prefixed release tag parsed as unparseable, short-circuited the method to `false`, and the in-app update banner never fired.
- Minimal fix: route `latest` through the same `NormalizeVersion` call as `current`. The sibling `UnparseableLatest` pin still holds — `NormalizeVersion` only strips the leading `v`/`V` and pre-release/build suffixes, so truly malformed strings (`"not a version"`) still fail `TryParse`.
- Drop `Skip` on the regression test scaffolded in #2616 so it now runs and pins the contract.

## Code changes

- `src/Equibles.Web/Services/VersionCheckService.cs` — change `Version.TryParse(latest, …)` to `Version.TryParse(NormalizeVersion(latest), …)` inside `IsNewer`.
- `tests/Equibles.UnitTests/Web/VersionCheckServiceIsNewerVTaggedLatestTests.cs` — remove `Skip = "..."` so the `v`-prefixed-`latest` regression runs every commit.