### PR TITLE
feat(web): show price performance vs SPY on the stock price tab

### DIFF
--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Congress.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Extensions;
@@ -13,6 +14,7 @@ using Equibles.Sec.FinancialFacts.Repositories;
 using Equibles.Sec.Repositories;
 using Equibles.Web.Extensions;
 using Equibles.Web.ViewModels.Stocks;
+using Equibles.Yahoo.Data.Models;
 using Equibles.Yahoo.Repositories;
 using Microsoft.EntityFrameworkCore;
 
@@ -34,6 +36,15 @@ public class StockTabService
     private readonly DailyStockPriceRepository _dailyStockPriceRepository;
     private readonly FinancialFactRepository _financialFactRepository;
     private readonly FinancialConceptRepository _financialConceptRepository;
+    private readonly CommonStockRepository _commonStockRepository;
+
+    // Benchmark the Price tab compares each stock's returns against.
+    private const string BenchmarkTicker = "SPY";
+
+    // SPY history loaded back from the latest bar to cover every return window:
+    // the 120-trading-day window (~168 calendar days) and the YTD anchor (up to a
+    // full prior year). 420 days clears both with margin.
+    private const int BenchmarkLookbackDays = 420;
 
     public StockTabService(
         InstitutionalHoldingRepository institutionalHoldingRepository,
@@ -46,7 +57,8 @@ public class StockTabService
         CongressionalTradeRepository congressionalTradeRepository,
         DailyStockPriceRepository dailyStockPriceRepository,
         FinancialFactRepository financialFactRepository,
-        FinancialConceptRepository financialConceptRepository
+        FinancialConceptRepository financialConceptRepository,
+        CommonStockRepository commonStockRepository
     )
     {
         _institutionalHoldingRepository = institutionalHoldingRepository;
@@ -60,6 +72,7 @@ public class StockTabService
         _dailyStockPriceRepository = dailyStockPriceRepository;
         _financialFactRepository = financialFactRepository;
         _financialConceptRepository = financialConceptRepository;
+        _commonStockRepository = commonStockRepository;
     }
 
     public async Task<HoldingsTabViewModel> LoadHoldingsTab(CommonStock stock, DateOnly? date)
@@ -302,10 +315,18 @@ public class StockTabService
             closePrices
         );
 
+        var returns = PriceReturnCalculator.Compute(
+            prices.Select(p => p.Date).ToList(),
+            closePrices
+        );
+
         return new PriceTabViewModel
         {
             Ticker = stock.Ticker,
             Prices = prices,
+            Returns = returns,
+            BenchmarkTicker = BenchmarkTicker,
+            BenchmarkReturns = await LoadBenchmarkReturns(stock, prices),
             Sma20 = TechnicalIndicatorService.ComputeSma(closePrices, 20),
             Sma50 = TechnicalIndicatorService.ComputeSma(closePrices, 50),
             Sma200 = TechnicalIndicatorService.ComputeSma(closePrices, 200),
@@ -314,6 +335,37 @@ public class StockTabService
             MacdSignal = macdSignal,
             MacdHistogram = macdHistogram,
         };
