### PR TITLE
fix(holdings-mcp): parse reportDate arg with InvariantCulture

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1369,7 +1369,13 @@ public class InstitutionalHoldingsTools
     private static bool TryParseReportDate(string input, out DateOnly result)
     {
         result = default;
-        return !string.IsNullOrEmpty(input) && DateOnly.TryParse(input, out result);
+        return !string.IsNullOrEmpty(input)
+            && DateOnly.TryParse(
+                input,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out result
+            );
     }
 
     private static DateOnly ResolveReportDate(string input, IReadOnlyList<DateOnly> validDates) =>

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsTryParseReportDateCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsTryParseReportDateCultureInvarianceTests.cs
@@ -15,7 +15,7 @@ public class InstitutionalHoldingsToolsTryParseReportDateCultureInvarianceTests
     // Buddhist-era year (-> 1481 CE); the parsed date then fails the
     // validDates Contains() check in ResolveReportDate, so the caller's
     // explicit quarter selection is silently dropped to the latest filing.
-    [Fact(Skip = "GH-2677 — reportDate MCP arg parsed with host culture, not InvariantCulture")]
+    [Fact]
     public void TryParseReportDate_IsoQuarterEndUnderThaiBuddhistCulture_ResolvesGregorianDate()
     {
         var method = typeof(InstitutionalHoldingsTools).GetMethod(


### PR DESCRIPTION
## Summary

- `InstitutionalHoldingsTools.TryParseReportDate` parsed the LLM-supplied `reportDate` MCP argument with `DateOnly.TryParse` and no `IFormatProvider`.
- The arg is an ISO `yyyy-MM-dd` quarter end, so under a non-Gregorian-calendar host (e.g. `th-TH`, ThaiBuddhist) `2024-06-30` parsed as a Buddhist-era year (1481 CE). The wrong date then failed the `validDates` lookup in `ResolveReportDate`, silently dropping the caller's explicit quarter selection to the latest filing.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — pass `CultureInfo.InvariantCulture` + `DateTimeStyles.None` to `DateOnly.TryParse`, matching the sibling `McpToolExecutor` date parsing (#2661).
- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsTryParseReportDateCultureInvarianceTests.cs` — un-skip the regression test asserting an ISO quarter end resolves to the Gregorian date under `th-TH`.

closes #2677