### PR TITLE
fix(mcp): parse ParseDateOr dates with InvariantCulture

### DIFF
--- a/src/Equibles.Mcp/McpToolExecutor.cs
+++ b/src/Equibles.Mcp/McpToolExecutor.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 
 namespace Equibles.Mcp;
@@ -5,7 +6,15 @@ namespace Equibles.Mcp;
 public static class McpToolExecutor
 {
     public static DateOnly ParseDateOr(string text, DateOnly fallback) =>
-        !string.IsNullOrEmpty(text) && DateOnly.TryParse(text, out var parsed) ? parsed : fallback;
+        !string.IsNullOrEmpty(text)
+        && DateOnly.TryParse(
+            text,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var parsed
+        )
+            ? parsed
+            : fallback;
 
     public static (DateOnly Start, DateOnly End) ParseDateRange(
         string startText,

--- a/tests/Equibles.UnitTests/Mcp/McpToolExecutorParseDateOrHijriCultureTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpToolExecutorParseDateOrHijriCultureTests.cs
@@ -23,7 +23,7 @@ public class McpToolExecutorParseDateOrHijriCultureTests
     // default range. The sibling unparseable-input test pins "returns
     // fallback"; this pins that a *valid* ISO date round-trips regardless
     // of host culture.
-    [Fact(Skip = "GH-2640 — ParseDateOr omits InvariantCulture; ISO dates misparse under ar-SA")]
+    [Fact]
     public void ParseDateOr_IsoDateUnderHijriCulture_ReturnsParsedDate()
     {
         var fallback = new DateOnly(1999, 12, 31);


### PR DESCRIPTION
## Summary

- `McpToolExecutor.ParseDateOr` parsed ISO date arguments with `DateOnly.TryParse` and no `IFormatProvider`, so dates were interpreted against the thread's current calendar.
- On a non-Gregorian-calendar host (e.g. `ar-SA` / Umm al-Qura) a valid ISO date such as `2024-01-15` failed to round-trip and the helper silently fell back to the default range — every MCP `fromDate`/`toDate` collapsed to the caller's fallback, quietly returning a window the caller never asked for.

## Code changes

- `src/Equibles.Mcp/McpToolExecutor.cs` — pass `CultureInfo.InvariantCulture` + `DateTimeStyles.None` to `DateOnly.TryParse`, matching the sibling parse helpers (Fred, Holdings, Disclosure) and `NormalizeTicker`.
- `tests/Equibles.UnitTests/Mcp/McpToolExecutorParseDateOrHijriCultureTests.cs` — un-skip the regression test that pins ISO round-trip under `ar-SA`.

closes #2640