### PR TITLE
feat(holdings): add background worker to recompute fund scores

### DIFF
--- a/src/Equibles.Holdings.HostedService/Equibles.Holdings.HostedService.csproj
+++ b/src/Equibles.Holdings.HostedService/Equibles.Holdings.HostedService.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
     <ProjectReference Include="..\Equibles.Integrations.Sec\Equibles.Integrations.Sec.csproj" />
     <ProjectReference Include="..\Equibles.Holdings.Repositories\Equibles.Holdings.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Holdings.BusinessLogic\Equibles.Holdings.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.BusinessLogic\Equibles.CommonStocks.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Worker\Equibles.Worker.csproj" />

--- a/src/Equibles.Holdings.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Holdings.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Equibles.Core.AutoWiring;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.HostedService.Services;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,11 +10,15 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddHoldingsWorker(this IServiceCollection services)
     {
         services.AutoWireServicesFrom<HoldingsImportService>();
+        // The scoring worker's only domain dependency lives in the BusinessLogic assembly;
+        // register it here so the worker's composition root is self-contained.
+        services.AutoWireServicesFrom<FundScoringManager>();
 
         services.AddHostedService<HoldingsScraperWorker>();
         services.AddHostedService<Holdings13FRealtimeWorker>();
         services.AddHostedService<AumSnapshotDrainWorker>();
         services.AddHostedService<AumSnapshotRebuildWorker>();
+        services.AddHostedService<FundScoringWorker>();
 
         return services;
     }

