### PR TITLE
feat(sec): import Form ADV advisers in the worker

### DIFF
--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -11,6 +11,7 @@ public sealed class ErrorSource
     public static readonly ErrorSource HoldingsScraper = new("HoldingsScraper");
     public static readonly ErrorSource FinraScraper = new("FinraScraper");
     public static readonly ErrorSource FtdScraper = new("FtdScraper");
+    public static readonly ErrorSource FormAdvScraper = new("FormAdvScraper");
     public static readonly ErrorSource FinancialFactsScraper = new("FinancialFactsScraper");
     public static readonly ErrorSource DocumentProcessor = new("DocumentProcessor");
     public static readonly ErrorSource CongressScraper = new("CongressScraper");
@@ -28,6 +29,7 @@ public sealed class ErrorSource
             HoldingsScraper,
             FinraScraper,
             FtdScraper,
+            FormAdvScraper,
             FinancialFactsScraper,
             DocumentProcessor,
             CongressScraper,

--- a/src/Equibles.Sec.HostedService/Configuration/FormAdvScraperOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/FormAdvScraperOptions.cs
@@ -1,0 +1,5 @@
+using Equibles.Worker;
+
+namespace Equibles.Sec.HostedService.Configuration;
+
+public class FormAdvScraperOptions : ScraperOptions { }

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<SecScraperWorker>();
         services.AddHostedService<DocumentProcessorWorker>();
         services.AddHostedService<FtdScraperWorker>();
+        services.AddHostedService<FormAdvScraperWorker>();
 
         return services;
     }

--- a/src/Equibles.Sec.HostedService/FormAdvScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/FormAdvScraperWorker.cs
@@ -1,0 +1,50 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Worker;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Sec.HostedService;
+
+public class FormAdvScraperWorker : BaseScraperWorker
+{
+    private readonly IConfiguration _configuration;
+
+    protected override string WorkerName => "Form ADV scraper";
+    protected override TimeSpan SleepInterval { get; }
+    protected override ErrorSource ErrorSource => ErrorSource.FormAdvScraper;
+
+    // Staggered behind the other SEC scrapers so they don't all drain the shared
+    // EDGAR request budget at deploy time before the time-sensitive sweeps run.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(7);
+
+    public FormAdvScraperWorker(
+        ILogger<FormAdvScraperWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<FormAdvScraperOptions> options,
+        IConfiguration configuration
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
+        _configuration = configuration;
+    }
+
+    protected override bool ValidateConfiguration()
+    {
+        if (string.IsNullOrEmpty(_configuration["Sec:ContactEmail"]))
+        {
+            Logger.LogWarning(
+                "Form ADV Scraper stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."
+            );
+            return false;
+        }
+        return true;
+    }
+
+    protected override Task DoWork(CancellationToken stoppingToken) =>
+        RunImport<FormAdvImportService>(stoppingToken);
+}

