### PR TITLE
feat(web): add moving-average cross and price-streak detection

### DIFF
--- a/src/Equibles.Yahoo.Repositories/MovingAverageCrossSignal.cs
+++ b/src/Equibles.Yahoo.Repositories/MovingAverageCrossSignal.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Yahoo.Repositories;
+
+/// <summary>
+/// The most recent moving-average crossover within a lookback window. A golden
+/// cross (shorter average rising above the longer one) is a bullish signal; a
+/// death cross (shorter average falling below the longer one) is bearish.
+/// </summary>
+public enum MovingAverageCrossSignal
+{
+    [Display(Name = "None")]
+    None,
+
+    [Display(Name = "Golden Cross")]
+    GoldenCross,
+
+    [Display(Name = "Death Cross")]
+    DeathCross,
+}

--- a/src/Equibles.Yahoo.Repositories/PriceStreakDirection.cs
+++ b/src/Equibles.Yahoo.Repositories/PriceStreakDirection.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Yahoo.Repositories;
+
+/// <summary>
+/// The direction of a run of consecutive daily closes that each moved the same
+/// way relative to the prior close.
+/// </summary>
+public enum PriceStreakDirection
+{
+    [Display(Name = "None")]
+    None,
+
+    [Display(Name = "Up")]
+    Up,
+
+    [Display(Name = "Down")]
+    Down,
+}

--- a/src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs
+++ b/src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs
@@ -336,4 +336,80 @@ public static class TechnicalIndicatorService
 
         return (macdLine, signal, histogram);
     }
+
+    /// <summary>
+    /// Detects the most recent moving-average crossover between a shorter average
+    /// (e.g. 50-day) and a longer one (e.g. 200-day) within the last
+    /// <paramref name="lookback"/> bars. A golden cross is the bar where the shorter
+    /// average rises from at-or-below to strictly above the longer average; a death
+    /// cross is the mirror. Both series must be aligned to the same bars (as produced
+    /// by <see cref="ComputeSma"/>); nulls from the warm-up period are skipped.
+    /// Returns <see cref="MovingAverageCrossSignal.None"/> when no crossover occurred
+    /// in the window or there is insufficient data to compare adjacent bars.
+    /// </summary>
+    public static MovingAverageCrossSignal DetectMaCross(
+        List<decimal?> shortMa,
+        List<decimal?> longMa,
+        int lookback = 5
+    )
+    {
+        if (shortMa.Count != longMa.Count)
+            throw new ArgumentException("shortMa and longMa must have the same length");
+
+        // Walk adjacent bar-pairs from newest backwards; the first crossover found is
+        // the most recent one. Each pair needs all four values present to compare.
+        var lastIndex = shortMa.Count - 1;
+        var oldestPair = Math.Max(1, lastIndex - lookback + 1);
+        for (var i = lastIndex; i >= oldestPair; i--)
+        {
+            var currShort = shortMa[i];
+            var currLong = longMa[i];
+            var prevShort = shortMa[i - 1];
+            var prevLong = longMa[i - 1];
+            if (currShort == null || currLong == null || prevShort == null || prevLong == null)
+                continue;
+
+            if (prevShort <= prevLong && currShort > currLong)
+                return MovingAverageCrossSignal.GoldenCross;
+            if (prevShort >= prevLong && currShort < currLong)
+                return MovingAverageCrossSignal.DeathCross;
+        }
+
+        return MovingAverageCrossSignal.None;
+    }
+
+    /// <summary>
+    /// Counts the run of consecutive most-recent closes that each moved the same way
+    /// versus the prior close. Returns the streak length and its direction; an
+    /// unchanged close ends the run, and fewer than two prices yields a zero-length
+    /// <see cref="PriceStreakDirection.None"/> streak.
+    /// </summary>
+    public static (int Days, PriceStreakDirection Direction) CountConsecutiveStreak(
+        List<decimal> closes
+    )
+    {
+        if (closes.Count < 2)
+            return (0, PriceStreakDirection.None);
+
+        var lastIndex = closes.Count - 1;
+        var lastMove = closes[lastIndex] - closes[lastIndex - 1];
+        if (lastMove == 0)
+            return (0, PriceStreakDirection.None);
+
+        var direction = lastMove > 0 ? PriceStreakDirection.Up : PriceStreakDirection.Down;
+        var days = 0;
+        for (var i = lastIndex; i >= 1; i--)
+        {
+            var move = closes[i] - closes[i - 1];
+            var moveUp = move > 0;
+            var moveDown = move < 0;
+            var matchesUp = direction == PriceStreakDirection.Up && moveUp;
+            var matchesDown = direction == PriceStreakDirection.Down && moveDown;
+            if (!matchesUp && !matchesDown)
+                break;
+            days++;
+        }
+
+        return (days, direction);
+    }
 }