--- a/src/Equibles.Holdings.HostedService/FundScoringWorker.cs
+++ b/src/Equibles.Holdings.HostedService/FundScoringWorker.cs
@@ -1,0 +1,141 @@
+using Equibles.Data;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.HostedService;
+
+/// <summary>
+/// Periodically (re)computes the fund score for every filer that has 13F holdings, so the
+/// institutions leaderboard can rank the universe by alpha vs the benchmark. A score depends on
+/// daily prices as well as quarterly 13F filings, so the job refreshes daily even though the
+/// underlying portfolio only changes each quarter.
+/// <para>
+/// Each filer is scored in its own DI scope: the backtest can load thousands of price rows, so a
+/// single shared context's change tracker would balloon across the run, and a fault scoring one
+/// filer stays contained instead of aborting the whole cycle.
+/// </para>
+/// </summary>
+public class FundScoringWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<FundScoringWorker> _logger;
+
+    // Virtual seams so tests can collapse the waits without changing production behaviour.
+    protected virtual TimeSpan StartupDelay => TimeSpan.FromMinutes(10);
+    protected virtual TimeSpan SleepInterval => TimeSpan.FromHours(24);
+    protected virtual int WindowYears => FundScoringManager.DefaultWindowYears;
+    protected virtual string BenchmarkTicker => FundScoringManager.DefaultBenchmark;
+
+    public FundScoringWorker(IServiceScopeFactory scopeFactory, ILogger<FundScoringWorker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (StartupDelay > TimeSpan.Zero)
+        {
+            try
+            {
+                await Task.Delay(StartupDelay, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var scored = await ScoreAllHolders(stoppingToken);
+                _logger.LogInformation(
+                    "Fund scoring cycle complete: scored {Count} filer(s)",
+                    scored
+                );
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Fund scoring cycle failed; will retry next cycle");
+            }
+
+            try
+            {
+                await Task.Delay(SleepInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Scores every filer with 13F holdings as of today, returning how many produced a score.
+    /// Internal so the worker's batch behaviour can be driven directly in tests.
+    /// </summary>
+    internal async Task<int> ScoreAllHolders(CancellationToken cancellationToken)
+    {
+        var asOf = DateOnly.FromDateTime(DateTime.UtcNow);
+        var holderIds = await LoadScoreableHolderIds(cancellationToken);
+
+        var scored = 0;
+        foreach (var holderId in holderIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (await ScoreHolder(holderId, asOf, cancellationToken))
+                scored++;
+        }
+        return scored;
+    }
+
+    private async Task<List<Guid>> LoadScoreableHolderIds(CancellationToken cancellationToken)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        return await dbContext
+            .Set<InstitutionalHolding>()
+            .Select(h => h.InstitutionalHolderId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+    }
+
+    private async Task<bool> ScoreHolder(
+        Guid holderId,
+        DateOnly asOf,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var holderRepository =
+                scope.ServiceProvider.GetRequiredService<InstitutionalHolderRepository>();
+            var manager = scope.ServiceProvider.GetRequiredService<FundScoringManager>();
+
+            var holder = await holderRepository.Get(holderId);
+            if (holder == null)
+                return false;
+
+            var score = await manager.ScoreHolder(holder, asOf, WindowYears, BenchmarkTicker);
+            return score != null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to score filer {HolderId}; skipping", holderId);
+            return false;
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/FundScoringWorkerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/FundScoringWorkerTests.cs
@@ -1,0 +1,167 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Contract: <see cref="FundScoringWorker"/> enumerates every filer that has 13F holdings,
+/// scores each in its own scope, and persists the results.
+/// </summary>
+public class FundScoringWorkerTests : IDisposable
+{
+    private static readonly DateOnly Today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+    // Start of the default 3-year window the worker scores. The seed anchors prices just inside
+    // the price-load lookback so forward-fill resolves a base close at the window's first day.
+    private static readonly DateOnly WindowFrom = Today.AddYears(-3);
+    private static readonly DateOnly EarlyPriceDate = WindowFrom.AddDays(-10);
+
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly FundScoreRepository _fundScoreRepository;
+    private readonly FundScoringWorker _worker;
+
+    public FundScoringWorkerTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new HoldingsModuleConfiguration(),
+            new CommonStocksModuleConfiguration(),
+            new YahooModuleConfiguration()
+        );
+        _fundScoreRepository = new FundScoreRepository(_dbContext);
+        _worker = new FundScoringWorker(
+            SharedContextScopeFactory(),
+            NullLogger<FundScoringWorker>.Instance
+        );
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    [Fact]
+    public async Task ScoreAllHolders_PersistsAScorePerFilerWithHoldings()
+    {
+        var holder = SeedDoublingPortfolioAgainstFlatBenchmark();
+
+        var scored = await _worker.ScoreAllHolders(CancellationToken.None);
+
+        scored.Should().Be(1);
+        var persisted = _fundScoreRepository.GetByHolder(holder).ToList();
+        persisted.Should().HaveCount(1);
+        persisted[0].AlphaPercent.Should().BeGreaterThan(0m);
+        persisted[0].BenchmarkTicker.Should().Be("SPY");
+    }
+
+    [Fact]
+    public async Task ScoreAllHolders_NoHoldings_ScoresNothing()
+    {
+        SeedBenchmark();
+
+        var scored = await _worker.ScoreAllHolders(CancellationToken.None);
+
+        scored.Should().Be(0);
+        _fundScoreRepository.GetAll().Should().BeEmpty();
+    }
+
+    // Every scope shares the one in-memory context so the worker's enumerate scope and per-holder
+    // scopes all see the same seeded data and writes.
+    private IServiceScopeFactory SharedContextScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var provider = Substitute.For<IServiceProvider>();
+                provider.GetService(typeof(EquiblesFinancialDbContext)).Returns(_dbContext);
+                provider
+                    .GetService(typeof(InstitutionalHolderRepository))
+                    .Returns(_ => new InstitutionalHolderRepository(_dbContext));
+                provider
+                    .GetService(typeof(FundScoringManager))
+                    .Returns(_ => new FundScoringManager(
+                        new InstitutionalHoldingRepository(_dbContext),
+                        new CommonStockRepository(_dbContext),
+                        new DailyStockPriceRepository(_dbContext),
+                        new FundScoreRepository(_dbContext)
+                    ));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(provider);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    private InstitutionalHolder SeedDoublingPortfolioAgainstFlatBenchmark()
+    {
+        SeedBenchmark();
+
+        var held = new CommonStock { Ticker = "AAA", Name = "Alpha Co" };
+        _dbContext.Set<CommonStock>().Add(held);
+        AddPrice(held, EarlyPriceDate, 100m);
+        AddPrice(held, Today, 200m);
+
+        var holder = new InstitutionalHolder { Cik = "0001234567", Name = "Doubler Capital" };
+        _dbContext.Set<InstitutionalHolder>().Add(holder);
+        // Rebalance (ReportDate + 45 days) lands before the window start, so the portfolio is
+        // held from day one of the window through to today.
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .Add(
+                new InstitutionalHolding
+                {
+                    InstitutionalHolderId = holder.Id,
+                    CommonStockId = held.Id,
+                    ReportDate = WindowFrom.AddDays(-60),
+                    FilingDate = WindowFrom.AddDays(-15),
+                    Shares = 1000,
+                    Value = 100_000,
+                }
+            );
+
+        _dbContext.SaveChanges();
+        return holder;
+    }
+
+    private void SeedBenchmark()
+    {
+        var benchmark = new CommonStock { Ticker = "SPY", Name = "S&P 500 ETF" };
+        _dbContext.Set<CommonStock>().Add(benchmark);
+        AddPrice(benchmark, EarlyPriceDate, 100m);
+        AddPrice(benchmark, Today, 100m);
+        _dbContext.SaveChanges();
+    }
+
+    private void AddPrice(CommonStock stock, DateOnly date, decimal close)
+    {
+        _dbContext
+            .Set<DailyStockPrice>()
+            .Add(
+                new DailyStockPrice
+                {
+                    CommonStockId = stock.Id,
+                    Date = date,
+                    Open = close,
+                    High = close,
+                    Low = close,
+                    Close = close,
+                    AdjustedClose = close,
+                }
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 3 of 4 toward the fund scoring system (#1862): the background job. The portal UI follows in the final slice.
- Adds a periodic worker that scores every filer with 13F holdings against the default benchmark over the default rolling window, so the institutions leaderboard always has fresh scores to rank.

## Code changes

- `src/Equibles.Holdings.HostedService/FundScoringWorker.cs` — `BackgroundService` that enumerates filers with holdings and scores each in its own DI scope (so a large portfolio or a single failure can't leak into the next), retrying a failed cycle on the next tick. Refreshes daily because scores depend on daily prices as well as quarterly 13F filings.
- `src/Equibles.Holdings.HostedService/Extensions/ServiceCollectionExtensions.cs` — register the worker in `AddHoldingsWorker`, and the scoring engine it depends on.
- `src/Equibles.Holdings.HostedService/Equibles.Holdings.HostedService.csproj` — reference the BusinessLogic project.
- `tests/Equibles.IntegrationTests/Holdings/FundScoringWorkerTests.cs` — cover that a filer with holdings gets a persisted positive-alpha score and that an empty universe scores nothing.

Refs #1862