--- a/src/Equibles.Sec.HostedService/Services/FormAdvImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FormAdvImportService.cs
@@ -1,0 +1,240 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Net;
+using System.Text;
+using Equibles.Core.AutoWiring;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.FormAdv;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Equibles.Worker;
+using FlexLabs.EntityFrameworkCore.Upsert;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Imports the SEC's bulk Form ADV adviser download. The SEC publishes one snapshot per month
+/// as <c>ia&lt;MMDDYY&gt;.zip</c> (always the first of the month, a month or two in arrears), so
+/// the importer probes recent months newest-first, downloads the most recent one available, and
+/// upserts every adviser keyed by Organization CRD number. Re-running once a snapshot is already
+/// stored is a no-op.
+/// </summary>
+[Service]
+public class FormAdvImportService : IImporter
+{
+    private const string BaseUrl =
+        "https://www.sec.gov/files/investment/data/information-about-registered-investment-advisers-and-exempt-reporting-advisers";
+    private const int MonthsToProbe = 4;
+    private const int UpsertBatchSize = 1000;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ISecEdgarClient _secEdgarClient;
+    private readonly ILogger<FormAdvImportService> _logger;
+    private readonly ErrorReporter _errorReporter;
+
+    public FormAdvImportService(
+        IServiceScopeFactory scopeFactory,
+        ISecEdgarClient secEdgarClient,
+        ILogger<FormAdvImportService> logger,
+        ErrorReporter errorReporter
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _secEdgarClient = secEdgarClient;
+        _logger = logger;
+        _errorReporter = errorReporter;
+    }
+
+    public async Task Import(CancellationToken cancellationToken)
+    {
+        var storedLatest = await GetStoredLatestReportDate(cancellationToken);
+
+        foreach (var fileDate in GetCandidateFileDates())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var fileName = $"ia{fileDate.ToString("MMddyy", CultureInfo.InvariantCulture)}.zip";
+            Stream zipStream;
+            try
+            {
+                zipStream = await _secEdgarClient.DownloadStream($"{BaseUrl}/{fileName}");
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                // This month's snapshot is not published yet — try the previous one.
+                continue;
+            }
+
+            await using (zipStream)
+            {
+                // The newest snapshot that exists. If it is already stored, nothing to do.
+                if (storedLatest.HasValue && storedLatest.Value >= fileDate)
+                {
+                    _logger.LogInformation(
+                        "Form ADV data is up to date (latest snapshot {Date})",
+                        fileDate
+                    );
+                    return;
+                }
+
+                _logger.LogInformation("Importing Form ADV snapshot {Date}", fileDate);
+                var imported = await ImportSnapshot(zipStream, fileDate, cancellationToken);
+                _logger.LogInformation(
+                    "Form ADV {Date}: upserted {Count} advisers",
+                    fileDate,
+                    imported
+                );
+            }
+
+            return;
+        }
+
+        _logger.LogWarning(
+            "No Form ADV snapshot found in the last {Months} months — SEC URL or schedule may have changed",
+            MonthsToProbe
+        );
+        await _errorReporter.Report(
+            ErrorSource.FormAdvScraper,
+            "FormAdvImport.NoSnapshot",
+            $"No Form ADV snapshot found in the last {MonthsToProbe} months — SEC URL or schedule may have changed",
+            null
+        );
+    }
+
+    private async Task<DateOnly?> GetStoredLatestReportDate(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<FormAdvAdviserRepository>();
+        var dates = await repo.GetAll()
+            .OrderByDescending(a => a.ReportDate)
+            .Select(a => (DateOnly?)a.ReportDate)
+            .FirstOrDefaultAsync(cancellationToken);
+        return dates;
+    }
+
+    private async Task<int> ImportSnapshot(
+        Stream zipStream,
+        DateOnly fileDate,
+        CancellationToken cancellationToken
+    )
+    {
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        var entry = archive.Entries.FirstOrDefault(e =>
+            e.Name.EndsWith(".csv", StringComparison.OrdinalIgnoreCase)
+        );
+
+        if (entry == null)
+        {
+            _logger.LogError(
+                "Form ADV snapshot {Date} contained no CSV entry — SEC format may have changed",
+                fileDate
+            );
+            await _errorReporter.Report(
+                ErrorSource.FormAdvScraper,
+                "FormAdvImport.NoCsvEntry",
+                $"Form ADV snapshot {fileDate} contained no CSV entry — SEC format may have changed",
+                null
+            );
+            return 0;
+        }
+
+        await using var entryStream = entry.Open();
+        // The SEC publishes the CSV in Latin-1; reading it as UTF-8 would corrupt accented names.
+        using var reader = new StreamReader(entryStream, Encoding.Latin1);
+
+        var now = DateTime.UtcNow;
+        var advisers = FormAdvCsvParser.Parse(reader).Select(d => ToEntity(d, fileDate, now));
+
+        return await BatchPersister.Persist(advisers, UpsertBatchSize, FlushBatch);
+    }
+
+    private async Task FlushBatch(List<FormAdvAdviser> batch)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+
+        await dbContext
+            .Set<FormAdvAdviser>()
+            .UpsertRange(batch)
+            .On(a => a.Crd)
+            .WhenMatched(
+                (existing, incoming) =>
+                    new FormAdvAdviser
+                    {
+                        SecNumber = incoming.SecNumber,
+                        LegalName = incoming.LegalName,
+                        PrimaryBusinessName = incoming.PrimaryBusinessName,
+                        MainOfficeCity = incoming.MainOfficeCity,
+                        MainOfficeState = incoming.MainOfficeState,
+                        MainOfficeCountry = incoming.MainOfficeCountry,
+                        WebsiteAddress = incoming.WebsiteAddress,
+                        SecStatus = incoming.SecStatus,
+                        NumberOfEmployees = incoming.NumberOfEmployees,
+                        TotalRegulatoryAum = incoming.TotalRegulatoryAum,
+                        DiscretionaryAum = incoming.DiscretionaryAum,
+                        NonDiscretionaryAum = incoming.NonDiscretionaryAum,
+                        ChargesPercentageOfAum = incoming.ChargesPercentageOfAum,
+                        ChargesHourly = incoming.ChargesHourly,
+                        ChargesSubscription = incoming.ChargesSubscription,
+                        ChargesFixed = incoming.ChargesFixed,
+                        ChargesCommissions = incoming.ChargesCommissions,
+                        ChargesPerformanceBased = incoming.ChargesPerformanceBased,
+                        ChargesOther = incoming.ChargesOther,
+                        ReportDate = incoming.ReportDate,
+                        UpdateTime = incoming.UpdateTime,
+                    }
+            )
+            .RunAsync();
+    }
+
+    private static FormAdvAdviser ToEntity(
+        FormAdvAdviserData data,
+        DateOnly fileDate,
+        DateTime now
+    ) =>
+        new()
+        {
+            Crd = data.Crd,
+            SecNumber = data.SecNumber,
+            LegalName = data.LegalName,
+            PrimaryBusinessName = data.PrimaryBusinessName,
+            MainOfficeCity = data.MainOfficeCity,
+            MainOfficeState = data.MainOfficeState,
+            MainOfficeCountry = data.MainOfficeCountry,
+            WebsiteAddress = data.WebsiteAddress,
+            SecStatus = data.SecStatus,
+            NumberOfEmployees = data.NumberOfEmployees,
+            TotalRegulatoryAum = data.TotalRegulatoryAum,
+            DiscretionaryAum = data.DiscretionaryAum,
+            NonDiscretionaryAum = data.NonDiscretionaryAum,
+            ChargesPercentageOfAum = data.ChargesPercentageOfAum,
+            ChargesHourly = data.ChargesHourly,
+            ChargesSubscription = data.ChargesSubscription,
+            ChargesFixed = data.ChargesFixed,
+            ChargesCommissions = data.ChargesCommissions,
+            ChargesPerformanceBased = data.ChargesPerformanceBased,
+            ChargesOther = data.ChargesOther,
+            ReportDate = fileDate,
+            CreationTime = now,
+            UpdateTime = now,
+        };
+
+    /// <summary>The first of the month for the current month and the prior months, newest first.</summary>
+    internal static IEnumerable<DateOnly> GetCandidateFileDates()
+    {
+        var firstOfThisMonth = new DateOnly(
+            DateOnly.FromDateTime(DateTime.UtcNow).Year,
+            DateOnly.FromDateTime(DateTime.UtcNow).Month,
+            1
+        );
+        for (var i = 0; i < MonthsToProbe; i++)
+        {
+            yield return firstOfThisMonth.AddMonths(-i);
+        }
+    }
+}

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -71,6 +71,9 @@ builder.Services.Configure<Equibles.Finra.HostedService.Configuration.FinraScrap
 builder.Services.Configure<Equibles.Sec.HostedService.Configuration.FtdScraperOptions>(
     builder.Configuration.GetSection("FtdScraper")
 );
