### PR TITLE
feat(web): add smart-money index page to the institutions portal

### DIFF
--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -19,16 +19,19 @@ public class InstitutionsController : BaseController
 
     private readonly InstitutionalHolderRepository _holderRepository;
     private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly SmartMoneyIndexManager _smartMoneyIndexManager;
 
     public InstitutionsController(
         InstitutionalHolderRepository holderRepository,
         EquiblesFinancialDbContext dbContext,
+        SmartMoneyIndexManager smartMoneyIndexManager,
         ILogger<InstitutionsController> logger
     )
         : base(logger)
     {
         _holderRepository = holderRepository;
         _dbContext = dbContext;
+        _smartMoneyIndexManager = smartMoneyIndexManager;
     }
 
     [HttpGet("~/institutions")]
@@ -202,6 +205,34 @@ public class InstitutionsController : BaseController
         };
 
         return View(viewModel);
+    }
+
+    // Smart-money index: the equal-weighted basket of the top-scoring funds' highest-conviction
+    // common holdings, with its forward performance tracked against the benchmark. Query params
+    // tune the construction; each is clamped so hand-edited URLs can't push the build off-range.
+    [HttpGet("~/institutions/smart-money-index")]
+    public async Task<IActionResult> SmartMoneyIndex(
+        int topFunds = SmartMoneyIndexCalculator.DefaultTopFunds,
+        int maxConstituents = SmartMoneyIndexCalculator.DefaultMaxConstituents,
+        int minConsensus = SmartMoneyIndexCalculator.DefaultMinConsensus
+    )
+    {
+        ViewData["Title"] = "Smart Money Index";
+
+        topFunds = Math.Clamp(topFunds, 1, 100);
+        maxConstituents = Math.Clamp(maxConstituents, 1, 100);
+        minConsensus = Math.Clamp(minConsensus, 1, topFunds);
+
+        var result = await _smartMoneyIndexManager.Build(
+            DateOnly.FromDateTime(DateTime.UtcNow),
+            topFunds,
+            maxConstituents,
+            minConsensus,
+            ScoreWindowYears,
+            ScoreBenchmark
+        );
+
+        return View(result);
     }
 
     // JSON typeahead endpoint backing the institution picker (overlap/compare/combined

--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -73,6 +73,9 @@ public partial class Program
 
         builder.Services.AutoWireServicesFrom<Equibles.Errors.BusinessLogic.ErrorManager>();
         builder.Services.AutoWireServicesFrom<Equibles.Web.Services.StockTabService>();
+        // Holdings business-logic services the portal consumes directly (e.g. the smart-money
+        // index manager). Repositories these depend on are registered by AddAllRepositories.
+        builder.Services.AutoWireServicesFrom<Equibles.Holdings.BusinessLogic.SmartMoneyIndexManager>();
 
         var authSettings =
             builder.Configuration.GetSection("Auth").Get<AuthSettings>() ?? new AuthSettings();

