### PR TITLE
feat(short-data): add GetLargestShortVolume market-wide ranking tool

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -219,6 +219,66 @@ public class ShortDataTools
         );
     }
 
+    [McpServerTool(Name = "GetLargestShortVolume")]
+    [Description(
+        "Get the stocks with the largest daily short volume for a single trading day (defaults to the latest available), sorted by short volume descending. Useful for spotting where short selling was most concentrated on a given day."
+    )]
+    public Task<string> GetLargestShortVolume(
+        [Description("Trading day in YYYY-MM-DD format (defaults to the latest available day)")]
+            string date = null,
+        [Description("Minimum short volume filter (default: 0)")] long minShortVolume = 0,
+        [Description("Maximum number of results to return (default: 50)")] int maxResults = 50
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var latestDate = await _shortVolumeRepository.GetLatestDate().FirstOrDefaultAsync();
+                if (latestDate == default)
+                    return "No short volume data available.";
+
+                var tradingDay = McpToolExecutor.ParseDateOr(date, latestDate);
+
+                var query = _shortVolumeRepository
+                    .GetByDate(tradingDay)
+                    .Include(d => d.CommonStock)
+                    .Where(d => d.TotalVolume > 0);
+
+                if (minShortVolume > 0)
+                {
+                    query = query.Where(d => d.ShortVolume >= minShortVolume);
+                }
+
+                var records = await query
+                    .OrderByDescending(d => d.ShortVolume)
+                    .Take(maxResults)
+                    .ToListAsync();
+
+                if (records.Count == 0)
+                    return $"No short volume data found for trading day {tradingDay:yyyy-MM-dd} with short volume >= {minShortVolume:N0}.";
+
+                var result = MarkdownTable.Start(
+                    $"Largest short volume — trading day {tradingDay:yyyy-MM-dd}:",
+                    "| Ticker | Short Volume | Exempt | Total Volume | Short % |",
+                    "|--------|-------------|--------|-------------|---------|"
+                );
+
+                foreach (var r in records)
+                {
+                    var shortPct =
+                        r.TotalVolume > 0 ? (double)r.ShortVolume / r.TotalVolume * 100 : 0;
+                    result.AppendLine(
+                        $"| {r.CommonStock.Ticker} | {r.ShortVolume:N0} | {r.ShortExemptVolume:N0} | {r.TotalVolume:N0} | {shortPct:F1}% |"
+                    );
+                }
+
+                return result.ToString();
+            },
+            "GetLargestShortVolume",
+            $"date: {date}"
+        );
+    }
+
     private static string FormatSignedChange(long change) =>
         change >= 0
             ? $"+{change.ToString("N0", CultureInfo.InvariantCulture)}"

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
@@ -441,4 +441,180 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
         result.Should().NotContain("99,999");
         result.Should().NotContain("2026-02-28");
     }
