### PR TITLE
feat(web): add largest short volume browser page

### DIFF
--- a/src/Equibles.Web/Controllers/ShortVolumeController.cs
+++ b/src/Equibles.Web/Controllers/ShortVolumeController.cs
@@ -1,0 +1,117 @@
+using System.Globalization;
+using Equibles.Finra.Repositories;
+using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Extensions;
+using Equibles.Web.ViewModels.ShortVolume;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Web.Controllers;
+
+public class ShortVolumeController : BaseController
+{
+    private readonly DailyShortVolumeRepository _shortVolumeRepository;
+
+    public ShortVolumeController(
+        DailyShortVolumeRepository shortVolumeRepository,
+        ILogger<ShortVolumeController> logger
+    )
+        : base(logger)
+    {
+        _shortVolumeRepository = shortVolumeRepository;
+    }
+
+    // Market-wide "largest short volume" ranking for a single trading day (defaults to the
+    // latest available), mirroring the GetLargestShortVolume MCP tool and the institutions
+    // browser's list/filter/pager shape.
+    [HttpGet("~/short-volume")]
+    public async Task<IActionResult> Index(
+        string date,
+        ShortVolumeSort sort = ShortVolumeSort.ShortVolumeDescending,
+        int page = 1
+    )
+    {
+        ViewData["Title"] = "Largest Short Volume";
+
+        page = Pagination.ClampPage(page);
+        const int pageSize = 50;
+
+        var latestDate = await _shortVolumeRepository.GetLatestDate().FirstOrDefaultAsync();
+        if (latestDate == default)
+        {
+            return View(new ShortVolumeBrowserViewModel { Sort = sort, Page = page });
+        }
+
+        var availableDates = await _shortVolumeRepository
+            .GetAll()
+            .Select(d => d.Date)
+            .Distinct()
+            .OrderByDescending(d => d)
+            .ToListAsync();
+
+        // The day selector posts yyyy-MM-dd values; an unparseable or missing value falls
+        // back to the latest available trading day.
+        var selectedDate = latestDate;
+        if (
+            !string.IsNullOrWhiteSpace(date)
+            && DateOnly.TryParseExact(
+                date,
+                "yyyy-MM-dd",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var parsed
+            )
+        )
+        {
+            selectedDate = parsed;
+        }
+
+        // Zero-volume rows carry no meaningful short percentage, so they're excluded — same
+        // rule the GetLargestShortVolume MCP tool applies.
+        var query = _shortVolumeRepository
+            .GetByDate(selectedDate)
+            .Include(d => d.CommonStock)
+            .Where(d => d.TotalVolume > 0);
+
+        var ordered = sort switch
+        {
+            ShortVolumeSort.ShortPercentDescending => query
+                .OrderByDescending(d => (double)d.ShortVolume / d.TotalVolume)
+                .ThenBy(d => d.CommonStock.Ticker),
+            ShortVolumeSort.TotalVolumeDescending => query
+                .OrderByDescending(d => d.TotalVolume)
+                .ThenBy(d => d.CommonStock.Ticker),
+            ShortVolumeSort.Ticker => query.OrderBy(d => d.CommonStock.Ticker),
+            _ => query.OrderByDescending(d => d.ShortVolume).ThenBy(d => d.CommonStock.Ticker),
+        };
+
+        var totalCount = await ordered.CountAsync();
+
+        var pageRows = await ordered
+            .Page(page, pageSize)
+            .Select(d => new ShortVolumeListItemViewModel
+            {
+                Ticker = d.CommonStock.Ticker,
+                Name = d.CommonStock.Name,
+                ShortVolume = d.ShortVolume,
+                ShortExemptVolume = d.ShortExemptVolume,
+                TotalVolume = d.TotalVolume,
+                ShortPercent = (double)d.ShortVolume / d.TotalVolume * 100,
+            })
+            .ToListAsync();
+
+        var viewModel = new ShortVolumeBrowserViewModel
+        {
+            Records = pageRows,
+            SelectedDate = selectedDate,
+            LatestDate = latestDate,
+            AvailableDates = availableDates,
+            Sort = sort,
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = totalCount,
+        };
+
+        return View(viewModel);
+    }
+}

