### PR TITLE
test(web): pin DateOnlyListExtensions.ResolveSelectedDateOrFirst fallback semantics

### DIFF
--- a/tests/Equibles.UnitTests/Web/DateOnlyListExtensionsResolveSelectedDateOrFirstTests.cs
+++ b/tests/Equibles.UnitTests/Web/DateOnlyListExtensionsResolveSelectedDateOrFirstTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class DateOnlyListExtensionsResolveSelectedDateOrFirstTests
+{
+    // Contract: return the requested date when it appears in the list, otherwise
+    // the first (latest) entry. The load-bearing part is the Contains guard — an
+    // absent requested value must fall back to the first, NOT pass through; and a
+    // present-but-not-first value must be honored, NOT collapse to the first.
+    [Fact]
+    public void ResolveSelectedDateOrFirst_AbsentRequestedFallsBackToFirst_PresentRequestedHonored()
+    {
+        var available = new List<DateOnly> { new(2024, 9, 30), new(2024, 6, 30), new(2024, 3, 31) };
+
+        // Present but not first → returned as-is (proves it isn't hard-wired to [0]).
+        available
+            .ResolveSelectedDateOrFirst(new DateOnly(2024, 3, 31))
+            .Should()
+            .Be(new DateOnly(2024, 3, 31));
+        // Absent → falls back to the first/latest entry (proves the Contains guard).
+        available
+            .ResolveSelectedDateOrFirst(new DateOnly(2020, 1, 1))
+            .Should()
+            .Be(new DateOnly(2024, 9, 30));
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `ResolveSelectedDateOrFirst`: it returns the requested date when present in the list and otherwise falls back to the first (latest) entry. The `Contains` guard is load-bearing — an absent requested value must not pass through, and a present-but-not-first value must not collapse to the first.
- The method had no test coverage (only its sibling `PreviousFrom` was tested). Adversarial test derived from the contract; passes.

## Code changes

- `tests/Equibles.UnitTests/Web/DateOnlyListExtensionsResolveSelectedDateOrFirstTests.cs` — new unit test. Over a latest-first list, asserts a present-but-not-first date is returned as-is and an absent date falls back to the first entry. No production code touched.