### PR TITLE
fix: render Sec document banner date with invariant calendar

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using System.Text;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -160,7 +161,7 @@ public class DocumentTextTools
     }
 
     private static string FormatDocumentHeader(Document document) =>
-        $"{document.CommonStock.Name} ({document.CommonStock.Ticker}) {document.DocumentType} filed {document.ReportingDate:yyyy-MM-dd}";
+        $"{document.CommonStock.Name} ({document.CommonStock.Ticker}) {document.DocumentType} filed {document.ReportingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
 
     private static string HighlightKeyword(string line, string keyword)
     {

--- a/tests/Equibles.UnitTests/Sec/DocumentTextToolsFormatDocumentHeaderCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTextToolsFormatDocumentHeaderCalendarTests.cs
@@ -15,7 +15,7 @@ public class DocumentTextToolsFormatDocumentHeaderCalendarTests
     // th-TH (Buddhist, year + 543) the banner the LLM consumer parses must
     // still carry the Gregorian ISO date — same bug class fixed for the
     // holdings MCP date headers (GH-2681).
-    [Fact(Skip = "GH-2773 — bare :yyyy-MM-dd renders Buddhist year under th-TH calendar")]
+    [Fact]
     public void FormatDocumentHeader_UnderNonGregorianCalendar_RendersGregorianIsoDate()
     {
         var document = new Document


### PR DESCRIPTION
## Summary

- `DocumentTextTools.FormatDocumentHeader` builds the banner opening every `ReadDocumentLines` / `SearchDocumentKeyword` MCP response. It rendered the filing date with a bare `:yyyy-MM-dd`, so `DateOnly.ToString` formatted the year through the thread `CurrentCulture`'s calendar. On a non-Gregorian host (e.g. `th-TH`, Buddhist calendar) the banner emitted the Buddhist year (`2569` instead of `2026`), breaking LLM consumers and any ISO-date regex.
- Renders the date with `CultureInfo.InvariantCulture`. Under the default Gregorian culture this is byte-identical to before — the change only affects non-Gregorian hosts.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs` — format `ReportingDate` via `ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)`; add the `System.Globalization` using.
- `tests/Equibles.UnitTests/Sec/DocumentTextToolsFormatDocumentHeaderCalendarTests.cs` — un-skipped the pre-staged repro asserting the Gregorian ISO date under `th-TH`. Fails before the fix, passes after.

closes #2773