### PR TITLE
feat(sec): expose Form D exempt offerings via MCP

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
@@ -1,0 +1,89 @@
+using System.ComponentModel;
+using System.Globalization;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
+using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Equibles.Sec.Mcp.Tools;
+
+[McpServerToolType]
+public class FormDTools
+{
+    private readonly FormDFilingRepository _formDRepository;
+    private readonly CommonStockRepository _commonStockRepository;
+    private readonly McpToolRunner _runner;
+
+    public FormDTools(
+        FormDFilingRepository formDRepository,
+        CommonStockRepository commonStockRepository,
+        ErrorManager errorManager,
+        ILogger<FormDTools> logger
+    )
+    {
+        _formDRepository = formDRepository;
+        _commonStockRepository = commonStockRepository;
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
+    }
+
+    [McpServerTool(Name = "GetExemptOfferings")]
+    [Description(
+        "Get recent exempt securities offerings (private placements) for a company from SEC Form D notices. Each Form D reports a Regulation D offering, showing the issuer, the total offering amount and amount sold so far (either a dollar figure or \"Indefinite\"), the minimum investment, the number of investors, the claimed exemptions, and whether the notice is an amendment. Use this to track how a company is raising private capital alongside its public filings."
+    )]
+    public Task<string> GetExemptOfferings(
+        [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Maximum number of notices to return (default: 50)")] int maxResults = 50
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
+
+                var filings = await _formDRepository
+                    .GetByStock(stock)
+                    .OrderByDescending(f => f.FilingDate)
+                    .Take(maxResults)
+                    .ToListAsync();
+
+                if (filings.Count == 0)
+                    return $"No Form D exempt offerings found for {ticker}.";
+
+                var result = MarkdownTable.Start(
+                    $"Recent exempt offerings (Form D) for {stock.Name} ({ticker}) — showing {filings.Count} most recent notices:",
+                    "| Filed | Amendment | Industry | Offering Amount | Sold | Min. Investment | Investors | Exemptions |",
+                    "|-------|-----------|----------|-----------------|------|-----------------|-----------|------------|"
+                );
+
+                foreach (var f in filings)
+                {
+                    result.AppendLine(
+                        $"| {f.FilingDate:yyyy-MM-dd} | {(f.IsAmendment ? "Yes" : "No")} | {f.IndustryGroup ?? "-"} | {FormatAmount(f.TotalOfferingAmount, f.IsOfferingAmountIndefinite)} | ${f.TotalAmountSold.ToString("N0", CultureInfo.InvariantCulture)} | ${f.MinimumInvestmentAccepted.ToString("N0", CultureInfo.InvariantCulture)} | {f.TotalNumberAlreadyInvested.ToString("N0", CultureInfo.InvariantCulture)} | {f.FederalExemptions ?? "-"} |"
+                    );
+                }
+
+                return result.ToString();
+            },
+            "GetExemptOfferings",
+            $"ticker: {ticker}"
+        );
+    }
+
+    private static string FormatAmount(long? amount, bool isIndefinite)
+    {
+        if (isIndefinite)
+            return "Indefinite";
+        return amount.HasValue
+            ? $"${amount.Value.ToString("N0", CultureInfo.InvariantCulture)}"
+            : "-";
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/FormDExemptOfferingsToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FormDExemptOfferingsToolTests.cs
@@ -1,0 +1,148 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+public class FormDExemptOfferingsToolTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly FormDTools _tools;
+
+    public FormDExemptOfferingsToolTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration()
+        );
+        _tools = new FormDTools(
+            new FormDFilingRepository(_dbContext),
+            new CommonStockRepository(_dbContext),
+            errorManager: null,
+            NullLogger<FormDTools>.Instance
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    private CommonStock SeedStock(string ticker = "AAPL", string cik = "0000320193")
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = "Apple Inc.",
+            Cik = cik,
+        };
+        _dbContext.Set<CommonStock>().Add(stock);
+        _dbContext.SaveChanges();
+        return stock;
+    }
+
+    [Fact]
+    public async Task GetExemptOfferings_StockNotFound_ReturnsNotFoundMessage()
+    {
+        var result = await _tools.GetExemptOfferings("ZZZZ");
+
+        result.Should().Contain("ZZZZ");
+    }
+
+    [Fact]
+    public async Task GetExemptOfferings_NoFilings_ReturnsEmptyMessage()
+    {
+        SeedStock();
+
+        var result = await _tools.GetExemptOfferings("AAPL");
+
+        result.Should().Contain("No Form D exempt offerings found for AAPL.");
+    }
+
+    [Fact]
+    public async Task GetExemptOfferings_WithFilings_RendersTableNewestFirst()
+    {
+        var stock = SeedStock();
+        _dbContext
+            .Set<FormDFiling>()
+            .Add(MakeFiling(stock.Id, "older", new DateOnly(2025, 1, 5), offeringAmount: 1000000));
+        _dbContext
+            .Set<FormDFiling>()
+            .Add(MakeFiling(stock.Id, "newer", new DateOnly(2025, 5, 27), offeringAmount: 5000000));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetExemptOfferings("AAPL");
+
+        result.Should().Contain("Apple Inc.");
+        result.Should().Contain("5,000,000"); // invariant-culture grouping
+        // Newest filing renders before the older one.
+        result
+            .IndexOf("5,000,000", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(result.IndexOf("1,000,000", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetExemptOfferings_IndefiniteAmount_RendersIndefinite()
+    {
+        var stock = SeedStock();
+        _dbContext
+            .Set<FormDFiling>()
+            .Add(MakeFiling(stock.Id, "acc", new DateOnly(2025, 2, 28), indefinite: true));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetExemptOfferings("AAPL");
+
+        result.Should().Contain("Indefinite");
+    }
+
+    [Fact]
+    public async Task GetExemptOfferings_RespectsMaxResults()
+    {
+        var stock = SeedStock();
+        for (var i = 0; i < 5; i++)
+        {
+            _dbContext
+                .Set<FormDFiling>()
+                .Add(MakeFiling(stock.Id, $"acc-{i}", new DateOnly(2025, 1, 1).AddDays(i)));
+        }
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetExemptOfferings("AAPL", maxResults: 2);
+
+        result.Should().Contain("showing 2 most recent notices");
+    }
+
+    private static FormDFiling MakeFiling(
+        Guid stockId,
+        string accession,
+        DateOnly filingDate,
+        long offeringAmount = 1000000,
+        bool indefinite = false
+    )
+    {
+        return new FormDFiling
+        {
+            CommonStockId = stockId,
+            AccessionNumber = accession,
+            FilingDate = filingDate,
+            IsAmendment = false,
+            EntityName = "Apple Inc.",
+            EntityType = "Corporation",
+            JurisdictionOfInc = "CALIFORNIA",
+            IndustryGroup = "Technology",
+            FederalExemptions = "06b",
+            TotalOfferingAmount = indefinite ? null : offeringAmount,
+            IsOfferingAmountIndefinite = indefinite,
+            TotalAmountSold = indefinite ? 0 : offeringAmount / 2,
+            TotalRemaining = indefinite ? null : offeringAmount / 2,
+            IsRemainingIndefinite = indefinite,
+            MinimumInvestmentAccepted = 25000,
+            TotalNumberAlreadyInvested = 10,
+        };
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -303,6 +303,7 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("SearchDocumentKeyword");
         toolNames.Should().Contain("ReadDocumentLines");
         toolNames.Should().Contain("GetFailsToDeliver");
+        toolNames.Should().Contain("GetExemptOfferings");
     }
 
     // ── Cross-module uniqueness ─────────────────────────────────────────
@@ -395,6 +396,7 @@ public class McpModuleToolDiscoveryTests
                     "SearchDocumentKeyword",
                     "ReadDocumentLines",
                     "GetFailsToDeliver",
+                    "GetExemptOfferings",
                 }
             },
             { typeof(CboeTools), new[] { "GetPutCallRatios", "GetVixHistory" } },


### PR DESCRIPTION
## Summary

- Slice 3 of 4 for Form D ingestion — see #1867.
- Adds a `GetExemptOfferings` MCP tool so AI assistants can pull a company's recent Form D private-placement notices.
- Returns industry, total offering amount and amount sold (a dollar figure or "Indefinite"), minimum investment, investor count, claimed exemptions, and an amendment flag, newest first.
- Does not close the issue; the final slice surfaces the data in the web portal.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/FormDTools.cs` — new MCP tool type, resolves the stock by ticker and renders the recent Form D filings as a Markdown table (invariant-culture number formatting).
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — add `GetExemptOfferings` to the Sec module's expected-tools pins (presence + exact count).
- `tests/Equibles.IntegrationTests/Mcp/FormDExemptOfferingsToolTests.cs` — tool tests: not-found, empty, newest-first ordering, "Indefinite" rendering, max-results.

Refs #1867