### PR TITLE
refactor(holdings): extract duplicated price-loading helpers into shared BacktestPriceLoader

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/BacktestPriceLoader.cs
+++ b/src/Equibles.Holdings.BusinessLogic/BacktestPriceLoader.cs
@@ -1,0 +1,57 @@
+using Equibles.Yahoo.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.BusinessLogic;
+
+/// <summary>
+/// Loads adjusted-close price series and forward-fills them for the BusinessLogic backtests
+/// (<see cref="FundScoringManager"/>, <see cref="SmartMoneyIndexManager"/>). Kept self-contained
+/// in the BusinessLogic assembly so the scoring worker and the index have no dependency on the
+/// web host.
+/// </summary>
+internal static class BacktestPriceLoader
+{
+    // Forward-fill needs a few trading days of pre-window history so day-zero resolves to the
+    // last close even on a weekend or holiday.
+    public const int PriceLookbackDays = 14;
+
+    // OrderBy must precede the record projection — EF can't translate an OrderBy keyed off a
+    // projected record's property because the constructor isn't translatable.
+    public static Task<List<PriceRow>> LoadPrices(IQueryable<DailyStockPrice> query) =>
+        query
+            .OrderBy(p => p.Date)
+            .Select(p => new PriceRow(p.CommonStockId, p.Date, p.AdjustedClose))
+            .ToListAsync();
+
+    public static decimal? ForwardFill(
+        Dictionary<Guid, PriceRow[]> pricesByStock,
+        Guid stockId,
+        DateOnly date
+    ) => pricesByStock.TryGetValue(stockId, out var series) ? ForwardFill(series, date) : null;
+
+    // Largest close on or before `date` via binary search; null when the series starts later.
+    public static decimal? ForwardFill(PriceRow[] series, DateOnly date)
+    {
+        if (series.Length == 0)
+            return null;
+        var lo = 0;
+        var hi = series.Length - 1;
+        var matchIdx = -1;
+        while (lo <= hi)
+        {
+            var mid = (lo + hi) >>> 1;
+            if (series[mid].Date <= date)
+            {
+                matchIdx = mid;
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+        return matchIdx < 0 ? null : series[matchIdx].Price;
+    }
+
+    public readonly record struct PriceRow(Guid StockId, DateOnly Date, decimal Price);
+}

--- a/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
@@ -4,7 +4,6 @@ using Equibles.Core.AutoWiring;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Models;
-using Equibles.Yahoo.Data.Models;
 using Equibles.Yahoo.Repositories;
 using Microsoft.EntityFrameworkCore;
 
@@ -26,10 +25,6 @@ public class FundScoringManager
 {
     public const string DefaultBenchmark = "SPY";
     public const int DefaultWindowYears = 3;
-
-    // Forward-fill needs a few trading days of pre-window history so day-zero resolves to the
-    // last close even on a weekend or holiday.
-    private const int PriceLookbackDays = 14;
 
     // Annualised compounding can saturate to decimal.MaxValue on degenerate inputs; numeric(18,4)
     // tops out far below that, so anything past this magnitude isn't a storable (or meaningful) score.
@@ -116,8 +111,8 @@ public class FundScoringManager
         var snapshots = BuildSnapshots(holdings);
 
         var priceWindowFrom =
-            from > DateOnly.MinValue.AddDays(PriceLookbackDays)
-                ? from.AddDays(-PriceLookbackDays)
+            from > DateOnly.MinValue.AddDays(BacktestPriceLoader.PriceLookbackDays)
+                ? from.AddDays(-BacktestPriceLoader.PriceLookbackDays)
                 : DateOnly.MinValue;
 
         var stockIds = holdings
@@ -129,13 +124,17 @@ public class FundScoringManager
         var pricesByStock = (
             stockIds.Count == 0
                 ? []
-                : await LoadPrices(_priceRepository.GetByStocks(stockIds, priceWindowFrom, to))
+                : await BacktestPriceLoader.LoadPrices(
+                    _priceRepository.GetByStocks(stockIds, priceWindowFrom, to)
+                )
         )
             .GroupBy(p => p.StockId)
             .ToDictionary(g => g.Key, g => g.ToArray());
 
         var benchmarkSeries = (
-            await LoadPrices(_priceRepository.GetByStock(benchmarkStock, priceWindowFrom, to))
+            await BacktestPriceLoader.LoadPrices(
+                _priceRepository.GetByStock(benchmarkStock, priceWindowFrom, to)
+            )
         ).ToArray();
         if (benchmarkSeries.Length == 0)
             return null;
@@ -144,8 +143,9 @@ public class FundScoringManager
             snapshots,
             from,
             to,
-            priceOf: (stockId, date) => ForwardFill(pricesByStock, stockId, date),
-            benchmarkPriceOf: date => ForwardFill(benchmarkSeries, date)
+            priceOf: (stockId, date) =>
+                BacktestPriceLoader.ForwardFill(pricesByStock, stockId, date),
+            benchmarkPriceOf: date => BacktestPriceLoader.ForwardFill(benchmarkSeries, date)
         );
     }
 
@@ -226,14 +226,6 @@ public class FundScoringManager
             })
             .ToList();
 
