### PR TITLE
fix(sec): parse XBRL period dates with InvariantCulture

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -144,7 +144,13 @@ public class InlineXbrlParser
     {
         date = default;
         var child = FindFirstChildByLocalName(parent, localName);
-        return child != null && DateOnly.TryParse(child.TextContent.Trim(), out date);
+        return child != null
+            && DateOnly.TryParse(
+                child.TextContent.Trim(),
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out date
+            );
     }
 
     private static List<ParsedXbrlDimension> ExtractDimensions(IElement contextElement)

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
@@ -119,7 +119,15 @@ public class StandaloneXbrlParser
     )
     {
         var instant = period.Element(InstantElement);
-        if (instant != null && DateOnly.TryParse(instant.Value, out var instantDate))
+        if (
+            instant != null
+            && DateOnly.TryParse(
+                instant.Value,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var instantDate
+            )
+        )
         {
             isInstant = true;
             start = instantDate;
@@ -132,8 +140,18 @@ public class StandaloneXbrlParser
         if (
             startElement != null
             && endElement != null
-            && DateOnly.TryParse(startElement.Value, out var startDate)
-            && DateOnly.TryParse(endElement.Value, out var endDate)
+            && DateOnly.TryParse(
+                startElement.Value,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var startDate
+            )
+            && DateOnly.TryParse(
+                endElement.Value,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var endDate
+            )
         )
         {
             isInstant = false;

--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserPeriodCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserPeriodCultureInvarianceTests.cs
@@ -23,7 +23,7 @@ public class InlineXbrlParserPeriodCultureInvarianceTests
     // "2024-01-31" must resolve to 2024-01-31 on any host; under th-TH
     // (ThaiBuddhist, +543-year era) the ambient parser reads "2024" as a
     // Buddhist-era year (-> 1481 CE), corrupting the persisted period.
-    [Fact(Skip = "GH-2670 — XBRL ISO period dates misparsed under non-Gregorian host cultures")]
+    [Fact]
     public void Parse_InstantDateUnderThaiBuddhistCulture_ResolvesGregorianIsoDate()
     {
         var html =

--- a/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserPeriodCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserPeriodCultureInvarianceTests.cs
@@ -16,7 +16,7 @@ public class StandaloneXbrlParserPeriodCultureInvarianceTests
     // InvariantCulture; under th-TH (ThaiBuddhist calendar, +543-year era) the
     // ambient parser reads "2024" as a Buddhist-era year (-> 1481 CE), feeding
     // a corrupt period into the financial-facts pipeline on a non-US host.
-    [Fact(Skip = "GH-2670 — XBRL ISO period dates misparsed under non-Gregorian host cultures")]
+    [Fact]
     public void Parse_InstantDateUnderThaiBuddhistCulture_ResolvesGregorianIsoDate()
     {
         var xml =

--- a/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserPeriodHijriCultureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StandaloneXbrlParserPeriodHijriCultureTests.cs
@@ -19,9 +19,7 @@ public class StandaloneXbrlParserPeriodHijriCultureTests
     // host would ingest zero financial facts from otherwise-valid filings.
     // Pin: a valid duration fact survives parsing and keeps its ISO period
     // regardless of thread culture.
-    [Fact(
-        Skip = "GH-2652 — TryParsePeriod omits InvariantCulture; ISO xs:date periods drop facts under ar-SA"
-    )]
+    [Fact]
     public void Parse_DurationContextUnderHijriCulture_EmitsFactWithIsoPeriod()
     {
         var xml =


### PR DESCRIPTION
## Summary

- `StandaloneXbrlParser.TryParsePeriod` and `InlineXbrlParser.TryParseChildDate` parsed XBRL `xbrli:instant`/`startDate`/`endDate` (ISO `xs:date`) with `DateOnly.TryParse` and no `IFormatProvider`.
- Under a non-Gregorian host calendar the ISO year is reinterpreted (`th-TH` reads `2024` as Buddhist-era `1481`) or fails outright (`ar-SA`), so fact periods are stamped wrong, or the context is dropped and every referencing fact is silently discarded (a Hijri-locale host ingests zero financial facts from an otherwise-valid filing).

## Code changes

- `src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs` — pass `CultureInfo.InvariantCulture` + `DateTimeStyles.None` to the instant/start/end `DateOnly.TryParse` calls.
- `src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs` — same fix in `TryParseChildDate`.
- Un-skipped three regression tests (Standalone th-TH instant, Standalone ar-SA duration, Inline th-TH instant). The genuinely-malformed-date fallback stays pinned by the sibling malformed-period tests.

closes #2670
closes #2652