### PR TITLE
fix(holdings-mcp): format FormatSignedShares with InvariantCulture

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1335,7 +1335,8 @@ public class InstitutionalHoldingsTools
     // Raw dollar values rendered in $millions with an explicit leading +/- sign.
     // `+` for positive deltas; N0 already emits `-` for negatives.
     private static string FormatSignedShares<T>(T value)
-        where T : INumber<T> => (value > T.Zero ? "+" : "") + value.ToString("N0", null);
+        where T : INumber<T> =>
+        (value > T.Zero ? "+" : "") + value.ToString("N0", CultureInfo.InvariantCulture);
 
     // Uses the ambient culture to match the previous inline formatting; see #2658 for the
     // pending switch to InvariantCulture (the other cells here are already invariant).

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsFormatSignedSharesCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsFormatSignedSharesCultureInvarianceTests.cs
@@ -19,7 +19,7 @@ public class InstitutionalHoldingsToolsFormatSignedSharesCultureInvarianceTests
     // file is invariant, so the contract is that a share count renders
     // byte-identically regardless of host CurrentCulture (en-US grouping). This
     // attacks the culture/encoding risk surface under de-DE.
-    [Fact(Skip = "GH-2675 — FormatSignedShares passes null IFormatProvider; share counts misformat under de-DE")]
+    [Fact]
     public void FormatSignedShares_UnderNonInvariantCulture_RendersInvariantGrouping()
     {
         var original = CultureInfo.CurrentCulture;


### PR DESCRIPTION
## Summary

- `InstitutionalHoldingsTools.FormatSignedShares<T>` passed `null` as the `IFormatProvider` to `ToString("N0")`, so the shared Δ Shares formatter followed the thread `CurrentCulture`.
- Under a comma-decimal locale (e.g. `de-DE`) share counts rendered as `+1.234.567` instead of `+1,234,567` across `GetMarketWide13FActivity`, `GetTopBuyersSellers` and `GetInstitutionQuarterlyActivity`, forking the MCP markdown by host locale.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — pass `CultureInfo.InvariantCulture` to the `ToString("N0", …)` call, matching the `FormatMillions` sibling and the rest of the file's invariant cells.
- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsFormatSignedSharesCultureInvarianceTests.cs` — un-skip the regression test asserting byte-identical output under `de-DE` and invariant culture.

closes #2675