### PR TITLE
test(holdings): add skipped repro for GH-2637 — RenderInstitutionSummary host-locale separators

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionSummaryCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionSummaryCultureInvarianceTests.cs
@@ -1,0 +1,67 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class InstitutionalHoldingsToolsRenderInstitutionSummaryCultureInvarianceTests
+{
+    private static readonly MethodInfo RenderInstitutionSummaryMethod =
+        typeof(InstitutionalHoldingsTools).GetMethod(
+            "RenderInstitutionSummary",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // RenderInstitutionSummary builds the metric cells (Reported AUM :N0,
+    // concentration / turnover :F1) with culture-implicit format specifiers
+    // that resolve through the thread CurrentCulture. Same bug class as the
+    // already-fixed RenderInstitutionPortfolio (GH-2597) and RenderTopHoldersTable
+    // (GH-2628) siblings in this class: de-DE swaps the thousand/decimal
+    // separators (1,234,567 → 1.234.567, 12.3 → 12,3), forking the LLM-consumed
+    // MCP output by host locale. The contract (repo convention; cf. FactMarkdown
+    // threading InvariantCulture) is that the same call renders byte-identically
+    // regardless of host CurrentCulture.
+    [Fact(
+        Skip = "GH-2637 — RenderInstitutionSummary :N0/:F1 metric cells follow CurrentCulture (de-DE → 1.234.567.890 / 12,3 vs Invariant 1,234,567,890 / 12.3); MCP output forks by host locale"
+    )]
+    public void RenderInstitutionSummary_UnderNonInvariantCulture_RendersMetricCellsCultureInvariantly()
+    {
+        var holder = new InstitutionalHolder { Name = "ACME Capital" };
+        var targetDate = new DateOnly(2024, 12, 31);
+        var summary = new InstitutionPortfolioSummary
+        {
+            ReportedAum = 1_234_567_890L,
+            PositionCount = 1_234,
+            Top10ConcentrationPercent = 12.34,
+            Top25ConcentrationPercent = 56.78,
+            QoQTurnoverPercent = 9.87,
+            QuartersReported = 8,
+        };
+        object[] args = [holder, targetDate, (DateOnly?)new DateOnly(2024, 9, 30), summary];
+
+        var original = CultureInfo.CurrentCulture;
+        string invariantOutput;
+        string deDeOutput;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            invariantOutput = (string)RenderInstitutionSummaryMethod.Invoke(null, args);
+
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            deDeOutput = (string)RenderInstitutionSummaryMethod.Invoke(null, args);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+
+        deDeOutput
+            .Should()
+            .Be(
+                invariantOutput,
+                "MCP markdown output is consumed by LLMs trained on en-US conventions; the :N0 / :F1 metric cells without an explicit IFormatProvider follow CurrentCulture (de-DE → 1.234.567.890 / 12,3), forking the response by host locale — same bug class as the RenderInstitutionPortfolio and RenderTopHoldersTable culture-invariance siblings"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial culture-invariance test surfaced a defect in `InstitutionalHoldingsTools.RenderInstitutionSummary`: its `:N0` (Reported AUM, # positions) and `:F1` (concentration, turnover) metric cells resolve through the thread `CurrentCulture`, so under a non-en-US/Invariant host locale (de-DE) the thousand/decimal separators swap (`1,234,567,890` → `1.234.567.890`, `12.3%` → `12,3%`), forking the LLM-consumed MCP output by host locale.
- Same bug class as the just-fixed `RenderInstitutionPortfolio` (#2597) and `RenderTopHoldersTable` (#2628) siblings. Filed as #2637.
- Test ships skipped — see GH-2637. Un-skip as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionSummaryCultureInvarianceTests.cs` — new `[Fact(Skip = "GH-2637 …")]` reflection-invoking the private static `RenderInstitutionSummary` under InvariantCulture and de-DE, asserting byte-identical output. Fails on current code (bug), will pass once the cells thread `InvariantCulture`.