### PR TITLE
fix: render congressional-trade amount with invariant separators

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Congress.Data.Models;
@@ -88,7 +89,8 @@ public class CongressTools
                 {
                     var position = t.CongressMember.Position.NameForHumans();
                     var type = t.TransactionType.NameForHumans();
-                    var amount = $"${t.AmountFrom:N0}–${t.AmountTo:N0}";
+                    var amount =
+                        $"${t.AmountFrom.ToString("N0", CultureInfo.InvariantCulture)}–${t.AmountTo.ToString("N0", CultureInfo.InvariantCulture)}";
                     result.AppendLine(
                         $"| {t.TransactionDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {t.OwnerType ?? "—"} |"
                     );

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetCongressionalTradesCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetCongressionalTradesCultureInvarianceTests.cs
@@ -31,7 +31,7 @@ public class CongressToolsGetCongressionalTradesCultureInvarianceTests : ParadeD
     // LLM-facing markdown renders the same on every host. de-DE swaps the thousand separator
     // (1,000,000 → 1.000.000), forking the response — same bug class as the fixed Holdings
     // render methods (#2628).
-    [Fact(Skip = "GH-2785 — GetCongressionalTrades :N0 amount cells follow host CurrentCulture")]
+    [Fact]
     public async Task GetCongressionalTrades_UnderNonInvariantCulture_RendersAmountCultureInvariantly()
     {
         var stock = new CommonStock
@@ -78,7 +78,9 @@ public class CongressToolsGetCongressionalTradesCultureInvarianceTests : ParadeD
             CultureInfo.CurrentCulture = previous;
         }
 
-        // $1,000,000 must render with en-US grouping on every host locale.
+        // Both amount-range bounds (:N0) must render with en-US grouping on every
+        // host locale; de-DE would produce $1.000.000 and $5.000.000.
         result.Should().Contain("$1,000,000");
+        result.Should().Contain("$5,000,000");
     }
 }


### PR DESCRIPTION
## Summary

- `GetCongressionalTrades` built the Amount Range cell with culture-implicit `:N0` specifiers on `AmountFrom`/`AmountTo`, so on a non-invariant host (e.g. de-DE) the thousand separator flipped, forking the LLM-consumed markdown by host locale.
- Threads `CultureInfo.InvariantCulture` through both amount bounds; adds the `System.Globalization` using (the file previously had none).

## Code changes

- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — format `AmountFrom`/`AmountTo` in the `GetCongressionalTrades` amount cell with `InvariantCulture`.
- `tests/Equibles.IntegrationTests/Mcp/CongressToolsGetCongressionalTradesCultureInvarianceTests.cs` — un-skipped the pre-staged repro and strengthened it to assert both range bounds (`$1,000,000` and `$5,000,000`) under de-DE. Fails before the fix, passes after.

closes #2785