### PR TITLE
fix: log Error when DocumentScraper retries are exhausted

### DIFF
--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -714,7 +714,7 @@ public class DocumentScraper : IDocumentScraper
                     Delay = TimeSpan.FromSeconds(2),
                     OnRetry = context =>
                     {
-                        if (context.AttemptNumber < maxRetryAttempts)
+                        if (context.AttemptNumber < maxRetryAttempts - 1)
                         {
                             _logger.LogWarning(
                                 context.Outcome.Exception,

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperBuildRetryPipelineFinalAttemptErrorLogTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperBuildRetryPipelineFinalAttemptErrorLogTests.cs
@@ -25,11 +25,7 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class DocumentScraperBuildRetryPipelineFinalAttemptErrorLogTests
 {
-    [Fact(
-        Skip = "GH-2771 — OnRetry's zero-based AttemptNumber (0,1,2) never reaches "
-            + "maxRetryAttempts (3), so the final-attempt LogError branch is dead code.",
-        Timeout = 60000
-    )]
+    [Fact(Timeout = 60000)]
     public async Task BuildRetryPipeline_AfterExhaustingAllRetries_LogsErrorOnFinalAttempt()
     {
         var logger = Substitute.For<ILogger<DocumentScraper>>();


### PR DESCRIPTION
## Summary

- `DocumentScraper.BuildRetryPipeline`'s `OnRetry` gated the Error log on `context.AttemptNumber < maxRetryAttempts`. In Polly v8 `OnRetry` fires with a zero-based `AttemptNumber` (0,1,2 for `MaxRetryAttempts=3`), always below 3 — so the `else` branch logging "Document creation failed after N attempts" was dead code, and exhausted retries emitted only Warnings.
- Compares against the zero-based bound (`maxRetryAttempts - 1`) so the final retry logs at Error, letting operators distinguish a permanent document-creation failure from a transient retry.

## Code changes

- `src/Equibles.Sec.HostedService/DocumentScraper.cs` — `OnRetry` Warning branch now uses `context.AttemptNumber < maxRetryAttempts - 1`; the final attempt hits the Error branch.
- `tests/Equibles.UnitTests/Sec/DocumentScraperBuildRetryPipelineFinalAttemptErrorLogTests.cs` — un-skipped the pre-staged adversarial repro asserting ≥1 Error log after exhausting retries. Fails before the fix (3 Warning / 0 Error), passes after.

closes #2771