### PR TITLE
feat(sec): expose fund portfolio holdings via MCP

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -1,0 +1,94 @@
+using System.ComponentModel;
+using System.Globalization;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
+using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Equibles.Sec.Mcp.Tools;
+
+[McpServerToolType]
+public class NportTools
+{
+    private readonly NportFilingRepository _nportRepository;
+    private readonly CommonStockRepository _commonStockRepository;
+    private readonly McpToolRunner _runner;
+
+    public NportTools(
+        NportFilingRepository nportRepository,
+        CommonStockRepository commonStockRepository,
+        ErrorManager errorManager,
+        ILogger<NportTools> logger
+    )
+    {
+        _nportRepository = nportRepository;
+        _commonStockRepository = commonStockRepository;
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
+    }
+
+    [McpServerTool(Name = "GetFundHoldings")]
+    [Description(
+        "Get the portfolio holdings of a registered investment company (mutual fund or ETF) from its most recent SEC Form NPORT-P monthly report. Returns the fund's series, reporting period and net assets, followed by its largest holdings — issuer name, CUSIP, position size, U.S.-dollar value and share of net assets, with the asset category (e.g. EC equity-common, DBT debt, DE derivative). Use this to see what a fund or ETF owns. Only registered funds file NPORT-P; operating companies will return no data."
+    )]
+    public Task<string> GetFundHoldings(
+        [Description("Fund or ETF ticker symbol (e.g., SPY, VOO)")] string ticker,
+        [Description("Maximum number of holdings to return, largest first (default: 20)")]
+            int maxResults = 20
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
+
+                var filing = await _nportRepository
+                    .GetByStock(stock)
+                    .Include(f => f.Holdings)
+                    .OrderByDescending(f => f.FilingDate)
+                    .FirstOrDefaultAsync();
+
+                if (filing == null)
+                    return $"No Form NPORT-P portfolio reports found for {ticker}.";
+
+                var holdings = filing
+                    .Holdings.OrderByDescending(h => h.ValueUsd)
+                    .Take(maxResults)
+                    .ToList();
+
+                var result = MarkdownTable.Start(
+                    $"Portfolio holdings for {filing.SeriesName ?? stock.Name} ({ticker}) — "
+                        + $"reported {filing.ReportPeriodDate:yyyy-MM-dd}, net assets ${FormatAmount(filing.NetAssets)}, "
+                        + $"{filing.Holdings.Count} total holdings, showing the largest {holdings.Count}:",
+                    "| Holding | CUSIP | Balance | Units | Value (USD) | % Net Assets | Category | Country |",
+                    "|---------|-------|---------|-------|-------------|--------------|----------|---------|"
+                );
+
+                foreach (var h in holdings)
+                {
+                    result.AppendLine(
+                        $"| {h.Name ?? "-"} | {h.Cusip ?? "-"} | {FormatAmount(h.Balance)} | {h.Units ?? "-"} | ${FormatAmount(h.ValueUsd)} | {FormatPercent(h.PercentValue)} | {h.AssetCategory ?? "-"} | {h.InvestmentCountry ?? "-"} |"
+                    );
+                }
+
+                return result.ToString();
+            },
+            "GetFundHoldings",
+            $"ticker: {ticker}"
+        );
+    }
+
+    private static string FormatAmount(decimal value) =>
+        value.ToString("N2", CultureInfo.InvariantCulture);
+
+    private static string FormatPercent(decimal value) =>
+        value.ToString("N2", CultureInfo.InvariantCulture) + "%";
+}

