### PR TITLE
fix: render insider-transaction cells with invariant separators

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
@@ -87,7 +88,7 @@ public class InsiderTradingTools
 
                     var value = t.Shares * t.PricePerShare;
                     result.AppendLine(
-                        $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {t.Shares:N0} | ${t.PricePerShare:N2} | ${value:N0} | {t.SharesOwnedAfter:N0} |"
+                        $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {t.Shares.ToString("N0", CultureInfo.InvariantCulture)} | ${t.PricePerShare.ToString("N2", CultureInfo.InvariantCulture)} | ${value.ToString("N0", CultureInfo.InvariantCulture)} | {t.SharesOwnedAfter.ToString("N0", CultureInfo.InvariantCulture)} |"
                     );
                 }
 

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests.cs
@@ -31,7 +31,7 @@ public class InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests : P
     // separators by host locale") is that the LLM-facing markdown renders the same
     // on every host. de-DE swaps the thousand separator (1,234,567 → 1.234.567),
     // forking the response — same bug class as the fixed Holdings render methods (#2628).
-    [Fact(Skip = "GH-2781 — GetInsiderTransactions :N0/:N2 cells follow host CurrentCulture")]
+    [Fact]
     public async Task GetInsiderTransactions_UnderNonInvariantCulture_RendersSharesCultureInvariantly()
     {
         var stock = new CommonStock
@@ -82,7 +82,12 @@ public class InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests : P
             CultureInfo.CurrentCulture = previous;
         }
 
-        // 1,234,567 shares must render with en-US grouping on every host locale.
+        // Every numeric cell must render with en-US separators on any host locale:
+        // Shares (:N0), Price (:N2), Value (:N0), Owned After (:N0). de-DE would
+        // produce 1.234.567 / $175,50 / $216.666.509 / 7.654.321.
         result.Should().Contain("| 1,234,567 |");
+        result.Should().Contain("| $175.50 |");
+        result.Should().Contain("| $216,666,509 |");
+        result.Should().Contain("| 7,654,321 |");
     }
 }


### PR DESCRIPTION
## Summary

- `GetInsiderTransactions` formatted the Shares, Price, Value, and Owned-After cells with culture-implicit specifiers (`:N0` / `:N2`), so on a non-invariant host (e.g. de-DE) the thousand/decimal separators flipped, forking the LLM-consumed markdown by host locale.
- Threads `CultureInfo.InvariantCulture` through the four numeric cells; adds the `System.Globalization` using (the file previously had none).

## Code changes

- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — format Shares / Price / Value / Owned-After in the `GetInsiderTransactions` row with `InvariantCulture`.
- `tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests.cs` — un-skipped the pre-staged repro and strengthened it to assert all four numeric cells under de-DE. Fails before the fix, passes after.

closes #2781