### PR TITLE
test(insider-trading): pin GetInsiderTransactions culture-invariant rendering

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests.cs
@@ -1,0 +1,88 @@
+using System.Globalization;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Mcp.Tools;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests : ParadeDbMcpTestBase
+{
+    public InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private InsiderTradingTools Sut() =>
+        new(
+            new InsiderTransactionRepository(DbContext),
+            new InsiderOwnerRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<InsiderTradingTools>()
+        );
+
+    // GetInsiderTransactions renders the Shares / Price / Value / Owned After cells
+    // with the culture-implicit :N0 / :N2 specifiers, which honour the thread
+    // CurrentCulture. The established repo contract (the dozens of InvariantCulture
+    // call sites across the MCP tools commenting "MCP markdown must not fork the
+    // separators by host locale") is that the LLM-facing markdown renders the same
+    // on every host. de-DE swaps the thousand separator (1,234,567 → 1.234.567),
+    // forking the response — same bug class as the fixed Holdings render methods (#2628).
+    [Fact(Skip = "GH-2781 — GetInsiderTransactions :N0/:N2 cells follow host CurrentCulture")]
+    public async Task GetInsiderTransactions_UnderNonInvariantCulture_RendersSharesCultureInvariantly()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var owner = new InsiderOwner
+        {
+            OwnerCik = "0001234567",
+            Name = "John Doe",
+            City = "New York",
+            StateOrCountry = "NY",
+            IsDirector = true,
+        };
+        var transaction = new InsiderTransaction
+        {
+            CommonStock = stock,
+            InsiderOwner = owner,
+            TransactionDate = new DateOnly(2024, 6, 14),
+            FilingDate = new DateOnly(2024, 6, 15),
+            TransactionCode = TransactionCode.Sale,
+            Shares = 1_234_567,
+            PricePerShare = 175.50m,
+            AcquiredDisposed = AcquiredDisposed.Disposed,
+            SharesOwnedAfter = 7_654_321,
+            OwnershipNature = OwnershipNature.Direct,
+            SecurityTitle = "Common Stock",
+            AccessionNumber = "0001234567-24-000001",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<InsiderOwner>().Add(owner);
+        DbContext.Set<InsiderTransaction>().Add(transaction);
+        await DbContext.SaveChangesAsync();
+
+        // Pin de-DE only for the rendering call; CurrentCulture flows through the
+        // tool's await chain via ExecutionContext. Base class restores invariant.
+        var previous = CultureInfo.CurrentCulture;
+        string result;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            result = await Sut().GetInsiderTransactions("AAPL");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+
+        // 1,234,567 shares must render with en-US grouping on every host locale.
+        result.Should().Contain("| 1,234,567 |");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an integration test asserting `InsiderTradingTools.GetInsiderTransactions` renders its numeric cells with invariant (en-US) separators under a non-invariant host locale.
- The test currently fails (skipped — see GH-2781): the Shares / Price / Value / Owned After cells use bare `:N0`/`:N2`, so under `de-DE` the whole row forks (`1.234.567 | $175,50 | $216.666.509 | 7.654.321`). `InsiderTradingTools.cs` has no `InvariantCulture` usage at all. Same bug class as the fixed Holdings render methods (#2628 / #2637 / #2641 / #2647 / #2656 / #2660).

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests.cs` — seeds a 1,234,567-share transaction on the ParadeDB MCP fixture, renders the table under `de-DE`, and asserts the en-US grouping survives. Marked `[Fact(Skip = "GH-2781 …")]` until the production fix lands; un-skip as part of that fix.