--- a/tests/Equibles.IntegrationTests/Mcp/NportFundHoldingsToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NportFundHoldingsToolTests.cs
@@ -1,0 +1,143 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+public class NportFundHoldingsToolTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly NportTools _tools;
+
+    public NportFundHoldingsToolTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration()
+        );
+        _tools = new NportTools(
+            new NportFilingRepository(_dbContext),
+            new CommonStockRepository(_dbContext),
+            errorManager: null,
+            NullLogger<NportTools>.Instance
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    private CommonStock SeedStock(string ticker = "VOO", string cik = "0000036405")
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = "Vanguard 500 Index Fund",
+            Cik = cik,
+        };
+        _dbContext.Set<CommonStock>().Add(stock);
+        _dbContext.SaveChanges();
+        return stock;
+    }
+
+    [Fact]
+    public async Task GetFundHoldings_StockNotFound_ReturnsNotFoundMessage()
+    {
+        var result = await _tools.GetFundHoldings("ZZZZ");
+
+        result.Should().Contain("ZZZZ");
+    }
+
+    [Fact]
+    public async Task GetFundHoldings_NoFilings_ReturnsEmptyMessage()
+    {
+        SeedStock();
+
+        var result = await _tools.GetFundHoldings("VOO");
+
+        result.Should().Contain("No Form NPORT-P portfolio reports found for VOO.");
+    }
+
+    [Fact]
+    public async Task GetFundHoldings_UsesLatestFilingAndOrdersByValueDescending()
+    {
+        var stock = SeedStock();
+
+        var older = MakeFiling(stock.Id, "older", new DateOnly(2024, 6, 30));
+        older.Holdings.Add(MakeHolding("STALE CORP", 999_999m));
+        _dbContext.Set<NportFiling>().Add(older);
+
+        var latest = MakeFiling(stock.Id, "latest", new DateOnly(2025, 1, 31));
+        latest.Holdings.Add(MakeHolding("SMALL CO", 100_000m));
+        latest.Holdings.Add(MakeHolding("BIG CO", 5_000_000m));
+        _dbContext.Set<NportFiling>().Add(latest);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundHoldings("VOO");
+
+        result.Should().Contain("Vanguard 500 Index Fund");
+        result.Should().Contain("BIG CO").And.Contain("SMALL CO");
+        result.Should().NotContain("STALE CORP", "only the latest filing's holdings are shown");
+        // Largest holding renders before the smaller one.
+        result
+            .IndexOf("BIG CO", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(result.IndexOf("SMALL CO", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetFundHoldings_RespectsMaxResults()
+    {
+        var stock = SeedStock();
+        var filing = MakeFiling(stock.Id, "acc", new DateOnly(2025, 1, 31));
+        for (var i = 0; i < 5; i++)
+            filing.Holdings.Add(MakeHolding($"CO {i}", 1_000m * (i + 1)));
+        _dbContext.Set<NportFiling>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundHoldings("VOO", maxResults: 2);
+
+        result.Should().Contain("showing the largest 2");
+    }
+
+    private static NportFiling MakeFiling(Guid stockId, string accession, DateOnly filingDate)
+    {
+        return new NportFiling
+        {
+            CommonStockId = stockId,
+            AccessionNumber = accession,
+            FilingDate = filingDate,
+            IsAmendment = false,
+            RegistrantName = "VANGUARD INDEX FUNDS",
+            SeriesName = "Vanguard 500 Index Fund",
+            SeriesId = "S000002277",
+            ReportPeriodDate = filingDate.AddMonths(-1),
+            ReportPeriodEnd = filingDate,
+            TotalAssets = 1_200_000_000m,
+            TotalLiabilities = 50_000_000m,
+            NetAssets = 1_150_000_000m,
+        };
+    }
+
+    private static NportHolding MakeHolding(string name, decimal valueUsd)
+    {
+        return new NportHolding
+        {
+            Name = name,
+            Balance = valueUsd,
+            Units = "NS",
+            Currency = "USD",
+            ValueUsd = valueUsd,
+            PercentValue = 1.0m,
+            PayoffProfile = "Long",
+            AssetCategory = "EC",
+            IssuerCategory = "CORP",
+            InvestmentCountry = "US",
+        };
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -305,6 +305,7 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("GetFailsToDeliver");
         toolNames.Should().Contain("GetExemptOfferings");
         toolNames.Should().Contain("GetFundOperations");
+        toolNames.Should().Contain("GetFundHoldings");
     }
 
     // ── Cross-module uniqueness ─────────────────────────────────────────
@@ -399,6 +400,7 @@ public class McpModuleToolDiscoveryTests
                     "GetFailsToDeliver",
                     "GetExemptOfferings",
                     "GetFundOperations",
+                    "GetFundHoldings",
                 }
             },
             { typeof(CboeTools), new[] { "GetPutCallRatios", "GetVixHistory" } },


### PR DESCRIPTION
## Summary

- Slice 3 of 4 for NPORT fund-holdings support (#1868). Adds the GetFundHoldings MCP tool returning a fund or ETF's most recent NPORT-P portfolio report by ticker.
- Refs #1868 — does not close the issue.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/NportTools.cs` — new tool: resolves the ticker, loads the latest NPORT-P filing, and renders the series/period/net-assets header plus the largest holdings (issuer, CUSIP, balance, value, percent of net assets, category, country). Amounts use the invariant culture.
- `tests/Equibles.IntegrationTests/Mcp/NportFundHoldingsToolTests.cs` — not-found, no-data, latest-filing-only, value-ordering and max-results tests.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — add GetFundHoldings to the discovered-tools guard.