### PR TITLE
refactor(sec-financialfacts): extract duplicated ParsedContext struct shared by both XBRL parsers

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -395,11 +395,4 @@ public class InlineXbrlParser
         value = parsed;
         return true;
     }
-
-    private record struct ParsedContext(
-        bool IsInstant,
-        DateOnly Start,
-        DateOnly End,
-        List<ParsedXbrlDimension> Dimensions
-    );
 }

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/ParsedContext.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/ParsedContext.cs
@@ -1,0 +1,13 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Models;
+
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+// Parsed xbrli:context shared by StandaloneXbrlParser (LINQ-to-XML) and
+// InlineXbrlParser (AngleSharp): both build the same context shape from their
+// respective engines, so the type stays identical across the two.
+internal record struct ParsedContext(
+    bool IsInstant,
+    DateOnly Start,
+    DateOnly End,
+    List<ParsedXbrlDimension> Dimensions
+);

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/StandaloneXbrlParser.cs
@@ -271,11 +271,4 @@ public class StandaloneXbrlParser
         };
         return true;
     }
-
-    private record struct ParsedContext(
-        bool IsInstant,
-        DateOnly Start,
-        DateOnly End,
-        List<ParsedXbrlDimension> Dimensions
-    );
 }


### PR DESCRIPTION
## Summary

- `StandaloneXbrlParser` (LINQ-to-XML) and `InlineXbrlParser` (AngleSharp) each declared a byte-identical private `ParsedContext` record struct. This collapses both into one shared `internal record struct` so the parsed-context shape can no longer drift between the two engines. Follow-up to #2831 (shared `XbrlValueParser`).
- Behavior-preserving: the struct is moved verbatim to its own file in the same namespace/assembly; positional construction and member access (`IsInstant`/`Start`/`End`/`Dimensions`) are unchanged, and both parsers' public `Parse()` output is identical (full unit suite green).

## Code changes

- `Parsers/ParsedContext.cs` — new shared `internal record struct ParsedContext(bool, DateOnly, DateOnly, List<ParsedXbrlDimension>)`.
- `Parsers/StandaloneXbrlParser.cs` — removed the private `ParsedContext` definition.
- `Parsers/InlineXbrlParser.cs` — removed the private `ParsedContext` definition.