### PR TITLE
feat(sec): parse Form NPORT fund holdings in the worker

### DIFF
--- a/src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs
+++ b/src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs
@@ -51,4 +51,10 @@ public enum DocumentTypeFilter
 
     [Display(Name = "N-CEN/A")]
     NCenA,
+
+    [Display(Name = "NPORT-P")]
+    NportP,
+
+    [Display(Name = "NPORT-P/A")]
+    NportPa,
 }

--- a/src/Equibles.Sec.Data/Models/DocumentType.cs
+++ b/src/Equibles.Sec.Data/Models/DocumentType.cs
@@ -31,6 +31,8 @@ public sealed class DocumentType
     public static readonly DocumentType FormDa = new("FormDa", "D/A");
     public static readonly DocumentType NCen = new("NCen", "N-CEN");
     public static readonly DocumentType NCenA = new("NCenA", "N-CEN/A");
+    public static readonly DocumentType NportP = new("NportP", "NPORT-P");
+    public static readonly DocumentType NportPa = new("NportPa", "NPORT-P/A");
     public static readonly DocumentType Other = new("Other", "Other");
 
     private static readonly ConcurrentDictionary<string, DocumentType> AllByValue = new(
@@ -52,6 +54,8 @@ public sealed class DocumentType
             new KeyValuePair<string, DocumentType>(FormDa.Value, FormDa),
             new KeyValuePair<string, DocumentType>(NCen.Value, NCen),
             new KeyValuePair<string, DocumentType>(NCenA.Value, NCenA),
+            new KeyValuePair<string, DocumentType>(NportP.Value, NportP),
+            new KeyValuePair<string, DocumentType>(NportPa.Value, NportPa),
             new KeyValuePair<string, DocumentType>(Other.Value, Other),
         },
         StringComparer.OrdinalIgnoreCase
@@ -76,6 +80,8 @@ public sealed class DocumentType
             new KeyValuePair<string, DocumentType>(FormDa.DisplayName, FormDa),
             new KeyValuePair<string, DocumentType>(NCen.DisplayName, NCen),
             new KeyValuePair<string, DocumentType>(NCenA.DisplayName, NCenA),
+            new KeyValuePair<string, DocumentType>(NportP.DisplayName, NportP),
+            new KeyValuePair<string, DocumentType>(NportPa.DisplayName, NportPa),
             new KeyValuePair<string, DocumentType>(Other.DisplayName, Other),
         },
         StringComparer.OrdinalIgnoreCase

--- a/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
@@ -16,5 +16,7 @@ public class DocumentScraperOptions
         DocumentType.FormDa,
         DocumentType.NCen,
         DocumentType.NCenA,
+        DocumentType.NportP,
+        DocumentType.NportPa,
     ];
 }

--- a/src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs
@@ -24,6 +24,8 @@ public static class DocumentTypeExtensions
             { DocumentType.FormDa, DocumentTypeFilter.FormDa },
             { DocumentType.NCen, DocumentTypeFilter.NCen },
             { DocumentType.NCenA, DocumentTypeFilter.NCenA },
+            { DocumentType.NportP, DocumentTypeFilter.NportP },
+            { DocumentType.NportPa, DocumentTypeFilter.NportPa },
         };
 
     public static DocumentTypeFilter? ToSecEdgarFilter(this DocumentType docType)

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IFilingProcessor, Form144FilingProcessor>();
         services.AddScoped<IFilingProcessor, FormDFilingProcessor>();
         services.AddScoped<IFilingProcessor, NCenFilingProcessor>();
+        services.AddScoped<IFilingProcessor, NportFilingProcessor>();
         services.AddScoped<IDocumentPersistenceService, DocumentPersistenceService>();
         services.AddScoped<ICompanySyncService, CompanySyncService>();
         services.AddScoped<IDocumentScraper, DocumentScraper>();

