### PR TITLE
refactor(holdings-mcp): reuse FormatWholeNumber for AppendActivitySection share cells

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1047,7 +1047,7 @@ public class InstitutionalHoldingsTools
         {
             var r = rows[i];
             result.AppendLine(
-                $"| {i + 1} | {r.Ticker} | {r.Name} | {r.PreviousShares.ToString("N0", CultureInfo.InvariantCulture)} | {r.CurrentShares.ToString("N0", CultureInfo.InvariantCulture)} | {FormatSignedShares(r.DeltaShares)} | {FormatSignedMillions(r.DeltaValue)} |"
+                $"| {i + 1} | {r.Ticker} | {r.Name} | {FormatWholeNumber(r.PreviousShares)} | {FormatWholeNumber(r.CurrentShares)} | {FormatSignedShares(r.DeltaShares)} | {FormatSignedMillions(r.DeltaValue)} |"
             );
         }
         result.AppendLine();


### PR DESCRIPTION
## Summary

- The Prior/New share-count cells in `AppendActivitySection` were rendered with two inline `ToString("N0", CultureInfo.InvariantCulture)` calls, duplicating the existing `FormatWholeNumber` helper that every other invariant whole-number cell in the file already uses.
- Reuse the helper so there is one place that owns invariant whole-number formatting, matching the rest of the file.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — replace the two inline `ToString("N0", CultureInfo.InvariantCulture)` calls on `PreviousShares`/`CurrentShares` with `FormatWholeNumber(...)`. Output is byte-identical (`FormatWholeNumber` is defined as that exact expression), so the rendered table is unchanged.