### PR TITLE
feat(web): show Bollinger Bands on the stock price chart

### DIFF
--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -326,6 +326,11 @@ public class StockTabService
             closePrices
         );
 
+        // Middle band is the 20-bar SMA (already exposed as Sma20), so discard it here.
+        var (_, bollingerUpper, bollingerLower) = TechnicalIndicatorService.ComputeBollingerBands(
+            closePrices
+        );
+
         return new PriceTabViewModel
         {
             Ticker = stock.Ticker,
@@ -340,6 +345,8 @@ public class StockTabService
             MacdLine = macdLine,
             MacdSignal = macdSignal,
             MacdHistogram = macdHistogram,
+            BollingerUpper = bollingerUpper,
+            BollingerLower = bollingerLower,
             MaCross = TechnicalIndicatorService.DetectMaCross(sma50, sma200),
             PriceStreakDays = streakDays,
             PriceStreakDirection = streakDirection,

--- a/src/Equibles.Web/ViewModels/Stocks/PriceTabViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/PriceTabViewModel.cs
@@ -26,6 +26,11 @@ public class PriceTabViewModel : StockTabViewModel
     public List<decimal?> MacdSignal { get; set; } = [];
     public List<decimal?> MacdHistogram { get; set; } = [];
 
+    // Bollinger Bands (20, 2) upper/lower envelope. The middle band equals Sma20,
+    // so only the envelope is carried to avoid drawing a duplicate line.
+    public List<decimal?> BollingerUpper { get; set; } = [];
+    public List<decimal?> BollingerLower { get; set; } = [];
+
     // Technical signals surfaced as badges near the top of the tab.
     public MovingAverageCrossSignal MaCross { get; set; }
     public int PriceStreakDays { get; set; }

--- a/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
@@ -39,9 +39,9 @@
     <!-- Price + SMA Chart -->
     <div class="card bg-base-100 shadow-sm mb-2">
         <div class="card-body p-4 lg:p-6 pb-2 lg:pb-2">
-            <h2 class="font-semibold text-sm mb-3">Price &amp; Moving Averages</h2>
+            <h2 class="font-semibold text-sm mb-3">Price, Moving Averages &amp; Bollinger Bands</h2>
             <div class="h-[350px]">
-                <canvas id="price-chart" role="img" aria-label="Stock price with moving averages"></canvas>
+                <canvas id="price-chart" role="img" aria-label="Stock price with moving averages and Bollinger Bands"></canvas>
             </div>
         </div>
     </div>
@@ -190,6 +190,8 @@
         const allMacdLine = @Html.Json(Model.MacdLine);
         const allMacdSignal = @Html.Json(Model.MacdSignal);
         const allMacdHist = @Html.Json(Model.MacdHistogram);
+        const allBbUpper = @Html.Json(Model.BollingerUpper);
+        const allBbLower = @Html.Json(Model.BollingerLower);
 
         let priceChart, volumeChart, rsiChart, macdChart;
 
@@ -212,6 +214,8 @@
             const macdLine = allMacdLine.slice(startIdx);
             const macdSignal = allMacdSignal.slice(startIdx);
             const macdHist = allMacdHist.slice(startIdx);
+            const bbUpper = allBbUpper.slice(startIdx);
+            const bbLower = allBbLower.slice(startIdx);
 
             // Destroy previous charts if they exist
             if (priceChart) priceChart.destroy();
@@ -229,6 +233,9 @@
                         { label: 'SMA 20', data: sma20, borderColor: 'oklch(65% 0.15 145)', borderWidth: 1, pointRadius: 0, borderDash: [4, 2] },
                         { label: 'SMA 50', data: sma50, borderColor: 'oklch(65% 0.2 45)', borderWidth: 1, pointRadius: 0, borderDash: [4, 2] },
                         { label: 'SMA 200', data: sma200, borderColor: 'oklch(55% 0.2 15)', borderWidth: 1, pointRadius: 0, borderDash: [6, 3] },
+                        // Bollinger Bands (20, 2): upper band fills down to the lower band ('+1' = next dataset) to shade the envelope.
+                        { label: 'BB Upper (20, 2)', data: bbUpper, borderColor: 'oklch(60% 0.06 250 / 0.7)', backgroundColor: 'oklch(70% 0.06 250 / 0.08)', borderWidth: 1, pointRadius: 0, fill: '+1' },
+                        { label: 'BB Lower (20, 2)', data: bbLower, borderColor: 'oklch(60% 0.06 250 / 0.7)', borderWidth: 1, pointRadius: 0 },
                     ]
                 },
                 options: {

--- a/tests/Equibles.FunctionalTests/Tests/StocksPriceSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksPriceSeededTests.cs
@@ -92,8 +92,17 @@ public class StocksPriceSeededTests
             .Expect(page.Locator("h2").Filter(new() { HasTextString = "No Price Data" }))
             .ToHaveCountAsync(0);
         await Assertions
-            .Expect(page.Locator("h2").Filter(new() { HasTextString = "Price & Moving Averages" }))
+            .Expect(
+                page.Locator("h2")
+                    .Filter(new() { HasTextString = "Price, Moving Averages & Bollinger Bands" })
+            )
             .ToHaveCountAsync(1);
+
+        // Bollinger Bands are drawn on the price chart canvas, so assert the band series
+        // and dataset are wired into the inline chart script rather than into the DOM.
+        var html = await page.ContentAsync();
+        html.Should().Contain("allBbUpper");
+        html.Should().Contain("BB Upper");
 
         // Data Range text is rendered as `{first.Date} — {last.Date}` (em-dash). The text
         // is built from Model.Prices.First()/Last() — LoadPriceTab uses OrderBy(Date), so


### PR DESCRIPTION
## Summary

Slice 3 of 3 for #684 (Bollinger Bands) — the final slice.

Overlays the Bollinger Bands (20, 2) on the price chart in the Stocks price tab, completing the feature: the bands are now computed in the shared service (slice 1, #2833), exposed over the stock price tools (slice 2, #2834), and visualised here.

Closes #684.

## Code changes

- **`src/Equibles.Web/ViewModels/Stocks/PriceTabViewModel.cs`** — adds `BollingerUpper` / `BollingerLower` series. The middle band equals the existing `Sma20`, so only the envelope is carried to avoid drawing a duplicate line.
- **`src/Equibles.Web/Services/StockTabService.cs`** — `LoadPriceTab` computes the bands via `ComputeBollingerBands` and populates the new fields.
- **`src/Equibles.Web/Views/Stocks/_PriceTab.cshtml`** — draws the upper/lower bands on the price chart as a shaded envelope (the upper band fills down to the lower band), serialised and sliced alongside the existing indicator series; chart heading and aria-label updated.
- **`tests/Equibles.FunctionalTests/Tests/StocksPriceSeededTests.cs`** — extends the seeded price-tab e2e to assert the new heading and that the band data/dataset are wired into the chart.

## Test plan

- `dotnet test tests/Equibles.FunctionalTests --filter StocksPriceSeededTests` — real Chromium against a seeded ParadeDB; price tab renders all charts including the new bands. 1 passed.
- `dotnet test tests/Equibles.UnitTests` — 1538 passed, 0 failed.
- Web builds clean; `dotnet csharpier check` clean on the changed `.cs` files.
