### PR TITLE
feat(insider-trading): expose Form 144 proposed sales via MCP

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -21,12 +21,14 @@ public class InsiderTradingTools
 {
     private readonly InsiderTransactionRepository _transactionRepository;
     private readonly InsiderOwnerRepository _ownerRepository;
+    private readonly Form144FilingRepository _form144Repository;
     private readonly CommonStockRepository _commonStockRepository;
     private readonly McpToolRunner _runner;
 
     public InsiderTradingTools(
         InsiderTransactionRepository transactionRepository,
         InsiderOwnerRepository ownerRepository,
+        Form144FilingRepository form144Repository,
         CommonStockRepository commonStockRepository,
         ErrorManager errorManager,
         ILogger<InsiderTradingTools> logger
@@ -34,6 +36,7 @@ public class InsiderTradingTools
     {
         _transactionRepository = transactionRepository;
         _ownerRepository = ownerRepository;
+        _form144Repository = form144Repository;
         _commonStockRepository = commonStockRepository;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
@@ -157,6 +160,59 @@ public class InsiderTradingTools
                 return result.ToString();
             },
             "GetInsiderOwnership",
+            $"ticker: {ticker}"
+        );
+    }
+
+    [McpServerTool(Name = "GetProposedSales")]
+    [Description(
+        "Get recent proposed insider sales for a stock from SEC Form 144 notices. Each Form 144 is an affiliate's declaration of intent to sell restricted or control securities, showing the seller, their relationship to the company, the number of shares and aggregate market value to be sold, the approximate sale date, and the broker. Use this to anticipate upcoming insider selling before it shows up as an executed Form 4."
+    )]
+    public Task<string> GetProposedSales(
+        [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Maximum number of notices to return (default: 50)")] int maxResults = 50
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
+
+                var filings = await _form144Repository
+                    .GetByStock(stock)
+                    .OrderByDescending(f => f.FilingDate)
+                    .Take(maxResults)
+                    .ToListAsync();
+
+                if (filings.Count == 0)
+                    return $"No Form 144 proposed sales found for {ticker}.";
+
+                var result = new StringBuilder();
+                result.AppendLine($"Recent proposed sales (Form 144) for {stock.Name} ({ticker}):");
+                result.AppendLine($"Showing {filings.Count} most recent notices");
+                result.AppendLine();
+                result.AppendLine(
+                    "| Filed | Seller | Relationship | Shares | Market Value | Approx. Sale Date | Broker |"
+                );
+                result.AppendLine(
+                    "|-------|--------|--------------|--------|--------------|-------------------|--------|"
+                );
+
+                foreach (var f in filings)
+                {
+                    var approxSaleDate =
+                        f.ApproxSaleDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
+                        ?? "-";
+                    result.AppendLine(
+                        $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {f.SharesToBeSold.ToString("N0", CultureInfo.InvariantCulture)} | ${f.AggregateMarketValue.ToString("N0", CultureInfo.InvariantCulture)} | {approxSaleDate} | {f.BrokerName} |"
+                    );
+                }
+
+                return result.ToString();
+            },
+            "GetProposedSales",
             $"ticker: {ticker}"
         );
     }

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTradingToolsResolveStockByTickerNormalizationTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTradingToolsResolveStockByTickerNormalizationTests.cs
@@ -32,6 +32,7 @@ public class InsiderTradingToolsResolveStockByTickerNormalizationTests : IDispos
         _tools = new InsiderTradingTools(
             new InsiderTransactionRepository(_dbContext),
             new InsiderOwnerRepository(_dbContext),
+            new Form144FilingRepository(_dbContext),
             new CommonStockRepository(_dbContext),
             errorManager: null,
             NullLogger<InsiderTradingTools>.Instance

--- a/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs
@@ -1,0 +1,145 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Mcp.Tools;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+public class Form144ProposedSalesToolTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly InsiderTradingTools _tools;
+
+    public Form144ProposedSalesToolTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new InsiderTradingModuleConfiguration()
+        );
+        _tools = new InsiderTradingTools(
+            new InsiderTransactionRepository(_dbContext),
+            new InsiderOwnerRepository(_dbContext),
+            new Form144FilingRepository(_dbContext),
+            new CommonStockRepository(_dbContext),
+            errorManager: null,
+            NullLogger<InsiderTradingTools>.Instance
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    private CommonStock SeedStock(string ticker = "AAPL", string cik = "0000320193")
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = "Apple Inc.",
+            Cik = cik,
+        };
+        _dbContext.Set<CommonStock>().Add(stock);
+        _dbContext.SaveChanges();
+        return stock;
+    }
+
+    [Fact]
+    public async Task GetProposedSales_StockNotFound_ReturnsNotFoundMessage()
+    {
+        var result = await _tools.GetProposedSales("ZZZZ");
+
+        result.Should().Contain("ZZZZ");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_NoFilings_ReturnsEmptyMessage()
+    {
+        SeedStock();
+
+        var result = await _tools.GetProposedSales("AAPL");
+
+        result.Should().Contain("No Form 144 proposed sales found for AAPL.");
+    }
+
+    [Fact]
+    public async Task GetProposedSales_WithFilings_RendersTableNewestFirst()
+    {
+        var stock = SeedStock();
+        _dbContext
+            .Set<Form144Filing>()
+            .Add(MakeFiling(stock.Id, "older", new DateOnly(2026, 1, 5), "ALICE", 1000));
+        _dbContext
+            .Set<Form144Filing>()
+            .Add(
+                MakeFiling(stock.Id, "newer", new DateOnly(2026, 5, 27), "LEVINSON ARTHUR D", 50000)
+            );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales("AAPL");
+
+        result.Should().Contain("Apple Inc.");
+        result.Should().Contain("LEVINSON ARTHUR D");
+        result.Should().Contain("50,000"); // invariant-culture grouping
+        result.Should().Contain("Director");
+        // Newest filing renders before the older one.
+        result
+            .IndexOf("LEVINSON ARTHUR D", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(result.IndexOf("ALICE", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetProposedSales_RespectsMaxResults()
+    {
+        var stock = SeedStock();
+        for (var i = 0; i < 5; i++)
+        {
+            _dbContext
+                .Set<Form144Filing>()
+                .Add(
+                    MakeFiling(
+                        stock.Id,
+                        $"acc-{i}",
+                        new DateOnly(2026, 1, 1).AddDays(i),
+                        "SELLER",
+                        100
+                    )
+                );
+        }
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetProposedSales("AAPL", maxResults: 2);
+
+        result.Should().Contain("Showing 2 most recent notices");
+    }
+
+    private static Form144Filing MakeFiling(
+        Guid stockId,
+        string accession,
+        DateOnly filingDate,
+        string seller,
+        long shares
+    )
+    {
+        return new Form144Filing
+        {
+            CommonStockId = stockId,
+            AccessionNumber = accession,
+            FilingDate = filingDate,
+            SellerName = seller,
+            RelationshipToIssuer = "Director",
+            SecurityClassTitle = "Common",
+            BrokerName = "Charles Schwab & Co., Inc.",
+            SharesToBeSold = shares,
+            AggregateMarketValue = shares * 300m,
+            SharesOutstanding = 14687356000,
+            ApproxSaleDate = filingDate,
+            SecuritiesExchangeName = "NASDAQ",
+        };
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests.cs
@@ -19,6 +19,7 @@ public class InsiderTradingToolsGetInsiderTransactionsCultureInvarianceTests : P
         new(
             new InsiderTransactionRepository(DbContext),
             new InsiderOwnerRepository(DbContext),
+            new Form144FilingRepository(DbContext),
             new CommonStockRepository(DbContext),
             ErrorManager,
             NullLogger<InsiderTradingTools>()

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
@@ -18,6 +18,7 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
         new(
             new InsiderTransactionRepository(DbContext),
             new InsiderOwnerRepository(DbContext),
+            new Form144FilingRepository(DbContext),
             new CommonStockRepository(DbContext),
             ErrorManager,
             NullLogger<InsiderTradingTools>()

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -286,6 +286,7 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("GetInsiderTransactions");
         toolNames.Should().Contain("GetInsiderOwnership");
         toolNames.Should().Contain("SearchInsiders");
+        toolNames.Should().Contain("GetProposedSales");
     }
 
     // ── SEC module specific ─────────────────────────────────────────────
@@ -375,7 +376,13 @@ public class McpModuleToolDiscoveryTests
             },
             {
                 typeof(InsiderTradingTools),
-                new[] { "GetInsiderTransactions", "GetInsiderOwnership", "SearchInsiders" }
+                new[]
+                {
+                    "GetInsiderTransactions",
+                    "GetInsiderOwnership",
+                    "SearchInsiders",
+                    "GetProposedSales",
+                }
             },
             {
                 typeof(RagSearchTools),


### PR DESCRIPTION
## Summary

- Slice 3 of 4 for Form 144 (Refs #1865). Surfaces the data through the assistant interface.
- A new `GetProposedSales` tool lets an assistant see upcoming insider selling (Form 144 notices) before it shows up as an executed Form 4.

## Code changes

- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — inject `Form144FilingRepository`; add the `GetProposedSales` tool returning a markdown table of recent notices (seller, relationship, shares, aggregate market value, approximate sale date, broker), invariant-culture formatted.
- `tests/Equibles.IntegrationTests/Mcp/Form144ProposedSalesToolTests.cs` — covers not-found, empty, ordering, and max-results behavior.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — add the new tool to the discovery / tool-count pins.
- `tests/.../InsiderTradingTools*Tests.cs` — pass the new repository to the tool's constructor.