### PR TITLE
feat(yahoo): add Bollinger Bands to the technical indicator service

### DIFF
--- a/src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs
+++ b/src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs
@@ -412,4 +412,56 @@ public static class TechnicalIndicatorService
 
         return (days, direction);
     }
+
+    /// <summary>
+    /// Bollinger Bands. The middle band is the <paramref name="period"/>-bar simple moving
+    /// average of close; the upper and lower bands sit <paramref name="stdDev"/> standard
+    /// deviations above and below it. The population standard deviation (denominator =
+    /// <paramref name="period"/>) is used, per John Bollinger's original definition.
+    /// Returns three lists aligned to input length, null-padded at the start while the
+    /// lookback window fills.
+    /// </summary>
+    public static (
+        List<decimal?> Middle,
+        List<decimal?> Upper,
+        List<decimal?> Lower
+    ) ComputeBollingerBands(List<decimal> prices, int period = 20, decimal stdDev = 2m)
+    {
+        var count = prices.Count;
+        var middle = new List<decimal?>(count);
+        var upper = new List<decimal?>(count);
+        var lower = new List<decimal?>(count);
+
+        for (var i = 0; i < count; i++)
+        {
+            if (i < period - 1)
+            {
+                middle.Add(null);
+                upper.Add(null);
+                lower.Add(null);
+                continue;
+            }
+
+            var mean = 0m;
+            for (var j = i - period + 1; j <= i; j++)
+                mean += prices[j];
+            mean /= period;
+
+            var sumSquares = 0m;
+            for (var j = i - period + 1; j <= i; j++)
+            {
+                var diff = prices[j] - mean;
+                sumSquares += diff * diff;
+            }
+            // Population standard deviation (denominator = period) — the Bollinger convention.
+            var deviation = (decimal)Math.Sqrt((double)(sumSquares / period));
+            var offset = stdDev * deviation;
+
+            middle.Add(Math.Round(mean, RoundingDigits));
+            upper.Add(Math.Round(mean + offset, RoundingDigits));
+            lower.Add(Math.Round(mean - offset, RoundingDigits));
+        }
+
+        return (middle, upper, lower);
+    }
 }

--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceBollingerBandsTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceBollingerBandsTests.cs
@@ -1,0 +1,88 @@
+using Equibles.Yahoo.Repositories;
+using FluentAssertions;
+
+namespace Equibles.UnitTests.Web;
+
+public class TechnicalIndicatorServiceBollingerBandsTests
+{
+    [Fact]
+    public void ComputeBollingerBands_NullPadsWarmupAndAlignsToInput()
+    {
+        var prices = Enumerable.Range(1, 25).Select(i => (decimal)i).ToList();
+
+        var (middle, upper, lower) = TechnicalIndicatorService.ComputeBollingerBands(
+            prices,
+            period: 20
+        );
+
+        middle.Should().HaveCount(prices.Count);
+        upper.Should().HaveCount(prices.Count);
+        lower.Should().HaveCount(prices.Count);
+
+        // First (period - 1) bars are warm-up and stay null on every band.
+        middle.Take(19).Should().AllSatisfy(v => v.Should().BeNull());
+        upper.Take(19).Should().AllSatisfy(v => v.Should().BeNull());
+        lower.Take(19).Should().AllSatisfy(v => v.Should().BeNull());
+        middle.Skip(19).Should().AllSatisfy(v => v.Should().NotBeNull());
+    }
+
+    [Fact]
+    public void ComputeBollingerBands_FlatPrices_BandsCollapseToTheMiddle()
+    {
+        var prices = Enumerable.Repeat(50m, 20).ToList();
+
+        var (middle, upper, lower) = TechnicalIndicatorService.ComputeBollingerBands(
+            prices,
+            period: 20
+        );
+
+        // Zero variance ⇒ zero deviation ⇒ all three bands equal the mean.
+        middle[^1].Should().Be(50m);
+        upper[^1].Should().Be(50m);
+        lower[^1].Should().Be(50m);
+    }
+
+    [Fact]
+    public void ComputeBollingerBands_KnownWindow_MatchesPopulationStdDev()
+    {
+        // A single full window of 1..5 so the math is hand-checkable.
+        // mean = 3; population variance = ((-2)²+(-1)²+0²+1²+2²)/5 = 10/5 = 2;
+        // population std = √2 ≈ 1.4142; with stdDev = 2 the offset ≈ 2.8284.
+        var prices = new List<decimal> { 1m, 2m, 3m, 4m, 5m };
+
+        var (middle, upper, lower) = TechnicalIndicatorService.ComputeBollingerBands(
+            prices,
+            period: 5,
+            stdDev: 2m
+        );
+
+        middle[^1].Should().Be(3m);
+        upper[^1].Should().BeApproximately(5.8284m, 0.0001m);
+        lower[^1].Should().BeApproximately(0.1716m, 0.0001m);
+    }
+
+    [Fact]
+    public void ComputeBollingerBands_PeriodLargerThanInput_AllNull()
+    {
+        var prices = new List<decimal> { 1m, 2m, 3m };
+
+        var (middle, upper, lower) = TechnicalIndicatorService.ComputeBollingerBands(
+            prices,
+            period: 20
+        );
+
+        middle.Should().AllSatisfy(v => v.Should().BeNull());
+        upper.Should().AllSatisfy(v => v.Should().BeNull());
+        lower.Should().AllSatisfy(v => v.Should().BeNull());
+    }
+
+    [Fact]
+    public void ComputeBollingerBands_EmptyInput_ReturnsEmptyLists()
+    {
+        var (middle, upper, lower) = TechnicalIndicatorService.ComputeBollingerBands([]);
+
+        middle.Should().BeEmpty();
+        upper.Should().BeEmpty();
+        lower.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Slice 1 of 3 for #684 (Bollinger Bands).

Adds Bollinger Bands to the shared technical indicator service so the bands can be computed once and reused by both the stock price tools and the web price chart in the following slices.

This pull request does not close the issue — the final UI slice does. Refs #684.

## Code changes

- **`src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs`** — new `ComputeBollingerBands(prices, period=20, stdDev=2)` returning the middle band (period SMA) plus upper/lower bands at N standard deviations. Uses the population standard deviation, per Bollinger's original definition, and null-pads the warm-up window so the output aligns to the input length like the other indicators.
- **`tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceBollingerBandsTests.cs`** — unit tests covering warm-up null-padding and alignment, flat-price band collapse, a hand-checkable known window against the population standard deviation, period-larger-than-input, and empty input.

## Test plan

- `dotnet test tests/Equibles.UnitTests --filter BollingerBands` — 5 passed.
- `dotnet csharpier check` clean on the changed files.
