### PR TITLE
test(web): add skipped repro for GH-2654 — DateOptionTagHelper culture-dependent option value

### DIFF
--- a/tests/Equibles.UnitTests/Web/DateOptionTagHelperCultureTests.cs
+++ b/tests/Equibles.UnitTests/Web/DateOptionTagHelperCultureTests.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using Equibles.Web.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.UnitTests.Web;
+
+// Lane A (adversarial): the rendered <option value> is posted back and parsed
+// as a date server-side, so it must be a culture-invariant ISO-8601 Gregorian
+// date. Thai culture defaults to the Buddhist calendar (year + 543), so a
+// culture-dependent ToString would emit "2567-01-15" and break the round-trip.
+public class DateOptionTagHelperCultureTests
+{
+    [Fact(Skip = "GH-2654 — DateOptionTagHelper emits option value in the host-locale calendar")]
+    public void Process_UnderNonGregorianCulture_EmitsInvariantIsoDateValue()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("th-TH");
+
+            var sut = new DateOptionTagHelper { Date = new DateOnly(2024, 1, 15) };
+            var context = new TagHelperContext(
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                "test-id"
+            );
+            var output = new TagHelperOutput(
+                "date-option",
+                new TagHelperAttributeList(),
+                (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent())
+            );
+
+            sut.Process(context, output);
+
+            output.Attributes["value"].Value.Should().Be("2024-01-15");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test capturing that `DateOptionTagHelper` should render the `<option value>` as a culture-invariant ISO-8601 Gregorian date.
- The test currently fails — it reproduces GH-2654, where a non-Gregorian host calendar (Thai Buddhist `th-TH`) produces `value="2567-01-15"` instead of `2024-01-15`, breaking the posted-back date round-trip. Committed as `[Skip]` until the fix lands.

## Code changes

- `tests/Equibles.UnitTests/Web/DateOptionTagHelperCultureTests.cs` — new unit test asserting the option `value` stays `2024-01-15` under `th-TH`; marked `[Fact(Skip = "GH-2654 …")]` (skipped — see GH-2654). Un-skip as part of the fix.