### PR TITLE
feat(sec): add N-CEN registered-fund operational data model

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260530080559_AddNCen.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260530080559_AddNCen.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530080559_AddNCen")]
+    partial class AddNCen
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260530080559_AddNCen.cs
+++ b/src/Equibles.Migrations/Migrations/20260530080559_AddNCen.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNCen : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "NCenFiling",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccessionNumber = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    FilingDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    IsAmendment = table.Column<bool>(type: "boolean", nullable: false),
+                    RegistrantName = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    InvestmentCompanyType = table.Column<string>(
+                        type: "character varying(16)",
+                        maxLength: 16,
+                        nullable: true
+                    ),
+                    InvestmentCompanyFileNumber = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    RegistrantLei = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    State = table.Column<string>(
+                        type: "character varying(16)",
+                        maxLength: 16,
+                        nullable: true
+                    ),
+                    Country = table.Column<string>(
+                        type: "character varying(8)",
+                        maxLength: 8,
+                        nullable: true
+                    ),
+                    ReportEndingPeriod = table.Column<DateOnly>(type: "date", nullable: false),
+                    IsReportPeriodLessThan12Months = table.Column<bool>(
+                        type: "boolean",
+                        nullable: false
+                    ),
+                    IsFirstFiling = table.Column<bool>(type: "boolean", nullable: false),
+                    IsLastFiling = table.Column<bool>(type: "boolean", nullable: false),
+                    IsFamilyInvestmentCompany = table.Column<bool>(
+                        type: "boolean",
+                        nullable: false
+                    ),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NCenFiling", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_NCenFiling_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "NCenServiceProvider",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    NCenFilingId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProviderType = table.Column<int>(type: "integer", nullable: false),
+                    Name = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    Country = table.Column<string>(
+                        type: "character varying(8)",
+                        maxLength: 8,
+                        nullable: true
+                    ),
+                    IsAffiliated = table.Column<bool>(type: "boolean", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NCenServiceProvider", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_NCenServiceProvider_NCenFiling_NCenFilingId",
+                        column: x => x.NCenFilingId,
+                        principalTable: "NCenFiling",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NCenFiling_AccessionNumber",
+                table: "NCenFiling",
+                column: "AccessionNumber",
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NCenFiling_CommonStockId_FilingDate",
+                table: "NCenFiling",
+                columns: new[] { "CommonStockId", "FilingDate" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NCenFiling_FilingDate",
+                table: "NCenFiling",
+                column: "FilingDate"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NCenServiceProvider_NCenFilingId",
+                table: "NCenServiceProvider",
+                column: "NCenFilingId"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "NCenServiceProvider");
+
+            migrationBuilder.DropTable(name: "NCenFiling");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/NCenFiling.cs
+++ b/src/Equibles.Sec.Data/Models/NCenFiling.cs
@@ -1,0 +1,85 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// A SEC Form N-CEN annual report filed by a registered investment company (mutual fund, ETF or
+/// closed-end fund). N-CEN appears in the registrant's EDGAR submissions feed, so each report is
+/// attributed to the registrant's <see cref="CommonStock"/>. The record captures the registrant's
+/// operational facts — classification, file number, reporting period — plus the fund's key service
+/// providers (advisers, custodians, transfer agents, auditors and so on) in
+/// <see cref="ServiceProviders"/>. Both the original report ("N-CEN") and its amendments
+/// ("N-CEN/A") are stored, flagged via <see cref="IsAmendment"/>.
+/// </summary>
+[Index(nameof(CommonStockId), nameof(FilingDate))]
+[Index(nameof(AccessionNumber), IsUnique = true)]
+[Index(nameof(FilingDate))]
+public class NCenFiling
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    [MaxLength(32)]
+    public string AccessionNumber { get; set; }
+
+    public DateOnly FilingDate { get; set; }
+
+    /// <summary>True when the submission type is "N-CEN/A" (an amendment) rather than "N-CEN".</summary>
+    public bool IsAmendment { get; set; }
+
+    /// <summary>The registrant's legal name exactly as reported on the filing.</summary>
+    [MaxLength(512)]
+    public string RegistrantName { get; set; }
+
+    /// <summary>
+    /// The investment-company registration type, e.g. "N-1A" (open-end fund/ETF), "N-2"
+    /// (closed-end fund), "N-3"/"N-4"/"N-6" (insurance products), "N-5" (small business).
+    /// </summary>
+    [MaxLength(16)]
+    public string InvestmentCompanyType { get; set; }
+
+    /// <summary>The Investment Company Act file number, e.g. "811-02409".</summary>
+    [MaxLength(32)]
+    public string InvestmentCompanyFileNumber { get; set; }
+
+    /// <summary>The registrant's Legal Entity Identifier when reported.</summary>
+    [MaxLength(32)]
+    public string RegistrantLei { get; set; }
+
+    /// <summary>The registrant's state or province code, e.g. "US-MD".</summary>
+    [MaxLength(16)]
+    public string State { get; set; }
+
+    /// <summary>The registrant's country code, e.g. "US".</summary>
+    [MaxLength(8)]
+    public string Country { get; set; }
+
+    /// <summary>The last day of the fiscal period the report covers.</summary>
+    public DateOnly ReportEndingPeriod { get; set; }
+
+    /// <summary>True when the report period covers fewer than twelve months.</summary>
+    public bool IsReportPeriodLessThan12Months { get; set; }
+
+    /// <summary>True when this is the registrant's first N-CEN filing.</summary>
+    public bool IsFirstFiling { get; set; }
+
+    /// <summary>True when the registrant marked this as its last filing (e.g. deregistration).</summary>
+    public bool IsLastFiling { get; set; }
+
+    /// <summary>True when the registrant is part of a fund family.</summary>
+    public bool IsFamilyInvestmentCompany { get; set; }
+
+    /// <summary>
+    /// The advisers, custodians, transfer agents, auditors and other firms the fund named on the
+    /// filing — the operational backbone behind the registrant.
+    /// </summary>
+    public virtual List<NCenServiceProvider> ServiceProviders { get; set; } = [];
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Sec.Data/Models/NCenServiceProvider.cs
+++ b/src/Equibles.Sec.Data/Models/NCenServiceProvider.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// A firm named on a <see cref="NCenFiling"/> as serving the registered investment company in a
+/// particular role (see <see cref="NCenServiceProviderType"/>) — for example its investment
+/// adviser, custodian, transfer agent or independent auditor. N-CEN carries the provider's name and
+/// country but no resolvable identifier we track, so the name is stored as free text.
+/// </summary>
+[Index(nameof(NCenFilingId))]
+public class NCenServiceProvider
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid NCenFilingId { get; set; }
+    public virtual NCenFiling NCenFiling { get; set; }
+
+    /// <summary>The role this firm plays for the fund.</summary>
+    public NCenServiceProviderType ProviderType { get; set; }
+
+    /// <summary>The firm's name exactly as reported on the filing.</summary>
+    [MaxLength(512)]
+    public string Name { get; set; }
+
+    /// <summary>The firm's country code when reported, e.g. "US".</summary>
+    [MaxLength(8)]
+    public string Country { get; set; }
+
+    /// <summary>True when the filing reports the firm as affiliated with the registrant.</summary>
+    public bool IsAffiliated { get; set; }
+}

