### PR TITLE
test(finra): pin GetAllSettlementDates returns empty on empty relational table

### DIFF
--- a/tests/Equibles.IntegrationTests/Finra/ShortInterestRepositoryGetAllSettlementDatesEmptyRelationalTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortInterestRepositoryGetAllSettlementDatesEmptyRelationalTests.cs
@@ -1,0 +1,30 @@
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Finra;
+
+// On the relational provider GetAllSettlementDates runs a recursive-CTE whose anchor scalar
+// subquery yields NULL when the table is empty; the `WHERE "Value" IS NOT NULL` filter must
+// terminate to zero rows — not a spurious default(DateOnly) entry and not an exception.
+// ShortInterestImportService calls GetAllSettlementDates().ToListAsync() directly, so a fresh
+// DB (no short-interest rows yet) hits exactly this path on the first import run.
+[Collection(ParadeDbCollection.Name)]
+public class ShortInterestRepositoryGetAllSettlementDatesEmptyRelationalTests : ParadeDbMcpTestBase
+{
+    public ShortInterestRepositoryGetAllSettlementDatesEmptyRelationalTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetAllSettlementDates_OnRelationalProviderWithNoRows_ReturnsEmpty()
+    {
+        // The base fixture resets to an empty schema before each test — no rows seeded.
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new ShortInterestRepository(verify);
+
+        var dates = await sut.GetAllSettlementDates().ToListAsync();
+
+        dates.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- On the relational provider `GetAllSettlementDates` (after #2808) runs a recursive CTE whose anchor scalar subquery yields `NULL` when the table is empty; the `WHERE "Value" IS NOT NULL` filter must terminate to zero rows — not a spurious `default(DateOnly)` entry and not an exception.
- `ShortInterestImportService` calls `GetAllSettlementDates().ToListAsync()` directly, so a fresh DB (no short-interest rows) hits exactly this path on the first import run. This pins the empty-table boundary against a ParadeDB container; previously only the seeded case and the in-memory fallback were covered.

## Code changes

- `tests/Equibles.IntegrationTests/Finra/ShortInterestRepositoryGetAllSettlementDatesEmptyRelationalTests.cs` — new `[Collection(ParadeDb)]` integration test asserting `GetAllSettlementDates().ToListAsync()` returns empty on a freshly-reset (rowless) relational database.