### PR TITLE
refactor(views): extract repeated page-header markup into a tag helper

### DIFF
--- a/src/Equibles.Web/TagHelpers/PageHeaderTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/PageHeaderTagHelper.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.Web.TagHelpers;
+
+[HtmlTargetElement("page-header")]
+public class PageHeaderTagHelper : TagHelper
+{
+    [HtmlAttributeName("title")]
+    public string Title { get; set; }
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var subtitle = await output.GetChildContentAsync();
+
+        output.TagName = "div";
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.Attributes.Clear();
+        output.Attributes.SetAttribute("class", "mb-8");
+
+        output.Content.AppendHtml("<h1 class=\"text-3xl font-bold mb-2\">");
+        output.Content.Append(Title);
+        output.Content.AppendHtml("</h1>");
+        output.Content.AppendHtml("<p class=\"text-base-content/60\">");
+        output.Content.AppendHtml(subtitle);
+        output.Content.AppendHtml("</p>");
+    }
+}

--- a/src/Equibles.Web/Views/Cftc/Index.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Index.cshtml
@@ -6,15 +6,12 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Futures</h1>
-        <p class="text-base-content/60">
+    <page-header title="Futures">
             @Model.Categories.Sum(c => c.Contracts.Count) contracts from
             <a href="https://www.cftc.gov/MarketReports/CommitmentsofTraders/index.htm" target="_blank" rel="noopener" class="link link-primary">CFTC</a>
             across @Model.Categories.Count categories.
             Click any contract to explore positioning charts and historical data.