--- a/src/Equibles.Sec.Data/Models/NCenServiceProviderType.cs
+++ b/src/Equibles.Sec.Data/Models/NCenServiceProviderType.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// The role a service provider plays for a registered investment company, as reported on a
+/// Form N-CEN filing. A single filing names many providers across these categories.
+/// </summary>
+public enum NCenServiceProviderType
+{
+    [Display(Name = "Investment Adviser")]
+    InvestmentAdviser,
+
+    [Display(Name = "Sub-Adviser")]
+    SubAdviser,
+
+    [Display(Name = "Custodian")]
+    Custodian,
+
+    [Display(Name = "Transfer Agent")]
+    TransferAgent,
+
+    [Display(Name = "Administrator")]
+    Administrator,
+
+    [Display(Name = "Pricing Service")]
+    PricingService,
+
+    [Display(Name = "Shareholder Servicing Agent")]
+    ShareholderServicingAgent,
+
+    [Display(Name = "Principal Underwriter")]
+    PrincipalUnderwriter,
+
+    [Display(Name = "Independent Public Accountant")]
+    PublicAccountant,
+}

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -26,6 +26,8 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<FailToDeliver>();
         builder.Entity<FormDFiling>();
         builder.Entity<FormDRelatedPerson>();
+        builder.Entity<NCenFiling>();
+        builder.Entity<NCenServiceProvider>();
         builder.Entity<TranscriptCheckStatus>();
     }
 }

