### PR TITLE
feat(sec): parse Form 144 proposed-sale filings in the worker

### DIFF
--- a/src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs
+++ b/src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs
@@ -36,4 +36,7 @@ public enum DocumentTypeFilter
 
     [Display(Name = "3")]
     FormThree,
+
+    [Display(Name = "144")]
+    Form144,
 }

--- a/src/Equibles.Sec.Data/Models/DocumentType.cs
+++ b/src/Equibles.Sec.Data/Models/DocumentType.cs
@@ -26,6 +26,7 @@ public sealed class DocumentType
     public static readonly DocumentType FortyF = new("FortyF", "40-F");
     public static readonly DocumentType FormFour = new("FormFour", "4");
     public static readonly DocumentType FormThree = new("FormThree", "3");
+    public static readonly DocumentType Form144 = new("Form144", "144");
     public static readonly DocumentType Other = new("Other", "Other");
 
     private static readonly ConcurrentDictionary<string, DocumentType> AllByValue = new(
@@ -42,6 +43,7 @@ public sealed class DocumentType
             new KeyValuePair<string, DocumentType>(FortyF.Value, FortyF),
             new KeyValuePair<string, DocumentType>(FormFour.Value, FormFour),
             new KeyValuePair<string, DocumentType>(FormThree.Value, FormThree),
+            new KeyValuePair<string, DocumentType>(Form144.Value, Form144),
             new KeyValuePair<string, DocumentType>(Other.Value, Other),
         },
         StringComparer.OrdinalIgnoreCase
@@ -61,6 +63,7 @@ public sealed class DocumentType
             new KeyValuePair<string, DocumentType>(FortyF.DisplayName, FortyF),
             new KeyValuePair<string, DocumentType>(FormFour.DisplayName, FormFour),
             new KeyValuePair<string, DocumentType>(FormThree.DisplayName, FormThree),
+            new KeyValuePair<string, DocumentType>(Form144.DisplayName, Form144),
             new KeyValuePair<string, DocumentType>(Other.DisplayName, Other),
         },
         StringComparer.OrdinalIgnoreCase

--- a/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
@@ -11,5 +11,6 @@ public class DocumentScraperOptions
         DocumentType.EightK,
         DocumentType.FormFour,
         DocumentType.FormThree,
+        DocumentType.Form144,
     ];
 }

--- a/src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs
@@ -19,6 +19,7 @@ public static class DocumentTypeExtensions
             { DocumentType.FortyF, DocumentTypeFilter.FortyF },
             { DocumentType.FormFour, DocumentTypeFilter.FormFour },
             { DocumentType.FormThree, DocumentTypeFilter.FormThree },
+            { DocumentType.Form144, DocumentTypeFilter.Form144 },
         };
 
     public static DocumentTypeFilter? ToSecEdgarFilter(this DocumentType docType)

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ public static class ServiceCollectionExtensions
         services.AutoWireServicesFrom<Equibles.Integrations.Sec.SecEdgarClient>();
 
         services.AddScoped<IFilingProcessor, InsiderTradingFilingProcessor>();
+        services.AddScoped<IFilingProcessor, Form144FilingProcessor>();
         services.AddScoped<IDocumentPersistenceService, DocumentPersistenceService>();
         services.AddScoped<ICompanySyncService, CompanySyncService>();
         services.AddScoped<IDocumentScraper, DocumentScraper>();

