### PR TITLE
feat(web): add investment advisers browse page

### DIFF
--- a/src/Equibles.Sec.Repositories/FormAdvAdviserRepository.cs
+++ b/src/Equibles.Sec.Repositories/FormAdvAdviserRepository.cs
@@ -31,12 +31,14 @@ public class FormAdvAdviserRepository : BaseRepository<FormAdvAdviser>
                 EF.Functions.ILike(a.LegalName, $"%{trimmed}%")
                 || EF.Functions.ILike(a.PrimaryBusinessName, $"%{trimmed}%")
             )
-            .OrderByDescending(a => a.TotalRegulatoryAum);
+            // Coalesce so advisers that did not report assets sort last rather than first
+            // (Postgres orders NULL highest under a plain DESC).
+            .OrderByDescending(a => a.TotalRegulatoryAum ?? 0L);
     }
 
     /// <summary>Advisers ordered by total regulatory assets under management, largest first.</summary>
     public IQueryable<FormAdvAdviser> GetLargestByAum()
     {
-        return GetAll().OrderByDescending(a => a.TotalRegulatoryAum);
+        return GetAll().OrderByDescending(a => a.TotalRegulatoryAum ?? 0L);
     }
 }

--- a/src/Equibles.Web/Controllers/AdvisersController.cs
+++ b/src/Equibles.Web/Controllers/AdvisersController.cs
@@ -1,0 +1,67 @@
+using Equibles.Sec.Repositories;
+using Equibles.Web.Controllers.Abstract;
+using Equibles.Web.Extensions;
+using Equibles.Web.ViewModels.Advisers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Web.Controllers;
+
+public class AdvisersController : BaseController
+{
+    private const int PageSize = 50;
+
+    private readonly FormAdvAdviserRepository _adviserRepository;
+
+    public AdvisersController(
+        FormAdvAdviserRepository adviserRepository,
+        ILogger<AdvisersController> logger
+    )
+        : base(logger)
+    {
+        _adviserRepository = adviserRepository;
+    }
+
+    [HttpGet("~/advisers")]
+    public async Task<IActionResult> Index(string q, int page = 1)
+    {
+        ViewData["Title"] = "Investment Advisers";
+        ViewData["Description"] =
+            "Browse SEC-registered investment advisers from Form ADV — assets under management, location and fee structure.";
+
+        page = Pagination.ClampPage(page);
+
+        var query = string.IsNullOrWhiteSpace(q)
+            ? _adviserRepository.GetLargestByAum()
+            : _adviserRepository.Search(q);
+
+        var totalCount = await query.CountAsync();
+        var advisers = await query.Page(page, PageSize).ToListAsync();
+
+        return View(
+            new AdvisersIndexViewModel
+            {
+                Query = q,
+                Advisers = advisers,
+                Page = page,
+                TotalPages = Pagination.PageCount(totalCount, PageSize),
+                TotalCount = totalCount,
+            }
+        );
+    }
+
+    [HttpGet("~/advisers/{crd:int}")]
+    public async Task<IActionResult> Show(int crd)
+    {
+        var adviser = await _adviserRepository.GetByCrd(crd).FirstOrDefaultAsync();
+        if (adviser == null)
+        {
+            return NotFound();
+        }
+
+        ViewData["Title"] = adviser.LegalName ?? $"Adviser CRD {adviser.Crd}";
+        ViewData["Description"] =
+            $"Form ADV profile for {ViewData["Title"]} — assets under management, location and fee structure.";
+        return View(adviser);
+    }
+}

--- a/src/Equibles.Web/ViewModels/Advisers/AdvisersIndexViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Advisers/AdvisersIndexViewModel.cs
@@ -1,0 +1,12 @@
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.Web.ViewModels.Advisers;
+
+public class AdvisersIndexViewModel
+{
+    public string Query { get; set; }
+    public List<FormAdvAdviser> Advisers { get; set; } = [];
+    public int Page { get; set; }
+    public int TotalPages { get; set; }
+    public int TotalCount { get; set; }
+}

