### PR TITLE
feat(sec): parse Form D exempt-offering filings in the worker

### DIFF
--- a/src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs
+++ b/src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs
@@ -39,4 +39,10 @@ public enum DocumentTypeFilter
 
     [Display(Name = "144")]
     Form144,
+
+    [Display(Name = "D")]
+    FormD,
+
+    [Display(Name = "D/A")]
+    FormDa,
 }

--- a/src/Equibles.Sec.Data/Models/DocumentType.cs
+++ b/src/Equibles.Sec.Data/Models/DocumentType.cs
@@ -27,6 +27,8 @@ public sealed class DocumentType
     public static readonly DocumentType FormFour = new("FormFour", "4");
     public static readonly DocumentType FormThree = new("FormThree", "3");
     public static readonly DocumentType Form144 = new("Form144", "144");
+    public static readonly DocumentType FormD = new("FormD", "D");
+    public static readonly DocumentType FormDa = new("FormDa", "D/A");
     public static readonly DocumentType Other = new("Other", "Other");
 
     private static readonly ConcurrentDictionary<string, DocumentType> AllByValue = new(
@@ -44,6 +46,8 @@ public sealed class DocumentType
             new KeyValuePair<string, DocumentType>(FormFour.Value, FormFour),
             new KeyValuePair<string, DocumentType>(FormThree.Value, FormThree),
             new KeyValuePair<string, DocumentType>(Form144.Value, Form144),
+            new KeyValuePair<string, DocumentType>(FormD.Value, FormD),
+            new KeyValuePair<string, DocumentType>(FormDa.Value, FormDa),
             new KeyValuePair<string, DocumentType>(Other.Value, Other),
         },
         StringComparer.OrdinalIgnoreCase
@@ -64,6 +68,8 @@ public sealed class DocumentType
             new KeyValuePair<string, DocumentType>(FormFour.DisplayName, FormFour),
             new KeyValuePair<string, DocumentType>(FormThree.DisplayName, FormThree),
             new KeyValuePair<string, DocumentType>(Form144.DisplayName, Form144),
+            new KeyValuePair<string, DocumentType>(FormD.DisplayName, FormD),
+            new KeyValuePair<string, DocumentType>(FormDa.DisplayName, FormDa),
             new KeyValuePair<string, DocumentType>(Other.DisplayName, Other),
         },
         StringComparer.OrdinalIgnoreCase

--- a/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
@@ -12,5 +12,7 @@ public class DocumentScraperOptions
         DocumentType.FormFour,
         DocumentType.FormThree,
         DocumentType.Form144,
+        DocumentType.FormD,
+        DocumentType.FormDa,
     ];
 }

--- a/src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs
@@ -20,6 +20,8 @@ public static class DocumentTypeExtensions
             { DocumentType.FormFour, DocumentTypeFilter.FormFour },
             { DocumentType.FormThree, DocumentTypeFilter.FormThree },
             { DocumentType.Form144, DocumentTypeFilter.Form144 },
+            { DocumentType.FormD, DocumentTypeFilter.FormD },
+            { DocumentType.FormDa, DocumentTypeFilter.FormDa },
         };
 
     public static DocumentTypeFilter? ToSecEdgarFilter(this DocumentType docType)

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ public static class ServiceCollectionExtensions
 
         services.AddScoped<IFilingProcessor, InsiderTradingFilingProcessor>();
         services.AddScoped<IFilingProcessor, Form144FilingProcessor>();
+        services.AddScoped<IFilingProcessor, FormDFilingProcessor>();
         services.AddScoped<IDocumentPersistenceService, DocumentPersistenceService>();
         services.AddScoped<ICompanySyncService, CompanySyncService>();
         services.AddScoped<IDocumentScraper, DocumentScraper>();

