### PR TITLE
fix(holdings-mcp): render most-held-stocks cells with InvariantCulture

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -750,7 +750,7 @@ public class InstitutionalHoldingsTools
         var result = new StringBuilder();
         result.AppendLine($"Most-held 13F stocks as of {targetDate:yyyy-MM-dd}");
         result.AppendLine(
-            $"vs prior quarter {previousDate:yyyy-MM-dd} · {universeFilers:N0} filers in the 13F universe"
+            $"vs prior quarter {previousDate:yyyy-MM-dd} · {universeFilers.ToString("N0", CultureInfo.InvariantCulture)} filers in the 13F universe"
         );
         result.AppendLine($"Sorted by: {sort}");
         result.AppendLine();
@@ -767,7 +767,7 @@ public class InstitutionalHoldingsTools
             var pct = universeFilers > 0 ? (double)r.CurrentFilerCount / universeFilers * 100.0 : 0;
             var deltaFilers = r.CurrentFilerCount - r.PreviousFilerCount;
             result.AppendLine(
-                $"| {i + 1} | {ticker} | {name} | {r.CurrentFilerCount:N0} | {FormatSignedShares(deltaFilers)} | {r.CurrentValue / 1_000_000m:N1} | {FormatSignedMillions(r.DeltaValue)} | {pct:F1}% |"
+                $"| {i + 1} | {ticker} | {name} | {r.CurrentFilerCount.ToString("N0", CultureInfo.InvariantCulture)} | {FormatSignedShares(deltaFilers)} | {(r.CurrentValue / 1_000_000m).ToString("N1", CultureInfo.InvariantCulture)} | {FormatSignedMillions(r.DeltaValue)} | {pct.ToString("F1", CultureInfo.InvariantCulture)}% |"
             );
         }
         return result.ToString();

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderMostHeldStocksTableCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderMostHeldStocksTableCultureInvarianceTests.cs
@@ -22,7 +22,7 @@ public class InstitutionalHoldingsToolsRenderMostHeldStocksTableCultureInvarianc
     // (GH-2637) and RenderSectorAllocationTable (GH-2641) siblings. The repo
     // convention (cf. FactMarkdown threading InvariantCulture) is that the same
     // call renders byte-identically regardless of host CurrentCulture.
-    [Fact(Skip = "GH-2656 — RenderMostHeldStocksTable emits host-locale digit separators")]
+    [Fact]
     public void RenderMostHeldStocksTable_UnderNonInvariantCulture_RendersCellsCultureInvariantly()
     {
         var targetDate = new DateOnly(2024, 12, 31);


### PR DESCRIPTION
## Summary

- `RenderMostHeldStocksTable` (the `GetMostHeldStocks` tool) interpolated the universe-filer count, per-row filer count, total $ value ($M) and %-of-universe cells with bare `:N0`/`:N1`/`:F1` specifiers.
- Under a comma-decimal locale (e.g. `de-DE`) the group/decimal separators swapped, forking the MCP markdown by host locale.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — thread `CultureInfo.InvariantCulture` through the `:N0`/`:N1`/`:F1` cells, matching the fixed sibling render methods. The Δ cells already route through the invariant `FormatSignedShares` / `FormatSignedMillions` helpers.
- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderMostHeldStocksTableCultureInvarianceTests.cs` — un-skip the regression test asserting byte-identical output under `de-DE` and invariant culture.

closes #2656