-    // OrderBy must precede the record projection — EF can't translate an OrderBy keyed off a
-    // projected record's property because the constructor isn't translatable.
-    private static Task<List<PriceRow>> LoadPrices(IQueryable<DailyStockPrice> query) =>
-        query
-            .OrderBy(p => p.Date)
-            .Select(p => new PriceRow(p.CommonStockId, p.Date, p.AdjustedClose))
-            .ToListAsync();
-
     private static bool IsStorable(BacktestResult result) =>
         InRange(result.PortfolioSummary.TotalReturnPercent)
         && InRange(result.PortfolioSummary.CagrPercent)
@@ -243,36 +235,6 @@ public class FundScoringManager
 
     private static bool InRange(decimal value) => Math.Abs(value) < MaxStorableMagnitude;
 
-    private static decimal? ForwardFill(
-        Dictionary<Guid, PriceRow[]> pricesByStock,
-        Guid stockId,
-        DateOnly date
-    ) => pricesByStock.TryGetValue(stockId, out var series) ? ForwardFill(series, date) : null;
-
-    // Largest close on or before `date` via binary search; null when the series starts later.
-    private static decimal? ForwardFill(PriceRow[] series, DateOnly date)
-    {
-        if (series.Length == 0)
-            return null;
-        var lo = 0;
-        var hi = series.Length - 1;
-        var matchIdx = -1;
-        while (lo <= hi)
-        {
-            var mid = (lo + hi) >>> 1;
-            if (series[mid].Date <= date)
-            {
-                matchIdx = mid;
-                lo = mid + 1;
-            }
-            else
-            {
-                hi = mid - 1;
-            }
-        }
-        return matchIdx < 0 ? null : series[matchIdx].Price;
-    }
-
     private readonly record struct HoldingRow(
         DateOnly ReportDate,
         Guid CommonStockId,
@@ -280,6 +242,4 @@ public class FundScoringManager
         long Value,
         OptionType? OptionType
     );
-
-    private readonly record struct PriceRow(Guid StockId, DateOnly Date, decimal Price);
 }

--- a/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
@@ -5,7 +5,6 @@ using Equibles.Holdings.BusinessLogic.Models;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Holdings.Repositories.Models;
-using Equibles.Yahoo.Data.Models;
 using Equibles.Yahoo.Repositories;
 using Microsoft.EntityFrameworkCore;
 
