### PR TITLE
feat(web): add most shorted stocks page

### DIFF
--- a/src/Equibles.Web/Controllers/ShortActivityController.cs
+++ b/src/Equibles.Web/Controllers/ShortActivityController.cs
@@ -1,0 +1,117 @@
+using System.Globalization;
+using Equibles.Finra.Repositories;
+using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Extensions;
+using Equibles.Web.ViewModels.ShortActivity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Web.Controllers;
+
+public class ShortActivityController : BaseController
+{
+    private readonly ShortInterestRepository _shortInterestRepository;
+
+    public ShortActivityController(
+        ShortInterestRepository shortInterestRepository,
+        ILogger<ShortActivityController> logger
+    )
+        : base(logger)
+    {
+        _shortInterestRepository = shortInterestRepository;
+    }
+
+    // Market-wide "most shorted" leaderboard for a single FINRA bi-monthly settlement date
+    // (defaulting to the latest available), mirroring the most-held holdings leaderboard and
+    // the largest-short-volume page. Reads go straight through the repository.
+    [HttpGet("~/most-shorted")]
+    public async Task<IActionResult> MostShorted(
+        string date,
+        MostShortedSort sort = MostShortedSort.CurrentShortPositionDescending,
+        int page = 1
+    )
+    {
+        ViewData["Title"] = "Most Shorted";
+
+        page = Pagination.ClampPage(page);
+        const int pageSize = 50;
+
+        var latestDate = await _shortInterestRepository
+            .GetLatestSettlementDate()
+            .FirstOrDefaultAsync();
+        if (latestDate == default)
+        {
+            return View(new MostShortedBrowserViewModel { Sort = sort, Page = page });
+        }
+
+        var availableDates = await _shortInterestRepository
+            .GetAllSettlementDates()
+            .OrderByDescending(d => d)
+            .ToListAsync();
+
+        // The date selector posts yyyy-MM-dd values; an unparseable or missing value falls
+        // back to the latest available settlement date.
+        var selectedDate = latestDate;
+        if (
+            !string.IsNullOrWhiteSpace(date)
+            && DateOnly.TryParseExact(
+                date,
+                "yyyy-MM-dd",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var parsed
+            )
+        )
+        {
+            selectedDate = parsed;
+        }
+
+        var query = _shortInterestRepository
+            .GetBySettlementDate(selectedDate)
+            .Include(s => s.CommonStock);
+
+        // Null DaysToCover coalesces to 0 so it sorts last under descending order.
+        var ordered = sort switch
+        {
+            MostShortedSort.ChangeDescending => query
+                .OrderByDescending(s => s.ChangeInShortPosition)
+                .ThenBy(s => s.CommonStock.Ticker),
+            MostShortedSort.DaysToCoverDescending => query
+                .OrderByDescending(s => s.DaysToCover ?? 0m)
+                .ThenBy(s => s.CommonStock.Ticker),
+            MostShortedSort.Ticker => query.OrderBy(s => s.CommonStock.Ticker),
+            _ => query
+                .OrderByDescending(s => s.CurrentShortPosition)
+                .ThenBy(s => s.CommonStock.Ticker),
+        };
+
+        var totalCount = await ordered.CountAsync();
+
+        var pageRows = await ordered
+            .Page(page, pageSize)
+            .Select(s => new MostShortedListItemViewModel
+            {
+                Ticker = s.CommonStock.Ticker,
+                Name = s.CommonStock.Name,
+                CurrentShortPosition = s.CurrentShortPosition,
+                ChangeInShortPosition = s.ChangeInShortPosition,
+                AverageDailyVolume = s.AverageDailyVolume,
+                DaysToCover = s.DaysToCover,
+            })
+            .ToListAsync();
+
+        var viewModel = new MostShortedBrowserViewModel
+        {
+            Records = pageRows,
+            SelectedDate = selectedDate,
+            LatestDate = latestDate,
+            AvailableDates = availableDates,
+            Sort = sort,
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = totalCount,
+        };
+
+        return View(viewModel);
+    }
+}

