### PR TITLE
fix(holdings): thread InvariantCulture through RenderOverlapTable cells

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1150,10 +1150,18 @@ public class InstitutionalHoldingsTools
         result.AppendLine();
         result.AppendLine("| Metric | Value |");
         result.AppendLine("|--------|-------|");
-        result.AppendLine($"| Union positions | {overlap.UnionPositionCount:N0} |");
-        result.AppendLine($"| Shared positions | {overlap.IntersectionPositionCount:N0} |");
-        result.AppendLine($"| Jaccard similarity | {overlap.JaccardSimilarityPercent:F1}% |");
-        result.AppendLine($"| $-weighted overlap | {overlap.DollarWeightedOverlapPercent:F1}% |");
+        result.AppendLine(
+            $"| Union positions | {overlap.UnionPositionCount.ToString("N0", CultureInfo.InvariantCulture)} |"
+        );
+        result.AppendLine(
+            $"| Shared positions | {overlap.IntersectionPositionCount.ToString("N0", CultureInfo.InvariantCulture)} |"
+        );
+        result.AppendLine(
+            $"| Jaccard similarity | {overlap.JaccardSimilarityPercent.ToString("F1", CultureInfo.InvariantCulture)}% |"
+        );
+        result.AppendLine(
+            $"| $-weighted overlap | {overlap.DollarWeightedOverlapPercent.ToString("F1", CultureInfo.InvariantCulture)}% |"
+        );
         result.AppendLine();
 
         if (overlap.Rows.Count == 0)
@@ -1175,7 +1183,7 @@ public class InstitutionalHoldingsTools
             var a = row.Slices[0];
             var b = row.Slices[1];
             result.AppendLine(
-                $"| {i + 1} | {row.Ticker} | {row.Name} | {(a.Shares > 0 ? a.Shares.ToString("N0") : "—")} | {(a.Value > 0 ? a.PercentOfPortfolio.ToString("F1") + "%" : "—")} | {(b.Shares > 0 ? b.Shares.ToString("N0") : "—")} | {(b.Value > 0 ? b.PercentOfPortfolio.ToString("F1") + "%" : "—")} | {row.CombinedValue / 1_000_000m:N1} |"
+                $"| {i + 1} | {row.Ticker} | {row.Name} | {(a.Shares > 0 ? a.Shares.ToString("N0", CultureInfo.InvariantCulture) : "—")} | {(a.Value > 0 ? a.PercentOfPortfolio.ToString("F1", CultureInfo.InvariantCulture) + "%" : "—")} | {(b.Shares > 0 ? b.Shares.ToString("N0", CultureInfo.InvariantCulture) : "—")} | {(b.Value > 0 ? b.PercentOfPortfolio.ToString("F1", CultureInfo.InvariantCulture) + "%" : "—")} | {(row.CombinedValue / 1_000_000m).ToString("N1", CultureInfo.InvariantCulture)} |"
             );
         }
         return result.ToString();

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderOverlapTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderOverlapTableCultureInvarianceTests.cs
@@ -25,9 +25,7 @@ public class InstitutionalHoldingsToolsRenderOverlapTableCultureInvarianceTests
     // locale. The contract (repo convention; cf. FactMarkdown threading
     // InvariantCulture) is that the same call renders byte-identically regardless
     // of host CurrentCulture.
-    [Fact(
-        Skip = "GH-2647 — RenderOverlapTable :N0/:F1/:N1 and provider-less .ToString(\"N0\")/.ToString(\"F1\") cells follow CurrentCulture (de-DE swaps thousand/decimal separators); MCP output forks by host locale"
-    )]
+    [Fact]
     public void RenderOverlapTable_UnderNonInvariantCulture_RendersCellsCultureInvariantly()
     {
         var holder1 = new InstitutionalHolder { Name = "ACME Capital" };


### PR DESCRIPTION
## Summary

- `RenderOverlapTable` built its summary cells (`:N0` union / shared positions, `:F1` Jaccard / $-weighted overlap) and per-row cells (provider-less `.ToString("N0")` / `.ToString("F1")` for A/B shares and percentages, `:N1` Combined $M) with culture-implicit formatting, so they resolved through the thread `CurrentCulture`. Under a non-en-US host locale (e.g. de-DE) the thousand/decimal separators swapped, forking the `GetFundOverlap` MCP markdown by deploy locale and silently misleading LLM clients trained on en-US conventions.
- Fixes #2647. Same bug class as the already-fixed `RenderInstitutionPortfolio` (#2597), `RenderTopHoldersTable` (#2628), `RenderInstitutionSummary` (#2637) and `RenderSectorAllocationTable` (#2641) siblings.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — thread `CultureInfo.InvariantCulture` through the four summary cells and the per-row shares/percentage/combined cells in `RenderOverlapTable`.
- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderOverlapTableCultureInvarianceTests.cs` — un-skipped the regression test: renders the overlap table under Invariant and de-DE, asserts byte-equal output. Fails pre-fix, passes post-fix.