### PR TITLE
test(holdings): pin RenderOwnershipHistory culture-invariant rendering

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs
@@ -1,0 +1,96 @@
+using System.Globalization;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests
+    : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests(
+        ParadeDbFixture fixture
+    )
+        : base(fixture) { }
+
+    // RenderOwnershipHistory builds each row's Institutions / Total Shares / Total
+    // Value cells with the culture-implicit :N0 / :N1 specifiers (and the change
+    // column with :+0.0;-0.0), all honouring the thread CurrentCulture. The
+    // established repo contract (FormatDate / FormatSignedMillions in this same
+    // file thread InvariantCulture, commenting "MCP markdown must not fork the
+    // separators by host locale") is that the LLM-facing markdown renders the same
+    // on every host. de-DE swaps the thousand separator (1,234,567 → 1.234.567),
+    // forking the response — same bug class as the fixed sibling RenderTopHoldersTable (#2628).
+    [Fact(Skip = "GH-2779 — RenderOwnershipHistory :N0/:N1/:+0.0 cells follow host CurrentCulture")]
+    public async Task GetOwnershipHistory_UnderNonInvariantCulture_RendersTotalSharesCultureInvariantly()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var holder = new InstitutionalHolder
+        {
+            Cik = "0001067983",
+            Name = "Berkshire Hathaway Inc.",
+        };
+        DbContext.Add(stock);
+        DbContext.Add(holder);
+        DbContext.Add(MakeHolding(stock, holder, new DateOnly(2024, 12, 31), shares: 1_234_567));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new InstitutionalHoldingsTools(
+            new InstitutionalHoldingRepository(verify),
+            new InstitutionalHolderRepository(verify),
+            new CommonStockRepository(verify),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+        // Pin de-DE only for the rendering call; CurrentCulture flows through the
+        // tool's await chain via ExecutionContext. Base class restores invariant.
+        var previous = CultureInfo.CurrentCulture;
+        string output;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            output = await sut.GetOwnershipHistory("AAPL");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+
+        // 1,234,567 shares must render with en-US grouping on every host locale.
+        output.Should().Contain("| 1,234,567 |");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = shares * 100,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

- Adds an integration test asserting `InstitutionalHoldingsTools.RenderOwnershipHistory` (the `GetOwnershipHistory` MCP tool) renders its numeric cells with invariant (en-US) separators under a non-invariant host locale.
- The test currently fails (skipped — see GH-2779): the Institutions / Total Shares / Total Value cells use bare `:N0`/`:N1` and the change column uses `:+0.0;-0.0`, so under `de-DE` the row forks to `1.234.567 | 123,5`. Last remaining digit-separator hole in this class; siblings fixed in #2628 / #2637 / #2641 / #2647 / #2656 / #2660.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs` — seeds a 1,234,567-share holding on the ParadeDB MCP fixture, renders the history table under `de-DE`, and asserts the en-US grouping survives. Marked `[Fact(Skip = "GH-2779 …")]` until the production fix lands; un-skip as part of that fix.