+    }
+
+    // Returns for the benchmark (SPY) over the same windows, so the Price tab can
+    // show out/under-performance. Null when there's no benchmark to compare against:
+    // the stock has no prices, the benchmark isn't tracked, this stock IS the
+    // benchmark, or the benchmark has no prices in the lookback window.
+    private async Task<PriceReturns> LoadBenchmarkReturns(
+        CommonStock stock,
+        List<DailyStockPrice> stockPrices
+    )
+    {
+        if (stockPrices.Count == 0)
+            return null;
+
+        var benchmark = await _commonStockRepository.GetByPrimaryTicker(BenchmarkTicker);
+        if (benchmark == null || benchmark.Id == stock.Id)
+            return null;
+
+        var latestDate = stockPrices[^1].Date;
+        var benchmarkPrices = await _dailyStockPriceRepository
+            .GetByStock(benchmark, latestDate.AddDays(-BenchmarkLookbackDays), latestDate)
+            .OrderBy(p => p.Date)
+            .ToListAsync();
+
+        if (benchmarkPrices.Count == 0)
+            return null;
+
+        return PriceReturnCalculator.Compute(
+            benchmarkPrices.Select(p => p.Date).ToList(),
+            benchmarkPrices.Select(p => p.Close).ToList()
+        );
     }
 
     public async Task<FinancialsTabViewModel> LoadFinancialsTab(

--- a/src/Equibles.Web/ViewModels/Stocks/PriceTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/PriceTabViewModel.cs
@@ -1,10 +1,21 @@
 using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
 
 namespace Equibles.Web.ViewModels.Stocks;
 
 public class PriceTabViewModel : StockTabViewModel
 {
     public List<DailyStockPrice> Prices { get; set; } = [];
+
+    // Trailing- and calendar-window returns for this stock.
+    public PriceReturns Returns { get; set; } = new();
+
+    // Same windows for the benchmark (SPY); null when the benchmark is
+    // unavailable or this stock IS the benchmark.
+    public PriceReturns BenchmarkReturns { get; set; }
+
+    // Ticker of the benchmark the returns are compared against.
+    public string BenchmarkTicker { get; set; }
 
     // Pre-computed indicator series (same length as Prices, null-padded at start)
     public List<decimal?> Sma20 { get; set; } = [];

--- a/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
@@ -52,6 +52,65 @@
         </div>
     </div>
 
+    <!-- Performance vs benchmark -->
+    <div class="card bg-base-100 shadow-sm mb-2">
+        <div class="card-body p-4 lg:p-6">
+            <h2 class="font-semibold text-sm mb-3">Performance</h2>
+            @{
+                var windows = new[] {
+                    (Label: "5D", Stock: Model.Returns.FiveDay, Bench: Model.BenchmarkReturns?.FiveDay),
+                    (Label: "20D", Stock: Model.Returns.TwentyDay, Bench: Model.BenchmarkReturns?.TwentyDay),
+                    (Label: "120D", Stock: Model.Returns.OneHundredTwentyDay, Bench: Model.BenchmarkReturns?.OneHundredTwentyDay),
+                    (Label: "MTD", Stock: Model.Returns.MonthToDate, Bench: Model.BenchmarkReturns?.MonthToDate),
+                    (Label: "YTD", Stock: Model.Returns.YearToDate, Bench: Model.BenchmarkReturns?.YearToDate),
+                };
+                // Green for gains, red for losses, muted dash when the window has no data.
+                string Cls(decimal? v) => v == null ? "text-base-content/40" : v >= 0 ? "text-success" : "text-error";
+                // Signed percentage (e.g. "+12.5%"); em dash when unavailable. Invariant
+                // so the decimal separator stays a dot regardless of server culture.
+                string Fmt(decimal? v) => v == null ? "—" : (v >= 0 ? "+" : "") + v.Value.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture) + "%";
+            }
+            <div class="overflow-x-auto">
+                <table class="table table-sm">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            @foreach (var w in windows) {
+                                <th class="text-right font-mono">@w.Label</th>
+                            }
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="text-base-content/50">@Model.Ticker</td>
+                            @foreach (var w in windows) {
+                                <td class="text-right font-mono @Cls(w.Stock)">@Fmt(w.Stock)</td>
+                            }
+                        </tr>
+                        @if (Model.BenchmarkReturns != null) {
+                            <tr>
+                                <td class="text-base-content/50">@Model.BenchmarkTicker</td>
+                                @foreach (var w in windows) {
+                                    <td class="text-right font-mono @Cls(w.Bench)">@Fmt(w.Bench)</td>
+                                }
+                            </tr>
+                            <tr>
+                                <td class="text-base-content/50">vs @Model.BenchmarkTicker</td>
+                                @foreach (var w in windows) {
+                                    var delta = w.Stock.HasValue && w.Bench.HasValue ? w.Stock - w.Bench : null;
+                                    <td class="text-right font-mono @Cls(delta)">@Fmt(delta)</td>
+                                }
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+            @if (Model.BenchmarkReturns == null) {
+                <p class="text-xs text-base-content/50 mt-2">@(Model.BenchmarkTicker ?? "SPY") comparison unavailable.</p>
+            }
+        </div>
+    </div>
+
     <!-- Summary stats -->
     <div class="card bg-base-100 shadow-sm">
         <div class="card-body p-4 lg:p-6">

--- a/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/ControllersTests.cs
@@ -311,7 +311,8 @@ public class StocksControllerTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadHolderDetailTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadHolderDetailTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Congress.Data;
 using Equibles.Congress.Repositories;
 using Equibles.Data;
@@ -59,7 +60,8 @@ public class StockTabServiceLoadHolderDetailTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadHoldingsCombinedTabFewerThanTwoQuartersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadHoldingsCombinedTabFewerThanTwoQuartersTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Congress.Data;
 using Equibles.Congress.Repositories;
 using Equibles.Data;
@@ -59,7 +60,8 @@ public class StockTabServiceLoadHoldingsCombinedTabFewerThanTwoQuartersTests : I
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadHoldingsCombinedTabTwoQuartersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadHoldingsCombinedTabTwoQuartersTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Congress.Data;
 using Equibles.Congress.Repositories;
 using Equibles.Data;
@@ -57,7 +58,8 @@ public class StockTabServiceLoadHoldingsCombinedTabTwoQuartersTests : IDisposabl
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadHoldingsTabSoldOutTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadHoldingsTabSoldOutTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Congress.Data;
 using Equibles.Congress.Repositories;
 using Equibles.Data;
@@ -58,7 +59,8 @@ public class StockTabServiceLoadHoldingsTabSoldOutTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadKeyMetricsQuarterlyEpsTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadKeyMetricsQuarterlyEpsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Congress.Data;
 using Equibles.Congress.Repositories;
 using Equibles.Data;
@@ -58,7 +59,8 @@ public class StockTabServiceLoadKeyMetricsQuarterlyEpsTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
     }
 

--- a/tests/Equibles.IntegrationTests/Web/StockTabServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServiceTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Congress.Data;
 using Equibles.Congress.Data.Models;
 using Equibles.Congress.Repositories;
@@ -59,7 +60,8 @@ public class StockTabServiceTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
     }
 
