### PR TITLE
test(congress): pin BuildTransaction drops PTR row with non-calendar date

### DIFF
--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientInvalidDateTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientInvalidDateTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class HouseDisclosureClientInvalidDateTests
+{
+    // Contract: the PTR anchor matches a date by digit-shape only (dd/dd/dddd),
+    // so a row can be recognised as a transaction yet carry a non-calendar date
+    // (OCR misreads of scanned House PTRs produce "13/45/2024" etc.).
+    // BuildTransaction must drop such a row — never emit a transaction with a
+    // bogus/default date. A parser that skipped date validation would persist a
+    // garbage TransactionDate.
+    [Fact]
+    public void ParseTransactionLines_TransactionDateMatchesShapeButIsNotACalendarDate_DropsRow()
+    {
+        var result = HouseDisclosureClient.ParseTransactionLines(
+            ["Apple Inc Common P 13/45/2024 $1,001 - $15,000"],
+            "Nancy Pelosi",
+            new DateOnly(2024, 7, 2)
+        );
+
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `HouseDisclosureClient.BuildTransaction`'s date validation: the PTR anchor matches a date by digit-shape only (`dd/dd/dddd`), so an OCR-misread row like `13/45/2024` is recognised as a transaction line but is not a real calendar date — it must be dropped, never emitted with a bogus/default `TransactionDate`.
- This invalid-date guard on the untrusted scanned-PDF text parser was previously unexercised by both the unit and integration suites.

## Code changes

- `tests/Equibles.UnitTests/Congress/HouseDisclosureClientInvalidDateTests.cs` — new unit test driving `ParseTransactionLines` with a shape-valid but non-calendar date and asserting no transaction is produced.