### PR TITLE
fix(sec): prune archive files with InvariantCulture date parsing

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -296,7 +296,12 @@ public class SecEdgarClient : ISecEdgarClient
             // Skip archive files whose date range is entirely outside the requested window
             if (
                 fromDate.HasValue
-                && DateOnly.TryParse(archiveFile.FilingTo, out var archiveTo)
+                && DateOnly.TryParse(
+                    archiveFile.FilingTo,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var archiveTo
+                )
                 && archiveTo < fromDate.Value
             )
             {
@@ -310,7 +315,12 @@ public class SecEdgarClient : ISecEdgarClient
 
             if (
                 toDate.HasValue
-                && DateOnly.TryParse(archiveFile.FilingFrom, out var archiveFrom)
+                && DateOnly.TryParse(
+                    archiveFile.FilingFrom,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var archiveFrom
+                )
                 && archiveFrom > toDate.Value
             )
             {

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientGetArchiveFilingsToDateSkipCultureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientGetArchiveFilingsToDateSkipCultureTests.cs
@@ -16,9 +16,7 @@ public class SecEdgarClientGetArchiveFilingsToDateSkipCultureTests
     // host calendar (ar-SA) the ISO date fails to parse, the skip guard
     // short-circuits, and the out-of-window archive is fetched anyway —
     // needless SEC load. The contract is host-culture-independent pruning.
-    [Fact(
-        Skip = "GH-2706 — GetArchiveFilings prune parses filingFrom/filingTo with host culture under ar-SA"
-    )]
+    [Fact]
     public async Task GetCompanyFilings_ArchiveFileAfterToDate_UnderHijriCulture_StillSkipsWithoutFetch()
     {
         var json =


### PR DESCRIPTION
## Summary

- `SecEdgarClient.GetCompanyFilings` prunes out-of-window SEC archive files by parsing their ISO `filingFrom`/`filingTo` with `DateOnly.TryParse` and no `IFormatProvider`.
- Under a non-Gregorian-calendar host (e.g. `ar-SA` / Umm al-Qura) the ISO dates failed to parse, the skip guard short-circuited, and every out-of-window archive was fetched anyway — needless SEC API load and rate-limit risk on Hijri-locale hosts.

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — pass `CultureInfo.InvariantCulture` + `DateTimeStyles.None` to both archive-window-prune `DateOnly.TryParse` calls, matching the sibling date helpers.
- `tests/Equibles.UnitTests/Sec/SecEdgarClientGetArchiveFilingsToDateSkipCultureTests.cs` — un-skip the regression test asserting the prune fires (one HTTP call, no extra fetch) under `ar-SA`.

closes #2706