### PR TITLE
feat(sec): add Form NPORT fund-holdings data model

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260530085403_AddNport.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260530085403_AddNport.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530085403_AddNport")]
+    partial class AddNport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260530085403_AddNport.cs
+++ b/src/Equibles.Migrations/Migrations/20260530085403_AddNport.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "NportFiling",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccessionNumber = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    FilingDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    IsAmendment = table.Column<bool>(type: "boolean", nullable: false),
+                    RegistrantName = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    SeriesName = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    SeriesId = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    SeriesLei = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    ReportPeriodDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    ReportPeriodEnd = table.Column<DateOnly>(type: "date", nullable: false),
+                    TotalAssets = table.Column<decimal>(type: "numeric", nullable: false),
+                    TotalLiabilities = table.Column<decimal>(type: "numeric", nullable: false),
+                    NetAssets = table.Column<decimal>(type: "numeric", nullable: false),
+                    IsFinalFiling = table.Column<bool>(type: "boolean", nullable: false),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NportFiling", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_NportFiling_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "NportHolding",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    NportFilingId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    Title = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    Cusip = table.Column<string>(
+                        type: "character varying(16)",
+                        maxLength: 16,
+                        nullable: true
+                    ),
+                    Isin = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    Lei = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    Balance = table.Column<decimal>(type: "numeric", nullable: false),
+                    Units = table.Column<string>(
+                        type: "character varying(16)",
+                        maxLength: 16,
+                        nullable: true
+                    ),
+                    Currency = table.Column<string>(
+                        type: "character varying(8)",
+                        maxLength: 8,
+                        nullable: true
+                    ),
+                    ValueUsd = table.Column<decimal>(type: "numeric", nullable: false),
+                    PercentValue = table.Column<decimal>(type: "numeric", nullable: false),
+                    PayoffProfile = table.Column<string>(
+                        type: "character varying(16)",
+                        maxLength: 16,
+                        nullable: true
+                    ),
+                    AssetCategory = table.Column<string>(
+                        type: "character varying(16)",
+                        maxLength: 16,
+                        nullable: true
+                    ),
+                    IssuerCategory = table.Column<string>(
+                        type: "character varying(16)",
+                        maxLength: 16,
+                        nullable: true
+                    ),
+                    InvestmentCountry = table.Column<string>(
+                        type: "character varying(8)",
+                        maxLength: 8,
+                        nullable: true
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NportHolding", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_NportHolding_NportFiling_NportFilingId",
+                        column: x => x.NportFilingId,
+                        principalTable: "NportFiling",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NportFiling_AccessionNumber",
+                table: "NportFiling",
+                column: "AccessionNumber",
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NportFiling_CommonStockId_FilingDate",
+                table: "NportFiling",
+                columns: new[] { "CommonStockId", "FilingDate" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NportFiling_FilingDate",
+                table: "NportFiling",
+                column: "FilingDate"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NportHolding_NportFilingId",
+                table: "NportHolding",
+                column: "NportFilingId"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "NportHolding");
+
+            migrationBuilder.DropTable(name: "NportFiling");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/NportFiling.cs
+++ b/src/Equibles.Sec.Data/Models/NportFiling.cs
@@ -1,0 +1,74 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// A SEC Form NPORT-P monthly portfolio report filed by a registered investment company (mutual
+/// fund, ETF or closed-end fund) for one of its series. NPORT-P appears in the registrant's EDGAR
+/// submissions feed, so each report is attributed to the registrant's <see cref="CommonStock"/>.
+/// The record captures the series' header facts — name, identifier, reporting period, total assets
+/// and liabilities, net assets — plus the schedule of portfolio investments in
+/// <see cref="Holdings"/>. Both the original report ("NPORT-P") and its amendments ("NPORT-P/A")
+/// are stored, flagged via <see cref="IsAmendment"/>.
+/// </summary>
+[Index(nameof(CommonStockId), nameof(FilingDate))]
+[Index(nameof(AccessionNumber), IsUnique = true)]
+[Index(nameof(FilingDate))]
+public class NportFiling
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    [MaxLength(32)]
+    public string AccessionNumber { get; set; }
+
+    public DateOnly FilingDate { get; set; }
+
+    /// <summary>True when the submission type is "NPORT-P/A" (an amendment) rather than "NPORT-P".</summary>
+    public bool IsAmendment { get; set; }
+
+    /// <summary>The registrant's legal name exactly as reported on the filing.</summary>
+    [MaxLength(512)]
+    public string RegistrantName { get; set; }
+
+    /// <summary>The fund series' name, e.g. "Vanguard 500 Index Fund".</summary>
+    [MaxLength(512)]
+    public string SeriesName { get; set; }
+
+    /// <summary>The series' SEC identifier, e.g. "S000002277".</summary>
+    [MaxLength(32)]
+    public string SeriesId { get; set; }
+
+    /// <summary>The series' Legal Entity Identifier when reported.</summary>
+    [MaxLength(32)]
+    public string SeriesLei { get; set; }
+
+    /// <summary>The date the reported portfolio is as of (the report's "as of" date).</summary>
+    public DateOnly ReportPeriodDate { get; set; }
+
+    /// <summary>The last day of the fiscal period the monthly report belongs to.</summary>
+    public DateOnly ReportPeriodEnd { get; set; }
+
+    /// <summary>Total assets of the series in U.S. dollars.</summary>
+    public decimal TotalAssets { get; set; }
+
+    /// <summary>Total liabilities of the series in U.S. dollars.</summary>
+    public decimal TotalLiabilities { get; set; }
+
+    /// <summary>Net assets of the series in U.S. dollars (assets less liabilities).</summary>
+    public decimal NetAssets { get; set; }
+
+    /// <summary>True when the registrant marked this as the series' final NPORT-P report.</summary>
+    public bool IsFinalFiling { get; set; }
+
+    /// <summary>The series' schedule of portfolio investments reported on the filing.</summary>
+    public virtual List<NportHolding> Holdings { get; set; } = [];
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Sec.Data/Models/NportHolding.cs
+++ b/src/Equibles.Sec.Data/Models/NportHolding.cs
@@ -1,0 +1,75 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// A single portfolio investment reported on a <see cref="NportFiling"/> — one line of the fund's
+/// schedule of investments. Captures the issuer/instrument name and identifiers, the position size
+/// and its U.S.-dollar value, the share of the fund's net assets it represents, and the asset and
+/// issuer categories NPORT reports as short codes (e.g. asset "EC" equity-common, "DBT" debt,
+/// "DE" derivative; issuer "CORP" corporate, "RF" registered fund).
+/// </summary>
+[Index(nameof(NportFilingId))]
+public class NportHolding
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid NportFilingId { get; set; }
+    public virtual NportFiling NportFiling { get; set; }
+
+    /// <summary>The issuer or instrument name exactly as reported.</summary>
+    [MaxLength(512)]
+    public string Name { get; set; }
+
+    /// <summary>The title of the issue, e.g. the security description.</summary>
+    [MaxLength(512)]
+    public string Title { get; set; }
+
+    /// <summary>The holding's CUSIP when reported (the literal "N/A" is stored as null).</summary>
+    [MaxLength(16)]
+    public string Cusip { get; set; }
+
+    /// <summary>The holding's ISIN when reported.</summary>
+    [MaxLength(32)]
+    public string Isin { get; set; }
+
+    /// <summary>The issuer's Legal Entity Identifier when reported.</summary>
+    [MaxLength(32)]
+    public string Lei { get; set; }
+
+    /// <summary>The position size in the reported units (shares, principal amount or contracts).</summary>
+    public decimal Balance { get; set; }
+
+    /// <summary>The unit the balance is expressed in: "NS" shares, "PA" principal amount, "NC" contracts.</summary>
+    [MaxLength(16)]
+    public string Units { get; set; }
+
+    /// <summary>The currency the holding is denominated in, e.g. "USD".</summary>
+    [MaxLength(8)]
+    public string Currency { get; set; }
+
+    /// <summary>The holding's value in U.S. dollars.</summary>
+    public decimal ValueUsd { get; set; }
+
+    /// <summary>The holding's share of the fund's net assets, as a percentage (can be negative for shorts).</summary>
+    public decimal PercentValue { get; set; }
+
+    /// <summary>The payoff profile, "Long" or "Short".</summary>
+    [MaxLength(16)]
+    public string PayoffProfile { get; set; }
+
+    /// <summary>The NPORT asset-category code, e.g. "EC" (equity-common), "DBT" (debt), "DE" (derivative).</summary>
+    [MaxLength(16)]
+    public string AssetCategory { get; set; }
+
+    /// <summary>The NPORT issuer-category code, e.g. "CORP" (corporate), "RF" (registered fund).</summary>
+    [MaxLength(16)]
+    public string IssuerCategory { get; set; }
+
+    /// <summary>The investment's country code, e.g. "US".</summary>
+    [MaxLength(8)]
+    public string InvestmentCountry { get; set; }
+}

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -28,6 +28,8 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<FormDRelatedPerson>();
         builder.Entity<NCenFiling>();
         builder.Entity<NCenServiceProvider>();
