### PR TITLE
feat(sec): add Form D exempt-offering data model

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260530072013_AddFormD.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260530072013_AddFormD.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530072013_AddFormD")]
+    partial class AddFormD
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260530072013_AddFormD.cs
+++ b/src/Equibles.Migrations/Migrations/20260530072013_AddFormD.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFormD : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FormDFiling",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccessionNumber = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    FilingDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    IsAmendment = table.Column<bool>(type: "boolean", nullable: false),
+                    EntityName = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    EntityType = table.Column<string>(
+                        type: "character varying(128)",
+                        maxLength: 128,
+                        nullable: true
+                    ),
+                    JurisdictionOfInc = table.Column<string>(
+                        type: "character varying(128)",
+                        maxLength: 128,
+                        nullable: true
+                    ),
+                    YearOfIncorporation = table.Column<int>(type: "integer", nullable: true),
+                    IndustryGroup = table.Column<string>(
+                        type: "character varying(128)",
+                        maxLength: 128,
+                        nullable: true
+                    ),
+                    FederalExemptions = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: true
+                    ),
+                    DateOfFirstSale = table.Column<DateOnly>(type: "date", nullable: true),
+                    TotalOfferingAmount = table.Column<long>(type: "bigint", nullable: true),
+                    IsOfferingAmountIndefinite = table.Column<bool>(
+                        type: "boolean",
+                        nullable: false
+                    ),
+                    TotalAmountSold = table.Column<long>(type: "bigint", nullable: false),
+                    TotalRemaining = table.Column<long>(type: "bigint", nullable: true),
+                    IsRemainingIndefinite = table.Column<bool>(type: "boolean", nullable: false),
+                    MinimumInvestmentAccepted = table.Column<long>(type: "bigint", nullable: false),
+                    HasNonAccreditedInvestors = table.Column<bool>(
+                        type: "boolean",
+                        nullable: false
+                    ),
+                    TotalNumberAlreadyInvested = table.Column<int>(
+                        type: "integer",
+                        nullable: false
+                    ),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FormDFiling", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FormDFiling_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "FormDRelatedPerson",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    FormDFilingId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    Relationships = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: true
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FormDRelatedPerson", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FormDRelatedPerson_FormDFiling_FormDFilingId",
+                        column: x => x.FormDFilingId,
+                        principalTable: "FormDFiling",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FormDFiling_AccessionNumber",
+                table: "FormDFiling",
+                column: "AccessionNumber",
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FormDFiling_CommonStockId_FilingDate",
+                table: "FormDFiling",
+                columns: new[] { "CommonStockId", "FilingDate" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FormDFiling_FilingDate",
+                table: "FormDFiling",
+                column: "FilingDate"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FormDRelatedPerson_FormDFilingId",
+                table: "FormDRelatedPerson",
+                column: "FormDFilingId"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "FormDRelatedPerson");
+
+            migrationBuilder.DropTable(name: "FormDFiling");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/FormDFiling.cs
+++ b/src/Equibles.Sec.Data/Models/FormDFiling.cs
@@ -1,0 +1,94 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// A SEC Form D notice — an issuer's report of an exempt (Regulation D) securities offering,
+/// i.e. a private placement. Form D appears in the issuer's EDGAR submissions feed, so each
+/// notice is attributed to the issuer's <see cref="CommonStock"/>. Offering amounts can be
+/// reported as the literal "Indefinite" rather than a number; those are stored as <c>null</c>
+/// and flagged via <see cref="IsOfferingAmountIndefinite"/> / <see cref="IsRemainingIndefinite"/>.
+/// </summary>
+[Index(nameof(CommonStockId), nameof(FilingDate))]
+[Index(nameof(AccessionNumber), IsUnique = true)]
+[Index(nameof(FilingDate))]
+public class FormDFiling
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    [MaxLength(32)]
+    public string AccessionNumber { get; set; }
+
+    public DateOnly FilingDate { get; set; }
+
+    /// <summary>
+    /// True when the submission type is "D/A" (an amendment to a prior Form D) rather than "D".
+    /// </summary>
+    public bool IsAmendment { get; set; }
+
+    /// <summary>The issuer's legal name exactly as reported on the filing.</summary>
+    [MaxLength(512)]
+    public string EntityName { get; set; }
+
+    /// <summary>Issuer entity type, e.g. "Limited Liability Company", "Corporation".</summary>
+    [MaxLength(128)]
+    public string EntityType { get; set; }
+
+    /// <summary>State or country of incorporation/organization, e.g. "DELAWARE".</summary>
+    [MaxLength(128)]
+    public string JurisdictionOfInc { get; set; }
+
+    /// <summary>Year of incorporation when disclosed; null when the issuer declined or is yet to be formed.</summary>
+    public int? YearOfIncorporation { get; set; }
+
+    /// <summary>Reported industry group, e.g. "Pooled Investment Fund", "Technology".</summary>
+    [MaxLength(128)]
+    public string IndustryGroup { get; set; }
+
+    /// <summary>
+    /// Claimed Regulation D exemptions/exclusions, joined with ", " (e.g. "06b, 3C, 3C.7").
+    /// </summary>
+    [MaxLength(256)]
+    public string FederalExemptions { get; set; }
+
+    /// <summary>Date of first sale when reported; null when the issuer marked it as yet to occur.</summary>
+    public DateOnly? DateOfFirstSale { get; set; }
+
+    /// <summary>Total dollar amount of the offering; null when reported as "Indefinite".</summary>
+    public long? TotalOfferingAmount { get; set; }
+
+    /// <summary>True when the issuer reported the total offering amount as "Indefinite".</summary>
+    public bool IsOfferingAmountIndefinite { get; set; }
+
+    /// <summary>Dollar amount sold to date.</summary>
+    public long TotalAmountSold { get; set; }
+
+    /// <summary>Dollar amount still being offered; null when reported as "Indefinite".</summary>
+    public long? TotalRemaining { get; set; }
+
+    /// <summary>True when the issuer reported the remaining amount as "Indefinite".</summary>
+    public bool IsRemainingIndefinite { get; set; }
+
+    /// <summary>Minimum investment the issuer will accept, in dollars.</summary>
+    public long MinimumInvestmentAccepted { get; set; }
+
+    /// <summary>Whether any non-accredited investors have been sold securities in the offering.</summary>
+    public bool HasNonAccreditedInvestors { get; set; }
+
+    /// <summary>Total number of investors who have already invested in the offering.</summary>
+    public int TotalNumberAlreadyInvested { get; set; }
+
+    /// <summary>
+    /// Executives, directors and promoters named on the filing — the people behind the offering.
+    /// </summary>
+    public virtual List<FormDRelatedPerson> RelatedPersons { get; set; } = [];
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Sec.Data/Models/FormDRelatedPerson.cs
+++ b/src/Equibles.Sec.Data/Models/FormDRelatedPerson.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// A person named in the related-persons section of a <see cref="FormDFiling"/> — an executive
+/// officer, director or promoter of the issuer. Form D carries the name and relationship(s) but
+/// no CIK, so the name is stored as free text rather than resolved to another entity.
+/// </summary>
+[Index(nameof(FormDFilingId))]
+public class FormDRelatedPerson
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid FormDFilingId { get; set; }
+    public virtual FormDFiling FormDFiling { get; set; }
+
+    /// <summary>The person's full name, assembled from the filing's first/middle/last name parts.</summary>
+    [MaxLength(512)]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// The person's relationship(s) to the issuer (e.g. "Executive Officer", "Director",
+    /// "Promoter"). A person can hold several — joined with ", ".
+    /// </summary>
+    [MaxLength(256)]
+    public string Relationships { get; set; }
+}

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -24,6 +24,8 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
         });
 
         builder.Entity<FailToDeliver>();
