### PR TITLE
feat(holdings): add fund-score data model and repository

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -44,6 +44,7 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<ProcessedDataSet>();
         builder.Entity<ProcessedFiling>();
         builder.Entity<RealtimeSweepState>();
+        builder.Entity<FundScore>();
 
         // AumQuarterlySnapshot uses ReportDate as the primary key. The [Key]
         // attribute can't be paired with [DatabaseGenerated(None)] without EF

--- a/src/Equibles.Holdings.Data/Models/FundScore.cs
+++ b/src/Equibles.Holdings.Data/Models/FundScore.cs
@@ -1,0 +1,65 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.Data.Models;
+
+/// <summary>
+/// The most recent performance score for an institutional filer: the hypothetical buy-and-hold
+/// return of its reported 13F portfolio over a rolling window, measured against a benchmark.
+/// One row per (holder, window length, benchmark) — recomputed in place, so this always holds
+/// the latest score rather than a history. Alpha is the portfolio's annualised return (CAGR)
+/// minus the benchmark's CAGR over the same simulated window.
+/// </summary>
+[Index(
+    nameof(InstitutionalHolderId),
+    nameof(WindowYears),
+    nameof(BenchmarkTicker),
+    IsUnique = true
+)]
+[Index(nameof(WindowYears), nameof(BenchmarkTicker), nameof(AlphaPercent))]
+public class FundScore
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid InstitutionalHolderId { get; set; }
+    public virtual InstitutionalHolder InstitutionalHolder { get; set; }
+
+    /// <summary>Benchmark the portfolio was measured against, e.g. "SPY".</summary>
+    [MaxLength(16)]
+    public string BenchmarkTicker { get; set; }
+
+    /// <summary>Length of the rolling window in years, e.g. 3.</summary>
+    public int WindowYears { get; set; }
+
+    /// <summary>First day of the simulated window (the backtest's resolved start).</summary>
+    public DateOnly WindowStart { get; set; }
+
+    /// <summary>Last day of the simulated window (the backtest's resolved end).</summary>
+    public DateOnly WindowEnd { get; set; }
+
+    /// <summary>Total portfolio return over the window, as a percentage (e.g. 42.5 = +42.5%).</summary>
+    [Precision(18, 4)]
+    public decimal PortfolioTotalReturnPercent { get; set; }
+
+    /// <summary>Annualised portfolio return (CAGR) over the window, as a percentage.</summary>
+    [Precision(18, 4)]
+    public decimal PortfolioCagrPercent { get; set; }
+
+    /// <summary>Total benchmark return over the window, as a percentage.</summary>
+    [Precision(18, 4)]
+    public decimal BenchmarkTotalReturnPercent { get; set; }
+
+    /// <summary>Annualised benchmark return (CAGR) over the window, as a percentage.</summary>
+    [Precision(18, 4)]
+    public decimal BenchmarkCagrPercent { get; set; }
+
+    /// <summary>Portfolio CAGR minus benchmark CAGR — the alpha the ranking sorts on.</summary>
+    [Precision(18, 4)]
+    public decimal AlphaPercent { get; set; }
+
+    /// <summary>Largest peak-to-trough portfolio decline over the window, as a percentage.</summary>
+    [Precision(18, 4)]
+    public decimal MaxDrawdownPercent { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Holdings.Repositories/FundScoreRepository.cs
+++ b/src/Equibles.Holdings.Repositories/FundScoreRepository.cs
@@ -1,0 +1,43 @@
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.Repositories;
+
+public class FundScoreRepository : BaseRepository<FundScore>
+{
+    public FundScoreRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    /// <summary>The current score for one filer in a given window/benchmark, or null if not scored yet.</summary>
+    public async Task<FundScore> GetByHolder(
+        InstitutionalHolder holder,
+        int windowYears,
+        string benchmarkTicker
+    )
+    {
+        return await GetAll()
+            .FirstOrDefaultAsync(s =>
+                s.InstitutionalHolderId == holder.Id
+                && s.WindowYears == windowYears
+                && s.BenchmarkTicker == benchmarkTicker
+            );
+    }
+
+    /// <summary>All current scores for one filer, latest window/benchmark variants included.</summary>
+    public IQueryable<FundScore> GetByHolder(InstitutionalHolder holder)
+    {
+        return GetAll().Where(s => s.InstitutionalHolderId == holder.Id);
+    }
+
+    /// <summary>
+    /// Scores for a given window/benchmark ranked by alpha, highest first — the leaderboard
+    /// query the institutions ranking sorts on. Caller materialises and pages.
+    /// </summary>
+    public IQueryable<FundScore> GetRankedByAlpha(int windowYears, string benchmarkTicker)
+    {
+        return GetAll()
+            .Where(s => s.WindowYears == windowYears && s.BenchmarkTicker == benchmarkTicker)
+            .OrderByDescending(s => s.AlphaPercent);
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260530042320_AddFundScore.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260530042320_AddFundScore.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530042320_AddFundScore")]
+    partial class AddFundScore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260530042320_AddFundScore.cs
+++ b/src/Equibles.Migrations/Migrations/20260530042320_AddFundScore.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFundScore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FundScore",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    InstitutionalHolderId = table.Column<Guid>(type: "uuid", nullable: false),
+                    BenchmarkTicker = table.Column<string>(
+                        type: "character varying(16)",
+                        maxLength: 16,
+                        nullable: true
+                    ),
+                    WindowYears = table.Column<int>(type: "integer", nullable: false),
+                    WindowStart = table.Column<DateOnly>(type: "date", nullable: false),
+                    WindowEnd = table.Column<DateOnly>(type: "date", nullable: false),
+                    PortfolioTotalReturnPercent = table.Column<decimal>(
+                        type: "numeric(18,4)",
+                        precision: 18,
+                        scale: 4,
+                        nullable: false
+                    ),
+                    PortfolioCagrPercent = table.Column<decimal>(
+                        type: "numeric(18,4)",
+                        precision: 18,
+                        scale: 4,
+                        nullable: false
+                    ),
+                    BenchmarkTotalReturnPercent = table.Column<decimal>(
+                        type: "numeric(18,4)",
+                        precision: 18,
+                        scale: 4,
+                        nullable: false
+                    ),
+                    BenchmarkCagrPercent = table.Column<decimal>(
+                        type: "numeric(18,4)",
+                        precision: 18,
+                        scale: 4,
+                        nullable: false
+                    ),
+                    AlphaPercent = table.Column<decimal>(
+                        type: "numeric(18,4)",
+                        precision: 18,
+                        scale: 4,
+                        nullable: false
+                    ),
+                    MaxDrawdownPercent = table.Column<decimal>(
+                        type: "numeric(18,4)",
+                        precision: 18,
+                        scale: 4,
+                        nullable: false
+                    ),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FundScore", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FundScore_InstitutionalHolder_InstitutionalHolderId",
+                        column: x => x.InstitutionalHolderId,
+                        principalTable: "InstitutionalHolder",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FundScore_InstitutionalHolderId_WindowYears_BenchmarkTicker",
+                table: "FundScore",
+                columns: new[] { "InstitutionalHolderId", "WindowYears", "BenchmarkTicker" },
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FundScore_WindowYears_BenchmarkTicker_AlphaPercent",
+                table: "FundScore",
+                columns: new[] { "WindowYears", "BenchmarkTicker", "AlphaPercent" }
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "FundScore");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/FundScoreRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/FundScoreRepositoryTests.cs
@@ -1,0 +1,78 @@
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class FundScoreRepositoryTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly FundScoreRepository _repository;
+
+    public FundScoreRepositoryTests()
+    {
+        _dbContext = TestDbContextFactory.Create(new HoldingsModuleConfiguration());
+        _repository = new FundScoreRepository(_dbContext);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    [Fact]
+    public async Task GetRankedByAlpha_OrdersDescendingAndFiltersWindowAndBenchmark()
+    {
+        var lowAlpha = MakeScore(alpha: 1.5m);
+        var highAlpha = MakeScore(alpha: 9.0m);
+        var otherWindow = MakeScore(alpha: 99.0m, windowYears: 5);
+        var otherBenchmark = MakeScore(alpha: 88.0m, benchmark: "QQQ");
+        _repository.Add(lowAlpha);
+        _repository.Add(highAlpha);
+        _repository.Add(otherWindow);
+        _repository.Add(otherBenchmark);
+        await _repository.SaveChanges();
+
+        var ranked = _repository.GetRankedByAlpha(windowYears: 3, benchmarkTicker: "SPY").ToList();
+
+        ranked.Select(s => s.Id).Should().Equal(highAlpha.Id, lowAlpha.Id);
+    }
+
+    [Fact]
+    public async Task GetByHolder_WithWindowAndBenchmark_ReturnsMatchingScore()
+    {
+        var holder = new InstitutionalHolder { Cik = "0001234567", Name = "Test Capital" };
+        var match = MakeScore(alpha: 4.2m);
+        match.InstitutionalHolderId = holder.Id;
+        var differentBenchmark = MakeScore(alpha: 5.0m, benchmark: "QQQ");
+        differentBenchmark.InstitutionalHolderId = holder.Id;
+        _repository.Add(match);
+        _repository.Add(differentBenchmark);
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetByHolder(holder, windowYears: 3, benchmarkTicker: "SPY");
+
+        result.Should().NotBeNull();
+        result.Id.Should().Be(match.Id);
+        result.AlphaPercent.Should().Be(4.2m);
+    }
+
+    private static FundScore MakeScore(
+        decimal alpha,
+        int windowYears = 3,
+        string benchmark = "SPY"
+    ) =>
+        new()
+        {
+            InstitutionalHolderId = Guid.NewGuid(),
+            BenchmarkTicker = benchmark,
+            WindowYears = windowYears,
+            WindowStart = new DateOnly(2023, 1, 1),
+            WindowEnd = new DateOnly(2026, 1, 1),
+            PortfolioCagrPercent = alpha + 8m,
+            BenchmarkCagrPercent = 8m,
+            AlphaPercent = alpha,
+        };
+}


### PR DESCRIPTION
## Summary

- Slice 1 of 4 toward the fund scoring system (#1862): the data/persistence foundation. The scoring engine, background worker, and portal UI follow in later slices.
- Adds a `FundScore` record holding the latest performance score per institutional filer for a given rolling window and benchmark, so the upcoming scoring engine has somewhere to persist results and the leaderboard has something to rank.

## Code changes

- `src/Equibles.Holdings.Data/Models/FundScore.cs` — new entity: portfolio/benchmark total return and CAGR, alpha (portfolio CAGR − benchmark CAGR), max drawdown, the simulated window bounds, and the benchmark ticker. Unique index on (holder, window, benchmark) — one row per combination, recomputed in place — plus an alpha-ranking index.
- `src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs` — register the new entity.
- `src/Equibles.Holdings.Repositories/FundScoreRepository.cs` — holder lookup (by window/benchmark and all variants) and an alpha-ranked query for the leaderboard.
- `src/Equibles.Migrations/Migrations/*_AddFundScore.*` — EF migration creating the table, indexes, and FK to InstitutionalHolder.
- `tests/Equibles.IntegrationTests/Holdings/FundScoreRepositoryTests.cs` — cover the alpha-ranking order/filter and the holder+window+benchmark lookup.

Refs #1862