### PR TITLE
test(holdings): add skipped repro for GH-2681 — RenderTopHoldersTable date calendar

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableDateCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableDateCalendarTests.cs
@@ -1,0 +1,68 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class InstitutionalHoldingsToolsRenderTopHoldersTableDateCalendarTests
+{
+    private static readonly MethodInfo RenderTopHoldersTableMethod =
+        typeof(InstitutionalHoldingsTools).GetMethod(
+            "RenderTopHoldersTable",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // RenderTopHoldersTable renders its "as of {targetDate:yyyy-MM-dd}" header
+    // with no IFormatProvider, so the date formats through the thread
+    // CurrentCulture's calendar. The digit-separator sibling test pins de-DE
+    // (a Gregorian-calendar locale, so the date is unaffected); this attacks
+    // the orthogonal calendar axis. Under th-TH (Buddhist, year + 543) the
+    // header must still be the Gregorian ISO date — same bug class as the
+    // DateOptionTagHelper calendar issue (GH-2654).
+    [Fact(Skip = "GH-2681 — RenderTopHoldersTable date header uses host-locale calendar under th-TH")]
+    public void RenderTopHoldersTable_UnderNonGregorianCalendar_RendersGregorianIsoDate()
+    {
+        var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
+        var holder = new InstitutionalHolder { Name = "ACME Capital" };
+        var holdings = new List<InstitutionalHolding>
+        {
+            new()
+            {
+                InstitutionalHolder = holder,
+                Shares = 1_234_567,
+                Value = 1_234_567_890L,
+            },
+        };
+        object[] args =
+        [
+            stock,
+            "AAPL",
+            new DateOnly(2024, 12, 31),
+            3,
+            9_876_543L,
+            9_876_543_210L,
+            holdings,
+        ];
+
+        var original = CultureInfo.CurrentCulture;
+        string output;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("th-TH");
+            output = (string)RenderTopHoldersTableMethod.Invoke(null, args);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+
+        output
+            .Should()
+            .Contain(
+                "as of 2024-12-31:",
+                "the report date must be a Gregorian ISO-8601 date regardless of host calendar; under th-TH the bare :yyyy-MM-dd specifier renders the Buddhist year 2567 instead of 2024"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test discovered an untracked calendar bug: `InstitutionalHoldingsTools.RenderTopHoldersTable` renders its `as of {targetDate:yyyy-MM-dd}` header with no `IFormatProvider`, so under a non-Gregorian-calendar locale (`th-TH`, Buddhist) the header emits `as of 2567-12-31:` instead of `2024-12-31:`.
- This is the calendar axis the existing digit-separator culture tests missed (they pin `de-DE`, a Gregorian-calendar locale). Filed as #2681.

## Code changes

- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderTopHoldersTableDateCalendarTests.cs` — new `[Fact(Skip)]` asserting the header stays Gregorian ISO under `th-TH`. Skipped — see GH-2681.