### PR TITLE
feat(insider-trading): add Form 144 proposed-sale data model

### DIFF
--- a/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
+++ b/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
@@ -8,6 +8,8 @@ public class InsiderTradingModuleConfiguration : Equibles.Data.IFinancialModule
     public void ConfigureEntities(ModelBuilder builder)
     {
         builder.Entity<InsiderOwner>();
+        builder.Entity<Form144Filing>();
+        builder.Entity<Form144PriorSale>();
         builder.Entity<InsiderTransaction>(entity =>
         {
             // SQL DEFAULT true so the column add doesn't backfill existing

--- a/src/Equibles.InsiderTrading.Data/Models/Form144Filing.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/Form144Filing.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel.DataAnnotations;
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.InsiderTrading.Data.Models;
+
+/// <summary>
+/// A SEC Form 144 notice — an affiliate's declaration of intent to sell restricted or
+/// control securities. Filed under the issuer's submissions feed, so each notice is
+/// attributed to the issuer's <see cref="CommonStock"/>. Unlike a Form 4, this records a
+/// <em>proposed</em> sale (shares, aggregate market value, approximate sale date), not an
+/// executed transaction.
+/// </summary>
+[Index(nameof(CommonStockId), nameof(FilingDate))]
+[Index(nameof(AccessionNumber), IsUnique = true)]
+[Index(nameof(FilingDate))]
+public class Form144Filing
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    [MaxLength(32)]
+    public string AccessionNumber { get; set; }
+
+    public DateOnly FilingDate { get; set; }
+
+    /// <summary>
+    /// Person for whose account the securities are to be sold (the affiliate). Form 144 XML
+    /// carries the seller's name but not a CIK, so this is stored as free text rather than
+    /// resolved to an <see cref="InsiderOwner"/>.
+    /// </summary>
+    [MaxLength(512)]
+    public string SellerName { get; set; }
+
+    /// <summary>
+    /// The seller's relationship(s) to the issuer (e.g. "Director", "Officer"). A filing can
+    /// list several — joined with ", ".
+    /// </summary>
+    [MaxLength(256)]
+    public string RelationshipToIssuer { get; set; }
+
+    [MaxLength(128)]
+    public string SecurityClassTitle { get; set; }
+
+    [MaxLength(256)]
+    public string BrokerName { get; set; }
+
+    public long SharesToBeSold { get; set; }
+
+    public decimal AggregateMarketValue { get; set; }
+
+    public long SharesOutstanding { get; set; }
+
+    public DateOnly? ApproxSaleDate { get; set; }
+
+    [MaxLength(64)]
+    public string SecuritiesExchangeName { get; set; }
+
+    [MaxLength(2048)]
+    public string Remarks { get; set; }
+
+    public virtual List<Form144PriorSale> PriorSales { get; set; } = [];
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.InsiderTrading.Data/Models/Form144PriorSale.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/Form144PriorSale.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.InsiderTrading.Data.Models;
+
+/// <summary>
+/// A sale of the issuer's securities by the same seller during the three months preceding a
+/// <see cref="Form144Filing"/>. Form 144 requires these to be disclosed alongside the proposed
+/// sale, and they are the key signal for how much the affiliate has already sold recently.
+/// </summary>
+[Index(nameof(Form144FilingId))]
+public class Form144PriorSale
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid Form144FilingId { get; set; }
+    public virtual Form144Filing Form144Filing { get; set; }
+
+    [MaxLength(512)]
+    public string SellerName { get; set; }
+
+    [MaxLength(128)]
+    public string SecurityClassTitle { get; set; }
+
+    public DateOnly? SaleDate { get; set; }
+
+    public long AmountSold { get; set; }
+
+    public decimal GrossProceeds { get; set; }
+}

--- a/src/Equibles.InsiderTrading.Repositories/Form144FilingRepository.cs
+++ b/src/Equibles.InsiderTrading.Repositories/Form144FilingRepository.cs
@@ -1,0 +1,26 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.InsiderTrading.Repositories;
+
+public class Form144FilingRepository : BaseRepository<Form144Filing>
+{
+    public Form144FilingRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<Form144Filing> GetByStock(CommonStock stock)
+    {
+        return GetAll().Where(f => f.CommonStockId == stock.Id);
+    }
+
+    public IQueryable<Form144Filing> GetByAccessionNumber(string accessionNumber)
+    {
+        return GetAll().Where(f => f.AccessionNumber == accessionNumber);
+    }
+
+    public IQueryable<Form144Filing> GetRecent(DateOnly since)
+    {
+        return GetAll().Where(f => f.FilingDate >= since);
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260530063219_AddForm144.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260530063219_AddForm144.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530063219_AddForm144")]
+    partial class AddForm144
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260530063219_AddForm144.cs
+++ b/src/Equibles.Migrations/Migrations/20260530063219_AddForm144.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddForm144 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Form144Filing",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccessionNumber = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    FilingDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    SellerName = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    RelationshipToIssuer = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: true
+                    ),
+                    SecurityClassTitle = table.Column<string>(
+                        type: "character varying(128)",
+                        maxLength: 128,
+                        nullable: true
+                    ),
+                    BrokerName = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: true
+                    ),
+                    SharesToBeSold = table.Column<long>(type: "bigint", nullable: false),
+                    AggregateMarketValue = table.Column<decimal>(type: "numeric", nullable: false),
+                    SharesOutstanding = table.Column<long>(type: "bigint", nullable: false),
+                    ApproxSaleDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    SecuritiesExchangeName = table.Column<string>(
+                        type: "character varying(64)",
+                        maxLength: 64,
+                        nullable: true
+                    ),
+                    Remarks = table.Column<string>(
+                        type: "character varying(2048)",
+                        maxLength: 2048,
+                        nullable: true
+                    ),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Form144Filing", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Form144Filing_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "Form144PriorSale",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Form144FilingId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SellerName = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    SecurityClassTitle = table.Column<string>(
+                        type: "character varying(128)",
+                        maxLength: 128,
+                        nullable: true
+                    ),
+                    SaleDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    AmountSold = table.Column<long>(type: "bigint", nullable: false),
+                    GrossProceeds = table.Column<decimal>(type: "numeric", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Form144PriorSale", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Form144PriorSale_Form144Filing_Form144FilingId",
+                        column: x => x.Form144FilingId,
+                        principalTable: "Form144Filing",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Form144Filing_AccessionNumber",
+                table: "Form144Filing",
+                column: "AccessionNumber",
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Form144Filing_CommonStockId_FilingDate",
+                table: "Form144Filing",
+                columns: new[] { "CommonStockId", "FilingDate" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Form144Filing_FilingDate",
+                table: "Form144Filing",
+                column: "FilingDate"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Form144PriorSale_Form144FilingId",
+                table: "Form144PriorSale",
+                column: "Form144FilingId"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "Form144PriorSale");
+
+            migrationBuilder.DropTable(name: "Form144Filing");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/InsiderTrading/Form144FilingRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/Form144FilingRepositoryTests.cs
@@ -1,0 +1,164 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.InsiderTrading;
+
+public class Form144FilingRepositoryTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly Form144FilingRepository _repository;
+
+    public Form144FilingRepositoryTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new InsiderTradingModuleConfiguration()
+        );
+        _repository = new Form144FilingRepository(_dbContext);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    private static CommonStock CreateStock(string ticker = "AAPL", string cik = "0000320193")
+    {
+        return new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = ticker,
+            Cik = cik,
+        };
+    }
+
+    private static Form144Filing CreateFiling(
+        Guid commonStockId,
+        string accessionNumber = "0001921094-26-000555",
+        DateOnly? filingDate = null,
+        string sellerName = "LEVINSON ARTHUR D"
+    )
+    {
+        return new Form144Filing
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = commonStockId,
+            AccessionNumber = accessionNumber,
+            FilingDate = filingDate ?? new DateOnly(2026, 5, 27),
+            SellerName = sellerName,
+            RelationshipToIssuer = "Director",
+            SecurityClassTitle = "Common",
+            BrokerName = "Charles Schwab & Co., Inc.",
+            SharesToBeSold = 50000,
+            AggregateMarketValue = 15551085.00m,
+            SharesOutstanding = 14687356000,
+            ApproxSaleDate = new DateOnly(2026, 5, 27),
+            SecuritiesExchangeName = "NASDAQ",
+        };
+    }
+
+    [Fact]
+    public async Task GetByStock_ReturnsOnlyFilingsForThatStock()
+    {
+        var apple = CreateStock("AAPL", "0000320193");
+        var microsoft = CreateStock("MSFT", "0000789019");
+        _dbContext.Set<CommonStock>().AddRange(apple, microsoft);
+        await _dbContext.SaveChangesAsync();
+
+        _repository.Add(CreateFiling(apple.Id, "0001921094-26-000555"));
+        _repository.Add(CreateFiling(apple.Id, "0001921094-26-000446"));
+        _repository.Add(CreateFiling(microsoft.Id, "0001950047-26-004044"));
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetByStock(apple).ToListAsync();
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(f => f.CommonStockId == apple.Id);
+    }
+
+    [Fact]
+    public async Task GetByAccessionNumber_ExistingAccession_ReturnsFiling()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+        _repository.Add(CreateFiling(stock.Id, "0001921094-26-000555"));
+        await _repository.SaveChanges();
+
+        var result = await _repository
+            .GetByAccessionNumber("0001921094-26-000555")
+            .FirstOrDefaultAsync();
+
+        result.Should().NotBeNull();
+        result.SellerName.Should().Be("LEVINSON ARTHUR D");
+    }
+
+    [Fact]
+    public async Task GetByAccessionNumber_NonExistentAccession_ReturnsEmpty()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+        _repository.Add(CreateFiling(stock.Id, "0001921094-26-000555"));
+        await _repository.SaveChanges();
+
+        var any = await _repository.GetByAccessionNumber("9999999999-99-999999").AnyAsync();
+
+        any.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetRecent_ReturnsOnlyFilingsOnOrAfterCutoff()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        _repository.Add(CreateFiling(stock.Id, "old", filingDate: new DateOnly(2026, 1, 1)));
+        _repository.Add(CreateFiling(stock.Id, "new", filingDate: new DateOnly(2026, 5, 27)));
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetRecent(new DateOnly(2026, 5, 1)).ToListAsync();
+
+        result.Should().ContainSingle();
+        result[0].AccessionNumber.Should().Be("new");
+    }
+
+    [Fact]
+    public async Task Add_FilingWithPriorSales_PersistsChildRows()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var filing = CreateFiling(stock.Id);
+        filing.PriorSales.Add(
+            new Form144PriorSale
+            {
+                SellerName = "ARTHUR D LEVINSON",
+                SecurityClassTitle = "Common",
+                SaleDate = new DateOnly(2026, 5, 6),
+                AmountSold = 250000,
+                GrossProceeds = 71190164.00m,
+            }
+        );
+        _repository.Add(filing);
+        await _repository.SaveChanges();
+
+        var loaded = await _repository
+            .GetByAccessionNumber(filing.AccessionNumber)
+            .Include(f => f.PriorSales)
+            .FirstAsync();
+
+        loaded.PriorSales.Should().ContainSingle();
+        loaded.PriorSales[0].AmountSold.Should().Be(250000);
+        loaded.PriorSales[0].GrossProceeds.Should().Be(71190164.00m);
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 1 of 4 toward Form 144 proposed-sale support (Refs #1865). Adds the data foundation only — no scraping or UI yet.
- Form 144 notices appear in the issuer's EDGAR submissions feed, so each notice is attributed to the issuer's stock (no separate filer entity).

## Code changes

- `src/Equibles.InsiderTrading.Data/Models/Form144Filing.cs` — new entity: issuer link, seller name, relationship, broker, shares to be sold, aggregate market value, shares outstanding, approximate sale date, exchange, remarks, accession (unique).
- `src/Equibles.InsiderTrading.Data/Models/Form144PriorSale.cs` — child entity for the seller's sales in the prior three months (date, amount, gross proceeds).
- `src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs` — register the two entities.
- `src/Equibles.InsiderTrading.Repositories/Form144FilingRepository.cs` — queries by stock, accession number, and recency.
- `src/Equibles.Migrations/Migrations/*_AddForm144.cs` — creates the two tables with indexes and cascade-delete FK.
- `tests/Equibles.IntegrationTests/InsiderTrading/Form144FilingRepositoryTests.cs` — covers the repository queries and prior-sale child persistence.