--- a/src/Equibles.Web/Views/Institutions/SmartMoneyIndex.cshtml
+++ b/src/Equibles.Web/Views/Institutions/SmartMoneyIndex.cshtml
@@ -1,0 +1,188 @@
+@model Equibles.Holdings.BusinessLogic.Models.SmartMoneyIndexResult
+
+@{
+    ViewData["Title"] = "Smart Money Index";
+    var hasConstituents = Model.Constituents.Count > 0;
+    var hasPoints = Model.Backtest.Points.Count > 0;
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <div class="mb-6">
+        <h1 class="text-3xl font-bold mb-1" data-testid="smart-money-heading">Smart Money Index</h1>
+        <p class="text-base-content/60 text-sm">
+            An equal-weighted basket of the highest-conviction common holdings among the top funds ranked by 3-year alpha vs @Model.BenchmarkTicker. Each fund's latest 13F portfolio votes; stocks held by enough of them are kept, ranked by consensus then average position weight. Performance is tracked forward from the construction date (45 days after the freshest filing) so the simulation never peeks at holdings before they were public.
+        </p>
+    </div>
+
+    <!-- Construction parameters — submitted via GET so the URL captures the chosen basket. -->
+    <div class="card bg-base-100 shadow-sm mb-6" data-testid="smart-money-filters">
+        <div class="card-body p-4">
+            <form method="get" class="grid grid-cols-1 md:grid-cols-4 gap-3">
+                <fieldset class="fieldset">
+                    <legend class="fieldset-legend">Top funds</legend>
+                    <input type="number" name="topFunds" min="1" max="100" value="@Model.RequestedTopFunds" class="input input-bordered w-full" />
+                </fieldset>
+                <fieldset class="fieldset">
+                    <legend class="fieldset-legend">Max holdings</legend>
+                    <input type="number" name="maxConstituents" min="1" max="100" value="@Model.MaxConstituents" class="input input-bordered w-full" />
+                </fieldset>
+                <fieldset class="fieldset">
+                    <legend class="fieldset-legend">Min funds holding</legend>
+                    <input type="number" name="minConsensus" min="1" max="100" value="@Model.MinConsensus" class="input input-bordered w-full" />
+                </fieldset>
+                <div class="flex items-end">
+                    <button type="submit" class="btn btn-primary w-full">Rebuild</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    @if (!hasConstituents) {
+        <div class="alert alert-warning mb-6" data-testid="smart-money-reason">
+            <span>@(Model.Reason ?? "The index could not be built.")</span>
+        </div>
+    } else {
+        <!-- Index meta line: how many funds fed the basket and which quarter it reflects. -->
+        <p class="text-sm text-base-content/60 mb-4" data-testid="smart-money-meta">
+            @Model.Constituents.Count holdings · drawn from the top @Model.FundCount funds@(Model.ConstructionDate.HasValue ? " · " + Model.ConstructionDate.Value.ToString("yyyy-MM-dd") + " portfolios" : "") · tracked vs @Model.BenchmarkTicker
+        </p>
+
+        @if (hasPoints) {
+            <!-- Summary cards: index vs benchmark, identical layout for visual comparison. -->
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+                @{
+                    var rows = new[] {
+                        new { Label = "Smart Money Index", Summary = Model.Backtest.PortfolioSummary, TestId = "smart-money-index-summary" },
+                        new { Label = "Benchmark (" + Model.BenchmarkTicker + ")", Summary = Model.Backtest.BenchmarkSummary, TestId = "smart-money-benchmark-summary" },
+                    };
+                }
+                @foreach (var row in rows) {
+                    <div class="card bg-base-100 shadow-sm" data-testid="@row.TestId">
+                        <div class="card-body p-4">
+                            <h2 class="text-base font-medium mb-2">@row.Label</h2>
+                            <div class="stats stats-vertical sm:stats-horizontal shadow-sm bg-base-200 w-full">
+                                <stat-tile title="Total return">@row.Summary.TotalReturnPercent.ToString("F2")%</stat-tile>
+                                <stat-tile title="CAGR">@row.Summary.CagrPercent.ToString("F2")%</stat-tile>
+                                <stat-tile title="Max drawdown">@row.Summary.MaxDrawdownPercent.ToString("F2")%</stat-tile>
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+
+            <!-- Cumulative-return chart — index vs benchmark, both normalized to 100 at the
+                 construction date. Values at 100 mean "broke even with the start", 200 = doubled. -->
+            <div class="card bg-base-100 shadow-sm mb-6" data-testid="smart-money-chart-card">
+                <div class="card-body p-4">
+                    <div class="flex items-baseline justify-between mb-3">
+                        <h2 class="text-base font-medium m-0">Cumulative return (=100)</h2>
+                        <span class="text-xs text-base-content/60">@Model.Backtest.StartDate.ToString("yyyy-MM-dd") → @Model.Backtest.EndDate.ToString("yyyy-MM-dd") · @Model.Backtest.Points.Count.ToString("N0") days</span>
+                    </div>
+                    <div class="h-[360px]">
+                        <canvas id="smart-money-chart" data-testid="smart-money-chart" role="img" aria-label="Smart money index cumulative return"></canvas>
+                    </div>
+                </div>
+            </div>
+        } else if (!string.IsNullOrWhiteSpace(Model.Backtest.Reason)) {
+            <div class="alert alert-info mb-6" data-testid="smart-money-backtest-reason">
+                <span>Performance can't be tracked yet: @Model.Backtest.Reason</span>
+            </div>
+        }
+
+        <!-- Constituents: one row per selected stock, ordered as the index weights them. -->
+        <div class="card bg-base-100 shadow-sm" data-testid="smart-money-constituents-card">
+            <div class="card-body p-4">
+                <h2 class="text-base font-medium mb-3">Constituents</h2>
+                <div class="overflow-x-auto">
+                    <table class="table table-sm" data-testid="smart-money-constituents">
+                        <thead>
+                            <tr>
+                                <th>Ticker</th>
+                                <th>Name</th>
+                                <th class="text-right">Held by</th>
+                                <th class="text-right">Avg position weight</th>
+                                <th class="text-right">Index weight</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var constituent in Model.Constituents) {
+                                <tr>
+                                    <td class="font-mono font-medium">@constituent.Ticker</td>
+                                    <td class="text-base-content/70">@constituent.Name</td>
+                                    <td class="text-right">@constituent.HeldByCount / @Model.FundCount</td>
+                                    <td class="text-right">@constituent.AverageWeightPercent.ToString("F1")%</td>
+                                    <td class="text-right">@constituent.IndexWeightPercent.ToString("F2")%</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    }
+</div>
+
+@if (hasPoints) {
+    @section Scripts {
+        <partial name="_ChartJs" />
+        <script>
+        // Render the smart-money index vs benchmark cumulative-return line chart.
+        document.addEventListener('DOMContentLoaded', function () {
+            const ctx = document.getElementById('smart-money-chart');
+            if (!ctx || typeof Chart === 'undefined') return;
+
+            const labels = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(Model.Backtest.Points.Select(p => p.Date.ToString("yyyy-MM-dd")).ToList()));
+            const index = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(Model.Backtest.Points.Select(p => p.PortfolioValue).ToList()));
+            const benchmark = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(Model.Backtest.Points.Select(p => p.BenchmarkValue).ToList()));
+            const benchmarkLabel = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(Model.BenchmarkTicker));
+
+            new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels,
+                    datasets: [
+                        {
+                            label: 'Smart Money Index',
+                            data: index,
+                            borderColor: 'oklch(55% 0.18 250)',
+                            backgroundColor: 'oklch(55% 0.18 250 / 0.08)',
+                            fill: true,
+                            tension: 0.2,
+                            pointRadius: 0,
+                            pointHitRadius: 6,
+                            borderWidth: 2,
+                        },
+                        {
+                            label: 'Benchmark · ' + benchmarkLabel,
+                            data: benchmark,
+                            borderColor: 'oklch(60% 0.15 30)',
+                            borderWidth: 1.5,
+                            borderDash: [4, 2],
+                            pointRadius: 0,
+                            fill: false,
+                            tension: 0.2,
+                        },
+                    ],
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: { mode: 'index', intersect: false },
+                    scales: {
+                        x: { ticks: { maxTicksLimit: 12, font: { size: 10 } } },
+                        y: { ticks: { callback: v => Number(v).toFixed(0) } },
+                    },
+                    plugins: {
+                        legend: { position: 'top', labels: { boxWidth: 12, font: { size: 11 } } },
+                        tooltip: {
+                            callbacks: {
+                                label: ctx => ctx.dataset.label + ': ' + Number(ctx.raw).toFixed(2),
+                            },
+                        },
+                    },
+                },
+            });
+        });
+        </script>
+    }
+}

