### PR TITLE
test(holdings): add skipped repro for GH-2641 — RenderSectorAllocationTable culture invariance

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderSectorAllocationTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderSectorAllocationTableCultureInvarianceTests.cs
@@ -1,0 +1,68 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class InstitutionalHoldingsToolsRenderSectorAllocationTableCultureInvarianceTests
+{
+    private static readonly MethodInfo RenderSectorAllocationTableMethod =
+        typeof(InstitutionalHoldingsTools).GetMethod(
+            "RenderSectorAllocationTable",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // RenderSectorAllocationTable builds each row's # Positions (:N0), Value $M
+    // (:N1) and % of Portfolio (:F1) with culture-implicit format specifiers that
+    // resolve through the thread CurrentCulture. Same bug class as the already-fixed
+    // RenderInstitutionPortfolio (GH-2597), RenderTopHoldersTable (GH-2628) and
+    // RenderInstitutionSummary (GH-2637) siblings in this class: de-DE swaps the
+    // thousand/decimal separators (1,234 → 1.234, 12,345.7 → 12.345,7, 42.3 → 42,3),
+    // forking the LLM-consumed MCP output by host locale. The contract (repo
+    // convention; cf. FactMarkdown threading InvariantCulture) is that the same call
+    // renders byte-identically regardless of host CurrentCulture.
+    [Fact(
+        Skip = "GH-2641 — RenderSectorAllocationTable :N0/:N1/:F1 row cells follow CurrentCulture (de-DE → 1.234 / 12.345,7 / 42,3 vs Invariant 1,234 / 12,345.7 / 42.3); MCP output forks by host locale"
+    )]
+    public void RenderSectorAllocationTable_UnderNonInvariantCulture_RendersRowCellsCultureInvariantly()
+    {
+        var holder = new InstitutionalHolder { Name = "ACME Capital" };
+        var targetDate = new DateOnly(2024, 12, 31);
+        var slices = new List<IndustryAllocationSlice>
+        {
+            new()
+            {
+                IndustryName = "Technology",
+                PositionCount = 1_234,
+                TotalValue = 12_345_678_900L,
+                PercentOfPortfolio = 42.34,
+            },
+        };
+        object[] args = [holder, targetDate, slices];
+
+        var original = CultureInfo.CurrentCulture;
+        string invariantOutput;
+        string deDeOutput;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            invariantOutput = (string)RenderSectorAllocationTableMethod.Invoke(null, args);
+
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            deDeOutput = (string)RenderSectorAllocationTableMethod.Invoke(null, args);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+
+        deDeOutput
+            .Should()
+            .Be(
+                invariantOutput,
+                "MCP markdown output is consumed by LLMs trained on en-US conventions; the :N0 / :N1 / :F1 row cells without an explicit IFormatProvider follow CurrentCulture (de-DE → 1.234 / 12.345,7 / 42,3), forking the response by host locale — same bug class as the RenderInstitutionPortfolio, RenderTopHoldersTable and RenderInstitutionSummary culture-invariance siblings"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial culture test on `InstitutionalHoldingsTools.RenderSectorAllocationTable` surfaced a latent defect: its `:N0`/`:N1`/`:F1` row cells follow the thread `CurrentCulture`, so a non-en-US host locale swaps the thousand/decimal separators and forks the `GetInstitutionSectorAllocation` MCP output by deploy locale.
- Same bug class as the fixed `RenderInstitutionPortfolio` (#2597), `RenderTopHoldersTable` (#2628) and `RenderInstitutionSummary` (#2637) siblings. Tracked in #2641.

## Code changes

- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderSectorAllocationTableCultureInvarianceTests.cs` — new regression test renders the table under Invariant and de-DE and asserts byte-equal output. Committed skipped — see GH-2641; un-skip as part of the fix.