### PR TITLE
test(web): pin Pagination.ClampPage floors non-positive pages to 1

### DIFF
--- a/tests/Equibles.UnitTests/Web/PaginationClampPageTests.cs
+++ b/tests/Equibles.UnitTests/Web/PaginationClampPageTests.cs
@@ -1,0 +1,18 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class PaginationClampPageTests
+{
+    // Contract: a non-positive page is clamped to 1. A page < 1 would make
+    // Skip((page-1)*pageSize) negative, which PostgreSQL rejects (22023) and
+    // surfaces as an HTTP 500 — so 0 and negatives must floor to 1, while a
+    // valid page passes through unchanged.
+    [Fact]
+    public void ClampPage_NonPositivePagesFloorToOne_ValidPagePassesThrough()
+    {
+        Pagination.ClampPage(0).Should().Be(1);
+        Pagination.ClampPage(-5).Should().Be(1);
+        Pagination.ClampPage(3).Should().Be(3);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `ClampPage`: a non-positive page is floored to 1, a valid page passes through. A page < 1 would make `Skip((page-1)*pageSize)` negative, which PostgreSQL rejects (22023) and surfaces as HTTP 500 — this guards that input-sanitization boundary.
- The method had no test coverage. Adversarial test derived from the documented contract; passes.

## Code changes

- `tests/Equibles.UnitTests/Web/PaginationClampPageTests.cs` — new unit test asserting `ClampPage(0)==1`, `ClampPage(-5)==1`, `ClampPage(3)==3`. No production code touched.