### PR TITLE
feat(web): location filters on the institutions index (1/2)

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
@@ -43,6 +43,17 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
     private static string EscapeLikePattern(string input) =>
         input.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
 
+    // Distinct non-empty state/country codes across the filer universe, used to
+    // populate the location filter dropdown on the institutions index so the user
+    // picks from values that actually exist rather than typing a free-form code.
+    public IQueryable<string> DistinctStatesOrCountries()
+    {
+        return GetAll()
+            .Where(h => h.StateOrCountry != null && h.StateOrCountry != "")
+            .Select(h => h.StateOrCountry)
+            .Distinct();
+    }
+
     public IQueryable<InstitutionalHolder> GetUnclassified()
     {
         return GetAll()

--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -28,6 +28,8 @@ public class InstitutionsController : BaseController
     [HttpGet("~/institutions")]
     public async Task<IActionResult> Index(
         string search,
+        string state,
+        string city,
         InstitutionSort sort = InstitutionSort.Name,
         int page = 1
     )
@@ -72,6 +74,19 @@ public class InstitutionsController : BaseController
             });
 
         var holders = _holderRepository.Search(search ?? string.Empty);
+
+        // Location filters narrow the filer set before the aggregate join. State
+        // is an exact match on a dropdown value; city is a case-insensitive
+        // substring so "new" matches "New York".
+        if (!string.IsNullOrWhiteSpace(state))
+        {
+            holders = holders.Where(h => h.StateOrCountry == state);
+        }
+        if (!string.IsNullOrWhiteSpace(city))
+        {
+            holders = holders.Where(h => EF.Functions.ILike(h.City, $"%{city.Trim()}%"));
+        }
+
         var joined = holders.GroupJoin(
             aggByHolder,
             h => h.Id,
@@ -109,10 +124,18 @@ public class InstitutionsController : BaseController
             })
             .ToListAsync();
 
