### PR TITLE
fix(holdings): thread InvariantCulture through RenderSectorAllocationTable row cells

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -891,7 +891,7 @@ public class InstitutionalHoldingsTools
         {
             var s = slices[i];
             result.AppendLine(
-                $"| {i + 1} | {s.IndustryName} | {s.PositionCount:N0} | {s.TotalValue / 1_000_000m:N1} | {s.PercentOfPortfolio:F1}% |"
+                $"| {i + 1} | {s.IndustryName} | {s.PositionCount.ToString("N0", CultureInfo.InvariantCulture)} | {(s.TotalValue / 1_000_000m).ToString("N1", CultureInfo.InvariantCulture)} | {s.PercentOfPortfolio.ToString("F1", CultureInfo.InvariantCulture)}% |"
             );
         }
         return result.ToString();

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderSectorAllocationTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderSectorAllocationTableCultureInvarianceTests.cs
@@ -23,9 +23,7 @@ public class InstitutionalHoldingsToolsRenderSectorAllocationTableCultureInvaria
     // forking the LLM-consumed MCP output by host locale. The contract (repo
     // convention; cf. FactMarkdown threading InvariantCulture) is that the same call
     // renders byte-identically regardless of host CurrentCulture.
-    [Fact(
-        Skip = "GH-2641 — RenderSectorAllocationTable :N0/:N1/:F1 row cells follow CurrentCulture (de-DE → 1.234 / 12.345,7 / 42,3 vs Invariant 1,234 / 12,345.7 / 42.3); MCP output forks by host locale"
-    )]
+    [Fact]
     public void RenderSectorAllocationTable_UnderNonInvariantCulture_RendersRowCellsCultureInvariantly()
     {
         var holder = new InstitutionalHolder { Name = "ACME Capital" };


### PR DESCRIPTION
## Summary

- `RenderSectorAllocationTable` built each industry row with culture-implicit numeric format specifiers (`:N0` for # Positions, `:N1` for Value $M, `:F1` for % of Portfolio), so they resolved through the thread `CurrentCulture`. Under a non-en-US host locale (e.g. de-DE) the thousand/decimal separators swapped, forking the `GetInstitutionSectorAllocation` MCP markdown by deploy locale and silently misleading LLM clients trained on en-US conventions.
- Fixes #2641. Same bug class as the already-fixed `RenderInstitutionPortfolio` (#2597), `RenderTopHoldersTable` (#2628) and `RenderInstitutionSummary` (#2637) siblings.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — thread `CultureInfo.InvariantCulture` through the three per-row cells in `RenderSectorAllocationTable` so the same arguments render byte-identically regardless of host culture.
- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderSectorAllocationTableCultureInvarianceTests.cs` — un-skipped the regression test: renders the table under Invariant and de-DE, asserts byte-equal output. Fails pre-fix, passes post-fix.