### PR TITLE
refactor(sec): extract TryParseInvariantDate helper in StandaloneXbrlParser

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
@@ -119,15 +119,7 @@ public class StandaloneXbrlParser
     )
     {
         var instant = period.Element(InstantElement);
-        if (
-            instant != null
-            && DateOnly.TryParse(
-                instant.Value,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.None,
-                out var instantDate
-            )
-        )
+        if (instant != null && TryParseInvariantDate(instant.Value, out var instantDate))
         {
             isInstant = true;
             start = instantDate;
@@ -140,18 +132,8 @@ public class StandaloneXbrlParser
         if (
             startElement != null
             && endElement != null
-            && DateOnly.TryParse(
-                startElement.Value,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.None,
-                out var startDate
-            )
-            && DateOnly.TryParse(
-                endElement.Value,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.None,
-                out var endDate
-            )
+            && TryParseInvariantDate(startElement.Value, out var startDate)
+            && TryParseInvariantDate(endElement.Value, out var endDate)
         )
         {
             isInstant = false;
@@ -165,6 +147,9 @@ public class StandaloneXbrlParser
         end = default;
         return false;
     }
+
+    private static bool TryParseInvariantDate(string value, out DateOnly date) =>
+        DateOnly.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out date);
 
     private static List<ParsedXbrlDimension> ExtractDimensions(XElement contextElement)
     {


### PR DESCRIPTION
## Summary

- Collapse three identical invariant `DateOnly.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out …)` calls in `StandaloneXbrlParser.TryParsePeriod` into a single `TryParseInvariantDate` helper.
- Behavior-preserving: the helper delegates to the exact same BCL call with the same arguments; each call site passes the same string and receives the same result and out date.

## Code changes

- `src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs` — replace the three repeated multi-line `DateOnly.TryParse` invocations in `TryParsePeriod` with calls to a new `private static bool TryParseInvariantDate(string value, out DateOnly date)`; the method body shrinks and the invariant-parse intent is named in one place.