### PR TITLE
feat(mcp): expose Bollinger Bands via a stock price tool

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -342,6 +342,75 @@ public class StockPriceTools
         );
     }
 
+    [McpServerTool(Name = "GetBollingerBands")]
+    [Description(
+        "Bollinger Bands for a stock. A middle band (simple moving average of close) with "
+            + "upper and lower bands set a number of standard deviations above and below it. "
+            + "Bands widen when volatility rises and contract when it falls; price touching "
+            + "the upper/lower band is a common overbought/oversold cue."
+    )]
+    public Task<string> GetBollingerBands(
+        [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Start date in YYYY-MM-DD format (defaults to 6 months ago)")]
+            string startDate = null,
+        [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
+            string endDate = null,
+        [Description("Moving-average window (default: 20)")] int period = 20,
+        [Description("Standard deviations for the upper/lower bands (default: 2)")]
+            decimal stdDev = 2m,
+        [Description("Maximum number of records to return (default: 60, newest first)")]
+            int maxResults = 60
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                if (period < 2)
+                    return "period must be at least 2.";
+                if (stdDev <= 0)
+                    return "stdDev must be greater than 0.";
+
+                var (stock, records, error) = await LoadAscendingPriceWindow(
+                    ticker,
+                    startDate,
+                    endDate
+                );
+                if (error != null)
+                    return error;
+
+                var closes = records.Select(p => p.Close).ToList();
+                var (middle, upper, lower) = TechnicalIndicatorService.ComputeBollingerBands(
+                    closes,
+                    period,
+                    stdDev
+                );
+
+                var result = StartTable(
+                    $"Bollinger Bands (period={period}, stdDev={stdDev.ToString("0.#", CultureInfo.InvariantCulture)}) for {stock.Ticker} ({stock.Name}):",
+                    "| Date | Close | Lower | Middle | Upper |",
+                    "|------|-------|-------|--------|-------|"
+                );
+
+                AppendNewestFirstRows(
+                    result,
+                    records.Count,
+                    maxResults,
+                    i =>
+                    {
+                        var lowerCell = McpFormat.OrDash(lower[i], "F2");
+                        var middleCell = McpFormat.OrDash(middle[i], "F2");
+                        var upperCell = McpFormat.OrDash(upper[i], "F2");
+                        return $"| {records[i].Date:yyyy-MM-dd} | {records[i].Close:F2} | {lowerCell} | {middleCell} | {upperCell} |";
+                    }
+                );
+
+                return result.ToString();
+            },
+            "GetBollingerBands",
+            $"ticker: {ticker}"
+        );
+    }
+
     private async Task<(
         CommonStock Stock,
         List<DailyStockPrice> Records,

--- a/tests/Equibles.UnitTests/Mcp/StockPriceToolsBollingerBandsRegistrationTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/StockPriceToolsBollingerBandsRegistrationTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using Equibles.Yahoo.Mcp.Tools;
+using FluentAssertions;
+
+namespace Equibles.UnitTests.Mcp;
+
+// The GetBollingerBands tool is a thin DB-backed wrapper over the (separately unit-tested)
+// ComputeBollingerBands math, so there is no host-free seam to exercise its body. What we
+// can pin without standing up the MCP host is its registration contract: the exposed tool
+// name and the default parameters clients depend on. A rename or a changed default would
+// silently break every caller, so this guards the boundary the same way the repo's other
+// StockPriceTools test reflection-pins the shared projection helper.
+public class StockPriceToolsBollingerBandsRegistrationTests
+{
+    private static readonly MethodInfo Method = typeof(StockPriceTools).GetMethod(
+        "GetBollingerBands"
+    );
+
+    [Fact]
+    public void GetBollingerBands_IsExposedAsAToolReturningAString()
+    {
+        Method.Should().NotBeNull();
+        Method.ReturnType.Should().Be(typeof(Task<string>));
+
+        // The MCP attribute is matched by type name to avoid a hard package reference here,
+        // mirroring how the host discovers it.
+        var toolAttribute = Method
+            .GetCustomAttributes()
+            .SingleOrDefault(a => a.GetType().Name == "McpServerToolAttribute");
+        toolAttribute.Should().NotBeNull();
+
+        var name = (string)toolAttribute.GetType().GetProperty("Name").GetValue(toolAttribute);
+        name.Should().Be("GetBollingerBands");
+    }
+
+    [Fact]
+    public void GetBollingerBands_DefaultsToTheConventionalPeriodAndDeviation()
+    {
+        var parameters = Method.GetParameters().ToDictionary(p => p.Name);
+
+        parameters["period"].DefaultValue.Should().Be(20);
+        parameters["stdDev"].DefaultValue.Should().Be(2m);
+        parameters["maxResults"].DefaultValue.Should().Be(60);
+    }
+}


### PR DESCRIPTION
## Summary

Slice 2 of 3 for #684 (Bollinger Bands).

Exposes Bollinger Bands over the stock price tools so clients get pre-computed bands instead of recomputing them from raw price output, alongside the existing Stochastic / ATR / OBV tools.

This pull request does not close the issue — the final UI slice does. Refs #684.

## Code changes

- **`src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs`** — new `GetBollingerBands` tool. Loads the ascending price window for a ticker (defaulting to the last six months), computes the bands via `ComputeBollingerBands`, and returns a newest-first `Date | Close | Lower | Middle | Upper` table. Accepts `period` (default 20) and `stdDev` (default 2) with the same validation style as the other tools.
- **`tests/Equibles.UnitTests/Mcp/StockPriceToolsBollingerBandsRegistrationTests.cs`** — reflection tests pinning the exposed tool name and the default `period`/`stdDev`/`maxResults`, matching the repo's existing reflection-pinning of the shared projection helper.

## Test plan

- `dotnet test tests/Equibles.UnitTests --filter BollingerBandsRegistration` — 2 passed.
- `dotnet csharpier check` clean on the changed files.
