### PR TITLE
test(sec): pin TableNormalizationStep.FixRowspan multi-row placeholder insertion

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepFixRowspanMultiRowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepFixRowspanMultiRowTests.cs
@@ -1,0 +1,47 @@
+using System.Reflection;
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class TableNormalizationStepFixRowspanMultiRowTests
+{
+    // FixRowspan must drop a placeholder into EACH of the next N-1 rows at the
+    // spanned column. Every existing rowspan pin uses rowspan=2 (one following
+    // row), so the loop's second-and-later iterations are unexercised — a bug
+    // that stops after the first row, or mis-advances `nextRow`, would slip
+    // through. Isolated via reflection so Execute's later empty-row/column
+    // removal doesn't delete the placeholders before they can be asserted.
+    [Fact]
+    public void FixRowspan_RowspanOfThree_InsertsPlaceholderInBothFollowingRows()
+    {
+        var parser = new HtmlParser();
+        var doc = parser.ParseDocument(
+            "<html><body><table>"
+                + "<tr><td rowspan=\"3\">A</td><td>B</td></tr>"
+                + "<tr><td>C</td><td>D</td></tr>"
+                + "<tr><td>E</td><td>F</td></tr>"
+                + "</table></body></html>"
+        );
+        var table = doc.QuerySelector("table");
+        var step = new TableNormalizationStep(parser);
+        var method = typeof(TableNormalizationStep).GetMethod(
+            "FixRowspan",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+        method.Invoke(step, [table, doc]);
+
+        var rows = table.QuerySelectorAll("tr").ToList();
+        var secondRowCells = rows[1].QuerySelectorAll("td").ToList();
+        var thirdRowCells = rows[2].QuerySelectorAll("td").ToList();
+
+        // Both following rows gain a leading placeholder at the spanned column 0.
+        secondRowCells.Should().HaveCount(3);
+        secondRowCells[0].TextContent.Should().BeNullOrWhiteSpace();
+        secondRowCells[1].TextContent.Should().Be("C");
+        thirdRowCells.Should().HaveCount(3);
+        thirdRowCells[0].TextContent.Should().BeNullOrWhiteSpace();
+        thirdRowCells[1].TextContent.Should().Be("E");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `FixRowspan`'s multi-row contract: a `rowspan=N` cell must drop a placeholder into each of the next N-1 rows at the spanned column. Every existing rowspan pin uses `rowspan=2` (one following row), leaving the loop's second-and-later iterations unexercised.
- Tested in isolation via reflection so `Execute`'s later empty-row/column removal doesn't delete the placeholders before they can be asserted.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepFixRowspanMultiRowTests.cs` — new unit test. Reflection-invokes the private `FixRowspan` on a 3-row table whose first row has `rowspan="3"` in column 0, and asserts both following rows gain a leading placeholder (3 cells each, cell[0] empty, original content shifted to cell[1]). No production code touched.