### PR TITLE
feat(sec): capture raw XBRL artifacts on filing ingest

### DIFF
--- a/src/Equibles.Sec.HostedService/Configuration/RawXbrlArtifactOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/RawXbrlArtifactOptions.cs
@@ -1,0 +1,25 @@
+namespace Equibles.Sec.HostedService.Configuration;
+
+/// <summary>
+/// Controls whether raw XBRL envelopes are persisted at filing-ingest time. Off by
+/// default: capture only runs once an operator has reviewed the storage-sizing
+/// implications and explicitly enables it. <see cref="Enabled"/> is the master
+/// switch; the two per-kind flags then select which envelopes to keep.
+/// </summary>
+public class RawXbrlArtifactOptions
+{
+    /// <summary>Master switch — no capture happens unless this is true.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Persist the inline iXBRL primary document (captured before the HTML normalizer
+    /// strips <c>ix:header</c>).
+    /// </summary>
+    public bool CaptureInlineIxbrl { get; set; }
+
+    /// <summary>
+    /// Fetch and persist the standalone XBRL <c>.xml</c> instance from the filing's
+    /// artifact list, when one is present.
+    /// </summary>
+    public bool CaptureStandaloneXbrl { get; set; }
+}

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -584,6 +584,13 @@ public class DocumentScraper : IDocumentScraper
                 var company = await companyRepository.Get(companyOutContext.Id);
                 var content = await secEdgarClient.GetDocumentContent(filing);
 
+                // Persist the raw XBRL envelope (when enabled): the inline iXBRL primary
+                // document and/or the standalone XBRL instance, fetched by name. Opt-in
+                // and best-effort — never breaks ingest.
+                var rawXbrlCapture =
+                    scope.ServiceProvider.GetRequiredService<RawXbrlArtifactCaptureService>();
+                await rawXbrlCapture.Capture(company, filing, cancellationToken);
+
                 var normalizedHtml = normalizer.Normalize(content);
                 var markdownDocument = converter.Convert(normalizedHtml);
 

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IFilingProcessor, NportFilingProcessor>();
         services.AddScoped<IDocumentPersistenceService, DocumentPersistenceService>();
         services.AddScoped<ICompanySyncService, CompanySyncService>();
+        services.AddScoped<RawXbrlArtifactCaptureService>();
         services.AddScoped<IDocumentScraper, DocumentScraper>();
 
         services.AddHostedService<SecScraperWorker>();

