### PR TITLE
fix: render CFTC positioning cells with invariant separators

### DIFF
--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using Equibles.Cftc.Data.Models;
 using Equibles.Cftc.Repositories;
 using Equibles.Core.Extensions;
@@ -83,7 +84,7 @@ public class CftcTools
                 foreach (var r in reports.OrderBy(r => r.ReportDate))
                 {
                     result.AppendLine(
-                        $"| {r.ReportDate:yyyy-MM-dd} | {r.OpenInterest:N0} | {r.CommLong:N0} | {r.CommShort:N0} | {r.NonCommLong:N0} | {r.NonCommShort:N0} | {r.NonCommSpreads:N0} |"
+                        $"| {r.ReportDate:yyyy-MM-dd} | {r.OpenInterest.ToString("N0", CultureInfo.InvariantCulture)} | {r.CommLong.ToString("N0", CultureInfo.InvariantCulture)} | {r.CommShort.ToString("N0", CultureInfo.InvariantCulture)} | {r.NonCommLong.ToString("N0", CultureInfo.InvariantCulture)} | {r.NonCommShort.ToString("N0", CultureInfo.InvariantCulture)} | {r.NonCommSpreads.ToString("N0", CultureInfo.InvariantCulture)} |"
                     );
                 }
 

--- a/tests/Equibles.IntegrationTests/Mcp/CftcToolsGetCftcPositioningCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CftcToolsGetCftcPositioningCultureInvarianceTests.cs
@@ -28,7 +28,7 @@ public class CftcToolsGetCftcPositioningCultureInvarianceTests : ParadeDbMcpTest
     // markdown renders the same on every host. de-DE swaps the thousand separator
     // (1,234,567 → 1.234.567), forking the response — same bug class as the fixed
     // Holdings render methods (#2628).
-    [Fact(Skip = "GH-2787 — GetCftcPositioning :N0 cells follow host CurrentCulture")]
+    [Fact]
     public async Task GetCftcPositioning_UnderNonInvariantCulture_RendersOpenInterestCultureInvariantly()
     {
         var contract = new CftcContract
@@ -71,7 +71,9 @@ public class CftcToolsGetCftcPositioningCultureInvarianceTests : ParadeDbMcpTest
             CultureInfo.CurrentCulture = previous;
         }
 
-        // 1,234,567 open interest must render with en-US grouping on every host locale.
+        // The :N0 positioning cells must render with en-US grouping on every host
+        // locale; de-DE would produce 1.234.567 and 600.000.
         result.Should().Contain("| 1,234,567 |");
+        result.Should().Contain("| 600,000 |");
     }
 }


### PR DESCRIPTION
## Summary

- `GetCftcPositioning` formatted all six positioning columns with culture-implicit `:N0` specifiers, so on a non-invariant host (e.g. de-DE) the thousand separator flipped, forking the LLM-consumed markdown by host locale.
- Threads `CultureInfo.InvariantCulture` through the six numeric cells; adds the `System.Globalization` using (the file previously had none).

## Code changes

- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs` — format the six positioning columns in the `GetCftcPositioning` row with `InvariantCulture`.
- `tests/Equibles.IntegrationTests/Mcp/CftcToolsGetCftcPositioningCultureInvarianceTests.cs` — un-skipped the pre-staged repro and strengthened it to assert two distinct cells (`1,234,567` and `600,000`) under de-DE. Fails before the fix, passes after.

closes #2787