### PR TITLE
test(web): pin StatisticsExtensions.ComputeSma trailing-window alignment

### DIFF
--- a/tests/Equibles.UnitTests/Web/StatisticsExtensionsComputeSmaWindowAlignmentTests.cs
+++ b/tests/Equibles.UnitTests/Web/StatisticsExtensionsComputeSmaWindowAlignmentTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class StatisticsExtensionsComputeSmaWindowAlignmentTests
+{
+    // Contract: ComputeSma is "aligned to the input"; positions before the first
+    // full window are null, and each subsequent position is the average of the
+    // `period` values ENDING at that index (a trailing SMA, the standard for a
+    // price chart whose latest point reflects the most recent window). For
+    // [1,2,3,4,5] period 2 the trailing windows are (1,2),(2,3),(3,4),(4,5), so
+    // index 0 is null and indices 1..4 are 1.5/2.5/3.5/4.5. A forward-looking or
+    // misaligned moving average would shift these and silently mislabel every
+    // SMA point on the chart by one bar.
+    [Fact]
+    public void ComputeSma_TrailingWindowOverShortSeries_AlignsAveragesToWindowEnd()
+    {
+        double[] values = [1, 2, 3, 4, 5];
+
+        var sma = values.ComputeSma(period: 2, digits: 2);
+
+        sma.Should().Equal(new decimal?[] { null, 1.5m, 2.5m, 3.5m, 4.5m });
+    }
+}


### PR DESCRIPTION
## Summary

- Coverage/contract pin (Lane A, passed) for `StatisticsExtensions.ComputeSma`: the documented "aligned to the input; positions before the first full window are null" contract had no normal-case alignment test — only the period-larger-than-input degenerate case.
- Confirms each non-null SMA point is the trailing average of the `period` values **ending** at that index. A forward-looking or off-by-one window would silently mislabel every SMA point on the market/VIX charts by one bar; this guards against that regression.

## Code changes

- `tests/Equibles.UnitTests/Web/StatisticsExtensionsComputeSmaWindowAlignmentTests.cs` — new `[Fact]`. `[1,2,3,4,5]` period 2 → asserts `[null, 1.5, 2.5, 3.5, 4.5]`.