### PR TITLE
feat(sec): add Form ADV investment-adviser data model

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260530112400_AddFormAdv.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260530112400_AddFormAdv.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530112400_AddFormAdv")]
+    partial class AddFormAdv
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260530112400_AddFormAdv.cs
+++ b/src/Equibles.Migrations/Migrations/20260530112400_AddFormAdv.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFormAdv : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FormAdvAdviser",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Crd = table.Column<int>(type: "integer", nullable: false),
+                    SecNumber = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: true
+                    ),
+                    LegalName = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    PrimaryBusinessName = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    MainOfficeCity = table.Column<string>(
+                        type: "character varying(128)",
+                        maxLength: 128,
+                        nullable: true
+                    ),
+                    MainOfficeState = table.Column<string>(
+                        type: "character varying(128)",
+                        maxLength: 128,
+                        nullable: true
+                    ),
+                    MainOfficeCountry = table.Column<string>(
+                        type: "character varying(128)",
+                        maxLength: 128,
+                        nullable: true
+                    ),
+                    WebsiteAddress = table.Column<string>(
+                        type: "character varying(512)",
+                        maxLength: 512,
+                        nullable: true
+                    ),
+                    SecStatus = table.Column<string>(
+                        type: "character varying(64)",
+                        maxLength: 64,
+                        nullable: true
+                    ),
+                    NumberOfEmployees = table.Column<int>(type: "integer", nullable: true),
+                    TotalRegulatoryAum = table.Column<long>(type: "bigint", nullable: true),
+                    DiscretionaryAum = table.Column<long>(type: "bigint", nullable: true),
+                    NonDiscretionaryAum = table.Column<long>(type: "bigint", nullable: true),
+                    ChargesPercentageOfAum = table.Column<bool>(type: "boolean", nullable: false),
+                    ChargesHourly = table.Column<bool>(type: "boolean", nullable: false),
+                    ChargesSubscription = table.Column<bool>(type: "boolean", nullable: false),
+                    ChargesFixed = table.Column<bool>(type: "boolean", nullable: false),
+                    ChargesCommissions = table.Column<bool>(type: "boolean", nullable: false),
+                    ChargesPerformanceBased = table.Column<bool>(type: "boolean", nullable: false),
+                    ChargesOther = table.Column<bool>(type: "boolean", nullable: false),
+                    ReportDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                    UpdateTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FormAdvAdviser", x => x.Id);
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FormAdvAdviser_Crd",
+                table: "FormAdvAdviser",
+                column: "Crd",
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FormAdvAdviser_LegalName",
+                table: "FormAdvAdviser",
+                column: "LegalName"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FormAdvAdviser_TotalRegulatoryAum",
+                table: "FormAdvAdviser",
+                column: "TotalRegulatoryAum"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "FormAdvAdviser");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/FormAdvAdviser.cs
+++ b/src/Equibles.Sec.Data/Models/FormAdvAdviser.cs
@@ -1,0 +1,97 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.Data.Models;
+
+/// <summary>
+/// An investment adviser as reported on SEC Form ADV Part 1A. The SEC publishes the full
+/// population of registered advisers and exempt reporting advisers as a monthly bulk download
+/// (one CSV row per firm). Unlike most SEC filings this data is not tied to a stock issuer —
+/// each firm is keyed by its Organization CRD number, the stable identifier FINRA/IARD assigns
+/// when the firm first enters the system. The federal SEC file number (the "801-…" / "802-…"
+/// value) is kept as a secondary attribute and is absent for state-registered firms.
+/// </summary>
+[Index(nameof(Crd), IsUnique = true)]
+[Index(nameof(LegalName))]
+[Index(nameof(TotalRegulatoryAum))]
+public class FormAdvAdviser
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>Organization CRD number — the adviser's stable primary identifier.</summary>
+    public int Crd { get; set; }
+
+    /// <summary>SEC file number, e.g. "801-54739" (federal IA) or "802-…" (exempt reporting adviser); null for state-only firms.</summary>
+    [MaxLength(32)]
+    public string SecNumber { get; set; }
+
+    /// <summary>The firm's legal name exactly as reported (Form ADV Item 1.A).</summary>
+    [MaxLength(512)]
+    public string LegalName { get; set; }
+
+    /// <summary>The primary business / "doing-business-as" name when it differs from the legal name (Item 1.B).</summary>
+    [MaxLength(512)]
+    public string PrimaryBusinessName { get; set; }
+
+    /// <summary>City of the firm's main office (Item 1.F).</summary>
+    [MaxLength(128)]
+    public string MainOfficeCity { get; set; }
+
+    /// <summary>State or province of the firm's main office (Item 1.F).</summary>
+    [MaxLength(128)]
+    public string MainOfficeState { get; set; }
+
+    /// <summary>Country of the firm's main office (Item 1.F).</summary>
+    [MaxLength(128)]
+    public string MainOfficeCountry { get; set; }
+
+    /// <summary>The firm's public website when disclosed (Item 1.I).</summary>
+    [MaxLength(512)]
+    public string WebsiteAddress { get; set; }
+
+    /// <summary>The firm's reported registration status with the SEC, e.g. "Approved"; null when not provided.</summary>
+    [MaxLength(64)]
+    public string SecStatus { get; set; }
+
+    /// <summary>Number of employees who perform investment advisory functions (Item 5.A); null when not reported.</summary>
+    public int? NumberOfEmployees { get; set; }
+
+    /// <summary>Total regulatory assets under management in US dollars (Item 5.F(2)(c)); null when not reported.</summary>
+    public long? TotalRegulatoryAum { get; set; }
+
+    /// <summary>Regulatory assets under management held on a discretionary basis (Item 5.F(2)(a)); null when not reported.</summary>
+    public long? DiscretionaryAum { get; set; }
+
+    /// <summary>Regulatory assets under management held on a non-discretionary basis (Item 5.F(2)(b)); null when not reported.</summary>
+    public long? NonDiscretionaryAum { get; set; }
+
+    /// <summary>Charges fees as a percentage of assets under management (Item 5.E(1)).</summary>
+    public bool ChargesPercentageOfAum { get; set; }
+
+    /// <summary>Charges hourly fees (Item 5.E(2)).</summary>
+    public bool ChargesHourly { get; set; }
+
+    /// <summary>Charges subscription fees (Item 5.E(3)).</summary>
+    public bool ChargesSubscription { get; set; }
+
+    /// <summary>Charges fixed fees other than subscription fees (Item 5.E(4)).</summary>
+    public bool ChargesFixed { get; set; }
+
+    /// <summary>Charges commissions (Item 5.E(5)).</summary>
+    public bool ChargesCommissions { get; set; }
+
+    /// <summary>Charges performance-based fees (Item 5.E(6)).</summary>
+    public bool ChargesPerformanceBased { get; set; }
+
+    /// <summary>Charges other types of compensation (Item 5.E(7)).</summary>
+    public bool ChargesOther { get; set; }
+
+    /// <summary>The snapshot date of the bulk file this record was last imported from.</summary>
+    public DateOnly ReportDate { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+
+    public DateTime UpdateTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -24,6 +24,7 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
         });
 
         builder.Entity<FailToDeliver>();
