### PR TITLE
feat(web): surface fund scores in the institutions portal

### DIFF
--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -1,4 +1,5 @@
 using Equibles.Data;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Web.Controllers.Abstract;
@@ -11,6 +12,11 @@ namespace Equibles.Web.Controllers;
 
 public class InstitutionsController : BaseController
 {
+    // The fund-score variant surfaced in the list: the same default rolling window and benchmark
+    // the scoring worker writes, so the alpha column and sort read the rows it produces.
+    private const int ScoreWindowYears = FundScoringManager.DefaultWindowYears;
+    private const string ScoreBenchmark = FundScoringManager.DefaultBenchmark;
+
     private readonly InstitutionalHolderRepository _holderRepository;
     private readonly EquiblesFinancialDbContext _dbContext;
 
@@ -118,6 +124,14 @@ public class InstitutionsController : BaseController
             joined = joined.Where(x => (x.agg != null ? x.agg.Positions : 0) <= maxPositions.Value);
         }
 
+        // Each filer's latest alpha for the surfaced window/benchmark, as a correlated scalar
+        // subquery. The unique index makes it 1:0..1; a missing score reads as null. Kept as a
+        // subquery (not a second GroupJoin) so it composes onto the aggregate join above without
+        // an untranslatable join-of-a-join.
+        var scoresQuery = _dbContext
+            .Set<FundScore>()
+            .Where(s => s.WindowYears == ScoreWindowYears && s.BenchmarkTicker == ScoreBenchmark);
+
         var ordered = sort switch
         {
             InstitutionSort.PositionsDescending => joined
@@ -126,6 +140,18 @@ public class InstitutionsController : BaseController
                 .ThenBy(x => x.h.Id),
             InstitutionSort.ValueDescending => joined
                 .OrderByDescending(x => x.agg != null ? x.agg.Value : 0L)
+                .ThenBy(x => x.h.Name)
+                .ThenBy(x => x.h.Id),
+            // Scored filers first (alpha highest to lowest), unscored filers last: a missing score
+            // coalesces to the smallest value so it sinks to the bottom of a descending sort.
+            InstitutionSort.AlphaDescending => joined
+                .OrderByDescending(x =>
+                    scoresQuery
+                        .Where(s => s.InstitutionalHolderId == x.h.Id)
+                        .Select(s => (decimal?)s.AlphaPercent)
+                        .FirstOrDefault()
+                    ?? decimal.MinValue
+                )
                 .ThenBy(x => x.h.Name)
                 .ThenBy(x => x.h.Id),
             _ => joined.OrderBy(x => x.h.Name).ThenBy(x => x.h.Id),
@@ -145,6 +171,10 @@ public class InstitutionsController : BaseController
                 PositionCount = x.agg != null ? x.agg.Positions : 0,
                 TotalValue = x.agg != null ? x.agg.Value : 0L,
                 LatestReportDate = x.agg != null ? (DateOnly?)x.agg.LatestDate : null,
+                AlphaPercent = scoresQuery
+                    .Where(s => s.InstitutionalHolderId == x.h.Id)
+                    .Select(s => (decimal?)s.AlphaPercent)
+                    .FirstOrDefault(),
             })
             .ToListAsync();
 

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -1,4 +1,5 @@
 using Equibles.Congress.Repositories;
