### PR TITLE
feat(web): sort global search results by date

### DIFF
--- a/src/Equibles.Search.Abstractions/SearchHit.cs
+++ b/src/Equibles.Search.Abstractions/SearchHit.cs
@@ -16,6 +16,12 @@ public class SearchHit
     /// <summary>Provider-local relevance; only meaningful for ranking within the same group.</summary>
     public double Score { get; set; }
 
+    /// <summary>
+    /// The hit's date dimension (e.g. a filing's reporting date), used by the aggregator for
+    /// <see cref="SearchSort.Date"/>. Null for hits with no date; those sink below dated hits.
+    /// </summary>
+    public DateOnly? Date { get; set; }
+
     /// <summary>Route components the consumer needs to build a link (e.g. ticker, id, seriesId).</summary>
     public Dictionary<string, string> RouteValues { get; set; } = [];
 }

--- a/src/Equibles.Search.Abstractions/SearchSort.cs
+++ b/src/Equibles.Search.Abstractions/SearchSort.cs
@@ -15,4 +15,11 @@ public enum SearchSort
     /// <summary>Alphabetical by <see cref="SearchHit.Title"/>, case-insensitive.</summary>
     [Display(Name = "Name (A–Z)")]
     Name = 1,
+
+    /// <summary>
+    /// Newest first by <see cref="SearchHit.Date"/>. Hits without a date keep their provider
+    /// order and sink below dated hits, so date-less groups (e.g. Stocks) are unaffected.
+    /// </summary>
+    [Display(Name = "Date (newest)")]
+    Date = 2,
 }

--- a/src/Equibles.Search/SearchAggregator.cs
+++ b/src/Equibles.Search/SearchAggregator.cs
@@ -75,7 +75,8 @@ public class SearchAggregator
     }
 
     // Reorders a group's hits per the requested sort. Relevance keeps the provider's own ranking
-    // (providers return hits already scored); Name is a stable, case-insensitive title sort.
+    // (providers return hits already scored); Name is a stable, case-insensitive title sort; Date
+    // is newest-first with undated hits sinking to the bottom in their original order.
     private static SearchResultGroup SortHits(SearchResultGroup group, SearchSort sortBy)
     {
         if (sortBy == SearchSort.Name)
@@ -83,6 +84,12 @@ public class SearchAggregator
             group.Hits = group
                 .Hits.OrderBy(hit => hit.Title ?? string.Empty, StringComparer.OrdinalIgnoreCase)
                 .ToList();
+        }
+        else if (sortBy == SearchSort.Date)
+        {
+            // OrderByDescending sorts a null DateOnly? last, and is stable — so undated groups
+            // (e.g. Stocks) keep their relevance order, and dated hits sharing a date do too.
+            group.Hits = group.Hits.OrderByDescending(hit => hit.Date).ToList();
         }
 
         return group;

--- a/src/Equibles.Sec.Repositories/Search/SecDocumentSearchProvider.cs
+++ b/src/Equibles.Sec.Repositories/Search/SecDocumentSearchProvider.cs
@@ -52,6 +52,7 @@ public class SecDocumentSearchProvider : ISearchProvider
                     Title = $"{chunk.DocumentType.DisplayName} · {chunk.Ticker}",
                     Subtitle = chunk.ReportingDate.ToString("yyyy-MM-dd"),
                     Kind = "Filing",
+                    Date = DateOnly.FromDateTime(chunk.ReportingDate),
                     RouteValues =
                     {
                         ["ticker"] = chunk.Ticker,

--- a/tests/Equibles.FunctionalTests/Tests/SearchIndexSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/SearchIndexSeededTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.FunctionalTests.Fixtures;
+using Equibles.Search.Abstractions;
 using FluentAssertions;
 using Microsoft.Playwright;
 using Xunit;
@@ -62,6 +63,46 @@ public class SearchIndexSeededTests
         // Results should appear — at least a "Stocks" category with AAPL.
         var resultsContainer = page.Locator("#search-results");
         await Assertions.Expect(resultsContainer).ToContainTextAsync("result");
+        await Assertions.Expect(resultsContainer).ToContainTextAsync("AAPL");
+        await Assertions.Expect(resultsContainer).ToContainTextAsync("Stocks");
+    }
+
+    [Fact]
+    public async Task Search_SortByDate_OffersOptionAndLeavesUndatedStockResultsIntact()
+    {
+        // Seed a stock — a date-less category, so the date sort must leave it untouched.
+        await _web.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        // Search by company name (not the exact ticker, which would redirect to the stock page)
+        // and request the date sort straight from the URL, so the assertions hold whether or not
+        // the instant-search script is bundled — the server renders the sorted results itself.
+        var response = await page.GotoAsync("/Search?q=Apple&sort=Date");
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        // The new sort mode must be offered and reflected as the active selection.
+        var sortSelect = page.Locator("#search-sort");
+        await Assertions
+            .Expect(sortSelect.Locator("option").Filter(new() { HasTextString = "Date (newest)" }))
+            .ToHaveCountAsync(1);
+        await Assertions.Expect(sortSelect).ToHaveValueAsync(((int)SearchSort.Date).ToString());
+
+        // The date-less Stocks group must still render under the date sort — providers without a
+        // date dimension are unaffected.
+        var resultsContainer = page.Locator("#search-results");
         await Assertions.Expect(resultsContainer).ToContainTextAsync("AAPL");
         await Assertions.Expect(resultsContainer).ToContainTextAsync("Stocks");
     }