--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -1,0 +1,318 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Contracts;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Processes SEC Form NPORT-P filings — a registered investment company's monthly portfolio report
+/// for one of its series — into a structured <see cref="NportFiling"/> record plus the series'
+/// schedule of portfolio investments (<see cref="NportHolding"/>). NPORT-P appears in the
+/// registrant's submissions feed, so each report is attributed to the registrant's stock. Both the
+/// original report ("NPORT-P") and its amendments ("NPORT-P/A") are processed. The XML root is
+/// <c>edgarSubmission</c> in the <c>http://www.sec.gov/edgar/nport</c> namespace, so elements are
+/// navigated by local name. Booleans are reported as "Y"/"N"; amounts are decimal strings.
+/// </summary>
+public class NportFilingProcessor : IFilingProcessor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<NportFilingProcessor> _logger;
+    private readonly ErrorReporter _errorReporter;
+
+    // NPORT dates are ISO yyyy-MM-dd.
+    private static readonly string[] DateFormats = ["yyyy-MM-dd"];
+
+    // Optional identifiers the filer leaves blank are reported as the literal "N/A"; treat as absent.
+    private const string NotApplicable = "N/A";
+
+    public NportFilingProcessor(
+        IServiceScopeFactory scopeFactory,
+        ILogger<NportFilingProcessor> logger,
+        ErrorReporter errorReporter
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _errorReporter = errorReporter;
+    }
+
+    public bool CanProcess(DocumentType documentType)
+    {
+        return documentType == DocumentType.NportP || documentType == DocumentType.NportPa;
+    }
+
+    public async Task<bool> Process(FilingData filing, CommonStock companyOutContext)
+    {
+        var companyId = companyOutContext.Id;
+        var companyTicker = companyOutContext.Ticker;
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var secEdgarClient = scope.ServiceProvider.GetRequiredService<ISecEdgarClient>();
+        var repository = scope.ServiceProvider.GetRequiredService<NportFilingRepository>();
+
+        var existing = await repository.GetByAccessionNumber(filing.AccessionNumber).AnyAsync();
+        if (existing)
+            return false;
+
+        var content = await secEdgarClient.GetDocumentContent(filing);
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            _logger.LogWarning(
+                "Empty content for {Ticker} NPORT-P - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return false;
+        }
+
+        var root = await TryParseSubmission(content, filing, companyTicker);
+        if (root == null)
+            return false;
+
+        var entity = ParseFiling(root, companyId, filing);
+        if (entity == null)
+        {
+            _logger.LogWarning(
+                "NPORT-P XML missing genInfo for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return false;
+        }
+
+        repository.Add(entity);
+        await repository.SaveChanges();
+
+        _logger.LogInformation(
+            "Imported NPORT-P for {Ticker} ({Series}, net assets {NetAssets}, {Holdings} holdings) from {AccessionNumber}",
+            companyTicker,
+            entity.SeriesName,
+            entity.NetAssets,
+            entity.Holdings.Count,
+            filing.AccessionNumber
+        );
+
+        return true;
+    }
+
+    private async Task<XElement> TryParseSubmission(
+        string content,
+        FilingData filing,
+        string companyTicker
+    )
+    {
+        var sanitized = SanitizeXml(content);
+
+        // NPORT-P has only ever been filed as XML, so a submission without the
+        // <edgarSubmission> root is unexpected — skip quietly.
+        if (!sanitized.Contains("<edgarSubmission", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug(
+                "Skipping non-XML NPORT-P filing for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return null;
+        }
+
+        try
+        {
+            return XDocument.Parse(sanitized).Root;
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Malformed NPORT-P XML for {Ticker} - {AccessionNumber}",
+                companyTicker,
+                filing.AccessionNumber
+            );
+            await _errorReporter.Report(
+                ErrorSource.DocumentScraper,
+                "Nport.ParseXml",
+                ex.Message,
+                ex.StackTrace,
+                $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
+            );
+            return null;
+        }
+    }
+
+    private static NportFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
+    {
+        var headerData = El(root, "headerData");
+        var formData = El(root, "formData");
+        var genInfo = El(formData, "genInfo");
+        if (genInfo == null)
+            return null;
+
+        var fundInfo = El(formData, "fundInfo");
+
+        var entity = new NportFiling
+        {
+            CommonStockId = companyId,
+            AccessionNumber = filing.AccessionNumber,
+            FilingDate = filing.FilingDate,
+            IsAmendment = ParseIsAmendment(headerData, filing),
+            RegistrantName = Clean(Val(genInfo, "regName")),
+            SeriesName = Clean(Val(genInfo, "seriesName")),
+            SeriesId = Clean(Val(genInfo, "seriesId")),
+            SeriesLei = Clean(Val(genInfo, "seriesLei")),
+            ReportPeriodDate = ParseDate(Val(genInfo, "repPdDate")) ?? filing.ReportDate,
+            ReportPeriodEnd = ParseDate(Val(genInfo, "repPdEnd")) ?? filing.ReportDate,
+            TotalAssets = ParseDecimal(Val(fundInfo, "totAssets")),
+            TotalLiabilities = ParseDecimal(Val(fundInfo, "totLiabs")),
+            NetAssets = ParseDecimal(Val(fundInfo, "netAssets")),
+            IsFinalFiling = ParseYesNo(Val(genInfo, "isFinalFiling")),
+        };
+
+        foreach (var investment in Els(El(fundInfo, "invstOrSecs"), "invstOrSec"))
+        {
+            var holding = ParseHolding(investment);
+            if (holding != null)
+                entity.Holdings.Add(holding);
+        }
+
+        return entity;
+    }
+
+    // Returns null when the line has neither a name nor a value — NPORT pads some sections with
+    // empty placeholder entries.
+    private static NportHolding ParseHolding(XElement element)
+    {
+        var name = Clean(Val(element, "name"));
+        var valueUsd = ParseDecimal(Val(element, "valUSD"));
+        if (name == null && valueUsd == 0)
+            return null;
+
+        var identifiers = El(element, "identifiers");
+
+        return new NportHolding
+        {
+            Name = name,
+            Title = Clean(Val(element, "title")),
+            Cusip = Clean(Val(element, "cusip")),
+            Isin = Clean(Attr(El(identifiers, "isin"), "value")),
+            Lei = Clean(Val(element, "lei")),
+            Balance = ParseDecimal(Val(element, "balance")),
+            Units = Clean(Val(element, "units")),
+            Currency = Clean(Val(element, "curCd")),
+            ValueUsd = valueUsd,
+            PercentValue = ParseDecimal(Val(element, "pctVal")),
+            PayoffProfile = Clean(Val(element, "payoffProfile")),
+            AssetCategory = Clean(Val(element, "assetCat")),
+            IssuerCategory = ParseIssuerCategory(element),
+            InvestmentCountry = Clean(Val(element, "invCountry")),
+        };
+    }
+
+    // NPORT reports the issuer category either as an <issuerCat> element or, for conditional
+    // categories (e.g. swaps), as the issuerCat attribute on <issuerConditional>.
+    private static string ParseIssuerCategory(XElement element)
+    {
+        var direct = Clean(Val(element, "issuerCat"));
+        if (direct != null)
+            return direct;
+
+        return Clean(Attr(El(element, "issuerConditional"), "issuerCat"));
+    }
+
+    private static bool ParseIsAmendment(XElement headerData, FilingData filing)
+    {
+        var submissionType = Val(headerData, "submissionType");
+        if (submissionType != null)
+            return submissionType.Contains("/A", StringComparison.OrdinalIgnoreCase);
+
+        return filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
+    }
+
+    // ── XML helpers (navigate by local name; NPORT declares the nport namespace) ──────
+
+    private static XElement El(XElement parent, string name) =>
+        parent?.Elements().FirstOrDefault(e => e.Name.LocalName == name);
+
+    private static IEnumerable<XElement> Els(XElement parent, string name) =>
+        parent?.Elements().Where(e => e.Name.LocalName == name) ?? [];
+
+    private static string Val(XElement parent, string name)
+    {
+        var value = El(parent, name)?.Value?.Trim();
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    private static string Attr(XElement element, string name)
+    {
+        var value = element?.Attributes().FirstOrDefault(a => a.Name.LocalName == name)?.Value;
+        return string.IsNullOrEmpty(value) ? null : value.Trim();
+    }
+
+    // Normalize the "N/A" placeholder and blanks to null.
+    private static string Clean(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        var trimmed = value.Trim();
+        return trimmed.Equals(NotApplicable, StringComparison.OrdinalIgnoreCase) ? null : trimmed;
+    }
+
+    private const string XmlEnvelopeStart = "<XML>";
+    private const string XmlEnvelopeEnd = "</XML>";
+
+    internal static string SanitizeXml(string xml)
+    {
+        // SEC filings wrap the actual XML inside an SGML envelope (one .txt holds the whole
+        // submission); pull out the <XML>...</XML> body before parsing.
+        var xmlStart = xml.IndexOf(XmlEnvelopeStart, StringComparison.OrdinalIgnoreCase);
+        var xmlEnd = xml.IndexOf(XmlEnvelopeEnd, StringComparison.OrdinalIgnoreCase);
+        if (xmlStart >= 0 && xmlEnd > xmlStart)
+        {
+            xml = xml[(xmlStart + XmlEnvelopeStart.Length)..xmlEnd].Trim();
+        }
+
+        // Escape stray ampersands that aren't already part of an entity.
+        return Regex.Replace(xml, @"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)", "&amp;");
+    }
+
+    internal static bool ParseYesNo(string value)
+    {
+        return value != null && value.Trim().Equals("Y", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static DateOnly? ParseDate(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        return DateOnly.TryParseExact(
+            value.Trim(),
+            DateFormats,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var parsed
+        )
+            ? parsed
+            : null;
+    }
+
+    internal static decimal ParseDecimal(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return 0;
+        return decimal.TryParse(
+            value,
+            NumberStyles.Any,
+            CultureInfo.InvariantCulture,
+            out var result
+        )
+            ? result
+            : 0;
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingProcessorTests.cs
@@ -1,0 +1,370 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class NportFilingProcessorTests
+{
+    // ── CanProcess ──
+
+    [Theory]
+    [InlineData("NportP")]
+    [InlineData("NportPa")]
+    public void CanProcess_NportTypes_ReturnsTrue(string value)
+    {
+        var (processor, _, _) = CreateProcessorWithDeps();
+        processor.CanProcess(DocumentType.FromValue(value)).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("NCen")]
+    [InlineData("FormD")]
+    [InlineData("TenK")]
+    public void CanProcess_OtherTypes_ReturnsFalse(string value)
+    {
+        var (processor, _, _) = CreateProcessorWithDeps();
+        processor.CanProcess(DocumentType.FromValue(value)).Should().BeFalse();
+    }
+
+    // ── ParseDecimal ──
+
+    [Theory]
+    [InlineData("287467294.33", 287467294.33)]
+    [InlineData("-477163.89", -477163.89)]
+    [InlineData("", 0)]
+    [InlineData(null, 0)]
+    [InlineData("not-a-number", 0)]
+    public void ParseDecimal_ParsesInvariantOrFallsBackToZero(string input, decimal expected)
+    {
+        NportFilingProcessor.ParseDecimal(input).Should().Be(expected);
+    }
+
+    // ── ParseDate ──
+
+    [Fact]
+    public void ParseDate_IsoFormat_Parses()
+    {
+        NportFilingProcessor.ParseDate("2026-02-28").Should().Be(new DateOnly(2026, 2, 28));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("02/28/2026")]
+    public void ParseDate_InvalidOrEmpty_ReturnsNull(string input)
+    {
+        NportFilingProcessor.ParseDate(input).Should().BeNull();
+    }
+
+    // ── SanitizeXml ──
+
+    [Fact]
+    public void SanitizeXml_WithSgmlEnvelope_ExtractsInnerXml()
+    {
+        var result = NportFilingProcessor.SanitizeXml(ValidNportSubmission);
+        result.Should().StartWith("<?xml").And.Contain("<edgarSubmission");
+        result.Should().NotContain("<SEC-DOCUMENT>");
+    }
+
+    // ── Process ──
+
+    [Fact]
+    public async Task Process_ValidNport_InsertsFilingWithHoldings()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(ValidNportSubmission);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().Include(f => f.Holdings).SingleAsync();
+        filing.RegistrantName.Should().Be("ETF Opportunities Trust");
+        filing.SeriesName.Should().Be("Big Tech Index ETF");
+        filing.SeriesId.Should().Be("S000087771");
+        filing.ReportPeriodDate.Should().Be(new DateOnly(2026, 2, 28));
+        filing.ReportPeriodEnd.Should().Be(new DateOnly(2026, 8, 31));
+        filing.TotalAssets.Should().Be(287467294.33m);
+        filing.TotalLiabilities.Should().Be(193875501.04m);
+        filing.NetAssets.Should().Be(93591793.29m);
+        filing.IsFinalFiling.Should().BeFalse();
+        filing.IsAmendment.Should().BeFalse();
+
+        filing.Holdings.Should().HaveCount(2);
+
+        var equity = filing.Holdings.Single(h => h.Name == "AT&T Inc");
+        equity.Cusip.Should().Be("00206R102");
+        equity.Isin.Should().Be("US00206R1023");
+        equity.Balance.Should().Be(112500m);
+        equity.Units.Should().Be("NS");
+        equity.Currency.Should().Be("USD");
+        equity.ValueUsd.Should().Be(1794375.00m);
+        equity.PercentValue.Should().Be(1.92m);
+        equity.PayoffProfile.Should().Be("Long");
+        equity.AssetCategory.Should().Be("EC");
+        equity.IssuerCategory.Should().Be("CORP");
+        equity.InvestmentCountry.Should().Be("US");
+
+        // The swap line reports its issuer category as the issuerConditional@issuerCat attribute.
+        var swap = filing.Holdings.Single(h => h.Name == "STRATEGY INC");
+        swap.IssuerCategory.Should().Be("OTHER");
+        swap.AssetCategory.Should().Be("DE");
+        swap.Cusip.Should().BeNull("the literal \"N/A\" CUSIP is stored as null");
+        swap.ValueUsd.Should().Be(-477163.89m);
+    }
+
+    [Fact]
+    public async Task Process_Amendment_SetsIsAmendment()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(AmendmentSubmission);
+
+        var result = await processor.Process(MakeFiling(form: "NPORT-P/A"), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().SingleAsync();
+        filing.IsAmendment.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Process_DuplicateAccession_IsNotInsertedTwice()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(ValidNportSubmission);
+        var filing = MakeFiling();
+
+        var first = await processor.Process(filing, MakeCompany());
+        var second = await processor.Process(filing, MakeCompany());
+
+        first.Should().BeTrue();
+        second.Should().BeFalse();
+        (await repo.GetAll().CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Process_EmptyContent_ReturnsFalse()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns("");
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeFalse();
+        (await repo.GetAll().AnyAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Process_NonXmlContent_ReturnsFalse()
+    {
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns("<SEC-DOCUMENT>legacy text</SEC-DOCUMENT>");
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeFalse();
+        (await repo.GetAll().AnyAsync()).Should().BeFalse();
+    }
+
+    // ── Helpers ──
+
+    private static (
+        NportFilingProcessor processor,
+        NportFilingRepository repo,
+        ISecEdgarClient secClient
+    ) CreateProcessorWithDeps()
+    {
+        var dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration(),
+            new ErrorsModuleConfiguration()
+        );
+
+        var repo = new NportFilingRepository(dbContext);
+        var errorRepo = new ErrorRepository(dbContext);
+        var errorManager = new ErrorManager(errorRepo);
+        var secClient = Substitute.For<ISecEdgarClient>();
+
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(ISecEdgarClient), secClient),
+            (typeof(NportFilingRepository), repo),
+            (typeof(ErrorManager), errorManager)
+        );
+
+        var errorReporter = new ErrorReporter(
+            scopeFactory,
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+        var processor = new NportFilingProcessor(
+            scopeFactory,
+            Substitute.For<ILogger<NportFilingProcessor>>(),
+            errorReporter
+        );
+
+        return (processor, repo, secClient);
+    }
+
+    private static FilingData MakeFiling(string accession = null, string form = "NPORT-P")
+    {
+        accession ??= $"0001104659-26-{Guid.NewGuid().ToString("N")[..6]}";
+        return new FilingData
+        {
+            AccessionNumber = accession,
+            Form = form,
+            FilingDate = new DateOnly(2026, 3, 30),
+            ReportDate = new DateOnly(2026, 2, 28),
+            Cik = "0001771146",
+        };
+    }
+
+    private static CommonStock MakeCompany()
+    {
+        return new CommonStock
+        {
+            Ticker = "BTEC",
+            Name = "Big Tech Index ETF",
+            Cik = "0001771146",
+        };
+    }
+
+    // A trimmed NPORT-P submission modelled on a real ETF filing: the SGML envelope plus the
+    // <XML> body the processor reads. Carries one equity holding (issuerCat element) and one
+    // total-return-swap holding (issuerConditional@issuerCat attribute, "N/A" CUSIP) to exercise
+    // both issuer-category shapes and the "N/A" placeholder.
+    private const string ValidNportSubmission = """
+        <SEC-DOCUMENT>0001104659-26-000002.txt : 20260330
+        <SEC-HEADER>...
+        <DOCUMENT>
+        <TYPE>NPORT-P
+        <TEXT>
+        <XML>
+        <?xml version="1.0" encoding="UTF-8"?>
+        <edgarSubmission xmlns="http://www.sec.gov/edgar/nport" xmlns:com="http://www.sec.gov/edgar/common" xmlns:ncom="http://www.sec.gov/edgar/nportcommon">
+          <headerData>
+            <submissionType>NPORT-P</submissionType>
+            <isConfidential>false</isConfidential>
+            <filerInfo>
+              <filer>
+                <issuerCredentials>
+                  <cik>0001771146</cik>
+                </issuerCredentials>
+              </filer>
+            </filerInfo>
+          </headerData>
+          <formData>
+            <genInfo>
+              <regName>ETF Opportunities Trust</regName>
+              <regCik>0001771146</regCik>
+              <regLei>549300FWST5041130Z58</regLei>
+              <seriesName>Big Tech Index ETF</seriesName>
+              <seriesId>S000087771</seriesId>
+              <seriesLei>254900FIJG81260G5N49</seriesLei>
+              <repPdEnd>2026-08-31</repPdEnd>
+              <repPdDate>2026-02-28</repPdDate>
+              <isFinalFiling>N</isFinalFiling>
+            </genInfo>
+            <fundInfo>
+              <totAssets>287467294.33</totAssets>
+              <totLiabs>193875501.04</totLiabs>
+              <netAssets>93591793.29</netAssets>
+              <invstOrSecs>
+                <invstOrSec>
+                  <name>AT&amp;T Inc</name>
+                  <lei>549300Z40J86GGSTL398</lei>
+                  <title>AT&amp;T Inc</title>
+                  <cusip>00206R102</cusip>
+                  <identifiers>
+                    <isin value="US00206R1023"/>
+                    <ticker value="T"/>
+                  </identifiers>
+                  <balance>112500.00000000</balance>
+                  <units>NS</units>
+                  <curCd>USD</curCd>
+                  <valUSD>1794375.00000000</valUSD>
+                  <pctVal>1.92000000</pctVal>
+                  <payoffProfile>Long</payoffProfile>
+                  <assetCat>EC</assetCat>
+                  <issuerCat>CORP</issuerCat>
+                  <invCountry>US</invCountry>
+                </invstOrSec>
+                <invstOrSec>
+                  <name>STRATEGY INC</name>
+                  <lei>549300WQTWEJUEHXQX21</lei>
+                  <title>RECV STRG TRS MSTR EQ</title>
+                  <cusip>N/A</cusip>
+                  <identifiers>
+                    <isin value="US5949724083"/>
+                  </identifiers>
+                  <balance>68370086.61000000</balance>
+                  <units>NC</units>
+                  <curCd>USD</curCd>
+                  <valUSD>-477163.89000000</valUSD>
+                  <pctVal>-0.50983518236</pctVal>
+                  <payoffProfile>Long</payoffProfile>
+                  <assetCat>DE</assetCat>
+                  <issuerConditional desc="Total Return Swap" issuerCat="OTHER"/>
+                  <invCountry>US</invCountry>
+                </invstOrSec>
+              </invstOrSecs>
+            </fundInfo>
+          </formData>
+        </edgarSubmission>
+        </XML>
+        </TEXT>
+        </DOCUMENT>
+        </SEC-DOCUMENT>
+        """;
+
+    private const string AmendmentSubmission = """
+        <SEC-DOCUMENT>0001104659-26-000003.txt : 20260330
+        <DOCUMENT>
+        <TYPE>NPORT-P/A
+        <TEXT>
+        <XML>
+        <?xml version="1.0" encoding="UTF-8"?>
+        <edgarSubmission xmlns="http://www.sec.gov/edgar/nport">
+          <headerData>
+            <submissionType>NPORT-P/A</submissionType>
+            <filerInfo>
+              <filer>
+                <issuerCredentials>
+                  <cik>0001771146</cik>
+                </issuerCredentials>
+              </filer>
+            </filerInfo>
+          </headerData>
+          <formData>
+            <genInfo>
+              <regName>ETF Opportunities Trust</regName>
+              <seriesName>Big Tech Index ETF</seriesName>
+              <seriesId>S000087771</seriesId>
+              <repPdEnd>2026-08-31</repPdEnd>
+              <repPdDate>2026-02-28</repPdDate>
+              <isFinalFiling>N</isFinalFiling>
+            </genInfo>
+            <fundInfo>
+              <totAssets>287467294.33</totAssets>
+              <totLiabs>193875501.04</totLiabs>
+              <netAssets>93591793.29</netAssets>
+              <invstOrSecs/>
+            </fundInfo>
+          </formData>
+        </edgarSubmission>
+        </XML>
+        </TEXT>
+        </DOCUMENT>
+        </SEC-DOCUMENT>
+        """;
+}

--- a/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
+++ b/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
@@ -144,7 +144,7 @@ public class ConfigurationTests
         options
             .DocumentTypesToSync.Should()
             .NotBeNull()
-            .And.HaveCount(10)
+            .And.HaveCount(12)
             .And.ContainInOrder(
                 DocumentType.TenK,
                 DocumentType.TenQ,
@@ -155,7 +155,9 @@ public class ConfigurationTests
                 DocumentType.FormD,
                 DocumentType.FormDa,
                 DocumentType.NCen,
-                DocumentType.NCenA
+                DocumentType.NCenA,
+                DocumentType.NportP,
+                DocumentType.NportPa
             );
     }
 

--- a/tests/Equibles.UnitTests/Sec/DocumentTypeExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeExtensionsTests.cs
@@ -23,6 +23,8 @@ public class DocumentTypeExtensionsTests
     [InlineData("FormDa", DocumentTypeFilter.FormDa)]
     [InlineData("NCen", DocumentTypeFilter.NCen)]
     [InlineData("NCenA", DocumentTypeFilter.NCenA)]
+    [InlineData("NportP", DocumentTypeFilter.NportP)]
+    [InlineData("NportPa", DocumentTypeFilter.NportPa)]
     public void ToSecEdgarFilter_MappedType_ReturnsCorrectFilter(
         string documentTypeValue,
         DocumentTypeFilter expectedFilter
@@ -84,6 +86,8 @@ public class DocumentTypeExtensionsTests
     [InlineData("D/A", DocumentTypeFilter.FormDa)]
     [InlineData("N-CEN", DocumentTypeFilter.NCen)]
     [InlineData("N-CEN/A", DocumentTypeFilter.NCenA)]
+    [InlineData("NPORT-P", DocumentTypeFilter.NportP)]
+    [InlineData("NPORT-P/A", DocumentTypeFilter.NportPa)]
     public void FromFormName_ThenToSecEdgarFilter_RoundTrips(
         string formName,
         DocumentTypeFilter expectedFilter

--- a/tests/Equibles.UnitTests/Sec/DocumentTypeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeTests.cs
@@ -48,6 +48,8 @@ public class DocumentTypeTests
     [InlineData("D/A", "FormDa")]
     [InlineData("N-CEN", "NCen")]
     [InlineData("N-CEN/A", "NCenA")]
+    [InlineData("NPORT-P", "NportP")]
+    [InlineData("NPORT-P/A", "NportPa")]
     public void FromDisplayName_ReturnsCorrectType(string displayName, string expectedValue)
     {
         var result = DocumentType.FromDisplayName(displayName);
@@ -100,6 +102,8 @@ public class DocumentTypeTests
                     DocumentType.FormDa,
                     DocumentType.NCen,
                     DocumentType.NCenA,
+                    DocumentType.NportP,
+                    DocumentType.NportPa,
                     DocumentType.Other,
                 }
             );

--- a/tests/Equibles.UnitTests/Sec/SecHostedServiceCollectionExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecHostedServiceCollectionExtensionsTests.cs
@@ -26,6 +26,7 @@ public class SecHostedServiceCollectionExtensionsTests
         //   • Form144FilingProcessor        — Form 144 proposed-sale notices
         //   • FormDFilingProcessor          — Form D exempt-offering notices
         //   • NCenFilingProcessor           — N-CEN registered-fund annual reports
+        //   • NportFilingProcessor          — NPORT-P fund portfolio holdings
         // The implementation_type binding matters: a refactor that swapped a
         // concrete to a stub (`services.AddScoped<IFilingProcessor,
         // StubFilingProcessor>()` — a common copy-paste mistake when adding
@@ -53,7 +54,7 @@ public class SecHostedServiceCollectionExtensionsTests
         descriptors
             .Should()
             .HaveCount(
-                4,
+                5,
                 "AddSecWorker registers one IFilingProcessor per supported structured form family"
             );
         descriptors
@@ -78,6 +79,12 @@ public class SecHostedServiceCollectionExtensionsTests
             .Should()
             .Contain(d =>
                 d.ImplementationType == typeof(NCenFilingProcessor)
+                && d.Lifetime == ServiceLifetime.Scoped
+            );
+        descriptors
+            .Should()
+            .Contain(d =>
+                d.ImplementationType == typeof(NportFilingProcessor)
                 && d.Lifetime == ServiceLifetime.Scoped
             );
     }


### PR DESCRIPTION
## Summary

- Slice 2 of 4 for NPORT fund-holdings support (#1868). Registers the NPORT-P / NPORT-P/A form types in the document scraper and adds a processor that turns each filing's XML into the structured records added in the previous slice.
- Refs #1868 — does not close the issue.

## Code changes

- `src/Equibles.Sec.Data/Models/DocumentType.cs`, `src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs`, `src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs` — register the NPORT-P and NPORT-P/A document types and their EDGAR filter mapping.
- `src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs` — add the two form types to the default scrape list.
- `src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs` — new processor: parses genInfo/fundInfo header facts and each invstOrSec holding, handling NPORT's two issuer-category shapes and its "N/A" placeholders.
- `src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs` — wire the processor into the strategy dispatch.
- `tests/Equibles.IntegrationTests/Sec/NportFilingProcessorTests.cs` — processor parsing tests over a real-shaped NPORT-P submission (equity + swap holdings, amendment, duplicate/empty/non-XML guards).
- `tests/Equibles.UnitTests/...` — extend the document-type, scraper-options and DI-registration pins for the new form types.