### PR TITLE
refactor(web): extract repeated sort option loop into _SortOptions partial

### DIFF
--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -42,12 +42,7 @@
             <label class="form-control">
                 <span class="label-text text-sm mb-1">Sort by</span>
                 <select name="sort" class="select select-bordered" aria-label="Sort institutions">
-                    @foreach (var option in Html.GetEnumSelectList<InstitutionSort>()) {
-                        <option value="@option.Value"
-                                selected="@(option.Value == ((int)Model.Sort).ToString())">
-                            @option.Text
-                        </option>
-                    }
+                    <partial name="_SortOptions" model='(Html.GetEnumSelectList<InstitutionSort>(), (int)Model.Sort)' />
                 </select>
             </label>
             <button type="submit" class="btn btn-primary">Apply</button>

--- a/src/Equibles.Web/Views/Search/Index.cshtml
+++ b/src/Equibles.Web/Views/Search/Index.cshtml
@@ -113,12 +113,7 @@
                             <legend class="text-xs font-semibold text-base-content/50 mb-2">Sort by</legend>
                             <select name="sort" id="search-sort" class="select select-bordered select-sm w-full"
                                     aria-label="Sort results">
-                                @foreach (var option in Html.GetEnumSelectList<SearchSort>()) {
-                                    <option value="@option.Value"
-                                            selected="@(option.Value == ((int)Model.SortBy).ToString())">
-                                        @option.Text
-                                    </option>
-                                }
+                                <partial name="_SortOptions" model='(Html.GetEnumSelectList<SearchSort>(), (int)Model.SortBy)' />
                             </select>
                         </fieldset>
 

--- a/src/Equibles.Web/Views/Shared/_SortOptions.cshtml
+++ b/src/Equibles.Web/Views/Shared/_SortOptions.cshtml
@@ -1,0 +1,14 @@
+@using Microsoft.AspNetCore.Mvc.Rendering
+@model (IEnumerable<SelectListItem> Options, int Selected)
+
+@* Renders the <option> list for an enum-backed sort <select>. The selected option is
+   matched by comparing each item's value to the current sort's numeric value, mirroring
+   how the query-param sort is bound. Shared across the browser pages (stocks, institutions,
+   short volume, search). *@
+@foreach (var option in Model.Options)
+{
+    <option value="@option.Value"
+            selected="@(option.Value == Model.Selected.ToString())">
+        @option.Text
+    </option>
+}

--- a/src/Equibles.Web/Views/ShortVolume/Index.cshtml
+++ b/src/Equibles.Web/Views/ShortVolume/Index.cshtml
@@ -50,12 +50,7 @@
             <label class="form-control">
                 <span class="label-text text-sm mb-1">Sort by</span>
                 <select name="sort" class="select select-bordered" aria-label="Sort stocks">
-                    @foreach (var option in Html.GetEnumSelectList<ShortVolumeSort>()) {
-                        <option value="@option.Value"
-                                selected="@(option.Value == ((int)Model.Sort).ToString())">
-                            @option.Text
-                        </option>
-                    }
+                    <partial name="_SortOptions" model='(Html.GetEnumSelectList<ShortVolumeSort>(), (int)Model.Sort)' />
                 </select>
             </label>
             <button type="submit" class="btn btn-primary">Apply</button>

--- a/src/Equibles.Web/Views/Stocks/Index.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Index.cshtml
@@ -38,12 +38,7 @@
             <label class="form-control">
                 <span class="label-text text-sm mb-1">Sort by</span>
                 <select name="sort" class="select select-bordered" aria-label="Sort stocks">
-                    @foreach (var option in Html.GetEnumSelectList<StockSort>()) {
-                        <option value="@option.Value"
-                                selected="@(option.Value == ((int)Model.Sort).ToString())">
-                            @option.Text
-                        </option>
-                    }
+                    <partial name="_SortOptions" model='(Html.GetEnumSelectList<StockSort>(), (int)Model.Sort)' />
                 </select>
             </label>
             <label class="form-control">


### PR DESCRIPTION
## Summary

- The four browser pages (stocks, institutions, short volume, search) each repeated the same `@foreach` over `Html.GetEnumSelectList<TEnum>()` rendering `<option>` elements with an identical `selected` comparison against the current sort's numeric value. The short-volume page added the fourth copy.
- Collapse the four identical option loops into a single shared `_SortOptions` partial. Rendered output is unchanged — each page passes its own enum select list and current sort value, and the partial emits the same option markup and selection logic.

## Code changes

- `src/Equibles.Web/Views/Shared/_SortOptions.cshtml` — new partial taking `(IEnumerable<SelectListItem> Options, int Selected)`; renders the `<option>` list and marks the matching option selected.
- `src/Equibles.Web/Views/{Stocks,Institutions,ShortVolume,Search}/Index.cshtml` — replace the inline sort `<option>` loop with the `_SortOptions` partial, passing the page's enum select list and current sort value.