-        </p>
-    </div>
+        </page-header>
 
     <div class="space-y-6">
         @foreach (var category in Model.Categories) {

--- a/src/Equibles.Web/Views/EconomicData/Index.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Index.cshtml
@@ -6,15 +6,12 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Economic Data</h1>
-        <p class="text-base-content/60">
+    <page-header title="Economic Data">
             @Model.Categories.Sum(c => c.Series.Count) indicators from
             <a href="https://fred.stlouisfed.org" target="_blank" rel="noopener" class="link link-primary">FRED</a>
             across @Model.Categories.Count categories.
             Click any indicator to explore charts, statistics, and historical data.
-        </p>
-    </div>
+        </page-header>
 
     @if (!Model.Categories.Any()) {
         <div class="card bg-base-100 shadow-sm">

--- a/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/DoubleDown.cshtml
@@ -17,13 +17,10 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Double-Down Report</h1>
-        <p class="text-base-content/60">
+    <page-header title="Double-Down Report">
             Positions where an institution increased its share count by
             @Model.MinPctIncrease.ToString("F0")%+ quarter over quarter — ranked by conviction
-        </p>
-    </div>
+        </page-header>
 
     @if (Model.AvailableDates.Count < 2) {
         <partial name="_EmptyStateCard" model='(IconName: "arrow-trending-up", Heading: "Not enough data", Message: "The double-down report needs at least two quarters of 13F data.")' />

--- a/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/HeatMap.cshtml
@@ -7,12 +7,9 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">13F Conviction Heat Map</h1>
-        <p class="text-base-content/60">
+    <page-header title="13F Conviction Heat Map">
             Each bubble is a stock. X = number of 13F filers, Y = conviction score, size = total institutional value.
-        </p>
-    </div>
+        </page-header>
 
     @if (Model.AvailableDates.Count < 2) {
         <partial name="_EmptyStateCard" model='(IconName: "fire", Heading: "Not enough data", Message: "At least two quarters of 13F filings are required for the heat map.")' />

--- a/src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/LatestFilings.cshtml
@@ -7,12 +7,9 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Latest 13F Filings</h1>
-        <p class="text-base-content/60">
+    <page-header title="Latest 13F Filings">
             @Model.TotalCount.ToString("N0") filings imported
-        </p>
-    </div>
+        </page-header>
 
     <!-- Results Table -->
     <div class="card bg-base-100 shadow-sm">

--- a/src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Stats.cshtml
@@ -7,12 +7,9 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">13F Statistics</h1>
-        <p class="text-base-content/60">
+    <page-header title="13F Statistics">
             Market-wide aggregate statistics across all 13F-HR filers
-        </p>
-    </div>
+        </page-header>
 
     @if (Model.Latest == null) {
         <partial name="_EmptyStateCard" model='(IconName: "chart-bar", Heading: "No 13F data yet", Message: "Once at least one quarter of 13F filings has been ingested, the statistics appear here.")' />

--- a/src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Trends.cshtml
@@ -7,12 +7,9 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">13F Trend Charts</h1>
-        <p class="text-base-content/60">
+    <page-header title="13F Trend Charts">
             Market-wide aggregates across all 13F-HR filers by report date
-        </p>
-    </div>
+        </page-header>
 
     @if (Model.AumSnapshots.Count == 0) {
         <partial name="_EmptyStateCard" model='(IconName: "chart-bar", Heading: "No 13F data yet", Message: "Once at least one quarter of 13F filings has been ingested, the trend charts appear here.")' />

--- a/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
+++ b/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
@@ -7,12 +7,9 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Insider Trading Dashboard</h1>
-        <p class="text-base-content/60">
+    <page-header title="Insider Trading Dashboard">
             Top insider transactions from the last 90 days (SEC Form 4 filings)
-        </p>
-    </div>
+        </page-header>
 
     @if (Model.TopBuys.Count == 0 && Model.TopSells.Count == 0) {
         <partial name="_EmptyStateCard" model='(IconName: "user-group", Heading: "No insider transactions yet", Message: "Once Form 4 filings have been ingested, the insider dashboard appears here.")' />

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -35,17 +35,14 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Institutions</h1>
-        <p class="text-base-content/60">
+    <page-header title="Institutions">
             Browse @Model.TotalCount.ToString("N0") 13F filers
             @if (Model.LatestReportDate.HasValue) {
                 <span> · aggregates from each filer's most-recent 13F report (universe latest @Model.LatestReportDate.Value.ToString("MMM dd, yyyy"))</span>
             } else {
                 <span> · no 13F data ingested yet</span>
             }
-        </p>
-    </div>
+        </page-header>
 
     <!-- Search + sort (plain query-param names, bound to InstitutionsController.Index) -->
     <form method="get" class="mb-6">

--- a/src/Equibles.Web/Views/Market/Index.cshtml
+++ b/src/Equibles.Web/Views/Market/Index.cshtml
@@ -6,14 +6,11 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Market Indicators</h1>
-        <p class="text-base-content/60">
+    <page-header title="Market Indicators">
             Sentiment and volatility data sourced from
             <a href="https://www.cboe.com" target="_blank" rel="noopener" class="link link-primary">CBOE</a>.
             Explore put/call ratios and VIX historical data.
-        </p>
-    </div>
+        </page-header>
 
     <div class="space-y-6">
         <!-- Put/Call Ratios -->

--- a/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
@@ -12,13 +12,10 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Combined portfolio</h1>
-        <p class="text-base-content/60">
+    <page-header title="Combined portfolio">
             Pool @InstitutionCombinedViewModel.MinCiks–@InstitutionCombinedViewModel.MaxCiks funds into a single combined portfolio.
             Consensus picks (held by the most funds) appear at the top.
-        </p>
-    </div>
+        </page-header>
 
     <partial name="_InstitutionPicker" model="pickerVm" />
 

--- a/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
@@ -12,12 +12,9 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Compare institutions</h1>
-        <p class="text-base-content/60">
+    <page-header title="Compare institutions">
             Side-by-side 13F portfolio overlap of @InstitutionCompareViewModel.MinCiks–@InstitutionCompareViewModel.MaxCiks selected funds.
-        </p>
-    </div>
+        </page-header>
 
     <partial name="_InstitutionPicker" model="pickerVm" />
 

--- a/src/Equibles.Web/Views/Profiles/Insider.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Insider.cshtml
@@ -6,12 +6,9 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">@Model.Name</h1>
-        <p class="text-base-content/60">
+    <page-header title="@Model.Name">
             Insider@(string.IsNullOrWhiteSpace(meta) ? "" : " · " + meta) · CIK @Model.OwnerCik
-        </p>
-    </div>
+        </page-header>
 
     <h2 class="text-xl font-semibold mb-3">Recent transactions</h2>
     @if (Model.Transactions.Count == 0) {

--- a/src/Equibles.Web/Views/Profiles/Member.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Member.cshtml
@@ -5,10 +5,7 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">@Model.Name</h1>
-        <p class="text-base-content/60">Member of Congress</p>
-    </div>
+    <page-header title="@Model.Name">Member of Congress</page-header>
 
     <h2 class="text-xl font-semibold mb-3">Recent trades</h2>
     @if (Model.Trades.Count == 0) {

--- a/src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml
+++ b/src/Equibles.Web/Views/Profiles/OverlapMatrix.cshtml
@@ -13,12 +13,9 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Institution Overlap Matrix</h1>
-        <p class="text-base-content/60">
+    <page-header title="Institution Overlap Matrix">
             Pairwise shared-ticker counts between selected 13F filers
-        </p>
-    </div>
+        </page-header>
 
     <partial name="_InstitutionPicker" model="pickerVm" />
 

--- a/src/Equibles.Web/Views/ShortActivity/MostShorted.cshtml
+++ b/src/Equibles.Web/Views/ShortActivity/MostShorted.cshtml
@@ -18,9 +18,7 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Most Shorted</h1>
-        <p class="text-base-content/60">
+    <page-header title="Most Shorted">
             @if (hasData) {
                 <span>@Model.TotalCount.ToString("N0") stocks ranked by FINRA short interest for settlement date <strong class="text-base-content">@Model.SelectedDate?.ToString("MMM dd, yyyy")</strong></span>
                 @if (Model.SelectedDate != Model.LatestDate) {
@@ -29,8 +27,7 @@
             } else {
                 <span>No short interest data has been ingested yet.</span>
             }
-        </p>
-    </div>
+        </page-header>
 
     <!-- Settlement-date + sort selector (plain query-param names, bound to ShortActivityController.MostShorted) -->
     <form method="get" class="mb-6">

--- a/src/Equibles.Web/Views/ShortVolume/Index.cshtml
+++ b/src/Equibles.Web/Views/ShortVolume/Index.cshtml
@@ -18,9 +18,7 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Largest Short Volume</h1>
-        <p class="text-base-content/60">
+    <page-header title="Largest Short Volume">
             @if (hasData) {
                 <span>@Model.TotalCount.ToString("N0") stocks ranked by FINRA consolidated daily short volume for <strong class="text-base-content">@Model.SelectedDate?.ToString("MMM dd, yyyy")</strong></span>
                 @if (Model.SelectedDate != Model.LatestDate) {
@@ -29,8 +27,7 @@
             } else {
                 <span>No daily short volume data has been ingested yet.</span>
             }
-        </p>
-    </div>
+        </page-header>
 
     <!-- Trading-day + sort selector (plain query-param names, bound to ShortVolumeController.Index) -->
     <form method="get" class="mb-6">

--- a/src/Equibles.Web/Views/Stocks/Index.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Index.cshtml
@@ -20,10 +20,7 @@
 }
 
 <div class="max-w-6xl mx-auto px-6 py-12">
-    <div class="mb-8">
-        <h1 class="text-3xl font-bold mb-2">Stocks</h1>
-        <p class="text-base-content/60">Browse @Model.TotalCount.ToString("N0") US common stocks</p>
-    </div>
+    <page-header title="Stocks">Browse @Model.TotalCount.ToString("N0") US common stocks</page-header>
 
     <!-- Search + filters (plain query-param names, bound to StocksController.Index) -->
     <form method="get" class="mb-6">


### PR DESCRIPTION
## Summary

- The same page-header block — `<div class="mb-8">` wrapping an `<h1 class="text-3xl font-bold mb-2">` title and a `<p class="text-base-content/60">` subtitle — was duplicated across 18 index/profile views.
- Extracted it into a reusable `<page-header title="…">subtitle</page-header>` tag helper so the title/subtitle structure lives in one place and pages no longer repeat the wrapper markup.

## Code changes

- `src/Equibles.Web/TagHelpers/PageHeaderTagHelper.cs` — new tag helper rendering `div.mb-8 > h1.text-3xl.font-bold.mb-2 + p.text-base-content/60`. The `title` attribute is HTML-encoded exactly as the previous `@`-expressions were; the subtitle is passed through as child content, so arbitrary subtitle markup (conditionals, spans, links) renders identically.
- 18 views under `Views/{HoldingsActivity,Profiles,Institutions,Stocks,ShortVolume,ShortActivity,InsiderActivity,Market,Cftc,EconomicData}` — replaced the inline header block with `<page-header>`. Rendered DOM is unchanged.

Behavior-preserving: all 18 views compile, and the Web suites stay green (328 integration view-render tests + 381 unit tests).