### PR TITLE
fix: render VIX history cells with invariant decimal point

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using Equibles.Cboe.Data.Models;
 using Equibles.Cboe.Repositories;
 using Equibles.Core.Extensions;
@@ -132,7 +133,7 @@ public class CboeTools
                 foreach (var v in records.OrderBy(v => v.Date))
                 {
                     result.AppendLine(
-                        $"| {v.Date:yyyy-MM-dd} | {v.Open:F2} | {v.High:F2} | {v.Low:F2} | {v.Close:F2} |"
+                        $"| {v.Date:yyyy-MM-dd} | {v.Open.ToString("F2", CultureInfo.InvariantCulture)} | {v.High.ToString("F2", CultureInfo.InvariantCulture)} | {v.Low.ToString("F2", CultureInfo.InvariantCulture)} | {v.Close.ToString("F2", CultureInfo.InvariantCulture)} |"
                     );
                 }
 

--- a/tests/Equibles.IntegrationTests/Mcp/CboeToolsGetVixHistoryCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CboeToolsGetVixHistoryCultureInvarianceTests.cs
@@ -28,7 +28,7 @@ public class CboeToolsGetVixHistoryCultureInvarianceTests : ParadeDbMcpTestBase
     // markdown renders the same on every host. de-DE swaps the decimal separator
     // (18.55 → 18,55), forking the response — same bug class as the fixed Holdings
     // render methods (#2628).
-    [Fact(Skip = "GH-2789 — GetVixHistory :F2 cells follow host CurrentCulture")]
+    [Fact]
     public async Task GetVixHistory_UnderNonInvariantCulture_RendersCloseCultureInvariantly()
     {
         DbContext
@@ -59,7 +59,9 @@ public class CboeToolsGetVixHistoryCultureInvarianceTests : ParadeDbMcpTestBase
             CultureInfo.CurrentCulture = previous;
         }
 
-        // A VIX close of 18.55 must render with an en-US decimal point on every host locale.
+        // The :F2 OHLC cells must render with an en-US decimal point on every host
+        // locale; de-DE would produce 14,20 and 18,55.
         result.Should().Contain("| 18.55 |");
+        result.Should().Contain("| 14.20 |");
     }
 }


### PR DESCRIPTION
## Summary

- `GetVixHistory` formatted the VIX OHLC cells with culture-implicit `:F2` specifiers, so on a non-invariant host (e.g. de-DE) the decimal separator flipped from `.` to `,`, forking the LLM-consumed markdown by host locale.
- Threads `CultureInfo.InvariantCulture` through the four numeric cells; adds the `System.Globalization` using (the file previously had none).

## Code changes

- `src/Equibles.Cboe.Mcp/Tools/CboeTools.cs` — format Open/High/Low/Close in the `GetVixHistory` row with `InvariantCulture`.
- `tests/Equibles.IntegrationTests/Mcp/CboeToolsGetVixHistoryCultureInvarianceTests.cs` — un-skipped the pre-staged repro and strengthened it to assert two cells (`18.55` and `14.20`) under de-DE. Fails before the fix, passes after.

closes #2789