### PR TITLE
refactor(web): extract sold-out filer query from LoadHoldingsTab into helper

### DIFF
--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -95,37 +95,11 @@ public class StockTabService
             ? await LoadHoldingsByStockWithHolder(stock, previousDate.Value)
             : [];
 
-        // Narrow the Sold-Out filter to only holders who were in the previous
-        // quarter but are absent from the current quarter for this stock. The
-        // old query fetched ALL distinct filers market-wide for the quarter —
-        // millions of rows — just to build a HashSet. We only need to know
-        // whether each "gap" holder filed any 13F this quarter at all.
-        var currentHolderIds = allCurrent.Select(h => h.InstitutionalHolderId).ToHashSet();
-        var previousOnlyHolderIds = allPrevious
-            .Select(h => h.InstitutionalHolderId)
-            .Where(id => !currentHolderIds.Contains(id))
-            .Distinct()
-            .ToList();
-
-        HashSet<Guid> filersWithCurrentQuarterFilings;
-        if (previousOnlyHolderIds.Count == 0)
-        {
-            filersWithCurrentQuarterFilings = [];
-        }
-        else
-        {
-            filersWithCurrentQuarterFilings = (
-                await _institutionalHoldingRepository
-                    .GetAll()
-                    .Where(h =>
-                        h.ReportDate == selectedDate
-                        && previousOnlyHolderIds.Contains(h.InstitutionalHolderId)
-                    )
-                    .Select(h => h.InstitutionalHolderId)
-                    .Distinct()
-                    .ToListAsync()
-            ).ToHashSet();
-        }
+        var filersWithCurrentQuarterFilings = await GetFilersWithCurrentQuarterFilings(
+            allCurrent,
+            allPrevious,
+            selectedDate
+        );
 
         var grouped = HoldingsPositionGrouper.Group(
             allCurrent,
@@ -564,4 +538,38 @@ public class StockTabService
             .GetByStock(stock, reportDate)
             .Include(h => h.InstitutionalHolder)
             .ToListAsync();
+
+    // Narrow the Sold-Out filter to only holders who were in the previous
+    // quarter but are absent from the current quarter for this stock. The
+    // old query fetched ALL distinct filers market-wide for the quarter —
+    // millions of rows — just to build a HashSet. We only need to know
+    // whether each "gap" holder filed any 13F this quarter at all.
+    private async Task<HashSet<Guid>> GetFilersWithCurrentQuarterFilings(
+        List<InstitutionalHolding> allCurrent,
+        List<InstitutionalHolding> allPrevious,
+        DateOnly selectedDate
+    )
+    {
+        var currentHolderIds = allCurrent.Select(h => h.InstitutionalHolderId).ToHashSet();
+        var previousOnlyHolderIds = allPrevious
+            .Select(h => h.InstitutionalHolderId)
+            .Where(id => !currentHolderIds.Contains(id))
+            .Distinct()
+            .ToList();
+
+        if (previousOnlyHolderIds.Count == 0)
+            return [];
+
+        return (
+            await _institutionalHoldingRepository
+                .GetAll()
+                .Where(h =>
+                    h.ReportDate == selectedDate
+                    && previousOnlyHolderIds.Contains(h.InstitutionalHolderId)
+                )
+                .Select(h => h.InstitutionalHolderId)
+                .Distinct()
+                .ToListAsync()
+        ).ToHashSet();
+    }
 }


### PR DESCRIPTION
## Summary

- `StockTabService.LoadHoldingsTab` was a 97-line method with an embedded ~30-line block that computed which previous-quarter holders had filed a 13F in the current quarter (the Sold-Out filter input). Extracting that self-contained computation into a named helper shortens the orchestration method and makes the main flow read top-to-bottom.
- Pure code move — no behavior change: same LINQ, same database query, same empty-list short-circuit, same return value at the same call site.

## Code changes

- `src/Equibles.Web/Services/StockTabService.cs` — moved the current-holder set / previous-only holder / current-quarter filing query out of `LoadHoldingsTab` into a new private `GetFilersWithCurrentQuarterFilings(allCurrent, allPrevious, selectedDate)` helper. The existing WHY-comment explaining the narrowed query moved with it.