--- a/src/Equibles.Web/ViewModels/ShortVolume/ShortVolumeBrowserViewModel.cs
+++ b/src/Equibles.Web/ViewModels/ShortVolume/ShortVolumeBrowserViewModel.cs
@@ -1,0 +1,23 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.Web.ViewModels.ShortVolume;
+
+public class ShortVolumeBrowserViewModel
+{
+    public List<ShortVolumeListItemViewModel> Records { get; set; } = [];
+
+    // The trading day being shown (the parsed selection, or the latest available).
+    public DateOnly? SelectedDate { get; set; }
+
+    // The most recent trading day on file — drives the default selection and the subtitle.
+    public DateOnly? LatestDate { get; set; }
+
+    // Distinct trading days with short-volume data, newest first — populates the day selector.
+    public List<DateOnly> AvailableDates { get; set; } = [];
+
+    public ShortVolumeSort Sort { get; set; }
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 50;
+    public int TotalCount { get; set; }
+    public int TotalPages => Pagination.PageCount(TotalCount, PageSize);
+}

--- a/src/Equibles.Web/ViewModels/ShortVolume/ShortVolumeListItemViewModel.cs
+++ b/src/Equibles.Web/ViewModels/ShortVolume/ShortVolumeListItemViewModel.cs
@@ -1,0 +1,11 @@
+namespace Equibles.Web.ViewModels.ShortVolume;
+
+public class ShortVolumeListItemViewModel
+{
+    public string Ticker { get; set; }
+    public string Name { get; set; }
+    public long ShortVolume { get; set; }
+    public long ShortExemptVolume { get; set; }
+    public long TotalVolume { get; set; }
+    public double ShortPercent { get; set; }
+}

--- a/src/Equibles.Web/ViewModels/ShortVolume/ShortVolumeSort.cs
+++ b/src/Equibles.Web/ViewModels/ShortVolume/ShortVolumeSort.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Web.ViewModels.ShortVolume;
+
+public enum ShortVolumeSort
+{
+    [Display(Name = "Short Volume (high → low)")]
+    ShortVolumeDescending = 0,
+
+    [Display(Name = "Short % (high → low)")]
+    ShortPercentDescending = 1,
+
+    [Display(Name = "Total Volume (high → low)")]
+    TotalVolumeDescending = 2,
+
+    [Display(Name = "Ticker (A → Z)")]
+    Ticker = 3,
+}

--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -52,6 +52,7 @@
                             <li><a asp-action="Index" asp-controller="EconomicData">Economic Data</a></li>
                             <li><a asp-action="Index" asp-controller="Cftc">Futures</a></li>
                             <li><a asp-action="Index" asp-controller="Market">Market</a></li>
+                            <li><a asp-action="Index" asp-controller="ShortVolume">Largest Short Volume</a></li>
                         </ul>
                     </div>
                     <a asp-action="Connect" asp-controller="Home" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">MCP</a>
@@ -169,6 +170,11 @@
                         <li>
                             <a asp-action="Index" asp-controller="Market">
                                 <icon name="chart-bar-square" size="4" /> Market
+                            </a>
+                        </li>
+                        <li>
+                            <a asp-action="Index" asp-controller="ShortVolume">
+                                <icon name="arrow-trending-down" size="4" /> Largest Short Volume
                             </a>
                         </li>
                         <li>