@@ -804,6 +806,102 @@ public class StockTabServiceTests : IDisposable
         var result = await _service.LoadPriceTab(stock);
 
         result.Prices.Select(p => p.Date).Should().BeInAscendingOrder();
+    }
+
+    // Add one bar per close, on consecutive days starting at startDate. OHLC are all
+    // set to the close so returns (close-based) are exactly the intended values.
+    private void AddDailyPrices(CommonStock stock, DateOnly startDate, params decimal[] closes)
+    {
+        for (var i = 0; i < closes.Length; i++)
+        {
+            _dbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = startDate.AddDays(i),
+                        Open = closes[i],
+                        High = closes[i],
+                        Low = closes[i],
+                        Close = closes[i],
+                        AdjustedClose = closes[i],
+                        Volume = 1_000_000,
+                    }
+                );
+        }
+    }
+
+    [Fact]
+    public async Task LoadPriceTab_ComputesStockReturns()
+    {
+        var stock = CreateStock();
+        // 6 bars: the close 5 bars before the last (100) is the base, latest 110 → +10%.
+        AddDailyPrices(stock, new DateOnly(2025, 6, 2), 100m, 102m, 104m, 106m, 108m, 110m);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.LoadPriceTab(stock);
+
+        result.Returns.Should().NotBeNull();
+        result.Returns.FiveDay.Should().Be(10m);
+        result.BenchmarkTicker.Should().Be("SPY");
+    }
+
+    [Fact]
+    public async Task LoadPriceTab_WithBenchmark_ComputesBenchmarkReturns()
+    {
+        var stock = CreateStock("AAPL", "Apple Inc.");
+        var spy = CreateStock("SPY", "SPDR S&P 500 ETF", "0000884394");
+        AddDailyPrices(stock, new DateOnly(2025, 6, 2), 100m, 102m, 104m, 106m, 108m, 110m); // +10%
+        AddDailyPrices(spy, new DateOnly(2025, 6, 2), 100m, 101m, 102m, 103m, 104m, 105m); // +5%
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.LoadPriceTab(stock);
+
+        result.Returns.FiveDay.Should().Be(10m);
+        result.BenchmarkReturns.Should().NotBeNull();
+        result.BenchmarkReturns.FiveDay.Should().Be(5m);
+    }
+
+    [Fact]
+    public async Task LoadPriceTab_NoBenchmarkTracked_BenchmarkReturnsNull()
+    {
+        var stock = CreateStock();
+        AddDailyPrices(stock, new DateOnly(2025, 6, 2), 100m, 102m, 104m, 106m, 108m, 110m);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.LoadPriceTab(stock);
+
+        result.BenchmarkReturns.Should().BeNull();
+        result.BenchmarkTicker.Should().Be("SPY");
+    }
+
+    [Fact]
+    public async Task LoadPriceTab_StockIsBenchmark_DoesNotCompareToItself()
+    {
+        var spy = CreateStock("SPY", "SPDR S&P 500 ETF", "0000884394");
+        AddDailyPrices(spy, new DateOnly(2025, 6, 2), 100m, 102m, 104m, 106m, 108m, 110m);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.LoadPriceTab(spy);
+
+        result.Returns.FiveDay.Should().Be(10m);
+        result.BenchmarkReturns.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LoadPriceTab_NoPrices_BenchmarkReturnsNullEvenWhenSpyExists()
+    {
+        var stock = CreateStock("AAPL", "Apple Inc.");
+        var spy = CreateStock("SPY", "SPDR S&P 500 ETF", "0000884394");
+        AddDailyPrices(spy, new DateOnly(2025, 6, 2), 100m, 101m, 102m, 103m, 104m, 105m);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.LoadPriceTab(stock);
+
+        result.Prices.Should().BeEmpty();
+        result.Returns.FiveDay.Should().BeNull();
+        result.BenchmarkReturns.Should().BeNull();
     }
 
     // ── LoadHoldingsTab ─────────────────────────────────────────────────

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerCongressionalTradesTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerCongressionalTradesTabTests.cs
@@ -74,7 +74,8 @@ public class StocksControllerCongressionalTradesTabTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerDocumentsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerDocumentsTabTests.cs
@@ -74,7 +74,8 @@ public class StocksControllerDocumentsTabTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerFinancialsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerFinancialsTabTests.cs
@@ -131,7 +131,8 @@ public class StocksControllerFinancialsTabTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),
@@ -241,7 +242,8 @@ public class StocksControllerFinancialsTabTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
 
         var tab = await stockTabService.LoadFinancialsTab(

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerFtdTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerFtdTabTests.cs
@@ -73,7 +73,8 @@ public class StocksControllerFtdTabTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerHoldingsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerHoldingsTabTests.cs
@@ -75,7 +75,8 @@ public class StocksControllerHoldingsTabTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerInsiderTradingTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerInsiderTradingTabTests.cs
@@ -74,7 +74,8 @@ public class StocksControllerInsiderTradingTabTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShortInterestTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShortInterestTabTests.cs
@@ -74,7 +74,8 @@ public class StocksControllerShortInterestTabTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerShortVolumeTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerShortVolumeTabTests.cs
@@ -74,7 +74,8 @@ public class StocksControllerShortVolumeTabTests : IDisposable
             new CongressionalTradeRepository(_dbContext),
             new DailyStockPriceRepository(_dbContext),
             new FinancialFactRepository(_dbContext),
-            new FinancialConceptRepository(_dbContext)
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
         );
         var controller = new StocksController(
             new CommonStockRepository(_dbContext),

--- a/tests/Equibles.IntegrationTests/Web/StocksPriceTabViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksPriceTabViewRenderingTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data.Models;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Drives the real Razor pipeline for <c>Views/Stocks/_PriceTab.cshtml</c> to pin
+/// the Performance panel (returns vs SPY) added for the price-performance feature.
+/// Controller/tab-service tests instantiate types directly and never render the
+/// view, so the panel markup is otherwise uncovered.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class StocksPriceTabViewRenderingTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public StocksPriceTabViewRenderingTests(WebHostFixture fixture) => _fixture = fixture;
+
+    private static void AddDailyPrices(
+        EquiblesFinancialDbContext db,
+        Guid stockId,
+        DateOnly startDate,
+        decimal[] closes
+    )
+    {
+        for (var i = 0; i < closes.Length; i++)
+        {
+            db.Add(
+                new DailyStockPrice
+                {
+                    CommonStockId = stockId,
+                    Date = startDate.AddDays(i),
+                    Open = closes[i],
+                    High = closes[i],
+                    Low = closes[i],
+                    Close = closes[i],
+                    AdjustedClose = closes[i],
+                    Volume = 1_000_000,
+                }
+            );
+        }
+    }
+
+    [Fact]
+    public async Task GetPriceTab_WithStockAndBenchmarkPrices_RendersPerformancePanelVsSpy()
+    {
+        var aaplId = Guid.NewGuid();
+        var spyId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                }
+            );
+            db.Add(
+                new CommonStock
+                {
+                    Id = spyId,
+                    Ticker = "SPY",
+                    Name = "SPDR S&P 500 ETF",
+                }
+            );
+            var start = new DateOnly(2025, 6, 2);
+            // 6 bars each → the 5-day window is in range for both series, so the
+            // benchmark and "vs SPY" rows render with real numbers.
+            AddDailyPrices(db, aaplId, start, [100m, 102m, 104m, 106m, 108m, 110m]);
+            AddDailyPrices(db, spyId, start, [100m, 101m, 102m, 103m, 104m, 105m]);
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Stocks/AAPL/price");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Performance", "the Performance panel heading must render");
+        html.Should().Contain("vs SPY", "the benchmark-comparison row must render");
+        // Razor's HTML encoder emits the leading "+" as &#x2B; (renders as "+" in the
+        // browser); the percentage uses a dot via InvariantCulture regardless of host.
+        html.Should().Contain("10.0%", "AAPL's 5-day return must render");
+        html.Should().Contain("5.0%", "SPY's 5-day return must render");
+        html.Should().Contain("text-success", "gains must be colored as successes");
+    }
+
+    [Fact]
+    public async Task GetPriceTab_NoBenchmarkTracked_RendersPanelWithUnavailableNote()
+    {
+        var aaplId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                }
+            );
+            AddDailyPrices(
+                db,
+                aaplId,
+                new DateOnly(2025, 6, 2),
+                [100m, 102m, 104m, 106m, 108m, 110m]
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Stocks/AAPL/price");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Performance");
+        html.Should()
+            .Contain(
+                "SPY comparison unavailable",
+                "with no SPY tracked the fallback note must render"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 2 of 2 for #1857 — closes the issue. Surfaces the price-performance-vs-benchmark comparison on the stock Price tab.
- Adds a Performance panel showing the stock's trailing (5D/20D/120D) and calendar (MTD/YTD) returns next to SPY's returns and the stock's outperformance vs SPY. Builds on the returns calculator from #2825.
- Degrades gracefully: when SPY isn't tracked, has no prices, or the viewed stock is SPY itself, the benchmark rows are replaced with an "unavailable" note.

## Code changes

- `src/Equibles.Web/Services/StockTabService.cs` — inject `CommonStockRepository`; `LoadPriceTab` now computes the stock's returns and loads SPY's returns over a 420-day lookback (covers the 120-day and YTD windows). `LoadBenchmarkReturns` returns null for the no-stock-prices, no-benchmark, self-is-benchmark, and no-benchmark-prices cases.
- `src/Equibles.Web/ViewModels/Stocks/PriceTabViewModel.cs` — add `Returns`, `BenchmarkReturns`, and `BenchmarkTicker`.
- `src/Equibles.Web/Views/Stocks/_PriceTab.cshtml` — render the Performance panel (stock / SPY / vs-SPY rows across the five windows), gains green and losses red, percentages formatted with the invariant culture, and a fallback note when no benchmark is available.
- `tests/Equibles.IntegrationTests/Web/StockTabServiceTests.cs` — 5 tests covering the returns wiring (stock returns, vs-SPY comparison, no-benchmark, self-is-benchmark, no-prices).
- `tests/Equibles.IntegrationTests/Web/StocksPriceTabViewRenderingTests.cs` — 2 view-render tests driving the real Razor pipeline: the panel renders with the vs-SPY row and signed percentages, and the unavailable note when SPY is absent.
- Remaining test files — thread the new `CommonStockRepository` constructor argument through the existing `StockTabService` instantiations.

Closes #1857