### PR TITLE
fix: reject non-positive RateLimiter capacity at construction

### DIFF
--- a/src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs
+++ b/src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs
@@ -10,6 +10,11 @@ public class RateLimiter : IRateLimiter
 
     public RateLimiter(int maxRequests = 5, TimeSpan? timeWindow = null)
     {
+        // A capacity of zero or less can never release a request; fail fast at
+        // construction rather than throwing InvalidOperationException from the
+        // first WaitAsync (cf. SemaphoreSlim's initialCount).
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxRequests);
+
         _maxRequests = maxRequests;
         _timeWindow = timeWindow ?? TimeSpan.FromMinutes(1);
         _requestTimes = new Queue<DateTime>();

--- a/tests/Equibles.UnitTests/Integrations/RateLimiterZeroCapacityTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/RateLimiterZeroCapacityTests.cs
@@ -4,9 +4,7 @@ namespace Equibles.UnitTests.Integrations;
 
 public class RateLimiterZeroCapacityTests
 {
-    [Fact(
-        Skip = "GH-2806 — maxRequests <= 0 is accepted; first WaitAsync throws InvalidOperationException"
-    )]
+    [Fact]
     public void Constructor_ZeroMaxRequests_RejectsInvalidCapacity()
     {
         // A limiter whose capacity is zero can never release a request — it is an


### PR DESCRIPTION
## Summary

- `RateLimiter` accepted `maxRequests <= 0`. The first `WaitAsync()` then threw `InvalidOperationException` ("queue empty") from `Queue.Peek` deep inside `CalculateWaitTime` — the `0 < 0` capacity check falls through to peek an empty queue. A zero/negative capacity can never release a request.
- Validate `maxRequests` at construction with `ArgumentOutOfRangeException.ThrowIfNegativeOrZero`, the standard .NET convention for an out-of-range count argument (cf. `SemaphoreSlim`'s `initialCount`). Callers get a clear configuration error instead of an opaque first-use failure.

## Code changes

- `src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs` — guard `maxRequests` in the constructor.
- `tests/Equibles.UnitTests/Integrations/RateLimiterZeroCapacityTests.cs` — un-skipped the pre-staged repro asserting construction with `maxRequests: 0` throws `ArgumentOutOfRangeException`. Fails before the fix, passes after; the existing valid-capacity tests still pass.

closes #2806