### PR TITLE
test(web): pin Pagination.PageCount floor-of-1 and remainder round-up

### DIFF
--- a/tests/Equibles.UnitTests/Web/PaginationPageCountFloorAndRemainderTests.cs
+++ b/tests/Equibles.UnitTests/Web/PaginationPageCountFloorAndRemainderTests.cs
@@ -1,0 +1,18 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class PaginationPageCountFloorAndRemainderTests
+{
+    // Sibling to the exact-multiple pin (20/10 -> 2). Two untested arms:
+    // the floor-of-1 (an empty dataset must still report 1 page, never 0) and
+    // the ceiling round-up on a partial last page (21 items over 10 -> 3, not 2).
+    [Fact]
+    public void PageCount_EmptyDatasetFloorsToOne_PartialLastPageRoundsUp()
+    {
+        // Floor: 0 items must not collapse to 0 pages (the page picker needs >=1).
+        Pagination.PageCount(totalCount: 0, pageSize: 10).Should().Be(1);
+        // Ceiling: a remainder rounds up to an extra page.
+        Pagination.PageCount(totalCount: 21, pageSize: 10).Should().Be(3);
+    }
+}


### PR DESCRIPTION
## Summary

- Extends `PageCount` coverage to its two untested arms: the floor-of-1 (an empty dataset must report 1 page, never 0) and the ceiling round-up on a partial last page (21 items over 10 → 3). The existing pin only covered the exact-multiple case (20/10 → 2).

## Code changes

- `tests/Equibles.UnitTests/Web/PaginationPageCountFloorAndRemainderTests.cs` — new unit test asserting `PageCount(0, 10) == 1` and `PageCount(21, 10) == 3`. No production code touched.