### PR TITLE
fix: render GetShortInterest numeric cells with invariant separators

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -149,7 +149,7 @@ public class ShortDataTools
                     var advStr = McpFormat.OrDash(r.AverageDailyVolume, "N0");
                     var dtcStr = McpFormat.OrDash(r.DaysToCover, "F1");
                     result.AppendLine(
-                        $"| {r.SettlementDate:yyyy-MM-dd} | {r.CurrentShortPosition:N0} | {changeStr} | {advStr} | {dtcStr} |"
+                        $"| {r.SettlementDate:yyyy-MM-dd} | {r.CurrentShortPosition.ToString("N0", CultureInfo.InvariantCulture)} | {changeStr} | {advStr} | {dtcStr} |"
                     );
                 }
 

--- a/src/Equibles.Mcp/Helpers/McpFormat.cs
+++ b/src/Equibles.Mcp/Helpers/McpFormat.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Equibles.Mcp.Helpers;
 
 public static class McpFormat
@@ -5,8 +7,8 @@ public static class McpFormat
     private const string Dash = "—";
 
     // Formats a nullable value with the given format string, or the em-dash placeholder when null.
-    // A null format provider resolves to CurrentCulture, matching a direct value.ToString(format) call.
+    // Always formats with InvariantCulture so MCP markdown does not fork the separators by host locale.
     public static string OrDash<T>(T? value, string format)
         where T : struct, IFormattable =>
-        value.HasValue ? value.Value.ToString(format, null) : Dash;
+        value.HasValue ? value.Value.ToString(format, CultureInfo.InvariantCulture) : Dash;
 }

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
@@ -32,9 +32,7 @@ public class ShortDataToolsGetShortInterestCultureInvarianceTests : ParadeDbMcpT
     // LLM-facing markdown renders byte-identically regardless of host locale.
     // de-DE swaps the thousand separator (1,234,567 → 1.234.567), forking the
     // response — same bug class as the fixed Holdings RenderTopHoldersTable (#2628).
-    [Fact(
-        Skip = "GH-2777 — GetShortInterest numeric cells follow host CurrentCulture (bare :N0 + McpFormat.OrDash null provider)"
-    )]
+    [Fact]
     public async Task GetShortInterest_UnderNonInvariantCulture_RendersShortPositionCultureInvariantly()
     {
         var stock = new CommonStock
@@ -76,7 +74,11 @@ public class ShortDataToolsGetShortInterestCultureInvarianceTests : ParadeDbMcpT
             CultureInfo.CurrentCulture = previous;
         }
 
-        // 1,234,567 shares must render with en-US grouping on every host locale.
+        // Every numeric cell must render with en-US separators on any host locale:
+        // Short Position (bare :N0), Avg Daily Volume (OrDash "N0"), Days to Cover
+        // (OrDash "F1"). de-DE would produce 1.234.567 / 100.000 / 12,3.
         result.Should().Contain("| 1,234,567 |");
+        result.Should().Contain("| 100,000 |");
+        result.Should().Contain("| 12.3 |");
     }
 }


### PR DESCRIPTION
## Summary

- `GetShortInterest` forked its LLM-consumed markdown by host locale: the Short Position cell used a bare `:N0`, and Avg Daily Volume / Days to Cover came through `McpFormat.OrDash`, which formatted with a `null` provider that resolves to the thread `CurrentCulture`. On de-DE the separators flipped (`1,234,567 → 1.234.567`, `100,000 → 100.000`, `12.3 → 12,3`).
- Threads `InvariantCulture` through the bare cell and makes `OrDash` format with `InvariantCulture`, so the shared helper renders consistently for every tool that uses it. Under the invariant test culture this is byte-identical to the previous null-provider behavior — the change only affects non-invariant hosts.

## Code changes

- `src/Equibles.Mcp/Helpers/McpFormat.cs` — `OrDash` now formats with `CultureInfo.InvariantCulture` instead of a `null` provider.
- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — Short Position cell in `GetShortInterest` formats via `ToString("N0", CultureInfo.InvariantCulture)`.
- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs` — un-skipped the pre-staged repro and strengthened it to assert all three numeric cells render with en-US separators under `de-DE`. Fails before the fix, passes after.

closes #2777