### PR TITLE
feat(web): AUM and position-count range filters on institutions (2/2)

### DIFF
--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -30,6 +30,10 @@ public class InstitutionsController : BaseController
         string search,
         string state,
         string city,
+        long? minValue,
+        long? maxValue,
+        int? minPositions,
+        int? maxPositions,
         InstitutionSort sort = InstitutionSort.Name,
         int page = 1
     )
@@ -94,6 +98,26 @@ public class InstitutionsController : BaseController
             (h, aggs) => new { h, agg = aggs.FirstOrDefault() }
         );
 
+        // AUM ($ value) and position-count range filters apply to each filer's
+        // most-recent 13F aggregate. A filer with no holdings is treated as zero
+        // on both axes, so any positive lower bound excludes never-reported filers.
+        if (minValue.HasValue)
+        {
+            joined = joined.Where(x => (x.agg != null ? x.agg.Value : 0L) >= minValue.Value);
+        }
+        if (maxValue.HasValue)
+        {
+            joined = joined.Where(x => (x.agg != null ? x.agg.Value : 0L) <= maxValue.Value);
+        }
+        if (minPositions.HasValue)
+        {
+            joined = joined.Where(x => (x.agg != null ? x.agg.Positions : 0) >= minPositions.Value);
+        }
+        if (maxPositions.HasValue)
+        {
+            joined = joined.Where(x => (x.agg != null ? x.agg.Positions : 0) <= maxPositions.Value);
+        }
+
         var ordered = sort switch
         {
             InstitutionSort.PositionsDescending => joined
@@ -136,6 +160,10 @@ public class InstitutionsController : BaseController
             State = state,
             City = city,
             States = states,
+            MinValue = minValue,
+            MaxValue = maxValue,
+            MinPositions = minPositions,
+            MaxPositions = maxPositions,
             Sort = sort,
             LatestReportDate = latestReportDate,
             Page = page,

--- a/src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs
@@ -17,6 +17,14 @@ public class InstitutionBrowserViewModel
     // to render the location dropdown options.
     public List<string> States { get; set; } = [];
 
+    // Range filters on each filer's most-recent 13F aggregate. MinValue/MaxValue
+    // bound the total book size in dollars; MinPositions/MaxPositions bound the
+    // holding count. Null means that bound is unset.
+    public long? MinValue { get; set; }
+    public long? MaxValue { get; set; }
+    public int? MinPositions { get; set; }
+    public int? MaxPositions { get; set; }
+
     // Latest universe-wide 13F report date — drives the per-filer aggregates
     // and the page subtitle. Null when no holdings have been ingested yet.
     public DateOnly? LatestReportDate { get; set; }

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -16,6 +16,18 @@
     if (!string.IsNullOrEmpty(Model.City)) {
         filterRoute["city"] = Model.City;
     }
+    if (Model.MinValue.HasValue) {
+        filterRoute["minValue"] = Model.MinValue.Value.ToString();
+    }
+    if (Model.MaxValue.HasValue) {
+        filterRoute["maxValue"] = Model.MaxValue.Value.ToString();
+    }
+    if (Model.MinPositions.HasValue) {
+        filterRoute["minPositions"] = Model.MinPositions.Value.ToString();
+    }
+    if (Model.MaxPositions.HasValue) {
+        filterRoute["maxPositions"] = Model.MaxPositions.Value.ToString();
+    }
     if (Model.Sort != InstitutionSort.Name) {
         filterRoute["sort"] = Model.Sort.ToString();
     }
@@ -60,6 +72,28 @@
                        class="input input-bordered w-44"
                        aria-label="Filter institutions by city"
                        placeholder="City..." />
+            </label>
+            <label class="form-control">
+                <span class="label-text text-sm mb-1"># Positions</span>
+                <div class="join">
+                    <input type="number" name="minPositions" value="@(Model.MinPositions?.ToString())" min="0"
+                           class="input input-bordered join-item w-20"
+                           aria-label="Minimum number of positions" placeholder="Min" />
+                    <input type="number" name="maxPositions" value="@(Model.MaxPositions?.ToString())" min="0"
+                           class="input input-bordered join-item w-20"
+                           aria-label="Maximum number of positions" placeholder="Max" />
+                </div>
+            </label>
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">Total $ Value</span>
+                <div class="join">
+                    <input type="number" name="minValue" value="@(Model.MinValue?.ToString())" min="0"
+                           class="input input-bordered join-item w-28"
+                           aria-label="Minimum total dollar value" placeholder="Min $" />
+                    <input type="number" name="maxValue" value="@(Model.MaxValue?.ToString())" min="0"
+                           class="input input-bordered join-item w-28"
+                           aria-label="Maximum total dollar value" placeholder="Max $" />
+                </div>
             </label>
             <label class="form-control">
                 <span class="label-text text-sm mb-1">Sort by</span>

--- a/tests/Equibles.IntegrationTests/Web/InstitutionsControllerRangeFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/InstitutionsControllerRangeFilterTests.cs
@@ -1,0 +1,262 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the AUM ($ value) and position-count range filters on the /institutions
+/// index. Both bound each filer's most-recent 13F aggregate; a positive lower
+/// bound also excludes filers that have never reported a 13F (treated as zero).
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class InstitutionsControllerRangeFilterTests
+{
+    private static readonly DateOnly Quarter = new(2024, 12, 31);
+
+    private readonly WebHostFixture _fixture;
+
+    public InstitutionsControllerRangeFilterTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetIndex_MinPositions_ExcludesFilersBelowThreshold()
+    {
+        var aaplId = Guid.NewGuid();
+        var msftId = Guid.NewGuid();
+        var bigId = Guid.NewGuid();
+        var smallId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(MakeStock(aaplId, "AAPL", "0000320193"));
+            db.Add(MakeStock(msftId, "MSFT", "0000789019"));
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = bigId,
+                    Cik = "0000010",
+                    Name = "Big Fund LP",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = smallId,
+                    Cik = "0000020",
+                    Name = "Small Boutique LLC",
+                }
+            );
+            // Big Fund holds two positions; Small Boutique holds one.
+            db.Add(MakeHolding(aaplId, bigId, 1_000_000));
+            db.Add(MakeHolding(msftId, bigId, 1_000_000));
+            db.Add(MakeHolding(aaplId, smallId, 1_000_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions?minPositions=2");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Big Fund LP");
+        html.Should().NotContain("Small Boutique LLC");
+    }
+
+    [Fact]
+    public async Task GetIndex_MaxPositions_ExcludesFilersAboveThreshold()
+    {
+        var aaplId = Guid.NewGuid();
+        var msftId = Guid.NewGuid();
+        var bigId = Guid.NewGuid();
+        var smallId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(MakeStock(aaplId, "AAPL", "0000320193"));
+            db.Add(MakeStock(msftId, "MSFT", "0000789019"));
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = bigId,
+                    Cik = "0000010",
+                    Name = "Big Fund LP",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = smallId,
+                    Cik = "0000020",
+                    Name = "Small Boutique LLC",
+                }
+            );
+            db.Add(MakeHolding(aaplId, bigId, 1_000_000));
+            db.Add(MakeHolding(msftId, bigId, 1_000_000));
+            db.Add(MakeHolding(aaplId, smallId, 1_000_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions?maxPositions=1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Small Boutique LLC");
+        html.Should().NotContain("Big Fund LP");
+    }
+
+    [Fact]
+    public async Task GetIndex_MinValue_KeepsOnlyFilersWithBookSizeAtOrAboveBound()
+    {
+        var aaplId = Guid.NewGuid();
+        var whaleId = Guid.NewGuid();
+        var minnowId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(MakeStock(aaplId, "AAPL", "0000320193"));
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = whaleId,
+                    Cik = "0000050",
+                    Name = "Whale Fund LP",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = minnowId,
+                    Cik = "0000060",
+                    Name = "Minnow Fund LP",
+                }
+            );
+            db.Add(MakeHolding(aaplId, whaleId, 100_000_000));
+            db.Add(MakeHolding(aaplId, minnowId, 1_000));
+            await Task.CompletedTask;
+        });
+
+        // Lower bound of $1M keeps the whale ($100M) and drops the minnow ($1k).
+        var response = await _fixture.Client.GetAsync("/institutions?minValue=1000000");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Whale Fund LP");
+        html.Should().NotContain("Minnow Fund LP");
+    }
+
+    [Fact]
+    public async Task GetIndex_ValueRange_BoundsBothEnds()
+    {
+        var aaplId = Guid.NewGuid();
+        var whaleId = Guid.NewGuid();
+        var midId = Guid.NewGuid();
+        var minnowId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(MakeStock(aaplId, "AAPL", "0000320193"));
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = whaleId,
+                    Cik = "0000050",
+                    Name = "Whale Fund LP",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = midId,
+                    Cik = "0000055",
+                    Name = "Middle Fund LP",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = minnowId,
+                    Cik = "0000060",
+                    Name = "Minnow Fund LP",
+                }
+            );
+            db.Add(MakeHolding(aaplId, whaleId, 100_000_000));
+            db.Add(MakeHolding(aaplId, midId, 5_000_000));
+            db.Add(MakeHolding(aaplId, minnowId, 1_000));
+            await Task.CompletedTask;
+        });
+
+        // $1M..$10M window keeps only the middle fund.
+        var response = await _fixture.Client.GetAsync(
+            "/institutions?minValue=1000000&maxValue=10000000"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Middle Fund LP");
+        html.Should().NotContain("Whale Fund LP");
+        html.Should().NotContain("Minnow Fund LP");
+    }
+
+    [Fact]
+    public async Task GetIndex_PositiveLowerBound_ExcludesNeverReportedFilers()
+    {
+        var aaplId = Guid.NewGuid();
+        var activeId = Guid.NewGuid();
+        var dormantId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(MakeStock(aaplId, "AAPL", "0000320193"));
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = activeId,
+                    Cik = "0000070",
+                    Name = "Active Fund LP",
+                }
+            );
+            // Dormant filer with no holdings at all — aggregate is zero.
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = dormantId,
+                    Cik = "0000080",
+                    Name = "Dormant Fund LP",
+                }
+            );
+            db.Add(MakeHolding(aaplId, activeId, 1_000_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions?minPositions=1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Active Fund LP");
+        html.Should().NotContain("Dormant Fund LP");
+    }
+
+    private static CommonStock MakeStock(Guid id, string ticker, string cik) =>
+        new()
+        {
+            Id = id,
+            Ticker = ticker,
+            Name = ticker,
+            Cik = cik,
+        };
+
+    private static InstitutionalHolding MakeHolding(Guid stockId, Guid holderId, long value) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = Quarter,
+            FilingDate = Quarter.AddDays(45),
+            Shares = 1_000,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber =
+                $"acc-{holderId:N}".Substring(0, 12) + $"-{stockId:N}".Substring(0, 8),
+        };
+}


### PR DESCRIPTION
## Summary

- Slice 2 of 2 for #1859 — adds AUM ($ value) and position-count range filters to the `/institutions` index.
- Each bound applies to the filer's most-recent 13F aggregate; a positive lower bound also excludes filers that have never reported a 13F (treated as zero on both axes).
- Filters compose with the search, location, and sort controls from slice 1 and persist across pagination.
- Closes #1859.

## Code changes

- `src/Equibles.Web/Controllers/InstitutionsController.cs` — `Index` now accepts `minValue`/`maxValue` and `minPositions`/`maxPositions`; applies them to the post-join aggregate and forwards them to the view model.
- `src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs` — carries the four nullable range bounds.
- `src/Equibles.Web/Views/Institutions/Index.cshtml` — renders joined min/max number inputs for positions and total value, and carries the params across pagination and the clear button.
- `tests/Equibles.IntegrationTests/Web/InstitutionsControllerRangeFilterTests.cs` — five tests pinning min/max positions, the min-value floor, the two-sided value window, and never-reported filers being excluded by a positive lower bound.