+        builder.Entity<FormDFiling>();
+        builder.Entity<FormDRelatedPerson>();
         builder.Entity<TranscriptCheckStatus>();
     }
 }

--- a/src/Equibles.Sec.Repositories/FormDFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/FormDFilingRepository.cs
@@ -1,0 +1,26 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Sec.Repositories;
+
+public class FormDFilingRepository : BaseRepository<FormDFiling>
+{
+    public FormDFilingRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<FormDFiling> GetByStock(CommonStock stock)
+    {
+        return GetAll().Where(f => f.CommonStockId == stock.Id);
+    }
+
+    public IQueryable<FormDFiling> GetByAccessionNumber(string accessionNumber)
+    {
+        return GetAll().Where(f => f.AccessionNumber == accessionNumber);
+    }
+
+    public IQueryable<FormDFiling> GetRecent(DateOnly since)
+    {
+        return GetAll().Where(f => f.FilingDate >= since);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.IntegrationTests.Helpers;
 
 /// <summary>
-/// Registers only Document and FailToDeliver entities for InMemory tests.
+/// Registers the non-vector Sec entities (Document, FailToDeliver, Form D) for InMemory tests.
 /// The production <see cref="Equibles.Sec.Data.SecModuleConfiguration"/> also
 /// registers Chunk and Embedding, which use pgvector's <c>Vector</c> type that
 /// the EF Core InMemory provider cannot construct. We explicitly ignore those
@@ -28,6 +28,8 @@ public class SecTestModuleConfiguration : Equibles.Data.IModuleConfiguration
         });
 
         builder.Entity<FailToDeliver>();