--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceSignalTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceSignalTests.cs
@@ -1,0 +1,208 @@
+using Equibles.Yahoo.Repositories;
+
+namespace Equibles.UnitTests.Web;
+
+public class TechnicalIndicatorServiceSignalTests
+{
+    #region DetectMaCross
+
+    [Fact]
+    public void DetectMaCross_MismatchedLengths_Throws()
+    {
+        var act = () => TechnicalIndicatorService.DetectMaCross([1m, 2m], [1m]);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void DetectMaCross_EmptySeries_ReturnsNone()
+    {
+        var result = TechnicalIndicatorService.DetectMaCross([], []);
+
+        result.Should().Be(MovingAverageCrossSignal.None);
+    }
+
+    [Fact]
+    public void DetectMaCross_SingleBar_ReturnsNone()
+    {
+        // No prior bar to compare against.
+        var result = TechnicalIndicatorService.DetectMaCross([10m], [12m]);
+
+        result.Should().Be(MovingAverageCrossSignal.None);
+    }
+
+    [Fact]
+    public void DetectMaCross_ShortRisesAboveLong_ReturnsGoldenCross()
+    {
+        // Prior bar: short below long; latest bar: short above long.
+        List<decimal?> shortMa = [9m, 11m];
+        List<decimal?> longMa = [10m, 10m];
+
+        var result = TechnicalIndicatorService.DetectMaCross(shortMa, longMa);
+
+        result.Should().Be(MovingAverageCrossSignal.GoldenCross);
+    }
+
+    [Fact]
+    public void DetectMaCross_ShortFallsBelowLong_ReturnsDeathCross()
+    {
+        List<decimal?> shortMa = [11m, 9m];
+        List<decimal?> longMa = [10m, 10m];
+
+        var result = TechnicalIndicatorService.DetectMaCross(shortMa, longMa);
+
+        result.Should().Be(MovingAverageCrossSignal.DeathCross);
+    }
+
+    [Fact]
+    public void DetectMaCross_PriorBarEqual_ThenAbove_ReturnsGoldenCross()
+    {
+        // Equality on the prior bar still counts as a cross when the next bar separates.
+        List<decimal?> shortMa = [10m, 11m];
+        List<decimal?> longMa = [10m, 10m];
+
+        var result = TechnicalIndicatorService.DetectMaCross(shortMa, longMa);
+
+        result.Should().Be(MovingAverageCrossSignal.GoldenCross);
+    }
+
+    [Fact]
+    public void DetectMaCross_NoCross_ParallelSeries_ReturnsNone()
+    {
+        List<decimal?> shortMa = [11m, 12m, 13m];
+        List<decimal?> longMa = [10m, 10m, 10m];
+
+        var result = TechnicalIndicatorService.DetectMaCross(shortMa, longMa);
+
+        result.Should().Be(MovingAverageCrossSignal.None);
+    }
+
+    [Fact]
+    public void DetectMaCross_CrossOutsideLookbackWindow_ReturnsNone()
+    {
+        // Golden cross happens at index 1, but lookback only inspects the last 2
+        // bar-pairs (indices 4-5 and 3-4), so it is not reported.
+        List<decimal?> shortMa = [9m, 11m, 12m, 13m, 14m, 15m];
+        List<decimal?> longMa = [10m, 10m, 10m, 10m, 10m, 10m];
+
+        var result = TechnicalIndicatorService.DetectMaCross(shortMa, longMa, lookback: 2);
+
+        result.Should().Be(MovingAverageCrossSignal.None);
+    }
+
+    [Fact]
+    public void DetectMaCross_MostRecentCrossWins()
+    {
+        // Golden cross at index 1, death cross at index 3 — the latest is reported.
+        List<decimal?> shortMa = [9m, 11m, 11m, 9m];
+        List<decimal?> longMa = [10m, 10m, 10m, 10m];
+
+        var result = TechnicalIndicatorService.DetectMaCross(shortMa, longMa, lookback: 5);
+
+        result.Should().Be(MovingAverageCrossSignal.DeathCross);
+    }
+
+    [Fact]
+    public void DetectMaCross_WarmupNullsSkipped_DetectsLaterCross()
+    {
+        // Leading nulls (SMA warm-up) must not be treated as a comparable bar.
+        List<decimal?> shortMa = [null, null, 9m, 11m];
+        List<decimal?> longMa = [null, null, 10m, 10m];
+
+        var result = TechnicalIndicatorService.DetectMaCross(shortMa, longMa);
+
+        result.Should().Be(MovingAverageCrossSignal.GoldenCross);
+    }
+
+    #endregion
+
+    #region CountConsecutiveStreak
+
+    [Fact]
+    public void CountConsecutiveStreak_EmptySeries_ReturnsNone()
+    {
+        var (days, direction) = TechnicalIndicatorService.CountConsecutiveStreak([]);
+
+        days.Should().Be(0);
+        direction.Should().Be(PriceStreakDirection.None);
+    }
+
+    [Fact]
+    public void CountConsecutiveStreak_SinglePrice_ReturnsNone()
+    {
+        var (days, direction) = TechnicalIndicatorService.CountConsecutiveStreak([100m]);
+
+        days.Should().Be(0);
+        direction.Should().Be(PriceStreakDirection.None);
+    }
+
+    [Fact]
+    public void CountConsecutiveStreak_LastMoveFlat_ReturnsNone()
+    {
+        var (days, direction) = TechnicalIndicatorService.CountConsecutiveStreak([100m, 100m]);
+
+        days.Should().Be(0);
+        direction.Should().Be(PriceStreakDirection.None);
+    }
+
+    [Fact]
+    public void CountConsecutiveStreak_ThreeRisingCloses_ReturnsThreeUp()
+    {
+        var (days, direction) = TechnicalIndicatorService.CountConsecutiveStreak([
+            100m,
+            101m,
+            102m,
+            103m,
+        ]);
+
+        days.Should().Be(3);
+        direction.Should().Be(PriceStreakDirection.Up);
+    }
+
+    [Fact]
+    public void CountConsecutiveStreak_ThreeFallingCloses_ReturnsThreeDown()
+    {
+        var (days, direction) = TechnicalIndicatorService.CountConsecutiveStreak([
+            103m,
+            102m,
+            101m,
+            100m,
+        ]);
+
+        days.Should().Be(3);
+        direction.Should().Be(PriceStreakDirection.Down);
+    }
+
+    [Fact]
+    public void CountConsecutiveStreak_DirectionChange_CountsOnlyTrailingRun()
+    {
+        // Down, down, then two up days at the end — only the trailing up run counts.
+        var (days, direction) = TechnicalIndicatorService.CountConsecutiveStreak([
+            105m,
+            104m,
+            103m,
+            104m,
+            105m,
+        ]);
+
+        days.Should().Be(2);
+        direction.Should().Be(PriceStreakDirection.Up);
+    }
+
+    [Fact]
+    public void CountConsecutiveStreak_FlatDayBreaksRun()
+    {
+        // The flat move between the two latest-but-one closes stops the count.
+        var (days, direction) = TechnicalIndicatorService.CountConsecutiveStreak([
+            100m,
+            100m,
+            101m,
+            102m,
+        ]);
+
+        days.Should().Be(2);
+        direction.Should().Be(PriceStreakDirection.Up);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Slice 1 of 2 for #1858 (Refs #1858 — does not close the issue).
- Adds the moving-average cross (50-day vs 200-day golden/death cross) and consecutive up/down day-streak calculations to the shared technical-indicator service, with unit tests. The second slice surfaces these as badges on the stock Technicals tab.

## Code changes

- `src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs` — adds `DetectMaCross` (most-recent golden/death crossover of a shorter vs longer moving average within a lookback window, skipping warm-up nulls) and `CountConsecutiveStreak` (length and direction of the trailing run of same-direction daily closes).
- `src/Equibles.Yahoo.Repositories/MovingAverageCrossSignal.cs` — new enum (None / GoldenCross / DeathCross).
- `src/Equibles.Yahoo.Repositories/PriceStreakDirection.cs` — new enum (None / Up / Down).
- `tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceSignalTests.cs` — 17 unit tests covering warm-up nulls, lookback bounds, equality boundaries, most-recent-cross precedence, and streak direction changes / flat-day breaks.