### PR TITLE
test(congress): pin MapColumnIndices falls back to description column for asset name

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperDescriptionAssetColumnTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperDescriptionAssetColumnTests.cs
@@ -1,0 +1,52 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperDescriptionAssetColumnTests
+{
+    // Contract: MapColumnIndices ranks the asset column as asset+name, then a bare
+    // "asset" (not "type"), then "description". When a table has no Asset/Asset Name
+    // column, the parser must source the asset name from a "Description" column.
+    // Without that third-rank fallback the asset name would come back empty even
+    // though the disclosure clearly describes the security.
+    [Fact]
+    public void ParseTransactionsFromHtml_NoAssetColumnButDescriptionColumn_BindsAssetNameToDescription()
+    {
+        var html = """
+            <html><body>
+            <table>
+              <thead><tr>
+                <th>Transaction Date</th>
+                <th>Ticker</th>
+                <th>Description</th>
+                <th>Transaction Type</th>
+                <th>Amount</th>
+              </tr></thead>
+              <tbody>
+                <tr>
+                  <td>2024-03-15</td>
+                  <td>AAPL</td>
+                  <td>Apple Inc Common Stock</td>
+                  <td>Purchase</td>
+                  <td>$1,001 - $15,000</td>
+                </tr>
+              </tbody>
+            </table>
+            </body></html>
+            """;
+
+        var result = DisclosureParsingHelper.ParseTransactionsFromHtml(
+            html,
+            "Test Member",
+            CongressPosition.Representative,
+            new DateOnly(2024, 4, 1),
+            Substitute.For<ILogger>()
+        );
+
+        result.Should().ContainSingle();
+        result[0].AssetName.Should().Be("Apple Inc Common Stock");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `DisclosureParsingHelper.MapColumnIndices` third-rank asset-column selection: when a table has no Asset/Asset Name column, the asset name must be sourced from a "Description" column.
- Completes the asset-column priority coverage (asset+name → bare asset → description); this description fallback branch was previously unexercised by both the unit and integration suites.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperDescriptionAssetColumnTests.cs` — new unit test driving `ParseTransactionsFromHtml` with a Description-only (no Asset) table and asserting the parsed transaction's asset name comes from that column.