### PR TITLE
fix(cboe): persist put/call backfill incrementally so cold start populates

### DIFF
--- a/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
+++ b/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
@@ -85,6 +85,28 @@ public class CboeImportService : IImporter
 
         var pending = new List<CboePutCallRatio>();
         var perTypeInserts = new Dictionary<CboePutCallRatioType, int>();
+        var totalInserted = 0;
+
+        // Persist as we go rather than once at the end. A cold-start backfill
+        // walks years of trading days at ~10 requests/min, so deferring every
+        // write to the end means a worker restart (or cancellation) mid-backfill
+        // discards all scraped rows — and the next cycle, seeing an empty table,
+        // restarts from DailyPageMinDate, so put/call data would never land.
+        // Flushing each full batch makes progress durable and lets the next
+        // cycle resume from the last persisted date.
+        async Task Flush()
+        {
+            if (pending.Count == 0)
+                return;
+
+            await BatchPersister.Persist<CboePutCallRatio, CboePutCallRatioRepository>(
+                pending,
+                InsertBatchSize,
+                _scopeFactory
+            );
+            totalInserted += pending.Count;
+            pending.Clear();
+        }
 
         for (var date = start; date <= today; date = date.AddDays(1))
         {
@@ -149,19 +171,18 @@ public class CboeImportService : IImporter
                 perTypeInserts.TryGetValue(ratioType, out var n);
                 perTypeInserts[ratioType] = n + 1;
             }
+
+            if (pending.Count >= InsertBatchSize)
+                await Flush();
         }
 
-        if (pending.Count == 0)
+        await Flush();
+
+        if (totalInserted == 0)
         {
             _logger.LogDebug("CBOE put/call ratios are up to date");
             return;
         }
-
-        await BatchPersister.Persist<CboePutCallRatio, CboePutCallRatioRepository>(
-            pending,
-            InsertBatchSize,
-            _scopeFactory
-        );
 
         foreach (var (ratioType, count) in perTypeInserts)
         {

--- a/tests/Equibles.IntegrationTests/Cboe/CboeImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Cboe/CboeImportServiceFullPipelineTests.cs
@@ -105,6 +105,22 @@ public class CboeImportServiceFullPipelineTests : IAsyncLifetime
         return client;
     }
 
+    private static Dictionary<CboePutCallProductType, CboePutCallRecord> AllFiveProducts(
+        DateOnly date
+    ) =>
+        Enum.GetValues<CboePutCallProductType>()
+            .ToDictionary(
+                p => p,
+                p => new CboePutCallRecord
+                {
+                    Date = date,
+                    CallVolume = 1,
+                    PutVolume = 1,
+                    TotalVolume = 2,
+                    PutCallRatio = 1m,
+                }
+            );
+
     private static CboePutCallRatio Seed(CboePutCallRatioType type, DateOnly date) =>
         new()
         {
@@ -429,5 +445,48 @@ public class CboeImportServiceFullPipelineTests : IAsyncLifetime
                 Arg.Any<string>(),
                 Arg.Any<string>()
             );
+    }
+
+    [Fact]
+    public async Task Import_ColdStartCancelledMidBackfill_KeepsAlreadyFlushedBatches()
+    {
+        // Regression for the "put/call data never populates" bug. A cold-start
+        // backfill walks years of trading days at a throttled request rate. If
+        // every write is deferred to the end of the loop, a worker restart or
+        // cancellation mid-backfill discards every scraped row, and the next
+        // cycle — seeing an empty table — restarts from the beginning, so data
+        // never lands. Flushing each full batch must make that progress durable
+        // even when the cycle is cancelled before it finishes.
+        var cts = new CancellationTokenSource();
+        var downloads = 0;
+
+        var client = Substitute.For<ICboeClient>();
+        client.DownloadVixHistory().Returns(new List<CboeVixRecord>());
+        client
+            .DownloadDailyPutCallRatios(Arg.Any<DateOnly>())
+            .Returns(call =>
+            {
+                var date = call.Arg<DateOnly>();
+                downloads++;
+                // 200 weekdays × 5 products = one full 1000-row batch flushed.
+                // Cancel a little past that so exactly one batch is durable when
+                // the loop's next ThrowIfCancellationRequested fires.
+                if (downloads >= 250)
+                    cts.Cancel();
+                return Task.FromResult(AllFiveProducts(date));
+            });
+
+        // today is far enough past DailyPageMinDate (2019-10-07) to cover 250+
+        // weekdays without the cold-start loop ever reaching its end.
+        var sut = CreateSut(CreateScopeFactory(), client, new DateOnly(2020, 12, 31));
+
+        var act = async () => await sut.Import(cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        using var verify = FreshContext();
+        var persisted = await verify.Set<CboePutCallRatio>().CountAsync();
+        persisted
+            .Should()
+            .Be(1000, "the full batch flushed mid-backfill survives the cancellation");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2040 — CBOE put/call ratio data never populated, while VIX from the same module worked.

The parser is fine (it extracts all five products from current and 2019-era live CBOE daily-stats pages). The defect is in the persistence cadence of the backfill.

`ImportAllPutCallRatios` wrote to the database **once, after the entire catch-up loop finished**. On a fresh database the loop starts at the `2019-10-07` page-feed floor and walks every trading day to today — roughly **1,650 requests throttled to 10/min**, so nearly three hours of scraping before a single row lands. Any worker restart or cancellation before the loop completes throws out all in-memory rows (`ThrowIfCancellationRequested`), and the next cycle — still seeing an empty table — restarts from 2019. Put/call data never landed. VIX worked because it is one request followed by an immediate write.

## Code changes

- **`CboeImportService.ImportAllPutCallRatios`** — flush `pending` to the database each time it fills a batch (`InsertBatchSize`) during the loop, plus a final flush for the remainder. Progress is now durable and the next cycle resumes from the last persisted date instead of restarting from the floor. The "up to date" short-circuit now keys off the running insert total.
- **`CboeImportServiceFullPipelineTests`** — regression test: a cold start cancelled mid-backfill keeps the batch that was already flushed (previously zero rows survived).

## Verification

- `Equibles.Cboe.HostedService` and `Equibles.IntegrationTests` build clean; csharpier clean.
- Cboe unit tests pass (25/25).
- The new integration test is ParadeDB-backed (Testcontainers) and could not be run locally (Docker unavailable in this environment) — relying on CI to exercise it.