### PR TITLE
feat(sec): add raw XBRL filing artifact data model

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260530101258_AddRawFilingArtifacts.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260530101258_AddRawFilingArtifacts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530101258_AddRawFilingArtifacts")]
+    partial class AddRawFilingArtifacts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260530101258_AddRawFilingArtifacts.cs
+++ b/src/Equibles.Migrations/Migrations/20260530101258_AddRawFilingArtifacts.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRawFilingArtifacts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RawFilingArtifact",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccessionNumber = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    ArtifactType = table.Column<int>(type: "integer", nullable: false),
+                    SourceFileName = table.Column<string>(
+                        type: "character varying(256)",
+                        maxLength: 256,
+                        nullable: true
+                    ),
+                    Content = table.Column<byte[]>(type: "bytea", nullable: true),
+                    UncompressedSize = table.Column<long>(type: "bigint", nullable: false),
+                    CompressedSize = table.Column<long>(type: "bigint", nullable: false),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RawFilingArtifact", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RawFilingArtifact_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RawFilingArtifact_AccessionNumber_ArtifactType",
+                table: "RawFilingArtifact",
+                columns: new[] { "AccessionNumber", "ArtifactType" },
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RawFilingArtifact_CommonStockId",
+                table: "RawFilingArtifact",
+                column: "CommonStockId"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "RawFilingArtifact");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/RawFilingArtifact.cs
+++ b/src/Equibles.Sec.Data/Models/RawFilingArtifact.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// A raw XBRL envelope persisted at filing-ingest time so the dimensional-fact
+/// extractors can read it later without re-downloading the original filing. The
+/// bytes are gzip-compressed; <see cref="UncompressedSize"/> and
+/// <see cref="CompressedSize"/> are kept so storage can be sized before any
+/// large historical backfill. Each artifact is attributed to the issuer's
+/// <see cref="CommonStock"/> and is unique per accession + artifact type.
+/// </summary>
+[Index(nameof(AccessionNumber), nameof(ArtifactType), IsUnique = true)]
+[Index(nameof(CommonStockId))]
+public class RawFilingArtifact
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    /// <summary>The SEC accession number of the filing this artifact came from.</summary>
+    [MaxLength(32)]
+    public string AccessionNumber { get; set; }
+
+    /// <summary>Whether this is the inline iXBRL envelope or a standalone XBRL instance.</summary>
+    public RawFilingArtifactType ArtifactType { get; set; }
+
+    /// <summary>
+    /// The artifact's file name as listed by EDGAR (e.g. <c>aapl-20180929.xml</c>),
+    /// or the primary document name for inline iXBRL.
+    /// </summary>
+    [MaxLength(256)]
+    public string SourceFileName { get; set; }
+
+    /// <summary>The gzip-compressed raw envelope bytes.</summary>
+    public byte[] Content { get; set; }
+
+    /// <summary>Size in bytes of the envelope before compression.</summary>
+    public long UncompressedSize { get; set; }
+
+    /// <summary>Size in bytes of the stored (gzip-compressed) <see cref="Content"/>.</summary>
+    public long CompressedSize { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Sec.Data/Models/RawFilingArtifactType.cs
+++ b/src/Equibles.Sec.Data/Models/RawFilingArtifactType.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// The kind of raw XBRL envelope captured for a filing. A single filing can yield
+/// both: the inline iXBRL embedded in the primary HTML document, and a separate
+/// standalone XBRL <c>.xml</c> instance listed among the filing's artifacts.
+/// </summary>
+public enum RawFilingArtifactType
+{
+    /// <summary>
+    /// The raw primary document containing inline XBRL (<c>ix:header</c>,
+    /// <c>ix:nonFraction</c>, <c>ix:nonNumeric</c>), captured before the HTML
+    /// normalizer strips it.
+    /// </summary>
+    [Display(Name = "Inline iXBRL")]
+    InlineIxbrl = 0,
+
+    /// <summary>
+    /// A standalone XBRL instance document fetched from the filing's artifact list.
+    /// </summary>
+    [Display(Name = "Standalone XBRL")]
+    StandaloneXbrl = 1,
+}

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -30,6 +30,7 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<NCenServiceProvider>();
         builder.Entity<NportFiling>();
         builder.Entity<NportHolding>();
+        builder.Entity<RawFilingArtifact>();
         builder.Entity<TranscriptCheckStatus>();
     }
 }