+
+    // ── GetLargestShortVolume ────────────────────────────────────────────
+
+    private static DailyShortVolume ShortVolume(
+        CommonStock stock,
+        DateOnly date,
+        long shortVolume,
+        long totalVolume,
+        long exemptVolume = 0
+    ) =>
+        new()
+        {
+            CommonStock = stock,
+            CommonStockId = stock.Id,
+            Date = date,
+            ShortVolume = shortVolume,
+            ShortExemptVolume = exemptVolume,
+            TotalVolume = totalVolume,
+            Market = "ALL",
+        };
+
+    [Fact]
+    public async Task GetLargestShortVolume_NoData_ReturnsEmptyMessage()
+    {
+        var result = await Sut().GetLargestShortVolume();
+
+        result.Should().Be("No short volume data available.");
+    }
+
+    [Fact]
+    public async Task GetLargestShortVolume_RanksByShortVolumeDescending()
+    {
+        var gme = GmeStock();
+        var amc = AmcStock();
+        DbContext.Set<CommonStock>().AddRange(gme, amc);
+        var day = new DateOnly(2026, 4, 2);
+        DbContext
+            .Set<DailyShortVolume>()
+            .AddRange(
+                ShortVolume(gme, day, shortVolume: 5_000_000, totalVolume: 8_000_000),
+                ShortVolume(amc, day, shortVolume: 9_000_000, totalVolume: 20_000_000)
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLargestShortVolume();
+
+        result.Should().Contain($"trading day {day:yyyy-MM-dd}");
+        // AMC has the larger short volume so it must rank above GME.
+        result.IndexOf("AMC").Should().BeLessThan(result.IndexOf("GME"));
+    }
+
+    [Fact]
+    public async Task GetLargestShortVolume_DefaultsToLatestTradingDay()
+    {
+        var gme = GmeStock();
+        DbContext.Set<CommonStock>().Add(gme);
+        DbContext
+            .Set<DailyShortVolume>()
+            .AddRange(
+                ShortVolume(gme, new DateOnly(2026, 4, 1), shortVolume: 1_000, totalVolume: 2_000),
+                ShortVolume(gme, new DateOnly(2026, 4, 2), shortVolume: 9_999, totalVolume: 20_000)
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLargestShortVolume();
+
+        result.Should().Contain("2026-04-02");
+        result.Should().Contain("9,999");
+        result.Should().NotContain("2026-04-01");
+    }
+
+    [Fact]
+    public async Task GetLargestShortVolume_ExplicitDate_OverridesLatest()
+    {
+        var gme = GmeStock();
+        DbContext.Set<CommonStock>().Add(gme);
+        DbContext
+            .Set<DailyShortVolume>()
+            .AddRange(
+                ShortVolume(gme, new DateOnly(2026, 4, 1), shortVolume: 1_234, totalVolume: 5_000),
+                ShortVolume(gme, new DateOnly(2026, 4, 2), shortVolume: 9_999, totalVolume: 20_000)
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLargestShortVolume(date: "2026-04-01");
+
+        result.Should().Contain("2026-04-01");
+        result.Should().Contain("1,234");
+        result.Should().NotContain("9,999");
+    }
+
+    [Fact]
+    public async Task GetLargestShortVolume_ComputesShortPercentage()
+    {
+        var gme = GmeStock();
+        DbContext.Set<CommonStock>().Add(gme);
+        DbContext
+            .Set<DailyShortVolume>()
+            .Add(
+                ShortVolume(
+                    gme,
+                    new DateOnly(2026, 4, 2),
+                    shortVolume: 750_000,
+                    totalVolume: 1_000_000
+                )
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLargestShortVolume();
+
+        result.Should().Contain("75.0%");
+    }
+
+    [Fact]
+    public async Task GetLargestShortVolume_MinShortVolumeFiltersResults()
+    {
+        var gme = GmeStock();
+        var amc = AmcStock();
+        DbContext.Set<CommonStock>().AddRange(gme, amc);
+        var day = new DateOnly(2026, 4, 2);
+        DbContext
+            .Set<DailyShortVolume>()
+            .AddRange(
+                ShortVolume(gme, day, shortVolume: 5_000_000, totalVolume: 8_000_000),
+                ShortVolume(amc, day, shortVolume: 100_000, totalVolume: 500_000)
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLargestShortVolume(minShortVolume: 1_000_000);
+
+        result.Should().Contain("GME");
+        result.Should().NotContain("AMC");
+    }
+
+    [Fact]
+    public async Task GetLargestShortVolume_ExcludesZeroTotalVolume()
+    {
+        var gme = GmeStock();
+        var amc = AmcStock();
+        DbContext.Set<CommonStock>().AddRange(gme, amc);
+        var day = new DateOnly(2026, 4, 2);
+        DbContext
+            .Set<DailyShortVolume>()
+            .AddRange(
+                ShortVolume(gme, day, shortVolume: 5_000_000, totalVolume: 8_000_000),
+                ShortVolume(amc, day, shortVolume: 1_000, totalVolume: 0)
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLargestShortVolume();
+
+        result.Should().Contain("GME");
+        result.Should().NotContain("AMC");
+    }
+
+    [Fact]
+    public async Task GetLargestShortVolume_MaxResultsLimitsRows()
+    {
+        var gme = GmeStock();
+        var amc = AmcStock();
+        DbContext.Set<CommonStock>().AddRange(gme, amc);
+        var day = new DateOnly(2026, 4, 2);
+        DbContext
+            .Set<DailyShortVolume>()
+            .AddRange(
+                ShortVolume(gme, day, shortVolume: 5_000_000, totalVolume: 8_000_000),
+                ShortVolume(amc, day, shortVolume: 9_000_000, totalVolume: 20_000_000)
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetLargestShortVolume(maxResults: 1);
+
+        // Only the top-ranked stock (AMC) is retained.
+        result.Should().Contain("AMC");
+        result.Should().NotContain("GME");
+    }
 }


### PR DESCRIPTION
## Summary

- PR 1 of 2 implementing #2644. Adds a market-wide `GetLargestShortVolume` tool that ranks stocks by daily short volume for a single trading day (defaulting to the latest available), mirroring the existing short interest snapshot.
- Does **not** close the issue — the web browser page lands in PR 2 (Refs #2644).

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — new `GetLargestShortVolume` tool: resolves the trading day (explicit `date` override or latest available), ranks stocks by short volume descending, supports a minimum short volume filter and a result cap, excludes zero-total-volume rows, and reports each stock's short-volume percentage.
- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs` — 7 tests covering empty data, descending ranking, latest-day default, explicit-date override, short-percentage computation, minimum-volume filter, zero-volume exclusion, and the result cap.