### PR TITLE
fix(holdings): thread InvariantCulture through RenderInstitutionSummary metric cells

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -838,11 +838,21 @@ public class InstitutionalHoldingsTools
         result.AppendLine();
         result.AppendLine("| Metric | Value |");
         result.AppendLine("|--------|-------|");
-        result.AppendLine($"| Reported AUM | ${summary.ReportedAum:N0} |");
-        result.AppendLine($"| # Positions | {summary.PositionCount:N0} |");
-        result.AppendLine($"| Top 10 concentration | {summary.Top10ConcentrationPercent:F1}% |");
-        result.AppendLine($"| Top 25 concentration | {summary.Top25ConcentrationPercent:F1}% |");
-        result.AppendLine($"| QoQ turnover | {summary.QoQTurnoverPercent:F1}% |");
+        result.AppendLine(
+            $"| Reported AUM | ${summary.ReportedAum.ToString("N0", CultureInfo.InvariantCulture)} |"
+        );
+        result.AppendLine(
+            $"| # Positions | {summary.PositionCount.ToString("N0", CultureInfo.InvariantCulture)} |"
+        );
+        result.AppendLine(
+            $"| Top 10 concentration | {summary.Top10ConcentrationPercent.ToString("F1", CultureInfo.InvariantCulture)}% |"
+        );
+        result.AppendLine(
+            $"| Top 25 concentration | {summary.Top25ConcentrationPercent.ToString("F1", CultureInfo.InvariantCulture)}% |"
+        );
+        result.AppendLine(
+            $"| QoQ turnover | {summary.QoQTurnoverPercent.ToString("F1", CultureInfo.InvariantCulture)}% |"
+        );
         result.AppendLine($"| Quarters reported | {summary.QuartersReported} |");
         result.AppendLine();
         result.AppendLine(

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionSummaryCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionSummaryCultureInvarianceTests.cs
@@ -23,9 +23,7 @@ public class InstitutionalHoldingsToolsRenderInstitutionSummaryCultureInvariance
     // MCP output by host locale. The contract (repo convention; cf. FactMarkdown
     // threading InvariantCulture) is that the same call renders byte-identically
     // regardless of host CurrentCulture.
-    [Fact(
-        Skip = "GH-2637 — RenderInstitutionSummary :N0/:F1 metric cells follow CurrentCulture (de-DE → 1.234.567.890 / 12,3 vs Invariant 1,234,567,890 / 12.3); MCP output forks by host locale"
-    )]
+    [Fact]
     public void RenderInstitutionSummary_UnderNonInvariantCulture_RendersMetricCellsCultureInvariantly()
     {
         var holder = new InstitutionalHolder { Name = "ACME Capital" };


### PR DESCRIPTION
## Summary

- `RenderInstitutionSummary` built its metric cells with culture-implicit numeric format specifiers (`:N0` for Reported AUM / # Positions, `:F1` for the concentration and QoQ-turnover percentages), so they resolved through the thread `CurrentCulture`. Under a non-en-US host locale (e.g. de-DE) the thousand/decimal separators swapped, forking the `GetInstitutionSummary` MCP markdown by deploy locale and silently misleading LLM clients trained on en-US conventions.
- Fixes #2637. Same bug class as the already-fixed `RenderInstitutionPortfolio` (#2597) and `RenderTopHoldersTable` (#2628) siblings.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — thread `CultureInfo.InvariantCulture` through the five metric cells in `RenderInstitutionSummary` so the same arguments render byte-identically regardless of host culture.
- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionSummaryCultureInvarianceTests.cs` — un-skipped the regression test: renders the summary under Invariant and de-DE, asserts byte-equal output. Fails pre-fix, passes post-fix.