### PR TITLE
test(holdings): add skipped repro for GH-2660 — RenderConsensusHoldingsTable host-locale digit separators

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderConsensusHoldingsTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderConsensusHoldingsTableCultureInvarianceTests.cs
@@ -1,0 +1,70 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class InstitutionalHoldingsToolsRenderConsensusHoldingsTableCultureInvarianceTests
+{
+    private static readonly MethodInfo RenderConsensusHoldingsTableMethod =
+        typeof(InstitutionalHoldingsTools).GetMethod(
+            "RenderConsensusHoldingsTable",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // RenderConsensusHoldingsTable interpolates the Combined ($M) cell
+    // ({CombinedValue / 1_000_000m:N1}) with no IFormatProvider, so it formats
+    // through the thread CurrentCulture. Same bug class as the already-fixed
+    // RenderOverlapTable (GH-2647/#2651), RenderInstitutionSummary (GH-2637) and
+    // RenderSectorAllocationTable (GH-2641) siblings. The repo convention (cf.
+    // FactMarkdown threading InvariantCulture) is that the same call renders
+    // byte-identically regardless of host CurrentCulture.
+    [Fact(Skip = "GH-2660 — RenderConsensusHoldingsTable emits host-locale digit separators")]
+    public void RenderConsensusHoldingsTable_UnderNonInvariantCulture_RendersCellsCultureInvariantly()
+    {
+        var holders = new List<InstitutionalHolder>
+        {
+            new() { Name = "ACME Capital", Cik = "0000001" },
+        };
+        var missing = new List<string>();
+        var selected = new DateOnly(2024, 12, 31);
+        var rowsWithConsensus = new List<(FundOverlapRow Row, int HeldBy)>
+        {
+            (
+                new FundOverlapRow
+                {
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    CombinedValue = 9_876_500_000L,
+                },
+                1
+            ),
+        };
+        object[] args = [holders, missing, selected, rowsWithConsensus];
+
+        var original = CultureInfo.CurrentCulture;
+        string invariantOutput;
+        string deDeOutput;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            invariantOutput = (string)RenderConsensusHoldingsTableMethod.Invoke(null, args);
+
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            deDeOutput = (string)RenderConsensusHoldingsTableMethod.Invoke(null, args);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+
+        deDeOutput
+            .Should()
+            .Be(
+                invariantOutput,
+                "MCP markdown output is consumed by LLMs trained on en-US conventions; the Combined ($M) :N1 cell follows CurrentCulture (de-DE swaps the thousand/decimal separators), forking the response by host locale — same bug class as the RenderOverlapTable, RenderInstitutionSummary and RenderSectorAllocationTable culture-invariance siblings"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test asserting `RenderConsensusHoldingsTable` renders its Combined ($M) cell byte-identically regardless of host culture.
- The test currently fails — it reproduces GH-2660, where the `{CombinedValue / 1_000_000m:N1}` cell follows `CurrentCulture`, so `de-DE` swaps the thousand/decimal separators (`9.876,5` vs `9,876.5`) and forks the LLM-consumed MCP output by host locale. Committed as `[Skip]` until the fix lands.

## Code changes

- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderConsensusHoldingsTableCultureInvarianceTests.cs` — new unit test invoking the private static render method under `InvariantCulture` and `de-DE` and asserting equal output; marked `[Fact(Skip = "GH-2660 …")]` (skipped — see GH-2660). Distinct from the signed-millions cells tracked by #2658; this is the `:N1` Combined ($M) cell. Same bug class as the already-fixed `RenderOverlapTable` / `RenderInstitutionSummary` siblings. Un-skip as part of the fix.