### PR TITLE
style(mcp): add trailing comma to ShortDataTools expected-tools array

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -406,7 +406,7 @@ public class McpModuleToolDiscoveryTests
                     "GetShortVolume",
                     "GetShortInterest",
                     "GetShortInterestSnapshot",
-                    "GetLargestShortVolume"
+                    "GetLargestShortVolume",
                 }
             },
             {


### PR DESCRIPTION
## Summary

- CI's CSharpier format check rejected the previous fix (#2749): the multi-line expected-tools array needs a trailing comma after the last element.
- Reformat with CSharpier so the lint gate passes.

## Code changes

- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — add trailing comma to the `ShortDataTools` expected-tools array.