--- a/src/Equibles.Sec.HostedService/Services/RawXbrlArtifactCaptureService.cs
+++ b/src/Equibles.Sec.HostedService/Services/RawXbrlArtifactCaptureService.cs
@@ -1,0 +1,289 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.RegularExpressions;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Persists the raw XBRL envelope of a filing at ingest time so the dimensional-fact
+/// extractors can read it later without re-downloading the filing. Two complementary
+/// artifacts are captured by name: the inline iXBRL primary document (modern filings)
+/// and the standalone XBRL <c>.xml</c> instance (older filings). Capture is opt-in
+/// (see <see cref="RawXbrlArtifactOptions"/>), idempotent per accession + artifact
+/// type, and wrapped so it can never break the surrounding document ingest.
+/// </summary>
+public class RawXbrlArtifactCaptureService
+{
+    // Linkbase companions share the instance's base name but carry these suffixes;
+    // they are not the instance document and must be excluded when selecting it.
+    private static readonly string[] LinkbaseSuffixes =
+    [
+        "_cal.xml",
+        "_def.xml",
+        "_lab.xml",
+        "_pre.xml",
+        "_ref.xml",
+    ];
+
+    // EDGAR's rendered financial reports are named R1.xml, R2.xml, …; they are
+    // derived views, not the XBRL instance.
+    private static readonly Regex RenderedReportPattern = new(
+        @"^r\d+\.xml$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase
+    );
+
+    private readonly ISecEdgarClient _secEdgarClient;
+    private readonly RawFilingArtifactRepository _repository;
+    private readonly RawXbrlArtifactOptions _options;
+    private readonly ILogger<RawXbrlArtifactCaptureService> _logger;
+
+    public RawXbrlArtifactCaptureService(
+        ISecEdgarClient secEdgarClient,
+        RawFilingArtifactRepository repository,
+        IOptions<RawXbrlArtifactOptions> options,
+        ILogger<RawXbrlArtifactCaptureService> logger
+    )
+    {
+        _secEdgarClient = secEdgarClient;
+        _repository = repository;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Captures the enabled raw XBRL envelopes for a filing. Any failure is logged and
+    /// swallowed — capture must never interrupt ingest.
+    /// </summary>
+    public async Task Capture(
+        CommonStock company,
+        FilingData filing,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (!_options.Enabled)
+        {
+            return;
+        }
+
+        try
+        {
+            if (_options.CaptureInlineIxbrl)
+            {
+                await CaptureInline(company, filing, cancellationToken);
+            }
+
+            if (_options.CaptureStandaloneXbrl)
+            {
+                await CaptureStandalone(company, filing, cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to capture raw XBRL artifacts for {Ticker} {Accession}; ingest continues.",
+                company.Ticker,
+                filing.AccessionNumber
+            );
+        }
+    }
+
+    private async Task CaptureInline(
+        CommonStock company,
+        FilingData filing,
+        CancellationToken cancellationToken
+    )
+    {
+        if (string.IsNullOrWhiteSpace(filing.PrimaryDocument))
+        {
+            return;
+        }
+
+        if (await _repository.Exists(filing.AccessionNumber, RawFilingArtifactType.InlineIxbrl))
+        {
+            return;
+        }
+
+        var bytes = await _secEdgarClient.GetDocumentFileBytes(
+            filing.Cik,
+            filing.AccessionNumber,
+            filing.PrimaryDocument,
+            cancellationToken
+        );
+
+        if (bytes == null || bytes.Length == 0)
+        {
+            return;
+        }
+
+        // Only keep documents that actually carry inline XBRL; plain-HTML primary
+        // documents (older filings, Forms 3/4/5, …) have no ix:header to extract.
+        if (!ContainsInlineXbrl(Encoding.UTF8.GetString(bytes)))
+        {
+            return;
+        }
+
+        await Store(
+            company,
+            filing.AccessionNumber,
+            RawFilingArtifactType.InlineIxbrl,
+            filing.PrimaryDocument,
+            bytes
+        );
+    }
+
+    private async Task CaptureStandalone(
+        CommonStock company,
+        FilingData filing,
+        CancellationToken cancellationToken
+    )
+    {
+        if (await _repository.Exists(filing.AccessionNumber, RawFilingArtifactType.StandaloneXbrl))
+        {
+            return;
+        }
+
+        var artifactNames = await _secEdgarClient.GetFilingArtifactNames(
+            filing.Cik,
+            filing.AccessionNumber,
+            cancellationToken
+        );
+
+        var instanceName = SelectStandaloneXbrlInstance(artifactNames);
+        if (instanceName == null)
+        {
+            return;
+        }
+
+        var bytes = await _secEdgarClient.GetDocumentFileBytes(
+            filing.Cik,
+            filing.AccessionNumber,
+            instanceName,
+            cancellationToken
+        );
+
+        if (bytes == null || bytes.Length == 0)
+        {
+            return;
+        }
+
+        await Store(
+            company,
+            filing.AccessionNumber,
+            RawFilingArtifactType.StandaloneXbrl,
+            instanceName,
+            bytes
+        );
+    }
+
+    private async Task Store(
+        CommonStock company,
+        string accessionNumber,
+        RawFilingArtifactType artifactType,
+        string sourceFileName,
+        byte[] raw
+    )
+    {
+        var compressed = Compress(raw);
+
+        // The preceding Exists check is a fast-path skip; the unique
+        // (AccessionNumber, ArtifactType) index is the authoritative idempotency
+        // guard should two document workers race the same filing.
+        _repository.Add(
+            new RawFilingArtifact
+            {
+                CommonStockId = company.Id,
+                AccessionNumber = accessionNumber,
+                ArtifactType = artifactType,
+                SourceFileName = sourceFileName,
+                Content = compressed,
+                UncompressedSize = raw.Length,
+                CompressedSize = compressed.Length,
+            }
+        );
+        await _repository.SaveChanges();
+
+        _logger.LogInformation(
+            "Captured {ArtifactType} XBRL artifact for {Ticker} {Accession} ({Uncompressed} -> {Compressed} bytes)",
+            artifactType,
+            company.Ticker,
+            accessionNumber,
+            raw.Length,
+            compressed.Length
+        );
+    }
+
+    /// <summary>
+    /// True when the document carries inline XBRL — the <c>ix</c> namespace declaration
+    /// or any element in that namespace.
+    /// </summary>
+    internal static bool ContainsInlineXbrl(string content)
+    {
+        return content.Contains("xmlns:ix=", StringComparison.OrdinalIgnoreCase)
+            || content.Contains("<ix:", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Selects the XBRL instance document from a filing's artifact list: the first
+    /// <c>.xml</c> that is neither a linkbase companion, the filing summary, nor a
+    /// rendered report. Returns null when the filing has no standalone instance.
+    /// </summary>
+    internal static string SelectStandaloneXbrlInstance(IEnumerable<string> artifactNames)
+    {
+        if (artifactNames == null)
+        {
+            return null;
+        }
+
+        foreach (var name in artifactNames)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            var lower = name.ToLowerInvariant();
+            if (!lower.EndsWith(".xml"))
+            {
+                continue;
+            }
+
+            if (lower == "filingsummary.xml")
+            {
+                continue;
+            }
+
+            if (LinkbaseSuffixes.Any(suffix => lower.EndsWith(suffix)))
+            {
+                continue;
+            }
+
+            if (RenderedReportPattern.IsMatch(lower))
+            {
+                continue;
+            }
+
+            return name;
+        }
+
+        return null;
+    }
+
+    private static byte[] Compress(byte[] raw)
+    {
+        using var output = new MemoryStream();
+        using (var gzip = new GZipStream(output, CompressionLevel.Optimal))
+        {
+            gzip.Write(raw, 0, raw.Length);
+        }
+        return output.ToArray();
+    }
+}

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -71,6 +71,9 @@ builder.Services.Configure<Equibles.Finra.HostedService.Configuration.FinraScrap
 builder.Services.Configure<Equibles.Sec.HostedService.Configuration.FtdScraperOptions>(
     builder.Configuration.GetSection("FtdScraper")
 );
+builder.Services.Configure<Equibles.Sec.HostedService.Configuration.RawXbrlArtifactOptions>(
+    builder.Configuration.GetSection("RawXbrlArtifacts")
+);
 builder.Services.Configure<FinancialFactsScraperOptions>(
     builder.Configuration.GetSection("FinancialFactsScraper")
 );

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
@@ -623,6 +623,15 @@ public class DocumentScraperTests
             services.AddSingleton(Converter);
             services.AddSingleton(PdfTextExtractor);
             services.AddSingleton(Persistence);
+            // DocumentScraper resolves the raw-XBRL capture service per scope. These
+            // tests exercise the default markdown-persistence flow, so capture stays
+            // disabled (default options) and short-circuits without touching the repo.
+            services.AddLogging();
+            services.AddScoped<RawFilingArtifactRepository>();
+            services.AddSingleton<IOptions<RawXbrlArtifactOptions>>(
+                Options.Create(new RawXbrlArtifactOptions())
+            );
+            services.AddScoped<RawXbrlArtifactCaptureService>();
 
             var provider = services.BuildServiceProvider();
             ScopeFactory = provider.GetRequiredService<IServiceScopeFactory>();

--- a/tests/Equibles.UnitTests/Sec/RawFilingArtifactOnlyModuleConfiguration.cs
+++ b/tests/Equibles.UnitTests/Sec/RawFilingArtifactOnlyModuleConfiguration.cs
@@ -1,0 +1,18 @@
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Registers only <see cref="RawFilingArtifact"/> for in-memory tests — excludes the
+/// Sec entities whose <c>Pgvector.Vector</c> properties are incompatible with the
+/// in-memory EF Core provider.
+/// </summary>
+internal sealed class RawFilingArtifactOnlyModuleConfiguration : IModuleConfiguration
+{
+    public void ConfigureEntities(ModelBuilder builder)
+    {
+        builder.Entity<RawFilingArtifact>();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/RawXbrlArtifactCaptureServiceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RawXbrlArtifactCaptureServiceTests.cs
@@ -1,0 +1,284 @@
+using System.IO.Compression;
+using System.Text;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+public class RawXbrlArtifactCaptureServiceTests
+{
+    private readonly ISecEdgarClient _secEdgarClient = Substitute.For<ISecEdgarClient>();
+
+    private static EquiblesFinancialDbContext NewDbContext()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new RawFilingArtifactOnlyModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private RawXbrlArtifactCaptureService BuildService(
+        EquiblesFinancialDbContext dbContext,
+        RawXbrlArtifactOptions options
+    )
+    {
+        return new RawXbrlArtifactCaptureService(
+            _secEdgarClient,
+            new RawFilingArtifactRepository(dbContext),
+            Options.Create(options),
+            Substitute.For<ILogger<RawXbrlArtifactCaptureService>>()
+        );
+    }
+
+    private static CommonStock SeedStock(EquiblesFinancialDbContext db)
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        db.Set<CommonStock>().Add(stock);
+        db.SaveChanges();
+        return stock;
+    }
+
+    private static FilingData Filing(string accession = "0000320193-18-000145")
+    {
+        return new FilingData
+        {
+            Cik = "0000320193",
+            AccessionNumber = accession,
+            FilingDate = new DateOnly(2018, 11, 5),
+            Form = "10-K",
+            PrimaryDocument = "aapl-20180929.htm",
+        };
+    }
+
+    private const string InlineXbrlHtml =
+        "<html xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\"><body><ix:nonFraction>1</ix:nonFraction></body></html>";
+
+    private void StubPrimaryDocument(FilingData filing, string body)
+    {
+        _secEdgarClient
+            .GetDocumentFileBytes(filing.Cik, filing.AccessionNumber, filing.PrimaryDocument)
+            .Returns(Encoding.UTF8.GetBytes(body));
+    }
+
+    [Fact]
+    public async Task Capture_Disabled_StoresNothingAndDoesNotCallClient()
+    {
+        using var db = NewDbContext();
+        var stock = SeedStock(db);
+        var filing = Filing();
+        StubPrimaryDocument(filing, InlineXbrlHtml);
+        var service = BuildService(
+            db,
+            new RawXbrlArtifactOptions { Enabled = false, CaptureInlineIxbrl = true }
+        );
+
+        await service.Capture(stock, filing);
+
+        db.Set<RawFilingArtifact>().Should().BeEmpty();
+        await _secEdgarClient
+            .DidNotReceive()
+            .GetDocumentFileBytes(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task Capture_InlineEnabled_StoresGzippedPrimaryDocumentWithSizes()
+    {
+        using var db = NewDbContext();
+        var stock = SeedStock(db);
+        var filing = Filing();
+        StubPrimaryDocument(filing, InlineXbrlHtml);
+        var service = BuildService(
+            db,
+            new RawXbrlArtifactOptions { Enabled = true, CaptureInlineIxbrl = true }
+        );
+
+        await service.Capture(stock, filing);
+
+        var stored = db.Set<RawFilingArtifact>().Single();
+        stored.ArtifactType.Should().Be(RawFilingArtifactType.InlineIxbrl);
+        stored.SourceFileName.Should().Be("aapl-20180929.htm");
+        stored.UncompressedSize.Should().Be(Encoding.UTF8.GetByteCount(InlineXbrlHtml));
+        stored.CompressedSize.Should().Be(stored.Content.Length);
+        Decompress(stored.Content).Should().Be(InlineXbrlHtml);
+    }
+
+    [Fact]
+    public async Task Capture_InlinePrimaryDocumentWithoutXbrlMarkers_StoresNothing()
+    {
+        using var db = NewDbContext();
+        var stock = SeedStock(db);
+        var filing = Filing();
+        StubPrimaryDocument(filing, "<html><body>no inline xbrl here</body></html>");
+        var service = BuildService(
+            db,
+            new RawXbrlArtifactOptions { Enabled = true, CaptureInlineIxbrl = true }
+        );
+
+        await service.Capture(stock, filing);
+
+        db.Set<RawFilingArtifact>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Capture_InlineAlreadyExists_DoesNotFetchOrStoreDuplicate()
+    {
+        using var db = NewDbContext();
+        var stock = SeedStock(db);
+        var filing = Filing();
+        StubPrimaryDocument(filing, InlineXbrlHtml);
+        db.Set<RawFilingArtifact>()
+            .Add(
+                new RawFilingArtifact
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = stock.Id,
+                    AccessionNumber = filing.AccessionNumber,
+                    ArtifactType = RawFilingArtifactType.InlineIxbrl,
+                    SourceFileName = "old.htm",
+                    Content = [9, 9, 9],
+                    UncompressedSize = 3,
+                    CompressedSize = 3,
+                }
+            );
+        await db.SaveChangesAsync();
+        var service = BuildService(
+            db,
+            new RawXbrlArtifactOptions { Enabled = true, CaptureInlineIxbrl = true }
+        );
+
+        await service.Capture(stock, filing);
+
+        db.Set<RawFilingArtifact>().Should().ContainSingle();
+        db.Set<RawFilingArtifact>().Single().SourceFileName.Should().Be("old.htm");
+        await _secEdgarClient
+            .DidNotReceive()
+            .GetDocumentFileBytes(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task Capture_StandaloneEnabled_FetchesInstanceAndStoresGzip()
+    {
+        using var db = NewDbContext();
+        var stock = SeedStock(db);
+        var filing = Filing();
+        var instanceBytes = Encoding.UTF8.GetBytes("<xbrl>standalone instance</xbrl>");
+        _secEdgarClient
+            .GetFilingArtifactNames(filing.Cik, filing.AccessionNumber)
+            .Returns(["aapl-20180929_cal.xml", "aapl-20180929.xml", "R1.xml"]);
+        _secEdgarClient
+            .GetDocumentFileBytes(filing.Cik, filing.AccessionNumber, "aapl-20180929.xml")
+            .Returns(instanceBytes);
+        var service = BuildService(
+            db,
+            new RawXbrlArtifactOptions { Enabled = true, CaptureStandaloneXbrl = true }
+        );
+
+        await service.Capture(stock, filing);
+
+        var stored = db.Set<RawFilingArtifact>().Single();
+        stored.ArtifactType.Should().Be(RawFilingArtifactType.StandaloneXbrl);
+        stored.SourceFileName.Should().Be("aapl-20180929.xml");
+        Decompress(stored.Content).Should().Be("<xbrl>standalone instance</xbrl>");
+    }
+
+    [Fact]
+    public async Task Capture_StandaloneEnabled_NoInstanceInArtifactList_StoresNothing()
+    {
+        using var db = NewDbContext();
+        var stock = SeedStock(db);
+        var filing = Filing();
+        _secEdgarClient
+            .GetFilingArtifactNames(filing.Cik, filing.AccessionNumber)
+            .Returns(["aapl-20180929_cal.xml", "aapl-20180929_lab.xml", "R1.xml", "primary.htm"]);
+        var service = BuildService(
+            db,
+            new RawXbrlArtifactOptions { Enabled = true, CaptureStandaloneXbrl = true }
+        );
+
+        await service.Capture(stock, filing);
+
+        db.Set<RawFilingArtifact>().Should().BeEmpty();
+        await _secEdgarClient
+            .DidNotReceive()
+            .GetDocumentFileBytes(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public void SelectStandaloneXbrlInstance_ExcludesLinkbasesSummaryAndRenderedReports()
+    {
+        var names = new[]
+        {
+            "FilingSummary.xml",
+            "aapl-20180929_cal.xml",
+            "aapl-20180929_def.xml",
+            "aapl-20180929_lab.xml",
+            "aapl-20180929_pre.xml",
+            "R1.xml",
+            "R42.xml",
+            "aapl-20180929.xsd",
+            "aapl-20180929.xml",
+        };
+
+        var selected = RawXbrlArtifactCaptureService.SelectStandaloneXbrlInstance(names);
+
+        selected.Should().Be("aapl-20180929.xml");
+    }
+
+    [Fact]
+    public void SelectStandaloneXbrlInstance_NoInstancePresent_ReturnsNull()
+    {
+        var names = new[] { "aapl-20180929_cal.xml", "R1.xml", "primary.htm" };
+
+        RawXbrlArtifactCaptureService.SelectStandaloneXbrlInstance(names).Should().BeNull();
+    }
+
+    private static string Decompress(byte[] compressed)
+    {
+        using var input = new MemoryStream(compressed);
+        using var gzip = new GZipStream(input, CompressionMode.Decompress);
+        using var reader = new StreamReader(gzip, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 2 of 2 for #1118 (closes it). Persists the raw XBRL envelope of a filing when document ingest runs, so the dimensional-fact extractors have a stable source to read from without re-downloading historical filings.
- Two complementary artifacts are captured by name and gzip-compressed: the inline iXBRL primary document (modern filings) and the standalone XBRL `.xml` instance (older filings). Storage is idempotent per accession + artifact type.
- Capture is opt-in via `RawXbrlArtifactOptions` (master switch plus per-kind flags, all off by default) and wrapped so a capture failure can never interrupt ingest. Builds on the `RawFilingArtifact` data model added in #2864.

## Code changes

- `src/Equibles.Sec.HostedService/Services/RawXbrlArtifactCaptureService.cs` — new service: fetches the primary iXBRL document and/or standalone XBRL instance by name, keeps inline documents only when they actually carry inline XBRL, selects the instance document while skipping linkbases / filing summary / rendered reports, gzip-compresses, and stores idempotently (the unique index is the authoritative guard). All work is best-effort and logged-and-swallowed.
- `src/Equibles.Sec.HostedService/Configuration/RawXbrlArtifactOptions.cs` — new options (`Enabled`, `CaptureInlineIxbrl`, `CaptureStandaloneXbrl`), all false by default.
- `src/Equibles.Sec.HostedService/DocumentScraper.cs` — invoke the capture service per filing inside the existing per-document scope.
- `src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs` — register the capture service.
- `src/Equibles.Worker.Host/Program.cs` — bind the options from the `RawXbrlArtifacts` configuration section.
- `tests/Equibles.UnitTests/Sec/RawXbrlArtifactCaptureServiceTests.cs` (+ `RawFilingArtifactOnlyModuleConfiguration.cs`) — unit tests covering disabled/enabled, inline marker gating, idempotency, standalone instance selection, and gzip round-trip.
- `tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs` — register the capture service (capture disabled) in the existing scraper test scope so the default ingest flow resolves it.