### PR TITLE
fix(holdings-mcp): format FormatSignedMillions with InvariantCulture

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1336,10 +1336,10 @@ public class InstitutionalHoldingsTools
     private static string FormatSignedShares<T>(T value)
         where T : INumber<T> => (value > T.Zero ? "+" : "") + FormatWholeNumber(value);
 
-    // Uses the ambient culture to match the previous inline formatting; see #2658 for the
-    // pending switch to InvariantCulture (the other cells here are already invariant).
+    // Signed $millions with one decimal place, invariant culture (matches FormatMillions
+    // and the rest of this file; MCP markdown must not fork the separators by host locale).
     private static string FormatSignedMillions(decimal value) =>
-        (value / 1_000_000m).ToString("+#,##0.0;-#,##0.0;0.0");
+        (value / 1_000_000m).ToString("+#,##0.0;-#,##0.0;0.0", CultureInfo.InvariantCulture);
 
     // Raw dollar values rendered in $millions with one decimal place, invariant culture.
     private static string FormatMillions(decimal value) =>

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsFormatSignedMillionsCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsFormatSignedMillionsCultureInvarianceTests.cs
@@ -1,0 +1,52 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.Holdings.Mcp.Tools;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class InstitutionalHoldingsToolsFormatSignedMillionsCultureInvarianceTests
+{
+    private static readonly MethodInfo FormatSignedMillionsMethod =
+        typeof(InstitutionalHoldingsTools).GetMethod(
+            "FormatSignedMillions",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static string Invoke(decimal value) =>
+        (string)FormatSignedMillionsMethod.Invoke(null, [value]);
+
+    // FormatSignedMillions is the shared Δ Value ($M) formatter feeding the
+    // delta-value cells across GetInstitutionQuarterlyActivity, GetTopBuyersSellers,
+    // GetMarketWide13FActivity and GetMostHeldStocks. It applies the custom format
+    // "+#,##0.0;-#,##0.0;0.0" with no IFormatProvider, so it follows CurrentCulture.
+    // Its sibling FormatMillions threads InvariantCulture and every other numeric
+    // cell in this file is invariant, so the contract is byte-identical output
+    // regardless of host CurrentCulture. This attacks the culture risk surface under de-DE.
+    [Fact]
+    public void FormatSignedMillions_UnderNonInvariantCulture_RendersInvariantSeparators()
+    {
+        var original = CultureInfo.CurrentCulture;
+        string invariantOutput;
+        string deDeOutput;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            invariantOutput = Invoke(1_234_500_000m);
+
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            deDeOutput = Invoke(1_234_500_000m);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+
+        invariantOutput.Should().Be("+1,234.5");
+        deDeOutput
+            .Should()
+            .Be(
+                invariantOutput,
+                "MCP markdown is consumed by LLMs trained on en-US conventions; FormatSignedMillions omits the IFormatProvider, so it follows CurrentCulture (de-DE swaps the group/decimal separators to +1.234,5), forking the response by host locale — same bug class as the FormatMillions invariant sibling"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- `InstitutionalHoldingsTools.FormatSignedMillions` applied the custom `+#,##0.0;-#,##0.0;0.0` format with no `IFormatProvider`, so the shared Δ Value ($M) formatter followed the thread `CurrentCulture`.
- Under a comma-decimal locale (e.g. `de-DE`) the delta-value cells across `GetInstitutionQuarterlyActivity`, `GetTopBuyersSellers`, `GetMarketWide13FActivity` and `GetMostHeldStocks` rendered as `+1.234,5` instead of `+1,234.5`, forking the MCP markdown by host locale.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — pass `CultureInfo.InvariantCulture` to the `FormatSignedMillions` `ToString` call (and refresh the now-accurate comment), matching the `FormatMillions` sibling.
- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsFormatSignedMillionsCultureInvarianceTests.cs` — new regression test (reflection over the shared helper) asserting byte-identical output under `de-DE` and invariant culture.

closes #2658