### PR TITLE
refactor(sec-mcp): build company-documents table via shared MarkdownTable.Start

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -1,10 +1,10 @@
 using System.ComponentModel;
-using System.Text;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
 using Equibles.Sec.BusinessLogic.Search;
 using Equibles.Sec.BusinessLogic.Search.Models;
 using Equibles.Sec.Data.Models;
@@ -162,13 +162,11 @@ public class RagSearchTools
                     return $"No documents found for ticker {ticker}";
                 }
 
-                var result = new StringBuilder();
-                result.AppendLine(
-                    $"Financial documents for {documents.First().CompanyName} ({ticker}) — page {page}:"
+                var result = MarkdownTable.Start(
+                    $"Financial documents for {documents.First().CompanyName} ({ticker}) — page {page}:",
+                    "ID | Type | Filed | Reporting For | Lines",
+                    "---|------|-------|---------------|------"
                 );
-                result.AppendLine();
-                result.AppendLine("ID | Type | Filed | Reporting For | Lines");
-                result.AppendLine("---|------|-------|---------------|------");
 
                 foreach (var doc in documents)
                 {


### PR DESCRIPTION
## Summary

- `ListCompanyDocuments` hand-rolled the same `new StringBuilder()` + title / blank-line / header / separator sequence that the shared `MarkdownTable.Start` helper already provides (and which the sibling `FailToDeliverTools` in this module already uses). Route it through the helper to remove the duplicated preamble and prevent drift.
- Behavior-preserving: `MarkdownTable.Start` emits the identical four lines in the same order; rendered output is byte-identical (verified by the existing unit and integration tests that assert the tool's output).

## Code changes

- `src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs` — replace the inline `StringBuilder` table preamble in `ListCompanyDocuments` with `MarkdownTable.Start`; add the `Equibles.Mcp.Helpers` using and drop the now-unused `System.Text` using.