--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -48,6 +48,7 @@
                             <li><a asp-action="DoubleDown" asp-controller="HoldingsActivity">Double-Down Report</a></li>
                             <li><a asp-action="HeatMap" asp-controller="HoldingsActivity">Conviction Heat Map</a></li>
                             <li><a asp-action="OverlapMatrix" asp-controller="Profiles">Overlap Matrix</a></li>
+                            <li><a asp-action="SmartMoneyIndex" asp-controller="Institutions">Smart Money Index</a></li>
                             <li><a asp-action="Dashboard" asp-controller="InsiderActivity">Insider Trading</a></li>
                             <li><a asp-action="Index" asp-controller="EconomicData">Economic Data</a></li>
                             <li><a asp-action="Index" asp-controller="Cftc">Futures</a></li>
@@ -151,6 +152,11 @@
                         <li>
                             <a asp-action="OverlapMatrix" asp-controller="Profiles">
                                 <icon name="table-cells" size="4" /> Overlap Matrix
+                            </a>
+                        </li>
+                        <li>
+                            <a asp-action="SmartMoneyIndex" asp-controller="Institutions">
+                                <icon name="sparkles" size="4" /> Smart Money Index
                             </a>
                         </li>
                         <li>

--- a/tests/Equibles.IntegrationTests/Web/SmartMoneyIndexViewTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/SmartMoneyIndexViewTests.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Yahoo.Data.Models;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the smart-money index page: the consensus basket of the top-scoring funds' common
+/// holdings renders, below-threshold stocks are excluded, and the performance chart is drawn.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class SmartMoneyIndexViewTests
+{
+    private static readonly DateOnly Quarter = new(2024, 12, 31);
+
+    private readonly WebHostFixture _fixture;
+
+    public SmartMoneyIndexViewTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetSmartMoneyIndex_WithConsensusHoldings_RendersBasketAndTracksPerformance()
+    {
+        var spyId = Guid.NewGuid();
+        var consensusAId = Guid.NewGuid();
+        var consensusBId = Guid.NewGuid();
+        var soloId = Guid.NewGuid();
+        var funds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(MakeStock(spyId, "SPY", "S&P 500 ETF"));
+            db.Add(MakeStock(consensusAId, "WIDE", "Wide Consensus Co"));
+            db.Add(MakeStock(consensusBId, "BOTH", "Both Funds Co"));
+            db.Add(MakeStock(soloId, "SOLO", "Lonely Holding Co"));
+
+            // Benchmark flat; the two consensus names appreciate so the index posts a return.
+            AddPrice(db, spyId, 100m, 100m);
+            AddPrice(db, consensusAId, 100m, 150m);
+            AddPrice(db, consensusBId, 100m, 120m);
+            AddPrice(db, soloId, 100m, 100m);
+
+            decimal alpha = 30m;
+            foreach (var fundId in funds)
+            {
+                db.Add(
+                    new InstitutionalHolder
+                    {
+                        Id = fundId,
+                        Cik = $"000{fundId.ToString("N")[..4]}",
+                        Name = $"Top Fund {fundId:N}".Substring(0, 16),
+                    }
+                );
+                // Every top fund holds the two consensus names.
+                db.Add(MakeHolding(consensusAId, fundId));
+                db.Add(MakeHolding(consensusBId, fundId));
+                db.Add(MakeScore(fundId, alpha));
+                alpha -= 10m;
+            }
+
+            // SOLO is held by only one fund — below the default consensus threshold.
+            db.Add(MakeHolding(soloId, funds[0]));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions/smart-money-index");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+
+        html.Should().Contain("Smart Money Index");
+        html.Should().Contain("smart-money-constituents");
+        html.Should().Contain("WIDE");
+        html.Should().Contain("BOTH");
+        // SOLO is held by a single fund and must not make the basket.
+        html.Should().NotContain("SOLO");
+        // The basket appreciated against a flat benchmark — the index summary card renders.
+        html.Should().Contain("smart-money-index-summary");
+        html.Should().Contain("smart-money-chart");
+    }
+
+    [Fact]
+    public async Task GetSmartMoneyIndex_NoScoredFunds_RendersReasonWithoutError()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(MakeStock(Guid.NewGuid(), "SPY", "S&P 500 ETF"));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions/smart-money-index");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("smart-money-reason");
+        html.Should().Contain("No fund scores");
+    }
+
+    private static CommonStock MakeStock(Guid id, string ticker, string name) =>
+        new()
+        {
+            Id = id,
+            Ticker = ticker,
+            Name = name,
+            Cik = $"C{id.ToString("N")[..9]}",
+        };
+
+    private static void AddPrice(
+        Equibles.Data.EquiblesFinancialDbContext db,
+        Guid stockId,
+        decimal early,
+        decimal late
+    )
+    {
+        // The early close must land inside the backtest's price window (rebalance − 14 days) and
+        // on or before the rebalance date so day-zero forward-fills to it. The basket reflects the
+        // 2024-12-31 quarter, so rebalance is 2025-02-14.
+        db.Add(MakePrice(stockId, new DateOnly(2025, 2, 10), early));
+        db.Add(MakePrice(stockId, new DateOnly(2026, 5, 1), late));
+    }
+
+    private static DailyStockPrice MakePrice(Guid stockId, DateOnly date, decimal close) =>
+        new()
+        {
+            CommonStockId = stockId,
+            Date = date,
+            Open = close,
+            High = close,
+            Low = close,
+            Close = close,
+            AdjustedClose = close,
+        };
+
+    private static InstitutionalHolding MakeHolding(Guid stockId, Guid holderId) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = Quarter,
+            FilingDate = Quarter.AddDays(45),
+            Shares = 1_000,
+            Value = 1_000_000,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber =
+                $"acc-{holderId:N}".Substring(0, 12) + $"-{stockId:N}".Substring(0, 8),
+        };
+
+    private static FundScore MakeScore(Guid holderId, decimal alpha) =>
+        new()
+        {
+            InstitutionalHolderId = holderId,
+            BenchmarkTicker = "SPY",
+            WindowYears = 3,
+            WindowStart = new DateOnly(2021, 12, 31),
+            WindowEnd = new DateOnly(2024, 12, 31),
+            PortfolioCagrPercent = alpha + 8m,
+            BenchmarkCagrPercent = 8m,
+            PortfolioTotalReturnPercent = (alpha + 8m) * 3m,
+            BenchmarkTotalReturnPercent = 24m,
+            AlphaPercent = alpha,
+            MaxDrawdownPercent = 15m,
+        };
+}