--- a/src/Equibles.Web/ViewModels/ShortActivity/MostShortedBrowserViewModel.cs
+++ b/src/Equibles.Web/ViewModels/ShortActivity/MostShortedBrowserViewModel.cs
@@ -1,0 +1,23 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.Web.ViewModels.ShortActivity;
+
+public class MostShortedBrowserViewModel
+{
+    public List<MostShortedListItemViewModel> Records { get; set; } = [];
+
+    // The settlement date being shown (the parsed selection, or the latest available).
+    public DateOnly? SelectedDate { get; set; }
+
+    // The most recent settlement date on file — drives the default selection and the subtitle.
+    public DateOnly? LatestDate { get; set; }
+
+    // Distinct FINRA bi-monthly settlement dates, newest first — populates the date selector.
+    public List<DateOnly> AvailableDates { get; set; } = [];
+
+    public MostShortedSort Sort { get; set; }
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 50;
+    public int TotalCount { get; set; }
+    public int TotalPages => Pagination.PageCount(TotalCount, PageSize);
+}

--- a/src/Equibles.Web/ViewModels/ShortActivity/MostShortedListItemViewModel.cs
+++ b/src/Equibles.Web/ViewModels/ShortActivity/MostShortedListItemViewModel.cs
@@ -1,0 +1,11 @@
+namespace Equibles.Web.ViewModels.ShortActivity;
+
+public class MostShortedListItemViewModel
+{
+    public string Ticker { get; set; }
+    public string Name { get; set; }
+    public long CurrentShortPosition { get; set; }
+    public long ChangeInShortPosition { get; set; }
+    public long? AverageDailyVolume { get; set; }
+    public decimal? DaysToCover { get; set; }
+}

--- a/src/Equibles.Web/ViewModels/ShortActivity/MostShortedSort.cs
+++ b/src/Equibles.Web/ViewModels/ShortActivity/MostShortedSort.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Web.ViewModels.ShortActivity;
+
+public enum MostShortedSort
+{
+    [Display(Name = "Current Short Position (high → low)")]
+    CurrentShortPositionDescending = 0,
+
+    [Display(Name = "Change vs Previous (high → low)")]
+    ChangeDescending = 1,
+
+    [Display(Name = "Days to Cover (high → low)")]
+    DaysToCoverDescending = 2,
+
+    [Display(Name = "Ticker (A → Z)")]
+    Ticker = 3,
+}

--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -53,6 +53,7 @@
                             <li><a asp-action="Index" asp-controller="Cftc">Futures</a></li>
                             <li><a asp-action="Index" asp-controller="Market">Market</a></li>
                             <li><a asp-action="Index" asp-controller="ShortVolume">Largest Short Volume</a></li>
+                            <li><a asp-action="MostShorted" asp-controller="ShortActivity">Most Shorted</a></li>
                         </ul>
                     </div>
                     <a asp-action="Connect" asp-controller="Home" class="text-sm text-base-content/60 hover:text-base-content focus-visible:underline transition-colors">MCP</a>
@@ -175,6 +176,11 @@
                         <li>
                             <a asp-action="Index" asp-controller="ShortVolume">
                                 <icon name="arrow-trending-down" size="4" /> Largest Short Volume
+                            </a>
+                        </li>
+                        <li>
+                            <a asp-action="MostShorted" asp-controller="ShortActivity">
+                                <icon name="fire" size="4" /> Most Shorted
                             </a>
                         </li>
                         <li>

