### PR TITLE
test(sec): pin InlineXbrlParser currency-glyph strip in value decode

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserCurrencyGlyphTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserCurrencyGlyphTests.cs
@@ -1,0 +1,47 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// NormaliseDigits is documented to strip the currency glyphs ($, €, £, ¥)
+/// filers routinely embed in the value text before parsing. That branch was
+/// untested: drop the '$' case and decimal.TryParse("$1234.56") fails, so the
+/// fact is silently dropped instead of decoded. Pins the strip-then-parse path.
+/// </summary>
+public class InlineXbrlParserCurrencyGlyphTests
+{
+    private const string DocOpen =
+        "<html "
+        + "xmlns=\"http://www.w3.org/1999/xhtml\" "
+        + "xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\" "
+        + "xmlns:ixt=\"http://www.xbrl.org/inlineXBRL/transformation/2015-02-26\" "
+        + "xmlns:xbrli=\"http://www.xbrl.org/2003/instance\" "
+        + "xmlns:xbrldi=\"http://xbrl.org/2006/xbrldi\" "
+        + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+        + "xmlns:us-gaap=\"http://fasb.org/us-gaap/2018-01-31\""
+        + "><body><div style=\"display:none\"><ix:header><ix:resources>";
+
+    private const string ResourcesEnd = "</ix:resources></ix:header></div>";
+
+    private const string DocClose = "</body></html>";
+
+    [Fact]
+    public void Parse_ValueWithDollarGlyphAndThousands_StripsGlyphAndDecodes()
+    {
+        var html =
+            DocOpen
+            + "<xbrli:context id=\"C1\">"
+            + "  <xbrli:entity><xbrli:identifier scheme=\"x\">0</xbrli:identifier></xbrli:entity>"
+            + "  <xbrli:period><xbrli:instant>2020-06-30</xbrli:instant></xbrli:period>"
+            + "</xbrli:context>"
+            + "<xbrli:unit id=\"u\"><xbrli:measure>iso4217:USD</xbrli:measure></xbrli:unit>"
+            + ResourcesEnd
+            + "<ix:nonFraction name=\"us-gaap:Revenues\" contextRef=\"C1\" unitRef=\"u\" format=\"ixt:numdotdecimal\">$1,234.56</ix:nonFraction>"
+            + DocClose;
+
+        var fact = new InlineXbrlParser().Parse(html).Should().ContainSingle().Subject;
+
+        fact.Value.Should().Be(1234.56m);
+        fact.Unit.Should().Be("USD");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test exercising `NormaliseDigits`' currency-glyph stripping in `InlineXbrlParser` — a branch that was previously 0% covered.
- The glyph strip is load-bearing: without the `$` case, `decimal.TryParse("$1234.56")` fails and the whole fact is silently dropped rather than decoded. This pins the strip-then-parse path against regression.

## Code changes

- `tests/Equibles.UnitTests/Sec/InlineXbrlParserCurrencyGlyphTests.cs` — new unit test. Parses a minimal iXBRL document whose `ix:nonFraction` value text is `$1,234.56`, and asserts the fact decodes to `1234.56` with unit `USD` (glyph and thousands separator stripped, invariant parse).