### PR TITLE
feat(holdings): construct smart-money index from top-scoring funds

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/Models/SmartMoneyIndexResult.cs
+++ b/src/Equibles.Holdings.BusinessLogic/Models/SmartMoneyIndexResult.cs
@@ -1,0 +1,47 @@
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Holdings.BusinessLogic.Models;
+
+/// <summary>
+/// The constructed smart-money index: the equal-weighted basket of the top-scoring funds'
+/// highest-conviction common holdings, plus the forward backtest of that basket against the
+/// benchmark. When the index can't be built (no scored funds, no consensus stocks, no prices),
+/// <see cref="Constituents"/> is empty and <see cref="Reason"/> explains why.
+/// </summary>
+public class SmartMoneyIndexResult
+{
+    /// <summary>Number of top-alpha funds requested for the consensus.</summary>
+    public int RequestedTopFunds { get; set; }
+
+    /// <summary>Number of top-alpha funds actually found and used.</summary>
+    public int FundCount { get; set; }
+
+    /// <summary>Cap applied to the number of constituents.</summary>
+    public int MaxConstituents { get; set; }
+
+    /// <summary>Minimum number of funds that had to hold a stock for it to qualify.</summary>
+    public int MinConsensus { get; set; }
+
+    /// <summary>Rolling-window length (years) the funds were ranked by alpha over.</summary>
+    public int WindowYears { get; set; }
+
+    public string BenchmarkTicker { get; set; }
+
+    public string BenchmarkName { get; set; }
+
+    /// <summary>Last day of the tracked window — the as-of date the index was evaluated on.</summary>
+    public DateOnly AsOf { get; set; }
+
+    /// <summary>
+    /// Freshest 13F report date among the selected funds — the quarter the basket reflects.
+    /// Forward tracking starts 45 days after this (the latest legal filing deadline).
+    /// </summary>
+    public DateOnly? ConstructionDate { get; set; }
+
+    public List<SmartMoneyIndexConstituent> Constituents { get; set; } = [];
+
+    public BacktestResult Backtest { get; set; } = new();
+
+    /// <summary>Set when the index is empty or the backtest could not run; null on success.</summary>
+    public string Reason { get; set; }
+}

