### PR TITLE
fix: render ownership-history cells with invariant separators

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -207,11 +207,11 @@ public class InstitutionalHoldingsTools
 
             var change =
                 previousShares > 0
-                    ? $"{(double)(totalShares - previousShares) / previousShares * 100:+0.0;-0.0}%"
+                    ? $"{((double)(totalShares - previousShares) / previousShares * 100).ToString("+0.0;-0.0", CultureInfo.InvariantCulture)}%"
                     : "—";
 
             result.AppendLine(
-                $"| {FormatDate(date)} | {institutionCount:N0} | {totalShares:N0} | {totalValue / 1_000_000m:N1} | {change} |"
+                $"| {FormatDate(date)} | {institutionCount.ToString("N0", CultureInfo.InvariantCulture)} | {totalShares.ToString("N0", CultureInfo.InvariantCulture)} | {(totalValue / 1_000_000m).ToString("N1", CultureInfo.InvariantCulture)} | {change} |"
             );
 
             previousShares = totalShares;

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs
@@ -28,7 +28,7 @@ public class InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTe
     // separators by host locale") is that the LLM-facing markdown renders the same
     // on every host. de-DE swaps the thousand separator (1,234,567 → 1.234.567),
     // forking the response — same bug class as the fixed sibling RenderTopHoldersTable (#2628).
-    [Fact(Skip = "GH-2779 — RenderOwnershipHistory :N0/:N1/:+0.0 cells follow host CurrentCulture")]
+    [Fact]
     public async Task GetOwnershipHistory_UnderNonInvariantCulture_RendersTotalSharesCultureInvariantly()
     {
         var stock = new CommonStock
@@ -71,8 +71,11 @@ public class InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTe
             CultureInfo.CurrentCulture = previous;
         }
 
-        // 1,234,567 shares must render with en-US grouping on every host locale.
+        // Numeric cells must render with en-US separators on every host locale:
+        // Total Shares (:N0) and Total Value $M (:N1). de-DE would produce
+        // 1.234.567 and 123,5.
         output.Should().Contain("| 1,234,567 |");
+        output.Should().Contain("| 123.5 |");
     }
 
     private static InstitutionalHolding MakeHolding(


### PR DESCRIPTION
## Summary

- `RenderOwnershipHistory` (the `GetOwnershipHistory` MCP tool) formatted each row's institution count, total shares, total value, and change-percent with culture-implicit specifiers (`:N0` / `:N1` / `:+0.0;-0.0`), so on a non-invariant host (e.g. de-DE) the thousand/decimal separators flipped, forking the LLM-consumed markdown by host locale. Last digit-separator hole in `InstitutionalHoldingsTools`.
- Threads `CultureInfo.InvariantCulture` through the four numeric cells, consistent with the sibling render methods.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — format institution count / total shares / total value / change-percent with `InvariantCulture`.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsRenderOwnershipHistoryCultureInvarianceTests.cs` — un-skipped the pre-staged repro and strengthened it to assert both the Total Shares (`1,234,567`) and Total Value (`123.5`) cells under de-DE. Fails before the fix, passes after.

closes #2779