### PR TITLE
test(cboe): pin JsonStringUnescape preserves unrecognised escape literally

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CboeClientJsonStringUnescapeUnknownEscapeTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientJsonStringUnescapeUnknownEscapeTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Equibles.Integrations.Cboe;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CboeClientJsonStringUnescapeUnknownEscapeTests
+{
+    // Contract: an escape sequence the unescaper does not recognise (e.g. "\x")
+    // is not a defined JSON escape. The lenient unescaper must preserve it
+    // verbatim — keep the backslash and the following char — never silently drop
+    // the backslash or throw. This is the switch default arm; sibling pins cover
+    // the recognised escapes and the malformed-\u cases.
+    //
+    // ReadOnlySpan<char> is a ref struct and can't be boxed for MethodInfo.Invoke,
+    // so the private static method is bound via a typed delegate.
+    private delegate string JsonStringUnescapeFn(ReadOnlySpan<char> input);
+
+    [Fact]
+    public void JsonStringUnescape_UnrecognisedEscape_IsPreservedLiterally()
+    {
+        var method = typeof(CboeClient).GetMethod(
+            "JsonStringUnescape",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var unescape = (JsonStringUnescapeFn)
+            Delegate.CreateDelegate(typeof(JsonStringUnescapeFn), method!);
+
+        // Raw 2 chars: \ x — backslash-x is not a defined JSON escape.
+        var result = unescape("\\x".AsSpan());
+
+        result.Should().Be("\\x");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `CboeClient.JsonStringUnescape` switch default arm: an escape sequence it does not recognise (e.g. `\x`) is not a defined JSON escape and must be preserved verbatim — keep the backslash and following char, never drop the backslash or throw.
- This completes coverage of the hand-rolled unescaper for CBOE's scraped optionsData blob (sibling pins cover recognised escapes, escaped-backslash, control escapes, and malformed-`\u`).

## Code changes

- `tests/Equibles.UnitTests/Integrations/CboeClientJsonStringUnescapeUnknownEscapeTests.cs` — new unit test binding the private static method via a delegate and asserting `\x` is preserved as the literal `\x`.