### PR DESCRIPTION
## Summary

- Slice 2 of 2 for #1863 — this PR closes the issue (Closes #1863).
- Adds a Smart Money Index page to the public portal: the equal-weighted basket of the top-scoring funds' highest-conviction common holdings (built by the domain layer from slice 1), with its forward performance tracked against the benchmark.
- The page exposes a tunable construction form, a constituents table, summary stats, and a cumulative-return chart — mirroring the existing institution backtest page.

## Code changes

- `src/Equibles.Web/Controllers/InstitutionsController.cs` — new `SmartMoneyIndex` action at `~/institutions/smart-money-index`; clamps the construction query params (top funds, max holdings, min funds holding) so hand-edited URLs stay in range, and builds the index via the manager.
- `src/Equibles.Web/Views/Institutions/SmartMoneyIndex.cshtml` — the page: construction form, index-vs-benchmark summary cards, cumulative-return chart, and a constituents table showing each stock's consensus count, average position weight, and equal index weight. Renders a clear reason when no basket can be built.
- `src/Equibles.Web/Program.cs` — registers the Holdings business-logic services in the web host so the portal can resolve the index manager.
- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — links the new page from the desktop "More" menu and the mobile navigation.
- `tests/Equibles.IntegrationTests/Web/SmartMoneyIndexViewTests.cs` — drives routing → controller → Razor: the consensus basket renders with the performance chart and excludes below-threshold stocks, and the no-scored-funds state renders its reason without erroring.