### PR TITLE
test(congress): pin SplitContinuation keeps whole trailing dollar range as amount

### DIFF
--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientSplitContinuationRangeTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientSplitContinuationRangeTests.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class HouseDisclosureClientSplitContinuationRangeTests
+{
+    // SplitContinuation's contract: the amount is "always the trailing $… run",
+    // so a wrapped amount range carrying two '$' (e.g. "$1,000,001 - $5,000,000")
+    // must be returned WHOLE as the amount — splitting at the last '$' instead of
+    // the first would corrupt both the asset text and the amount range.
+    [Fact]
+    public void SplitContinuation_AssetThenAmountRangeWithTwoDollars_KeepsWholeRangeAsAmount()
+    {
+        var method = typeof(HouseDisclosureClient).GetMethod(
+            "SplitContinuation",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = method!.Invoke(null, ["Acme Corp Bonds $1,000,001 - $5,000,000"]);
+        var (asset, amount) = ((string, string))result;
+
+        asset.Should().Be("Acme Corp Bonds");
+        amount.Should().Be("$1,000,001 - $5,000,000");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `HouseDisclosureClient.SplitContinuation`, the continuation-line splitter that separates wrapped asset text from a wrapped amount.
- Its contract is "the amount is always the trailing `$…` run". This pins that a wrapped amount range carrying two `$` (e.g. `$1,000,001 - $5,000,000`) is returned whole as the amount — guarding against a refactor that splits at the last `$` instead of the first, which would corrupt both the asset and amount.

## Code changes

- `tests/Equibles.UnitTests/Congress/HouseDisclosureClientSplitContinuationRangeTests.cs` — new unit test reflection-invoking the private `SplitContinuation` with `"Acme Corp Bonds $1,000,001 - $5,000,000"`, asserting `asset == "Acme Corp Bonds"` and `amount == "$1,000,001 - $5,000,000"`.