### PR TITLE
feat(holdings): add fund scoring engine

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -157,6 +157,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Sec.FinancialFacts
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.InsiderTrading.BusinessLogic", "src\Equibles.InsiderTrading.BusinessLogic\Equibles.InsiderTrading.BusinessLogic.csproj", "{77F0FC50-E234-49F3-9A43-46253DE68A0F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Holdings.BusinessLogic", "src\Equibles.Holdings.BusinessLogic\Equibles.Holdings.BusinessLogic.csproj", "{946B8E31-D1FC-4649-9E0E-DCF389C97979}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1067,6 +1069,18 @@ Global
 		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Release|x64.Build.0 = Release|Any CPU
 		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Release|x86.ActiveCfg = Release|Any CPU
 		{77F0FC50-E234-49F3-9A43-46253DE68A0F}.Release|x86.Build.0 = Release|Any CPU
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Debug|x64.Build.0 = Debug|Any CPU
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Debug|x86.Build.0 = Debug|Any CPU
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Release|Any CPU.Build.0 = Release|Any CPU
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Release|x64.ActiveCfg = Release|Any CPU
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Release|x64.Build.0 = Release|Any CPU
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Release|x86.ActiveCfg = Release|Any CPU
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1147,6 +1161,7 @@ Global
 		{2E08AC17-1840-4BBE-A914-6133F83BB43B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{77F0FC50-E234-49F3-9A43-46253DE68A0F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{946B8E31-D1FC-4649-9E0E-DCF389C97979} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.Holdings.BusinessLogic/Equibles.Holdings.BusinessLogic.csproj
+++ b/src/Equibles.Holdings.BusinessLogic/Equibles.Holdings.BusinessLogic.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Equibles.Core.AutoWiring" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
+    <ProjectReference Include="..\Equibles.Holdings.Repositories\Equibles.Holdings.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Yahoo.Repositories\Equibles.Yahoo.Repositories.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
@@ -1,0 +1,285 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.AutoWiring;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.BusinessLogic;
+
+/// <summary>
+/// Computes a filer's fund score: the hypothetical buy-and-hold return of its reported 13F
+/// portfolio over a rolling window, against a benchmark. Reuses
+/// <see cref="HoldingsBacktestCalculator"/> (same look-ahead-safe rebalancing the on-demand
+/// institution backtest uses) and persists the result as a <see cref="FundScore"/>.
+/// <para>
+/// The snapshot-building and price forward-fill mirror the on-demand backtest in the web
+/// portal's HoldingsBacktestService; kept self-contained here so the scoring worker has no
+/// dependency on the web host.
+/// </para>
+/// </summary>
+[Service]
+public class FundScoringManager
+{
+    public const string DefaultBenchmark = "SPY";
+    public const int DefaultWindowYears = 3;
+
+    // Forward-fill needs a few trading days of pre-window history so day-zero resolves to the
+    // last close even on a weekend or holiday.
+    private const int PriceLookbackDays = 14;
+
+    // Annualised compounding can saturate to decimal.MaxValue on degenerate inputs; numeric(18,4)
+    // tops out far below that, so anything past this magnitude isn't a storable (or meaningful) score.
+    private const decimal MaxStorableMagnitude = 9_999_999_999_999m;
+
+    private readonly InstitutionalHoldingRepository _holdingRepository;
+    private readonly CommonStockRepository _stockRepository;
+    private readonly DailyStockPriceRepository _priceRepository;
+    private readonly FundScoreRepository _fundScoreRepository;
+
+    public FundScoringManager(
+        InstitutionalHoldingRepository holdingRepository,
+        CommonStockRepository stockRepository,
+        DailyStockPriceRepository priceRepository,
+        FundScoreRepository fundScoreRepository
+    )
+    {
+        _holdingRepository = holdingRepository;
+        _stockRepository = stockRepository;
+        _priceRepository = priceRepository;
+        _fundScoreRepository = fundScoreRepository;
+    }
+
+    /// <summary>
+    /// Computes and persists the rolling-window fund score for one filer, measured against
+    /// <paramref name="benchmarkTicker"/>. Returns the saved score, or null when there isn't
+    /// enough data to simulate (unknown benchmark, no 13F snapshots in range, missing benchmark
+    /// prices, or a non-finite result). Recomputes in place — an existing score for the same
+    /// (holder, window, benchmark) is updated rather than duplicated.
+    /// </summary>
+    public async Task<FundScore> ScoreHolder(
+        InstitutionalHolder holder,
+        DateOnly asOf,
+        int windowYears = DefaultWindowYears,
+        string benchmarkTicker = DefaultBenchmark
+    )
+    {
+        benchmarkTicker = benchmarkTicker.Trim().ToUpperInvariant();
+
+        var benchmarkStock = await _stockRepository.GetByTicker(benchmarkTicker);
+        if (benchmarkStock == null)
+            return null;
+
+        var result = await RunBacktest(holder, asOf, windowYears, benchmarkStock);
+        if (result == null || result.Points.Count == 0 || !IsStorable(result))
+            return null;
+
+        return await Upsert(holder, windowYears, benchmarkTicker, result);
+    }
+
+    private async Task<BacktestResult> RunBacktest(
+        InstitutionalHolder holder,
+        DateOnly asOf,
+        int windowYears,
+        CommonStock benchmarkStock
+    )
+    {
+        var reportDates = await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync();
+        if (reportDates.Count == 0)
+            return null;
+        // GetReportDatesByHolder returns latest-first; SelectRelevantSnapshotDates needs
+        // earliest-first so the "last snapshot before the window" lands on the most recent one.
+        reportDates.Sort();
+
+        var to = asOf;
+        var from = asOf.Year > windowYears ? asOf.AddYears(-windowYears) : DateOnly.MinValue;
+
+        var relevant = SelectRelevantSnapshotDates(reportDates, from, to);
+        if (relevant.Count == 0)
+            return null;
+
+        var holdings = await _holdingRepository
+            .GetHistoryByHolder(holder)
+            .Where(h => relevant.Contains(h.ReportDate))
+            .Select(h => new HoldingRow(
+                h.ReportDate,
+                h.CommonStockId,
+                h.Shares,
+                h.Value,
+                h.OptionType
+            ))
+            .ToListAsync();
+
+        var snapshots = BuildSnapshots(holdings);
+
+        var priceWindowFrom =
+            from > DateOnly.MinValue.AddDays(PriceLookbackDays)
+                ? from.AddDays(-PriceLookbackDays)
+                : DateOnly.MinValue;
+
+        var stockIds = holdings
+            .Where(h => h.OptionType == null && h.Value > 0)
+            .Select(h => h.CommonStockId)
+            .Distinct()
+            .ToList();
+
+        var pricesByStock = (
+            stockIds.Count == 0
+                ? []
+                : await LoadPrices(_priceRepository.GetByStocks(stockIds, priceWindowFrom, to))
+        )
+            .GroupBy(p => p.StockId)
+            .ToDictionary(g => g.Key, g => g.ToArray());
+
+        var benchmarkSeries = (
+            await LoadPrices(_priceRepository.GetByStock(benchmarkStock, priceWindowFrom, to))
+        ).ToArray();
+        if (benchmarkSeries.Length == 0)
+            return null;
+
+        return HoldingsBacktestCalculator.Calculate(
+            snapshots,
+            from,
+            to,
+            priceOf: (stockId, date) => ForwardFill(pricesByStock, stockId, date),
+            benchmarkPriceOf: date => ForwardFill(benchmarkSeries, date)
+        );
+    }
+
+    private async Task<FundScore> Upsert(
+        InstitutionalHolder holder,
+        int windowYears,
+        string benchmarkTicker,
+        BacktestResult result
+    )
+    {
+        var score = await _fundScoreRepository.GetByHolder(holder, windowYears, benchmarkTicker);
+        if (score == null)
+        {
+            score = new FundScore
+            {
+                InstitutionalHolderId = holder.Id,
+                WindowYears = windowYears,
+                BenchmarkTicker = benchmarkTicker,
+            };
+            _fundScoreRepository.Add(score);
+        }
+
+        score.WindowStart = result.StartDate;
+        score.WindowEnd = result.EndDate;
+        score.PortfolioTotalReturnPercent = result.PortfolioSummary.TotalReturnPercent;
+        score.PortfolioCagrPercent = result.PortfolioSummary.CagrPercent;
+        score.BenchmarkTotalReturnPercent = result.BenchmarkSummary.TotalReturnPercent;
+        score.BenchmarkCagrPercent = result.BenchmarkSummary.CagrPercent;
+        score.AlphaPercent =
+            result.PortfolioSummary.CagrPercent - result.BenchmarkSummary.CagrPercent;
+        score.MaxDrawdownPercent = result.PortfolioSummary.MaxDrawdownPercent;
+        score.CreationTime = DateTime.UtcNow;
+
+        await _fundScoreRepository.SaveChanges();
+        return score;
+    }
+
+    // All snapshots whose rebalance date falls in [from, to], plus the latest one whose rebalance
+    // precedes `from` so the simulation can open with an already-held portfolio.
+    private static List<DateOnly> SelectRelevantSnapshotDates(
+        IReadOnlyList<DateOnly> reportDates,
+        DateOnly from,
+        DateOnly to
+    )
+    {
+        var relevant = new List<DateOnly>();
+        DateOnly? lastBeforeWindow = null;
+        foreach (var date in reportDates)
+        {
+            var rebalance = date.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
+            if (rebalance < from)
+                lastBeforeWindow = date;
+            else if (rebalance <= to)
+                relevant.Add(date);
+        }
+        if (lastBeforeWindow.HasValue && !relevant.Contains(lastBeforeWindow.Value))
+            relevant.Insert(0, lastBeforeWindow.Value);
+        return relevant;
+    }
+
+    private static List<BacktestQuarterSnapshot> BuildSnapshots(
+        IReadOnlyList<HoldingRow> holdings
+    ) =>
+        holdings
+            .GroupBy(h => h.ReportDate)
+            .OrderBy(g => g.Key)
+            .Select(g => new BacktestQuarterSnapshot
+            {
+                ReportDate = g.Key,
+                Positions = g.Select(h => new BacktestPosition
+                    {
+                        CommonStockId = h.CommonStockId,
+                        Shares = h.Shares,
+                        Value = h.Value,
+                        IsOption = h.OptionType != null,
+                    })
+                    .ToList(),
+            })
+            .ToList();
+
+    // OrderBy must precede the record projection — EF can't translate an OrderBy keyed off a
+    // projected record's property because the constructor isn't translatable.
+    private static Task<List<PriceRow>> LoadPrices(IQueryable<DailyStockPrice> query) =>
+        query
+            .OrderBy(p => p.Date)
+            .Select(p => new PriceRow(p.CommonStockId, p.Date, p.AdjustedClose))
+            .ToListAsync();
+
+    private static bool IsStorable(BacktestResult result) =>
+        InRange(result.PortfolioSummary.TotalReturnPercent)
+        && InRange(result.PortfolioSummary.CagrPercent)
+        && InRange(result.PortfolioSummary.MaxDrawdownPercent)
+        && InRange(result.BenchmarkSummary.TotalReturnPercent)
+        && InRange(result.BenchmarkSummary.CagrPercent);
+
+    private static bool InRange(decimal value) => Math.Abs(value) < MaxStorableMagnitude;
+
+    private static decimal? ForwardFill(
+        Dictionary<Guid, PriceRow[]> pricesByStock,
+        Guid stockId,
+        DateOnly date
+    ) => pricesByStock.TryGetValue(stockId, out var series) ? ForwardFill(series, date) : null;
+
+    // Largest close on or before `date` via binary search; null when the series starts later.
+    private static decimal? ForwardFill(PriceRow[] series, DateOnly date)
+    {
+        if (series.Length == 0)
+            return null;
+        var lo = 0;
+        var hi = series.Length - 1;
+        var matchIdx = -1;
+        while (lo <= hi)
+        {
+            var mid = (lo + hi) >>> 1;
+            if (series[mid].Date <= date)
+            {
+                matchIdx = mid;
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+        return matchIdx < 0 ? null : series[matchIdx].Price;
+    }
+
+    private readonly record struct HoldingRow(
+        DateOnly ReportDate,
+        Guid CommonStockId,
+        long Shares,
+        long Value,
+        OptionType? OptionType
+    );
+
+    private readonly record struct PriceRow(Guid StockId, DateOnly Date, decimal Price);
+}

--- a/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
+++ b/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\..\src\Equibles.CommonStocks.BusinessLogic\Equibles.CommonStocks.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Holdings.Data\Equibles.Holdings.Data.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Holdings.BusinessLogic\Equibles.Holdings.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Holdings.HostedService\Equibles.Holdings.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.InsiderTrading.Data\Equibles.InsiderTrading.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.InsiderTrading.BusinessLogic\Equibles.InsiderTrading.BusinessLogic.csproj" />

--- a/tests/Equibles.IntegrationTests/Holdings/FundScoringManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/FundScoringManagerTests.cs
@@ -1,0 +1,176 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class FundScoringManagerTests : IDisposable
+{
+    private static readonly DateOnly AsOf = new(2026, 1, 2);
+    private static readonly DateOnly WindowStart = new(2023, 1, 2); // AsOf minus 3 years
+
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly InstitutionalHolderRepository _holderRepository;
+    private readonly FundScoreRepository _fundScoreRepository;
+    private readonly FundScoringManager _manager;
+
+    public FundScoringManagerTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new HoldingsModuleConfiguration(),
+            new CommonStocksModuleConfiguration(),
+            new YahooModuleConfiguration()
+        );
+        _holderRepository = new InstitutionalHolderRepository(_dbContext);
+        _fundScoreRepository = new FundScoreRepository(_dbContext);
+        _manager = new FundScoringManager(
+            new InstitutionalHoldingRepository(_dbContext),
+            new CommonStockRepository(_dbContext),
+            new DailyStockPriceRepository(_dbContext),
+            _fundScoreRepository
+        );
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    [Fact]
+    public async Task ScoreHolder_PortfolioDoublesAgainstFlatBenchmark_PersistsPositiveAlpha()
+    {
+        var holder = SeedDoublingPortfolioAgainstFlatBenchmark();
+
+        var score = await _manager.ScoreHolder(
+            holder,
+            AsOf,
+            windowYears: 3,
+            benchmarkTicker: "SPY"
+        );
+
+        score.Should().NotBeNull();
+        // The single held stock doubles over the window held buy-and-hold => ~+100% total return.
+        score.PortfolioTotalReturnPercent.Should().BeApproximately(100m, 0.5m);
+        // Flat benchmark => ~0% return, so the portfolio's whole CAGR is alpha.
+        score.BenchmarkTotalReturnPercent.Should().BeApproximately(0m, 0.01m);
+        score.PortfolioCagrPercent.Should().BeGreaterThan(0m);
+        score.AlphaPercent.Should().Be(score.PortfolioCagrPercent - score.BenchmarkCagrPercent);
+        score.AlphaPercent.Should().BeGreaterThan(0m);
+        score.WindowStart.Should().Be(WindowStart);
+        score.WindowEnd.Should().Be(AsOf);
+        score.BenchmarkTicker.Should().Be("SPY");
+        score.WindowYears.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ScoreHolder_Recomputed_UpdatesInPlaceWithoutDuplicating()
+    {
+        var holder = SeedDoublingPortfolioAgainstFlatBenchmark();
+
+        await _manager.ScoreHolder(holder, AsOf, windowYears: 3, benchmarkTicker: "SPY");
+        await _manager.ScoreHolder(holder, AsOf, windowYears: 3, benchmarkTicker: "SPY");
+
+        _fundScoreRepository.GetByHolder(holder).Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ScoreHolder_UnknownBenchmark_ReturnsNull()
+    {
+        var holder = SeedDoublingPortfolioAgainstFlatBenchmark();
+
+        var score = await _manager.ScoreHolder(
+            holder,
+            AsOf,
+            windowYears: 3,
+            benchmarkTicker: "NOSUCHTICKER"
+        );
+
+        score.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ScoreHolder_HolderWithNoHoldings_ReturnsNull()
+    {
+        SeedBenchmark();
+        var holder = new InstitutionalHolder { Cik = "0009999999", Name = "Empty Fund" };
+        _holderRepository.Add(holder);
+        await _holderRepository.SaveChanges();
+
+        var score = await _manager.ScoreHolder(
+            holder,
+            AsOf,
+            windowYears: 3,
+            benchmarkTicker: "SPY"
+        );
+
+        score.Should().BeNull();
+    }
+
+    private InstitutionalHolder SeedDoublingPortfolioAgainstFlatBenchmark()
+    {
+        SeedBenchmark();
+
+        var held = new CommonStock { Ticker = "AAA", Name = "Alpha Co" };
+        _dbContext.Set<CommonStock>().Add(held);
+        AddPrice(held, new DateOnly(2022, 12, 20), 100m);
+        AddPrice(held, AsOf, 200m); // doubles over the window
+
+        var holder = new InstitutionalHolder { Cik = "0001234567", Name = "Doubler Capital" };
+        _dbContext.Set<InstitutionalHolder>().Add(holder);
+
+        // Rebalance (ReportDate + 45 days) lands before the window start, so the portfolio is
+        // held from day one of the window through to AsOf.
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .Add(
+                new InstitutionalHolding
+                {
+                    InstitutionalHolderId = holder.Id,
+                    CommonStockId = held.Id,
+                    ReportDate = new DateOnly(2022, 9, 30),
+                    FilingDate = new DateOnly(2022, 11, 10),
+                    Shares = 1000,
+                    Value = 100_000,
+                }
+            );
+
+        _dbContext.SaveChanges();
+        return holder;
+    }
+
+    private void SeedBenchmark()
+    {
+        var benchmark = new CommonStock { Ticker = "SPY", Name = "S&P 500 ETF" };
+        _dbContext.Set<CommonStock>().Add(benchmark);
+        AddPrice(benchmark, new DateOnly(2022, 12, 20), 100m);
+        AddPrice(benchmark, AsOf, 100m); // flat over the window
+        _dbContext.SaveChanges();
+    }
+
+    private void AddPrice(CommonStock stock, DateOnly date, decimal close)
+    {
+        _dbContext
+            .Set<DailyStockPrice>()
+            .Add(
+                new DailyStockPrice
+                {
+                    CommonStockId = stock.Id,
+                    Date = date,
+                    Open = close,
+                    High = close,
+                    Low = close,
+                    Close = close,
+                    AdjustedClose = close,
+                }
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 2 of 4 toward the fund scoring system (#1862): the scoring engine. The background worker and portal UI follow.
- Computes a filer's fund score — the hypothetical buy-and-hold return of its reported 13F portfolio over a rolling window against a benchmark — by reusing the existing look-ahead-safe backtest engine. Alpha is portfolio CAGR minus benchmark CAGR.

## Code changes

- `src/Equibles.Holdings.BusinessLogic/` — new project (mirrors the other `*.BusinessLogic` modules) housing `FundScoringManager`. It loads the holder's 13F snapshots and the relevant price history, runs `HoldingsBacktestCalculator`, derives alpha, and upserts a `FundScore` in place per (holder, window, benchmark). Returns no score when there isn't enough data to simulate (unknown benchmark, no snapshots in range, missing benchmark prices, or a non-finite result).
- `Equibles.sln` — register the new project.
- `tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj` / `Holdings/FundScoringManagerTests.cs` — reference the new project and cover the happy path (a doubling portfolio vs a flat benchmark yields ~+100% return and positive alpha), in-place recompute, unknown benchmark, and a holder with no holdings.

Refs #1862