### PR TITLE
test(congress): pin ParseTransactionRow drops row with no ticker or asset name

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperRowWithoutSecurityTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperRowWithoutSecurityTests.cs
@@ -1,0 +1,51 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperRowWithoutSecurityTests
+{
+    // Contract: a disclosure transaction must identify a security. ParseTransactionRow
+    // drops any row that has a parseable date but neither a ticker nor an asset name —
+    // such a row (a stray/blank/filler row in scraped HTML) carries no security and
+    // must not become a transaction. A parser that emitted it would yield a record
+    // with null ticker AND null asset, polluting downstream data.
+    [Fact]
+    public void ParseTransactionsFromHtml_RowWithDateButNoTickerOrAssetName_IsDropped()
+    {
+        var html = """
+            <html><body>
+            <table>
+              <thead><tr>
+                <th>Transaction Date</th>
+                <th>Ticker</th>
+                <th>Asset Name</th>
+                <th>Transaction Type</th>
+                <th>Amount</th>
+              </tr></thead>
+              <tbody>
+                <tr>
+                  <td>2024-03-15</td>
+                  <td></td>
+                  <td></td>
+                  <td>Purchase</td>
+                  <td>$1,001 - $15,000</td>
+                </tr>
+              </tbody>
+            </table>
+            </body></html>
+            """;
+
+        var result = DisclosureParsingHelper.ParseTransactionsFromHtml(
+            html,
+            "Test Member",
+            CongressPosition.Representative,
+            new DateOnly(2024, 4, 1),
+            Substitute.For<ILogger>()
+        );
+
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `DisclosureParsingHelper.ParseTransactionRow`'s identity guard: a disclosure row with a parseable date but neither a ticker nor an asset name carries no security and must be dropped, not emitted as a transaction with null identifiers.
- This row-level skip branch (a stray/blank/filler row in scraped HTML) was previously unexercised by both the unit and integration suites.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperRowWithoutSecurityTests.cs` — new unit test driving `ParseTransactionsFromHtml` with a dated row whose ticker and asset-name cells are empty, asserting no transaction is produced.