### PR TITLE
fix(cboe): treat \" as string delimiter in optionsData brace walk

### DIFF
--- a/src/Equibles.Integrations.Cboe/CboeClient.cs
+++ b/src/Equibles.Integrations.Cboe/CboeClient.cs
@@ -171,24 +171,18 @@ public class CboeClient : ICboeClient
 
         var depth = 0;
         var inString = false;
-        var escaped = false;
         var end = -1;
         for (var i = start; i < html.Length; i++)
         {
             var c = html[i];
-            if (escaped)
+            if (c == '\\' && i + 1 < html.Length)
             {
-                escaped = false;
-                continue;
-            }
-            if (c == '\\')
-            {
-                escaped = true;
-                continue;
-            }
-            if (c == '"')
-            {
-                inString = !inString;
+                // String delimiters in the double-escaped RSC payload appear as \" .
+                // Toggle string context on \" ; skip any other escape (\\, \n, …)
+                // whole so its payload can't be misread as a structural brace.
+                if (html[i + 1] == '"')
+                    inString = !inString;
+                i++;
                 continue;
             }
             if (inString)

--- a/tests/Equibles.UnitTests/Integrations/CboeClientExtractOptionsDataJsonBraceInStringTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientExtractOptionsDataJsonBraceInStringTests.cs
@@ -16,9 +16,7 @@ public class CboeClientExtractOptionsDataJsonBraceInStringTests
     // `\"`), so each '"' is consumed by the escape branch and inString never
     // becomes true. A '}' inside a string value therefore decrements depth to
     // zero and truncates extraction to invalid JSON.
-    [Fact(
-        Skip = "GH-2722 — ExtractOptionsDataJson truncates JSON on a brace inside a string value"
-    )]
+    [Fact]
     public void ExtractOptionsDataJson_BraceInsideStringValue_ReturnsCompleteObject()
     {
         var method = typeof(CboeClient).GetMethod(


### PR DESCRIPTION
## Summary

- `CboeClient.ExtractOptionsDataJson` walks balanced braces over the double-escaped Next.js RSC payload, where every JSON quote appears as `\"`.
- The old escape tracking set `escaped` on the backslash and consumed the following quote, so `inString` never toggled. A literal `}` inside a string value then decremented `depth` and truncated the captured JSON to invalid output (which `JsonDocument.Parse` later drops). Today's values carry no braces so the cassette path works, but any brace-bearing field or upstream format change silently loses the day's put/call data.

## Code changes

- `src/Equibles.Integrations.Cboe/CboeClient.cs` — recognise `\"` as the string-context toggle (and skip any other backslash-escape whole), so braces inside string values are not treated as structural delimiters.
- `tests/Equibles.UnitTests/Integrations/CboeClientExtractOptionsDataJsonBraceInStringTests.cs` — un-skip the regression test (a `label` value containing `a}b`).

closes #2722