### PR TITLE
refactor(views): extract repeated card section heading into _SectionHeading partial

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -44,10 +44,7 @@
             @foreach (var board in deltaBoards) {
                 <div class="card bg-base-100 shadow-sm" data-testid="@board.TestId">
                     <div class="card-body p-4">
-                        <div class="flex items-center gap-2 mb-2">
-                            <h2 class="text-base font-medium m-0">@board.Label</h2>
-                            <span class="badge @board.BadgeCss badge-sm">@board.Rows.Count.ToString("N0")</span>
-                        </div>
+                        <partial name="_SectionHeading" model='(Title: board.Label, BadgeClass: board.BadgeCss, BadgeContent: board.Rows.Count.ToString("N0"))' />
                         @if (board.Rows.Count == 0) {
                             <div class="text-xs text-base-content/50">No stocks in this bucket for the selected quarter.</div>
                         } else {
@@ -99,10 +96,7 @@
             @foreach (var board in churnBoards) {
                 <div class="card bg-base-100 shadow-sm" data-testid="@board.TestId">
                     <div class="card-body p-4">
-                        <div class="flex items-center gap-2 mb-2">
-                            <h2 class="text-base font-medium m-0">@board.Label</h2>
-                            <span class="badge @board.BadgeCss badge-sm">@board.Rows.Count.ToString("N0")</span>
-                        </div>
+                        <partial name="_SectionHeading" model='(Title: board.Label, BadgeClass: board.BadgeCss, BadgeContent: board.Rows.Count.ToString("N0"))' />
                         @if (board.Rows.Count == 0) {
                             <div class="text-xs text-base-content/50">No stocks in this bucket for the selected quarter.</div>
                         } else {

--- a/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
+++ b/src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml
@@ -18,10 +18,7 @@
             <!-- Top Buys -->
             <div class="card bg-base-100 shadow-sm" data-testid="insider-top-buys">
                 <div class="card-body p-4">
-                    <div class="flex items-center gap-2 mb-2">
-                        <h2 class="text-base font-medium m-0">Top Buys</h2>
-                        <span class="badge badge-success badge-sm">@Model.TopBuys.Count</span>
-                    </div>
+                    <partial name="_SectionHeading" model='(Title: "Top Buys", BadgeClass: "badge-success", BadgeContent: Model.TopBuys.Count.ToString())' />
                     @if (Model.TopBuys.Count == 0) {
                         <div class="text-xs text-base-content/50">No insider purchases in the last 90 days.</div>
                     } else {
@@ -58,10 +55,7 @@
             <!-- Top Sells -->
             <div class="card bg-base-100 shadow-sm" data-testid="insider-top-sells">
                 <div class="card-body p-4">
-                    <div class="flex items-center gap-2 mb-2">
-                        <h2 class="text-base font-medium m-0">Top Sells</h2>
-                        <span class="badge badge-error badge-sm">@Model.TopSells.Count</span>
-                    </div>
+                    <partial name="_SectionHeading" model='(Title: "Top Sells", BadgeClass: "badge-error", BadgeContent: Model.TopSells.Count.ToString())' />
                     @if (Model.TopSells.Count == 0) {
                         <div class="text-xs text-base-content/50">No insider sales in the last 90 days.</div>
                     } else {
@@ -99,10 +93,7 @@
         <!-- Biggest Transactions -->
         <div class="card bg-base-100 shadow-sm" data-testid="insider-biggest">
             <div class="card-body p-4">
-                <div class="flex items-center gap-2 mb-2">
-                    <h2 class="text-base font-medium m-0">Biggest Transactions</h2>
-                    <span class="badge badge-neutral badge-sm">@Model.BiggestTransactions.Count</span>
-                </div>
+                <partial name="_SectionHeading" model='(Title: "Biggest Transactions", BadgeClass: "badge-neutral", BadgeContent: Model.BiggestTransactions.Count.ToString())' />
                 @if (Model.BiggestTransactions.Count == 0) {
                     <div class="text-xs text-base-content/50">No insider transactions in the last 90 days.</div>
                 } else {

--- a/src/Equibles.Web/Views/Shared/_SectionHeading.cshtml
+++ b/src/Equibles.Web/Views/Shared/_SectionHeading.cshtml
@@ -1,0 +1,5 @@
+@model (string Title, string BadgeClass, string BadgeContent)
+<div class="flex items-center gap-2 mb-2">
+    <h2 class="text-base font-medium m-0">@Model.Title</h2>
+    <span class="badge @Model.BadgeClass badge-sm">@Model.BadgeContent</span>
+</div>


### PR DESCRIPTION
## Summary

- The same card "section heading" markup (a title with a count badge) was duplicated inline across five places in two views. Extracted it into a shared `_SectionHeading` partial so the markup lives in one place.
- Behavior-preserving: each call site renders the same element structure, classes, and text as before.

## Code changes

- `src/Equibles.Web/Views/Shared/_SectionHeading.cshtml` — new tuple-model partial `(Title, BadgeClass, BadgeContent)` rendering `<div class="flex items-center gap-2 mb-2"><h2 class="text-base font-medium m-0">…</h2><span class="badge … badge-sm">…</span></div>`, mirroring the existing `_MetricCard` convention.
- `src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml` — replaced the two inline heading blocks (delta boards, churn boards) with the partial.
- `src/Equibles.Web/Views/InsiderActivity/Dashboard.cshtml` — replaced the three inline heading blocks (Top Buys, Top Sells, Biggest Transactions) with the partial.

The smaller `h3`/`text-sm` subsection heading in `Profiles/Institution.cshtml` is intentionally left as-is — it is a different visual treatment, not the same block.