### PR TITLE
fix(sec): thread InvariantCulture through RagManager.BuildContext LLM prompt formatting

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Search/RagManager.cs
+++ b/src/Equibles.Sec.BusinessLogic/Search/RagManager.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
@@ -122,7 +123,7 @@ public class RagManager : IRagManager
             var firstChunk = group.First();
             context.AppendLine($"## {firstChunk.Document.CommonStock.Name} ({group.Key.Ticker})");
             context.AppendLine(
-                $"**Document:** {group.Key.DocumentType} filed on {group.Key.ReportingDate}"
+                $"**Document:** {group.Key.DocumentType} filed on {group.Key.ReportingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}"
             );
             context.AppendLine();
 
@@ -132,7 +133,7 @@ public class RagManager : IRagManager
                 {
                     context.AppendLine(
                         chunk.StartLineNumber > 0
-                            ? $"**Excerpt {chunk.Index + 1} (line ~{chunk.StartLineNumber:N0}):**"
+                            ? $"**Excerpt {chunk.Index + 1} (line ~{chunk.StartLineNumber.ToString("N0", CultureInfo.InvariantCulture)}):**"
                             : $"**Excerpt {chunk.Index + 1}:**"
                     );
                     context.AppendLine(chunk.Content);

--- a/tests/Equibles.UnitTests/Sec/RagManagerBuildContextCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RagManagerBuildContextCultureInvarianceTests.cs
@@ -37,9 +37,7 @@ public class RagManagerBuildContextCultureInvarianceTests
     // RenderInstitutionPortfolio culture-invariance siblings: capture
     // CurrentCulture, render once under Invariant, render once under
     // de-DE, restore in finally, and assert byte-equality.
-    [Fact(
-        Skip = "GH-2608 — BuildContext :N0 on StartLineNumber and default DateOnly.ToString() on ReportingDate follow CurrentCulture (de-DE → `1.234` and `31.12.2024` vs Invariant `1,234` and `12/31/2024`); LLM prompt forks by host locale"
-    )]
+    [Fact]
     public async Task BuildContext_UnderNonInvariantCulture_RendersCultureInvariantly()
     {
         var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };


### PR DESCRIPTION
## Summary

- Closes #2608.
- `RagManager.BuildContext` interpolated `StartLineNumber` with `:N0` and `DateOnly ReportingDate` with default `ToString()`, both resolving through the thread `CurrentCulture`. On a German-locale host the same chunks render as `1.234` and `31.12.2024`; on en-US they render as `1,234` and `12/31/2024`. The output is fed straight into an LLM prompt window, so the prompt forks by host locale and breaks reproducibility.
- Same fix shape as the recent culture-invariance pins #2426 (`FormatInterval`) and #2444 (`FormatSignedChange`).

## Code changes

- `src/Equibles.Sec.BusinessLogic/Search/RagManager.cs` — format `StartLineNumber` via `.ToString("N0", CultureInfo.InvariantCulture)` and `ReportingDate` via `.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)`; add `using System.Globalization;`.
- `tests/Equibles.UnitTests/Sec/RagManagerBuildContextCultureInvarianceTests.cs` — drop the `[Fact(Skip = ...)]` repro added with the issue (now a passing regression test).