--- a/src/Equibles.Web/Views/Advisers/Index.cshtml
+++ b/src/Equibles.Web/Views/Advisers/Index.cshtml
@@ -1,0 +1,101 @@
+@model Equibles.Web.ViewModels.Advisers.AdvisersIndexViewModel
+
+@{
+    ViewData["Title"] = "Investment Advisers";
+    var filterRoute = new Dictionary<string, string>();
+    if (!string.IsNullOrWhiteSpace(Model.Query))
+    {
+        filterRoute["q"] = Model.Query;
+    }
+
+    string Location(Equibles.Sec.Data.Models.FormAdvAdviser a)
+    {
+        var parts = new[] { a.MainOfficeCity, a.MainOfficeState, a.MainOfficeCountry }
+            .Where(p => !string.IsNullOrEmpty(p));
+        return string.Join(", ", parts);
+    }
+}
+
+<div class="max-w-6xl mx-auto px-6 py-12">
+    <page-header title="Investment Advisers">
+        @Model.TotalCount.ToString("N0") SEC-registered investment advisers from
+        <a href="https://www.sec.gov/foia-services/frequently-requested-documents/form-adv-data" target="_blank" rel="noopener" class="link link-primary">Form ADV</a>.
+        Click any adviser to see assets under management, location and fee structure.
+    </page-header>
+
+    <!-- Name search: GETs back to this action so the query is shareable/bookmarkable. -->
+    <form method="get" asp-action="Index" class="mb-6">
+        <div class="join w-full max-w-md">
+            <input type="search" name="q" value="@Model.Query"
+                   class="input input-bordered join-item w-full"
+                   placeholder="Search advisers by name..." aria-label="Search investment advisers by name" />
+            <button type="submit" class="btn btn-primary join-item">
+                <icon name="magnifying-glass" size="4" /> Search
+            </button>
+            @if (!string.IsNullOrWhiteSpace(Model.Query))
+            {
+                <a asp-action="Index" class="btn btn-ghost join-item">Clear</a>
+            }
+        </div>
+    </form>
+
+    @if (Model.Advisers.Count == 0)
+    {
+        <partial name="_EmptyStateCard" model='(IconName: "building-library", Heading: "No investment advisers found", Message: "Try a different name, or clear the search to browse the largest advisers.")' />
+    }
+    else
+    {
+        <div class="card bg-base-100 shadow-sm">
+            <div class="card-body p-0">
+                <div class="overflow-x-auto">
+                    <table class="table table-zebra" aria-label="Investment advisers">
+                        <thead>
+                            <tr>
+                                <th scope="col">Adviser</th>
+                                <th scope="col" class="hidden md:table-cell">Location</th>
+                                <th scope="col" class="text-right">Regulatory AUM</th>
+                                <th scope="col" class="text-right hidden sm:table-cell">Employees</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var adviser in Model.Advisers)
+                            {
+                                <tr class="hover">
+                                    <td>
+                                        <a asp-action="Show" asp-route-crd="@adviser.Crd" class="link link-primary font-medium">
+                                            @(adviser.LegalName ?? $"CRD {adviser.Crd}")
+                                        </a>
+                                        <div class="text-xs text-base-content/50 font-mono">CRD @adviser.Crd</div>
+                                    </td>
+                                    <td class="hidden md:table-cell text-sm text-base-content/70">@Location(adviser)</td>
+                                    <td class="text-right tabular-nums">
+                                        @if (adviser.TotalRegulatoryAum.HasValue)
+                                        {
+                                            <text>$@adviser.TotalRegulatoryAum.Value.ToString("N0")</text>
+                                        }
+                                        else
+                                        {
+                                            <span class="text-base-content/30">&mdash;</span>
+                                        }
+                                    </td>
+                                    <td class="text-right tabular-nums hidden sm:table-cell">
+                                        @if (adviser.NumberOfEmployees.HasValue)
+                                        {
+                                            @adviser.NumberOfEmployees.Value.ToString("N0")
+                                        }
+                                        else
+                                        {
+                                            <span class="text-base-content/30">&mdash;</span>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <partial name="_Pager" model='(Model.Page, Model.TotalPages, "Index", "Investment advisers pagination", "advisers-pager", (IDictionary<string, string>)filterRoute)' />
+    }
+</div>

--- a/src/Equibles.Web/Views/Advisers/Show.cshtml
+++ b/src/Equibles.Web/Views/Advisers/Show.cshtml
@@ -1,0 +1,116 @@
+@model Equibles.Sec.Data.Models.FormAdvAdviser
+
+@{
+    ViewData["Title"] = Model.LegalName ?? $"Adviser CRD {Model.Crd}";
+
+    var location = string.Join(", ", new[] { Model.MainOfficeCity, Model.MainOfficeState, Model.MainOfficeCountry }
+        .Where(p => !string.IsNullOrEmpty(p)));
+
+    var feeTypes = new List<string>();
+    if (Model.ChargesPercentageOfAum) { feeTypes.Add("Percentage of AUM"); }
+    if (Model.ChargesHourly) { feeTypes.Add("Hourly"); }
+    if (Model.ChargesSubscription) { feeTypes.Add("Subscription"); }
+    if (Model.ChargesFixed) { feeTypes.Add("Fixed fees"); }
+    if (Model.ChargesCommissions) { feeTypes.Add("Commissions"); }
+    if (Model.ChargesPerformanceBased) { feeTypes.Add("Performance-based"); }
+    if (Model.ChargesOther) { feeTypes.Add("Other"); }
+
+    string Aum(long? amount) => amount.HasValue ? "$" + amount.Value.ToString("N0") : "—";
+}
+
+<div class="max-w-4xl mx-auto px-6 py-12">
+    <div class="mb-6">
+        <a asp-action="Index" class="link link-primary text-sm">&larr; All investment advisers</a>
+    </div>
+
+    <page-header title="@(Model.LegalName ?? $"Adviser CRD {Model.Crd}")">
+        @if (!string.IsNullOrEmpty(Model.PrimaryBusinessName)
+            && !string.Equals(Model.PrimaryBusinessName, Model.LegalName, StringComparison.OrdinalIgnoreCase))
+        {
+            <span>Doing business as <strong>@Model.PrimaryBusinessName</strong>.</span>
+        }
+        SEC Form ADV registration profile.
+    </page-header>
+
+    <!-- Headline assets-under-management figures -->
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+        <div class="stat bg-base-100 rounded-box shadow-sm">
+            <div class="stat-title">Total regulatory AUM</div>
+            <div class="stat-value text-2xl tabular-nums">@Aum(Model.TotalRegulatoryAum)</div>
+        </div>
+        <div class="stat bg-base-100 rounded-box shadow-sm">
+            <div class="stat-title">Discretionary</div>
+            <div class="stat-value text-2xl tabular-nums">@Aum(Model.DiscretionaryAum)</div>
+        </div>
+        <div class="stat bg-base-100 rounded-box shadow-sm">
+            <div class="stat-title">Non-discretionary</div>
+            <div class="stat-value text-2xl tabular-nums">@Aum(Model.NonDiscretionaryAum)</div>
+        </div>
+    </div>
+
+    <div class="card bg-base-100 shadow-sm">
+        <div class="card-body">
+            <h2 class="card-title text-lg">Firm details</h2>
+            <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3 mt-2">
+                <div>
+                    <dt class="text-sm text-base-content/60">CRD number</dt>
+                    <dd class="font-mono">@Model.Crd</dd>
+                </div>
+                @if (!string.IsNullOrEmpty(Model.SecNumber))
+                {
+                    <div>
+                        <dt class="text-sm text-base-content/60">SEC file number</dt>
+                        <dd class="font-mono">@Model.SecNumber</dd>
+                    </div>
+                }
+                @if (!string.IsNullOrEmpty(location))
+                {
+                    <div>
+                        <dt class="text-sm text-base-content/60">Main office</dt>
+                        <dd>@location</dd>
+                    </div>
+                }
+                @if (Model.NumberOfEmployees.HasValue)
+                {
+                    <div>
+                        <dt class="text-sm text-base-content/60">Employees</dt>
+                        <dd class="tabular-nums">@Model.NumberOfEmployees.Value.ToString("N0")</dd>
+                    </div>
+                }
+                @if (!string.IsNullOrEmpty(Model.SecStatus))
+                {
+                    <div>
+                        <dt class="text-sm text-base-content/60">SEC status</dt>
+                        <dd>@Model.SecStatus</dd>
+                    </div>
+                }
+                @if (!string.IsNullOrEmpty(Model.WebsiteAddress))
+                {
+                    <div>
+                        <dt class="text-sm text-base-content/60">Website</dt>
+                        <dd><a href="@Model.WebsiteAddress" target="_blank" rel="noopener nofollow" class="link link-primary break-all">@Model.WebsiteAddress</a></dd>
+                    </div>
+                }
+                <div>
+                    <dt class="text-sm text-base-content/60">Fee structure</dt>
+                    <dd>
+                        @if (feeTypes.Count == 0)
+                        {
+                            <span class="text-base-content/40">Not reported</span>
+                        }
+                        else
+                        {
+                            <div class="flex flex-wrap gap-1">
+                                @foreach (var fee in feeTypes)
+                                {
+                                    <span class="badge badge-ghost">@fee</span>
+                                }
+                            </div>
+                        }
+                    </dd>
+                </div>
+            </dl>
+            <p class="text-xs text-base-content/50 mt-4">As of @Model.ReportDate.ToString("MMMM yyyy").</p>
+        </div>
+    </div>
+</div>

--- a/src/Equibles.Web/Views/Shared/_Layout.cshtml
+++ b/src/Equibles.Web/Views/Shared/_Layout.cshtml
@@ -50,6 +50,7 @@
                             <li><a asp-action="OverlapMatrix" asp-controller="Profiles">Overlap Matrix</a></li>
                             <li><a asp-action="SmartMoneyIndex" asp-controller="Institutions">Smart Money Index</a></li>
                             <li><a asp-action="Dashboard" asp-controller="InsiderActivity">Insider Trading</a></li>
+                            <li><a asp-action="Index" asp-controller="Advisers">Investment Advisers</a></li>
                             <li><a asp-action="Index" asp-controller="EconomicData">Economic Data</a></li>
                             <li><a asp-action="Index" asp-controller="Cftc">Futures</a></li>
                             <li><a asp-action="Index" asp-controller="Market">Market</a></li>
@@ -162,6 +163,11 @@
                         <li>
                             <a asp-action="Dashboard" asp-controller="InsiderActivity">
                                 <icon name="user-group" size="4" /> Insider Trading
+                            </a>
+                        </li>
+                        <li>
+                            <a asp-action="Index" asp-controller="Advisers">
+                                <icon name="building-library" size="4" /> Investment Advisers
                             </a>
                         </li>
                         <li>

--- a/tests/Equibles.FunctionalTests/Tests/AdvisersIndexTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/AdvisersIndexTests.cs
@@ -1,0 +1,75 @@
+using Equibles.FunctionalTests.Fixtures;
+using Equibles.Sec.Data.Models;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class AdvisersIndexTests
+{
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public AdvisersIndexTests(WebAppFixture web, PlaywrightFixture playwright)
+    {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    private static Task SeedBnyMellon(Equibles.Data.EquiblesFinancialDbContext db)
+    {
+        db.Add(
+            new FormAdvAdviser
+            {
+                Crd = 231,
+                SecNumber = "801-54739",
+                LegalName = "BNY MELLON SECURITIES CORPORATION",
+                PrimaryBusinessName = "BNY MELLON",
+                MainOfficeCity = "NEW YORK",
+                MainOfficeState = "NY",
+                MainOfficeCountry = "United States",
+                NumberOfEmployees = 333,
+                TotalRegulatoryAum = 2_481_367_832L,
+                DiscretionaryAum = 829_845_109L,
+                ChargesPercentageOfAum = true,
+                ReportDate = new DateOnly(2022, 4, 1),
+            }
+        );
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Index_GetWithSeededAdviser_RendersHeaderAndAdviserName()
+    {
+        await _web.ResetAndSeedAsync(SeedBnyMellon);
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        var response = await page.GotoAsync("/advisers");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        await Assertions.Expect(page.Locator("h1")).ToHaveTextAsync("Investment Advisers");
+        await Assertions
+            .Expect(page.Locator("body"))
+            .ToContainTextAsync("BNY MELLON SECURITIES CORPORATION");
+    }
+
+    [Fact]
+    public async Task Index_ClickAdviser_NavigatesToProfileWithAumAndSecNumber()
+    {
+        await _web.ResetAndSeedAsync(SeedBnyMellon);
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+
+        await page.GotoAsync("/advisers");
+        await page.GetByRole(AriaRole.Link, new() { Name = "BNY MELLON SECURITIES CORPORATION" })
+            .First.ClickAsync();
+
+        await page.WaitForURLAsync("**/advisers/231");
+        await Assertions.Expect(page.Locator("body")).ToContainTextAsync("801-54739");
+        await Assertions.Expect(page.Locator("body")).ToContainTextAsync("Percentage of AUM");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Web/AdvisersViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/AdvisersViewRenderingTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Text.Encodings.Web;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Renders the investment-advisers browse and detail views end-to-end through the real router and
+/// Razor pipeline. Pins the populated path: a seeded adviser appears in the list with a resolved
+/// <c>asp-action="Show"</c> link and formatted AUM, the name search filters the list, and the
+/// detail page surfaces the firm's profile. An unknown CRD must 404 rather than render an empty
+/// page.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class AdvisersViewRenderingTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public AdvisersViewRenderingTests(WebHostFixture fixture) => _fixture = fixture;
+
+    private static Task Seed(EquiblesFinancialDbContext db)
+    {
+        db.Add(
+            new FormAdvAdviser
+            {
+                Crd = 231,
+                SecNumber = "801-54739",
+                LegalName = "BNY MELLON SECURITIES CORPORATION",
+                PrimaryBusinessName = "BNY MELLON",
+                MainOfficeCity = "NEW YORK",
+                MainOfficeState = "NY",
+                MainOfficeCountry = "United States",
+                NumberOfEmployees = 333,
+                TotalRegulatoryAum = 2_481_367_832L,
+                DiscretionaryAum = 829_845_109L,
+                ChargesPercentageOfAum = true,
+                ReportDate = new DateOnly(2022, 4, 1),
+            }
+        );
+        db.Add(
+            new FormAdvAdviser
+            {
+                Crd = 777,
+                LegalName = "TINY CAPITAL PARTNERS",
+                TotalRegulatoryAum = 5_000_000L,
+                ReportDate = new DateOnly(2022, 4, 1),
+            }
+        );
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task GetAdvisers_WithSeededAdvisers_RendersRowWithResolvedLinkAndAum()
+    {
+        await _fixture.ResetAndSeedAsync(Seed);
+
+        var response = await _fixture.Client.GetAsync("/advisers");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("BNY MELLON SECURITIES CORPORATION");
+        html.Should()
+            .Contain(
+                "/advisers/231",
+                "asp-action=\"Show\" must resolve to the (lowercased) Show route, not an empty href"
+            );
+        var expectedAum = HtmlEncoder.Default.Encode(2_481_367_832L.ToString("N0"));
+        html.Should().Contain(expectedAum, "the total regulatory AUM must render formatted N0");
+    }
+
+    [Fact]
+    public async Task GetAdvisers_WithNameQuery_FiltersTheList()
+    {
+        await _fixture.ResetAndSeedAsync(Seed);
+
+        var response = await _fixture.Client.GetAsync("/advisers?q=mellon");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("BNY MELLON SECURITIES CORPORATION");
+        html.Should()
+            .NotContain("TINY CAPITAL PARTNERS", "the search term excludes non-matching advisers");
+    }
+
+    [Fact]
+    public async Task GetAdviser_KnownCrd_RendersProfile()
+    {
+        await _fixture.ResetAndSeedAsync(Seed);
+
+        var response = await _fixture.Client.GetAsync("/advisers/231");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("BNY MELLON SECURITIES CORPORATION");
+        html.Should().Contain("801-54739");
+        html.Should().Contain("Percentage of AUM");
+    }
+
+    [Fact]
+    public async Task GetAdviser_UnknownCrd_Returns404()
+    {
+        await _fixture.ResetAndSeedAsync(Seed);
+
+        var response = await _fixture.Client.GetAsync("/advisers/999999");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}


### PR DESCRIPTION
## Summary

- Final PR for Form ADV investment-adviser data (#1866). Adds the web surface so anyone can browse the adviser data the worker imports.
- `/advisers` lists advisers largest-by-assets with a name search; `/advisers/{crd}` shows a firm's full profile. Linked from the main navigation's "More" menu (desktop + mobile).

## Code changes

- `src/Equibles.Web/Controllers/AdvisersController.cs` + `ViewModels/Advisers/AdvisersIndexViewModel.cs` — paginated Index (search or largest-by-AUM) and Show-by-CRD (404 on unknown).
- `src/Equibles.Web/Views/Advisers/Index.cshtml`, `Show.cshtml` — DaisyUI list with search + pager, and a profile page with AUM stats, firm details and fee-structure badges.
- `src/Equibles.Web/Views/Shared/_Layout.cshtml` — navigation links.
- `src/Equibles.Sec.Repositories/FormAdvAdviserRepository.cs` — coalesce AUM in the ordering so advisers with no reported assets sort last, not first.
- Tests — integration view-rendering tests (list, name filter, profile, unknown-CRD 404) and a Playwright golden-path e2e (browse → click → profile).

Closes #1866