### PR TITLE
test(web): pin Pagination.PageCount has no phantom page on exact multiples

### DIFF
--- a/tests/Equibles.UnitTests/Web/PaginationPageCountTests.cs
+++ b/tests/Equibles.UnitTests/Web/PaginationPageCountTests.cs
@@ -1,0 +1,15 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class PaginationPageCountTests
+{
+    [Fact]
+    public void PageCount_TotalIsExactMultipleOfPageSize_DoesNotAddPhantomPage()
+    {
+        // Ceiling division: 20 items at 10/page is exactly 2 pages. The classic
+        // off-by-one in this pattern emits a phantom 3rd page on exact multiples;
+        // pin that it doesn't.
+        Pagination.PageCount(totalCount: 20, pageSize: 10).Should().Be(2);
+    }
+}


### PR DESCRIPTION
## Summary

- `Pagination` had **zero** test coverage. `PageCount` is documented as ceiling division with a floor of 1; this pins the most error-prone case — an exact multiple must not emit a phantom extra page (the classic off-by-one in `(n + size - 1) / size`).
- Adversarial lane: oracle derived from "ceiling division" (`ceil(20/10) = 2`), not the implementation. Test passes — behavior confirmed and pinned.

## Code changes

- `tests/Equibles.UnitTests/Web/PaginationPageCountTests.cs` — new unit test asserting `PageCount(20, 10) == 2`.