### PR TITLE
test(holdings): add skipped repro for GH-2677 — TryParseReportDate host-culture parse

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsTryParseReportDateCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsTryParseReportDateCultureInvarianceTests.cs
@@ -1,0 +1,41 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.Holdings.Mcp.Tools;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class InstitutionalHoldingsToolsTryParseReportDateCultureInvarianceTests
+{
+    // TryParseReportDate parses the LLM-supplied `reportDate` MCP argument via
+    // DateOnly.TryParse(input, out result) with no InvariantCulture. The
+    // tool's reportDate is an ISO yyyy-MM-dd quarter end (e.g. "2024-06-30"),
+    // so it must resolve identically on any host — the sibling McpToolExecutor
+    // date parsing was already moved to InvariantCulture (#2661). Under th-TH
+    // (ThaiBuddhist, +543-year era) the ambient parser reads "2024" as a
+    // Buddhist-era year (-> 1481 CE); the parsed date then fails the
+    // validDates Contains() check in ResolveReportDate, so the caller's
+    // explicit quarter selection is silently dropped to the latest filing.
+    [Fact(Skip = "GH-2677 — reportDate MCP arg parsed with host culture, not InvariantCulture")]
+    public void TryParseReportDate_IsoQuarterEndUnderThaiBuddhistCulture_ResolvesGregorianDate()
+    {
+        var method = typeof(InstitutionalHoldingsTools).GetMethod(
+            "TryParseReportDate",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var previous = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo("th-TH");
+        try
+        {
+            var args = new object[] { "2024-06-30", null };
+            var parsed = (bool)method!.Invoke(null, args);
+
+            parsed.Should().BeTrue();
+            ((DateOnly)args[1]).Should().Be(new DateOnly(2024, 6, 30));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial (Lane A) test that **found a real bug**: `InstitutionalHoldingsTools.TryParseReportDate` parses the LLM-supplied `reportDate` MCP arg with `DateOnly.TryParse(input, out result)` and no `InvariantCulture`.
- Under `th-TH` (ThaiBuddhist calendar) the ISO quarter end `2024-06-30` parses to `1481-06-30`; it then fails `ResolveReportDate`'s `validDates.Contains` check, so the caller's explicit quarter is silently dropped to the latest filing. Sibling `McpToolExecutor` parsing was already fixed to Invariant (#2661).
- Tracked in GH-2677. Committed `[Skip]` (no production change here) — un-skip as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsTryParseReportDateCultureInvarianceTests.cs` — new `[Fact(Skip = "GH-2677 …")]`. Reflection-invokes the private static `TryParseReportDate` under `th-TH` with `"2024-06-30"` and asserts the out date is `2024-06-30`. Verified to fail (`1481-06-30`) before skipping — skipped pending the fix in GH-2677.