### PR TITLE
fix(holdings-mcp): render AppendActivitySection share counts with InvariantCulture

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1047,7 +1047,7 @@ public class InstitutionalHoldingsTools
         {
             var r = rows[i];
             result.AppendLine(
-                $"| {i + 1} | {r.Ticker} | {r.Name} | {r.PreviousShares:N0} | {r.CurrentShares:N0} | {FormatSignedShares(r.DeltaShares)} | {FormatSignedMillions(r.DeltaValue)} |"
+                $"| {i + 1} | {r.Ticker} | {r.Name} | {r.PreviousShares.ToString("N0", CultureInfo.InvariantCulture)} | {r.CurrentShares.ToString("N0", CultureInfo.InvariantCulture)} | {FormatSignedShares(r.DeltaShares)} | {FormatSignedMillions(r.DeltaValue)} |"
             );
         }
         result.AppendLine();

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsAppendActivitySectionCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsAppendActivitySectionCultureInvarianceTests.cs
@@ -21,7 +21,7 @@ public class InstitutionalHoldingsToolsAppendActivitySectionCultureInvarianceTes
     // share counts gain '.' group separators (1.234.567), forking the LLM-
     // consumed MCP output by host locale. Asserts only the share-count cell so
     // it is independent of the Δ Value cell tracked separately by #2658.
-    [Fact(Skip = "GH-2665 — AppendActivitySection emits host-locale digit separators in share-count cells")]
+    [Fact]
     public void AppendActivitySection_UnderNonInvariantCulture_RendersShareCountsCultureInvariantly()
     {
         var rows = new List<StockPositionChange>


### PR DESCRIPTION
## Summary

- `AppendActivitySection` (used by `GetInstitutionQuarterlyActivity`) rendered the Prior / New share-count cells with bare `:N0` specifiers.
- Under a comma-decimal locale (e.g. `de-DE`) the counts gained `.` group separators (`1.234.567` instead of `1,234,567`), forking the MCP markdown by host locale.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — format both `:N0` share-count cells with `CultureInfo.InvariantCulture`, matching the rest of the file. The Δ cells already route through the invariant `FormatSignedShares` / `FormatSignedMillions` helpers.
- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsAppendActivitySectionCultureInvarianceTests.cs` — un-skip the regression test asserting invariant grouping under `de-DE`.

closes #2665