### PR TITLE
refactor(holdings): collapse duplicated backtest price-load orchestration into BacktestPriceLoader.RunBacktest

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/BacktestPriceLoader.cs
+++ b/src/Equibles.Holdings.BusinessLogic/BacktestPriceLoader.cs
@@ -1,19 +1,67 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
 using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Holdings.BusinessLogic;
 
 /// <summary>
-/// Loads adjusted-close price series and forward-fills them for the BusinessLogic backtests
-/// (<see cref="FundScoringManager"/>, <see cref="SmartMoneyIndexManager"/>). Kept self-contained
-/// in the BusinessLogic assembly so the scoring worker and the index have no dependency on the
-/// web host.
+/// Loads adjusted-close price series and runs the look-ahead-safe backtest for the BusinessLogic
+/// backtests (<see cref="FundScoringManager"/>, <see cref="SmartMoneyIndexManager"/>). Kept
+/// self-contained in the BusinessLogic assembly so the scoring worker and the index have no
+/// dependency on the web host.
 /// </summary>
 internal static class BacktestPriceLoader
 {
     // Forward-fill needs a few trading days of pre-window history so day-zero resolves to the
     // last close even on a weekend or holiday.
     public const int PriceLookbackDays = 14;
+
+    /// <summary>
+    /// Loads the constituent and benchmark adjusted-close series for [<paramref name="from"/>,
+    /// <paramref name="to"/>] (padded with <see cref="PriceLookbackDays"/> of pre-window history)
+    /// and runs the look-ahead-safe backtest over <paramref name="snapshots"/>. Returns null when
+    /// the benchmark has no prices in the window — without a benchmark series the simulation can't
+    /// produce comparable returns.
+    /// </summary>
+    public static async Task<BacktestResult> RunBacktest(
+        DailyStockPriceRepository priceRepository,
+        IReadOnlyList<BacktestQuarterSnapshot> snapshots,
+        IReadOnlyCollection<Guid> stockIds,
+        CommonStock benchmarkStock,
+        DateOnly from,
+        DateOnly to
+    )
+    {
+        var priceWindowFrom =
+            from > DateOnly.MinValue.AddDays(PriceLookbackDays)
+                ? from.AddDays(-PriceLookbackDays)
+                : DateOnly.MinValue;
+
+        var pricesByStock = (
+            stockIds.Count == 0
+                ? []
+                : await LoadPrices(priceRepository.GetByStocks(stockIds, priceWindowFrom, to))
+        )
+            .GroupBy(p => p.StockId)
+            .ToDictionary(g => g.Key, g => g.ToArray());
+
+        var benchmarkSeries = (
+            await LoadPrices(priceRepository.GetByStock(benchmarkStock, priceWindowFrom, to))
+        ).ToArray();
+        if (benchmarkSeries.Length == 0)
+            return null;
+
+        return HoldingsBacktestCalculator.Calculate(
+            snapshots,
+            from,
+            to,
+            priceOf: (stockId, date) => ForwardFill(pricesByStock, stockId, date),
+            benchmarkPriceOf: date => ForwardFill(benchmarkSeries, date)
+        );
+    }
 
     // OrderBy must precede the record projection — EF can't translate an OrderBy keyed off a
     // projected record's property because the constructor isn't translatable.

--- a/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
@@ -110,42 +110,19 @@ public class FundScoringManager
 
         var snapshots = BuildSnapshots(holdings);
 
-        var priceWindowFrom =
-            from > DateOnly.MinValue.AddDays(BacktestPriceLoader.PriceLookbackDays)
-                ? from.AddDays(-BacktestPriceLoader.PriceLookbackDays)
-                : DateOnly.MinValue;
-
         var stockIds = holdings
             .Where(h => h.OptionType == null && h.Value > 0)
             .Select(h => h.CommonStockId)
             .Distinct()
             .ToList();
 
-        var pricesByStock = (
-            stockIds.Count == 0
-                ? []
-                : await BacktestPriceLoader.LoadPrices(
-                    _priceRepository.GetByStocks(stockIds, priceWindowFrom, to)
-                )
-        )
-            .GroupBy(p => p.StockId)
-            .ToDictionary(g => g.Key, g => g.ToArray());
-
-        var benchmarkSeries = (
-            await BacktestPriceLoader.LoadPrices(
-                _priceRepository.GetByStock(benchmarkStock, priceWindowFrom, to)
-            )
-        ).ToArray();
-        if (benchmarkSeries.Length == 0)
-            return null;
-
-        return HoldingsBacktestCalculator.Calculate(
+        return await BacktestPriceLoader.RunBacktest(
+            _priceRepository,
             snapshots,
+            stockIds,
+            benchmarkStock,
             from,
-            to,
-            priceOf: (stockId, date) =>
-                BacktestPriceLoader.ForwardFill(pricesByStock, stockId, date),
-            benchmarkPriceOf: date => BacktestPriceLoader.ForwardFill(benchmarkSeries, date)
+            to
         );
     }
 

--- a/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
@@ -228,39 +228,23 @@ public class SmartMoneyIndexManager
                 ? DateOnly.MaxValue
                 : constructionDate.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
 
-        var priceWindowFrom =
-            from > DateOnly.MinValue.AddDays(BacktestPriceLoader.PriceLookbackDays)
-                ? from.AddDays(-BacktestPriceLoader.PriceLookbackDays)
-                : DateOnly.MinValue;
-
         var stockIds = constituents.Select(c => c.CommonStockId).ToList();
-        var pricesByStock = (
-            await BacktestPriceLoader.LoadPrices(
-                _priceRepository.GetByStocks(stockIds, priceWindowFrom, asOf)
-            )
-        )
-            .GroupBy(p => p.StockId)
-            .ToDictionary(g => g.Key, g => g.ToArray());
 
-        var benchmarkSeries = (
-            await BacktestPriceLoader.LoadPrices(
-                _priceRepository.GetByStock(benchmarkStock, priceWindowFrom, asOf)
-            )
-        ).ToArray();
-        if (benchmarkSeries.Length == 0)
+        var backtest = await BacktestPriceLoader.RunBacktest(
+            _priceRepository,
+            [snapshot],
+            stockIds,
+            benchmarkStock,
+            from,
+            asOf
+        );
+        if (backtest == null)
         {
             result.Backtest.Reason =
                 $"No price data available for benchmark {result.BenchmarkTicker} in the tracked window.";
             return;
         }
 
-        result.Backtest = HoldingsBacktestCalculator.Calculate(
-            [snapshot],
-            from,
-            asOf,
-            priceOf: (stockId, date) =>
-                BacktestPriceLoader.ForwardFill(pricesByStock, stockId, date),
-            benchmarkPriceOf: date => BacktestPriceLoader.ForwardFill(benchmarkSeries, date)
-        );
+        result.Backtest = backtest;
     }
 }


### PR DESCRIPTION
## Summary

- `FundScoringManager.RunBacktest` and `SmartMoneyIndexManager.RunBacktest` each carried a near-verbatim copy of the same price-loading + forward-fill + backtest-run block, despite already sharing the `BacktestPriceLoader` helper.
- Collapsed that duplication into a single `BacktestPriceLoader.RunBacktest` method, so the price-window padding, per-stock and benchmark price loading, and look-ahead-safe calculation now live in one place.
- Behavior-preserving: identical queries, grouping, forward-fill, and empty-benchmark handling. Each caller maps the helper's `null` (empty benchmark series) to its existing outcome — the scorer returns `null`, the index sets the same "no price data" reason.

## Code changes

- `src/Equibles.Holdings.BusinessLogic/BacktestPriceLoader.cs` — add a `RunBacktest` method that loads the constituent and benchmark series for the padded window and runs `HoldingsBacktestCalculator.Calculate`, returning `null` when the benchmark has no prices; update the class doc to reflect the broadened role.
- `src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs` — replace the inline price-load + calculate block with a call to the shared helper.
- `src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs` — same replacement; map a `null` result to the existing "no price data for benchmark" reason.