### PR TITLE
refactor(sec-mcp): collapse repeated N0 invariant formatting in FormDTools into FormatWholeNumber

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
@@ -67,7 +67,7 @@ public class FormDTools
                 foreach (var f in filings)
                 {
                     result.AppendLine(
-                        $"| {f.FilingDate:yyyy-MM-dd} | {(f.IsAmendment ? "Yes" : "No")} | {f.IndustryGroup ?? "-"} | {FormatAmount(f.TotalOfferingAmount, f.IsOfferingAmountIndefinite)} | ${f.TotalAmountSold.ToString("N0", CultureInfo.InvariantCulture)} | ${f.MinimumInvestmentAccepted.ToString("N0", CultureInfo.InvariantCulture)} | {f.TotalNumberAlreadyInvested.ToString("N0", CultureInfo.InvariantCulture)} | {f.FederalExemptions ?? "-"} |"
+                        $"| {f.FilingDate:yyyy-MM-dd} | {(f.IsAmendment ? "Yes" : "No")} | {f.IndustryGroup ?? "-"} | {FormatAmount(f.TotalOfferingAmount, f.IsOfferingAmountIndefinite)} | ${FormatWholeNumber(f.TotalAmountSold)} | ${FormatWholeNumber(f.MinimumInvestmentAccepted)} | {FormatWholeNumber(f.TotalNumberAlreadyInvested)} | {f.FederalExemptions ?? "-"} |"
                     );
                 }
 
@@ -82,8 +82,9 @@ public class FormDTools
     {
         if (isIndefinite)
             return "Indefinite";
-        return amount.HasValue
-            ? $"${amount.Value.ToString("N0", CultureInfo.InvariantCulture)}"
-            : "-";
+        return amount.HasValue ? $"${FormatWholeNumber(amount.Value)}" : "-";
     }
+
+    private static string FormatWholeNumber(long value) =>
+        value.ToString("N0", CultureInfo.InvariantCulture);
 }


### PR DESCRIPTION
## Summary

- The newly added `FormDTools.GetExemptOfferings` MCP tool repeated the inline expression `.ToString("N0", CultureInfo.InvariantCulture)` four times to format whole-number dollar and count cells.
- Collapse those four call sites into a single private `FormatWholeNumber` helper, matching the per-file `FormatWholeNumber` convention used by sibling MCP tools. This centralises the invariant-culture number formatting so a future copied row can't silently fork the thousands separators by host locale.
- Behaviour-preserving: the helper body is exactly `value.ToString("N0", CultureInfo.InvariantCulture)`; the one `int` argument widens to `long` with identical N0 output, and the `-`/`Indefinite`/`$` placeholders are unchanged.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/FormDTools.cs` — add `private static string FormatWholeNumber(long value)`; route the three row cells (amount sold, minimum investment, investor count) and the `FormatAmount` dollar branch through it.