### PR TITLE
refactor(sec-financialfacts): extract duplicated XBRL value-parsing helpers into shared XbrlValueParser

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -200,8 +200,8 @@ public class InlineXbrlParser
                     : FindFirstChildByLocalName(denominator, MeasureLocalName)?.TextContent;
             if (string.IsNullOrEmpty(numeratorMeasure) || string.IsNullOrEmpty(denominatorMeasure))
                 return null;
-            var numeratorLocal = StripPrefix(numeratorMeasure.Trim());
-            var denominatorLocal = StripPrefix(denominatorMeasure.Trim());
+            var numeratorLocal = XbrlValueParser.StripPrefix(numeratorMeasure.Trim());
+            var denominatorLocal = XbrlValueParser.StripPrefix(denominatorMeasure.Trim());
             if (numeratorLocal == null || denominatorLocal == null)
                 return null;
             return $"{numeratorLocal}/{denominatorLocal}";
@@ -211,18 +211,7 @@ public class InlineXbrlParser
         var measureValue = measure?.TextContent?.Trim();
         if (string.IsNullOrEmpty(measureValue))
             return null;
-        return StripPrefix(measureValue);
-    }
-
-    // Returns null when the QName has a prefix but an empty local name
-    // (e.g. "iso4217:"); such a measure is unresolvable.
-    private static string StripPrefix(string qname)
-    {
-        var colonIdx = qname.IndexOf(':');
-        if (colonIdx < 0)
-            return qname;
-        var local = qname.Substring(colonIdx + 1);
-        return local.Length == 0 ? null : local;
+        return XbrlValueParser.StripPrefix(measureValue);
     }
 
     private static bool TryParseFact(
@@ -275,7 +264,7 @@ public class InlineXbrlParser
             PeriodStart = context.Start,
             PeriodEnd = context.End,
             Dimensions = context.Dimensions,
-            Decimals = ParseDecimals(element.GetAttribute("decimals")),
+            Decimals = XbrlValueParser.ParseDecimals(element.GetAttribute("decimals")),
         };
         return true;
     }
@@ -405,15 +394,6 @@ public class InlineXbrlParser
 
         value = parsed;
         return true;
-    }
-
-    private static int? ParseDecimals(string decimalsAttribute)
-    {
-        if (string.IsNullOrEmpty(decimalsAttribute))
-            return null;
-        if (string.Equals(decimalsAttribute, "INF", StringComparison.OrdinalIgnoreCase))
-            return int.MaxValue;
-        return int.TryParse(decimalsAttribute, out var value) ? value : null;
     }
 
     private record struct ParsedContext(

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
@@ -202,8 +202,8 @@ public class StandaloneXbrlParser
             var denominatorMeasure = denominator?.Element(MeasureElement)?.Value?.Trim();
             if (string.IsNullOrEmpty(numeratorMeasure) || string.IsNullOrEmpty(denominatorMeasure))
                 return null;
-            var numeratorLocal = StripPrefix(numeratorMeasure);
-            var denominatorLocal = StripPrefix(denominatorMeasure);
+            var numeratorLocal = XbrlValueParser.StripPrefix(numeratorMeasure);
+            var denominatorLocal = XbrlValueParser.StripPrefix(denominatorMeasure);
             if (numeratorLocal == null || denominatorLocal == null)
                 return null;
             return $"{numeratorLocal}/{denominatorLocal}";
@@ -213,18 +213,7 @@ public class StandaloneXbrlParser
         var measureValue = measure?.Value?.Trim();
         if (string.IsNullOrEmpty(measureValue))
             return null;
-        return StripPrefix(measureValue);
-    }
-
-    // Returns null when the QName has a prefix but an empty local name
-    // (e.g. "iso4217:"); such a measure is unresolvable.
-    private static string StripPrefix(string qname)
-    {
-        var colonIdx = qname.IndexOf(':');
-        if (colonIdx < 0)
-            return qname;
-        var local = qname.Substring(colonIdx + 1);
-        return local.Length == 0 ? null : local;
+        return XbrlValueParser.StripPrefix(measureValue);
     }
 
     private static bool TryParseFact(
@@ -278,18 +267,9 @@ public class StandaloneXbrlParser
             PeriodStart = context.Start,
             PeriodEnd = context.End,
             Dimensions = context.Dimensions,
-            Decimals = ParseDecimals((string)element.Attribute("decimals")),
+            Decimals = XbrlValueParser.ParseDecimals((string)element.Attribute("decimals")),
         };
         return true;
-    }
-
-    private static int? ParseDecimals(string decimalsAttribute)
-    {
-        if (string.IsNullOrEmpty(decimalsAttribute))
-            return null;
-        if (string.Equals(decimalsAttribute, "INF", StringComparison.OrdinalIgnoreCase))
-            return int.MaxValue;
-        return int.TryParse(decimalsAttribute, out var value) ? value : null;
     }
 
     private record struct ParsedContext(

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/XbrlValueParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/XbrlValueParser.cs
@@ -1,0 +1,27 @@
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+// Engine-agnostic XBRL value-parsing primitives shared by StandaloneXbrlParser
+// (LINQ-to-XML) and InlineXbrlParser (AngleSharp): both operate on the same string
+// attribute/QName values, so this logic stays identical across the two engines.
+internal static class XbrlValueParser
+{
+    // Returns null when the QName has a prefix but an empty local name
+    // (e.g. "iso4217:"); such a measure is unresolvable.
+    public static string StripPrefix(string qname)
+    {
+        var colonIdx = qname.IndexOf(':');
+        if (colonIdx < 0)
+            return qname;
+        var local = qname.Substring(colonIdx + 1);
+        return local.Length == 0 ? null : local;
+    }
+
+    public static int? ParseDecimals(string decimalsAttribute)
+    {
+        if (string.IsNullOrEmpty(decimalsAttribute))
+            return null;
+        if (string.Equals(decimalsAttribute, "INF", StringComparison.OrdinalIgnoreCase))
+            return int.MaxValue;
+        return int.TryParse(decimalsAttribute, out var value) ? value : null;
+    }
+}


### PR DESCRIPTION
## Summary

- `StandaloneXbrlParser` (LINQ-to-XML) and `InlineXbrlParser` (AngleSharp) each carried byte-identical private copies of two engine-agnostic value-parsing helpers — `StripPrefix` (QName local-name resolution) and `ParseDecimals` (the XBRL `decimals` attribute). This collapses both copies into one shared `XbrlValueParser` so the two parsers can no longer drift apart.
- Behavior-preserving: the helpers are pure functions of their string inputs and were moved verbatim; both parsers' public `Parse()` output is unchanged (full unit suite green, including 72 XBRL parser tests).

## Code changes

- `Parsers/XbrlValueParser.cs` — new `internal static` helper holding `StripPrefix` and `ParseDecimals` (the `StripPrefix` empty-local-name WHY-comment is preserved).
- `Parsers/StandaloneXbrlParser.cs` — removed the two duplicated private helpers; call sites now use `XbrlValueParser`.
- `Parsers/InlineXbrlParser.cs` — same removal and routing.