--- a/src/Equibles.Sec.Repositories/NCenFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NCenFilingRepository.cs
@@ -1,0 +1,26 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Sec.Repositories;
+
+public class NCenFilingRepository : BaseRepository<NCenFiling>
+{
+    public NCenFilingRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<NCenFiling> GetByStock(CommonStock stock)
+    {
+        return GetAll().Where(f => f.CommonStockId == stock.Id);
+    }
+
+    public IQueryable<NCenFiling> GetByAccessionNumber(string accessionNumber)
+    {
+        return GetAll().Where(f => f.AccessionNumber == accessionNumber);
+    }
+
+    public IQueryable<NCenFiling> GetRecent(DateOnly since)
+    {
+        return GetAll().Where(f => f.FilingDate >= since);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.IntegrationTests.Helpers;
 
 /// <summary>
-/// Registers the non-vector Sec entities (Document, FailToDeliver, Form D) for InMemory tests.
+/// Registers the non-vector Sec entities (Document, FailToDeliver, Form D, N-CEN) for InMemory tests.
 /// The production <see cref="Equibles.Sec.Data.SecModuleConfiguration"/> also
 /// registers Chunk and Embedding, which use pgvector's <c>Vector</c> type that
 /// the EF Core InMemory provider cannot construct. We explicitly ignore those
@@ -30,6 +30,8 @@ public class SecTestModuleConfiguration : Equibles.Data.IModuleConfiguration
         builder.Entity<FailToDeliver>();
         builder.Entity<FormDFiling>();
         builder.Entity<FormDRelatedPerson>();
+        builder.Entity<NCenFiling>();
+        builder.Entity<NCenServiceProvider>();
         builder.Ignore<Chunk>();
         builder.Ignore<Embedding>();
     }

--- a/tests/Equibles.IntegrationTests/Sec/NCenFilingRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NCenFilingRepositoryTests.cs
@@ -1,0 +1,178 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class NCenFilingRepositoryTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly NCenFilingRepository _repository;
+
+    public NCenFilingRepositoryTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration()
+        );
+        _repository = new NCenFilingRepository(_dbContext);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    private static CommonStock CreateStock(string ticker = "MXF", string cik = "0000065433")
+    {
+        return new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = ticker,
+            Cik = cik,
+        };
+    }
+
+    private static NCenFiling CreateFiling(
+        Guid commonStockId,
+        string accessionNumber = "0000065433-24-000002",
+        DateOnly? filingDate = null,
+        string registrantName = "MEXICO FUND INC"
+    )
+    {
+        return new NCenFiling
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = commonStockId,
+            AccessionNumber = accessionNumber,
+            FilingDate = filingDate ?? new DateOnly(2025, 1, 15),
+            IsAmendment = false,
+            RegistrantName = registrantName,
+            InvestmentCompanyType = "N-2",
+            InvestmentCompanyFileNumber = "811-02409",
+            RegistrantLei = "00000000000000238096",
+            State = "US-MD",
+            Country = "US",
+            ReportEndingPeriod = new DateOnly(2024, 10, 31),
+            IsReportPeriodLessThan12Months = false,
+            IsFirstFiling = false,
+            IsLastFiling = false,
+            IsFamilyInvestmentCompany = false,
+        };
+    }
+
+    [Fact]
+    public async Task GetByStock_ReturnsOnlyFilingsForThatStock()
+    {
+        var mexico = CreateStock("MXF", "0000065433");
+        var other = CreateStock("ASA", "0000004969");
+        _dbContext.Set<CommonStock>().AddRange(mexico, other);
+        await _dbContext.SaveChangesAsync();
+
+        _repository.Add(CreateFiling(mexico.Id, "0000065433-24-000002"));
+        _repository.Add(CreateFiling(mexico.Id, "0000065433-23-000003"));
+        _repository.Add(CreateFiling(other.Id, "0000004969-24-000001"));
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetByStock(mexico).ToListAsync();
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(f => f.CommonStockId == mexico.Id);
+    }
+
+    [Fact]
+    public async Task GetByAccessionNumber_ExistingAccession_ReturnsFiling()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+        _repository.Add(CreateFiling(stock.Id, "0000065433-24-000002"));
+        await _repository.SaveChanges();
+
+        var result = await _repository
+            .GetByAccessionNumber("0000065433-24-000002")
+            .FirstOrDefaultAsync();
+
+        result.Should().NotBeNull();
+        result.RegistrantName.Should().Be("MEXICO FUND INC");
+    }
+
+    [Fact]
+    public async Task GetByAccessionNumber_NonExistentAccession_ReturnsEmpty()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+        _repository.Add(CreateFiling(stock.Id, "0000065433-24-000002"));
+        await _repository.SaveChanges();
+
+        var any = await _repository.GetByAccessionNumber("9999999999-99-999999").AnyAsync();
+
+        any.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetRecent_ReturnsOnlyFilingsOnOrAfterCutoff()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        _repository.Add(CreateFiling(stock.Id, "old", filingDate: new DateOnly(2024, 1, 1)));
+        _repository.Add(CreateFiling(stock.Id, "new", filingDate: new DateOnly(2025, 1, 15)));
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetRecent(new DateOnly(2025, 1, 1)).ToListAsync();
+
+        result.Should().ContainSingle();
+        result[0].AccessionNumber.Should().Be("new");
+    }
+
+    [Fact]
+    public async Task Add_FilingWithServiceProviders_PersistsChildRows()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var filing = CreateFiling(stock.Id);
+        filing.ServiceProviders.Add(
+            new NCenServiceProvider
+            {
+                ProviderType = NCenServiceProviderType.InvestmentAdviser,
+                Name = "IMPULSORA DEL FONDO MEXICO SC",
+                Country = "MX",
+                IsAffiliated = false,
+            }
+        );
+        filing.ServiceProviders.Add(
+            new NCenServiceProvider
+            {
+                ProviderType = NCenServiceProviderType.PublicAccountant,
+                Name = "TAIT, WELLER & BAKER LLP",
+                Country = "US",
+                IsAffiliated = false,
+            }
+        );
+        _repository.Add(filing);
+        await _repository.SaveChanges();
+
+        var loaded = await _repository
+            .GetByAccessionNumber(filing.AccessionNumber)
+            .Include(f => f.ServiceProviders)
+            .FirstAsync();
+
+        loaded.ServiceProviders.Should().HaveCount(2);
+        loaded
+            .ServiceProviders.Should()
+            .Contain(p =>
+                p.ProviderType == NCenServiceProviderType.InvestmentAdviser
+                && p.Name == "IMPULSORA DEL FONDO MEXICO SC"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 1 of 4 of N-CEN support (#1869): the data model. SEC Form N-CEN is the annual report filed by registered investment companies (mutual funds, ETFs, closed-end funds); it appears in the registrant's EDGAR submissions feed, so each report is attributed to the registrant's stock — the same pattern as the recent Form D work.
- This slice only lays down the schema and repository; the worker parser, MCP tool and stock-page tab follow in later PRs. Refs #1869 (does not close).

## Code changes

- `src/Equibles.Sec.Data/Models/NCenFiling.cs` — new entity, one row per N-CEN filing, with the registrant's operational facts (classification, file number, LEI, reporting period, first/last/family flags) and a child service-provider list.
- `src/Equibles.Sec.Data/Models/NCenServiceProvider.cs` — child entity for a firm named on the filing (adviser, custodian, transfer agent, auditor, …).
- `src/Equibles.Sec.Data/Models/NCenServiceProviderType.cs` — enum of the provider roles, each with a display name.
- `src/Equibles.Sec.Data/SecModuleConfiguration.cs` — register the two new entities.
- `src/Equibles.Sec.Repositories/NCenFilingRepository.cs` — `GetByStock` / `GetByAccessionNumber` / `GetRecent` queries.
- `src/Equibles.Migrations/Migrations/20260530080559_AddNCen.*` + snapshot — `NCenFiling` and `NCenServiceProvider` tables.
- `tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs` — register the new entities for the in-memory test context.
- `tests/Equibles.IntegrationTests/Sec/NCenFilingRepositoryTests.cs` — repository coverage including the service-provider child rows.