### PR TITLE
test(web): pin InstitutionsController.Search case-insensitive match and lowercase wire keys

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/InstitutionsControllerSearchTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/InstitutionsControllerSearchTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the /institutions/search typeahead endpoint (previously untested): a
+/// lower-case query must match a title-cased holder via case-insensitive ILike
+/// (a regression to case-sensitive Like would silently return nothing), and the
+/// JSON must use the documented lower-case wire keys the JS picker reads.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class InstitutionsControllerSearchTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public InstitutionsControllerSearchTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetSearch_LowercaseQuery_MatchesTitleCasedHolderWithLowercaseWireKeys()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Cik = "0000001",
+                    Name = "Vanguard Group Inc",
+                    City = "Malvern",
+                    StateOrCountry = "PA",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Cik = "0000002",
+                    Name = "Berkshire Hathaway Inc",
+                    City = "Omaha",
+                    StateOrCountry = "NE",
+                }
+            );
+            await db.SaveChangesAsync();
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions/search?q=van");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadAsStringAsync();
+        json.Should().Contain("Vanguard Group Inc"); // lowercase "van" matches via ILike
+        json.Should().NotContain("Berkshire"); // non-matching holder filtered out
+        json.Should().Contain("\"cik\"").And.Contain("\"name\""); // documented lowercase wire keys
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for the `/institutions/search` typeahead endpoint, whose action body was previously uncovered by both the unit and integration suites.
- Pins two behaviours the institution picker depends on: a lower-case query matches a title-cased holder via case-insensitive `ILike` (a regression to case-sensitive `Like` would silently return nothing), and the JSON uses the documented lower-case wire keys (`cik`, `name`, …) that the JS picker reads regardless of the host's casing policy.

## Code changes

- `tests/Equibles.IntegrationTests/Web/InstitutionsControllerSearchTests.cs` — new integration test. Seeds two holders ("Vanguard Group Inc", "Berkshire Hathaway Inc") via the `WebHostFixture`, GETs `/institutions/search?q=van`, and asserts 200 plus a JSON body that contains the Vanguard match, excludes the non-matching holder, and carries lower-case `"cik"`/`"name"` keys.