--- a/src/Equibles.Web/Views/ShortActivity/MostShorted.cshtml
+++ b/src/Equibles.Web/Views/ShortActivity/MostShorted.cshtml
@@ -1,0 +1,118 @@
+@using Equibles.Web.ViewModels.ShortActivity
+@model MostShortedBrowserViewModel
+
+@{
+    ViewData["Title"] = "Most Shorted";
+    ViewData["Description"] = "The most shorted stocks across the market for a FINRA bi-monthly settlement date — ranked by current short position, with change vs. the previous report, days to cover, and average daily volume.";
+
+    // Active filters carried across pagination links so paging never drops the
+    // selected settlement date or sort order.
+    var filterRoute = new Dictionary<string, string>();
+    if (Model.SelectedDate.HasValue) {
+        filterRoute["date"] = Model.SelectedDate.Value.ToString("yyyy-MM-dd");
+    }
+    if (Model.Sort != MostShortedSort.CurrentShortPositionDescending) {
+        filterRoute["sort"] = Model.Sort.ToString();
+    }
+    var hasData = Model.LatestDate.HasValue;
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold mb-2">Most Shorted</h1>
+        <p class="text-base-content/60">
+            @if (hasData) {
+                <span>@Model.TotalCount.ToString("N0") stocks ranked by FINRA short interest for settlement date <strong class="text-base-content">@Model.SelectedDate?.ToString("MMM dd, yyyy")</strong></span>
+                @if (Model.SelectedDate != Model.LatestDate) {
+                    <span> · latest available @Model.LatestDate?.ToString("MMM dd, yyyy")</span>
+                }
+            } else {
+                <span>No short interest data has been ingested yet.</span>
+            }
+        </p>
+    </div>
+
+    <!-- Settlement-date + sort selector (plain query-param names, bound to ShortActivityController.MostShorted) -->
+    <form method="get" class="mb-6">
+        <div class="flex flex-wrap gap-3 items-end">
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">Settlement date</span>
+                <select name="date" class="select select-bordered" aria-label="Select settlement date"
+                        @(Model.AvailableDates.Count == 0 ? "disabled" : null)>
+                    @foreach (var day in Model.AvailableDates) {
+                        <option value="@day.ToString("yyyy-MM-dd")"
+                                selected="@(day == Model.SelectedDate)">
+                            @day.ToString("MMM dd, yyyy")
+                        </option>
+                    }
+                </select>
+            </label>
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">Sort by</span>
+                <select name="sort" class="select select-bordered" aria-label="Sort stocks">
+                    <partial name="_SortOptions" model='(Html.GetEnumSelectList<MostShortedSort>(), (int)Model.Sort)' />
+                </select>
+            </label>
+            <button type="submit" class="btn btn-primary">Apply</button>
+            @if (filterRoute.ContainsKey("sort")) {
+                <a asp-action="MostShorted" asp-route-date="@Model.SelectedDate?.ToString("yyyy-MM-dd")" class="btn btn-ghost">Reset sort</a>
+            }
+        </div>
+    </form>
+
+    <!-- Results Table -->
+    <div class="card bg-base-100 shadow-sm">
+        <div class="overflow-x-auto">
+            <table class="table table-zebra table-sm" aria-label="Most shorted stocks" data-testid="most-shorted-table">
+                <thead>
+                    <tr>
+                        <th scope="col">Ticker</th>
+                        <th scope="col" class="hidden md:table-cell">Name</th>
+                        <th scope="col" class="text-right">Current Short Position</th>
+                        <th scope="col" class="text-right">Change vs Prev</th>
+                        <th scope="col" class="text-right">Days to Cover</th>
+                        <th scope="col" class="text-right hidden lg:table-cell">Avg Daily Volume</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var row in Model.Records) {
+                        <tr class="hover">
+                            <td class="font-mono font-semibold">
+                                <a asp-controller="Stocks" asp-action="ShortInterest" asp-route-ticker="@row.Ticker" class="link link-primary">@row.Ticker</a>
+                            </td>
+                            <td class="hidden md:table-cell max-w-xs truncate text-base-content/70">@row.Name</td>
+                            <td class="text-right font-mono"><compactable-number value="@row.CurrentShortPosition" /></td>
+                            <td class="text-right font-mono">
+                                @* Rising short interest is bearish (red); a covered/reduced position is green. *@
+                                @{
+                                    var change = row.ChangeInShortPosition;
+                                    var changeClass = change > 0 ? "text-error" : change < 0 ? "text-success" : "text-base-content/50";
+                                }
+                                <span class="@changeClass">@(change > 0 ? "+" : "")<compactable-number value="@change" /></span>
+                            </td>
+                            <td class="text-right font-mono">@(row.DaysToCover.HasValue ? row.DaysToCover.Value.ToString("F1", System.Globalization.CultureInfo.InvariantCulture) : "—")</td>
+                            <td class="text-right font-mono hidden lg:table-cell">
+                                @if (row.AverageDailyVolume.HasValue) {
+                                    <compactable-number value="@row.AverageDailyVolume.Value" />
+                                } else {
+                                    <span class="text-base-content/30">—</span>
+                                }
+                            </td>
+                        </tr>
+                    }
+                    @if (Model.Records.Count == 0) {
+                        <empty-row colspan="6">
+                            @if (hasData) {
+                                <span>No short interest data for @Model.SelectedDate?.ToString("MMM dd, yyyy").</span>
+                            } else {
+                                <span>No short interest has been ingested yet. This page lights up once the worker finishes its first FINRA short-interest cycle.</span>
+                            }
+                        </empty-row>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <partial name="_Pager" model='(Model.Page, Model.TotalPages, "MostShorted", "Most shorted pagination", "most-shorted-pager", (IDictionary<string, string>)filterRoute)' />
+</div>

--- a/tests/Equibles.IntegrationTests/Web/ShortActivityControllerTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ShortActivityControllerTests.cs
@@ -1,0 +1,186 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Finra.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the /most-shorted market-wide leaderboard: for a settlement date (default
+/// latest) the controller ranks stocks by current short position and the rendered
+/// HTML carries the listing in the right order, honours the sort and settlement-date
+/// selectors, and links each row to the stock's short-interest tab.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class ShortActivityControllerTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public ShortActivityControllerTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetMostShorted_NoData_RendersEmptyState()
+    {
+        await _fixture.ResetAndSeedAsync(_ => Task.CompletedTask);
+
+        var response = await _fixture.Client.GetAsync("/most-shorted");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("No short interest");
+        html.Should().Contain("most-shorted-table");
+    }
+
+    [Fact]
+    public async Task GetMostShorted_DefaultSort_RanksByCurrentShortPositionDescending()
+    {
+        var settlement = new DateOnly(2026, 5, 15);
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            SeedShortInterest(
+                db,
+                "HIGH",
+                "High Short Co.",
+                settlement,
+                currentShort: 9_000_000,
+                daysToCover: 5.0m
+            );
+            SeedShortInterest(
+                db,
+                "MID",
+                "Mid Short Co.",
+                settlement,
+                currentShort: 5_000_000,
+                daysToCover: 3.0m
+            );
+            SeedShortInterest(
+                db,
+                "LOW",
+                "Low Short Co.",
+                settlement,
+                currentShort: 1_000_000,
+                daysToCover: 1.0m
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/most-shorted");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        var highIdx = html.IndexOf(">HIGH<", StringComparison.Ordinal);
+        var midIdx = html.IndexOf(">MID<", StringComparison.Ordinal);
+        var lowIdx = html.IndexOf(">LOW<", StringComparison.Ordinal);
+        highIdx.Should().BeGreaterThan(-1);
+        midIdx.Should().BeGreaterThan(highIdx);
+        lowIdx.Should().BeGreaterThan(midIdx);
+    }
+
+    [Fact]
+    public async Task GetMostShorted_SortByDaysToCover_OrdersByDaysToCoverDescending()
+    {
+        var settlement = new DateOnly(2026, 5, 15);
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            // BIG has the largest short position but a tiny days-to-cover; SQUEEZE inverts that.
+            SeedShortInterest(
+                db,
+                "BIG",
+                "Big Co.",
+                settlement,
+                currentShort: 9_000_000,
+                daysToCover: 1.0m
+            );
+            SeedShortInterest(
+                db,
+                "SQUEEZE",
+                "Squeeze Co.",
+                settlement,
+                currentShort: 1_000_000,
+                daysToCover: 12.0m
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/most-shorted?sort=DaysToCoverDescending");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        var squeezeIdx = html.IndexOf(">SQUEEZE<", StringComparison.Ordinal);
+        var bigIdx = html.IndexOf(">BIG<", StringComparison.Ordinal);
+        squeezeIdx.Should().BeGreaterThan(-1);
+        bigIdx.Should().BeGreaterThan(squeezeIdx);
+    }
+
+    [Fact]
+    public async Task GetMostShorted_DateParam_SelectsThatSettlementDate()
+    {
+        var latest = new DateOnly(2026, 5, 29);
+        var older = new DateOnly(2026, 5, 15);
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            SeedShortInterest(
+                db,
+                "NEW",
+                "Newdate Co.",
+                latest,
+                currentShort: 8_000_000,
+                daysToCover: 4.0m
+            );
+            SeedShortInterest(
+                db,
+                "OLD",
+                "Olddate Co.",
+                older,
+                currentShort: 8_000_000,
+                daysToCover: 4.0m
+            );
+            await Task.CompletedTask;
+        });
+
+        var latestHtml = await (
+            await _fixture.Client.GetAsync("/most-shorted")
+        ).Content.ReadAsStringAsync();
+        latestHtml.Should().Contain(">NEW<");
+        latestHtml.Should().NotContain(">OLD<");
+
+        var olderHtml = await (
+            await _fixture.Client.GetAsync("/most-shorted?date=2026-05-15")
+        ).Content.ReadAsStringAsync();
+        olderHtml.Should().Contain(">OLD<");
+        olderHtml.Should().NotContain(">NEW<");
+    }
+
+    private static void SeedShortInterest(
+        EquiblesFinancialDbContext db,
+        string ticker,
+        string name,
+        DateOnly settlementDate,
+        long currentShort,
+        decimal daysToCover
+    )
+    {
+        var stockId = Guid.NewGuid();
+        db.Add(
+            new CommonStock
+            {
+                Id = stockId,
+                Ticker = ticker,
+                Name = name,
+            }
+        );
+        db.Add(
+            new ShortInterest
+            {
+                CommonStockId = stockId,
+                SettlementDate = settlementDate,
+                CurrentShortPosition = currentShort,
+                PreviousShortPosition = currentShort / 2,
+                ChangeInShortPosition = currentShort - currentShort / 2,
+                AverageDailyVolume = 1_000_000,
+                DaysToCover = daysToCover,
+            }
+        );
+    }
+}

--- a/tests/Equibles.IntegrationTests/Web/ShortActivityMostShortedViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ShortActivityMostShortedViewRenderingTests.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Finra.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Drives the /most-shorted Razor view end-to-end: the ranked row renders the
+/// ticker linked to the stock's short-interest tab, the company name, days to
+/// cover, average daily volume, and the settlement-date selector option.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class ShortActivityMostShortedViewRenderingTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public ShortActivityMostShortedViewRenderingTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetMostShorted_WithData_RendersRowAndDateSelector()
+    {
+        var settlement = new DateOnly(2026, 5, 15);
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            var stockId = Guid.NewGuid();
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "GME",
+                    Name = "GameStop Corp.",
+                }
+            );
+            db.Add(
+                new ShortInterest
+                {
+                    CommonStockId = stockId,
+                    SettlementDate = settlement,
+                    CurrentShortPosition = 12_345_678,
+                    PreviousShortPosition = 10_000_000,
+                    ChangeInShortPosition = 2_345_678,
+                    AverageDailyVolume = 5_000_000,
+                    DaysToCover = 2.5m,
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/most-shorted");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        // Ticker links to the per-stock short-interest tab.
+        html.Should().Contain("/stocks/gme/short-interest");
+        html.Should().Contain("GameStop Corp.");
+        // Days to cover renders with one decimal (InvariantCulture).
+        html.Should().Contain("2.5");
+        // The settlement-date selector carries the selected day option.
+        html.Should().Contain("value=\"2026-05-15\"");
+        html.Should().Contain("May 15, 2026");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a market-wide `/most-shorted` leaderboard ranking stocks by FINRA short interest for a selected bi-monthly settlement date (defaulting to the latest available) — current short position, change vs. the previous report, days to cover, and average daily volume.
- Settlement-date selector, server-side sort (current short position / change / days to cover / ticker) and pagination; each row links to the stock's short-interest tab. Models the most-held holdings leaderboard and matches the largest-short-volume page.

## Code changes

- `src/Equibles.Web/Controllers/ShortActivityController.cs` — `~/most-shorted` action: resolves the latest settlement date, lists available dates, ranks `ShortInterest` for the selected date, applies the chosen sort (null days-to-cover coalesced to sort last), and paginates.
- `src/Equibles.Web/ViewModels/ShortActivity/` — `MostShortedBrowserViewModel`, `MostShortedListItemViewModel`, and the `MostShortedSort` enum.
- `src/Equibles.Web/Views/ShortActivity/MostShorted.cshtml` — settlement-date + sort selector, ranked table (signed/colored change, days-to-cover formatted with InvariantCulture, em-dash for missing values), empty state, and pager carrying the active date/sort.
- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — "Most Shorted" link in the desktop "More" dropdown and the mobile nav.
- `tests/Equibles.IntegrationTests/Web/ShortActivityControllerTests.cs`, `ShortActivityMostShortedViewRenderingTests.cs` — in-process host tests: empty state, default ranking, days-to-cover sort, settlement-date selection, and rendered row/date-selector/short-interest-tab link.

Closes #2536