### PR TITLE
fix: render short-volume cells with invariant separators

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -87,7 +87,7 @@ public class ShortDataTools
                     var shortPct =
                         r.TotalVolume > 0 ? (double)r.ShortVolume / r.TotalVolume * 100 : 0;
                     result.AppendLine(
-                        $"| {r.Date:yyyy-MM-dd} | {r.ShortVolume:N0} | {r.ShortExemptVolume:N0} | {r.TotalVolume:N0} | {shortPct:F1}% |"
+                        $"| {r.Date:yyyy-MM-dd} | {r.ShortVolume.ToString("N0", CultureInfo.InvariantCulture)} | {r.ShortExemptVolume.ToString("N0", CultureInfo.InvariantCulture)} | {r.TotalVolume.ToString("N0", CultureInfo.InvariantCulture)} | {shortPct.ToString("F1", CultureInfo.InvariantCulture)}% |"
                     );
                 }
 

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
@@ -32,7 +32,7 @@ public class ShortDataToolsGetShortVolumeCultureInvarianceTests : ParadeDbMcpTes
     // markdown renders byte-identically regardless of host locale. de-DE swaps the
     // thousand separator (1,234,567 → 1.234.567), forking the response — same bug
     // class as the sibling GetShortInterest cells (#2777).
-    [Fact(Skip = "GH-2794 — GetShortVolume :N0/:F1 cells follow host CurrentCulture")]
+    [Fact]
     public async Task GetShortVolume_UnderNonInvariantCulture_RendersVolumeCultureInvariantly()
     {
         var stock = new CommonStock
@@ -73,7 +73,11 @@ public class ShortDataToolsGetShortVolumeCultureInvarianceTests : ParadeDbMcpTes
             CultureInfo.CurrentCulture = previous;
         }
 
-        // 1,234,567 shares of short volume must render with en-US grouping on every host locale.
+        // Numeric cells must render with en-US separators on any host locale:
+        // volumes (:N0) and short-% (:F1). de-DE would produce 1.234.567,
+        // 2.000.000, and 61,7%.
         result.Should().Contain("| 1,234,567 |");
+        result.Should().Contain("| 2,000,000 |");
+        result.Should().Contain("| 61.7% |");
     }
 }


### PR DESCRIPTION
## Summary

- `GetShortVolume` formatted the volume cells (`:N0`) and short-percentage (`:F1`) with culture-implicit specifiers, so on a non-invariant host (e.g. de-DE) the thousand/decimal separators flipped, forking the LLM-consumed markdown by host locale.
- Threads `CultureInfo.InvariantCulture` through the four numeric cells (the file already imports `System.Globalization` from the GetShortInterest fix #2777).

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — format Short Volume / Exempt / Total Volume / Short % in the `GetShortVolume` row with `InvariantCulture`.
- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs` — un-skipped the pre-staged repro and strengthened it to assert two volume cells (`1,234,567`, `2,000,000`) and the percentage (`61.7%`) under de-DE. Fails before the fix, passes after.

closes #2794