--- a/src/Equibles.Sec.Repositories/RawFilingArtifactRepository.cs
+++ b/src/Equibles.Sec.Repositories/RawFilingArtifactRepository.cs
@@ -1,0 +1,28 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Repositories;
+
+public class RawFilingArtifactRepository : BaseRepository<RawFilingArtifact>
+{
+    public RawFilingArtifactRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<RawFilingArtifact> GetByStock(CommonStock stock)
+    {
+        return GetAll().Where(a => a.CommonStockId == stock.Id);
+    }
+
+    public IQueryable<RawFilingArtifact> GetByAccessionNumber(string accessionNumber)
+    {
+        return GetAll().Where(a => a.AccessionNumber == accessionNumber);
+    }
+
+    public Task<bool> Exists(string accessionNumber, RawFilingArtifactType artifactType)
+    {
+        return GetAll()
+            .AnyAsync(a => a.AccessionNumber == accessionNumber && a.ArtifactType == artifactType);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs
@@ -34,6 +34,7 @@ public class SecTestModuleConfiguration : Equibles.Data.IModuleConfiguration
         builder.Entity<NCenServiceProvider>();
         builder.Entity<NportFiling>();
         builder.Entity<NportHolding>();
+        builder.Entity<RawFilingArtifact>();
         builder.Ignore<Chunk>();
         builder.Ignore<Embedding>();
     }

--- a/tests/Equibles.IntegrationTests/Sec/RawFilingArtifactRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/RawFilingArtifactRepositoryTests.cs
@@ -1,0 +1,167 @@
+using System.Text;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class RawFilingArtifactRepositoryTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly RawFilingArtifactRepository _repository;
+
+    public RawFilingArtifactRepositoryTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration()
+        );
+        _repository = new RawFilingArtifactRepository(_dbContext);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    private static CommonStock CreateStock(string ticker = "AAPL", string cik = "0000320193")
+    {
+        return new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = ticker,
+            Cik = cik,
+        };
+    }
+
+    private static RawFilingArtifact CreateArtifact(
+        Guid commonStockId,
+        string accessionNumber = "0000320193-18-000145",
+        RawFilingArtifactType artifactType = RawFilingArtifactType.InlineIxbrl,
+        string sourceFileName = "aapl-20180929.htm",
+        byte[] content = null
+    )
+    {
+        content ??= [1, 2, 3, 4, 5];
+        return new RawFilingArtifact
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = commonStockId,
+            AccessionNumber = accessionNumber,
+            ArtifactType = artifactType,
+            SourceFileName = sourceFileName,
+            Content = content,
+            UncompressedSize = 1000,
+            CompressedSize = content.Length,
+        };
+    }
+
+    [Fact]
+    public async Task GetByStock_ReturnsOnlyArtifactsForThatStock()
+    {
+        var apple = CreateStock("AAPL", "0000320193");
+        var microsoft = CreateStock("MSFT", "0000789019");
+        _dbContext.Set<CommonStock>().AddRange(apple, microsoft);
+        await _dbContext.SaveChangesAsync();
+
+        _repository.Add(CreateArtifact(apple.Id, "0000320193-18-000145"));
+        _repository.Add(
+            CreateArtifact(
+                apple.Id,
+                "0000320193-18-000145",
+                RawFilingArtifactType.StandaloneXbrl,
+                "aapl-20180929.xml"
+            )
+        );
+        _repository.Add(CreateArtifact(microsoft.Id, "0000789019-18-000123"));
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetByStock(apple).ToListAsync();
+
+        result.Should().HaveCount(2);
+        result.Should().OnlyContain(a => a.CommonStockId == apple.Id);
+    }
+
+    [Fact]
+    public async Task GetByAccessionNumber_ExistingAccession_ReturnsArtifact()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+        _repository.Add(CreateArtifact(stock.Id, "0000320193-18-000145"));
+        await _repository.SaveChanges();
+
+        var result = await _repository
+            .GetByAccessionNumber("0000320193-18-000145")
+            .FirstOrDefaultAsync();
+
+        result.Should().NotBeNull();
+        result.SourceFileName.Should().Be("aapl-20180929.htm");
+    }
+
+    [Fact]
+    public async Task GetByAccessionNumber_NonExistentAccession_ReturnsEmpty()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+        _repository.Add(CreateArtifact(stock.Id, "0000320193-18-000145"));
+        await _repository.SaveChanges();
+
+        var any = await _repository.GetByAccessionNumber("9999999999-99-999999").AnyAsync();
+
+        any.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RoundTrip_PreservesCompressedContentBytes()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var bytes = Encoding.UTF8.GetBytes("the gzip-compressed envelope stand-in");
+        _repository.Add(CreateArtifact(stock.Id, "0000320193-18-000145", content: bytes));
+        await _repository.SaveChanges();
+
+        var loaded = await _repository.GetByAccessionNumber("0000320193-18-000145").FirstAsync();
+
+        loaded.Content.Should().Equal(bytes);
+        loaded.CompressedSize.Should().Be(bytes.Length);
+        loaded.UncompressedSize.Should().Be(1000);
+    }
+
+    [Fact]
+    public async Task Exists_MatchesOnAccessionAndArtifactType()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+        _repository.Add(
+            CreateArtifact(stock.Id, "0000320193-18-000145", RawFilingArtifactType.InlineIxbrl)
+        );
+        await _repository.SaveChanges();
+
+        var inlineExists = await _repository.Exists(
+            "0000320193-18-000145",
+            RawFilingArtifactType.InlineIxbrl
+        );
+        var standaloneExists = await _repository.Exists(
+            "0000320193-18-000145",
+            RawFilingArtifactType.StandaloneXbrl
+        );
+        var otherAccession = await _repository.Exists(
+            "9999999999-99-999999",
+            RawFilingArtifactType.InlineIxbrl
+        );
+
+        inlineExists.Should().BeTrue();
+        standaloneExists.Should().BeFalse();
+        otherAccession.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 1 of 2 for #1118. Adds a `RawFilingArtifact` entity so the raw XBRL envelope of a filing (inline iXBRL primary document and/or standalone XBRL instance) can be persisted at ingest time and read later by the dimensional-fact extractors without re-downloading the original filing.
- Bytes are stored gzip-compressed, alongside the uncompressed and compressed sizes, so storage can be sized before any historical backfill. Each artifact is attributed to the issuer's common stock and is unique per accession number + artifact type.
- This slice lands the data layer only; capture on ingest follows in slice 2 (which closes the issue). Refs #1118.

## Code changes

- `src/Equibles.Sec.Data/Models/RawFilingArtifact.cs` — new entity (accession, artifact type, gzip bytes, uncompressed/compressed sizes, common-stock attribution; unique index on accession + type, index on common stock).
- `src/Equibles.Sec.Data/Models/RawFilingArtifactType.cs` — new enum distinguishing inline iXBRL from standalone XBRL.
- `src/Equibles.Sec.Data/SecModuleConfiguration.cs` — register the entity in the Sec module.
- `src/Equibles.Sec.Repositories/RawFilingArtifactRepository.cs` — `GetByStock`, `GetByAccessionNumber`, and an `Exists(accession, type)` helper for idempotent capture.
- `src/Equibles.Migrations/Migrations/*AddRawFilingArtifacts*` + snapshot — EF migration creating the `RawFilingArtifact` table and its indexes.
- `tests/Equibles.IntegrationTests/Helpers/SecTestModuleConfiguration.cs` — register the entity for in-memory tests.
- `tests/Equibles.IntegrationTests/Sec/RawFilingArtifactRepositoryTests.cs` — repository tests (per-stock filter, accession lookup, byte round-trip, `Exists`).