### PR TITLE
test(web): pin SignedFormatting.ToStringWithSign positive-only prefix

### DIFF
--- a/tests/Equibles.UnitTests/Web/SignedFormattingToStringWithSignTests.cs
+++ b/tests/Equibles.UnitTests/Web/SignedFormattingToStringWithSignTests.cs
@@ -1,0 +1,17 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class SignedFormattingToStringWithSignTests
+{
+    // Contract: a leading "+" is added only for positive values; negatives keep
+    // the format's own "-" (never "+-"), and zero is unsigned. Format "0" avoids
+    // grouping separators so the assertion is culture-independent.
+    [Fact]
+    public void ToStringWithSign_PrefixesPositiveOnly_NegativeAndZeroUnprefixed()
+    {
+        5.ToStringWithSign("0").Should().Be("+5");
+        (-5).ToStringWithSign("0").Should().Be("-5");
+        0.ToStringWithSign("0").Should().Be("0");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `ToStringWithSign`: a leading "+" is added only for positive values; negatives keep the format's own "-" (never "+-") and zero is unsigned.
- The extension had no test coverage. Format "0" keeps the assertion culture-independent (no grouping separators).

## Code changes

- `tests/Equibles.UnitTests/Web/SignedFormattingToStringWithSignTests.cs` — new unit test asserting `5 -> "+5"`, `-5 -> "-5"`, `0 -> "0"`. No production code touched.