### PR TITLE
fix: render InstitutionPortfolio share/value cells culture-invariantly

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
@@ -273,7 +274,9 @@ public class InstitutionalHoldingsTools
         {
             var h = holdings[i];
             result.AppendLine(
-                $"| {i + 1} | {h.CommonStock.Ticker} | {h.CommonStock.Name} | {h.Shares:N0} | {h.Value / 1_000_000m:N1} |"
+                $"| {i + 1} | {h.CommonStock.Ticker} | {h.CommonStock.Name} | "
+                    + $"{h.Shares.ToString("N0", CultureInfo.InvariantCulture)} | "
+                    + $"{(h.Value / 1_000_000m).ToString("N1", CultureInfo.InvariantCulture)} |"
             );
         }
 

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarianceTests.cs
@@ -31,9 +31,7 @@ public class InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarian
     // reflection-invoke the private static, restore in finally, compare
     // against the Invariant rendering. A failure manifests as the
     // thousand/decimal-separator swap.
-    [Fact(
-        Skip = "GH-2597 — RenderInstitutionPortfolio :N0/:N1 cells follow CurrentCulture (de-DE → 1.234.567 / 1.234,6 vs Invariant 1,234,567 / 1,234.6); MCP output forks by host locale"
-    )]
+    [Fact]
     public void RenderInstitutionPortfolio_UnderNonInvariantCulture_RendersSharesAndValueCellsCultureInvariantly()
     {
         var method = typeof(InstitutionalHoldingsTools).GetMethod(


### PR DESCRIPTION
## Summary

- `InstitutionalHoldingsTools.RenderInstitutionPortfolio` built each markdown row with the culture-implicit `:N0` / `:N1` format specifiers, which resolve through the thread `CurrentCulture`. Under a non-en-US/Invariant host locale (de-DE, fr-FR) the thousand/decimal separators swap (`1,234,567` → `1.234.567`), forking the LLM-consumed MCP output by host locale.
- Fix threads `CultureInfo.InvariantCulture` through both cells so the same `(holder, targetDate, holdings)` call renders byte-identically regardless of host culture — matching the `FactMarkdown`, `FormatSignedChange` (#2444), and `FormatInterval` (#2426) conventions.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — render the Shares (`N0`) and Value ($M, `N1`) cells via `.ToString(..., CultureInfo.InvariantCulture)`; added `System.Globalization` using.
- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarianceTests.cs` — un-skipped the regression test pinning de-DE output equal to Invariant output (fails pre-fix, passes post-fix).

closes #2597