+using Equibles.Holdings.BusinessLogic;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Models;
@@ -18,8 +19,14 @@ public class ProfilesController : BaseController
 {
     private const int RecentRowLimit = 25;
 
+    // The fund-score variant shown on the profile: the default rolling window and benchmark the
+    // scoring worker writes.
+    private const int ScoreWindowYears = FundScoringManager.DefaultWindowYears;
+    private const string ScoreBenchmark = FundScoringManager.DefaultBenchmark;
+
     private readonly InstitutionalHolderRepository _institutionalHolderRepository;
     private readonly InstitutionalHoldingRepository _institutionalHoldingRepository;
+    private readonly FundScoreRepository _fundScoreRepository;
     private readonly InsiderOwnerRepository _insiderOwnerRepository;
     private readonly InsiderTransactionRepository _insiderTransactionRepository;
     private readonly CongressMemberRepository _congressMemberRepository;
@@ -29,6 +36,7 @@ public class ProfilesController : BaseController
     public ProfilesController(
         InstitutionalHolderRepository institutionalHolderRepository,
         InstitutionalHoldingRepository institutionalHoldingRepository,
+        FundScoreRepository fundScoreRepository,
         InsiderOwnerRepository insiderOwnerRepository,
         InsiderTransactionRepository insiderTransactionRepository,
         CongressMemberRepository congressMemberRepository,
@@ -40,6 +48,7 @@ public class ProfilesController : BaseController
     {
         _institutionalHolderRepository = institutionalHolderRepository;
         _institutionalHoldingRepository = institutionalHoldingRepository;
+        _fundScoreRepository = fundScoreRepository;
         _insiderOwnerRepository = insiderOwnerRepository;
         _insiderTransactionRepository = insiderTransactionRepository;
         _congressMemberRepository = congressMemberRepository;
@@ -80,6 +89,12 @@ public class ProfilesController : BaseController
             activityDate
         );
 
+        var fundScore = await _fundScoreRepository.GetByHolder(
+            holder,
+            ScoreWindowYears,
+            ScoreBenchmark
+        );
+
         ViewData["Title"] = holder.Name;
         return View(
             new InstitutionProfileViewModel
@@ -90,6 +105,7 @@ public class ProfilesController : BaseController
                 ConfidentialTreatmentRequested = holder.ConfidentialTreatmentRequested,
                 Location = ProfileFormatting.JoinLocation(holder.City, holder.StateOrCountry),
                 Holdings = holdings,
+                FundScore = fundScore,
                 Summary = summary,
                 IndustryAllocation = industryAllocation,
                 AvailableReportDates = distinctDates,

--- a/src/Equibles.Web/Equibles.Web.csproj
+++ b/src/Equibles.Web/Equibles.Web.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Holdings.Repositories\Equibles.Holdings.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Holdings.BusinessLogic\Equibles.Holdings.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.InsiderTrading.Repositories\Equibles.InsiderTrading.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Congress.Repositories\Equibles.Congress.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Finra.Repositories\Equibles.Finra.Repositories.csproj" />

--- a/src/Equibles.Web/ViewModels/Institutions/InstitutionListItemViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Institutions/InstitutionListItemViewModel.cs
@@ -15,4 +15,8 @@ public class InstitutionListItemViewModel
     public int PositionCount { get; set; }
     public long TotalValue { get; set; }
     public DateOnly? LatestReportDate { get; set; }
+
+    // Latest 3-year alpha vs the S&P 500 (portfolio CAGR minus benchmark CAGR),
+    // as a percentage. Null when the filer has no fund score yet.
+    public decimal? AlphaPercent { get; set; }
 }

--- a/src/Equibles.Web/ViewModels/Institutions/InstitutionSort.cs
+++ b/src/Equibles.Web/ViewModels/Institutions/InstitutionSort.cs
@@ -12,4 +12,7 @@ public enum InstitutionSort
 
     [Display(Name = "Total $ Value (latest 13F)")]
     ValueDescending = 2,
+
+    [Display(Name = "3Y alpha vs S&P 500")]
+    AlphaDescending = 3,
 }

--- a/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Profiles/InstitutionProfileViewModel.cs
@@ -11,6 +11,11 @@ public class InstitutionProfileViewModel
     public FundClassification Classification { get; set; }
     public bool ConfidentialTreatmentRequested { get; set; }
     public List<HoldingRowViewModel> Holdings { get; set; } = [];
+
+    // Latest fund score for the default rolling window / benchmark, or null when this filer
+    // hasn't been scored yet (e.g. no price history for its holdings).
+    public FundScore FundScore { get; set; }
+
     public InstitutionPortfolioSummary Summary { get; set; } = new();
     public List<IndustryAllocationSlice> IndustryAllocation { get; set; } = [];
 

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -116,6 +116,7 @@
                         <th scope="col" class="hidden lg:table-cell">Location</th>
                         <th scope="col" class="text-right"># Positions</th>
                         <th scope="col" class="text-right hidden md:table-cell">Total $ Value</th>
+                        <th scope="col" class="text-right hidden lg:table-cell" title="Latest 3-year portfolio CAGR minus the S&P 500's, from the 13F backtest">3Y alpha</th>
                         <th scope="col" class="text-right hidden xl:table-cell">Last filed</th>
                         <th scope="col" class="w-8"><span class="sr-only">Open</span></th>
                     </tr>
@@ -132,6 +133,15 @@
                             <td class="hidden lg:table-cell text-sm text-base-content/60">@(string.IsNullOrEmpty(location) ? "—" : location)</td>
                             <td class="text-right font-mono"><compactable-number value="@inst.PositionCount" /></td>
                             <td class="text-right font-mono hidden md:table-cell"><compactable-number value="@inst.TotalValue" prefix="$" /></td>
+                            <td class="text-right font-mono hidden lg:table-cell" data-testid="institution-alpha">
+                                @if (inst.AlphaPercent.HasValue) {
+                                    <span class="@(inst.AlphaPercent.Value >= 0 ? "text-success" : "text-error")">
+                                        @(inst.AlphaPercent.Value >= 0 ? "+" : "")@inst.AlphaPercent.Value.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)%
+                                    </span>
+                                } else {
+                                    <span class="text-base-content/40">—</span>
+                                }
+                            </td>
                             <td class="text-right font-mono text-sm text-base-content/60 hidden xl:table-cell">@(inst.LatestReportDate?.ToString("yyyy-MM-dd") ?? "—")</td>
                             <td class="text-base-content/30">
                                 <icon name="chevron-right" size="4" />
