### PR TITLE
fix: stop double-negating parenthesised XBRL values with sign="-"

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -323,7 +323,16 @@ public class InlineXbrlParser
         )
             return false;
 
-        if (parenthesised)
+        // Accounting parentheses and the sign="-" attribute are two encodings of
+        // the same negativity; applying both would double-negate into a positive.
+        // Negate for parentheses only when sign="-" is absent (TryApplyScaleAndSign
+        // applies the sign negation).
+        var signNegative = string.Equals(
+            element.GetAttribute("sign"),
+            "-",
+            StringComparison.Ordinal
+        );
+        if (parenthesised && !signNegative)
             parsed = -parsed;
 
         return TryApplyScaleAndSign(parsed, element, out value);

--- a/tests/Equibles.UnitTests/Sec/InlineXbrlParserParenthesisedWithSignNegativeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlParserParenthesisedWithSignNegativeTests.cs
@@ -21,7 +21,7 @@ public class InlineXbrlParserParenthesisedWithSignNegativeTests
 
     private const string DocClose = "</body></html>";
 
-    [Fact(Skip = "GH-2799 — parens + sign=\"-\" double-negates to positive")]
+    [Fact]
     public void Parse_ParenthesisedValueWithSignNegative_StaysNegative()
     {
         // Accounting parentheses and the sign="-" attribute are two encodings of


### PR DESCRIPTION
## Summary

- `InlineXbrlParser` decoded an `ix:nonFraction` fact written in accounting parentheses **and** carrying `sign="-"` as a positive number. The parenthesis negation (in `TryDecodeValue`) and the `sign="-"` negation (in `TryApplyScaleAndSign`) both fired, compounding `(500)` + `sign="-"` into `+500` instead of `-500` — a sign error for downstream financial consumers.
- Parentheses and `sign="-"` are two encodings of the same negativity. Apply the parenthesis negation only when `sign="-"` is absent; the sign path handles the rest. Each mechanism's isolated behaviour (parens-only, sign-only) is unchanged.

## Code changes

- `src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs` — gate the parenthesis negation on `sign="-"` being absent so the two don't compound.
- `tests/Equibles.UnitTests/Sec/InlineXbrlParserParenthesisedWithSignNegativeTests.cs` — un-skipped the pre-staged repro asserting `(500)` + `sign="-"` decodes to `-500`. Fails before the fix, passes after; the existing parens-only and sign-only pins still pass.

closes #2799