--- a/src/Equibles.Web/Views/ShortVolume/Index.cshtml
+++ b/src/Equibles.Web/Views/ShortVolume/Index.cshtml
@@ -1,0 +1,110 @@
+@using Equibles.Web.ViewModels.ShortVolume
+@model ShortVolumeBrowserViewModel
+
+@{
+    ViewData["Title"] = "Largest Short Volume";
+    ViewData["Description"] = "The stocks with the largest FINRA consolidated daily short volume for a selected trading day — ranked by short volume, with short-volume percentage of total volume.";
+
+    // Active filters carried across pagination links so paging never drops the
+    // selected day or sort order.
+    var filterRoute = new Dictionary<string, string>();
+    if (Model.SelectedDate.HasValue) {
+        filterRoute["date"] = Model.SelectedDate.Value.ToString("yyyy-MM-dd");
+    }
+    if (Model.Sort != ShortVolumeSort.ShortVolumeDescending) {
+        filterRoute["sort"] = Model.Sort.ToString();
+    }
+    var hasData = Model.LatestDate.HasValue;
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold mb-2">Largest Short Volume</h1>
+        <p class="text-base-content/60">
+            @if (hasData) {
+                <span>@Model.TotalCount.ToString("N0") stocks ranked by FINRA consolidated daily short volume for <strong class="text-base-content">@Model.SelectedDate?.ToString("MMM dd, yyyy")</strong></span>
+                @if (Model.SelectedDate != Model.LatestDate) {
+                    <span> · latest available @Model.LatestDate?.ToString("MMM dd, yyyy")</span>
+                }
+            } else {
+                <span>No daily short volume data has been ingested yet.</span>
+            }
+        </p>
+    </div>
+
+    <!-- Trading-day + sort selector (plain query-param names, bound to ShortVolumeController.Index) -->
+    <form method="get" class="mb-6">
+        <div class="flex flex-wrap gap-3 items-end">
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">Trading day</span>
+                <select name="date" class="select select-bordered" aria-label="Select trading day"
+                        @(Model.AvailableDates.Count == 0 ? "disabled" : null)>
+                    @foreach (var day in Model.AvailableDates) {
+                        <option value="@day.ToString("yyyy-MM-dd")"
+                                selected="@(day == Model.SelectedDate)">
+                            @day.ToString("MMM dd, yyyy")
+                        </option>
+                    }
+                </select>
+            </label>
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">Sort by</span>
+                <select name="sort" class="select select-bordered" aria-label="Sort stocks">
+                    @foreach (var option in Html.GetEnumSelectList<ShortVolumeSort>()) {
+                        <option value="@option.Value"
+                                selected="@(option.Value == ((int)Model.Sort).ToString())">
+                            @option.Text
+                        </option>
+                    }
+                </select>
+            </label>
+            <button type="submit" class="btn btn-primary">Apply</button>
+            @if (filterRoute.ContainsKey("sort")) {
+                <a asp-action="Index" asp-route-date="@Model.SelectedDate?.ToString("yyyy-MM-dd")" class="btn btn-ghost">Reset sort</a>
+            }
+        </div>
+    </form>
+
+    <!-- Results Table -->
+    <div class="card bg-base-100 shadow-sm">
+        <div class="overflow-x-auto">
+            <table class="table table-zebra table-sm" aria-label="Largest short volume" data-testid="short-volume-table">
+                <thead>
+                    <tr>
+                        <th scope="col">Ticker</th>
+                        <th scope="col" class="hidden md:table-cell">Name</th>
+                        <th scope="col" class="text-right">Short Volume</th>
+                        <th scope="col" class="text-right hidden lg:table-cell">Short Exempt</th>
+                        <th scope="col" class="text-right">Total Volume</th>
+                        <th scope="col" class="text-right">Short %</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var row in Model.Records) {
+                        <tr class="hover">
+                            <td class="font-mono font-semibold">
+                                <partial name="_StockLink" model='(Ticker: row.Ticker, Class: "link link-primary")' />
+                            </td>
+                            <td class="hidden md:table-cell max-w-xs truncate text-base-content/70">@row.Name</td>
+                            <td class="text-right font-mono"><compactable-number value="@row.ShortVolume" /></td>
+                            <td class="text-right font-mono hidden lg:table-cell"><compactable-number value="@row.ShortExemptVolume" /></td>
+                            <td class="text-right font-mono"><compactable-number value="@row.TotalVolume" /></td>
+                            <td class="text-right font-mono">@row.ShortPercent.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%</td>
+                        </tr>
+                    }
+                    @if (Model.Records.Count == 0) {
+                        <empty-row colspan="6">
+                            @if (hasData) {
+                                <span>No short volume data for @Model.SelectedDate?.ToString("MMM dd, yyyy").</span>
+                            } else {
+                                <span>No daily short volume has been ingested yet. This page lights up once the worker finishes its first FINRA short-volume cycle.</span>
+                            }
+                        </empty-row>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <partial name="_Pager" model='(Model.Page, Model.TotalPages, "Index", "Short volume pagination", "short-volume-pager", (IDictionary<string, string>)filterRoute)' />
+</div>

--- a/tests/Equibles.IntegrationTests/Web/ShortVolumeControllerTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ShortVolumeControllerTests.cs
@@ -1,0 +1,192 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Finra.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the /short-volume market-wide ranking page: for a trading day (default
+/// latest) the controller ranks stocks by daily short volume and the rendered
+/// HTML carries the listing in the right order, honours the sort and trading-day
+/// selectors, and excludes zero-total-volume rows (matching the
+/// GetLargestShortVolume MCP tool).
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class ShortVolumeControllerTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public ShortVolumeControllerTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetIndex_NoData_RendersEmptyState()
+    {
+        await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
+
+        var response = await _fixture.Client.GetAsync("/short-volume");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("No daily short volume");
+        html.Should().Contain("short-volume-table");
+    }
+
+    [Fact]
+    public async Task GetIndex_DefaultSort_RanksByShortVolumeDescending()
+    {
+        var day = new DateOnly(2026, 5, 20);
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            SeedStockWithVolume(
+                db,
+                "HIGH",
+                "High Short Co.",
+                day,
+                shortVolume: 900,
+                totalVolume: 1_000
+            );
+            SeedStockWithVolume(
+                db,
+                "MID",
+                "Mid Short Co.",
+                day,
+                shortVolume: 500,
+                totalVolume: 1_000
+            );
+            SeedStockWithVolume(
+                db,
+                "LOW",
+                "Low Short Co.",
+                day,
+                shortVolume: 100,
+                totalVolume: 1_000
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/short-volume");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        var highIdx = html.IndexOf(">HIGH<", StringComparison.Ordinal);
+        var midIdx = html.IndexOf(">MID<", StringComparison.Ordinal);
+        var lowIdx = html.IndexOf(">LOW<", StringComparison.Ordinal);
+        highIdx.Should().BeGreaterThan(-1);
+        midIdx.Should().BeGreaterThan(highIdx);
+        lowIdx.Should().BeGreaterThan(midIdx);
+    }
+
+    [Fact]
+    public async Task GetIndex_SortByTicker_OrdersAlphabetically()
+    {
+        var day = new DateOnly(2026, 5, 20);
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            SeedStockWithVolume(db, "ZZZ", "Zeta Co.", day, shortVolume: 900, totalVolume: 1_000);
+            SeedStockWithVolume(db, "AAA", "Alpha Co.", day, shortVolume: 100, totalVolume: 1_000);
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/short-volume?sort=Ticker");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        // AAA (lowest short volume) sorts first by ticker despite ranking last by volume.
+        var aaaIdx = html.IndexOf(">AAA<", StringComparison.Ordinal);
+        var zzzIdx = html.IndexOf(">ZZZ<", StringComparison.Ordinal);
+        aaaIdx.Should().BeGreaterThan(-1);
+        zzzIdx.Should().BeGreaterThan(aaaIdx);
+    }
+
+    [Fact]
+    public async Task GetIndex_DateParam_SelectsThatTradingDay()
+    {
+        var latest = new DateOnly(2026, 5, 20);
+        var older = new DateOnly(2026, 5, 13);
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            SeedStockWithVolume(
+                db,
+                "NEW",
+                "Newday Co.",
+                latest,
+                shortVolume: 800,
+                totalVolume: 1_000
+            );
+            SeedStockWithVolume(
+                db,
+                "OLD",
+                "Oldday Co.",
+                older,
+                shortVolume: 800,
+                totalVolume: 1_000
+            );
+            await Task.CompletedTask;
+        });
+
+        // Default request resolves to the latest day.
+        var latestHtml = await (
+            await _fixture.Client.GetAsync("/short-volume")
+        ).Content.ReadAsStringAsync();
+        latestHtml.Should().Contain(">NEW<");
+        latestHtml.Should().NotContain(">OLD<");
+
+        // Explicit older day swaps the listing.
+        var olderHtml = await (
+            await _fixture.Client.GetAsync("/short-volume?date=2026-05-13")
+        ).Content.ReadAsStringAsync();
+        olderHtml.Should().Contain(">OLD<");
+        olderHtml.Should().NotContain(">NEW<");
+    }
+
+    [Fact]
+    public async Task GetIndex_ExcludesZeroTotalVolumeRows()
+    {
+        var day = new DateOnly(2026, 5, 20);
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            SeedStockWithVolume(db, "REAL", "Real Co.", day, shortVolume: 400, totalVolume: 1_000);
+            SeedStockWithVolume(db, "ZERO", "Zero Co.", day, shortVolume: 0, totalVolume: 0);
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/short-volume");
+
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain(">REAL<");
+        html.Should().NotContain(">ZERO<");
+    }
+
+    private static void SeedStockWithVolume(
+        EquiblesFinancialDbContext db,
+        string ticker,
+        string name,
+        DateOnly date,
+        long shortVolume,
+        long totalVolume
+    )
+    {
+        var stockId = Guid.NewGuid();
+        db.Add(
+            new CommonStock
+            {
+                Id = stockId,
+                Ticker = ticker,
+                Name = name,
+            }
+        );
+        db.Add(
+            new DailyShortVolume
+            {
+                CommonStockId = stockId,
+                Date = date,
+                ShortVolume = shortVolume,
+                ShortExemptVolume = 0,
+                TotalVolume = totalVolume,
+                Market = "FNYX",
+            }
+        );
+    }
+}