@@ -139,7 +149,7 @@
                         </tr>
                     }
                     @if (Model.Institutions.Count == 0) {
-                        <empty-row colspan="7">
+                        <empty-row colspan="8">
                             @if (Model.LatestReportDate.HasValue) {
                                 <span>No institutions match these filters.</span>
                             } else {

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -67,6 +67,34 @@
         </div>
     }
 
+    @if (Model.FundScore != null) {
+        <!-- Fund score: a rolling-window backtest of the reported 13F portfolio vs the S&P 500.
+             Alpha is the portfolio's annualised return (CAGR) minus the benchmark's over the same
+             window, using the same look-ahead-safe rebalancing as the on-demand backtest. -->
+        <div class="card bg-base-100 shadow-sm mb-8" data-testid="institution-fund-score">
+            <div class="card-body p-4">
+                <div class="flex flex-wrap items-center justify-between gap-3 mb-3">
+                    <h2 class="text-base font-medium m-0">@Model.FundScore.WindowYears-year performance vs @Model.FundScore.BenchmarkTicker</h2>
+                    <span class="text-xs text-base-content/50">
+                        @Model.FundScore.WindowStart.ToString("MMM yyyy") – @Model.FundScore.WindowEnd.ToString("MMM yyyy")
+                    </span>
+                </div>
+                <div class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200 w-full">
+                    <stat-tile title="Alpha vs @Model.FundScore.BenchmarkTicker">
+                        <span class="@(Model.FundScore.AlphaPercent >= 0 ? "text-success" : "text-error")" data-testid="fund-score-alpha">@(Model.FundScore.AlphaPercent >= 0 ? "+" : "")@Model.FundScore.AlphaPercent.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)%</span>
+                    </stat-tile>
+                    <stat-tile title="Portfolio CAGR">@Model.FundScore.PortfolioCagrPercent.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)%</stat-tile>
+                    <stat-tile title="@(Model.FundScore.BenchmarkTicker) CAGR">@Model.FundScore.BenchmarkCagrPercent.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)%</stat-tile>
+                    <stat-tile title="Max drawdown">@Model.FundScore.MaxDrawdownPercent.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)%</stat-tile>
+                </div>
+                <p class="text-xs text-base-content/50 mt-2">
+                    Hypothetical buy-and-hold of the reported 13F portfolio, rebalanced 45 days after each
+                    quarter-end. Past performance does not guarantee future results.
+                </p>
+            </div>
+        </div>
+    }
+
     @if (Model.IndustryAllocation.Count > 0) {
         <!-- Sector / industry allocation for the latest reported quarter. Unclassified
              stocks (no IndustryId on CommonStock) collapse into a single row at the end. -->

--- a/tests/Equibles.FunctionalTests/Tests/InstitutionsFundScoreSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/InstitutionsFundScoreSeededTests.cs
@@ -1,0 +1,113 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using Equibles.Holdings.Data.Models;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class InstitutionsFundScoreSeededTests
+{
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public InstitutionsFundScoreSeededTests(WebAppFixture web, PlaywrightFixture playwright)
+    {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task AlphaSort_RanksByAlphaAndProfileShowsPerformanceCard()
+    {
+        var stockId = Guid.NewGuid();
+        var reportDate = new DateOnly(2024, 12, 31);
+        const string winnerCik = "0001000001";
+
+        await _web.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+
+            var winner = new InstitutionalHolder { Cik = winnerCik, Name = "Aaa Alpha Fund" };
+            var laggard = new InstitutionalHolder { Cik = "0001000002", Name = "Aaa Beta Fund" };
+            db.AddRange(winner, laggard);
+            db.AddRange(
+                MakeHolding(stockId, winner.Id, reportDate),
+                MakeHolding(stockId, laggard.Id, reportDate),
+                MakeScore(winner.Id, 12.3m),
+                MakeScore(laggard.Id, -4.5m)
+            );
+
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        var response = await page.GotoAsync("/institutions?sort=AlphaDescending");
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        // The alpha column renders both funds' values; the +12.3% fund ranks above the -4.5% one.
+        var rows = page.Locator("[data-testid='institutions-table'] tbody tr");
+        await Assertions.Expect(rows.First).ToContainTextAsync("Aaa Alpha Fund");
+        await Assertions.Expect(rows.Nth(1)).ToContainTextAsync("Aaa Beta Fund");
+        await Assertions
+            .Expect(rows.First.Locator("[data-testid='institution-alpha']"))
+            .ToContainTextAsync("12.3%");
+
+        // Open the top fund's profile and confirm the performance card with its 3-year alpha.
+        await page.Locator($"a[href='/institutions/{winnerCik}']").First.ClickAsync();
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var card = page.Locator("[data-testid='institution-fund-score']");
+        await Assertions.Expect(card).ToBeVisibleAsync();
+        await Assertions.Expect(card).ToContainTextAsync("3-year performance vs SPY");
+        await Assertions
+            .Expect(card.Locator("[data-testid='fund-score-alpha']"))
+            .ToContainTextAsync("12.30%");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Value = 5_000_000,
+            Shares = 1_000,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+        };
+
+    private static FundScore MakeScore(Guid holderId, decimal alpha) =>
+        new()
+        {
+            InstitutionalHolderId = holderId,
+            BenchmarkTicker = "SPY",
+            WindowYears = 3,
+            WindowStart = new DateOnly(2021, 12, 31),
+            WindowEnd = new DateOnly(2024, 12, 31),
+            PortfolioCagrPercent = alpha + 8m,
+            BenchmarkCagrPercent = 8m,
+            PortfolioTotalReturnPercent = (alpha + 8m) * 3m,
+            BenchmarkTotalReturnPercent = 24m,
+            AlphaPercent = alpha,
+            MaxDrawdownPercent = 15m,
+        };
+}

--- a/tests/Equibles.IntegrationTests/Web/FundScoreWebViewTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/FundScoreWebViewTests.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the fund-score surfaces: the institutions index alpha column + alpha sort, and the
+/// institution profile's performance-score card.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class FundScoreWebViewTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public FundScoreWebViewTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetIndex_SortByAlphaDesc_RanksHigherAlphaFirstAndRendersTheColumn()
+    {
+        var quarter = new DateOnly(2024, 12, 31);
+        var aaplId = Guid.NewGuid();
+        var winnerId = Guid.NewGuid();
+        var laggardId = Guid.NewGuid();
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = winnerId,
+                    Cik = "0000070",
+                    Name = "Aardvark Alpha Fund",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = laggardId,
+                    Cik = "0000080",
+                    Name = "Aardvark Beta Fund",
+                }
+            );
+            db.Add(MakeHolding(aaplId, winnerId, quarter));
+            db.Add(MakeHolding(aaplId, laggardId, quarter));
+            db.Add(MakeScore(winnerId, alpha: 12.3m));
+            db.Add(MakeScore(laggardId, alpha: -4.5m));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions?sort=AlphaDescending");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("3Y alpha");
+        // The view formats with InvariantCulture, so the separator is a dot regardless of host.
+        // The leading "+" on positive values is HTML-encoded by Razor, so assert the number only.
+        html.Should().Contain("12.3%");
+        html.Should().Contain("-4.5%");
+        var winnerIdx = html.IndexOf("Aardvark Alpha Fund", StringComparison.Ordinal);
+        var laggardIdx = html.IndexOf("Aardvark Beta Fund", StringComparison.Ordinal);
+        winnerIdx.Should().BeGreaterThan(-1);
+        laggardIdx.Should().BeGreaterThan(winnerIdx, "the +12.3% fund outranks the -4.5% fund");
+    }
+
+    [Fact]
+    public async Task GetInstitution_WithFundScore_RendersThePerformanceCard()
+    {
+        var quarter = new DateOnly(2024, 12, 31);
+        var aaplId = Guid.NewGuid();
+        var holderId = Guid.NewGuid();
+        const string cik = "0000090";
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = aaplId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = holderId,
+                    Cik = cik,
+                    Name = "Scored Capital",
+                }
+            );
+            db.Add(MakeHolding(aaplId, holderId, quarter));
+            db.Add(MakeScore(holderId, alpha: 7.5m));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync($"/institutions/{cik}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("institution-fund-score");
+        html.Should().Contain("3-year performance vs SPY");
+        html.Should().Contain("fund-score-alpha");
+        // Positive alpha renders green; the leading "+" is HTML-encoded, so assert the number only.
+        html.Should().Contain("7.50%");
+        html.Should().Contain("text-success");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = 1_000,
+            Value = 1_000_000,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber =
+                $"acc-{holderId:N}".Substring(0, 12) + $"-{stockId:N}".Substring(0, 8),
+        };
+
+    private static FundScore MakeScore(Guid holderId, decimal alpha) =>
+        new()
+        {
+            InstitutionalHolderId = holderId,
+            BenchmarkTicker = "SPY",
+            WindowYears = 3,
+            WindowStart = new DateOnly(2021, 12, 31),
+            WindowEnd = new DateOnly(2024, 12, 31),
+            PortfolioCagrPercent = alpha + 8m,
+            BenchmarkCagrPercent = 8m,
+            PortfolioTotalReturnPercent = (alpha + 8m) * 3m,
+            BenchmarkTotalReturnPercent = 24m,
+            AlphaPercent = alpha,
+            MaxDrawdownPercent = 15m,
+        };
+}


