### PR TITLE
test(cboe): pin JsonStringUnescape escaped backslash before u is not a unicode escape

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CboeClientJsonStringUnescapeEscapedBackslashTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientJsonStringUnescapeEscapedBackslashTests.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using Equibles.Integrations.Cboe;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CboeClientJsonStringUnescapeEscapedBackslashTests
+{
+    // Contract (JSON spec, RFC 8259): an escaped backslash `\\` decodes to a
+    // single literal `\`, and that backslash must NOT then combine with a
+    // following `u` to form a unicode escape. So `\\u0041` is backslash +
+    // the literal text "u0041" — six characters — never the letter "A".
+    // This is the classic unescaper state-machine trap: a parser that scans
+    // for the substring `\u` instead of consuming `\\` as one unit would
+    // wrongly emit "A". The escaped-backslash arm and its literal-passthrough
+    // are otherwise unexercised by the existing trailing-unicode pin.
+    //
+    // ReadOnlySpan<char> is a ref struct and can't be boxed into the object[]
+    // MethodInfo.Invoke needs, so bind the private static method via a delegate.
+    private delegate string JsonStringUnescapeFn(ReadOnlySpan<char> input);
+
+    [Fact]
+    public void JsonStringUnescape_EscapedBackslashBeforeU_DoesNotFormUnicodeEscape()
+    {
+        var method = typeof(CboeClient).GetMethod(
+            "JsonStringUnescape",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var unescape = (JsonStringUnescapeFn)
+            Delegate.CreateDelegate(typeof(JsonStringUnescapeFn), method!);
+
+        // Raw 7 chars: \ \ u 0 0 4 1 — first pair is an escaped backslash.
+        var result = unescape("\\\\u0041".AsSpan());
+
+        result.Should().Be("\\u0041"); // literal backslash + "u0041", not "A"
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `CboeClient.JsonStringUnescape` (the hand-rolled unescaper for the scraped CBOE `optionsData` blob): an escaped backslash `\\` must decode to a single literal `\` and must not combine with a following `u` to form a unicode escape.
- Per JSON (RFC 8259), `\\u0041` is backslash + literal "u0041" — never the letter "A". This is the classic unescaper state-machine trap; the escaped-backslash arm was otherwise unexercised by the existing trailing-unicode pin.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CboeClientJsonStringUnescapeEscapedBackslashTests.cs` — new unit test binding the private static method via a delegate (ReadOnlySpan can't be boxed for MethodInfo.Invoke) and asserting `\\u0041` decodes to the literal `A`.