### PR TITLE
fix: render stock-price cells with invariant separators

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
@@ -80,7 +81,7 @@ public class StockPriceTools
                 foreach (var p in records.OrderBy(p => p.Date))
                 {
                     result.AppendLine(
-                        $"| {p.Date:yyyy-MM-dd} | {p.Open:F2} | {p.High:F2} | {p.Low:F2} | {p.Close:F2} | {p.Volume:N0} |"
+                        $"| {p.Date:yyyy-MM-dd} | {p.Open.ToString("F2", CultureInfo.InvariantCulture)} | {p.High.ToString("F2", CultureInfo.InvariantCulture)} | {p.Low.ToString("F2", CultureInfo.InvariantCulture)} | {p.Close.ToString("F2", CultureInfo.InvariantCulture)} | {p.Volume.ToString("N0", CultureInfo.InvariantCulture)} |"
                     );
                 }
 

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetStockPricesCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetStockPricesCultureInvarianceTests.cs
@@ -30,7 +30,7 @@ public class StockPriceToolsGetStockPricesCultureInvarianceTests : ParadeDbMcpTe
     // is that the LLM-facing markdown renders the same on every host. de-DE swaps the
     // thousand separator (1,234,567 → 1.234.567), forking the response — same bug
     // class as the fixed Holdings render methods (#2628).
-    [Fact(Skip = "GH-2783 — GetStockPrices :F2/:N0 cells follow host CurrentCulture")]
+    [Fact]
     public async Task GetStockPrices_UnderNonInvariantCulture_RendersVolumeCultureInvariantly()
     {
         var stock = new CommonStock
@@ -69,7 +69,10 @@ public class StockPriceToolsGetStockPricesCultureInvarianceTests : ParadeDbMcpTe
             CultureInfo.CurrentCulture = previous;
         }
 
-        // 1,234,567 shares of volume must render with en-US grouping on every host locale.
+        // Numeric cells must render with en-US separators on any host locale:
+        // OHLC (:F2, decimal point) and Volume (:N0, thousand comma). de-DE would
+        // produce 149,00 and 1.234.567.
+        result.Should().Contain("| 149.00 |");
         result.Should().Contain("| 1,234,567 |");
     }
 }


### PR DESCRIPTION
## Summary

- `GetStockPrices` formatted the OHLC (`:F2`) and Volume (`:N0`) cells with culture-implicit specifiers, so on a non-invariant host (e.g. de-DE) the decimal/thousand separators flipped, forking the LLM-consumed markdown by host locale.
- Threads `CultureInfo.InvariantCulture` through the five numeric cells; adds the `System.Globalization` using (the file previously had none).

## Code changes

- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — format Open/High/Low/Close/Volume in the `GetStockPrices` row with `InvariantCulture`.
- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetStockPricesCultureInvarianceTests.cs` — un-skipped the pre-staged repro and strengthened it to assert both an OHLC cell (`149.00`) and Volume (`1,234,567`) under de-DE. Fails before the fix, passes after.

closes #2783