### PR TITLE
fix: render top-holders table cells culture-invariantly

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -129,7 +129,9 @@ public class InstitutionalHoldingsTools
             $"Top institutional holders of {stock.Name} ({ticker}) as of {targetDate:yyyy-MM-dd}:"
         );
         result.AppendLine(
-            $"Showing {holdings.Count} of {totalInstitutions} institutions. Total: {totalSharesAll:N0} shares, ${totalValueAll / 1_000_000m:N1}M value"
+            $"Showing {holdings.Count} of {totalInstitutions} institutions. Total: "
+                + $"{totalSharesAll.ToString("N0", CultureInfo.InvariantCulture)} shares, "
+                + $"${(totalValueAll / 1_000_000m).ToString("N1", CultureInfo.InvariantCulture)}M value"
         );
         result.AppendLine();
         result.AppendLine("| # | Institution | Shares | Value ($M) | % of Total |");
@@ -140,7 +142,10 @@ public class InstitutionalHoldingsTools
             var h = holdings[i];
             var pct = totalSharesAll > 0 ? (double)h.Shares / totalSharesAll * 100 : 0;
             result.AppendLine(
-                $"| {i + 1} | {h.InstitutionalHolder.Name} | {h.Shares:N0} | {h.Value / 1_000_000m:N1} | {pct:F2}% |"
+                $"| {i + 1} | {h.InstitutionalHolder.Name} | "
+                    + $"{h.Shares.ToString("N0", CultureInfo.InvariantCulture)} | "
+                    + $"{(h.Value / 1_000_000m).ToString("N1", CultureInfo.InvariantCulture)} | "
+                    + $"{pct.ToString("F2", CultureInfo.InvariantCulture)}% |"
             );
         }
 

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableCultureInvarianceTests.cs
@@ -24,9 +24,7 @@ public class InstitutionalHoldingsToolsRenderTopHoldersTableCultureInvarianceTes
     // host locale. The contract (repo convention; cf. FactMarkdown threading
     // InvariantCulture) is that the same call renders byte-identically
     // regardless of host CurrentCulture.
-    [Fact(
-        Skip = "GH-2628 — RenderTopHoldersTable :N0/:N1/:F2 cells follow CurrentCulture (de-DE → 9.876.543 / $9.876,5M / 12,50% vs Invariant 9,876,543 / $9,876.5M / 12.50%); MCP output forks by host locale"
-    )]
+    [Fact]
     public void RenderTopHoldersTable_UnderNonInvariantCulture_RendersCellsCultureInvariantly()
     {
         var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };


### PR DESCRIPTION
## Summary

- `RenderTopHoldersTable` built its summary line and per-row cells with the culture-implicit `:N0` (shares), `:N1` (value $M), and `:F2` (% of total) specifiers, which resolve through the thread `CurrentCulture`. Under a non-en-US/Invariant host locale (de-DE) the thousand/decimal separators swap (`9,876,543` → `9.876.543`, `$9,876.5M` → `$9.876,5M`, `12.50%` → `12,50%`), forking the LLM-consumed MCP output by host locale.
- Fix threads `CultureInfo.InvariantCulture` through each cell so the same call renders byte-identically regardless of host culture — matching the `RenderInstitutionPortfolio` (#2597), `FormatSignedChange` (#2444), and `FormatInterval` (#2426) conventions.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — render the summary `N0`/`N1` cells and the per-row `N0`/`N1`/`F2` cells via `.ToString(..., CultureInfo.InvariantCulture)`.
- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableCultureInvarianceTests.cs` — un-skipped the regression test (committed skipped under #2629) pinning de-DE output equal to Invariant; fails pre-fix, passes post-fix.

closes #2628