+        builder.Entity<NportFiling>();
+        builder.Entity<NportHolding>();
         builder.Entity<TranscriptCheckStatus>();
     }
 }

--- a/src/Equibles.Sec.Repositories/NportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NportFilingRepository.cs
@@ -1,0 +1,26 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Sec.Repositories;
+
+public class NportFilingRepository : BaseRepository<NportFiling>
+{
+    public NportFilingRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<NportFiling> GetByStock(CommonStock stock)
+    {
+        return GetAll().Where(f => f.CommonStockId == stock.Id);
+    }
+
+    public IQueryable<NportFiling> GetByAccessionNumber(string accessionNumber)
+    {
+        return GetAll().Where(f => f.AccessionNumber == accessionNumber);
+    }
+
+    public IQueryable<NportFiling> GetRecent(DateOnly since)
+    {
+        return GetAll().Where(f => f.FilingDate >= since);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.IntegrationTests.Helpers;
 
 /// <summary>
-/// Registers the non-vector Sec entities (Document, FailToDeliver, Form D, N-CEN) for InMemory tests.
+/// Registers the non-vector Sec entities (Document, FailToDeliver, Form D, N-CEN, NPORT) for InMemory tests.
 /// The production <see cref="Equibles.Sec.Data.SecModuleConfiguration"/> also
 /// registers Chunk and Embedding, which use pgvector's <c>Vector</c> type that
 /// the EF Core InMemory provider cannot construct. We explicitly ignore those
@@ -32,6 +32,8 @@ public class SecTestModuleConfiguration : Equibles.Data.IModuleConfiguration
         builder.Entity<FormDRelatedPerson>();
         builder.Entity<NCenFiling>();
         builder.Entity<NCenServiceProvider>();
+        builder.Entity<NportFiling>();
+        builder.Entity<NportHolding>();
         builder.Ignore<Chunk>();
         builder.Ignore<Embedding>();
     }

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs
@@ -1,0 +1,190 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class NportFilingRepositoryTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly NportFilingRepository _repository;
+
+    public NportFilingRepositoryTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration()
+        );
+        _repository = new NportFilingRepository(_dbContext);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    private static CommonStock CreateStock(string ticker = "VOO", string cik = "0000036405")
+    {
+        return new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = ticker,
+            Cik = cik,
+        };
+    }
+
+    private static NportFiling CreateFiling(
+        Guid commonStockId,
+        string accessionNumber = "0000036405-24-000002",
+        DateOnly? filingDate = null,
+        string seriesName = "Vanguard 500 Index Fund"
+    )
+    {
+        return new NportFiling
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = commonStockId,
+            AccessionNumber = accessionNumber,
+            FilingDate = filingDate ?? new DateOnly(2025, 1, 15),
+            IsAmendment = false,
+            RegistrantName = "VANGUARD INDEX FUNDS",
+            SeriesName = seriesName,
+            SeriesId = "S000002277",
+            SeriesLei = "5493007GHODQRGNTGS28",
+            ReportPeriodDate = new DateOnly(2024, 12, 31),
+            ReportPeriodEnd = new DateOnly(2025, 12, 31),
+            TotalAssets = 1_200_000_000m,
+            TotalLiabilities = 50_000_000m,
+            NetAssets = 1_150_000_000m,
+            IsFinalFiling = false,
+        };
+    }
+
+    [Fact]
+    public async Task GetByStock_ReturnsOnlyFilingsForThatStock()
+    {
+        var voo = CreateStock("VOO", "0000036405");
+        var other = CreateStock("SPY", "0000884394");
+        _dbContext.Set<CommonStock>().AddRange(voo, other);
+        await _dbContext.SaveChangesAsync();
+
+        _repository.Add(CreateFiling(voo.Id, "0000036405-24-000002"));
+        _repository.Add(CreateFiling(voo.Id, "0000036405-23-000003"));
+        _repository.Add(CreateFiling(other.Id, "0000884394-24-000001"));
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetByStock(voo).ToListAsync();
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(f => f.CommonStockId == voo.Id);
+    }
+
+    [Fact]
+    public async Task GetByAccessionNumber_ExistingAccession_ReturnsFiling()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+        _repository.Add(CreateFiling(stock.Id, "0000036405-24-000002"));
+        await _repository.SaveChanges();
+
+        var result = await _repository
+            .GetByAccessionNumber("0000036405-24-000002")
+            .FirstOrDefaultAsync();
+
+        result.Should().NotBeNull();
+        result.SeriesName.Should().Be("Vanguard 500 Index Fund");
+    }
+
+    [Fact]
+    public async Task GetByAccessionNumber_NonExistentAccession_ReturnsEmpty()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+        _repository.Add(CreateFiling(stock.Id, "0000036405-24-000002"));
+        await _repository.SaveChanges();
+
+        var any = await _repository.GetByAccessionNumber("9999999999-99-999999").AnyAsync();
+
+        any.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetRecent_ReturnsOnlyFilingsOnOrAfterCutoff()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        _repository.Add(CreateFiling(stock.Id, "old", filingDate: new DateOnly(2024, 1, 1)));
+        _repository.Add(CreateFiling(stock.Id, "new", filingDate: new DateOnly(2025, 1, 15)));
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetRecent(new DateOnly(2025, 1, 1)).ToListAsync();
+
+        result.Should().ContainSingle();
+        result[0].AccessionNumber.Should().Be("new");
+    }
+
+    [Fact]
+    public async Task Add_FilingWithHoldings_PersistsChildRows()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var filing = CreateFiling(stock.Id);
+        filing.Holdings.Add(
+            new NportHolding
+            {
+                Name = "AT&T Inc",
+                Title = "AT&T Inc",
+                Cusip = "00206R102",
+                Isin = "US00206R1023",
+                Balance = 112500m,
+                Units = "NS",
+                Currency = "USD",
+                ValueUsd = 1_794_375m,
+                PercentValue = 0.49m,
+                PayoffProfile = "Long",
+                AssetCategory = "EC",
+                IssuerCategory = "CORP",
+                InvestmentCountry = "US",
+            }
+        );
+        filing.Holdings.Add(
+            new NportHolding
+            {
+                Name = "US Treasury Note",
+                Balance = 5_000_000m,
+                Units = "PA",
+                Currency = "USD",
+                ValueUsd = 4_900_000m,
+                PercentValue = 4.26m,
+                PayoffProfile = "Long",
+                AssetCategory = "DBT",
+                IssuerCategory = "UST",
+            }
+        );
+        _repository.Add(filing);
+        await _repository.SaveChanges();
+
+        var loaded = await _repository
+            .GetByAccessionNumber(filing.AccessionNumber)
+            .Include(f => f.Holdings)
+            .FirstAsync();
+
+        loaded.Holdings.Should().HaveCount(2);
+        loaded
+            .Holdings.Should()
+            .Contain(h =>
+                h.Name == "AT&T Inc" && h.Cusip == "00206R102" && h.AssetCategory == "EC"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 1 of 4 for NPORT fund-holdings support (#1868). Adds the data layer for SEC Form NPORT-P monthly portfolio reports, which appear in a registered fund/ETF registrant's EDGAR submissions feed and are attributed to that registrant's stock, mirroring how Form D and N-CEN are stored.
- Refs #1868 — does not close the issue; the final web-tab slice does.

## Code changes

- `src/Equibles.Sec.Data/Models/NportFiling.cs` — new entity: registrant, series, reporting period, total assets/liabilities, net assets, with the holdings navigation.
- `src/Equibles.Sec.Data/Models/NportHolding.cs` — new child entity: one portfolio investment (name, title, CUSIP/ISIN, LEI, balance, units, currency, value, percent of net assets, payoff profile, asset/issuer category, country).
- `src/Equibles.Sec.Data/SecModuleConfiguration.cs` — register the two entities.
- `src/Equibles.Sec.Repositories/NportFilingRepository.cs` — GetByStock / GetByAccessionNumber / GetRecent queries.
- `src/Equibles.Migrations/Migrations/*_AddNport.*` + snapshot — EF migration creating the NportFiling and NportHolding tables and indexes.
- `tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs` — register the entities for InMemory tests.
- `tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs` — repository query and holdings-persistence tests.