### PR TITLE
fix(mcp): add GetBollingerBands to Yahoo module tool-count guard

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -418,6 +418,7 @@ public class McpModuleToolDiscoveryTests
                     "GetStochasticOscillator",
                     "GetAverageTrueRange",
                     "GetOnBalanceVolume",
+                    "GetBollingerBands",
                 }
             },
         };


### PR DESCRIPTION
## Summary

Follow-up fix for #684. The `GetBollingerBands` tool added in #2834 expanded the Yahoo module's MCP tool set, but the expected-tools list in `McpModuleToolDiscoveryTests` was not updated in that pull request, so the full unit suite went red on `main` (the count and discovery guards for `StockPriceTools` expected 5 tools, not 6).

This adds `GetBollingerBands` to the expected list, restoring the suite. Test-only change.

## Code changes

- **`tests/Equibles.UnitTests/Mcp/McpModuleTests.cs`** — add `GetBollingerBands` to the `StockPriceTools` entry of `ToolAssembliesWithExpectedTools`.

## Test plan

- `dotnet test tests/Equibles.UnitTests --filter McpModuleToolDiscovery` — 59 passed, 0 failed.
