### PR TITLE
fix: render fails-to-deliver cells with invariant separators

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -79,7 +80,7 @@ public class FailToDeliverTools
                 {
                     var value = f.Quantity * f.Price;
                     result.AppendLine(
-                        $"| {f.SettlementDate:yyyy-MM-dd} | {f.Quantity:N0} | ${f.Price:F2} | ${value:N0} |"
+                        $"| {f.SettlementDate:yyyy-MM-dd} | {f.Quantity.ToString("N0", CultureInfo.InvariantCulture)} | ${f.Price.ToString("F2", CultureInfo.InvariantCulture)} | ${value.ToString("N0", CultureInfo.InvariantCulture)} |"
                     );
                 }
 

--- a/tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests.cs
@@ -30,7 +30,7 @@ public class FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests : ParadeD
     // markdown renders the same on every host. de-DE swaps the thousand separator
     // (1,234,567 → 1.234.567), forking the response — same bug class as the fixed Holdings
     // render methods (#2628).
-    [Fact(Skip = "GH-2791 — GetFailsToDeliver :N0/:F2 cells follow host CurrentCulture")]
+    [Fact]
     public async Task GetFailsToDeliver_UnderNonInvariantCulture_RendersQuantityCultureInvariantly()
     {
         var stock = new CommonStock
@@ -66,7 +66,11 @@ public class FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests : ParadeD
             CultureInfo.CurrentCulture = previous;
         }
 
-        // 1,234,567 fail-to-deliver shares must render with en-US grouping on every host locale.
+        // Every numeric cell must render with en-US separators on any host locale:
+        // Quantity (:N0), Price (:F2), Value (:N0). de-DE would produce
+        // 1.234.567 / $25,50 / $31.481.459.
         result.Should().Contain("| 1,234,567 |");
+        result.Should().Contain("| $25.50 |");
+        result.Should().Contain("| $31,481,459 |");
     }
 }


### PR DESCRIPTION
## Summary

- `GetFailsToDeliver` formatted the Quantity (`:N0`), Price (`:F2`), and Value (`:N0`) cells with culture-implicit specifiers, so on a non-invariant host (e.g. de-DE) the thousand/decimal separators flipped, forking the LLM-consumed markdown by host locale.
- Threads `CultureInfo.InvariantCulture` through the three numeric cells; adds the `System.Globalization` using (the file previously had none).

## Code changes

- `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs` — format Quantity/Price/Value in the `GetFailsToDeliver` row with `InvariantCulture`.
- `tests/Equibles.IntegrationTests/Mcp/FailToDeliverToolsGetFailsToDeliverCultureInvarianceTests.cs` — un-skipped the pre-staged repro and strengthened it to assert all three cells (`1,234,567`, `$25.50`, `$31,481,459`) under de-DE. Fails before the fix, passes after.

closes #2791