### PR TITLE
fix: neutralize javascript: scheme in markdown autolinks

### DIFF
--- a/src/Equibles.Web/Extensions/MarkdownExtensions.cs
+++ b/src/Equibles.Web/Extensions/MarkdownExtensions.cs
@@ -70,6 +70,20 @@ public static partial class MarkdownExtensions
             link.Url = string.Empty;
         }
 
+        // Markdig represents the autolink syntax `<scheme:body>` as AutolinkInline,
+        // not LinkInline, so it bypasses the loop above. Neutralize unsafe-scheme
+        // autolinks by replacing the node with its plain text — no active href.
+        // Materialize first: ReplaceBy mutates the tree during enumeration.
+        foreach (
+            var autolink in document
+                .Descendants<AutolinkInline>()
+                .Where(autolink => !IsSafeUrl(autolink.Url))
+                .ToList()
+        )
+        {
+            autolink.ReplaceBy(new LiteralInline(autolink.Url));
+        }
+
         return htmlHelper.Raw(document.ToHtml(pipeline));
     }
 }

--- a/tests/Equibles.UnitTests/Web/MarkdownExtensionsAutolinkJavascriptUriTests.cs
+++ b/tests/Equibles.UnitTests/Web/MarkdownExtensionsAutolinkJavascriptUriTests.cs
@@ -13,7 +13,7 @@ public class MarkdownExtensionsAutolinkJavascriptUriTests
     // construct in the same grammar and falls under the same contract — the AST
     // node is AutolinkInline, not LinkInline, so it bypasses any sanitizer that
     // only walks LinkInline descendants.
-    [Fact(Skip = "GH-2624 — MarkdownToHtml emits active javascript: href for autolink syntax")]
+    [Fact]
     public void MarkdownToHtml_JavascriptAutolink_DoesNotEmitActiveJavascriptHref()
     {
         string captured = null;


### PR DESCRIPTION
## Summary

- `MarkdownToHtml` renders untrusted ingested content (SEC filings, transcripts) and sanitizes link/image destinations by walking `LinkInline` descendants against a scheme allowlist. Markdig represents the autolink syntax `<scheme:body>` as `AutolinkInline`, not `LinkInline`, so `<javascript:alert(document.cookie)>` bypassed the allowlist and rendered as an active `href` — a stored XSS vector.
- Fix walks `AutolinkInline` as well, replacing any unsafe-scheme autolink with its plain text so no active `href` is emitted (covers `javascript:`, `data:`, `vbscript:`, etc. via the same `IsSafeUrl` allowlist). Safe schemes (http/https/mailto) and relative/fragment autolinks are untouched.

## Code changes

- `src/Equibles.Web/Extensions/MarkdownExtensions.cs` — after the existing `LinkInline` pass, add an `AutolinkInline` pass that `ReplaceBy`s unsafe-scheme autolinks with a `LiteralInline` of the original text (materialized to a list first, since `ReplaceBy` mutates the tree during enumeration).
- `tests/Equibles.UnitTests/Web/MarkdownExtensionsAutolinkJavascriptUriTests.cs` — un-skipped the regression test asserting the rendered HTML contains no `href="javascript:` (fails pre-fix, passes post-fix).

closes #2624