### PR TITLE
feat(sec): expose investment advisers via MCP

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs
@@ -1,0 +1,167 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
+using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Equibles.Sec.Mcp.Tools;
+
+[McpServerToolType]
+public class InvestmentAdviserTools
+{
+    private readonly FormAdvAdviserRepository _adviserRepository;
+    private readonly McpToolRunner _runner;
+
+    public InvestmentAdviserTools(
+        FormAdvAdviserRepository adviserRepository,
+        ErrorManager errorManager,
+        ILogger<InvestmentAdviserTools> logger
+    )
+    {
+        _adviserRepository = adviserRepository;
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
+    }
+
+    [McpServerTool(Name = "SearchInvestmentAdvisers")]
+    [Description(
+        "Search SEC-registered investment advisers (Form ADV) by firm name. Returns matching advisory firms with their CRD number, main office location, regulatory assets under management and employee count, largest by assets first. Use the CRD number with GetInvestmentAdviser for full detail."
+    )]
+    public Task<string> SearchInvestmentAdvisers(
+        [Description(
+            "Part of the firm's legal or business name (e.g., \"Vanguard\", \"Renaissance\")"
+        )]
+            string query,
+        [Description("Maximum number of advisers to return (default: 20)")] int maxResults = 20
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                if (string.IsNullOrWhiteSpace(query))
+                    return "Provide part of an adviser's name to search for.";
+
+                var advisers = await _adviserRepository
+                    .Search(query)
+                    .Take(maxResults)
+                    .ToListAsync();
+
+                if (advisers.Count == 0)
+                    return $"No investment advisers found matching \"{query}\".";
+
+                var result = MarkdownTable.Start(
+                    $"Investment advisers matching \"{query}\" ({advisers.Count} shown, largest by assets first):",
+                    "| CRD | Name | Location | Regulatory AUM | Employees |",
+                    "|-----|------|----------|----------------|-----------|"
+                );
+
+                foreach (var a in advisers)
+                {
+                    result.AppendLine(
+                        $"| {a.Crd} | {a.LegalName ?? "-"} | {FormatLocation(a)} | {FormatAum(a.TotalRegulatoryAum)} | {FormatCount(a.NumberOfEmployees)} |"
+                    );
+                }
+
+                return result.ToString();
+            },
+            "SearchInvestmentAdvisers",
+            $"query: {query}"
+        );
+    }
+
+    [McpServerTool(Name = "GetInvestmentAdviser")]
+    [Description(
+        "Get the full Form ADV profile for a single SEC-registered investment adviser by its Organization CRD number: legal and business names, SEC file number, main office, website, regulatory assets under management (discretionary, non-discretionary and total), employee count, and how the firm is compensated (fee structure)."
+    )]
+    public Task<string> GetInvestmentAdviser(
+        [Description("The adviser's Organization CRD number (e.g., 231)")] int crd
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var adviser = await _adviserRepository.GetByCrd(crd).FirstOrDefaultAsync();
+
+                if (adviser == null)
+                    return $"No investment adviser found with CRD {crd}.";
+
+                var sb = new StringBuilder();
+                sb.AppendLine($"# {adviser.LegalName ?? $"Adviser CRD {adviser.Crd}"}");
+                if (
+                    !string.IsNullOrEmpty(adviser.PrimaryBusinessName)
+                    && !string.Equals(
+                        adviser.PrimaryBusinessName,
+                        adviser.LegalName,
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
+                {
+                    sb.AppendLine($"Doing business as: {adviser.PrimaryBusinessName}");
+                }
+                sb.AppendLine();
+                sb.AppendLine($"- **CRD number:** {adviser.Crd}");
+                if (!string.IsNullOrEmpty(adviser.SecNumber))
+                    sb.AppendLine($"- **SEC file number:** {adviser.SecNumber}");
+                sb.AppendLine($"- **Main office:** {FormatLocation(adviser)}");
+                if (!string.IsNullOrEmpty(adviser.WebsiteAddress))
+                    sb.AppendLine($"- **Website:** {adviser.WebsiteAddress}");
+                if (!string.IsNullOrEmpty(adviser.SecStatus))
+                    sb.AppendLine($"- **SEC status:** {adviser.SecStatus}");
+                sb.AppendLine($"- **Employees:** {FormatCount(adviser.NumberOfEmployees)}");
+                sb.AppendLine(
+                    $"- **Total regulatory AUM:** {FormatAum(adviser.TotalRegulatoryAum)}"
+                );
+                sb.AppendLine($"- **Discretionary AUM:** {FormatAum(adviser.DiscretionaryAum)}");
+                sb.AppendLine(
+                    $"- **Non-discretionary AUM:** {FormatAum(adviser.NonDiscretionaryAum)}"
+                );
+                sb.AppendLine($"- **Fee structure:** {FormatFeeStructure(adviser)}");
+                sb.AppendLine($"- **As of:** {adviser.ReportDate:yyyy-MM-dd}");
+
+                return sb.ToString();
+            },
+            "GetInvestmentAdviser",
+            $"crd: {crd}"
+        );
+    }
+
+    private static string FormatLocation(FormAdvAdviser a)
+    {
+        var parts = new[] { a.MainOfficeCity, a.MainOfficeState, a.MainOfficeCountry }
+            .Where(p => !string.IsNullOrEmpty(p))
+            .ToArray();
+        return parts.Length == 0 ? "-" : string.Join(", ", parts);
+    }
+
+    private static string FormatAum(long? amount) =>
+        amount.HasValue ? $"${amount.Value.ToString("N0", CultureInfo.InvariantCulture)}" : "-";
+
+    private static string FormatCount(int? count) =>
+        count.HasValue ? count.Value.ToString("N0", CultureInfo.InvariantCulture) : "-";
+
+    private static string FormatFeeStructure(FormAdvAdviser a)
+    {
+        var fees = new List<string>();
+        if (a.ChargesPercentageOfAum)
+            fees.Add("percentage of AUM");
+        if (a.ChargesHourly)
+            fees.Add("hourly");
+        if (a.ChargesSubscription)
+            fees.Add("subscription");
+        if (a.ChargesFixed)
+            fees.Add("fixed fees");
+        if (a.ChargesCommissions)
+            fees.Add("commissions");
+        if (a.ChargesPerformanceBased)
+            fees.Add("performance-based");
+        if (a.ChargesOther)
+            fees.Add("other");
+        return fees.Count == 0 ? "-" : string.Join(", ", fees);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/InvestmentAdviserToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InvestmentAdviserToolsTests.cs
@@ -1,0 +1,122 @@
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+using Equibles.Sec.Repositories;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins the Form ADV MCP tools against ParadeDB. The search tool runs an <c>ILIKE</c> query that
+/// has no in-memory translation, so the real provider is required; the assertions also cover the
+/// markdown the tools hand back to an assistant — AUM grouping, fee-structure rendering, and the
+/// largest-assets-first ordering.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class InvestmentAdviserToolsTests : ParadeDbMcpTestBase
+{
+    public InvestmentAdviserToolsTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private InvestmentAdviserTools CreateTools() =>
+        new(
+            new FormAdvAdviserRepository(DbContext),
+            errorManager: null,
+            NullLogger<InvestmentAdviserTools>()
+        );
+
+    private async Task Seed()
+    {
+        DbContext
+            .Set<FormAdvAdviser>()
+            .AddRange(
+                new FormAdvAdviser
+                {
+                    Crd = 231,
+                    SecNumber = "801-54739",
+                    LegalName = "BNY MELLON SECURITIES CORPORATION",
+                    PrimaryBusinessName = "BNY MELLON",
+                    MainOfficeCity = "NEW YORK",
+                    MainOfficeState = "NY",
+                    MainOfficeCountry = "United States",
+                    NumberOfEmployees = 333,
+                    TotalRegulatoryAum = 2_481_367_832L,
+                    DiscretionaryAum = 829_845_109L,
+                    NonDiscretionaryAum = 1_651_522_723L,
+                    ChargesPercentageOfAum = true,
+                    ReportDate = new DateOnly(2022, 4, 1),
+                },
+                new FormAdvAdviser
+                {
+                    Crd = 999,
+                    LegalName = "MELLON CAPITAL SMALL",
+                    PrimaryBusinessName = "MELLON SMALL",
+                    MainOfficeState = "CA",
+                    TotalRegulatoryAum = 10_000_000L,
+                    ChargesHourly = true,
+                    ReportDate = new DateOnly(2022, 4, 1),
+                }
+            );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+    }
+
+    [Fact]
+    public async Task SearchInvestmentAdvisers_BlankQuery_PromptsForName()
+    {
+        var result = await CreateTools().SearchInvestmentAdvisers("  ");
+
+        result.Should().Contain("Provide part of an adviser's name");
+    }
+
+    [Fact]
+    public async Task SearchInvestmentAdvisers_NoMatch_ReturnsNotFound()
+    {
+        await Seed();
+
+        var result = await CreateTools().SearchInvestmentAdvisers("nonexistent firm");
+
+        result.Should().Contain("No investment advisers found");
+    }
+
+    [Fact]
+    public async Task SearchInvestmentAdvisers_Match_RendersTableLargestAssetsFirst()
+    {
+        await Seed();
+
+        var result = await CreateTools().SearchInvestmentAdvisers("mellon");
+
+        result.Should().Contain("BNY MELLON SECURITIES CORPORATION");
+        result.Should().Contain("2,481,367,832"); // invariant grouping
+        // Largest by AUM (CRD 231) renders before the smaller match (CRD 999).
+        result
+            .IndexOf("2,481,367,832", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(result.IndexOf("10,000,000", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetInvestmentAdviser_UnknownCrd_ReturnsNotFound()
+    {
+        await Seed();
+
+        var result = await CreateTools().GetInvestmentAdviser(123456);
+
+        result.Should().Contain("No investment adviser found with CRD 123456");
+    }
+
+    [Fact]
+    public async Task GetInvestmentAdviser_KnownCrd_RendersProfileWithAumAndFees()
+    {
+        await Seed();
+
+        var result = await CreateTools().GetInvestmentAdviser(231);
+
+        result.Should().Contain("BNY MELLON SECURITIES CORPORATION");
+        result.Should().Contain("801-54739");
+        result.Should().Contain("NEW YORK, NY, United States");
+        result.Should().Contain("$2,481,367,832");
+        result.Should().Contain("$829,845,109");
+        result.Should().Contain("percentage of AUM");
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -306,6 +306,8 @@ public class McpModuleToolDiscoveryTests
         toolNames.Should().Contain("GetExemptOfferings");
         toolNames.Should().Contain("GetFundOperations");
         toolNames.Should().Contain("GetFundHoldings");
+        toolNames.Should().Contain("SearchInvestmentAdvisers");
+        toolNames.Should().Contain("GetInvestmentAdviser");
     }
 
     // ── Cross-module uniqueness ─────────────────────────────────────────
@@ -401,6 +403,8 @@ public class McpModuleToolDiscoveryTests
                     "GetExemptOfferings",
                     "GetFundOperations",
                     "GetFundHoldings",
+                    "SearchInvestmentAdvisers",
+                    "GetInvestmentAdviser",
                 }
             },
             { typeof(CboeTools), new[] { "GetPutCallRatios", "GetVixHistory" } },


### PR DESCRIPTION
## Summary

- Fourth PR toward Form ADV investment-adviser data (#1866). Exposes the adviser data through the MCP server so an assistant can look advisers up.
- Two tools: `SearchInvestmentAdvisers` (by name, largest by assets first) and `GetInvestmentAdviser` (full profile by CRD number).

## Code changes

- `src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs` — the two tools, rendering CRD, SEC file number, main office, website, regulatory AUM (discretionary / non-discretionary / total), employee count and fee structure. The Sec MCP module auto-discovers the class, so no DI change.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — add the two tool names to the Sec module's expected-tools list (the exact-count guard).
- `tests/Equibles.IntegrationTests/Mcp/InvestmentAdviserToolsTests.cs` — pin search ordering, blank-query and not-found paths, and the rendered profile against ParadeDB.

Refs #1866