### PR TITLE
feat(sec): parse N-CEN registered-fund filings in the worker

### DIFF
--- a/src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs
+++ b/src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs
@@ -45,4 +45,10 @@ public enum DocumentTypeFilter
 
     [Display(Name = "D/A")]
     FormDa,
+
+    [Display(Name = "N-CEN")]
+    NCen,
+
+    [Display(Name = "N-CEN/A")]
+    NCenA,
 }

--- a/src/Equibles.Sec.Data/Models/DocumentType.cs
+++ b/src/Equibles.Sec.Data/Models/DocumentType.cs
@@ -29,6 +29,8 @@ public sealed class DocumentType
     public static readonly DocumentType Form144 = new("Form144", "144");
     public static readonly DocumentType FormD = new("FormD", "D");
     public static readonly DocumentType FormDa = new("FormDa", "D/A");
+    public static readonly DocumentType NCen = new("NCen", "N-CEN");
+    public static readonly DocumentType NCenA = new("NCenA", "N-CEN/A");
     public static readonly DocumentType Other = new("Other", "Other");
 
     private static readonly ConcurrentDictionary<string, DocumentType> AllByValue = new(
@@ -48,6 +50,8 @@ public sealed class DocumentType
             new KeyValuePair<string, DocumentType>(Form144.Value, Form144),
             new KeyValuePair<string, DocumentType>(FormD.Value, FormD),
             new KeyValuePair<string, DocumentType>(FormDa.Value, FormDa),
+            new KeyValuePair<string, DocumentType>(NCen.Value, NCen),
+            new KeyValuePair<string, DocumentType>(NCenA.Value, NCenA),
             new KeyValuePair<string, DocumentType>(Other.Value, Other),
         },
         StringComparer.OrdinalIgnoreCase
@@ -70,6 +74,8 @@ public sealed class DocumentType
             new KeyValuePair<string, DocumentType>(Form144.DisplayName, Form144),
             new KeyValuePair<string, DocumentType>(FormD.DisplayName, FormD),
             new KeyValuePair<string, DocumentType>(FormDa.DisplayName, FormDa),
+            new KeyValuePair<string, DocumentType>(NCen.DisplayName, NCen),
+            new KeyValuePair<string, DocumentType>(NCenA.DisplayName, NCenA),
             new KeyValuePair<string, DocumentType>(Other.DisplayName, Other),
         },
         StringComparer.OrdinalIgnoreCase

--- a/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
@@ -14,5 +14,7 @@ public class DocumentScraperOptions
         DocumentType.Form144,
         DocumentType.FormD,
         DocumentType.FormDa,
+        DocumentType.NCen,
+        DocumentType.NCenA,
     ];
 }

--- a/src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs
@@ -22,6 +22,8 @@ public static class DocumentTypeExtensions
             { DocumentType.Form144, DocumentTypeFilter.Form144 },
             { DocumentType.FormD, DocumentTypeFilter.FormD },
             { DocumentType.FormDa, DocumentTypeFilter.FormDa },
+            { DocumentType.NCen, DocumentTypeFilter.NCen },
+            { DocumentType.NCenA, DocumentTypeFilter.NCenA },
         };
 
     public static DocumentTypeFilter? ToSecEdgarFilter(this DocumentType docType)

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IFilingProcessor, InsiderTradingFilingProcessor>();
         services.AddScoped<IFilingProcessor, Form144FilingProcessor>();
         services.AddScoped<IFilingProcessor, FormDFilingProcessor>();
+        services.AddScoped<IFilingProcessor, NCenFilingProcessor>();
         services.AddScoped<IDocumentPersistenceService, DocumentPersistenceService>();
         services.AddScoped<ICompanySyncService, CompanySyncService>();
         services.AddScoped<IDocumentScraper, DocumentScraper>();

