### PR TITLE
test(sec): pin SecDocumentHtmlNormalizer skips unterminated DOCUMENT block

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerUnterminatedDocumentTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerUnterminatedDocumentTests.cs
@@ -1,0 +1,30 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentHtmlNormalizerUnterminatedDocumentTests
+{
+    private readonly SecDocumentHtmlNormalizer _sut = new();
+
+    // Contract: SEC submissions are framed as <DOCUMENT>…</DOCUMENT> blocks. A
+    // truncated submission whose block opens but is never closed must be skipped
+    // safely — the extractor scans for the closing tag and, not finding it, must
+    // stop without slicing past the buffer. A naive substring from the open tag
+    // without the missing-close guard would throw; the contract is empty output,
+    // no exception.
+    [Fact]
+    public void Normalize_DocumentBlockWithoutClosingTag_ReturnsEmptyWithoutThrowing()
+    {
+        var sgml = """
+            <DOCUMENT>
+            <TYPE>10-K
+            <FILENAME>filing.htm
+            <TEXT>
+            <html><body><p>Truncated submission</p></body></html>
+            """;
+
+        var result = _sut.Normalize(sgml);
+
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `SecDocumentHtmlNormalizer`'s handling of a truncated SEC submission: a `<DOCUMENT>` block that opens but is never closed must be skipped safely, yielding empty output and never slicing past the buffer.
- The block-extraction loop's missing-closing-tag guard was previously unexercised by both the unit and integration suites; without it a substring from the open tag would throw on malformed external input.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerUnterminatedDocumentTests.cs` — new unit test driving `Normalize` with an unterminated `<DOCUMENT>` block and asserting empty output with no exception.