### PR TITLE
test(web): pin Pagination.Page one-based slice arithmetic

### DIFF
--- a/tests/Equibles.UnitTests/Web/PaginationPageSliceTests.cs
+++ b/tests/Equibles.UnitTests/Web/PaginationPageSliceTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class PaginationPageSliceTests
+{
+    // Page is 1-based: Page(2, 10) must skip the first page and return the
+    // second slice (items 10..19), not 0..9 (page treated as 0-based) nor
+    // 20..29 (double-skip). Pins the Skip((page-1)*pageSize) arithmetic.
+    [Fact]
+    public void Page_SecondPage_ReturnsExactlyThatPageSlice()
+    {
+        var source = Enumerable.Range(0, 30).AsQueryable();
+
+        var pageTwo = source.Page(page: 2, pageSize: 10).ToList();
+
+        pageTwo.Should().HaveCount(10);
+        pageTwo.Should().Equal(Enumerable.Range(10, 10));
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `Page<T>` extension's 1-based slicing: `Page(2, 10)` over 30 items must return items 10..19 — not 0..9 (page treated as 0-based) nor 20..29 (double-skip). Guards the `Skip((page-1)*pageSize)` arithmetic.
- The extension had no test coverage (only the sibling `PageCount` was tested).

## Code changes

- `tests/Equibles.UnitTests/Web/PaginationPageSliceTests.cs` — new unit test over an in-memory `IQueryable` of 0..29 asserting `Page(2, 10)` yields exactly `[10..19]`. No production code touched.