### PR TITLE
test(sec): pin TableNormalizationStep.FixColspan expands colspan to N cells

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepFixColspanCellCountTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepFixColspanCellCountTests.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class TableNormalizationStepFixColspanCellCountTests
+{
+    // FixColspan must expand colspan=N into exactly N sibling cells (the
+    // original plus N-1 new empties), preserving the original's content. The
+    // existing pin only checks the attribute is removed; an off-by-one in the
+    // `for (i=1; i<colspanValue)` loop (too few/many cells) would pass that yet
+    // corrupt the grid. Tested in isolation because Execute's later
+    // RemoveEmptyColumns deletes the inserted empties, masking the count.
+    [Fact]
+    public void FixColspan_ColspanOfThree_ExpandsToThreeCellsPreservingContent()
+    {
+        var parser = new HtmlParser();
+        var doc = parser.ParseDocument(
+            "<html><body><table><tr><td colspan=\"3\">A</td></tr></table></body></html>"
+        );
+        var table = doc.QuerySelector("table");
+        var step = new TableNormalizationStep(parser);
+        var method = typeof(TableNormalizationStep).GetMethod(
+            "FixColspan",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+        method.Invoke(step, [table, doc]);
+
+        var cells = table.QuerySelectorAll("td");
+        cells.Length.Should().Be(3);
+        cells[0].TextContent.Should().Be("A");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `FixColspan`'s expansion contract: a `colspan=N` cell must become exactly N sibling cells (the original plus N-1 empties), preserving the original's content. The existing pin only asserted the attribute was removed — an off-by-one in the expansion loop would pass that yet corrupt the grid.
- Tested in isolation via reflection because `Execute`'s later `RemoveEmptyColumns` deletes the inserted empty cells, masking the count when run end-to-end.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepFixColspanCellCountTests.cs` — new unit test. Reflection-invokes the private `FixColspan` on a `<td colspan="3">A</td>` row and asserts the row has exactly 3 `td` cells with the first still containing "A". No production code touched.