### PR TITLE
test(sec): pin CurrencyConsolidationStep.RemoveCurrencySymbols word-boundary code removal

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepRemoveCurrencySymbolsWordBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepRemoveCurrencySymbolsWordBoundaryTests.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class CurrencyConsolidationStepRemoveCurrencySymbolsWordBoundaryTests
+{
+    // RemoveCurrencySymbols must strip a currency symbol ($) and a STANDALONE
+    // ISO code (USD) while preserving an acronym that merely embeds the code
+    // (USDA). The code removal uses a \bUSD\b word-boundary regex, not a plain
+    // Replace — a plain Replace would shred "USDA" into "A". Same word-boundary
+    // contract DetectCurrency relies on, but on the removal path.
+    [Fact]
+    public void RemoveCurrencySymbols_AcronymEmbeddingCode_PreservesAcronymAndStripsSymbol()
+    {
+        var method = typeof(CurrencyConsolidationStep).GetMethod(
+            "RemoveCurrencySymbols",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var step = new CurrencyConsolidationStep();
+
+        var result = (string)method.Invoke(step, ["USDA $5"]);
+
+        // "$" stripped; "USDA" left intact (no \bUSD\b boundary inside it).
+        result.Should().Be("USDA 5");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `RemoveCurrencySymbols`: it strips a currency symbol ($) and a standalone ISO code (USD) while preserving an acronym that merely embeds the code (USDA), via a `\bUSD\b` word-boundary regex. A plain `Replace("USD", "")` would shred "USDA" into "A".
- The removal path had no direct test (the existing substring test only covers detection, which returns null for acronyms and never reaches removal). Adversarial test derived from the contract; passes.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepRemoveCurrencySymbolsWordBoundaryTests.cs` — new unit test. Reflection-invokes the private `RemoveCurrencySymbols("USDA $5")` and asserts the result is `"USDA 5"` ($ stripped, USDA preserved). No production code touched.