### PR TITLE
test(sec): pin TryExtractPaperPdfFilename skips unsafe block, returns later safe pdf

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserUnsafeThenSafePdfTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserUnsafeThenSafePdfTests.cs
@@ -1,0 +1,47 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentEnvelopeParserUnsafeThenSafePdfTests
+{
+    [Fact]
+    public void TryExtractPaperPdfFilename_UnsafePdfInFirstBlockThenSafePdfInSecond_ReturnsSafeFilename()
+    {
+        // A traversal `.pdf` in an earlier DOCUMENT block must `continue` the scan,
+        // not abort it — otherwise an injected first-block filename suppresses a
+        // legitimate paper PDF (and the safe later block must still be returned).
+        var envelope = """
+            <SEC-DOCUMENT>
+            <SEC-HEADER>
+            </SEC-HEADER>
+            <DOCUMENT>
+            <TYPE>EX-99
+            <SEQUENCE>1
+            <FILENAME>../../etc/passwd.pdf
+            <DESCRIPTION>Hostile attachment
+            <TEXT>
+            </TEXT>
+            </DOCUMENT>
+            <DOCUMENT>
+            <TYPE>6-K
+            <SEQUENCE>2
+            <FILENAME>form6k.pdf
+            <DESCRIPTION>Form 6-K
+            <TEXT>
+            begin 644 form6k.pdf
+            (uuencoded body)
+            end
+            </TEXT>
+            </DOCUMENT>
+            </SEC-DOCUMENT>
+            """;
+
+        var success = SecDocumentEnvelopeParser.TryExtractPaperPdfFilename(
+            envelope,
+            out var filename
+        );
+
+        success.Should().BeTrue();
+        filename.Should().Be("form6k.pdf");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins a previously untested branch of `SecDocumentEnvelopeParser.TryExtractPaperPdfFilename`: when an earlier DOCUMENT block carries a traversal `.pdf` filename, the scan must `continue` and still return a legitimate `.pdf` in a later block.
- Existing tests cover single-block traversal rejection and "pdf in second block" only when the first block is a non-pdf (cover.htm); neither exercises the `continue`-after-`IsSafeFilename` path. This prevents an injected hostile first-block filename from suppressing a real paper PDF.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserUnsafeThenSafePdfTests.cs` — new unit test feeding an envelope whose first block has `../../etc/passwd.pdf` and second block has `form6k.pdf`, asserting the parser returns `form6k.pdf`.