### PR TITLE
test(web): add skipped repro for GH-2624 — MarkdownToHtml autolink emits javascript: href

### DIFF
--- a/tests/Equibles.UnitTests/Web/MarkdownExtensionsAutolinkJavascriptUriTests.cs
+++ b/tests/Equibles.UnitTests/Web/MarkdownExtensionsAutolinkJavascriptUriTests.cs
@@ -1,0 +1,30 @@
+using Equibles.Web.Extensions;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Web;
+
+public class MarkdownExtensionsAutolinkJavascriptUriTests
+{
+    // The sibling `[x](javascript:…)` pin establishes the contract: MarkdownToHtml
+    // renders untrusted ingested content and must never emit an active javascript:
+    // href. Markdig's autolink syntax `<scheme:body>` is a second URL-producing
+    // construct in the same grammar and falls under the same contract — the AST
+    // node is AutolinkInline, not LinkInline, so it bypasses any sanitizer that
+    // only walks LinkInline descendants.
+    [Fact(Skip = "GH-2624 — MarkdownToHtml emits active javascript: href for autolink syntax")]
+    public void MarkdownToHtml_JavascriptAutolink_DoesNotEmitActiveJavascriptHref()
+    {
+        string captured = null;
+        var htmlHelper = Substitute.For<IHtmlHelper>();
+        htmlHelper
+            .Raw(Arg.Do<string>(s => captured = s))
+            .Returns(callInfo => new HtmlString(callInfo.Arg<string>()));
+
+        htmlHelper.MarkdownToHtml("<javascript:alert(document.cookie)>");
+
+        captured.Should().NotBeNull();
+        captured.Should().NotContain("href=\"javascript:");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the security contract for `MarkdownExtensions.MarkdownToHtml` against Markdig's autolink syntax: `<javascript:…>` produces an `AutolinkInline` AST node, not a `LinkInline`, so it bypasses the existing `Descendants<LinkInline>()` URL allowlist and renders an active `javascript:` `href` (stored XSS in any ingested content).
- Skipped until GH-2624 is fixed; un-skip as part of the fix. The fix should walk `AutolinkInline` (and any other URL-producing inline node) in addition to `LinkInline`, applying the same `IsSafeUrl` allowlist — this also closes `<data:…>` / `<vbscript:…>` variants.

## Code changes

- `tests/Equibles.UnitTests/Web/MarkdownExtensionsAutolinkJavascriptUriTests.cs` — new `[Fact(Skip = "GH-2624 — …")]` mirroring the sibling `MarkdownExtensionsJavascriptUriTests` shape; asserts the rendered HTML for `<javascript:alert(document.cookie)>` does not contain `href="javascript:"`. Currently observed: `<a href="javascript:alert(document.cookie)">…</a>`.