+        var states = await _holderRepository
+            .DistinctStatesOrCountries()
+            .OrderBy(s => s)
+            .ToListAsync();
+
         var viewModel = new InstitutionBrowserViewModel
         {
             Institutions = pageRows,
             Search = search,
+            State = state,
+            City = city,
+            States = states,
             Sort = sort,
             LatestReportDate = latestReportDate,
             Page = page,

--- a/src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs
@@ -8,6 +8,15 @@ public class InstitutionBrowserViewModel
     public string Search { get; set; }
     public InstitutionSort Sort { get; set; } = InstitutionSort.Name;
 
+    // Active location filters. State is an exact match on the dropdown value;
+    // City is a case-insensitive substring match. Null/empty means unfiltered.
+    public string State { get; set; }
+    public string City { get; set; }
+
+    // Distinct state/country codes present in the filer universe, sorted, used
+    // to render the location dropdown options.
+    public List<string> States { get; set; } = [];
+
     // Latest universe-wide 13F report date — drives the per-filer aggregates
     // and the page subtitle. Null when no holdings have been ingested yet.
     public DateOnly? LatestReportDate { get; set; }

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -10,6 +10,12 @@
     if (!string.IsNullOrEmpty(Model.Search)) {
         filterRoute["search"] = Model.Search;
     }
+    if (!string.IsNullOrEmpty(Model.State)) {
+        filterRoute["state"] = Model.State;
+    }
+    if (!string.IsNullOrEmpty(Model.City)) {
+        filterRoute["city"] = Model.City;
+    }
     if (Model.Sort != InstitutionSort.Name) {
         filterRoute["sort"] = Model.Sort.ToString();
     }
@@ -38,6 +44,22 @@
                        class="input input-bordered w-64"
                        aria-label="Search institutions by name"
                        placeholder="Institution name..." />
+            </label>
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">State / Country</span>
+                <select name="state" class="select select-bordered" aria-label="Filter institutions by state or country">
+                    <option value="">All locations</option>
+                    @foreach (var st in Model.States) {
+                        <option value="@st" selected="@(st == Model.State)">@st</option>
+                    }
+                </select>
+            </label>
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">City</span>
+                <input type="text" name="city" value="@Model.City"
+                       class="input input-bordered w-44"
+                       aria-label="Filter institutions by city"
+                       placeholder="City..." />
             </label>
             <label class="form-control">
                 <span class="label-text text-sm mb-1">Sort by</span>

--- a/tests/Equibles.IntegrationTests/Web/InstitutionsControllerLocationFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/InstitutionsControllerLocationFilterTests.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the location filters on the /institutions index: a state/country exact
+/// match and a case-insensitive city substring, both narrowing the listed filer
+/// set. Also pins that the state dropdown is populated from the distinct
+/// state/country values present in the universe.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class InstitutionsControllerLocationFilterTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public InstitutionsControllerLocationFilterTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetIndex_FilterByState_ReturnsOnlyHoldersInThatState()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Cik = "0000001",
+                    Name = "Malvern Capital",
+                    City = "Malvern",
+                    StateOrCountry = "PA",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Cik = "0000002",
+                    Name = "Omaha Holdings",
+                    City = "Omaha",
+                    StateOrCountry = "NE",
+                }
+            );
+            await db.SaveChangesAsync();
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions?state=PA");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Malvern Capital");
+        html.Should().NotContain("Omaha Holdings");
+    }
+
+    [Fact]
+    public async Task GetIndex_FilterByCity_MatchesCaseInsensitiveSubstring()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Cik = "0000001",
+                    Name = "Gotham Asset Management",
+                    City = "New York",
+                    StateOrCountry = "NY",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Cik = "0000002",
+                    Name = "Bay Area Partners",
+                    City = "San Francisco",
+                    StateOrCountry = "CA",
+                }
+            );
+            await db.SaveChangesAsync();
+        });
+
+        // Lowercase substring "new" must match "New York" via ILike.
+        var response = await _fixture.Client.GetAsync("/institutions?city=new");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Gotham Asset Management");
+        html.Should().NotContain("Bay Area Partners");
+    }
+
+    [Fact]
+    public async Task GetIndex_RendersStateDropdown_FromDistinctUniverseValues()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Cik = "0000001",
+                    Name = "Alpha Fund",
+                    City = "Austin",
+                    StateOrCountry = "TX",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Cik = "0000002",
+                    Name = "Beta Fund",
+                    City = "Boston",
+                    StateOrCountry = "MA",
+                }
+            );
+            await db.SaveChangesAsync();
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        // The location dropdown offers every state present in the universe.
+        html.Should().Contain("<option value=\"TX\"");
+        html.Should().Contain("<option value=\"MA\"");
+    }
+
+    [Fact]
+    public async Task GetIndex_StateAndSearchCombined_ApplyTogether()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Cik = "0000001",
+                    Name = "Vanguard Group",
+                    City = "Malvern",
+                    StateOrCountry = "PA",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Cik = "0000002",
+                    Name = "Vanguard Texas LLC",
+                    City = "Dallas",
+                    StateOrCountry = "TX",
+                }
+            );
+            await db.SaveChangesAsync();
+        });
+
+        // Search matches both "Vanguard" names; the PA state filter narrows to one.
+        var response = await _fixture.Client.GetAsync("/institutions?search=vanguard&state=PA");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Vanguard Group");
+        html.Should().NotContain("Vanguard Texas LLC");
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 1 of 2 for #1859 — adds location filtering to the `/institutions` index.
- Users can narrow the 13F filer universe by state/country (dropdown) and city (substring), composing with the existing name search and sort.
- Refs #1859 — does not close the issue; the AUM and position-count range filters land in slice 2.

## Code changes

- `src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs` — new `DistinctStatesOrCountries()` query returning the distinct non-empty state/country codes that populate the dropdown.
- `src/Equibles.Web/Controllers/InstitutionsController.cs` — `Index` now accepts `state` and `city`; applies an exact state match and a case-insensitive city `ILike` before the aggregate join, and loads the distinct-states list for the view.
- `src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs` — carries `State`, `City`, and the `States` option list.
- `src/Equibles.Web/Views/Institutions/Index.cshtml` — renders the state dropdown and city input, and carries both params across pagination and the clear button.
- `tests/Equibles.IntegrationTests/Web/InstitutionsControllerLocationFilterTests.cs` — four tests pinning state filtering, case-insensitive city matching, the distinct-state dropdown, and state+search composing.