### PR DESCRIPTION
## Summary

- Slice 4 of 4 — the final slice for the fund scoring system (#1862). Surfaces each filer's latest 3-year alpha vs the S&P 500 in the portal.
- Institutions index gains a "3Y alpha" column and a "3Y alpha vs S&P 500" sort (scored filers ranked highest-to-lowest, unscored last).
- Institution profile gains a performance-score card: alpha, portfolio CAGR, benchmark CAGR, and max drawdown over the simulated window.

## Code changes

- `Controllers/InstitutionsController.cs` — join the latest fund score for the default window/benchmark via a correlated scalar subquery, add the alpha sort, and project the alpha.
- `Controllers/ProfilesController.cs` — load the filer's fund score and pass it to the profile view.
- `ViewModels/Institutions/InstitutionSort.cs`, `InstitutionListItemViewModel.cs`, `ViewModels/Profiles/InstitutionProfileViewModel.cs` — carry the new sort option and alpha/score fields.
- `Views/Institutions/Index.cshtml` — render the alpha column (green/red, em-dash when unscored).
- `Views/Profiles/Institution.cshtml` — render the performance-score card. Percentages use InvariantCulture so the decimal separator is stable across hosts.
- `Equibles.Web.csproj` — reference the BusinessLogic project to reuse the default window/benchmark constants.
- Tests: `IntegrationTests/Web/FundScoreWebViewTests.cs` (alpha column + sort order + profile card render against the real app/DB) and `FunctionalTests/Tests/InstitutionsFundScoreSeededTests.cs` (Playwright golden path: alpha sort → click into the top fund → see its performance card).

Closes #1862