--- a/tests/Equibles.IntegrationTests/Web/ShortVolumeIndexViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ShortVolumeIndexViewRenderingTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Finra.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Drives the /short-volume Razor view end-to-end: the ranked row renders the
+/// ticker as a resolved stock link, the company name, the short-volume
+/// percentage, and the trading-day selector reflects the selected day.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class ShortVolumeIndexViewRenderingTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public ShortVolumeIndexViewRenderingTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetIndex_WithData_RendersRowAndDaySelector()
+    {
+        var day = new DateOnly(2026, 5, 20);
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            var stockId = Guid.NewGuid();
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                }
+            );
+            db.Add(
+                new DailyShortVolume
+                {
+                    CommonStockId = stockId,
+                    Date = day,
+                    ShortVolume = 600,
+                    ShortExemptVolume = 25,
+                    TotalVolume = 1_000,
+                    Market = "FNYX",
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/short-volume");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        // Ticker resolves to the per-stock page via the shared _StockLink partial.
+        html.Should().Contain("/stocks/aapl");
+        html.Should().Contain("Apple Inc.");
+        // 600 / 1000 → 60.0% short of total volume.
+        html.Should().Contain("60.0%");
+        // The day selector carries the selected trading day option.
+        html.Should().Contain("value=\"2026-05-20\"");
+        html.Should().Contain("May 20, 2026");
+    }
+}


