### PR TITLE
fix(holdings-mcp): render consensus-holdings Combined ($M) cell culture-invariantly

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1290,7 +1290,7 @@ public class InstitutionalHoldingsTools
         {
             var x = rowsWithConsensus[i];
             result.AppendLine(
-                $"| {i + 1} | {x.Row.Ticker} | {x.Row.Name} | {x.HeldBy}/{holders.Count} | {x.Row.CombinedValue / 1_000_000m:N1} |"
+                $"| {i + 1} | {x.Row.Ticker} | {x.Row.Name} | {x.HeldBy}/{holders.Count} | {(x.Row.CombinedValue / 1_000_000m).ToString("N1", CultureInfo.InvariantCulture)} |"
             );
         }
         return result.ToString();

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderConsensusHoldingsTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderConsensusHoldingsTableCultureInvarianceTests.cs
@@ -21,7 +21,7 @@ public class InstitutionalHoldingsToolsRenderConsensusHoldingsTableCultureInvari
     // RenderSectorAllocationTable (GH-2641) siblings. The repo convention (cf.
     // FactMarkdown threading InvariantCulture) is that the same call renders
     // byte-identically regardless of host CurrentCulture.
-    [Fact(Skip = "GH-2660 — RenderConsensusHoldingsTable emits host-locale digit separators")]
+    [Fact]
     public void RenderConsensusHoldingsTable_UnderNonInvariantCulture_RendersCellsCultureInvariantly()
     {
         var holders = new List<InstitutionalHolder>


### PR DESCRIPTION
## Summary

- `InstitutionalHoldingsTools.RenderConsensusHoldingsTable` interpolated the Combined ($M) cell with a bare `:N1` specifier, so it formatted through the thread `CurrentCulture`.
- Under a comma-decimal locale (e.g. `de-DE`) the thousand/decimal separators swap, so the MCP markdown — consumed by LLMs trained on en-US conventions — forked by host locale.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — format the Combined ($M) cell via `.ToString("N1", CultureInfo.InvariantCulture)`, matching the already-fixed sibling render methods in the same file.
- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderConsensusHoldingsTableCultureInvarianceTests.cs` — un-skip the regression test asserting byte-identical output under `de-DE` and invariant culture.

closes #2660