+        builder.Entity<FormDFiling>();
+        builder.Entity<FormDRelatedPerson>();
         builder.Ignore<Chunk>();
         builder.Ignore<Embedding>();
     }

--- a/tests/Equibles.IntegrationTests/Sec/FormDFilingRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FormDFilingRepositoryTests.cs
@@ -1,0 +1,166 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class FormDFilingRepositoryTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly FormDFilingRepository _repository;
+
+    public FormDFilingRepositoryTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration()
+        );
+        _repository = new FormDFilingRepository(_dbContext);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    private static CommonStock CreateStock(string ticker = "AAPL", string cik = "0000320193")
+    {
+        return new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = ticker,
+            Cik = cik,
+        };
+    }
+
+    private static FormDFiling CreateFiling(
+        Guid commonStockId,
+        string accessionNumber = "0002058722-25-000001",
+        DateOnly? filingDate = null,
+        string entityName = "AJ BOULDER FUND LLC"
+    )
+    {
+        return new FormDFiling
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = commonStockId,
+            AccessionNumber = accessionNumber,
+            FilingDate = filingDate ?? new DateOnly(2025, 2, 28),
+            IsAmendment = false,
+            EntityName = entityName,
+            EntityType = "Limited Liability Company",
+            JurisdictionOfInc = "DELAWARE",
+            YearOfIncorporation = 2024,
+            IndustryGroup = "Pooled Investment Fund",
+            FederalExemptions = "06b, 3C, 3C.7",
+            TotalOfferingAmount = null,
+            IsOfferingAmountIndefinite = true,
+            TotalAmountSold = 0,
+            TotalRemaining = null,
+            IsRemainingIndefinite = true,
+            MinimumInvestmentAccepted = 0,
+            HasNonAccreditedInvestors = false,
+            TotalNumberAlreadyInvested = 0,
+        };
+    }
+
+    [Fact]
+    public async Task GetByStock_ReturnsOnlyFilingsForThatStock()
+    {
+        var apple = CreateStock("AAPL", "0000320193");
+        var microsoft = CreateStock("MSFT", "0000789019");
+        _dbContext.Set<CommonStock>().AddRange(apple, microsoft);
+        await _dbContext.SaveChangesAsync();
+
+        _repository.Add(CreateFiling(apple.Id, "0002058722-25-000001"));
+        _repository.Add(CreateFiling(apple.Id, "0002058722-25-000002"));
+        _repository.Add(CreateFiling(microsoft.Id, "0001950047-25-004044"));
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetByStock(apple).ToListAsync();
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(f => f.CommonStockId == apple.Id);
+    }
+
+    [Fact]
+    public async Task GetByAccessionNumber_ExistingAccession_ReturnsFiling()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+        _repository.Add(CreateFiling(stock.Id, "0002058722-25-000001"));
+        await _repository.SaveChanges();
+
+        var result = await _repository
+            .GetByAccessionNumber("0002058722-25-000001")
+            .FirstOrDefaultAsync();
+
+        result.Should().NotBeNull();
+        result.EntityName.Should().Be("AJ BOULDER FUND LLC");
+    }
+
+    [Fact]
+    public async Task GetByAccessionNumber_NonExistentAccession_ReturnsEmpty()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+        _repository.Add(CreateFiling(stock.Id, "0002058722-25-000001"));
+        await _repository.SaveChanges();
+
+        var any = await _repository.GetByAccessionNumber("9999999999-99-999999").AnyAsync();
+
+        any.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetRecent_ReturnsOnlyFilingsOnOrAfterCutoff()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        _repository.Add(CreateFiling(stock.Id, "old", filingDate: new DateOnly(2025, 1, 1)));
+        _repository.Add(CreateFiling(stock.Id, "new", filingDate: new DateOnly(2025, 5, 27)));
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetRecent(new DateOnly(2025, 5, 1)).ToListAsync();
+
+        result.Should().ContainSingle();
+        result[0].AccessionNumber.Should().Be("new");
+    }
+
+    [Fact]
+    public async Task Add_FilingWithRelatedPersons_PersistsChildRows()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var filing = CreateFiling(stock.Id);
+        filing.RelatedPersons.Add(
+            new FormDRelatedPerson
+            {
+                Name = "BENJAMIN WEPRIN",
+                Relationships = "Executive Officer, Promoter",
+            }
+        );
+        _repository.Add(filing);
+        await _repository.SaveChanges();
+
+        var loaded = await _repository
+            .GetByAccessionNumber(filing.AccessionNumber)
+            .Include(f => f.RelatedPersons)
+            .FirstAsync();
+
+        loaded.RelatedPersons.Should().ContainSingle();
+        loaded.RelatedPersons[0].Name.Should().Be("BENJAMIN WEPRIN");
+        loaded.RelatedPersons[0].Relationships.Should().Be("Executive Officer, Promoter");
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 1 of 4 for Form D (Regulation D exempt-offering / private-placement) ingestion — see #1867.
- Adds the structured data model for SEC Form D notices, attributed to the issuer's stock since Form D appears in the issuer's EDGAR submissions feed (same approach as the recent Form 144 work).
- Offering amounts reported as the literal "Indefinite" are stored as null and flagged via boolean columns.
- Does not close the issue; subsequent slices add the worker parser, MCP tool, and web tab.

## Code changes

- `src/Equibles.Sec.Data/Models/FormDFiling.cs` — new entity: issuer, offering amounts, exemptions, investor counts, related-persons collection.
- `src/Equibles.Sec.Data/Models/FormDRelatedPerson.cs` — new child entity: executives/directors/promoters named on the filing.
- `src/Equibles.Sec.Data/SecModuleConfiguration.cs` — register the two entities.
- `src/Equibles.Sec.Repositories/FormDFilingRepository.cs` — query helpers (by stock, by accession, recent).
- `src/Equibles.Migrations/Migrations/*_AddFormD.*` — migration creating the two tables and indexes.
- `tests/Equibles.IntegrationTests/Sec/FormDFilingRepositoryTests.cs` — repository tests.
- `tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs` — register the entities for the InMemory test context.

Refs #1867