### PR TITLE
test(web): pin DateOnlyListExtensions.PreviousFrom returns immediately-older quarter

### DIFF
--- a/tests/Equibles.UnitTests/Web/DateOnlyListExtensionsPreviousFromTests.cs
+++ b/tests/Equibles.UnitTests/Web/DateOnlyListExtensionsPreviousFromTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class DateOnlyListExtensionsPreviousFromTests
+{
+    [Fact]
+    public void PreviousFrom_MiddleQuarterInDescendingList_ReturnsImmediatelyOlderQuarter()
+    {
+        // Contract: the list is latest-first (descending), so the quarter "immediately
+        // older than current" is the entry AFTER it, not the newer one before it.
+        // Pins the direction — a sign/index flip would return the newer quarter instead.
+        var available = new List<DateOnly>
+        {
+            new(2025, 12, 31),
+            new(2025, 9, 30),
+            new(2025, 6, 30),
+            new(2025, 3, 31),
+        };
+
+        var previous = available.PreviousFrom(new DateOnly(2025, 9, 30));
+
+        previous.Should().Be(new DateOnly(2025, 6, 30));
+    }
+}


### PR DESCRIPTION
## Summary

- `DateOnlyListExtensions` had **zero** test coverage. This pins the direction semantics of `PreviousFrom` — the most error-prone aspect, since the list is latest-first (descending) and "previous" means the *older* quarter (the next index), not the newer one.
- Adversarial lane: oracle derived from the doc-comment, not the implementation. Test passes — behavior confirmed and pinned against a future sign/index flip.

## Code changes

- `tests/Equibles.UnitTests/Web/DateOnlyListExtensionsPreviousFromTests.cs` — new unit test asserting `PreviousFrom` over a descending quarter-end list returns the immediately-older quarter for a middle element.