### PR TITLE
test(web): pin SignCssExtensions.InverseSignCss colors positive values as error

### DIFF
--- a/tests/Equibles.UnitTests/Web/SignCssExtensionsInverseSignCssTests.cs
+++ b/tests/Equibles.UnitTests/Web/SignCssExtensionsInverseSignCssTests.cs
@@ -1,0 +1,15 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class SignCssExtensionsInverseSignCssTests
+{
+    [Fact]
+    public void InverseSignCss_PositiveValue_ReturnsErrorNotSuccess()
+    {
+        // "Inverse" is for lower-is-better metrics (short interest, days-to-cover):
+        // a positive value is bad and must color red. A copy-paste from SignCss that
+        // forgot to swap would return "text-success" here, mis-coloring the UI.
+        5m.InverseSignCss().Should().Be("text-error");
+    }
+}


### PR DESCRIPTION
## Summary

- `SignCssExtensions` had **zero** test coverage despite being used across many financial views (gain/loss coloring). This pins `InverseSignCss`'s defining contract — for lower-is-better metrics a positive value must color red (`text-error`), the *inverse* of `SignCss`.
- Adversarial lane: oracle derived from the "Inverse" name, not the implementation. A copy-paste from `SignCss` that forgot to swap success/error would fail this. Test passes — behavior confirmed and pinned.

## Code changes

- `tests/Equibles.UnitTests/Web/SignCssExtensionsInverseSignCssTests.cs` — new unit test asserting `5m.InverseSignCss() == "text-error"`.