### PR TITLE
test(mcp): include GetLargestShortVolume in ShortDataTools tool-count pin

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -401,7 +401,13 @@ public class McpModuleToolDiscoveryTests
             },
             {
                 typeof(ShortDataTools),
-                new[] { "GetShortVolume", "GetShortInterest", "GetShortInterestSnapshot" }
+                new[]
+                {
+                    "GetShortVolume",
+                    "GetShortInterest",
+                    "GetShortInterestSnapshot",
+                    "GetLargestShortVolume"
+                }
             },
             {
                 typeof(StockPriceTools),


### PR DESCRIPTION
## Summary

- CI on main was red: the MCP tool-discovery pin expected exactly 3 tools for `ShortDataTools`, but `GetLargestShortVolume` (added in #2646) made it 4.
- Update the expected tool list so the count and name pins match the shipped tools.

## Code changes

- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — add `GetLargestShortVolume` to the `ShortDataTools` expected-tools entry feeding `Module_ToolCount_MatchesExpected` and `Module_ExposesExpectedTools`.