### PR TITLE
feat(web): show MA-cross and price-streak badges on the technicals tab

### DIFF
--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -320,6 +320,12 @@ public class StockTabService
             closePrices
         );
 
+        var sma50 = TechnicalIndicatorService.ComputeSma(closePrices, 50);
+        var sma200 = TechnicalIndicatorService.ComputeSma(closePrices, 200);
+        var (streakDays, streakDirection) = TechnicalIndicatorService.CountConsecutiveStreak(
+            closePrices
+        );
+
         return new PriceTabViewModel
         {
             Ticker = stock.Ticker,
@@ -328,12 +334,15 @@ public class StockTabService
             BenchmarkTicker = BenchmarkTicker,
             BenchmarkReturns = await LoadBenchmarkReturns(stock, prices),
             Sma20 = TechnicalIndicatorService.ComputeSma(closePrices, 20),
-            Sma50 = TechnicalIndicatorService.ComputeSma(closePrices, 50),
-            Sma200 = TechnicalIndicatorService.ComputeSma(closePrices, 200),
+            Sma50 = sma50,
+            Sma200 = sma200,
             Rsi14 = TechnicalIndicatorService.ComputeRsi(closePrices),
             MacdLine = macdLine,
             MacdSignal = macdSignal,
             MacdHistogram = macdHistogram,
+            MaCross = TechnicalIndicatorService.DetectMaCross(sma50, sma200),
+            PriceStreakDays = streakDays,
+            PriceStreakDirection = streakDirection,
         };
     }
 

--- a/src/Equibles.Web/ViewModels/Stocks/PriceTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/PriceTabViewModel.cs
@@ -25,4 +25,9 @@ public class PriceTabViewModel : StockTabViewModel
     public List<decimal?> MacdLine { get; set; } = [];
     public List<decimal?> MacdSignal { get; set; } = [];
     public List<decimal?> MacdHistogram { get; set; } = [];
+
+    // Technical signals surfaced as badges near the top of the tab.
+    public MovingAverageCrossSignal MaCross { get; set; }
+    public int PriceStreakDays { get; set; }
+    public PriceStreakDirection PriceStreakDirection { get; set; }
 }

--- a/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
@@ -1,3 +1,4 @@
+@using Equibles.Yahoo.Repositories
 @model Equibles.Web.ViewModels.Stocks.PriceTabViewModel
 
 @if (Model.Prices.Count == 0) {
@@ -12,6 +13,28 @@
         <button class="btn btn-sm btn-ghost border border-base-300 period-btn" data-months="60">5Y</button>
         <button class="btn btn-sm btn-ghost border border-base-300 period-btn" data-months="0">All</button>
     </div>
+
+    // Technical signal badges: the 50- vs 200-day moving-average cross and the
+    // current run of consecutive same-direction daily closes. Each renders only
+    // when present so most pages show a single, uncluttered badge.
+    var hasCross = Model.MaCross != MovingAverageCrossSignal.None;
+    var hasStreak = Model.PriceStreakDays > 0
+        && Model.PriceStreakDirection != PriceStreakDirection.None;
+    var streakDayLabel = Model.PriceStreakDays == 1 ? "Day" : "Days";
+    if (hasCross || hasStreak) {
+        <div class="flex flex-wrap items-center gap-2 mb-4" aria-label="Technical signals">
+            @if (Model.MaCross == MovingAverageCrossSignal.GoldenCross) {
+                <span class="badge badge-success" title="The 50-day moving average has crossed above the 200-day moving average — a bullish trend signal.">Golden Cross (50/200)</span>
+            } else if (Model.MaCross == MovingAverageCrossSignal.DeathCross) {
+                <span class="badge badge-error" title="The 50-day moving average has crossed below the 200-day moving average — a bearish trend signal.">Death Cross (50/200)</span>
+            }
+            @if (hasStreak && Model.PriceStreakDirection == PriceStreakDirection.Up) {
+                <span class="badge badge-success" title="Consecutive days closing higher than the previous close.">@Model.PriceStreakDays Up @streakDayLabel</span>
+            } else if (hasStreak) {
+                <span class="badge badge-error" title="Consecutive days closing lower than the previous close.">@Model.PriceStreakDays Down @streakDayLabel</span>
+            }
+        </div>
+    }
 
     <!-- Price + SMA Chart -->
     <div class="card bg-base-100 shadow-sm mb-2">

--- a/tests/Equibles.IntegrationTests/Web/PutCallAndStockViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/PutCallAndStockViewRenderingTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Equibles.Cboe.Data.Models;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data.Models;
 using Xunit;
 
 namespace Equibles.IntegrationTests.Web;
@@ -78,5 +79,57 @@ public class PutCallAndStockViewRenderingTests
         var html = await response.Content.ReadAsStringAsync();
         html.Should().Contain("AAPL", "the Show shell must render the stock ticker");
         html.Should().Contain("Apple Inc.", "the Show shell must render the stock name");
+    }
+
+    [Fact]
+    public async Task GetStocksPrice_WithRisingPriceStreak_RendersUpStreakBadge()
+    {
+        var stockId = Guid.NewGuid();
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Cik = "0000789019",
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corporation",
+                }
+            );
+
+            // 40 trading days of strictly rising closes — every day closed higher
+            // than the prior, so the Price tab must surface a consecutive up-day
+            // streak badge.
+            var start = new DateOnly(2026, 1, 5);
+            for (var i = 0; i < 40; i++)
+            {
+                var close = 100m + i;
+                db.Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stockId,
+                        Date = start.AddDays(i),
+                        Open = close,
+                        High = close,
+                        Low = close,
+                        Close = close,
+                        AdjustedClose = close,
+                        Volume = 1_000_000,
+                    }
+                );
+            }
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Stocks/MSFT/Price");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Technical signals", "the technical-signal badge row must render");
+        html.Should()
+            .Contain(
+                "Up Days",
+                "a rising price series must surface a consecutive up-day streak badge"
+            );
     }
 }


### PR DESCRIPTION
## Summary

- Slice 2 of 2 for #1858 — Closes #1858.
- Surfaces two technical signals as badges at the top of the stock Technicals (Price) tab: the 50- vs 200-day moving-average golden/death cross, and the current run of consecutive up/down daily closes. Builds on the detection helpers added in #2827.
- Badges render only when a signal is present, so most pages stay uncluttered.

## Code changes

- `src/Equibles.Web/ViewModels/Stocks/PriceTabViewModel.cs` — adds `MaCross`, `PriceStreakDays`, and `PriceStreakDirection` to the view model.
- `src/Equibles.Web/Services/StockTabService.cs` — `LoadPriceTab` now computes the 50/200 cross via `DetectMaCross` and the close-streak via `CountConsecutiveStreak`, reusing the SMA-50/200 series it already builds.
- `src/Equibles.Web/Views/Stocks/_PriceTab.cshtml` — renders the golden/death-cross and up/down-streak badges (DaisyUI `badge-success`/`badge-error`) in a labelled signal row, each with an explanatory tooltip.
- `tests/Equibles.IntegrationTests/Web/PutCallAndStockViewRenderingTests.cs` — in-process view-rendering test seeding a strictly-rising price series and asserting the consecutive up-day streak badge renders.