### PR TITLE
refactor(insider-trading): replace manual keyword loop in IsDerivativeSecurity with LINQ Any

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
@@ -66,11 +66,8 @@ public class InsiderTransactionPriceValidator
     {
         if (string.IsNullOrWhiteSpace(securityTitle))
             return false;
-        foreach (var keyword in DerivativeTitleKeywords)
-        {
-            if (securityTitle.Contains(keyword, StringComparison.OrdinalIgnoreCase))
-                return true;
-        }
-        return false;
+        return DerivativeTitleKeywords.Any(keyword =>
+            securityTitle.Contains(keyword, StringComparison.OrdinalIgnoreCase)
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Replace the hand-rolled `foreach` keyword-match loop in `InsiderTransactionPriceValidator.IsDerivativeSecurity` with `DerivativeTitleKeywords.Any(...)`.
- Behavior-preserving readability cleanup: same case-insensitive (`OrdinalIgnoreCase`) substring check, same short-circuit, same boolean result, same null/whitespace guard.

## Code changes

- `src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs` — collapse the 5-line keyword loop into a single LINQ `Any` predicate; no signature, contract, or behavior change.