### PR TITLE
test(sec): add skipped repro for GH-2773 — DocumentTextTools.FormatDocumentHeader

### DIFF
--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsFormatDocumentHeaderCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsFormatDocumentHeaderCalendarTests.cs
@@ -1,0 +1,52 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class DocumentTextToolsFormatDocumentHeaderCalendarTests
+{
+    // FormatDocumentHeader renders "filed {ReportingDate:yyyy-MM-dd}" with no
+    // IFormatProvider, so the year formats through the thread CurrentCulture's
+    // calendar. The sibling header test pins the ISO shape under the default
+    // (Gregorian) culture; this attacks the orthogonal calendar axis. Under
+    // th-TH (Buddhist, year + 543) the banner the LLM consumer parses must
+    // still carry the Gregorian ISO date — same bug class fixed for the
+    // holdings MCP date headers (GH-2681).
+    [Fact(Skip = "GH-2773 — bare :yyyy-MM-dd renders Buddhist year under th-TH calendar")]
+    public void FormatDocumentHeader_UnderNonGregorianCalendar_RendersGregorianIsoDate()
+    {
+        var document = new Document
+        {
+            CommonStock = new CommonStock { Name = "Apple Inc.", Ticker = "AAPL" },
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2026, 5, 27),
+        };
+
+        var method = typeof(DocumentTextTools).GetMethod(
+            "FormatDocumentHeader",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var original = CultureInfo.CurrentCulture;
+        string result;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("th-TH");
+            result = (string)method!.Invoke(null, [document]);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+
+        result
+            .Should()
+            .Be(
+                "Apple Inc. (AAPL) 10-K filed 2026-05-27",
+                "the filing date in the MCP banner must be a Gregorian ISO-8601 date regardless of host calendar; under th-TH the bare :yyyy-MM-dd specifier renders the Buddhist year 2569"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped regression test pinning that the MCP document banner (`DocumentTextTools.FormatDocumentHeader`) renders the filing date as a Gregorian ISO-8601 date regardless of host calendar.
- The bare `:yyyy-MM-dd` specifier (no `IFormatProvider`) renders the year through the thread `CurrentCulture` calendar; under `th-TH` (Buddhist, +543) it emits `2569-05-27` instead of `2026-05-27`. Test is `[Skip]` pending the fix — see GH-2773.

## Code changes

- `tests/Equibles.UnitTests/Sec/DocumentTextToolsFormatDocumentHeaderCalendarTests.cs` — new unit test: sets `CurrentCulture` to `th-TH`, reflection-invokes the private static `FormatDocumentHeader`, asserts the Gregorian ISO date in the banner. Skipped (`GH-2773`) — un-skip when the bare format is converted to `CultureInfo.InvariantCulture`.