### PR TITLE
test(finra): pin ShortDataTools.GetShortInterest culture-invariant rendering

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
@@ -1,0 +1,82 @@
+using System.Globalization;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Mcp.Tools;
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class ShortDataToolsGetShortInterestCultureInvarianceTests : ParadeDbMcpTestBase
+{
+    private ShortDataTools Sut() =>
+        new(
+            new DailyShortVolumeRepository(DbContext),
+            new ShortInterestRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<ShortDataTools>()
+        );
+
+    public ShortDataToolsGetShortInterestCultureInvarianceTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    // The "Short Position" cell renders {r.CurrentShortPosition:N0} with the
+    // culture-implicit specifier, which honours the thread CurrentCulture. The
+    // established repo contract (FormatSignedChange in this same file, and the
+    // dozens of InvariantCulture call sites across the MCP tools commenting
+    // "MCP markdown must not fork the separators by host locale") is that the
+    // LLM-facing markdown renders byte-identically regardless of host locale.
+    // de-DE swaps the thousand separator (1,234,567 → 1.234.567), forking the
+    // response — same bug class as the fixed Holdings RenderTopHoldersTable (#2628).
+    [Fact(
+        Skip = "GH-2777 — GetShortInterest numeric cells follow host CurrentCulture (bare :N0 + McpFormat.OrDash null provider)"
+    )]
+    public async Task GetShortInterest_UnderNonInvariantCulture_RendersShortPositionCultureInvariantly()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "GME",
+            Name = "GameStop Corp",
+            Cik = "0001326380",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext
+            .Set<ShortInterest>()
+            .Add(
+                new ShortInterest
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    SettlementDate = new DateOnly(2026, 3, 15),
+                    CurrentShortPosition = 1_234_567,
+                    PreviousShortPosition = 1_234_567,
+                    ChangeInShortPosition = 0,
+                    AverageDailyVolume = 100_000,
+                    DaysToCover = 12.3m,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        // Pin de-DE only for the rendering call; CurrentCulture flows through the
+        // tool's await chain via ExecutionContext. Base class restores invariant.
+        var previous = CultureInfo.CurrentCulture;
+        string result;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            result = await Sut()
+                .GetShortInterest("GME", startDate: "2026-01-01", endDate: "2026-04-30");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+
+        // 1,234,567 shares must render with en-US grouping on every host locale.
+        result.Should().Contain("| 1,234,567 |");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an integration test asserting `ShortDataTools.GetShortInterest` renders its short-interest table with invariant (en-US) digit separators under a non-invariant host locale.
- The test currently fails (skipped — see GH-2777): the "Short Position" cell uses a bare `:N0` and the Avg Daily Volume / Days to Cover cells route through `McpFormat.OrDash` (null format provider → `CurrentCulture`), so under `de-DE` the row forks to `1.234.567 | … | 100.000 | 12,3`. Same bug class as the fixed Holdings render methods (#2628 / #2637 / #2641 / #2647) and the open #2775.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs` — seeds a 1,234,567-share position on the ParadeDB MCP fixture, renders the table under `de-DE`, and asserts the en-US grouping survives. Marked `[Fact(Skip = "GH-2777 …")]` until the production fix lands; un-skip as part of that fix.