--- a/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
@@ -1,0 +1,282 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Contracts;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Processes SEC Form 144 filings — an affiliate's notice of intent to sell restricted or
+/// control securities — into structured <see cref="Form144Filing"/> records (plus the prior
+/// three months of sales). Form 144 appears in the issuer's submissions feed, so each notice
+/// is attributed to the issuer's stock. The XML uses the same <c>edgar/ownership</c> namespace
+/// as Forms 3/4/5 but a different root (<c>edgarSubmission</c>) and flat (unwrapped) values.
+/// </summary>
+public class Form144FilingProcessor : IFilingProcessor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<Form144FilingProcessor> _logger;
+    private readonly ErrorReporter _errorReporter;
+
+    private static readonly string[] DateFormats = ["MM/dd/yyyy", "M/d/yyyy"];
+
+    public Form144FilingProcessor(
+        IServiceScopeFactory scopeFactory,
+        ILogger<Form144FilingProcessor> logger,
+        ErrorReporter errorReporter
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _errorReporter = errorReporter;
+    }
+
+    public bool CanProcess(DocumentType documentType)
+    {
+        return documentType == DocumentType.Form144;
+    }
+
+    public async Task<bool> Process(FilingData filing, CommonStock companyOutContext)
+    {
+        // Capture IDs from the outer-scope entity to avoid leaking untracked entities into inner scope.
+        var companyId = companyOutContext.Id;
+        var companyTicker = companyOutContext.Ticker;
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var secEdgarClient = scope.ServiceProvider.GetRequiredService<ISecEdgarClient>();
+        var repository = scope.ServiceProvider.GetRequiredService<Form144FilingRepository>();
+
+        var existing = await repository.GetByAccessionNumber(filing.AccessionNumber).AnyAsync();
+        if (existing)
+            return false;
+
+        var content = await secEdgarClient.GetDocumentContent(filing);
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            _logger.LogWarning(
+                "Empty content for {Ticker} Form 144 - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return false;
+        }
+
+        var root = await TryParseSubmission(content, filing, companyTicker);
+        if (root == null)
+            return false;
+
+        var entity = ParseFiling(root, companyId, filing);
+        if (entity == null)
+        {
+            _logger.LogWarning(
+                "Form 144 XML missing formData for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return false;
+        }
+
+        repository.Add(entity);
+        await repository.SaveChanges();
+
+        _logger.LogInformation(
+            "Imported Form 144 for {Ticker} ({Shares} shares, {Prior} prior sales) from {AccessionNumber}",
+            companyTicker,
+            entity.SharesToBeSold,
+            entity.PriorSales.Count,
+            filing.AccessionNumber
+        );
+
+        return true;
+    }
+
+    private async Task<XElement> TryParseSubmission(
+        string content,
+        FilingData filing,
+        string companyTicker
+    )
+    {
+        var sanitized = SanitizeXml(content);
+
+        // Form 144 has only been filed as XML since the SEC's April 2022 e-filing mandate,
+        // so a submission without the <edgarSubmission> root is unexpected — skip quietly.
+        if (!sanitized.Contains("<edgarSubmission", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug(
+                "Skipping non-XML Form 144 filing for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return null;
+        }
+
+        try
+        {
+            return XDocument.Parse(sanitized).Root;
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Malformed Form 144 XML for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            await _errorReporter.Report(
+                ErrorSource.DocumentScraper,
+                "Form144.ParseXml",
+                ex.Message,
+                ex.StackTrace,
+                $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
+            );
+            return null;
+        }
+    }
+
+    private static Form144Filing ParseFiling(XElement root, Guid companyId, FilingData filing)
+    {
+        var formData = El(root, "formData");
+        if (formData == null)
+            return null;
+
+        var issuerInfo = El(formData, "issuerInfo");
+        var securities = El(formData, "securitiesInformation");
+
+        var relationships = El(issuerInfo, "relationshipsToIssuer");
+        var relationship = string.Join(
+            ", ",
+            Els(relationships, "relationshipToIssuer")
+                .Select(e => e.Value.Trim())
+                .Where(v => !string.IsNullOrEmpty(v))
+        );
+
+        var entity = new Form144Filing
+        {
+            CommonStockId = companyId,
+            AccessionNumber = filing.AccessionNumber,
+            FilingDate = filing.FilingDate,
+            SellerName = Val(issuerInfo, "nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold"),
+            RelationshipToIssuer = string.IsNullOrEmpty(relationship) ? null : relationship,
+            SecurityClassTitle = Val(securities, "securitiesClassTitle"),
+            BrokerName = Val(El(securities, "brokerOrMarketmakerDetails"), "name"),
+            SharesToBeSold = ParseLong(Val(securities, "noOfUnitsSold")),
+            AggregateMarketValue = ParseDecimal(Val(securities, "aggregateMarketValue")),
+            SharesOutstanding = ParseLong(Val(securities, "noOfUnitsOutstanding")),
+            ApproxSaleDate = ParseDate(Val(securities, "approxSaleDate")),
+            SecuritiesExchangeName = Val(securities, "securitiesExchangeName"),
+            Remarks = Val(formData, "remarks"),
+        };
+
+        foreach (var saleElement in Els(formData, "securitiesSoldInPast3Months"))
+        {
+            var priorSale = ParsePriorSale(saleElement);
+            if (priorSale != null)
+                entity.PriorSales.Add(priorSale);
+        }
+
+        return entity;
+    }
+
+    private static Form144PriorSale ParsePriorSale(XElement element)
+    {
+        var saleDate = ParseDate(Val(element, "saleDate"));
+        var amount = ParseLong(Val(element, "amountOfSecuritiesSold"));
+        var grossProceeds = ParseDecimal(Val(element, "grossProceeds"));
+
+        // When the filer reports nothing to disclose, the element can still be emitted as an
+        // empty shell — skip rows that carry no sale data so they don't pollute the table.
+        if (saleDate == null && amount == 0 && grossProceeds == 0)
+            return null;
+
+        return new Form144PriorSale
+        {
+            SellerName = Val(El(element, "sellerDetails"), "name"),
+            SecurityClassTitle = Val(element, "securitiesClassTitle"),
+            SaleDate = saleDate,
+            AmountSold = amount,
+            GrossProceeds = grossProceeds,
+        };
+    }
+
+    // ── XML helpers (namespace-agnostic: Form 144 declares a default xmlns) ──────────
+
+    private static XElement El(XElement parent, string name) =>
+        parent?.Elements().FirstOrDefault(e => e.Name.LocalName == name);
+
+    private static IEnumerable<XElement> Els(XElement parent, string name) =>
+        parent?.Elements().Where(e => e.Name.LocalName == name) ?? [];
+
+    private static string Val(XElement parent, string name)
+    {
+        var value = El(parent, name)?.Value?.Trim();
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    private const string XmlEnvelopeStart = "<XML>";
+    private const string XmlEnvelopeEnd = "</XML>";
+
+    internal static string SanitizeXml(string xml)
+    {
+        // SEC filings wrap the actual XML inside an SGML envelope (one .txt holds the whole
+        // submission); pull out the <XML>...</XML> body before parsing.
+        var xmlStart = xml.IndexOf(XmlEnvelopeStart, StringComparison.OrdinalIgnoreCase);
+        var xmlEnd = xml.IndexOf(XmlEnvelopeEnd, StringComparison.OrdinalIgnoreCase);
+        if (xmlStart >= 0 && xmlEnd > xmlStart)
+        {
+            xml = xml[(xmlStart + XmlEnvelopeStart.Length)..xmlEnd].Trim();
+        }
+
+        // Escape stray ampersands that aren't already part of an entity.
+        return Regex.Replace(xml, @"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)", "&amp;");
+    }
+
+    // Form 144 dates are US-format MM/dd/yyyy. Parse culture-independently so a non-Gregorian
+    // host culture doesn't silently drop every date.
+    internal static DateOnly? ParseDate(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        return DateOnly.TryParseExact(
+            value.Trim(),
+            DateFormats,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var parsed
+        )
+            ? parsed
+            : null;
+    }
+
+    internal static long ParseLong(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return 0;
+        if (long.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
+            return result;
+        var d = ParseDecimal(value);
+        return d > long.MaxValue || d < long.MinValue ? 0 : (long)d;
+    }
+
+    internal static decimal ParseDecimal(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return 0;
+        return decimal.TryParse(
+            value,
+            NumberStyles.Any,
+            CultureInfo.InvariantCulture,
+            out var result
+        )
+            ? result
+            : 0;
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/Form144FilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/Form144FilingProcessorTests.cs
@@ -1,0 +1,342 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class Form144FilingProcessorTests
+{
+    // ── CanProcess ──
+
+    [Fact]
+    public void CanProcess_Form144_ReturnsTrue()
+    {
+        var (processor, _, _) = CreateProcessorWithDeps();
+        processor.CanProcess(DocumentType.Form144).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("FormFour")]
+    [InlineData("FormThree")]
+    [InlineData("TenK")]
+    public void CanProcess_OtherTypes_ReturnsFalse(string value)
+    {
+        var (processor, _, _) = CreateProcessorWithDeps();
+        processor.CanProcess(DocumentType.FromValue(value)).Should().BeFalse();
+    }
+
+    // ── ParseDate ──
+
+    [Theory]
+    [InlineData("05/27/2026", 2026, 5, 27)]
+    [InlineData("8/1/2002", 2002, 8, 1)]
+    public void ParseDate_UsFormat_Parses(string input, int y, int m, int d)
+    {
+        Form144FilingProcessor.ParseDate(input).Should().Be(new DateOnly(y, m, d));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-date")]
+    [InlineData("2026-05-27")] // ISO is not the Form 144 wire format
+    public void ParseDate_InvalidOrEmpty_ReturnsNull(string input)
+    {
+        Form144FilingProcessor.ParseDate(input).Should().BeNull();
+    }
+
+    // ── ParseLong / ParseDecimal ──
+
+    [Fact]
+    public void ParseLong_DecimalString_TruncatesToLong()
+    {
+        Form144FilingProcessor.ParseLong("50000.00").Should().Be(50000);
+        Form144FilingProcessor.ParseLong("14687356000").Should().Be(14687356000);
+        Form144FilingProcessor.ParseLong("").Should().Be(0);
+    }
+
+    [Fact]
+    public void ParseDecimal_InvariantCulture_Parses()
+    {
+        Form144FilingProcessor.ParseDecimal("15551085.00").Should().Be(15551085.00m);
+        Form144FilingProcessor.ParseDecimal("bad").Should().Be(0);
+    }
+
+    // ── SanitizeXml ──
+
+    [Fact]
+    public void SanitizeXml_WithSgmlEnvelope_ExtractsInnerXml()
+    {
+        var result = Form144FilingProcessor.SanitizeXml(ValidForm144Submission);
+        result.Should().StartWith("<?xml").And.Contain("<edgarSubmission");
+        result.Should().NotContain("<SEC-DOCUMENT>");
+    }
+
+    // ── Process ──
+
+    [Fact]
+    public async Task Process_ValidForm144_InsertsFilingWithPriorSale()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(ValidForm144Submission);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().Include(f => f.PriorSales).SingleAsync();
+        filing.SellerName.Should().Be("LEVINSON ARTHUR D");
+        filing.RelationshipToIssuer.Should().Be("Director");
+        filing.SecurityClassTitle.Should().Be("Common");
+        filing.BrokerName.Should().Be("Charles Schwab & Co., Inc.");
+        filing.SharesToBeSold.Should().Be(50000);
+        filing.AggregateMarketValue.Should().Be(15551085.00m);
+        filing.SharesOutstanding.Should().Be(14687356000);
+        filing.ApproxSaleDate.Should().Be(new DateOnly(2026, 5, 27));
+        filing.SecuritiesExchangeName.Should().Be("NASDAQ");
+        filing.Remarks.Should().Contain("HOMEPLACE TRUST");
+
+        filing.PriorSales.Should().ContainSingle();
+        filing.PriorSales[0].AmountSold.Should().Be(250000);
+        filing.PriorSales[0].GrossProceeds.Should().Be(71190164.00m);
+        filing.PriorSales[0].SaleDate.Should().Be(new DateOnly(2026, 5, 6));
+    }
+
+    [Fact]
+    public async Task Process_MultipleRelationships_JoinsWithComma()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(MultiRelationshipSubmission);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().SingleAsync();
+        filing.RelationshipToIssuer.Should().Be("Director, Officer");
+    }
+
+    [Fact]
+    public async Task Process_NothingToReportPriorSales_StoresNoChildRows()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(NothingToReportSubmission);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().Include(f => f.PriorSales).SingleAsync();
+        filing.PriorSales.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Process_DuplicateAccession_IsNotInsertedTwice()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(ValidForm144Submission);
+        var filing = MakeFiling();
+
+        var first = await processor.Process(filing, MakeCompany());
+        var second = await processor.Process(filing, MakeCompany());
+
+        first.Should().BeTrue();
+        second.Should().BeFalse();
+        (await repo.GetAll().CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Process_EmptyContent_ReturnsFalse()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns("");
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeFalse();
+        (await repo.GetAll().AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Process_NonXmlContent_ReturnsFalse()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns("<SEC-DOCUMENT>legacy text</SEC-DOCUMENT>");
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeFalse();
+        (await repo.GetAll().AnyAsync()).Should().BeFalse();
+    }
+
+    // ── Helpers ──
+
+    private static (
+        Form144FilingProcessor processor,
+        Form144FilingRepository repo,
+        ISecEdgarClient secClient
+    ) CreateProcessorWithDeps()
+    {
+        var dbContext = TestDbContextFactory.Create(
+            new InsiderTradingModuleConfiguration(),
+            new CommonStocksModuleConfiguration(),
+            new ErrorsModuleConfiguration()
+        );
+
+        var repo = new Form144FilingRepository(dbContext);
+        var errorRepo = new ErrorRepository(dbContext);
+        var errorManager = new ErrorManager(errorRepo);
+        var secClient = Substitute.For<ISecEdgarClient>();
+
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(ISecEdgarClient), secClient),
+            (typeof(Form144FilingRepository), repo),
+            (typeof(ErrorManager), errorManager)
+        );
+
+        var errorReporter = new ErrorReporter(
+            scopeFactory,
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+        var processor = new Form144FilingProcessor(
+            scopeFactory,
+            Substitute.For<ILogger<Form144FilingProcessor>>(),
+            errorReporter
+        );
+
+        return (processor, repo, secClient);
+    }
+
+    private static FilingData MakeFiling(string accession = null)
+    {
+        accession ??= $"0001921094-26-{Guid.NewGuid().ToString("N")[..6]}";
+        return new FilingData
+        {
+            AccessionNumber = accession,
+            Form = "144",
+            FilingDate = new DateOnly(2026, 5, 27),
+            ReportDate = new DateOnly(2026, 5, 27),
+            Cik = "0000320193",
+        };
+    }
+
+    private static CommonStock MakeCompany()
+    {
+        return new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+    }
+
+    // A real Apple Form 144 submission (accession 0001921094-26-000555), trimmed to the
+    // SGML envelope plus the <XML> ownership body the processor reads.
+    private const string ValidForm144Submission = """
+        <SEC-DOCUMENT>0001921094-26-000555.txt : 20260527
+        <SEC-HEADER>...
+        <DOCUMENT>
+        <TYPE>144
+        <XML>
+        <?xml version="1.0" encoding="UTF-8"?><edgarSubmission xmlns="http://www.sec.gov/edgar/ownership" xmlns:com="http://www.sec.gov/edgar/common">
+          <headerData>
+            <submissionType>144</submissionType>
+          </headerData>
+          <formData>
+            <issuerInfo>
+              <issuerCik>0000320193</issuerCik>
+              <issuerName>Apple Inc.</issuerName>
+              <nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>LEVINSON ARTHUR D</nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>
+              <relationshipsToIssuer>
+                <relationshipToIssuer>Director</relationshipToIssuer>
+              </relationshipsToIssuer>
+            </issuerInfo>
+            <securitiesInformation>
+              <securitiesClassTitle>Common</securitiesClassTitle>
+              <brokerOrMarketmakerDetails>
+                <name>Charles Schwab &amp; Co., Inc.</name>
+              </brokerOrMarketmakerDetails>
+              <noOfUnitsSold>50000</noOfUnitsSold>
+              <aggregateMarketValue>15551085.00</aggregateMarketValue>
+              <noOfUnitsOutstanding>14687356000</noOfUnitsOutstanding>
+              <approxSaleDate>05/27/2026</approxSaleDate>
+              <securitiesExchangeName>NASDAQ</securitiesExchangeName>
+            </securitiesInformation>
+            <nothingToReportFlagOnSecuritiesSoldInPast3Months>N</nothingToReportFlagOnSecuritiesSoldInPast3Months>
+            <securitiesSoldInPast3Months>
+              <sellerDetails>
+                <name>ARTHUR D LEVINSON</name>
+              </sellerDetails>
+              <securitiesClassTitle>Apple Inc.</securitiesClassTitle>
+              <saleDate>05/06/2026</saleDate>
+              <amountOfSecuritiesSold>250000</amountOfSecuritiesSold>
+              <grossProceeds>71190164.00</grossProceeds>
+            </securitiesSoldInPast3Months>
+            <remarks>Shares sold in the THE HOMEPLACE TRUST U/A DTD 03/05/1999.</remarks>
+          </formData>
+        </edgarSubmission>
+        </XML>
+        </DOCUMENT>
+        </SEC-DOCUMENT>
+        """;
+
+    private const string MultiRelationshipSubmission = """
+        <XML>
+        <edgarSubmission xmlns="http://www.sec.gov/edgar/ownership">
+          <formData>
+            <issuerInfo>
+              <nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>JANE DOE</nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>
+              <relationshipsToIssuer>
+                <relationshipToIssuer>Director</relationshipToIssuer>
+                <relationshipToIssuer>Officer</relationshipToIssuer>
+              </relationshipsToIssuer>
+            </issuerInfo>
+            <securitiesInformation>
+              <securitiesClassTitle>Common</securitiesClassTitle>
+              <noOfUnitsSold>100</noOfUnitsSold>
+              <aggregateMarketValue>1000.00</aggregateMarketValue>
+              <approxSaleDate>01/02/2026</approxSaleDate>
+            </securitiesInformation>
+          </formData>
+        </edgarSubmission>
+        </XML>
+        """;
+
+    private const string NothingToReportSubmission = """
+        <XML>
+        <edgarSubmission xmlns="http://www.sec.gov/edgar/ownership">
+          <formData>
+            <issuerInfo>
+              <nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>JOHN ROE</nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>
+              <relationshipsToIssuer>
+                <relationshipToIssuer>Officer</relationshipToIssuer>
+              </relationshipsToIssuer>
+            </issuerInfo>
+            <securitiesInformation>
+              <securitiesClassTitle>Common</securitiesClassTitle>
+              <noOfUnitsSold>500</noOfUnitsSold>
+              <aggregateMarketValue>5000.00</aggregateMarketValue>
+              <approxSaleDate>02/03/2026</approxSaleDate>
+            </securitiesInformation>
+            <nothingToReportFlagOnSecuritiesSoldInPast3Months>Y</nothingToReportFlagOnSecuritiesSoldInPast3Months>
+            <securitiesSoldInPast3Months>
+              <sellerDetails>
+                <name>JOHN ROE</name>
+              </sellerDetails>
+            </securitiesSoldInPast3Months>
+          </formData>
+        </edgarSubmission>
+        </XML>
+        """;
+}

--- a/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
+++ b/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
@@ -144,13 +144,14 @@ public class ConfigurationTests
         options
             .DocumentTypesToSync.Should()
             .NotBeNull()
-            .And.HaveCount(5)
+            .And.HaveCount(6)
             .And.ContainInOrder(
                 DocumentType.TenK,
                 DocumentType.TenQ,
                 DocumentType.EightK,
                 DocumentType.FormFour,
-                DocumentType.FormThree
+                DocumentType.FormThree,
+                DocumentType.Form144
             );
     }
 

--- a/tests/Equibles.UnitTests/Sec/DocumentTypeExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeExtensionsTests.cs
@@ -18,6 +18,7 @@ public class DocumentTypeExtensionsTests
     [InlineData("FortyF", DocumentTypeFilter.FortyF)]
     [InlineData("FormFour", DocumentTypeFilter.FormFour)]
     [InlineData("FormThree", DocumentTypeFilter.FormThree)]
+    [InlineData("Form144", DocumentTypeFilter.Form144)]
     public void ToSecEdgarFilter_MappedType_ReturnsCorrectFilter(
         string documentTypeValue,
         DocumentTypeFilter expectedFilter
@@ -74,6 +75,7 @@ public class DocumentTypeExtensionsTests
     [InlineData("20-F", DocumentTypeFilter.TwentyF)]
     [InlineData("4", DocumentTypeFilter.FormFour)]
     [InlineData("3", DocumentTypeFilter.FormThree)]
+    [InlineData("144", DocumentTypeFilter.Form144)]
     public void FromFormName_ThenToSecEdgarFilter_RoundTrips(
         string formName,
         DocumentTypeFilter expectedFilter

--- a/tests/Equibles.UnitTests/Sec/DocumentTypeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeTests.cs
@@ -91,6 +91,7 @@ public class DocumentTypeTests
                     DocumentType.FortyF,
                     DocumentType.FormFour,
                     DocumentType.FormThree,
+                    DocumentType.Form144,
                     DocumentType.Other,
                 }
             );

--- a/tests/Equibles.UnitTests/Sec/SecHostedServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecHostedServiceCollectionExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace Equibles.UnitTests.Sec;
 public class SecHostedServiceCollectionExtensionsTests
 {
     [Fact]
-    public void AddSecWorker_RegistersIFilingProcessorAsInsiderTradingFilingProcessor()
+    public void AddSecWorker_RegistersFilingProcessorsAsScoped()
     {
         // Sibling to `AddSecWorker_RegistersIDocumentScraperAsScoped`. That
         // pin covers the IDocumentScraper binding shape. This pin covers
@@ -20,43 +20,52 @@ public class SecHostedServiceCollectionExtensionsTests
         //
         // IFilingProcessor is a one-of-many extension point: callers
         // register one or more implementations and DocumentScraper
-        // resolves them all via `IEnumerable<IFilingProcessor>`. Today
-        // the only registered implementation is
-        // InsiderTradingFilingProcessor (handles Form 3/4/5 ownership
-        // filings). The implementation_type binding matters: a refactor
-        // that swapped the concrete to a stub
-        // (`services.AddScoped<IFilingProcessor, StubFilingProcessor>()`
-        // — a common copy-paste mistake when adding NEW processors to
-        // the list) would compile, pass the IDocumentScraper sibling,
-        // and silently disable insider-trading filing processing while
-        // looking like a "wiring works" green test.
+        // resolves them all via `IEnumerable<IFilingProcessor>`. Two are
+        // registered today:
+        //   • InsiderTradingFilingProcessor — Form 3/4/5 ownership filings
+        //   • Form144FilingProcessor        — Form 144 proposed-sale notices
+        // The implementation_type binding matters: a refactor that swapped a
+        // concrete to a stub (`services.AddScoped<IFilingProcessor,
+        // StubFilingProcessor>()` — a common copy-paste mistake when adding
+        // NEW processors to the list) would compile, pass the IDocumentScraper
+        // sibling, and silently disable a form family while looking like a
+        // "wiring works" green test.
         //
         // The risk this catches:
-        //   • Dropped binding: every Form 4 (insider transactions) would
-        //     download but never persist insider transactions. The
-        //     "Insider Transactions" page would silently stop receiving
-        //     new data.
-        //   • Lifetime drift: AddScoped vs AddSingleton/AddTransient
-        //     matters because InsiderTradingFilingProcessor depends on
-        //     scoped repositories (transaction-per-request semantics).
-        //     A singleton lifetime would cache repositories across
-        //     requests, breaking EF Core's tracking and producing
-        //     unpredictable concurrency errors.
-        //   • Wrong concrete type: tests above this pin (the IDocumentScraper
-        //     sibling) only assert ServiceType+Lifetime; ImplementationType
-        //     can drift without that pin failing. This pin asserts the
-        //     IMPLEMENTATION TYPE explicitly.
-        //
-        // Assert ALL THREE: descriptor exists, ImplementationType is the
-        // concrete InsiderTradingFilingProcessor, Lifetime is Scoped.
+        //   • Dropped binding: a missing processor means its form family
+        //     downloads but never persists. The matching page would silently
+        //     stop receiving new data.
+        //   • Lifetime drift: AddScoped vs AddSingleton/AddTransient matters
+        //     because the processors depend on scoped repositories
+        //     (transaction-per-request semantics). A singleton lifetime would
+        //     cache repositories across requests, breaking EF Core's tracking
+        //     and producing unpredictable concurrency errors.
+        //   • Wrong concrete type: the IDocumentScraper sibling only asserts
+        //     ServiceType+Lifetime; ImplementationType can drift without that
+        //     pin failing. This pin asserts the IMPLEMENTATION TYPES explicitly.
         var services = new ServiceCollection();
 
         services.AddSecWorker();
 
-        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IFilingProcessor));
-        descriptor.Should().NotBeNull();
-        descriptor.ImplementationType.Should().Be(typeof(InsiderTradingFilingProcessor));
-        descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
+        var descriptors = services.Where(d => d.ServiceType == typeof(IFilingProcessor)).ToList();
+        descriptors
+            .Should()
+            .HaveCount(
+                2,
+                "AddSecWorker registers one IFilingProcessor per supported structured form family"
+            );
+        descriptors
+            .Should()
+            .Contain(d =>
+                d.ImplementationType == typeof(InsiderTradingFilingProcessor)
+                && d.Lifetime == ServiceLifetime.Scoped
+            );
+        descriptors
+            .Should()
+            .Contain(d =>
+                d.ImplementationType == typeof(Form144FilingProcessor)
+                && d.Lifetime == ServiceLifetime.Scoped
+            );
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Slice 2 of 4 for Form 144 (Refs #1865). Makes the worker actually populate the tables added in slice 1.
- Form 144 notices appear in the issuer's EDGAR submissions feed, so the existing per-company scraper discovers them once Form 144 is a tracked type — no new scraper needed.

## Code changes

- `src/Equibles.Sec.Data/Models/DocumentType.cs`, `src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs` — add the `144` document type / filter.
- `src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs` — map the type to the EDGAR `144` form filter.
- `src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs` — track Form 144 by default.
- `src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs` — new processor that parses the `edgar/ownership` XML (root `edgarSubmission`) into `Form144Filing` + prior-sale rows; skips duplicates by accession and non-XML/malformed filings.
- `src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs` — register the processor (scoped).
- `tests/Equibles.IntegrationTests/Sec/Form144FilingProcessorTests.cs` — parser coverage against a real Apple Form 144 plus edge cases (multiple relationships, nothing-to-report, duplicate, empty, non-XML).
- `tests/Equibles.UnitTests/...` — update the document-type, config, and DI-registration pins for the new type and second processor.