### PR TITLE
test(sec): add skipped repro for GH-2801 — TableNormalizationStep rowspan+colspan

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepRowspanColspanCombinedTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepRowspanColspanCombinedTests.cs
@@ -1,0 +1,40 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class TableNormalizationStepRowspanColspanCombinedTests
+{
+    // A cell with BOTH rowspan and colspan occupies a rectangular block, so the
+    // normalizer must expand it into that full block — leaving every row with the
+    // same column count and trailing cells column-aligned. Existing pins cover
+    // colspan and rowspan in isolation; this pins their combination, where the
+    // colspan width must also propagate down the rowspan-spanned rows.
+    [Fact(Skip = "GH-2801 — rowspan+colspan cell expands to a ragged grid")]
+    public void Execute_CellWithBothRowspanAndColspan_ProducesRectangularGrid()
+    {
+        // Cell A spans rows 0-1 and cols 0-1; B sits at col 2 of row 0, so C
+        // (the only cell of row 1) belongs at col 2, directly under B.
+        var parser = new HtmlParser();
+        var doc = parser.ParseDocument(
+            "<html><body><table>"
+                + "<tr><td rowspan=\"2\" colspan=\"2\">A</td><td>B</td></tr>"
+                + "<tr><td>C</td></tr>"
+                + "</table></body></html>"
+        );
+        var step = new TableNormalizationStep(parser);
+
+        step.Execute(doc);
+
+        var rows = doc.QuerySelectorAll("tr");
+        rows.Should().HaveCount(2);
+
+        var firstRowCells = rows[0].QuerySelectorAll("td").Length;
+        var secondRowCells = rows[1].QuerySelectorAll("td").Length;
+
+        // Rectangular grid: every row carries the same column count once spans
+        // are expanded. A ragged result means the colspan width was not carried
+        // into the rowspan-spanned row, misaligning C from B.
+        secondRowCells.Should().Be(firstRowCells);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped regression test reproducing GH-2801: `TableNormalizationStep` expands a cell carrying both `rowspan` and `colspan` into a ragged grid instead of a rectangular one.
- `FixColspan` runs before `FixRowspan` and leaves the `rowspan` attribute on the original cell only, so `FixRowspan` under-fills each spanned row by `colspan - 1` cells — misaligning every column to the right of the merged block.
- Skipped — see GH-2801. The fix should drop the `Skip` in the same change.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepRowspanColspanCombinedTests.cs` — new `[Fact(Skip = "GH-2801 …")]` normalizing a table whose first cell is `rowspan="2" colspan="2"`, asserting both rows end with the same column count. Currently fails (`secondRowCells` 2 vs 3), documenting the ragged-grid defect; no production code touched.