### PR TITLE
test(integrations): add skipped repro for GH-2806 — RateLimiter zero maxRequests

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/RateLimiterZeroCapacityTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/RateLimiterZeroCapacityTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Integrations.Common.RateLimiter;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class RateLimiterZeroCapacityTests
+{
+    [Fact(
+        Skip = "GH-2806 — maxRequests <= 0 is accepted; first WaitAsync throws InvalidOperationException"
+    )]
+    public void Constructor_ZeroMaxRequests_RejectsInvalidCapacity()
+    {
+        // A limiter whose capacity is zero can never release a request — it is an
+        // impossible configuration. The .NET convention for an out-of-range count
+        // argument (cf. SemaphoreSlim's initialCount) is to fail fast at construction
+        // with ArgumentOutOfRangeException. Instead the value is silently accepted and
+        // the FIRST WaitAsync throws InvalidOperationException ("queue empty") from
+        // Queue.Peek deep inside CalculateWaitTime (0 < 0 is false, so the empty queue
+        // is peeked) — an internal invariant leaking out as the wrong exception type.
+        var act = () => new RateLimiter(maxRequests: 0, timeWindow: TimeSpan.FromMinutes(1));
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test for `RateLimiter` on the zero/negative-capacity boundary. It revealed a latent bug: `maxRequests <= 0` is silently accepted, and the first `WaitAsync()` throws `InvalidOperationException` ("Queue empty") from `Queue.Peek()` instead of failing fast at construction.
- Test ships skipped — see GH-2806. Un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Integrations/RateLimiterZeroCapacityTests.cs` — new `[Fact(Skip = "GH-2806 ...")]` asserting the constructor rejects `maxRequests: 0` with `ArgumentOutOfRangeException` (the .NET fail-fast convention for an out-of-range count argument). Currently fails because construction is accepted and the opaque exception only surfaces later inside `WaitAsync`.