@@ -29,10 +28,6 @@ public class SmartMoneyIndexManager
 {
     public const string DefaultBenchmark = FundScoringManager.DefaultBenchmark;
     public const int DefaultWindowYears = FundScoringManager.DefaultWindowYears;
-
-    // Forward-fill needs a few trading days of pre-window history so day-zero resolves to the
-    // last close even on a weekend or holiday.
-    private const int PriceLookbackDays = 14;
 
     // Equal-weighted basket: every constituent gets the same nominal value so the backtest's
     // value-weighting collapses to equal weighting.
@@ -234,19 +229,23 @@ public class SmartMoneyIndexManager
                 : constructionDate.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
 
         var priceWindowFrom =
-            from > DateOnly.MinValue.AddDays(PriceLookbackDays)
-                ? from.AddDays(-PriceLookbackDays)
+            from > DateOnly.MinValue.AddDays(BacktestPriceLoader.PriceLookbackDays)
+                ? from.AddDays(-BacktestPriceLoader.PriceLookbackDays)
                 : DateOnly.MinValue;
 
         var stockIds = constituents.Select(c => c.CommonStockId).ToList();
         var pricesByStock = (
-            await LoadPrices(_priceRepository.GetByStocks(stockIds, priceWindowFrom, asOf))
+            await BacktestPriceLoader.LoadPrices(
+                _priceRepository.GetByStocks(stockIds, priceWindowFrom, asOf)
+            )
         )
             .GroupBy(p => p.StockId)
             .ToDictionary(g => g.Key, g => g.ToArray());
 
         var benchmarkSeries = (
-            await LoadPrices(_priceRepository.GetByStock(benchmarkStock, priceWindowFrom, asOf))
+            await BacktestPriceLoader.LoadPrices(
+                _priceRepository.GetByStock(benchmarkStock, priceWindowFrom, asOf)
+            )
         ).ToArray();
         if (benchmarkSeries.Length == 0)
         {
@@ -259,48 +258,9 @@ public class SmartMoneyIndexManager
             [snapshot],
             from,
             asOf,
-            priceOf: (stockId, date) => ForwardFill(pricesByStock, stockId, date),
-            benchmarkPriceOf: date => ForwardFill(benchmarkSeries, date)
+            priceOf: (stockId, date) =>
+                BacktestPriceLoader.ForwardFill(pricesByStock, stockId, date),
+            benchmarkPriceOf: date => BacktestPriceLoader.ForwardFill(benchmarkSeries, date)
         );
     }
-
-    // OrderBy must precede the record projection — EF can't translate an OrderBy keyed off a
-    // projected record's property because the constructor isn't translatable.
-    private static Task<List<PriceRow>> LoadPrices(IQueryable<DailyStockPrice> query) =>
-        query
-            .OrderBy(p => p.Date)
-            .Select(p => new PriceRow(p.CommonStockId, p.Date, p.AdjustedClose))
-            .ToListAsync();
-
-    private static decimal? ForwardFill(
-        Dictionary<Guid, PriceRow[]> pricesByStock,
-        Guid stockId,
-        DateOnly date
-    ) => pricesByStock.TryGetValue(stockId, out var series) ? ForwardFill(series, date) : null;
-
-    // Largest close on or before `date` via binary search; null when the series starts later.
-    private static decimal? ForwardFill(PriceRow[] series, DateOnly date)
-    {
-        if (series.Length == 0)
-            return null;
-        var lo = 0;
-        var hi = series.Length - 1;
-        var matchIdx = -1;
-        while (lo <= hi)
-        {
-            var mid = (lo + hi) >>> 1;
-            if (series[mid].Date <= date)
-            {
-                matchIdx = mid;
-                lo = mid + 1;
-            }
-            else
-            {
-                hi = mid - 1;
-            }
-        }
-        return matchIdx < 0 ? null : series[matchIdx].Price;
-    }
-
-    private readonly record struct PriceRow(Guid StockId, DateOnly Date, decimal Price);
 }


### PR DESCRIPTION
## Summary

- The smart-money index feature (#2843) added a third byte-identical copy of the backtest price-loading helpers, which already lived privately in both `FundScoringManager` and `SmartMoneyIndexManager`. This collapses the two BusinessLogic copies into one shared internal utility.
- Behavior-preserving: the moved code is identical, both managers call the shared helper with the same arguments, and the manager/worker integration tests that drive the public `Build`/`ScoreHolder` paths stay green.

## Code changes

- `src/Equibles.Holdings.BusinessLogic/BacktestPriceLoader.cs` (new) — shared `internal static` helper holding `LoadPrices`, the two `ForwardFill` overloads, the `PriceRow` record struct, and the `PriceLookbackDays` constant, with the existing WHY comments preserved.
- `src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs` — removed the private price-loading helpers and now calls `BacktestPriceLoader`; dropped the now-unused `Equibles.Yahoo.Data.Models` using.
- `src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs` — same removal and rewiring to the shared helper.

The web portal's `HoldingsBacktestService` keeps its own copy intentionally (it lives in a different assembly and its private members are pinned by reflection-based tests).