### PR TITLE
test(sec): pin GetFailsToDeliver culture-invariant rendering

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests.cs
@@ -1,0 +1,72 @@
+using System.Globalization;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+using Equibles.Sec.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests : ParadeDbMcpTestBase
+{
+    private FailToDeliverTools Sut() =>
+        new(
+            new FailToDeliverRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<FailToDeliverTools>()
+        );
+
+    public FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    // GetFailsToDeliver renders the Quantity / Price / Value cells with the culture-implicit
+    // :N0 / :F2 specifiers, which honour the thread CurrentCulture. The established repo
+    // contract (the dozens of InvariantCulture call sites across the MCP tools commenting
+    // "MCP markdown must not fork the separators by host locale") is that the LLM-facing
+    // markdown renders the same on every host. de-DE swaps the thousand separator
+    // (1,234,567 → 1.234.567), forking the response — same bug class as the fixed Holdings
+    // render methods (#2628).
+    [Fact(Skip = "GH-2791 — GetFailsToDeliver :N0/:F2 cells follow host CurrentCulture")]
+    public async Task GetFailsToDeliver_UnderNonInvariantCulture_RendersQuantityCultureInvariantly()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "GME",
+            Name = "GameStop Corp",
+            Cik = "0001326380",
+        };
+        var ftd = new FailToDeliver
+        {
+            CommonStock = stock,
+            CommonStockId = stock.Id,
+            SettlementDate = new DateOnly(2026, 3, 15),
+            Quantity = 1_234_567,
+            Price = 25.50m,
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<FailToDeliver>().Add(ftd);
+        await DbContext.SaveChangesAsync();
+
+        // Pin de-DE only for the rendering call; CurrentCulture flows through the
+        // tool's await chain via ExecutionContext. Base class restores invariant.
+        var previous = CultureInfo.CurrentCulture;
+        string result;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            result = await Sut()
+                .GetFailsToDeliver("GME", startDate: "2026-01-01", endDate: "2026-12-31");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+
+        // 1,234,567 fail-to-deliver shares must render with en-US grouping on every host locale.
+        result.Should().Contain("| 1,234,567 |");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an integration test asserting `FailToDeliverTools.GetFailsToDeliver` renders its numeric cells with invariant (en-US) separators under a non-invariant host locale.
- The test currently fails (skipped — see GH-2791): the Quantity/Price/Value cells use bare `:N0`/`:F2`, so under `de-DE` the row forks (`1.234.567 | $25,50 | $31.481.459`). `FailToDeliverTools.cs` has no `InvariantCulture` usage at all. Same bug class as the fixed Holdings render methods (#2628 / #2637 / #2641 / #2647 / #2656 / #2660).

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests.cs` — seeds an FTD row (quantity 1,234,567) on the ParadeDB MCP fixture, renders the table under `de-DE`, and asserts the en-US grouping survives. Marked `[Fact(Skip = "GH-2791 …")]` until the production fix lands; un-skip as part of that fix.