### PR TITLE
fix(web): render DateOptionTagHelper dates with InvariantCulture

### DIFF
--- a/src/Equibles.Web/TagHelpers/DateOptionTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/DateOptionTagHelper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace Equibles.Web.TagHelpers;
@@ -15,9 +16,12 @@ public class DateOptionTagHelper : TagHelper
     {
         output.TagName = "option";
         output.TagMode = TagMode.StartTagAndEndTag;
-        output.Attributes.SetAttribute("value", Date.ToString("yyyy-MM-dd"));
+        output.Attributes.SetAttribute(
+            "value",
+            Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
+        );
         if (Selected)
             output.Attributes.SetAttribute("selected", "selected");
-        output.Content.SetContent(Date.ToString("MMM dd, yyyy"));
+        output.Content.SetContent(Date.ToString("MMM dd, yyyy", CultureInfo.InvariantCulture));
     }
 }

--- a/tests/Equibles.UnitTests/Web/DateOptionTagHelperCultureTests.cs
+++ b/tests/Equibles.UnitTests/Web/DateOptionTagHelperCultureTests.cs
@@ -10,7 +10,7 @@ namespace Equibles.UnitTests.Web;
 // culture-dependent ToString would emit "2567-01-15" and break the round-trip.
 public class DateOptionTagHelperCultureTests
 {
-    [Fact(Skip = "GH-2654 — DateOptionTagHelper emits option value in the host-locale calendar")]
+    [Fact]
     public void Process_UnderNonGregorianCulture_EmitsInvariantIsoDateValue()
     {
         var original = CultureInfo.CurrentCulture;


### PR DESCRIPTION
## Summary

- `DateOptionTagHelper` formatted the `<option>` value (`yyyy-MM-dd`) and display content (`MMM dd, yyyy`) with the ambient `CurrentCulture`.
- The value is posted back and parsed server-side as a date, so on a non-Gregorian-calendar host (e.g. `th-TH`, Buddhist) it rendered `2567-01-15` instead of `2024-01-15`, breaking the date round-trip.

## Code changes

- `src/Equibles.Web/TagHelpers/DateOptionTagHelper.cs` — format both the value attribute and the display content with `CultureInfo.InvariantCulture`.
- `tests/Equibles.UnitTests/Web/DateOptionTagHelperCultureTests.cs` — un-skip the regression test asserting the ISO value under `th-TH`.

closes #2654