--- a/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
@@ -1,0 +1,324 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Contracts;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Processes SEC Form D filings — an issuer's notice of an exempt (Regulation D) securities
+/// offering, i.e. a private placement — into structured <see cref="FormDFiling"/> records (plus
+/// the executives, directors and promoters named on the filing). Form D appears in the issuer's
+/// submissions feed, so each notice is attributed to the issuer's stock. Both the original
+/// notice ("D") and its amendments ("D/A") are processed. The XML root is
+/// <c>edgarSubmission</c> with no default namespace, so elements are navigated by local name.
+/// </summary>
+public class FormDFilingProcessor : IFilingProcessor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<FormDFilingProcessor> _logger;
+    private readonly ErrorReporter _errorReporter;
+
+    // Form D dates are ISO yyyy-MM-dd; accept the US MM/dd/yyyy fallback defensively.
+    private static readonly string[] DateFormats = ["yyyy-MM-dd", "MM/dd/yyyy", "M/d/yyyy"];
+
+    private const string IndefiniteValue = "Indefinite";
+
+    public FormDFilingProcessor(
+        IServiceScopeFactory scopeFactory,
+        ILogger<FormDFilingProcessor> logger,
+        ErrorReporter errorReporter
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _errorReporter = errorReporter;
+    }
+
+    public bool CanProcess(DocumentType documentType)
+    {
+        return documentType == DocumentType.FormD || documentType == DocumentType.FormDa;
+    }
+
+    public async Task<bool> Process(FilingData filing, CommonStock companyOutContext)
+    {
+        // Capture IDs from the outer-scope entity to avoid leaking untracked entities into inner scope.
+        var companyId = companyOutContext.Id;
+        var companyTicker = companyOutContext.Ticker;
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var secEdgarClient = scope.ServiceProvider.GetRequiredService<ISecEdgarClient>();
+        var repository = scope.ServiceProvider.GetRequiredService<FormDFilingRepository>();
+
+        var existing = await repository.GetByAccessionNumber(filing.AccessionNumber).AnyAsync();
+        if (existing)
+            return false;
+
+        var content = await secEdgarClient.GetDocumentContent(filing);
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            _logger.LogWarning(
+                "Empty content for {Ticker} Form D - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return false;
+        }
+
+        var root = await TryParseSubmission(content, filing, companyTicker);
+        if (root == null)
+            return false;
+
+        var entity = ParseFiling(root, companyId, filing);
+        if (entity == null)
+        {
+            _logger.LogWarning(
+                "Form D XML missing offeringData for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return false;
+        }
+
+        repository.Add(entity);
+        await repository.SaveChanges();
+
+        _logger.LogInformation(
+            "Imported Form D for {Ticker} ({EntityName}, sold {Sold}, {Persons} related persons) from {AccessionNumber}",
+            companyTicker,
+            entity.EntityName,
+            entity.TotalAmountSold,
+            entity.RelatedPersons.Count,
+            filing.AccessionNumber
+        );
+
+        return true;
+    }
+
+    private async Task<XElement> TryParseSubmission(
+        string content,
+        FilingData filing,
+        string companyTicker
+    )
+    {
+        var sanitized = SanitizeXml(content);
+
+        // Form D has only been filed as XML since 2008, so a submission without the
+        // <edgarSubmission> root is unexpected — skip quietly.
+        if (!sanitized.Contains("<edgarSubmission", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug(
+                "Skipping non-XML Form D filing for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return null;
+        }
+
+        try
+        {
+            return XDocument.Parse(sanitized).Root;
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Malformed Form D XML for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            await _errorReporter.Report(
+                ErrorSource.DocumentScraper,
+                "FormD.ParseXml",
+                ex.Message,
+                ex.StackTrace,
+                $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
+            );
+            return null;
+        }
+    }
+
+    private static FormDFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
+    {
+        var offeringData = El(root, "offeringData");
+        if (offeringData == null)
+            return null;
+
+        var issuer = El(root, "primaryIssuer");
+        var typeOfFiling = El(offeringData, "typeOfFiling");
+        var salesAmounts = El(offeringData, "offeringSalesAmounts");
+        var investors = El(offeringData, "investors");
+
+        var (offeringAmount, offeringIndefinite) = ParseAmount(
+            Val(salesAmounts, "totalOfferingAmount")
+        );
+        var (remaining, remainingIndefinite) = ParseAmount(Val(salesAmounts, "totalRemaining"));
+
+        var exemptions = string.Join(
+            ", ",
+            Els(El(offeringData, "federalExemptionsExclusions"), "item")
+                .Select(e => e.Value.Trim())
+                .Where(v => !string.IsNullOrEmpty(v))
+        );
+
+        var entity = new FormDFiling
+        {
+            CommonStockId = companyId,
+            AccessionNumber = filing.AccessionNumber,
+            FilingDate = filing.FilingDate,
+            IsAmendment = ParseIsAmendment(typeOfFiling, filing),
+            EntityName = Val(issuer, "entityName"),
+            EntityType = Val(issuer, "entityType"),
+            JurisdictionOfInc = Val(issuer, "jurisdictionOfInc"),
+            YearOfIncorporation = ParseNullableInt(Val(El(issuer, "yearOfInc"), "value")),
+            IndustryGroup = Val(El(offeringData, "industryGroup"), "industryGroupType"),
+            FederalExemptions = string.IsNullOrEmpty(exemptions) ? null : exemptions,
+            DateOfFirstSale = ParseDate(Val(El(typeOfFiling, "dateOfFirstSale"), "value")),
+            TotalOfferingAmount = offeringAmount,
+            IsOfferingAmountIndefinite = offeringIndefinite,
+            TotalAmountSold = ParseLong(Val(salesAmounts, "totalAmountSold")),
+            TotalRemaining = remaining,
+            IsRemainingIndefinite = remainingIndefinite,
+            MinimumInvestmentAccepted = ParseLong(Val(offeringData, "minimumInvestmentAccepted")),
+            HasNonAccreditedInvestors = ParseBool(Val(investors, "hasNonAccreditedInvestors")),
+            TotalNumberAlreadyInvested = (int)ParseLong(
+                Val(investors, "totalNumberAlreadyInvested")
+            ),
+        };
+
+        foreach (var personElement in Els(El(root, "relatedPersonsList"), "relatedPersonInfo"))
+        {
+            var person = ParseRelatedPerson(personElement);
+            if (person != null)
+                entity.RelatedPersons.Add(person);
+        }
+
+        return entity;
+    }
+
+    private static FormDRelatedPerson ParseRelatedPerson(XElement element)
+    {
+        var name = El(element, "relatedPersonName");
+        var fullName = string.Join(
+            " ",
+            new[] { Val(name, "firstName"), Val(name, "middleName"), Val(name, "lastName") }.Where(
+                v => !string.IsNullOrEmpty(v)
+            )
+        );
+
+        var relationships = string.Join(
+            ", ",
+            Els(El(element, "relatedPersonRelationshipList"), "relationship")
+                .Select(e => e.Value.Trim())
+                .Where(v => !string.IsNullOrEmpty(v))
+        );
+
+        if (string.IsNullOrEmpty(fullName) && string.IsNullOrEmpty(relationships))
+            return null;
+
+        return new FormDRelatedPerson
+        {
+            Name = string.IsNullOrEmpty(fullName) ? null : fullName,
+            Relationships = string.IsNullOrEmpty(relationships) ? null : relationships,
+        };
+    }
+
+    private static bool ParseIsAmendment(XElement typeOfFiling, FilingData filing)
+    {
+        var flag = Val(El(typeOfFiling, "newOrAmendment"), "isAmendment");
+        if (flag != null)
+            return ParseBool(flag);
+
+        // Fall back to the submission form string ("D/A") when the flag is absent.
+        return filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
+    }
+
+    // ── XML helpers (navigate by local name; Form D declares no namespace) ──────────
+
+    private static XElement El(XElement parent, string name) =>
+        parent?.Elements().FirstOrDefault(e => e.Name.LocalName == name);
+
+    private static IEnumerable<XElement> Els(XElement parent, string name) =>
+        parent?.Elements().Where(e => e.Name.LocalName == name) ?? [];
+
+    private static string Val(XElement parent, string name)
+    {
+        var value = El(parent, name)?.Value?.Trim();
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    private const string XmlEnvelopeStart = "<XML>";
+    private const string XmlEnvelopeEnd = "</XML>";
+
+    internal static string SanitizeXml(string xml)
+    {
+        // SEC filings wrap the actual XML inside an SGML envelope (one .txt holds the whole
+        // submission); pull out the <XML>...</XML> body before parsing.
+        var xmlStart = xml.IndexOf(XmlEnvelopeStart, StringComparison.OrdinalIgnoreCase);
+        var xmlEnd = xml.IndexOf(XmlEnvelopeEnd, StringComparison.OrdinalIgnoreCase);
+        if (xmlStart >= 0 && xmlEnd > xmlStart)
+        {
+            xml = xml[(xmlStart + XmlEnvelopeStart.Length)..xmlEnd].Trim();
+        }
+
+        // Escape stray ampersands that aren't already part of an entity.
+        return Regex.Replace(xml, @"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)", "&amp;");
+    }
+
+    // Returns (amount, isIndefinite). Form D reports offering amounts either as a dollar figure
+    // or the literal "Indefinite"; the latter is stored as null and flagged.
+    internal static (long?, bool) ParseAmount(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return (null, false);
+        if (value.Trim().Equals(IndefiniteValue, StringComparison.OrdinalIgnoreCase))
+            return (null, true);
+        return (ParseLong(value), false);
+    }
+
+    internal static DateOnly? ParseDate(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        return DateOnly.TryParseExact(
+            value.Trim(),
+            DateFormats,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var parsed
+        )
+            ? parsed
+            : null;
+    }
+
+    internal static bool ParseBool(string value)
+    {
+        return bool.TryParse(value, out var result) && result;
+    }
+
+    internal static int? ParseNullableInt(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var r)
+            ? r
+            : null;
+    }
+
+    internal static long ParseLong(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return 0;
+        if (long.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
+            return result;
+        return 0;
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/FormDFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FormDFilingProcessorTests.cs
@@ -1,0 +1,402 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class FormDFilingProcessorTests
+{
+    // ── CanProcess ──
+
+    [Theory]
+    [InlineData("FormD")]
+    [InlineData("FormDa")]
+    public void CanProcess_FormDTypes_ReturnsTrue(string value)
+    {
+        var (processor, _, _) = CreateProcessorWithDeps();
+        processor.CanProcess(DocumentType.FromValue(value)).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("FormFour")]
+    [InlineData("Form144")]
+    [InlineData("TenK")]
+    public void CanProcess_OtherTypes_ReturnsFalse(string value)
+    {
+        var (processor, _, _) = CreateProcessorWithDeps();
+        processor.CanProcess(DocumentType.FromValue(value)).Should().BeFalse();
+    }
+
+    // ── ParseAmount ──
+
+    [Fact]
+    public void ParseAmount_NumericValue_ReturnsAmountNotIndefinite()
+    {
+        FormDFilingProcessor.ParseAmount("5000000").Should().Be((5000000L, false));
+    }
+
+    [Fact]
+    public void ParseAmount_Indefinite_ReturnsNullFlagged()
+    {
+        FormDFilingProcessor.ParseAmount("Indefinite").Should().Be(((long?)null, true));
+        FormDFilingProcessor.ParseAmount("indefinite").Should().Be(((long?)null, true));
+    }
+
+    [Fact]
+    public void ParseAmount_EmptyOrNull_ReturnsNullNotIndefinite()
+    {
+        FormDFilingProcessor.ParseAmount("").Should().Be(((long?)null, false));
+        FormDFilingProcessor.ParseAmount(null).Should().Be(((long?)null, false));
+    }
+
+    // ── ParseDate ──
+
+    [Theory]
+    [InlineData("2025-02-28", 2025, 2, 28)]
+    [InlineData("02/28/2025", 2025, 2, 28)]
+    public void ParseDate_IsoOrUsFormat_Parses(string input, int y, int m, int d)
+    {
+        FormDFilingProcessor.ParseDate(input).Should().Be(new DateOnly(y, m, d));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-date")]
+    public void ParseDate_InvalidOrEmpty_ReturnsNull(string input)
+    {
+        FormDFilingProcessor.ParseDate(input).Should().BeNull();
+    }
+
+    // ── SanitizeXml ──
+
+    [Fact]
+    public void SanitizeXml_WithSgmlEnvelope_ExtractsInnerXml()
+    {
+        var result = FormDFilingProcessor.SanitizeXml(ValidFormDSubmission);
+        result.Should().StartWith("<?xml").And.Contain("<edgarSubmission");
+        result.Should().NotContain("<SEC-DOCUMENT>");
+    }
+
+    // ── Process ──
+
+    [Fact]
+    public async Task Process_ValidFormD_InsertsFilingWithRelatedPersons()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(ValidFormDSubmission);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().Include(f => f.RelatedPersons).SingleAsync();
+        filing.EntityName.Should().Be("AJ BOULDER FUND LLC");
+        filing.EntityType.Should().Be("Limited Liability Company");
+        filing.JurisdictionOfInc.Should().Be("DELAWARE");
+        filing.YearOfIncorporation.Should().Be(2024);
+        filing.IndustryGroup.Should().Be("Pooled Investment Fund");
+        filing.FederalExemptions.Should().Be("06b, 3C, 3C.7");
+        filing.IsAmendment.Should().BeFalse();
+        filing.TotalOfferingAmount.Should().BeNull();
+        filing.IsOfferingAmountIndefinite.Should().BeTrue();
+        filing.TotalAmountSold.Should().Be(0);
+        filing.TotalRemaining.Should().BeNull();
+        filing.IsRemainingIndefinite.Should().BeTrue();
+        filing.MinimumInvestmentAccepted.Should().Be(0);
+        filing.HasNonAccreditedInvestors.Should().BeFalse();
+        filing.TotalNumberAlreadyInvested.Should().Be(0);
+
+        filing.RelatedPersons.Should().HaveCount(2);
+        filing.RelatedPersons.Should().Contain(p => p.Name == "BENJAMIN WEPRIN");
+        filing
+            .RelatedPersons.Should()
+            .OnlyContain(p => p.Relationships == "Executive Officer, Promoter");
+    }
+
+    [Fact]
+    public async Task Process_NumericAmounts_ParsesDollarFiguresAndDate()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(NumericAmountsSubmission);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().SingleAsync();
+        filing.TotalOfferingAmount.Should().Be(10000000);
+        filing.IsOfferingAmountIndefinite.Should().BeFalse();
+        filing.TotalAmountSold.Should().Be(2500000);
+        filing.TotalRemaining.Should().Be(7500000);
+        filing.IsRemainingIndefinite.Should().BeFalse();
+        filing.MinimumInvestmentAccepted.Should().Be(25000);
+        filing.HasNonAccreditedInvestors.Should().BeTrue();
+        filing.TotalNumberAlreadyInvested.Should().Be(12);
+        filing.DateOfFirstSale.Should().Be(new DateOnly(2025, 1, 15));
+    }
+
+    [Fact]
+    public async Task Process_AmendmentFlag_SetsIsAmendment()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentSubmission);
+
+        var result = await processor.Process(MakeFiling(form: "D/A"), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().SingleAsync();
+        filing.IsAmendment.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Process_DuplicateAccession_IsNotInsertedTwice()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(ValidFormDSubmission);
+        var filing = MakeFiling();
+
+        var first = await processor.Process(filing, MakeCompany());
+        var second = await processor.Process(filing, MakeCompany());
+
+        first.Should().BeTrue();
+        second.Should().BeFalse();
+        (await repo.GetAll().CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Process_EmptyContent_ReturnsFalse()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns("");
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeFalse();
+        (await repo.GetAll().AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Process_NonXmlContent_ReturnsFalse()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns("<SEC-DOCUMENT>legacy text</SEC-DOCUMENT>");
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeFalse();
+        (await repo.GetAll().AnyAsync()).Should().BeFalse();
+    }
+
+    // ── Helpers ──
+
+    private static (
+        FormDFilingProcessor processor,
+        FormDFilingRepository repo,
+        ISecEdgarClient secClient
+    ) CreateProcessorWithDeps()
+    {
+        var dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration(),
+            new ErrorsModuleConfiguration()
+        );
+
+        var repo = new FormDFilingRepository(dbContext);
+        var errorRepo = new ErrorRepository(dbContext);
+        var errorManager = new ErrorManager(errorRepo);
+        var secClient = Substitute.For<ISecEdgarClient>();
+
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(ISecEdgarClient), secClient),
+            (typeof(FormDFilingRepository), repo),
+            (typeof(ErrorManager), errorManager)
+        );
+
+        var errorReporter = new ErrorReporter(
+            scopeFactory,
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+        var processor = new FormDFilingProcessor(
+            scopeFactory,
+            Substitute.For<ILogger<FormDFilingProcessor>>(),
+            errorReporter
+        );
+
+        return (processor, repo, secClient);
+    }
+
+    private static FilingData MakeFiling(string accession = null, string form = "D")
+    {
+        accession ??= $"0002058722-25-{Guid.NewGuid().ToString("N")[..6]}";
+        return new FilingData
+        {
+            AccessionNumber = accession,
+            Form = form,
+            FilingDate = new DateOnly(2025, 2, 28),
+            ReportDate = new DateOnly(2025, 2, 28),
+            Cik = "0002058722",
+        };
+    }
+
+    private static CommonStock MakeCompany()
+    {
+        return new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+    }
+
+    // A real Form D submission (accession 0002058722-25-000001), trimmed to the SGML envelope
+    // plus the <XML> body the processor reads.
+    private const string ValidFormDSubmission = """
+        <SEC-DOCUMENT>0002058722-25-000001.txt : 20250228
+        <SEC-HEADER>...
+        <DOCUMENT>
+        <TYPE>D
+        <TEXT>
+        <XML>
+        <?xml version="1.0"?>
+        <edgarSubmission>
+          <schemaVersion>X0708</schemaVersion>
+          <submissionType>D</submissionType>
+          <testOrLive>LIVE</testOrLive>
+          <primaryIssuer>
+            <cik>0002058722</cik>
+            <entityName>AJ BOULDER FUND LLC</entityName>
+            <jurisdictionOfInc>DELAWARE</jurisdictionOfInc>
+            <entityType>Limited Liability Company</entityType>
+            <yearOfInc>
+              <withinFiveYears>true</withinFiveYears>
+              <value>2024</value>
+            </yearOfInc>
+          </primaryIssuer>
+          <relatedPersonsList>
+            <relatedPersonInfo>
+              <relatedPersonName>
+                <firstName>BENJAMIN</firstName>
+                <lastName>WEPRIN</lastName>
+              </relatedPersonName>
+              <relatedPersonRelationshipList>
+                <relationship>Executive Officer</relationship>
+                <relationship>Promoter</relationship>
+              </relatedPersonRelationshipList>
+            </relatedPersonInfo>
+            <relatedPersonInfo>
+              <relatedPersonName>
+                <firstName>ERIC</firstName>
+                <lastName>HASSBERGER</lastName>
+              </relatedPersonName>
+              <relatedPersonRelationshipList>
+                <relationship>Executive Officer</relationship>
+                <relationship>Promoter</relationship>
+              </relatedPersonRelationshipList>
+            </relatedPersonInfo>
+          </relatedPersonsList>
+          <offeringData>
+            <industryGroup>
+              <industryGroupType>Pooled Investment Fund</industryGroupType>
+            </industryGroup>
+            <federalExemptionsExclusions>
+              <item>06b</item>
+              <item>3C</item>
+              <item>3C.7</item>
+            </federalExemptionsExclusions>
+            <typeOfFiling>
+              <newOrAmendment>
+                <isAmendment>false</isAmendment>
+              </newOrAmendment>
+              <dateOfFirstSale>
+                <yetToOccur>true</yetToOccur>
+              </dateOfFirstSale>
+            </typeOfFiling>
+            <minimumInvestmentAccepted>0</minimumInvestmentAccepted>
+            <offeringSalesAmounts>
+              <totalOfferingAmount>Indefinite</totalOfferingAmount>
+              <totalAmountSold>0</totalAmountSold>
+              <totalRemaining>Indefinite</totalRemaining>
+            </offeringSalesAmounts>
+            <investors>
+              <hasNonAccreditedInvestors>false</hasNonAccreditedInvestors>
+              <totalNumberAlreadyInvested>0</totalNumberAlreadyInvested>
+            </investors>
+          </offeringData>
+        </edgarSubmission>
+        </XML>
+        </TEXT>
+        </DOCUMENT>
+        </SEC-DOCUMENT>
+        """;
+
+    private const string NumericAmountsSubmission = """
+        <XML>
+        <edgarSubmission>
+          <submissionType>D</submissionType>
+          <primaryIssuer>
+            <entityName>ACME ROBOTICS INC</entityName>
+            <entityType>Corporation</entityType>
+            <jurisdictionOfInc>DELAWARE</jurisdictionOfInc>
+          </primaryIssuer>
+          <offeringData>
+            <industryGroup>
+              <industryGroupType>Technology</industryGroupType>
+            </industryGroup>
+            <typeOfFiling>
+              <newOrAmendment>
+                <isAmendment>false</isAmendment>
+              </newOrAmendment>
+              <dateOfFirstSale>
+                <value>2025-01-15</value>
+              </dateOfFirstSale>
+            </typeOfFiling>
+            <minimumInvestmentAccepted>25000</minimumInvestmentAccepted>
+            <offeringSalesAmounts>
+              <totalOfferingAmount>10000000</totalOfferingAmount>
+              <totalAmountSold>2500000</totalAmountSold>
+              <totalRemaining>7500000</totalRemaining>
+            </offeringSalesAmounts>
+            <investors>
+              <hasNonAccreditedInvestors>true</hasNonAccreditedInvestors>
+              <totalNumberAlreadyInvested>12</totalNumberAlreadyInvested>
+            </investors>
+          </offeringData>
+        </edgarSubmission>
+        </XML>
+        """;
+
+    private const string AmendmentSubmission = """
+        <XML>
+        <edgarSubmission>
+          <submissionType>D/A</submissionType>
+          <primaryIssuer>
+            <entityName>ACME ROBOTICS INC</entityName>
+          </primaryIssuer>
+          <offeringData>
+            <typeOfFiling>
+              <newOrAmendment>
+                <isAmendment>true</isAmendment>
+              </newOrAmendment>
+            </typeOfFiling>
+            <offeringSalesAmounts>
+              <totalOfferingAmount>10000000</totalOfferingAmount>
+              <totalAmountSold>5000000</totalAmountSold>
+              <totalRemaining>5000000</totalRemaining>
+            </offeringSalesAmounts>
+          </offeringData>
+        </edgarSubmission>
+        </XML>
+        """;
+}

--- a/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
+++ b/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
@@ -144,14 +144,16 @@ public class ConfigurationTests
         options
             .DocumentTypesToSync.Should()
             .NotBeNull()
-            .And.HaveCount(6)
+            .And.HaveCount(8)
             .And.ContainInOrder(
                 DocumentType.TenK,
                 DocumentType.TenQ,
                 DocumentType.EightK,
                 DocumentType.FormFour,
                 DocumentType.FormThree,
-                DocumentType.Form144
+                DocumentType.Form144,
+                DocumentType.FormD,
+                DocumentType.FormDa
             );
     }
 

--- a/tests/Equibles.UnitTests/Sec/DocumentTypeExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeExtensionsTests.cs
@@ -19,6 +19,8 @@ public class DocumentTypeExtensionsTests
     [InlineData("FormFour", DocumentTypeFilter.FormFour)]
     [InlineData("FormThree", DocumentTypeFilter.FormThree)]
     [InlineData("Form144", DocumentTypeFilter.Form144)]
+    [InlineData("FormD", DocumentTypeFilter.FormD)]
+    [InlineData("FormDa", DocumentTypeFilter.FormDa)]
     public void ToSecEdgarFilter_MappedType_ReturnsCorrectFilter(
         string documentTypeValue,
         DocumentTypeFilter expectedFilter
@@ -76,6 +78,8 @@ public class DocumentTypeExtensionsTests
     [InlineData("4", DocumentTypeFilter.FormFour)]
     [InlineData("3", DocumentTypeFilter.FormThree)]
     [InlineData("144", DocumentTypeFilter.Form144)]
+    [InlineData("D", DocumentTypeFilter.FormD)]
+    [InlineData("D/A", DocumentTypeFilter.FormDa)]
     public void FromFormName_ThenToSecEdgarFilter_RoundTrips(
         string formName,
         DocumentTypeFilter expectedFilter

--- a/tests/Equibles.UnitTests/Sec/DocumentTypeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeTests.cs
@@ -44,6 +44,8 @@ public class DocumentTypeTests
     [InlineData("20-F", "TwentyF")]
     [InlineData("4", "FormFour")]
     [InlineData("3", "FormThree")]
+    [InlineData("D", "FormD")]
+    [InlineData("D/A", "FormDa")]
     public void FromDisplayName_ReturnsCorrectType(string displayName, string expectedValue)
     {
         var result = DocumentType.FromDisplayName(displayName);
@@ -92,6 +94,8 @@ public class DocumentTypeTests
                     DocumentType.FormFour,
                     DocumentType.FormThree,
                     DocumentType.Form144,
+                    DocumentType.FormD,
+                    DocumentType.FormDa,
                     DocumentType.Other,
                 }
             );

--- a/tests/Equibles.UnitTests/Sec/SecHostedServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecHostedServiceCollectionExtensionsTests.cs
@@ -24,6 +24,7 @@ public class SecHostedServiceCollectionExtensionsTests
         // registered today:
         //   • InsiderTradingFilingProcessor — Form 3/4/5 ownership filings
         //   • Form144FilingProcessor        — Form 144 proposed-sale notices
+        //   • FormDFilingProcessor          — Form D exempt-offering notices
         // The implementation_type binding matters: a refactor that swapped a
         // concrete to a stub (`services.AddScoped<IFilingProcessor,
         // StubFilingProcessor>()` — a common copy-paste mistake when adding
@@ -51,7 +52,7 @@ public class SecHostedServiceCollectionExtensionsTests
         descriptors
             .Should()
             .HaveCount(
-                2,
+                3,
                 "AddSecWorker registers one IFilingProcessor per supported structured form family"
             );
         descriptors
@@ -64,6 +65,12 @@ public class SecHostedServiceCollectionExtensionsTests
             .Should()
             .Contain(d =>
                 d.ImplementationType == typeof(Form144FilingProcessor)
+                && d.Lifetime == ServiceLifetime.Scoped
+            );
+        descriptors
+            .Should()
+            .Contain(d =>
+                d.ImplementationType == typeof(FormDFilingProcessor)
                 && d.Lifetime == ServiceLifetime.Scoped
             );
     }


### PR DESCRIPTION
## Summary

- Slice 2 of 4 for Form D ingestion — see #1867.
- Parses Form D `primary_doc.xml` from the issuer's EDGAR submissions feed into the structured `FormDFiling` records added in the previous slice, including the named executives, directors and promoters.
- Registers both `D` (original notice) and `D/A` (amendment) document types end to end and adds them to the default scraper sync list, so the existing per-company SEC scraper picks them up with no new scraper.
- Offering amounts reported as the literal "Indefinite" are stored as null and flagged.
- Does not close the issue; remaining slices expose the data via MCP and the web portal.

## Code changes

- `src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs` — new `IFilingProcessor`: fetches the submission, strips the SGML envelope, parses the `edgarSubmission` body, dedupes by accession number, and persists the filing plus related persons.
- `src/Equibles.Sec.Data/Models/DocumentType.cs` — add `FormD` ("D") and `FormDa` ("D/A") with value and display-name lookup entries.
- `src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs` — add `FormD`/`FormDa` EDGAR form filters.
- `src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs` — map the new database types to their EDGAR filters.
- `src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs` — sync the new types by default.
- `src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs` — register the processor.
- Tests — new processor tests; updated the configuration, document-type, mapping, and DI-registration pins.

Refs #1867