--- a/tests/Equibles.UnitTests/Search/SearchAggregatorTests.cs
+++ b/tests/Equibles.UnitTests/Search/SearchAggregatorTests.cs
@@ -76,6 +76,18 @@ public class SearchAggregatorTests
         };
     }
 
+    // Builds a group whose hits carry the given dates (null = undated), titled by index so the
+    // test can assert order independently of the dates.
+    private static SearchResultGroup GroupWithDates(string category, params DateOnly?[] dates)
+    {
+        return new SearchResultGroup
+        {
+            Category = category,
+            Order = 0,
+            Hits = dates.Select((d, i) => new SearchHit { Title = $"hit-{i}", Date = d }).ToList(),
+        };
+    }
+
     [Fact]
     public async Task Search_SortByName_OrdersHitsByTitleCaseInsensitive()
     {
@@ -106,6 +118,51 @@ public class SearchAggregatorTests
             CancellationToken.None,
             SearchSort.Relevance
         );
+
+        result.Should().ContainSingle();
+        result[0].Hits.Select(h => h.Title).Should().Equal("zeta", "alpha", "mid");
+    }
+
+    [Fact]
+    public async Task Search_SortByDate_OrdersNewestFirstWithUndatedHitsLast()
+    {
+        var aggregator = Build(
+            new StubA(
+                "SEC Filings",
+                0,
+                _ =>
+                    GroupWithDates(
+                        "SEC Filings",
+                        new DateOnly(2024, 3, 1),
+                        null,
+                        new DateOnly(2024, 9, 1),
+                        new DateOnly(2024, 6, 1)
+                    )
+            )
+        );
+
+        var result = await aggregator.Search("are", 5, CancellationToken.None, SearchSort.Date);
+
+        result.Should().ContainSingle();
+        result[0]
+            .Hits.Select(h => h.Date)
+            .Should()
+            .Equal(
+                new DateOnly(2024, 9, 1),
+                new DateOnly(2024, 6, 1),
+                new DateOnly(2024, 3, 1),
+                null
+            );
+    }
+
+    [Fact]
+    public async Task Search_SortByDate_LeavesUndatedGroupInProviderOrder()
+    {
+        var aggregator = Build(
+            new StubA("Stocks", 0, _ => GroupWithTitles("Stocks", "zeta", "alpha", "mid"))
+        );
+
+        var result = await aggregator.Search("are", 5, CancellationToken.None, SearchSort.Date);
 
         result.Should().ContainSingle();
         result[0].Hits.Select(h => h.Title).Should().Equal("zeta", "alpha", "mid");


### PR DESCRIPTION
## Summary

- Slice 1 of 1 for #935. Completes the richer global search filters feature by adding the **date** sort mode (relevance | name | date); the category/sort/date-range sidebar, instant-search wiring, and total-results indicator already shipped.
- Selecting "Date (newest)" reorders results that carry a date dimension newest-first (currently SEC Filings, by reporting date). Categories without a date — Stocks, Institutions, Insiders, etc. — keep their existing order and are unaffected.
- Closes #935.

## Code changes

- `src/Equibles.Search.Abstractions/SearchHit.cs` — add nullable `Date` so the aggregator can order hits by their date dimension.
- `src/Equibles.Search.Abstractions/SearchSort.cs` — add the `Date` sort value (trailing enum member, `[Display(Name = "Date (newest)")]`), so the existing enum-backed sort dropdown renders it automatically.
- `src/Equibles.Search/SearchAggregator.cs` — `SortHits` handles `Date`: newest-first via `OrderByDescending`, undated hits sink last and keep provider order (stable sort), so date-less groups are untouched.
- `src/Equibles.Sec.Repositories/Search/SecDocumentSearchProvider.cs` — populate each filing hit's `Date` from its reporting date; the provider stays sort-agnostic (sorting remains centralized in the aggregator).
- `tests/Equibles.UnitTests/Search/SearchAggregatorTests.cs` — unit tests for newest-first-with-undated-last and for leaving an undated group in provider order.
- `tests/Equibles.FunctionalTests/Tests/SearchIndexSeededTests.cs` — end-to-end test that the date sort option is offered and selected, and that date-less Stocks results survive the sort.