### PR TITLE
refactor(web): extract duplicated QuarterFirstOwned enrichment into shared helper

### DIFF
--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -134,15 +134,7 @@ public class StockTabService
         );
 
         var allChanges = grouped.SelectMany(g => g.Value).ToList();
-        var holderIds = allChanges.Select(h => h.InstitutionalHolderId).Distinct().ToList();
-        var firstOwned = await _institutionalHoldingRepository
-            .GetFirstOwnedQuarters(stock, holderIds)
-            .ToDictionaryAsync(kv => kv.Key, kv => kv.Value);
-        foreach (var change in allChanges)
-        {
-            if (firstOwned.TryGetValue(change.InstitutionalHolderId, out var quarter))
-                change.QuarterFirstOwned = quarter;
-        }
+        await ApplyQuarterFirstOwned(stock, allChanges);
 
         var bucketCounts = grouped.ToDictionary(g => g.Key, g => g.Value.Count);
         var (topBuyers, topSellers) = HoldingsTopMoversSelector.Select(
@@ -213,15 +205,7 @@ public class StockTabService
             })
             .ToList();
 
-        var holderIds = holders.Select(h => h.InstitutionalHolderId).Distinct().ToList();
-        var firstOwned = await _institutionalHoldingRepository
-            .GetFirstOwnedQuarters(stock, holderIds)
-            .ToDictionaryAsync(kv => kv.Key, kv => kv.Value);
-        foreach (var holder in holders)
-        {
-            if (firstOwned.TryGetValue(holder.InstitutionalHolderId, out var quarter))
-                holder.QuarterFirstOwned = quarter;
-        }
+        await ApplyQuarterFirstOwned(stock, holders);
 
         var grouped = new Dictionary<PositionChangeType, List<HolderPositionChange>>
         {
@@ -556,6 +540,20 @@ public class StockTabService
             Holder = holder,
             Holdings = holdings,
         };
+    }
+
+    // Stamp each holder's first-owned quarter for this stock via one batched lookup.
+    private async Task ApplyQuarterFirstOwned(CommonStock stock, List<HolderPositionChange> changes)
+    {
+        var holderIds = changes.Select(h => h.InstitutionalHolderId).Distinct().ToList();
+        var firstOwned = await _institutionalHoldingRepository
+            .GetFirstOwnedQuarters(stock, holderIds)
+            .ToDictionaryAsync(kv => kv.Key, kv => kv.Value);
+        foreach (var change in changes)
+        {
+            if (firstOwned.TryGetValue(change.InstitutionalHolderId, out var quarter))
+                change.QuarterFirstOwned = quarter;
+        }
     }
 
     private Task<List<InstitutionalHolding>> LoadHoldingsByStockWithHolder(


### PR DESCRIPTION
## Summary

- `LoadHoldingsTab` and `LoadHoldingsCombinedTab` each contained the same block that resolves every holder's first-owned quarter for the stock and stamps it onto the position-change rows.
- Collapsed the two identical blocks into one private `ApplyQuarterFirstOwned` helper. Behavior is unchanged — the helper is the exact moved code, called with the same list at the same point in each method.

## Code changes

- `src/Equibles.Web/Services/StockTabService.cs` — added private `ApplyQuarterFirstOwned(CommonStock, List<HolderPositionChange>)` helper (batched `GetFirstOwnedQuarters` lookup + per-row stamping); replaced the two inline copies with calls to it.