### PR TITLE
refactor(mcp): collapse duplicated nullable-format-or-dash expressions into McpFormat.OrDash

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -76,10 +76,10 @@ public class CboeTools
 
                 foreach (var r in records.OrderBy(r => r.Date))
                 {
-                    var callStr = r.CallVolume?.ToString("N0") ?? "—";
-                    var putStr = r.PutVolume?.ToString("N0") ?? "—";
-                    var totalStr = r.TotalVolume?.ToString("N0") ?? "—";
-                    var ratioStr = r.PutCallRatio?.ToString("F2") ?? "—";
+                    var callStr = McpFormat.OrDash(r.CallVolume, "N0");
+                    var putStr = McpFormat.OrDash(r.PutVolume, "N0");
+                    var totalStr = McpFormat.OrDash(r.TotalVolume, "N0");
+                    var ratioStr = McpFormat.OrDash(r.PutCallRatio, "F2");
                     result.AppendLine(
                         $"| {r.Date:yyyy-MM-dd} | {callStr} | {putStr} | {totalStr} | {ratioStr} |"
                     );

--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -152,8 +152,8 @@ public class CftcTools
 
                     latestReports.TryGetValue(contract.Id, out var report);
 
-                    var dateStr = report?.ReportDate.ToString("yyyy-MM-dd") ?? "—";
-                    var oiStr = report?.OpenInterest.ToString("N0") ?? "—";
+                    var dateStr = McpFormat.OrDash(report?.ReportDate, "yyyy-MM-dd");
+                    var oiStr = McpFormat.OrDash(report?.OpenInterest, "N0");
                     var commNet =
                         report != null ? (report.CommLong - report.CommShort).ToString("N0") : "—";
                     var nonCommNet =

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -146,8 +146,8 @@ public class ShortDataTools
                 foreach (var r in records.OrderBy(r => r.SettlementDate))
                 {
                     var changeStr = FormatSignedChange(r.ChangeInShortPosition);
-                    var advStr = r.AverageDailyVolume?.ToString("N0") ?? "—";
-                    var dtcStr = r.DaysToCover?.ToString("F1") ?? "—";
+                    var advStr = McpFormat.OrDash(r.AverageDailyVolume, "N0");
+                    var dtcStr = McpFormat.OrDash(r.DaysToCover, "F1");
                     result.AppendLine(
                         $"| {r.SettlementDate:yyyy-MM-dd} | {r.CurrentShortPosition:N0} | {changeStr} | {advStr} | {dtcStr} |"
                     );
@@ -206,7 +206,7 @@ public class ShortDataTools
                 foreach (var r in records)
                 {
                     var changeStr = FormatSignedChange(r.ChangeInShortPosition);
-                    var advStr = r.AverageDailyVolume?.ToString("N0") ?? "—";
+                    var advStr = McpFormat.OrDash(r.AverageDailyVolume, "N0");
                     result.AppendLine(
                         $"| {r.CommonStock.Ticker} | {r.CurrentShortPosition:N0} | {changeStr} | {advStr} | {r.DaysToCover:F1} |"
                     );

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -152,8 +152,8 @@ public class FredTools
 
                     latestObservations.TryGetValue(series.Id, out var latestObs);
 
-                    var dateStr = latestObs?.Date.ToString("yyyy-MM-dd") ?? "—";
-                    var valueStr = latestObs?.Value?.ToString("G") ?? "—";
+                    var dateStr = McpFormat.OrDash(latestObs?.Date, "yyyy-MM-dd");
+                    var valueStr = McpFormat.OrDash(latestObs?.Value, "G");
 
                     result.AppendLine(
                         $"| {series.SeriesId} | {series.Title} | {dateStr} | {valueStr} | {series.Units} |"

--- a/src/Equibles.Mcp/Helpers/McpFormat.cs
+++ b/src/Equibles.Mcp/Helpers/McpFormat.cs
@@ -1,0 +1,12 @@
+namespace Equibles.Mcp.Helpers;
+
+public static class McpFormat
+{
+    private const string Dash = "—";
+
+    // Formats a nullable value with the given format string, or the em-dash placeholder when null.
+    // A null format provider resolves to CurrentCulture, matching a direct value.ToString(format) call.
+    public static string OrDash<T>(T? value, string format)
+        where T : struct, IFormattable =>
+        value.HasValue ? value.Value.ToString(format, null) : Dash;
+}


### PR DESCRIPTION
## Summary

- The pattern `value?.ToString(format) ?? "—"` for rendering a nullable value (or an em-dash placeholder when null) was duplicated across four MCP tool modules.
- Collapsed all 12 occurrences into a single generic helper, `McpFormat.OrDash`, alongside the existing `MarkdownTable` helper in `Equibles.Mcp.Helpers`.

## Code changes

- `src/Equibles.Mcp/Helpers/McpFormat.cs` — new public static helper; `OrDash<T>(T? value, string format)` returns `value.Value.ToString(format, null)` or the em-dash placeholder. A null format provider resolves to `CurrentCulture`, matching the previous direct `ToString(format)` calls exactly.
- `src/Equibles.Cboe.Mcp/Tools/CboeTools.cs` — 4 call/put/total volume and ratio cells.
- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — 4 average-daily-volume and days-to-cover cells.
- `src/Equibles.Fred.Mcp/Tools/FredTools.cs` — 2 latest-observation date and value cells.
- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs` — 2 report-date and open-interest cells.

Behavior is unchanged: the rendered output is identical. Verified by the existing MCP-tool rendering integration tests (67 passing).