### PR DESCRIPTION
## Summary

- Final slice (2/2) of #2644. PR 1/2 (the `GetLargestShortVolume` MCP tool) merged as #2646; this adds the web browser page and closes the issue.
- New `/short-volume` page ranks stocks by FINRA consolidated daily short volume for a selected trading day (defaulting to the latest available), showing ticker, name, short volume, total volume and short-volume %, with a trading-day selector, server-side sort, and pagination — mirroring the institutions browser and the `GetLargestShortVolume` tool.

## Code changes

- `src/Equibles.Web/Controllers/ShortVolumeController.cs` — `~/short-volume` action: resolves the latest trading day, lists available days, ranks `DailyShortVolume` for the selected day (excluding zero-total-volume rows), applies the chosen sort, and paginates.
- `src/Equibles.Web/ViewModels/ShortVolume/` — `ShortVolumeBrowserViewModel`, `ShortVolumeListItemViewModel`, and the `ShortVolumeSort` enum (short volume / short % / total volume / ticker).
- `src/Equibles.Web/Views/ShortVolume/Index.cshtml` — day + sort selector, ranked table (short % formatted with InvariantCulture for culture-stable output), empty state, and pager carrying the active day/sort.
- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — "Largest Short Volume" link in the desktop "More" dropdown and the mobile nav.
- `tests/Equibles.IntegrationTests/Web/ShortVolumeControllerTests.cs`, `ShortVolumeIndexViewRenderingTests.cs` — in-process host tests driving routing → controller → Razor: empty state, default ranking, ticker sort, trading-day selection, zero-volume exclusion, and rendered row/short-%/day-selector.

Closes #2644