### PR TITLE
test(finra): add skipped repro for GH-2794 — GetShortVolume culture-invariant cells

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Mcp.Tools;
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class ShortDataToolsGetShortVolumeCultureInvarianceTests : ParadeDbMcpTestBase
+{
+    private ShortDataTools Sut() =>
+        new(
+            new DailyShortVolumeRepository(DbContext),
+            new ShortInterestRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<ShortDataTools>()
+        );
+
+    public ShortDataToolsGetShortVolumeCultureInvarianceTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    // GetShortVolume renders the Short/Exempt/Total Volume cells with the
+    // culture-implicit :N0 specifier (and Short % with :F1), all of which honour
+    // the thread CurrentCulture. The established repo contract (the dozens of
+    // InvariantCulture call sites across the MCP tools commenting "MCP markdown
+    // must not fork the separators by host locale") is that the LLM-facing
+    // markdown renders byte-identically regardless of host locale. de-DE swaps the
+    // thousand separator (1,234,567 → 1.234.567), forking the response — same bug
+    // class as the sibling GetShortInterest cells (#2777).
+    [Fact(Skip = "GH-2794 — GetShortVolume :N0/:F1 cells follow host CurrentCulture")]
+    public async Task GetShortVolume_UnderNonInvariantCulture_RendersVolumeCultureInvariantly()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "GME",
+            Name = "GameStop Corp",
+            Cik = "0001326380",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext
+            .Set<DailyShortVolume>()
+            .Add(
+                new DailyShortVolume
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    Date = new DateOnly(2026, 3, 15),
+                    ShortVolume = 1_234_567,
+                    ShortExemptVolume = 12_345,
+                    TotalVolume = 2_000_000,
+                    Market = "FNRA",
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        // Pin de-DE only for the rendering call; CurrentCulture flows through the
+        // tool's await chain via ExecutionContext. Base class restores invariant.
+        var previous = CultureInfo.CurrentCulture;
+        string result;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            result = await Sut()
+                .GetShortVolume("GME", startDate: "2026-01-01", endDate: "2026-04-30");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+
+        // 1,234,567 shares of short volume must render with en-US grouping on every host locale.
+        result.Should().Contain("| 1,234,567 |");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an integration test pinning that `ShortDataTools.GetShortVolume` renders its numeric markdown cells with invariant (en-US) digit separators regardless of host `CurrentCulture`.
- The test currently fails — under `de-DE` the bare `:N0`/`:F1` specifiers emit `1.234.567` / `61,7%` instead of `1,234,567` / `61.7%`, forking the LLM-facing markdown by host locale. Committed skipped — see GH-2794.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs` — new `[Fact(Skip)]` regression test that seeds a short-volume row, renders the table under `de-DE`, and asserts en-US grouping is preserved. Marked `[Skip]` pending the production fix in GH-2794; un-skip as part of that fix.