--- a/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
@@ -1,0 +1,306 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.AutoWiring;
+using Equibles.Holdings.BusinessLogic.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.BusinessLogic;
+
+/// <summary>
+/// Builds a "smart-money index": takes the top-scoring funds for a window/benchmark (ranked by
+/// alpha via <see cref="FundScoreRepository"/>), draws their highest-conviction common holdings
+/// into an equal-weighted basket through <see cref="SmartMoneyIndexCalculator"/>, and tracks that
+/// basket's forward performance against the benchmark with the look-ahead-safe
+/// <see cref="HoldingsBacktestCalculator"/>.
+/// <para>
+/// The basket is constructed point-in-time from each fund's latest 13F portfolio and tracked
+/// forward from the rebalance date (45 days after the freshest report date). The price loading
+/// and forward-fill mirror <see cref="FundScoringManager"/>, kept self-contained so the index
+/// has no dependency on the web host.
+/// </para>
+/// </summary>
+[Service]
+public class SmartMoneyIndexManager
+{
+    public const string DefaultBenchmark = FundScoringManager.DefaultBenchmark;
+    public const int DefaultWindowYears = FundScoringManager.DefaultWindowYears;
+
+    // Forward-fill needs a few trading days of pre-window history so day-zero resolves to the
+    // last close even on a weekend or holiday.
+    private const int PriceLookbackDays = 14;
+
+    // Equal-weighted basket: every constituent gets the same nominal value so the backtest's
+    // value-weighting collapses to equal weighting.
+    private const long EqualWeightValue = 1;
+
+    private readonly FundScoreRepository _fundScoreRepository;
+    private readonly InstitutionalHolderRepository _holderRepository;
+    private readonly InstitutionalHoldingRepository _holdingRepository;
+    private readonly CommonStockRepository _stockRepository;
+    private readonly DailyStockPriceRepository _priceRepository;
+
+    public SmartMoneyIndexManager(
+        FundScoreRepository fundScoreRepository,
+        InstitutionalHolderRepository holderRepository,
+        InstitutionalHoldingRepository holdingRepository,
+        CommonStockRepository stockRepository,
+        DailyStockPriceRepository priceRepository
+    )
+    {
+        _fundScoreRepository = fundScoreRepository;
+        _holderRepository = holderRepository;
+        _holdingRepository = holdingRepository;
+        _stockRepository = stockRepository;
+        _priceRepository = priceRepository;
+    }
+
+    public async Task<SmartMoneyIndexResult> Build(
+        DateOnly asOf,
+        int topFunds = SmartMoneyIndexCalculator.DefaultTopFunds,
+        int maxConstituents = SmartMoneyIndexCalculator.DefaultMaxConstituents,
+        int minConsensus = SmartMoneyIndexCalculator.DefaultMinConsensus,
+        int windowYears = DefaultWindowYears,
+        string benchmarkTicker = DefaultBenchmark
+    )
+    {
+        topFunds = Math.Max(1, topFunds);
+        benchmarkTicker = benchmarkTicker.Trim().ToUpperInvariant();
+
+        var result = new SmartMoneyIndexResult
+        {
+            RequestedTopFunds = topFunds,
+            MaxConstituents = maxConstituents,
+            MinConsensus = minConsensus,
+            WindowYears = windowYears,
+            BenchmarkTicker = benchmarkTicker,
+            AsOf = asOf,
+        };
+
+        var benchmarkStock = await _stockRepository.GetByTicker(benchmarkTicker);
+        if (benchmarkStock == null)
+        {
+            result.Reason = $"Benchmark ticker '{benchmarkTicker}' is not known.";
+            return result;
+        }
+        result.BenchmarkName = benchmarkStock.Name;
+
+        var topScores = await _fundScoreRepository
+            .GetRankedByAlpha(windowYears, benchmarkTicker)
+            .Take(topFunds)
+            .ToListAsync();
+        if (topScores.Count == 0)
+        {
+            result.Reason =
+                "No fund scores are available for this window and benchmark yet — run the scoring worker first.";
+            return result;
+        }
+
+        var holderIds = topScores.Select(s => s.InstitutionalHolderId).ToList();
+        var holdersById = await _holderRepository
+            .GetAll()
+            .Where(h => holderIds.Contains(h.Id))
+            .ToDictionaryAsync(h => h.Id);
+
+        var fundPortfolios = new List<BacktestQuarterSnapshot>();
+        DateOnly? constructionDate = null;
+        foreach (var score in topScores)
+        {
+            if (!holdersById.TryGetValue(score.InstitutionalHolderId, out var holder))
+                continue;
+
+            var snapshot = await LoadLatestPortfolio(holder);
+            if (snapshot == null)
+                continue;
+
+            fundPortfolios.Add(snapshot);
+            if (constructionDate == null || snapshot.ReportDate > constructionDate.Value)
+                constructionDate = snapshot.ReportDate;
+        }
+
+        result.FundCount = fundPortfolios.Count;
+        if (fundPortfolios.Count == 0)
+        {
+            result.Reason = "The top-scoring funds have no holdings on file.";
+            return result;
+        }
+
+        var constituents = SmartMoneyIndexCalculator.Compose(
+            fundPortfolios,
+            maxConstituents,
+            minConsensus
+        );
+        if (constituents.Count == 0)
+        {
+            result.Reason =
+                $"No stock was held by at least {Math.Max(1, minConsensus)} of the top {fundPortfolios.Count} funds.";
+            return result;
+        }
+
+        await PopulateConstituentDetails(constituents);
+        result.Constituents = constituents;
+        result.ConstructionDate = constructionDate;
+
+        await RunBacktest(result, constituents, constructionDate.Value, asOf, benchmarkStock);
+        return result;
+    }
+
+    private async Task<BacktestQuarterSnapshot> LoadLatestPortfolio(InstitutionalHolder holder)
+    {
+        var reportDates = await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync();
+        if (reportDates.Count == 0)
+            return null;
+
+        // GetReportDatesByHolder returns latest-first; the index reflects each fund's freshest 13F.
+        var latest = reportDates[0];
+
+        var positions = await _holdingRepository
+            .GetByHolder(holder, latest)
+            .Where(h => h.OptionType == null && h.Value > 0)
+            .GroupBy(h => h.CommonStockId)
+            .Select(g => new { StockId = g.Key, Value = g.Sum(h => h.Value) })
+            .ToListAsync();
+        if (positions.Count == 0)
+            return null;
+
+        return new BacktestQuarterSnapshot
+        {
+            ReportDate = latest,
+            Positions = positions
+                .Select(p => new BacktestPosition
+                {
+                    CommonStockId = p.StockId,
+                    Value = p.Value,
+                    IsOption = false,
+                })
+                .ToList(),
+        };
+    }
+
+    private async Task PopulateConstituentDetails(
+        IReadOnlyList<SmartMoneyIndexConstituent> constituents
+    )
+    {
+        var stockIds = constituents.Select(c => c.CommonStockId).ToList();
+        var stocksById = await _stockRepository
+            .GetByIds(stockIds)
+            .Select(s => new
+            {
+                s.Id,
+                s.Ticker,
+                s.Name,
+            })
+            .ToDictionaryAsync(s => s.Id);
+
+        foreach (var constituent in constituents)
+        {
+            if (stocksById.TryGetValue(constituent.CommonStockId, out var stock))
+            {
+                constituent.Ticker = stock.Ticker;
+                constituent.Name = stock.Name;
+            }
+        }
+    }
+
+    private async Task RunBacktest(
+        SmartMoneyIndexResult result,
+        IReadOnlyList<SmartMoneyIndexConstituent> constituents,
+        DateOnly constructionDate,
+        DateOnly asOf,
+        CommonStock benchmarkStock
+    )
+    {
+        var snapshot = new BacktestQuarterSnapshot
+        {
+            ReportDate = constructionDate,
+            Positions = constituents
+                .Select(c => new BacktestPosition
+                {
+                    CommonStockId = c.CommonStockId,
+                    Value = EqualWeightValue,
+                    IsOption = false,
+                })
+                .ToList(),
+        };
+
+        var from =
+            constructionDate.DayNumber
+            > DateOnly.MaxValue.DayNumber - HoldingsBacktestCalculator.RebalanceDelayDays
+                ? DateOnly.MaxValue
+                : constructionDate.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
+
+        var priceWindowFrom =
+            from > DateOnly.MinValue.AddDays(PriceLookbackDays)
+                ? from.AddDays(-PriceLookbackDays)
+                : DateOnly.MinValue;
+
+        var stockIds = constituents.Select(c => c.CommonStockId).ToList();
+        var pricesByStock = (
+            await LoadPrices(_priceRepository.GetByStocks(stockIds, priceWindowFrom, asOf))
+        )
+            .GroupBy(p => p.StockId)
+            .ToDictionary(g => g.Key, g => g.ToArray());
+
+        var benchmarkSeries = (
+            await LoadPrices(_priceRepository.GetByStock(benchmarkStock, priceWindowFrom, asOf))
+        ).ToArray();
+        if (benchmarkSeries.Length == 0)
+        {
+            result.Backtest.Reason =
+                $"No price data available for benchmark {result.BenchmarkTicker} in the tracked window.";
+            return;
+        }
+
+        result.Backtest = HoldingsBacktestCalculator.Calculate(
+            [snapshot],
+            from,
+            asOf,
+            priceOf: (stockId, date) => ForwardFill(pricesByStock, stockId, date),
+            benchmarkPriceOf: date => ForwardFill(benchmarkSeries, date)
+        );
+    }
+
+    // OrderBy must precede the record projection — EF can't translate an OrderBy keyed off a
+    // projected record's property because the constructor isn't translatable.
+    private static Task<List<PriceRow>> LoadPrices(IQueryable<DailyStockPrice> query) =>
+        query
+            .OrderBy(p => p.Date)
+            .Select(p => new PriceRow(p.CommonStockId, p.Date, p.AdjustedClose))
+            .ToListAsync();
+
+    private static decimal? ForwardFill(
+        Dictionary<Guid, PriceRow[]> pricesByStock,
+        Guid stockId,
+        DateOnly date
+    ) => pricesByStock.TryGetValue(stockId, out var series) ? ForwardFill(series, date) : null;
+
+    // Largest close on or before `date` via binary search; null when the series starts later.
+    private static decimal? ForwardFill(PriceRow[] series, DateOnly date)
+    {
+        if (series.Length == 0)
+            return null;
+        var lo = 0;
+        var hi = series.Length - 1;
+        var matchIdx = -1;
+        while (lo <= hi)
+        {
+            var mid = (lo + hi) >>> 1;
+            if (series[mid].Date <= date)
+            {
+                matchIdx = mid;
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+        return matchIdx < 0 ? null : series[matchIdx].Price;
+    }
+
+    private readonly record struct PriceRow(Guid StockId, DateOnly Date, decimal Price);
+}

--- a/src/Equibles.Holdings.Repositories/Models/SmartMoneyIndexConstituent.cs
+++ b/src/Equibles.Holdings.Repositories/Models/SmartMoneyIndexConstituent.cs
@@ -1,0 +1,28 @@
+namespace Equibles.Holdings.Repositories.Models;
+
+/// <summary>
+/// One stock selected into a smart-money index: a high-conviction holding shared across the
+/// top-scoring funds. <see cref="Ticker"/> and <see cref="Name"/> are left null by
+/// <see cref="SmartMoneyIndexCalculator"/> (which works in stock ids) and filled in by the
+/// orchestrating manager for display.
+/// </summary>
+public class SmartMoneyIndexConstituent
+{
+    public Guid CommonStockId { get; set; }
+
+    public string Ticker { get; set; }
+
+    public string Name { get; set; }
+
+    /// <summary>How many of the top-scoring funds held this stock in their latest 13F.</summary>
+    public int HeldByCount { get; set; }
+
+    /// <summary>
+    /// Mean portfolio weight (as a percentage) of this stock across the funds that hold it —
+    /// the conviction signal the selection ranks on after consensus count.
+    /// </summary>
+    public decimal AverageWeightPercent { get; set; }
+
+    /// <summary>This stock's weight in the equal-weighted index (100 / constituent count).</summary>
+    public decimal IndexWeightPercent { get; set; }
+}

--- a/src/Equibles.Holdings.Repositories/SmartMoneyIndexCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/SmartMoneyIndexCalculator.cs
@@ -1,0 +1,104 @@
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Holdings.Repositories;
+
+/// <summary>
+/// Builds the constituent list of a "smart-money index" from the latest 13F portfolios of the
+/// top-scoring funds. Selects the funds' highest-conviction common holdings — stocks held by at
+/// least <c>minConsensus</c> of the funds — ranks them by consensus count then by average
+/// portfolio weight, caps the list at <c>maxConstituents</c>, and equal-weights what remains.
+/// <para>
+/// Pure and id-based: each input snapshot is one fund's latest portfolio (option rows and
+/// non-positive values ignored, the same convention <see cref="HoldingsBacktestCalculator"/>
+/// uses). The caller resolves tickers/names and runs the backtest.
+/// </para>
+/// </summary>
+public static class SmartMoneyIndexCalculator
+{
+    /// <summary>Default number of top-alpha funds to draw the consensus from.</summary>
+    public const int DefaultTopFunds = 20;
+
+    /// <summary>Default cap on the number of stocks in the index.</summary>
+    public const int DefaultMaxConstituents = 25;
+
+    /// <summary>Default minimum number of funds that must hold a stock for it to qualify.</summary>
+    public const int DefaultMinConsensus = 3;
+
+    public static List<SmartMoneyIndexConstituent> Compose(
+        IReadOnlyList<BacktestQuarterSnapshot> fundPortfolios,
+        int maxConstituents = DefaultMaxConstituents,
+        int minConsensus = DefaultMinConsensus
+    )
+    {
+        maxConstituents = Math.Max(1, maxConstituents);
+        minConsensus = Math.Max(1, minConsensus);
+
+        // Per stock: how many funds hold it, and the running sum of its per-fund portfolio weight.
+        var accumulator = new Dictionary<Guid, ConvictionAccumulator>();
+
+        foreach (var fund in fundPortfolios)
+        {
+            // Collapse a fund's multiple discretion rows for the same stock into one position,
+            // dropping options (notional) and non-positive values before weighting.
+            var positions = fund
+                .Positions.Where(p => !p.IsOption && p.Value > 0)
+                .GroupBy(p => p.CommonStockId)
+                .Select(g => (StockId: g.Key, Value: g.Sum(p => p.Value)))
+                .ToList();
+
+            var totalValue = positions.Sum(p => p.Value);
+            if (totalValue <= 0)
+                continue;
+
+            foreach (var (stockId, value) in positions)
+            {
+                var weightPercent = (decimal)value / totalValue * 100m;
+                if (accumulator.TryGetValue(stockId, out var current))
+                {
+                    current.HeldByCount++;
+                    current.WeightSum += weightPercent;
+                }
+                else
+                {
+                    accumulator[stockId] = new ConvictionAccumulator
+                    {
+                        HeldByCount = 1,
+                        WeightSum = weightPercent,
+                    };
+                }
+            }
+        }
+
+        var selected = accumulator
+            .Where(entry => entry.Value.HeldByCount >= minConsensus)
+            .OrderByDescending(entry => entry.Value.HeldByCount)
+            .ThenByDescending(entry => entry.Value.WeightSum / entry.Value.HeldByCount)
+            .ThenBy(entry => entry.Key) // deterministic tie-break so ties don't reorder run to run
+            .Take(maxConstituents)
+            .ToList();
+
+        if (selected.Count == 0)
+            return [];
+
+        var indexWeight = Math.Round(100m / selected.Count, 4);
+
+        return selected
+            .Select(entry => new SmartMoneyIndexConstituent
+            {
+                CommonStockId = entry.Key,
+                HeldByCount = entry.Value.HeldByCount,
+                AverageWeightPercent = Math.Round(
+                    entry.Value.WeightSum / entry.Value.HeldByCount,
+                    4
+                ),
+                IndexWeightPercent = indexWeight,
+            })
+            .ToList();
+    }
+
+    private sealed class ConvictionAccumulator
+    {
+        public int HeldByCount { get; set; }
+        public decimal WeightSum { get; set; }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/SmartMoneyIndexManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/SmartMoneyIndexManagerTests.cs
@@ -1,0 +1,200 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+public class SmartMoneyIndexManagerTests : IDisposable
+{
+    private static readonly DateOnly AsOf = new(2026, 1, 2);
+    private static readonly DateOnly ReportDate = new(2025, 9, 30);
+
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly SmartMoneyIndexManager _manager;
+
+    public SmartMoneyIndexManagerTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new HoldingsModuleConfiguration(),
+            new CommonStocksModuleConfiguration(),
+            new YahooModuleConfiguration()
+        );
+        _manager = new SmartMoneyIndexManager(
+            new FundScoreRepository(_dbContext),
+            new InstitutionalHolderRepository(_dbContext),
+            new InstitutionalHoldingRepository(_dbContext),
+            new CommonStockRepository(_dbContext),
+            new DailyStockPriceRepository(_dbContext)
+        );
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    [Fact]
+    public async Task Build_TopFundsWithConsensus_BuildsEqualWeightedIndexAndTracksPerformance()
+    {
+        SeedBenchmark();
+        var doubler = AddStock("AAA", "Alpha Co", start: 100m, end: 200m); // doubles
+        var flat = AddStock("BBB", "Beta Co", start: 100m, end: 100m); // flat
+        var solo = AddStock("CCC", "Gamma Co", start: 100m, end: 100m);
+
+        // Three top funds. AAA held by all three, BBB by two, CCC by one.
+        SeedFund("0000000001", alpha: 30m, (doubler, 60), (flat, 40));
+        SeedFund("0000000002", alpha: 20m, (doubler, 50), (solo, 50));
+        SeedFund("0000000003", alpha: 10m, (doubler, 70), (flat, 30));
+
+        var result = await _manager.Build(
+            AsOf,
+            topFunds: 10,
+            maxConstituents: 25,
+            minConsensus: 2,
+            windowYears: 3,
+            benchmarkTicker: "SPY"
+        );
+
+        result.Reason.Should().BeNull();
+        result.FundCount.Should().Be(3);
+        result.ConstructionDate.Should().Be(ReportDate);
+
+        // CCC is held by a single fund and falls below the consensus threshold.
+        result.Constituents.Select(c => c.Ticker).Should().BeEquivalentTo(["AAA", "BBB"]);
+        result.Constituents.Should().OnlyContain(c => c.IndexWeightPercent == 50m);
+        result.Constituents.Single(c => c.Ticker == "AAA").HeldByCount.Should().Be(3);
+        result.Constituents.Single(c => c.Ticker == "BBB").HeldByCount.Should().Be(2);
+
+        // Equal-weighted basket: AAA doubles (+100%), BBB flat (0%) => ~+50% over the window.
+        result.Backtest.Points.Should().NotBeEmpty();
+        result.Backtest.PortfolioSummary.TotalReturnPercent.Should().BeApproximately(50m, 1m);
+        result.Backtest.BenchmarkSummary.TotalReturnPercent.Should().BeApproximately(0m, 0.01m);
+    }
+
+    [Fact]
+    public async Task Build_UnknownBenchmark_ReturnsReasonAndNoConstituents()
+    {
+        SeedBenchmark();
+
+        var result = await _manager.Build(AsOf, benchmarkTicker: "NOSUCHTICKER");
+
+        result.Constituents.Should().BeEmpty();
+        result.Reason.Should().Contain("not known");
+    }
+
+    [Fact]
+    public async Task Build_NoFundScores_ReturnsReason()
+    {
+        SeedBenchmark();
+
+        var result = await _manager.Build(AsOf, benchmarkTicker: "SPY");
+
+        result.Constituents.Should().BeEmpty();
+        result.FundCount.Should().Be(0);
+        result.Reason.Should().Contain("No fund scores");
+    }
+
+    [Fact]
+    public async Task Build_NoStockMeetsConsensus_ReturnsReason()
+    {
+        SeedBenchmark();
+        var a = AddStock("AAA", "Alpha Co", 100m, 200m);
+        var b = AddStock("BBB", "Beta Co", 100m, 100m);
+
+        // Two funds with entirely disjoint portfolios — nothing is held by both.
+        SeedFund("0000000001", alpha: 30m, (a, 100));
+        SeedFund("0000000002", alpha: 20m, (b, 100));
+
+        var result = await _manager.Build(AsOf, minConsensus: 2, benchmarkTicker: "SPY");
+
+        result.FundCount.Should().Be(2);
+        result.Constituents.Should().BeEmpty();
+        result.Reason.Should().Contain("No stock");
+    }
+
+    private void SeedBenchmark()
+    {
+        AddStock("SPY", "S&P 500 ETF", start: 100m, end: 100m);
+    }
+
+    private CommonStock AddStock(string ticker, string name, decimal start, decimal end)
+    {
+        var stock = new CommonStock { Ticker = ticker, Name = name };
+        _dbContext.Set<CommonStock>().Add(stock);
+        AddPrice(stock, new DateOnly(2025, 11, 1), start);
+        AddPrice(stock, AsOf, end);
+        _dbContext.SaveChanges();
+        return stock;
+    }
+
+    private InstitutionalHolder SeedFund(
+        string cik,
+        decimal alpha,
+        params (CommonStock Stock, long Value)[] positions
+    )
+    {
+        var holder = new InstitutionalHolder { Cik = cik, Name = $"Fund {cik}" };
+        _dbContext.Set<InstitutionalHolder>().Add(holder);
+
+        foreach (var (stock, value) in positions)
+        {
+            _dbContext
+                .Set<InstitutionalHolding>()
+                .Add(
+                    new InstitutionalHolding
+                    {
+                        InstitutionalHolderId = holder.Id,
+                        CommonStockId = stock.Id,
+                        ReportDate = ReportDate,
+                        FilingDate = ReportDate.AddDays(20),
+                        Shares = value,
+                        Value = value,
+                    }
+                );
+        }
+
+        _dbContext
+            .Set<FundScore>()
+            .Add(
+                new FundScore
+                {
+                    InstitutionalHolderId = holder.Id,
+                    WindowYears = 3,
+                    BenchmarkTicker = "SPY",
+                    WindowStart = new DateOnly(2023, 1, 2),
+                    WindowEnd = AsOf,
+                    AlphaPercent = alpha,
+                }
+            );
+
+        _dbContext.SaveChanges();
+        return holder;
+    }
+
+    private void AddPrice(CommonStock stock, DateOnly date, decimal close)
+    {
+        _dbContext
+            .Set<DailyStockPrice>()
+            .Add(
+                new DailyStockPrice
+                {
+                    CommonStockId = stock.Id,
+                    Date = date,
+                    Open = close,
+                    High = close,
+                    Low = close,
+                    Close = close,
+                    AdjustedClose = close,
+                }
+            );
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/SmartMoneyIndexCalculatorTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/SmartMoneyIndexCalculatorTests.cs
@@ -1,0 +1,164 @@
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class SmartMoneyIndexCalculatorTests
+{
+    private static readonly Guid StockA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid StockB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid StockC = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid StockD = Guid.Parse("44444444-4444-4444-4444-444444444444");
+
+    [Fact]
+    public void Compose_NoFunds_ReturnsEmpty()
+    {
+        var constituents = SmartMoneyIndexCalculator.Compose([]);
+
+        constituents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Compose_StockBelowConsensusThreshold_IsExcluded()
+    {
+        // A held by 2 funds, B by only 1; require 2.
+        var funds = new[] { Fund((StockA, 100), (StockB, 100)), Fund((StockA, 100)) };
+
+        var constituents = SmartMoneyIndexCalculator.Compose(
+            funds,
+            maxConstituents: 10,
+            minConsensus: 2
+        );
+
+        constituents.Should().ContainSingle();
+        constituents[0].CommonStockId.Should().Be(StockA);
+        constituents[0].HeldByCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Compose_QualifyingStocks_AreEqualWeighted()
+    {
+        var funds = new[]
+        {
+            Fund((StockA, 100), (StockB, 100)),
+            Fund((StockA, 100), (StockB, 100)),
+        };
+
+        var constituents = SmartMoneyIndexCalculator.Compose(funds, minConsensus: 2);
+
+        constituents.Should().HaveCount(2);
+        constituents.Should().OnlyContain(c => c.IndexWeightPercent == 50m);
+    }
+
+    [Fact]
+    public void Compose_RanksByConsensusCountThenAverageWeight()
+    {
+        // A held by 3 funds, B and C by 2 each. Among B and C, C carries the higher conviction.
+        var funds = new[]
+        {
+            Fund((StockA, 50), (StockB, 25), (StockC, 25)),
+            Fund((StockA, 50), (StockB, 10), (StockC, 40)),
+            Fund((StockA, 100)),
+        };
+
+        var constituents = SmartMoneyIndexCalculator.Compose(funds, minConsensus: 2);
+
+        constituents.Select(c => c.CommonStockId).Should().Equal(StockA, StockC, StockB);
+    }
+
+    [Fact]
+    public void Compose_AverageWeightPercent_IsMeanAcrossHoldingFundsOnly()
+    {
+        // B is held by funds 1 and 2 at 20% and 40%; fund 3 doesn't hold it, so it is not
+        // averaged in. Expected average = (20 + 40) / 2 = 30%.
+        var funds = new[]
+        {
+            Fund((StockA, 80), (StockB, 20)),
+            Fund((StockA, 60), (StockB, 40)),
+            Fund((StockA, 100)),
+        };
+
+        var constituents = SmartMoneyIndexCalculator.Compose(funds, minConsensus: 2);
+
+        var b = constituents.Single(c => c.CommonStockId == StockB);
+        b.AverageWeightPercent.Should().Be(30m);
+    }
+
+    [Fact]
+    public void Compose_OptionRows_AreIgnored()
+    {
+        var funds = new[]
+        {
+            new BacktestQuarterSnapshot
+            {
+                ReportDate = new DateOnly(2025, 3, 31),
+                Positions =
+                [
+                    new BacktestPosition
+                    {
+                        CommonStockId = StockA,
+                        Value = 100,
+                        IsOption = false,
+                    },
+                    new BacktestPosition
+                    {
+                        CommonStockId = StockB,
+                        Value = 100,
+                        IsOption = true,
+                    },
+                ],
+            },
+            Fund((StockA, 100)),
+        };
+
+        var constituents = SmartMoneyIndexCalculator.Compose(funds, minConsensus: 1);
+
+        constituents.Select(c => c.CommonStockId).Should().NotContain(StockB);
+        constituents.Single(c => c.CommonStockId == StockA).HeldByCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Compose_NonPositiveValues_AreIgnored()
+    {
+        var funds = new[] { Fund((StockA, 100), (StockB, 0)), Fund((StockA, 100), (StockB, -5)) };
+
+        var constituents = SmartMoneyIndexCalculator.Compose(funds, minConsensus: 1);
+
+        constituents.Should().ContainSingle();
+        constituents[0].CommonStockId.Should().Be(StockA);
+    }
+
+    [Fact]
+    public void Compose_MoreQualifiersThanCap_TakesTopRankedUpToCap()
+    {
+        var funds = new[]
+        {
+            Fund((StockA, 40), (StockB, 30), (StockC, 20), (StockD, 10)),
+            Fund((StockA, 40), (StockB, 30), (StockC, 20), (StockD, 10)),
+        };
+
+        var constituents = SmartMoneyIndexCalculator.Compose(
+            funds,
+            maxConstituents: 2,
+            minConsensus: 2
+        );
+
+        // All four qualify on consensus; the cap keeps the two highest-conviction (A, B).
+        constituents.Should().HaveCount(2);
+        constituents.Select(c => c.CommonStockId).Should().Equal(StockA, StockB);
+    }
+
+    private static BacktestQuarterSnapshot Fund(params (Guid StockId, long Value)[] positions) =>
+        new()
+        {
+            ReportDate = new DateOnly(2025, 3, 31),
+            Positions = positions
+                .Select(p => new BacktestPosition
+                {
+                    CommonStockId = p.StockId,
+                    Value = p.Value,
+                    IsOption = false,
+                })
+                .ToList(),
+        };
+}


### PR DESCRIPTION
## Summary

- Slice 1 of 2 for #1863 — this PR does **not** close the issue (Refs #1863); the web page in slice 2 will.
- Adds the domain layer that builds a "smart-money index": the equal-weighted basket of the highest-conviction common holdings shared across the top-scoring funds, and tracks its forward performance against a benchmark.
- The basket is constructed point-in-time from each top fund's latest 13F portfolio and tracked forward from the rebalance date (45 days after the freshest report date) using the existing look-ahead-safe holdings backtest.

## Code changes

- `src/Equibles.Holdings.Repositories/SmartMoneyIndexCalculator.cs` — pure selection logic: across the funds' latest portfolios, keep stocks held by at least a minimum number of funds, rank by consensus count then average portfolio weight, cap the list, and equal-weight what remains.
- `src/Equibles.Holdings.Repositories/Models/SmartMoneyIndexConstituent.cs` — one selected stock with its consensus count, average conviction weight, and equal index weight.
- `src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs` — orchestration: rank funds by alpha for a window/benchmark, load each fund's latest portfolio, compose the basket, resolve tickers/names, and run the forward backtest vs the benchmark.
- `src/Equibles.Holdings.BusinessLogic/Models/SmartMoneyIndexResult.cs` — the built index: parameters, constituents, construction date, and the backtest result (with a reason when it can't be built).
- `tests/Equibles.UnitTests/Holdings/SmartMoneyIndexCalculatorTests.cs` — consensus threshold, ranking, equal-weighting, option/zero-value exclusion, and cap behavior.
- `tests/Equibles.IntegrationTests/Holdings/SmartMoneyIndexManagerTests.cs` — end-to-end construction over seeded funds/holdings/prices, plus the unknown-benchmark, no-scores, and no-consensus paths.