+builder.Services.Configure<Equibles.Sec.HostedService.Configuration.FormAdvScraperOptions>(
+    builder.Configuration.GetSection("FormAdvScraper")
+);
 builder.Services.Configure<Equibles.Sec.HostedService.Configuration.RawXbrlArtifactOptions>(
     builder.Configuration.GetSection("RawXbrlArtifacts")
 );

--- a/tests/Equibles.IntegrationTests/Sec/FormAdvImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FormAdvImportServiceFullPipelineTests.cs
@@ -1,0 +1,171 @@
+using System.IO.Compression;
+using System.Text;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// End-to-end pipeline test for <see cref="FormAdvImportService"/> against the shared ParadeDB
+/// fixture: a mocked SEC download returns a zipped CSV, and the importer must unzip, parse, and
+/// upsert advisers keyed by CRD. The DB-touching phases — the latest-snapshot lookup that drives
+/// the up-to-date guard and the per-batch UpsertRange with its On(Crd)/WhenMatched update — are
+/// not reachable from the unit tests, so a regression in the import wiring would silently drop
+/// adviser data on every worker tick.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FormAdvImportServiceFullPipelineTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public FormAdvImportServiceFullPipelineTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+        {
+            ctx.Dispose();
+        }
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+                sp.GetService(typeof(FormAdvAdviserRepository))
+                    .Returns(new FormAdvAdviserRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    private FormAdvImportService CreateSut(string csv)
+    {
+        var secEdgarClient = Substitute.For<ISecEdgarClient>();
+        secEdgarClient
+            .DownloadStream(Arg.Any<string>())
+            // Fresh stream per call — ZipArchive consumes/disposes the input on read.
+            .Returns(_ => Task.FromResult<Stream>(BuildZipStream(csv)));
+
+        return new FormAdvImportService(
+            CreateScopeFactory(),
+            secEdgarClient,
+            Substitute.For<ILogger<FormAdvImportService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+    }
+
+    [Fact]
+    public async Task Import_DownloadsNewestSnapshot_UpsertsAdvisersWithMappedFields()
+    {
+        await CreateSut(SampleCsv).Import(CancellationToken.None);
+
+        await using var verify = _fixture.CreateDbContext();
+        var adviser = await verify.Set<FormAdvAdviser>().SingleOrDefaultAsync(a => a.Crd == 111);
+
+        adviser
+            .Should()
+            .NotBeNull("the adviser row should be inserted through the UpsertRange INSERT path");
+        adviser!.LegalName.Should().Be("ACME ADVISORS");
+        adviser.MainOfficeState.Should().Be("CA");
+        adviser.NumberOfEmployees.Should().Be(42);
+        adviser.TotalRegulatoryAum.Should().Be(1_000_000L);
+        adviser.ChargesPercentageOfAum.Should().BeTrue();
+        adviser.ChargesPerformanceBased.Should().BeTrue();
+        // The snapshot date is the first of the current month (the newest candidate the importer probes).
+        var firstOfMonth = new DateOnly(
+            DateOnly.FromDateTime(DateTime.UtcNow).Year,
+            DateOnly.FromDateTime(DateTime.UtcNow).Month,
+            1
+        );
+        adviser.ReportDate.Should().Be(firstOfMonth);
+    }
+
+    [Fact]
+    public async Task Import_WhenSnapshotNewerThanStored_UpdatesExistingAdviserByCrd()
+    {
+        // Pre-seed CRD 111 from an older snapshot so the importer's up-to-date guard lets the
+        // newer (this-month) file through and the On(Crd)/WhenMatched UPDATE path runs.
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<FormAdvAdviser>()
+                .Add(
+                    new FormAdvAdviser
+                    {
+                        Crd = 111,
+                        LegalName = "STALE NAME",
+                        TotalRegulatoryAum = 1L,
+                        ReportDate = new DateOnly(2000, 1, 1),
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        await CreateSut(SampleCsv).Import(CancellationToken.None);
+
+        await using var verify = _fixture.CreateDbContext();
+        var advisers = await verify.Set<FormAdvAdviser>().Where(a => a.Crd == 111).ToListAsync();
+
+        advisers
+            .Should()
+            .HaveCount(1, "upsert must update the existing row rather than duplicate it");
+        advisers[0].LegalName.Should().Be("ACME ADVISORS");
+        advisers[0].TotalRegulatoryAum.Should().Be(1_000_000L);
+    }
+
+    private const string SampleCsv =
+        "Organization CRD#,SEC#,Legal Name,Primary Business Name,Main Office City,Main Office State,"
+        + "Main Office Country,Website Address,SEC Current Status,5A,5F(2)(a),5F(2)(b),5F(2)(c),"
+        + "5E(1),5E(2),5E(3),5E(4),5E(5),5E(6),5E(7)\n"
+        + "111,801-11111,ACME ADVISORS,ACME,LOS ANGELES,CA,United States,https://acme.test,Approved,"
+        + "42,400000.00,600000.00,1000000.00,Y,N,N,N,N,Y,N\n";
+
+    private static Stream BuildZipStream(string csvBody)
+    {
+        var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("ia010125.csv");
+            using var stream = entry.Open();
+            var bytes = Encoding.Latin1.GetBytes(csvBody);
+            stream.Write(bytes, 0, bytes.Length);
+        }
+        buffer.Position = 0;
+        return buffer;
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FormAdvImportServiceCandidateDatesTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormAdvImportServiceCandidateDatesTests.cs
@@ -1,0 +1,29 @@
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the order the importer probes SEC snapshots: newest first (so it stops at the most recent
+/// published file), the first of each month (the SEC's filename convention), and a bounded window
+/// so a permanently-missing file can't make the probe walk back indefinitely.
+/// </summary>
+public class FormAdvImportServiceCandidateDatesTests
+{
+    [Fact]
+    public void GetCandidateFileDates_AreFirstOfMonth_NewestFirst_AndBounded()
+    {
+        var dates = FormAdvImportService.GetCandidateFileDates().ToList();
+
+        dates.Should().HaveCount(4);
+        dates.Should().OnlyContain(d => d.Day == 1);
+        dates.Should().BeInDescendingOrder();
+
+        var thisMonth = new DateOnly(
+            DateOnly.FromDateTime(DateTime.UtcNow).Year,
+            DateOnly.FromDateTime(DateTime.UtcNow).Month,
+            1
+        );
+        dates[0].Should().Be(thisMonth);
+        dates[3].Should().Be(thisMonth.AddMonths(-3));
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FormAdvScraperWorkerTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormAdvScraperWorkerTests.cs
@@ -1,0 +1,97 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Sec.HostedService;
+using Equibles.Sec.HostedService.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the Form ADV scraper worker's identity and config guard, mirroring the per-worker pins
+/// the other SEC scrapers carry. The worker downloads from sec.gov, which rejects requests whose
+/// User-Agent lacks a contact email, so <see cref="FormAdvScraperWorker.ValidateConfiguration"/>
+/// must keep the worker from looping uselessly when Sec:ContactEmail is unset. ErrorSource routes
+/// failures to the right queue and must stay distinct from the sibling SEC scrapers'.
+/// </summary>
+public class FormAdvScraperWorkerTests
+{
+    private static TestableWorker Build(
+        IDictionary<string, string> config = null,
+        FormAdvScraperOptions options = null
+    )
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(config ?? new Dictionary<string, string>())
+            .Build();
+        return new TestableWorker(
+            Substitute.For<ILogger<FormAdvScraperWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(options ?? new FormAdvScraperOptions()),
+            configuration
+        );
+    }
+
+    [Fact]
+    public void ValidateConfiguration_SecContactEmailMissing_ReturnsFalse()
+    {
+        Build().InvokeValidateConfiguration().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateConfiguration_SecContactEmailConfigured_ReturnsTrue()
+    {
+        Build(new Dictionary<string, string> { ["Sec:ContactEmail"] = "bot@example.com" })
+            .InvokeValidateConfiguration()
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void ErrorSource_IsFormAdvScraper()
+    {
+        Build().InvokeErrorSource().Should().Be(ErrorSource.FormAdvScraper);
+    }
+
+    [Fact]
+    public void WorkerName_IsFormAdvScraper()
+    {
+        Build().InvokeWorkerName().Should().Be("Form ADV scraper");
+    }
+
+    [Fact]
+    public void Constructor_AppliesSleepIntervalHoursFromOptions()
+    {
+        Build(options: new FormAdvScraperOptions { SleepIntervalHours = 12 })
+            .InvokeSleepInterval()
+            .Should()
+            .Be(TimeSpan.FromHours(12));
+    }
+
+    private sealed class TestableWorker : FormAdvScraperWorker
+    {
+        public TestableWorker(
+            ILogger<FormAdvScraperWorker> logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            IOptions<FormAdvScraperOptions> options,
+            IConfiguration configuration
+        )
+            : base(logger, scopeFactory, errorReporter, options, configuration) { }
+
+        public bool InvokeValidateConfiguration() => ValidateConfiguration();
+
+        public TimeSpan InvokeSleepInterval() => SleepInterval;
+
+        public ErrorSource InvokeErrorSource() => ErrorSource;
+
+        public string InvokeWorkerName() => WorkerName;
+    }
+}


### PR DESCRIPTION
## Summary

- Third PR toward Form ADV investment-adviser data (#1866). Adds a scheduled worker that keeps the adviser table current from the SEC's bulk Form ADV download.
- The importer probes recent monthly snapshots newest-first, downloads the most recent available, parses it, and upserts advisers keyed by CRD. A stored-snapshot guard makes a re-run a no-op once the latest file is already imported.

## Code changes

- `src/Equibles.Sec.HostedService/Services/FormAdvImportService.cs` — download (via the existing rate-limited SEC client) → unzip → parse → batched `UpsertRange` on CRD; reads the CSV as Latin-1 so accented names survive.
- `src/Equibles.Sec.HostedService/FormAdvScraperWorker.cs` + `Configuration/FormAdvScraperOptions.cs` — `BaseScraperWorker` schedule, startup stagger, and the Sec:ContactEmail guard.
- `src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs`, `src/Equibles.Worker.Host/Program.cs` — register the hosted worker and bind its options.
- `src/Equibles.Errors.Data/Models/ErrorSource.cs` — add the `FormAdvScraper` error-routing source.
- Tests — full-pipeline integration test (insert and update-by-CRD paths against ParadeDB) plus unit tests for the snapshot probe order and the worker's identity/config guard.

Refs #1866