### PR TITLE
perf(finra): walk short-interest settlement dates with a loose index scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Short-interest pages (the `/most-shorted` leaderboard and the per-stock settlement-date selector) load faster: `ShortInterestRepository.GetAllSettlementDates` now walks the distinct settlement dates with a recursive loose index scan instead of `SELECT DISTINCT`, which scanned the whole `SettlementDate` index on every request and spiked on a cold buffer cache. Falls back to the `DISTINCT` query on non-relational providers.
 - `CommonStockManager.SetCusip` publishes `StockCusipChanged` via the root `IBus` instead of the scoped `IPublishEndpoint`. A commercial host that enables a bus outbox on a different DbContext (the customer database) would otherwise capture this publish into that context and never deliver it — the flow only saves the financial context. Tests updated to substitute `IBus`. PR #2271.
 - Culture-invariance hardening — MCP tool tables, web date/number formatting, SEC/CFTC/FINRA date parsing, and worker interval logging now consistently use the invariant culture, so output and parsing no longer depend on the server locale. Numerous PRs (e.g. #2748, #2735, #2724, #2705, #2661, #2464, #2460).
 - Ticker normalization uses `ToUpperInvariant` across the web `StocksController` and the Holdings / InsiderTrading MCP resolvers. PRs #2609, #2517.

--- a/src/Equibles.Finra.Repositories/ShortInterestRepository.cs
+++ b/src/Equibles.Finra.Repositories/ShortInterestRepository.cs
@@ -2,6 +2,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
 using Equibles.Data.Extensions;
 using Equibles.Finra.Data.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Finra.Repositories;
 
@@ -33,7 +34,43 @@ public class ShortInterestRepository : BaseRepository<ShortInterest>
 
     public IQueryable<DateOnly> GetAllSettlementDates()
     {
-        return GetAll().Select(s => s.SettlementDate).Distinct();
+        // A plain SELECT DISTINCT "SettlementDate" scans the entire SettlementDate
+        // index (one entry per row, ~hundreds of thousands), so it is slow and spikes
+        // when the buffer cache is cold. The settlement dates are a tiny set (a few
+        // hundred), so we walk them with a loose index ("skip") scan instead: jump to
+        // the newest date, then repeatedly fetch the next-lower one via the same
+        // IX_ShortInterest_SettlementDate index. That touches only one index entry per
+        // distinct date. Returned newest-first; callers need not re-sort.
+        if (!DbContext.Database.IsRelational())
+        {
+            // Non-relational providers (e.g. the in-memory provider used in tests)
+            // cannot run raw SQL — fall back to the equivalent DISTINCT query.
+            return GetAll().Select(s => s.SettlementDate).Distinct().OrderByDescending(d => d);
+        }
+
+        return DbContext.Database.SqlQueryRaw<DateOnly>(
+            """
+            WITH RECURSIVE "dates" AS (
+                SELECT (
+                    SELECT "SettlementDate"
+                    FROM "ShortInterest"
+                    ORDER BY "SettlementDate" DESC
+                    LIMIT 1
+                ) AS "Value"
+                UNION ALL
+                SELECT (
+                    SELECT "SettlementDate"
+                    FROM "ShortInterest"
+                    WHERE "SettlementDate" < "dates"."Value"
+                    ORDER BY "SettlementDate" DESC
+                    LIMIT 1
+                ) AS "Value"
+                FROM "dates"
+                WHERE "dates"."Value" IS NOT NULL
+            )
+            SELECT "Value" FROM "dates" WHERE "Value" IS NOT NULL
+            """
+        );
     }
 
     public IQueryable<Guid> GetStockIdsBySettlementDate(DateOnly settlementDate)

--- a/tests/Equibles.IntegrationTests/Finra/ShortInterestRepositoryGetAllSettlementDatesTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortInterestRepositoryGetAllSettlementDatesTests.cs
@@ -1,0 +1,59 @@
+using Equibles.CommonStocks.Data;
+using Equibles.Data;
+using Equibles.Finra.Data;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Finra;
+
+public class ShortInterestRepositoryGetAllSettlementDatesTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly ShortInterestRepository _repository;
+
+    public ShortInterestRepositoryGetAllSettlementDatesTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new FinraModuleConfiguration()
+        );
+        _repository = new ShortInterestRepository(_dbContext);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    // Contract: every distinct settlement date, each reported once regardless of how
+    // many stocks reported on it, ordered newest-first so callers (the date selector,
+    // the latest-date default) need not re-sort.
+    [Fact]
+    public async Task GetAllSettlementDates_ReturnsDistinctDatesNewestFirst()
+    {
+        var june = new DateOnly(2024, 6, 15);
+        var may = new DateOnly(2024, 5, 31);
+        var april = new DateOnly(2024, 4, 30);
+
+        _dbContext
+            .Set<ShortInterest>()
+            .AddRange(
+                ShortInterest(Guid.NewGuid(), may),
+                ShortInterest(Guid.NewGuid(), june),
+                ShortInterest(Guid.NewGuid(), june), // same date, different stock — collapsed
+                ShortInterest(Guid.NewGuid(), april)
+            );
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+
+        var dates = await _repository.GetAllSettlementDates().ToListAsync(CancellationToken.None);
+
+        dates.Should().Equal(june, may, april);
+    }
+
+    private static ShortInterest ShortInterest(Guid stockId, DateOnly settlementDate) =>
+        new()
+        {
+            CommonStockId = stockId,
+            SettlementDate = settlementDate,
+            CurrentShortPosition = 1000,
+        };
+}


### PR DESCRIPTION
## Summary

`ShortInterestRepository.GetAllSettlementDates` ran `SELECT DISTINCT "SettlementDate"`, which scans the entire `SettlementDate` index on every call. On a large table this is slow and spikes when the buffer cache is cold, slowing the `/most-shorted` leaderboard and the per-stock short-interest settlement-date selector.

## Code changes

- `Equibles.Finra.Repositories/ShortInterestRepository.cs` — replace the `DISTINCT` scan with a recursive **loose index (skip) scan** over `IX_ShortInterest_SettlementDate`: jump to the newest date, then repeatedly fetch the next-lower one. Touches one index entry per distinct date instead of scanning the whole index. Returns newest-first so callers need not re-sort. Falls back to the `DISTINCT` query on non-relational providers (the in-memory provider used in tests).
- `tests/Equibles.IntegrationTests/Finra/ShortInterestRepositoryGetAllSettlementDatesTests.cs` — covers the contract (distinct dates, collapsed duplicates, newest-first).
- `CHANGELOG.md` — entry under Unreleased → Fixed.

## Verification

- [x] Builds clean locally (`Equibles.Finra.Repositories`)
- [x] Measured on production data (839K rows, 153 dates): `EXPLAIN ANALYZE` of the recursive scan returns the 153 dates in ~1.9ms vs ~68ms for `SELECT DISTINCT` (which read 1,826 pages from disk)
- [x] CHANGELOG updated

## Notes for reviewers

The skip-scan is PostgreSQL-specific raw SQL; the `IsRelational()` guard keeps the in-memory test provider working via the `DISTINCT` fallback. The recursive CTE's final projection filters out the trailing `NULL` row, so an empty table returns an empty result.