### PR TITLE
fix: expand rowspan+colspan cells to a rectangular grid

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs
@@ -44,10 +44,20 @@ internal class TableNormalizationStep : IHtmlNormalizationStep
 
             cell.RemoveAttribute("colspan");
 
+            // A cell that also spans rows occupies a rectangular block; carry its
+            // rowspan onto the new colspan cells so FixRowspan fills the full width
+            // of every spanned row (otherwise those rows come out short by
+            // colspan - 1 cells and the grid is ragged).
+            var rowspanAttr = cell.GetAttribute("rowspan");
+
             var currentCell = cell;
             for (int i = 1; i < colspanValue; i++)
             {
                 var newCell = doc.CreateElement("td");
+                if (rowspanAttr != null)
+                {
+                    newCell.SetAttribute("rowspan", rowspanAttr);
+                }
                 if (currentCell.ParentElement != null)
                 {
                     HtmlElementExtensions.InsertAfter(

--- a/tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepRowspanColspanCombinedTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepRowspanColspanCombinedTests.cs
@@ -10,7 +10,7 @@ public class TableNormalizationStepRowspanColspanCombinedTests
     // same column count and trailing cells column-aligned. Existing pins cover
     // colspan and rowspan in isolation; this pins their combination, where the
     // colspan width must also propagate down the rowspan-spanned rows.
-    [Fact(Skip = "GH-2801 — rowspan+colspan cell expands to a ragged grid")]
+    [Fact]
     public void Execute_CellWithBothRowspanAndColspan_ProducesRectangularGrid()
     {
         // Cell A spans rows 0-1 and cols 0-1; B sits at col 2 of row 0, so C


### PR DESCRIPTION
## Summary

- `TableNormalizationStep.FixColspan` turned a cell's colspan into sibling cells but left the `rowspan` attribute on the original cell only. `FixRowspan` then inserted a single empty cell per spanned row, under-filling it by `colspan - 1` cells — producing a ragged grid that misaligned every column to the right of the merged block (e.g. a `rowspan=2 colspan=2` cell left the second row short, shifting trailing cells one column left).
- Carry the cell's `rowspan` onto the new colspan cells so `FixRowspan` fills the full width of each spanned row. Behaviour for cells with only colspan or only rowspan is unchanged.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs` — in `FixColspan`, copy the source cell's `rowspan` onto each generated colspan cell.
- `tests/Equibles.UnitTests/Sec/Normalizers/TableNormalizationStepRowspanColspanCombinedTests.cs` — un-skipped the pre-staged repro asserting a `rowspan+colspan` cell yields a rectangular grid (equal column counts). Fails before the fix, passes after; the existing colspan-only and rowspan-only pins still pass.

closes #2801