### PR TITLE
fix(sec): parse master.idx DateFiled with InvariantCulture

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -529,7 +530,14 @@ public class SecEdgarClient : ISecEdgarClient
             FormType = formType,
             CompanyName = company,
             Cik = cik,
-            DateFiled = DateOnly.TryParse(dateFiled, out var d) ? d : fallbackDate,
+            DateFiled = DateOnly.TryParse(
+                dateFiled,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var d
+            )
+                ? d
+                : fallbackDate,
             AccessionNumber = accession,
         };
         return true;

--- a/tests/Equibles.UnitTests/Integrations/Sec/SecEdgarClientTryParseMasterIndexLineHijriCultureTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/Sec/SecEdgarClientTryParseMasterIndexLineHijriCultureTests.cs
@@ -25,9 +25,7 @@ public class SecEdgarClientTryParseMasterIndexLineHijriCultureTests
     // stamped with the wrong filing date on a Hijri-locale host. Pin: a valid
     // ISO DateFiled round-trips regardless of thread culture (fallback is set
     // distinct so a fallback substitution is visible).
-    [Fact(
-        Skip = "GH-2649 — TryParseMasterIndexLine omits InvariantCulture; ISO DateFiled misparses under ar-SA"
-    )]
+    [Fact]
     public void TryParseMasterIndexLine_IsoDateFiledUnderHijriCulture_UsesParsedDateNotFallback()
     {
         const string line =


### PR DESCRIPTION
## Summary

- `SecEdgarClient.TryParseMasterIndexLine` parsed the ISO `DateFiled` column of EDGAR's daily `master.idx` with `DateOnly.TryParse` and no `IFormatProvider`, so it parsed against the thread's current calendar.
- Under a non-Gregorian-calendar host (e.g. `ar-SA` / Umm al-Qura) a valid ISO date like `2024-11-14` failed to parse and `DateFiled` silently fell back to the daily-index file date — stamping every 13F-HR row in the sweep with the wrong filing date and corrupting downstream consumers that key on or order by it.

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — pass `CultureInfo.InvariantCulture` + `DateTimeStyles.None` to `DateOnly.TryParse`, matching the sibling date helpers. The malformed-row fallback arm stays pinned by `SecEdgarClientTryParseMasterIndexLineMalformedDateTests`.
- `tests/Equibles.UnitTests/Integrations/Sec/SecEdgarClientTryParseMasterIndexLineHijriCultureTests.cs` — un-skip the regression test asserting a valid ISO `DateFiled` round-trips under `ar-SA`.

closes #2649