+        builder.Entity<FormAdvAdviser>();
         builder.Entity<FormDFiling>();
         builder.Entity<FormDRelatedPerson>();
         builder.Entity<NCenFiling>();

--- a/tests/Equibles.IntegrationTests/Sec/FormAdvAdviserPersistenceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FormAdvAdviserPersistenceTests.cs
@@ -1,0 +1,61 @@
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Pins that the Form ADV adviser entity (PR slice 1) maps and round-trips through the
+/// real ParadeDB schema — proving the AddFormAdv migration applies and that the column set,
+/// nullable regulatory-AUM figures, and fee-structure flags persist and read back intact.
+/// Querying by the Organization CRD number also exercises its unique index.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FormAdvAdviserPersistenceTests : ParadeDbMcpTestBase
+{
+    public FormAdvAdviserPersistenceTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task FormAdvAdviser_RoundTrips_ThroughTheParadeDbSchema()
+    {
+        var adviser = new FormAdvAdviser
+        {
+            Id = Guid.NewGuid(),
+            Crd = 231,
+            SecNumber = "801-54739",
+            LegalName = "BNY MELLON SECURITIES CORPORATION",
+            PrimaryBusinessName = "BNY MELLON SECURITIES CORPORATION",
+            MainOfficeCity = "NEW YORK",
+            MainOfficeState = "NY",
+            MainOfficeCountry = "United States",
+            WebsiteAddress = "HTTP://WWW.BNYMELLONIM.COM/US",
+            SecStatus = "Approved",
+            NumberOfEmployees = 333,
+            DiscretionaryAum = 829_845_109L,
+            NonDiscretionaryAum = 1_651_522_723L,
+            TotalRegulatoryAum = 2_481_367_832L,
+            ChargesPercentageOfAum = true,
+            ChargesPerformanceBased = false,
+            ReportDate = new DateOnly(2022, 4, 1),
+        };
+
+        DbContext.Set<FormAdvAdviser>().Add(adviser);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var loaded = await DbContext.Set<FormAdvAdviser>().SingleAsync(a => a.Crd == 231);
+
+        loaded.SecNumber.Should().Be("801-54739");
+        loaded.LegalName.Should().Be("BNY MELLON SECURITIES CORPORATION");
+        loaded.MainOfficeState.Should().Be("NY");
+        loaded.NumberOfEmployees.Should().Be(333);
+        loaded.TotalRegulatoryAum.Should().Be(2_481_367_832L);
+        loaded.DiscretionaryAum.Should().Be(829_845_109L);
+        loaded.NonDiscretionaryAum.Should().Be(1_651_522_723L);
+        loaded.ChargesPercentageOfAum.Should().BeTrue();
+        loaded.ChargesPerformanceBased.Should().BeFalse();
+        loaded.ReportDate.Should().Be(new DateOnly(2022, 4, 1));
+    }
+}


### PR DESCRIPTION
## Summary

- First PR toward Form ADV investment-adviser data (#1866). Adds the data model and schema for SEC Form ADV Part 1A advisers — the registered investment advisers and exempt reporting advisers the SEC publishes as a bulk download.
- Advisers are firms rather than stock issuers, so the record stands alone keyed by Organization CRD number (the firm's stable identifier) rather than hanging off a `CommonStock`.

## Code changes

- `src/Equibles.Sec.Data/Models/FormAdvAdviser.cs` — new entity: CRD, SEC file number, legal/business names, main office location, website, employee count, regulatory assets under management (discretionary / non-discretionary / total) and the Item 5.E fee-structure flags. Unique index on CRD; indexes on legal name and total AUM for browsing.
- `src/Equibles.Sec.Data/SecModuleConfiguration.cs` — register the entity with the shared model.
- `src/Equibles.Migrations/Migrations/20260530112400_AddFormAdv.cs` (+ designer, snapshot) — `AddFormAdv` migration creating the table and its indexes.
- `tests/Equibles.IntegrationTests/Sec/FormAdvAdviserPersistenceTests.cs` — round-trips an adviser through the ParadeDB schema, proving the migration applies and the columns persist intact.

Refs #1866