--- a/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
@@ -1,0 +1,427 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Contracts;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Processes SEC Form N-CEN filings — the annual report filed by registered investment companies
+/// (mutual funds, ETFs, closed-end funds) — into structured <see cref="NCenFiling"/> records plus
+/// the fund's named service providers. N-CEN appears in the registrant's submissions feed, so each
+/// report is attributed to the registrant's stock. Both the original report ("N-CEN") and its
+/// amendments ("N-CEN/A") are processed. The XML root is <c>edgarSubmission</c> in the
+/// <c>http://www.sec.gov/edgar/ncen</c> namespace, so elements are navigated by local name.
+/// Booleans are reported as "Y"/"N".
+/// </summary>
+public class NCenFilingProcessor : IFilingProcessor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<NCenFilingProcessor> _logger;
+    private readonly ErrorReporter _errorReporter;
+
+    // N-CEN dates are ISO yyyy-MM-dd.
+    private static readonly string[] DateFormats = ["yyyy-MM-dd"];
+
+    // Optional fields the filer leaves blank are reported as the literal "N/A"; treat as absent.
+    private const string NotApplicable = "N/A";
+
+    public NCenFilingProcessor(
+        IServiceScopeFactory scopeFactory,
+        ILogger<NCenFilingProcessor> logger,
+        ErrorReporter errorReporter
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _errorReporter = errorReporter;
+    }
+
+    public bool CanProcess(DocumentType documentType)
+    {
+        return documentType == DocumentType.NCen || documentType == DocumentType.NCenA;
+    }
+
+    public async Task<bool> Process(FilingData filing, CommonStock companyOutContext)
+    {
+        var companyId = companyOutContext.Id;
+        var companyTicker = companyOutContext.Ticker;
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var secEdgarClient = scope.ServiceProvider.GetRequiredService<ISecEdgarClient>();
+        var repository = scope.ServiceProvider.GetRequiredService<NCenFilingRepository>();
+
+        var existing = await repository.GetByAccessionNumber(filing.AccessionNumber).AnyAsync();
+        if (existing)
+            return false;
+
+        var content = await secEdgarClient.GetDocumentContent(filing);
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            _logger.LogWarning(
+                "Empty content for {Ticker} N-CEN - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return false;
+        }
+
+        var root = await TryParseSubmission(content, filing, companyTicker);
+        if (root == null)
+            return false;
+
+        var entity = ParseFiling(root, companyId, filing);
+        if (entity == null)
+        {
+            _logger.LogWarning(
+                "N-CEN XML missing registrantInfo for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return false;
+        }
+
+        repository.Add(entity);
+        await repository.SaveChanges();
+
+        _logger.LogInformation(
+            "Imported N-CEN for {Ticker} ({Registrant}, type {Type}, {Providers} service providers) from {AccessionNumber}",
+            companyTicker,
+            entity.RegistrantName,
+            entity.InvestmentCompanyType,
+            entity.ServiceProviders.Count,
+            filing.AccessionNumber
+        );
+
+        return true;
+    }
+
+    private async Task<XElement> TryParseSubmission(
+        string content,
+        FilingData filing,
+        string companyTicker
+    )
+    {
+        var sanitized = SanitizeXml(content);
+
+        // N-CEN has only ever been filed as XML, so a submission without the
+        // <edgarSubmission> root is unexpected — skip quietly.
+        if (!sanitized.Contains("<edgarSubmission", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug(
+                "Skipping non-XML N-CEN filing for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return null;
+        }
+
+        try
+        {
+            return XDocument.Parse(sanitized).Root;
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Malformed N-CEN XML for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            await _errorReporter.Report(
+                ErrorSource.DocumentScraper,
+                "NCen.ParseXml",
+                ex.Message,
+                ex.StackTrace,
+                $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
+            );
+            return null;
+        }
+    }
+
+    private static NCenFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
+    {
+        var headerData = El(root, "headerData");
+        var filerInfo = El(headerData, "filerInfo");
+        var formData = El(root, "formData");
+        var registrant = El(formData, "registrantInfo");
+        if (registrant == null)
+            return null;
+
+        var generalInfo = El(formData, "generalInfo");
+
+        var entity = new NCenFiling
+        {
+            CommonStockId = companyId,
+            AccessionNumber = filing.AccessionNumber,
+            FilingDate = filing.FilingDate,
+            IsAmendment = ParseIsAmendment(headerData, filing),
+            RegistrantName = Clean(Val(registrant, "registrantFullName")),
+            InvestmentCompanyType = Clean(Val(filerInfo, "investmentCompanyType")),
+            InvestmentCompanyFileNumber = Clean(Val(registrant, "investmentCompFileNo")),
+            RegistrantLei = Clean(Val(registrant, "registrantLei")),
+            State = Clean(Val(registrant, "registrantstate")),
+            Country = Clean(Val(registrant, "registrantcountry")),
+            ReportEndingPeriod =
+                ParseDate(Attr(generalInfo, "reportEndingPeriod")) ?? filing.ReportDate,
+            IsReportPeriodLessThan12Months = ParseYesNo(Attr(generalInfo, "isReportPeriodLt12")),
+            IsFirstFiling = ParseYesNo(Val(registrant, "isRegistrantFirstFiling")),
+            IsLastFiling = ParseYesNo(Val(registrant, "isRegistrantLastFiling")),
+            IsFamilyInvestmentCompany = ParseYesNo(Val(registrant, "isRegistrantFamilyInvComp")),
+        };
+
+        AddServiceProviders(entity, registrant, formData);
+
+        return entity;
+    }
+
+    private static void AddServiceProviders(
+        NCenFiling entity,
+        XElement registrant,
+        XElement formData
+    )
+    {
+        var providers = new List<NCenServiceProvider>();
+
+        // Registrant-level providers.
+        foreach (var accountant in Els(El(registrant, "publicAccountants"), "publicAccountant"))
+        {
+            providers.Add(
+                MakeProvider(
+                    NCenServiceProviderType.PublicAccountant,
+                    Val(accountant, "publicAccountantName"),
+                    Attr(El(accountant, "publicAccountantStateCountry"), "publicAccountantCountry"),
+                    affiliated: false
+                )
+            );
+        }
+
+        foreach (
+            var underwriter in Els(El(registrant, "principalUnderwriters"), "principalUnderwriter")
+        )
+        {
+            providers.Add(
+                MakeProvider(
+                    NCenServiceProviderType.PrincipalUnderwriter,
+                    Val(underwriter, "principalUnderwriterName"),
+                    Val(underwriter, "principalUnderWriterCountry"),
+                    ParseYesNo(Val(underwriter, "isPrincipalUnderwriterAffiliatedWithRegistrant"))
+                )
+            );
+        }
+
+        // Per-series (management investment company) providers. A multi-series fund repeats the
+        // same firms across series, so the list is de-duplicated by role + name below.
+        var seriesInfo = El(formData, "managementInvestmentQuestionSeriesInfo");
+        foreach (var question in Els(seriesInfo, "managementInvestmentQuestion"))
+        {
+            foreach (var adviser in Els(El(question, "investmentAdvisers"), "investmentAdviser"))
+            {
+                providers.Add(
+                    MakeProvider(
+                        NCenServiceProviderType.InvestmentAdviser,
+                        Val(adviser, "investmentAdviserName"),
+                        Val(adviser, "investmentAdviserCountry"),
+                        affiliated: false
+                    )
+                );
+            }
+
+            foreach (var subAdviser in Els(El(question, "subAdvisers"), "subAdviser"))
+            {
+                providers.Add(
+                    MakeProvider(
+                        NCenServiceProviderType.SubAdviser,
+                        Val(subAdviser, "subAdviserName"),
+                        Val(subAdviser, "subAdviserCountry"),
+                        ParseYesNo(Val(subAdviser, "isSubAdviserAffiliated"))
+                    )
+                );
+            }
+
+            foreach (var custodian in Els(El(question, "custodians"), "custodian"))
+            {
+                providers.Add(
+                    MakeProvider(
+                        NCenServiceProviderType.Custodian,
+                        Val(custodian, "custodianName"),
+                        Val(custodian, "custodianCountry"),
+                        ParseYesNo(Val(custodian, "isCustodianAffiliated"))
+                    )
+                );
+            }
+
+            foreach (var agent in Els(El(question, "transferAgents"), "transferAgent"))
+            {
+                providers.Add(
+                    MakeProvider(
+                        NCenServiceProviderType.TransferAgent,
+                        Val(agent, "transferAgentName"),
+                        Attr(El(agent, "transferAgentStateCountry"), "transferAgentCountry"),
+                        ParseYesNo(Val(agent, "isTransferAgentAffiliated"))
+                    )
+                );
+            }
+
+            foreach (var admin in Els(El(question, "admins"), "admin"))
+            {
+                providers.Add(
+                    MakeProvider(
+                        NCenServiceProviderType.Administrator,
+                        Val(admin, "adminName"),
+                        Attr(El(admin, "adminStateCountry"), "adminCountry"),
+                        ParseYesNo(Val(admin, "isAdminAffiliated"))
+                    )
+                );
+            }
+
+            foreach (var pricing in Els(El(question, "pricingServices"), "pricingService"))
+            {
+                providers.Add(
+                    MakeProvider(
+                        NCenServiceProviderType.PricingService,
+                        Val(pricing, "pricingServiceName"),
+                        Val(pricing, "pricingServiceCountry"),
+                        ParseYesNo(Val(pricing, "isPricingServiceAffiliated"))
+                    )
+                );
+            }
+
+            foreach (
+                var shareholder in Els(
+                    El(question, "shareholderServicingAgents"),
+                    "shareholderServicingAgent"
+                )
+            )
+            {
+                providers.Add(
+                    MakeProvider(
+                        NCenServiceProviderType.ShareholderServicingAgent,
+                        Val(shareholder, "shareholderServiceAgentName"),
+                        Attr(
+                            El(shareholder, "shareholderServiceAgentStateCountry"),
+                            "shareholderServiceAgentCountry"
+                        ),
+                        ParseYesNo(Val(shareholder, "isShareholderServiceAgentAffiliated"))
+                    )
+                );
+            }
+        }
+
+        foreach (
+            var provider in providers
+                .Where(p => p != null)
+                .GroupBy(p => (p.ProviderType, p.Name.ToUpperInvariant()))
+                .Select(g => g.First())
+        )
+        {
+            entity.ServiceProviders.Add(provider);
+        }
+    }
+
+    // Returns null when the firm has no usable name (blank or the literal "N/A"), so the caller
+    // skips it — N-CEN pads unused provider slots with "N/A" placeholders.
+    private static NCenServiceProvider MakeProvider(
+        NCenServiceProviderType type,
+        string name,
+        string country,
+        bool affiliated
+    )
+    {
+        var cleanName = Clean(name);
+        if (cleanName == null)
+            return null;
+
+        return new NCenServiceProvider
+        {
+            ProviderType = type,
+            Name = cleanName,
+            Country = Clean(country),
+            IsAffiliated = affiliated,
+        };
+    }
+
+    private static bool ParseIsAmendment(XElement headerData, FilingData filing)
+    {
+        var submissionType = Val(headerData, "submissionType");
+        if (submissionType != null)
+            return submissionType.Contains("/A", StringComparison.OrdinalIgnoreCase);
+
+        return filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
+    }
+
+    // ── XML helpers (navigate by local name; N-CEN declares the ncen namespace) ──────
+
+    private static XElement El(XElement parent, string name) =>
+        parent?.Elements().FirstOrDefault(e => e.Name.LocalName == name);
+
+    private static IEnumerable<XElement> Els(XElement parent, string name) =>
+        parent?.Elements().Where(e => e.Name.LocalName == name) ?? [];
+
+    private static string Val(XElement parent, string name)
+    {
+        var value = El(parent, name)?.Value?.Trim();
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    private static string Attr(XElement element, string name)
+    {
+        var value = element?.Attributes().FirstOrDefault(a => a.Name.LocalName == name)?.Value;
+        return string.IsNullOrEmpty(value) ? null : value.Trim();
+    }
+
+    // Normalize the "N/A" placeholder and blanks to null.
+    private static string Clean(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        var trimmed = value.Trim();
+        return trimmed.Equals(NotApplicable, StringComparison.OrdinalIgnoreCase) ? null : trimmed;
+    }
+
+    private const string XmlEnvelopeStart = "<XML>";
+    private const string XmlEnvelopeEnd = "</XML>";
+
+    internal static string SanitizeXml(string xml)
+    {
+        // SEC filings wrap the actual XML inside an SGML envelope (one .txt holds the whole
+        // submission); pull out the <XML>...</XML> body before parsing.
+        var xmlStart = xml.IndexOf(XmlEnvelopeStart, StringComparison.OrdinalIgnoreCase);
+        var xmlEnd = xml.IndexOf(XmlEnvelopeEnd, StringComparison.OrdinalIgnoreCase);
+        if (xmlStart >= 0 && xmlEnd > xmlStart)
+        {
+            xml = xml[(xmlStart + XmlEnvelopeStart.Length)..xmlEnd].Trim();
+        }
+
+        // Escape stray ampersands that aren't already part of an entity.
+        return Regex.Replace(xml, @"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)", "&amp;");
+    }
+
+    internal static bool ParseYesNo(string value)
+    {
+        return value != null && value.Trim().Equals("Y", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static DateOnly? ParseDate(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        return DateOnly.TryParseExact(
+            value.Trim(),
+            DateFormats,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var parsed
+        )
+            ? parsed
+            : null;
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/NCenFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NCenFilingProcessorTests.cs
@@ -1,0 +1,443 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class NCenFilingProcessorTests
+{
+    // ── CanProcess ──
+
+    [Theory]
+    [InlineData("NCen")]
+    [InlineData("NCenA")]
+    public void CanProcess_NCenTypes_ReturnsTrue(string value)
+    {
+        var (processor, _, _) = CreateProcessorWithDeps();
+        processor.CanProcess(DocumentType.FromValue(value)).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("FormD")]
+    [InlineData("Form144")]
+    [InlineData("TenK")]
+    public void CanProcess_OtherTypes_ReturnsFalse(string value)
+    {
+        var (processor, _, _) = CreateProcessorWithDeps();
+        processor.CanProcess(DocumentType.FromValue(value)).Should().BeFalse();
+    }
+
+    // ── ParseYesNo ──
+
+    [Theory]
+    [InlineData("Y", true)]
+    [InlineData("y", true)]
+    [InlineData("N", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void ParseYesNo_MapsYToTrue(string input, bool expected)
+    {
+        NCenFilingProcessor.ParseYesNo(input).Should().Be(expected);
+    }
+
+    // ── ParseDate ──
+
+    [Fact]
+    public void ParseDate_IsoFormat_Parses()
+    {
+        NCenFilingProcessor.ParseDate("2024-10-31").Should().Be(new DateOnly(2024, 10, 31));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("10/31/2024")]
+    public void ParseDate_InvalidOrEmpty_ReturnsNull(string input)
+    {
+        NCenFilingProcessor.ParseDate(input).Should().BeNull();
+    }
+
+    // ── SanitizeXml ──
+
+    [Fact]
+    public void SanitizeXml_WithSgmlEnvelope_ExtractsInnerXml()
+    {
+        var result = NCenFilingProcessor.SanitizeXml(ValidNCenSubmission);
+        result.Should().StartWith("<?xml").And.Contain("<edgarSubmission");
+        result.Should().NotContain("<SEC-DOCUMENT>");
+    }
+
+    // ── Process ──
+
+    [Fact]
+    public async Task Process_ValidNCen_InsertsFilingWithServiceProviders()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(ValidNCenSubmission);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().Include(f => f.ServiceProviders).SingleAsync();
+        filing.RegistrantName.Should().Be("MEXICO FUND INC");
+        filing.InvestmentCompanyType.Should().Be("N-2");
+        filing.InvestmentCompanyFileNumber.Should().Be("811-02409");
+        filing.RegistrantLei.Should().Be("00000000000000238096");
+        filing.State.Should().Be("US-MD");
+        filing.Country.Should().Be("US");
+        filing.ReportEndingPeriod.Should().Be(new DateOnly(2024, 10, 31));
+        filing.IsReportPeriodLessThan12Months.Should().BeFalse();
+        filing.IsFirstFiling.Should().BeFalse();
+        filing.IsLastFiling.Should().BeFalse();
+        filing.IsFamilyInvestmentCompany.Should().BeFalse();
+        filing.IsAmendment.Should().BeFalse();
+
+        filing
+            .ServiceProviders.Should()
+            .Contain(p =>
+                p.ProviderType == NCenServiceProviderType.InvestmentAdviser
+                && p.Name == "IMPULSORA DEL FONDO MEXICO SC"
+                && p.Country == "MX"
+            );
+        filing
+            .ServiceProviders.Should()
+            .Contain(p =>
+                p.ProviderType == NCenServiceProviderType.Custodian && p.Name == "BBVA MEXICO SA"
+            );
+        filing
+            .ServiceProviders.Should()
+            .Contain(p =>
+                p.ProviderType == NCenServiceProviderType.TransferAgent
+                && p.Name == "EQUINITI TRUST COMPANY LLC"
+                && p.Country == "US"
+            );
+        filing
+            .ServiceProviders.Should()
+            .Contain(p =>
+                p.ProviderType == NCenServiceProviderType.Administrator
+                && p.Name == "IFM CAPITAL LLC"
+                && p.IsAffiliated
+            );
+        filing
+            .ServiceProviders.Should()
+            .Contain(p =>
+                p.ProviderType == NCenServiceProviderType.PublicAccountant
+                && p.Name == "TAIT, WELLER & BAKER LLP"
+            );
+        // "N/A" placeholder providers (sub-adviser, pricing service, underwriter) are skipped.
+        filing
+            .ServiceProviders.Should()
+            .NotContain(p => p.ProviderType == NCenServiceProviderType.SubAdviser);
+        filing
+            .ServiceProviders.Should()
+            .NotContain(p => p.ProviderType == NCenServiceProviderType.PrincipalUnderwriter);
+    }
+
+    [Fact]
+    public async Task Process_MultiSeries_DeDuplicatesRepeatedProviders()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(MultiSeriesSubmission);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().Include(f => f.ServiceProviders).SingleAsync();
+        filing
+            .ServiceProviders.Count(p =>
+                p.ProviderType == NCenServiceProviderType.InvestmentAdviser
+                && p.Name == "VANGUARD GROUP INC"
+            )
+            .Should()
+            .Be(1, "the same adviser named on multiple series collapses to one row");
+        filing.ServiceProviders.Should().Contain(p => p.Name == "STATE STREET BANK AND TRUST");
+    }
+
+    [Fact]
+    public async Task Process_Amendment_SetsIsAmendment()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentSubmission);
+
+        var result = await processor.Process(MakeFiling(form: "N-CEN/A"), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().SingleAsync();
+        filing.IsAmendment.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Process_DuplicateAccession_IsNotInsertedTwice()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(ValidNCenSubmission);
+        var filing = MakeFiling();
+
+        var first = await processor.Process(filing, MakeCompany());
+        var second = await processor.Process(filing, MakeCompany());
+
+        first.Should().BeTrue();
+        second.Should().BeFalse();
+        (await repo.GetAll().CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Process_EmptyContent_ReturnsFalse()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns("");
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeFalse();
+        (await repo.GetAll().AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Process_NonXmlContent_ReturnsFalse()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns("<SEC-DOCUMENT>legacy text</SEC-DOCUMENT>");
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeFalse();
+        (await repo.GetAll().AnyAsync()).Should().BeFalse();
+    }
+
+    // ── Helpers ──
+
+    private static (
+        NCenFilingProcessor processor,
+        NCenFilingRepository repo,
+        ISecEdgarClient secClient
+    ) CreateProcessorWithDeps()
+    {
+        var dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration(),
+            new ErrorsModuleConfiguration()
+        );
+
+        var repo = new NCenFilingRepository(dbContext);
+        var errorRepo = new ErrorRepository(dbContext);
+        var errorManager = new ErrorManager(errorRepo);
+        var secClient = Substitute.For<ISecEdgarClient>();
+
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(ISecEdgarClient), secClient),
+            (typeof(NCenFilingRepository), repo),
+            (typeof(ErrorManager), errorManager)
+        );
+
+        var errorReporter = new ErrorReporter(
+            scopeFactory,
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+        var processor = new NCenFilingProcessor(
+            scopeFactory,
+            Substitute.For<ILogger<NCenFilingProcessor>>(),
+            errorReporter
+        );
+
+        return (processor, repo, secClient);
+    }
+
+    private static FilingData MakeFiling(string accession = null, string form = "N-CEN")
+    {
+        accession ??= $"0000065433-24-{Guid.NewGuid().ToString("N")[..6]}";
+        return new FilingData
+        {
+            AccessionNumber = accession,
+            Form = form,
+            FilingDate = new DateOnly(2025, 1, 15),
+            ReportDate = new DateOnly(2024, 10, 31),
+            Cik = "0000065433",
+        };
+    }
+
+    private static CommonStock MakeCompany()
+    {
+        return new CommonStock
+        {
+            Ticker = "MXF",
+            Name = "Mexico Fund Inc",
+            Cik = "0000065433",
+        };
+    }
+
+    // A real N-CEN submission (Mexico Fund Inc, accession 0000065433-24-000002), trimmed to the
+    // SGML envelope plus the <XML> body the processor reads. Includes "N/A" placeholder providers
+    // (sub-adviser, pricing service, underwriter) to verify they are filtered out.
+    private const string ValidNCenSubmission = """
+        <SEC-DOCUMENT>0000065433-24-000002.txt : 20250115
+        <SEC-HEADER>...
+        <DOCUMENT>
+        <TYPE>N-CEN
+        <TEXT>
+        <XML>
+        <?xml version="1.0" encoding="UTF-8"?>
+        <edgarSubmission xmlns="http://www.sec.gov/edgar/ncen" xmlns:com="http://www.sec.gov/edgar/common">
+          <headerData>
+            <submissionType>N-CEN</submissionType>
+            <filerInfo>
+              <investmentCompanyType>N-2</investmentCompanyType>
+            </filerInfo>
+          </headerData>
+          <formData>
+            <generalInfo isReportPeriodLt12="N" reportEndingPeriod="2024-10-31"/>
+            <registrantInfo>
+              <registrantFullName>MEXICO FUND INC</registrantFullName>
+              <investmentCompFileNo>811-02409</investmentCompFileNo>
+              <registrantLei>00000000000000238096</registrantLei>
+              <registrantstate>US-MD</registrantstate>
+              <registrantcountry>US</registrantcountry>
+              <isRegistrantFirstFiling>N</isRegistrantFirstFiling>
+              <isRegistrantLastFiling>N</isRegistrantLastFiling>
+              <isRegistrantFamilyInvComp>N</isRegistrantFamilyInvComp>
+              <principalUnderwriters>
+                <principalUnderwriter>
+                  <principalUnderwriterName>N/A</principalUnderwriterName>
+                  <principalUnderWriterCountry>MX</principalUnderWriterCountry>
+                  <isPrincipalUnderwriterAffiliatedWithRegistrant>N</isPrincipalUnderwriterAffiliatedWithRegistrant>
+                </principalUnderwriter>
+              </principalUnderwriters>
+              <publicAccountants>
+                <publicAccountant>
+                  <publicAccountantName>TAIT, WELLER &amp; BAKER LLP</publicAccountantName>
+                  <publicAccountantStateCountry publicAccountantState="US-PA" publicAccountantCountry="US"/>
+                </publicAccountant>
+              </publicAccountants>
+            </registrantInfo>
+            <managementInvestmentQuestionSeriesInfo>
+              <managementInvestmentQuestion>
+                <mgmtInvFundName>THE MEXICO FUND INC</mgmtInvFundName>
+                <investmentAdvisers>
+                  <investmentAdviser>
+                    <investmentAdviserName>IMPULSORA DEL FONDO MEXICO SC</investmentAdviserName>
+                    <investmentAdviserCountry>MX</investmentAdviserCountry>
+                  </investmentAdviser>
+                </investmentAdvisers>
+                <subAdvisers>
+                  <subAdviser>
+                    <subAdviserName>N/A</subAdviserName>
+                    <subAdviserCountry>MX</subAdviserCountry>
+                    <isSubAdviserAffiliated>N</isSubAdviserAffiliated>
+                  </subAdviser>
+                </subAdvisers>
+                <transferAgents>
+                  <transferAgent>
+                    <transferAgentName>EQUINITI TRUST COMPANY LLC</transferAgentName>
+                    <transferAgentStateCountry transferAgentState="US-NY" transferAgentCountry="US"/>
+                    <isTransferAgentAffiliated>N</isTransferAgentAffiliated>
+                  </transferAgent>
+                </transferAgents>
+                <pricingServices>
+                  <pricingService>
+                    <pricingServiceName>N/A</pricingServiceName>
+                    <pricingServiceCountry>MX</pricingServiceCountry>
+                    <isPricingServiceAffiliated>N</isPricingServiceAffiliated>
+                  </pricingService>
+                </pricingServices>
+                <custodians>
+                  <custodian>
+                    <custodianName>BBVA MEXICO SA</custodianName>
+                    <custodianCountry>MX</custodianCountry>
+                    <isCustodianAffiliated>N</isCustodianAffiliated>
+                  </custodian>
+                </custodians>
+                <admins>
+                  <admin>
+                    <adminName>IFM CAPITAL LLC</adminName>
+                    <adminStateCountry adminState="US-UT" adminCountry="US"/>
+                    <isAdminAffiliated>Y</isAdminAffiliated>
+                  </admin>
+                </admins>
+              </managementInvestmentQuestion>
+            </managementInvestmentQuestionSeriesInfo>
+          </formData>
+        </edgarSubmission>
+        </XML>
+        </TEXT>
+        </DOCUMENT>
+        </SEC-DOCUMENT>
+        """;
+
+    // Two series naming the same adviser, to verify provider de-duplication.
+    private const string MultiSeriesSubmission = """
+        <XML>
+        <edgarSubmission xmlns="http://www.sec.gov/edgar/ncen">
+          <headerData>
+            <submissionType>N-CEN</submissionType>
+            <filerInfo>
+              <investmentCompanyType>N-1A</investmentCompanyType>
+            </filerInfo>
+          </headerData>
+          <formData>
+            <generalInfo isReportPeriodLt12="N" reportEndingPeriod="2024-12-31"/>
+            <registrantInfo>
+              <registrantFullName>VANGUARD INDEX FUNDS</registrantFullName>
+              <isRegistrantFirstFiling>N</isRegistrantFirstFiling>
+            </registrantInfo>
+            <managementInvestmentQuestionSeriesInfo>
+              <managementInvestmentQuestion>
+                <investmentAdvisers>
+                  <investmentAdviser>
+                    <investmentAdviserName>VANGUARD GROUP INC</investmentAdviserName>
+                    <investmentAdviserCountry>US</investmentAdviserCountry>
+                  </investmentAdviser>
+                </investmentAdvisers>
+                <custodians>
+                  <custodian>
+                    <custodianName>STATE STREET BANK AND TRUST</custodianName>
+                    <custodianCountry>US</custodianCountry>
+                    <isCustodianAffiliated>N</isCustodianAffiliated>
+                  </custodian>
+                </custodians>
+              </managementInvestmentQuestion>
+              <managementInvestmentQuestion>
+                <investmentAdvisers>
+                  <investmentAdviser>
+                    <investmentAdviserName>VANGUARD GROUP INC</investmentAdviserName>
+                    <investmentAdviserCountry>US</investmentAdviserCountry>
+                  </investmentAdviser>
+                </investmentAdvisers>
+              </managementInvestmentQuestion>
+            </managementInvestmentQuestionSeriesInfo>
+          </formData>
+        </edgarSubmission>
+        </XML>
+        """;
+
+    private const string AmendmentSubmission = """
+        <XML>
+        <edgarSubmission xmlns="http://www.sec.gov/edgar/ncen">
+          <headerData>
+            <submissionType>N-CEN/A</submissionType>
+            <filerInfo>
+              <investmentCompanyType>N-2</investmentCompanyType>
+            </filerInfo>
+          </headerData>
+          <formData>
+            <generalInfo isReportPeriodLt12="N" reportEndingPeriod="2024-10-31"/>
+            <registrantInfo>
+              <registrantFullName>MEXICO FUND INC</registrantFullName>
+            </registrantInfo>
+          </formData>
+        </edgarSubmission>
+        </XML>
+        """;
+}

--- a/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
+++ b/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
@@ -144,7 +144,7 @@ public class ConfigurationTests
         options
             .DocumentTypesToSync.Should()
             .NotBeNull()
-            .And.HaveCount(8)
+            .And.HaveCount(10)
             .And.ContainInOrder(
                 DocumentType.TenK,
                 DocumentType.TenQ,
@@ -153,7 +153,9 @@ public class ConfigurationTests
                 DocumentType.FormThree,
                 DocumentType.Form144,
                 DocumentType.FormD,
-                DocumentType.FormDa
+                DocumentType.FormDa,
+                DocumentType.NCen,
+                DocumentType.NCenA
             );
     }
 

--- a/tests/Equibles.UnitTests/Sec/DocumentTypeExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeExtensionsTests.cs
@@ -21,6 +21,8 @@ public class DocumentTypeExtensionsTests
     [InlineData("Form144", DocumentTypeFilter.Form144)]
     [InlineData("FormD", DocumentTypeFilter.FormD)]
     [InlineData("FormDa", DocumentTypeFilter.FormDa)]
+    [InlineData("NCen", DocumentTypeFilter.NCen)]
+    [InlineData("NCenA", DocumentTypeFilter.NCenA)]
     public void ToSecEdgarFilter_MappedType_ReturnsCorrectFilter(
         string documentTypeValue,
         DocumentTypeFilter expectedFilter
@@ -80,6 +82,8 @@ public class DocumentTypeExtensionsTests
     [InlineData("144", DocumentTypeFilter.Form144)]
     [InlineData("D", DocumentTypeFilter.FormD)]
     [InlineData("D/A", DocumentTypeFilter.FormDa)]
+    [InlineData("N-CEN", DocumentTypeFilter.NCen)]
+    [InlineData("N-CEN/A", DocumentTypeFilter.NCenA)]
     public void FromFormName_ThenToSecEdgarFilter_RoundTrips(
         string formName,
         DocumentTypeFilter expectedFilter

--- a/tests/Equibles.UnitTests/Sec/DocumentTypeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeTests.cs
@@ -46,6 +46,8 @@ public class DocumentTypeTests
     [InlineData("3", "FormThree")]
     [InlineData("D", "FormD")]
     [InlineData("D/A", "FormDa")]
+    [InlineData("N-CEN", "NCen")]
+    [InlineData("N-CEN/A", "NCenA")]
     public void FromDisplayName_ReturnsCorrectType(string displayName, string expectedValue)
     {
         var result = DocumentType.FromDisplayName(displayName);
@@ -96,6 +98,8 @@ public class DocumentTypeTests
                     DocumentType.Form144,
                     DocumentType.FormD,
                     DocumentType.FormDa,
+                    DocumentType.NCen,
+                    DocumentType.NCenA,
                     DocumentType.Other,
                 }
             );

--- a/tests/Equibles.UnitTests/Sec/SecHostedServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecHostedServiceCollectionExtensionsTests.cs
@@ -25,6 +25,7 @@ public class SecHostedServiceCollectionExtensionsTests
         //   • InsiderTradingFilingProcessor — Form 3/4/5 ownership filings
         //   • Form144FilingProcessor        — Form 144 proposed-sale notices
         //   • FormDFilingProcessor          — Form D exempt-offering notices
+        //   • NCenFilingProcessor           — N-CEN registered-fund annual reports
         // The implementation_type binding matters: a refactor that swapped a
         // concrete to a stub (`services.AddScoped<IFilingProcessor,
         // StubFilingProcessor>()` — a common copy-paste mistake when adding
@@ -52,7 +53,7 @@ public class SecHostedServiceCollectionExtensionsTests
         descriptors
             .Should()
             .HaveCount(
-                3,
+                4,
                 "AddSecWorker registers one IFilingProcessor per supported structured form family"
             );
         descriptors
@@ -71,6 +72,12 @@ public class SecHostedServiceCollectionExtensionsTests
             .Should()
             .Contain(d =>
                 d.ImplementationType == typeof(FormDFilingProcessor)
+                && d.Lifetime == ServiceLifetime.Scoped
+            );
+        descriptors
+            .Should()
+            .Contain(d =>
+                d.ImplementationType == typeof(NCenFilingProcessor)
                 && d.Lifetime == ServiceLifetime.Scoped
             );
     }


### PR DESCRIPTION
## Summary

- Slice 2 of 4 of N-CEN support (#1869): the worker. Teaches the document scraper to recognise `N-CEN` / `N-CEN/A` filings in a registrant's EDGAR feed and parse each into the structured records added in slice 1.
- Refs #1869 (does not close).

## Code changes

- `src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs` — new `IFilingProcessor` that reads the N-CEN XML (ncen namespace, navigated by local name; Y/N booleans; attribute-valued `generalInfo`), maps the registrant's operational fields, and collects the fund's service providers — de-duplicating firms repeated across a multi-series fund and skipping `N/A` placeholder slots.
- `src/Equibles.Sec.Data/Models/DocumentType.cs` — add `NCen` / `NCenA` document types.
- `src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs` — add the matching `N-CEN` / `N-CEN/A` EDGAR form filters.
- `src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs` — map the new document types to their EDGAR filters.
- `src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs` — sync N-CEN/N-CEN/A by default.
- `src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs` — register the processor.
- Tests — `NCenFilingProcessorTests` (parse, multi-series de-dup, amendment, duplicate, empty/non-XML) plus updated wiring/config/type pins.