### PR TITLE
feat(sec): expose N-CEN registered-fund operations via MCP

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
@@ -1,0 +1,107 @@
+using System.ComponentModel;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.Core.Extensions;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
+using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Equibles.Sec.Mcp.Tools;
+
+[McpServerToolType]
+public class NCenTools
+{
+    private readonly NCenFilingRepository _nCenRepository;
+    private readonly CommonStockRepository _commonStockRepository;
+    private readonly McpToolRunner _runner;
+
+    public NCenTools(
+        NCenFilingRepository nCenRepository,
+        CommonStockRepository commonStockRepository,
+        ErrorManager errorManager,
+        ILogger<NCenTools> logger
+    )
+    {
+        _nCenRepository = nCenRepository;
+        _commonStockRepository = commonStockRepository;
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
+    }
+
+    [McpServerTool(Name = "GetFundOperations")]
+    [Description(
+        "Get operational data for a registered investment company (mutual fund, ETF or closed-end fund) from its SEC Form N-CEN annual reports. Each N-CEN shows the registrant's classification (e.g. N-1A open-end, N-2 closed-end), Investment Company Act file number, reporting period, and whether it was the fund's first or last filing, followed by the fund's named service providers — investment advisers, sub-advisers, custodians, transfer agents, administrators, auditors and underwriters. Use this to see who runs and services a fund. Only registered funds file N-CEN; operating companies will return no data."
+    )]
+    public Task<string> GetFundOperations(
+        [Description("Fund or ETF ticker symbol (e.g., MXF, SPY)")] string ticker,
+        [Description("Maximum number of annual reports to return (default: 10)")]
+            int maxResults = 10
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
+
+                var filings = await _nCenRepository
+                    .GetByStock(stock)
+                    .Include(f => f.ServiceProviders)
+                    .OrderByDescending(f => f.FilingDate)
+                    .Take(maxResults)
+                    .ToListAsync();
+
+                if (filings.Count == 0)
+                    return $"No Form N-CEN annual reports found for {ticker}.";
+
+                var result = MarkdownTable.Start(
+                    $"Form N-CEN annual reports for {stock.Name} ({ticker}) — showing {filings.Count} most recent:",
+                    "| Filed | Period End | Type | File Number | Amendment | First Filing | Last Filing |",
+                    "|-------|------------|------|-------------|-----------|--------------|-------------|"
+                );
+
+                foreach (var f in filings)
+                {
+                    result.AppendLine(
+                        $"| {f.FilingDate:yyyy-MM-dd} | {f.ReportEndingPeriod:yyyy-MM-dd} | {f.InvestmentCompanyType ?? "-"} | {f.InvestmentCompanyFileNumber ?? "-"} | {(f.IsAmendment ? "Yes" : "No")} | {(f.IsFirstFiling ? "Yes" : "No")} | {(f.IsLastFiling ? "Yes" : "No")} |"
+                    );
+                }
+
+                AppendServiceProviders(result, filings[0]);
+
+                return result.ToString();
+            },
+            "GetFundOperations",
+            $"ticker: {ticker}"
+        );
+    }
+
+    private static void AppendServiceProviders(System.Text.StringBuilder result, NCenFiling latest)
+    {
+        if (latest.ServiceProviders.Count == 0)
+            return;
+
+        result.AppendLine();
+        result.AppendLine(
+            $"Service providers reported on the latest report (filed {latest.FilingDate:yyyy-MM-dd}):"
+        );
+        result.AppendLine();
+        result.AppendLine("| Role | Firm | Country | Affiliated |");
+        result.AppendLine("|------|------|---------|------------|");
+
+        foreach (
+            var provider in latest.ServiceProviders.OrderBy(p => p.ProviderType).ThenBy(p => p.Name)
+        )
+        {
+            result.AppendLine(
+                $"| {provider.ProviderType.NameForHumans()} | {provider.Name} | {provider.Country ?? "-"} | {(provider.IsAffiliated ? "Yes" : "No")} |"
+            );
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolTests.cs
@@ -1,0 +1,133 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+public class NCenFundOperationsToolTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly NCenTools _tools;
+
+    public NCenFundOperationsToolTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration()
+        );
+        _tools = new NCenTools(
+            new NCenFilingRepository(_dbContext),
+            new CommonStockRepository(_dbContext),
+            errorManager: null,
+            NullLogger<NCenTools>.Instance
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    private CommonStock SeedStock(string ticker = "MXF", string cik = "0000065433")
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = "Mexico Fund Inc",
+            Cik = cik,
+        };
+        _dbContext.Set<CommonStock>().Add(stock);
+        _dbContext.SaveChanges();
+        return stock;
+    }
+
+    [Fact]
+    public async Task GetFundOperations_StockNotFound_ReturnsNotFoundMessage()
+    {
+        var result = await _tools.GetFundOperations("ZZZZ");
+
+        result.Should().Contain("ZZZZ");
+    }
+
+    [Fact]
+    public async Task GetFundOperations_NoFilings_ReturnsEmptyMessage()
+    {
+        SeedStock();
+
+        var result = await _tools.GetFundOperations("MXF");
+
+        result.Should().Contain("No Form N-CEN annual reports found for MXF.");
+    }
+
+    [Fact]
+    public async Task GetFundOperations_WithFilings_RendersTableNewestFirstWithProviders()
+    {
+        var stock = SeedStock();
+        _dbContext.Set<NCenFiling>().Add(MakeFiling(stock.Id, "older", new DateOnly(2023, 1, 5)));
+
+        var newer = MakeFiling(stock.Id, "newer", new DateOnly(2025, 1, 15));
+        newer.ServiceProviders.Add(
+            new NCenServiceProvider
+            {
+                ProviderType = NCenServiceProviderType.InvestmentAdviser,
+                Name = "IMPULSORA DEL FONDO MEXICO SC",
+                Country = "MX",
+                IsAffiliated = false,
+            }
+        );
+        _dbContext.Set<NCenFiling>().Add(newer);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundOperations("MXF");
+
+        result.Should().Contain("Mexico Fund Inc");
+        result.Should().Contain("811-02409");
+        result.Should().Contain("Investment Adviser");
+        result.Should().Contain("IMPULSORA DEL FONDO MEXICO SC");
+        // Newest filing renders before the older one.
+        result
+            .IndexOf("2025-01-15", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(result.IndexOf("2023-01-05", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetFundOperations_RespectsMaxResults()
+    {
+        var stock = SeedStock();
+        for (var i = 0; i < 5; i++)
+        {
+            _dbContext
+                .Set<NCenFiling>()
+                .Add(MakeFiling(stock.Id, $"acc-{i}", new DateOnly(2021, 1, 1).AddYears(i)));
+        }
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundOperations("MXF", maxResults: 2);
+
+        result.Should().Contain("showing 2 most recent");
+    }
+
+    private static NCenFiling MakeFiling(Guid stockId, string accession, DateOnly filingDate)
+    {
+        return new NCenFiling
+        {
+            CommonStockId = stockId,
+            AccessionNumber = accession,
+            FilingDate = filingDate,
+            IsAmendment = false,
+            RegistrantName = "MEXICO FUND INC",
+            InvestmentCompanyType = "N-2",
+            InvestmentCompanyFileNumber = "811-02409",
+            RegistrantLei = "00000000000000238096",
+            State = "US-MD",
+            Country = "US",
+            ReportEndingPeriod = filingDate.AddMonths(-2),
+            IsReportPeriodLessThan12Months = false,
+        };
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -304,6 +304,7 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("ReadDocumentLines");
         toolNames.Should().Contain("GetFailsToDeliver");
         toolNames.Should().Contain("GetExemptOfferings");
+        toolNames.Should().Contain("GetFundOperations");
     }
 
     // ── Cross-module uniqueness ─────────────────────────────────────────
@@ -397,6 +398,7 @@ public class McpModuleToolDiscoveryTests
                     "ReadDocumentLines",
                     "GetFailsToDeliver",
                     "GetExemptOfferings",
+                    "GetFundOperations",
                 }
             },
             { typeof(CboeTools), new[] { "GetPutCallRatios", "GetVixHistory" } },


### PR DESCRIPTION
## Summary

- Slice 3 of 4 of N-CEN support (#1869): the MCP tool. Surfaces the N-CEN data parsed by the worker so an assistant can answer "who runs and services this fund?".
- Refs #1869 (does not close; the stock-page tab follows in slice 4).

## Code changes

- `src/Equibles.Sec.Mcp/Tools/NCenTools.cs` — new `GetFundOperations` tool. Resolves a ticker, lists the fund's recent N-CEN reports (classification, Investment Company Act file number, reporting period, amendment / first / last flags) and the service providers named on the latest report. Returns a clear "no reports" message for non-fund tickers.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — add `GetFundOperations` to the Sec module's expected-tools list (presence + count guard).
- `tests/Equibles.IntegrationTests/Mcp/NCenFundOperationsToolTests.cs` — tool coverage: not-found, empty, ordering + provider rendering, max-results.