### PR TITLE
refactor(sec): extract shared EDGAR XML submission parsing from filing processors

### DIFF
--- a/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
+++ b/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
@@ -1,0 +1,92 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.Sec.HostedService.Helpers;
+
+/// <summary>
+/// Shared parsing for SEC issuer-feed XML submissions (Form 144, Form D, N-CEN, NPORT-P).
+/// Each of these forms wraps its payload in the same SGML envelope and uses the
+/// <c>edgarSubmission</c> root, so envelope stripping, ampersand escaping, and the
+/// parse/skip/error-report flow are identical across their processors.
+/// </summary>
+internal static class EdgarXmlSubmissionParser
+{
+    private const string XmlEnvelopeStart = "<XML>";
+    private const string XmlEnvelopeEnd = "</XML>";
+
+    /// <summary>
+    /// Strips the SGML envelope and escapes stray ampersands so the payload parses as XML.
+    /// </summary>
+    internal static string SanitizeXml(string xml)
+    {
+        // SEC filings wrap the actual XML inside an SGML envelope (one .txt holds the whole
+        // submission); pull out the <XML>...</XML> body before parsing.
+        var xmlStart = xml.IndexOf(XmlEnvelopeStart, StringComparison.OrdinalIgnoreCase);
+        var xmlEnd = xml.IndexOf(XmlEnvelopeEnd, StringComparison.OrdinalIgnoreCase);
+        if (xmlStart >= 0 && xmlEnd > xmlStart)
+        {
+            xml = xml[(xmlStart + XmlEnvelopeStart.Length)..xmlEnd].Trim();
+        }
+
+        // Escape stray ampersands that aren't already part of an entity.
+        return Regex.Replace(xml, @"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)", "&amp;");
+    }
+
+    /// <summary>
+    /// Sanitizes the raw submission and returns its <c>edgarSubmission</c> root, or
+    /// <c>null</c> when the filing isn't XML or is malformed (logging and reporting the case).
+    /// </summary>
+    /// <param name="filingTypeName">Human-readable form label used in log messages (e.g. "Form 144").</param>
+    /// <param name="errorContext">Error-reporter context label (e.g. "Form144.ParseXml").</param>
+    internal static async Task<XElement> TryParseSubmission(
+        string content,
+        FilingData filing,
+        string companyTicker,
+        string filingTypeName,
+        string errorContext,
+        ILogger logger,
+        ErrorReporter errorReporter
+    )
+    {
+        var sanitized = SanitizeXml(content);
+
+        // These forms are XML-only, so a submission without the <edgarSubmission> root is
+        // unexpected — skip quietly.
+        if (!sanitized.Contains("<edgarSubmission", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogDebug(
+                "Skipping non-XML {FilingType} filing for {Ticker} - {AccessionNumber}",
+                filingTypeName,
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return null;
+        }
+
+        try
+        {
+            return XDocument.Parse(sanitized).Root;
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Malformed {FilingType} XML for {Ticker} - {AccessionNumber}",
+                filingTypeName,
+                companyTicker,
+                filing.AccessionNumber
+            );
+            await errorReporter.Report(
+                ErrorSource.DocumentScraper,
+                errorContext,
+                ex.Message,
+                ex.StackTrace,
+                $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
+            );
+            return null;
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
@@ -1,15 +1,14 @@
 using System.Globalization;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Errors.BusinessLogic;
-using Equibles.Errors.Data.Models;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Contracts;
+using Equibles.Sec.HostedService.Helpers;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Sec.HostedService.Services;
@@ -70,7 +69,15 @@ public class Form144FilingProcessor : IFilingProcessor
             return false;
         }
 
-        var root = await TryParseSubmission(content, filing, companyTicker);
+        var root = await EdgarXmlSubmissionParser.TryParseSubmission(
+            content,
+            filing,
+            companyTicker,
+            "Form 144",
+            "Form144.ParseXml",
+            _logger,
+            _errorReporter
+        );
         if (root == null)
             return false;
 
@@ -97,49 +104,6 @@ public class Form144FilingProcessor : IFilingProcessor
         );
 
         return true;
-    }
-
-    private async Task<XElement> TryParseSubmission(
-        string content,
-        FilingData filing,
-        string companyTicker
-    )
-    {
-        var sanitized = SanitizeXml(content);
-
-        // Form 144 has only been filed as XML since the SEC's April 2022 e-filing mandate,
-        // so a submission without the <edgarSubmission> root is unexpected — skip quietly.
-        if (!sanitized.Contains("<edgarSubmission", StringComparison.OrdinalIgnoreCase))
-        {
-            _logger.LogDebug(
-                "Skipping non-XML Form 144 filing for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return null;
-        }
-
-        try
-        {
-            return XDocument.Parse(sanitized).Root;
-        }
-        catch (System.Xml.XmlException ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Malformed Form 144 XML for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            await _errorReporter.Report(
-                ErrorSource.DocumentScraper,
-                "Form144.ParseXml",
-                ex.Message,
-                ex.StackTrace,
-                $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
-            );
-            return null;
-        }
     }
 
     private static Form144Filing ParseFiling(XElement root, Guid companyId, FilingData filing)
@@ -221,23 +185,8 @@ public class Form144FilingProcessor : IFilingProcessor
         return string.IsNullOrEmpty(value) ? null : value;
     }
 
-    private const string XmlEnvelopeStart = "<XML>";
-    private const string XmlEnvelopeEnd = "</XML>";
-
-    internal static string SanitizeXml(string xml)
-    {
-        // SEC filings wrap the actual XML inside an SGML envelope (one .txt holds the whole
-        // submission); pull out the <XML>...</XML> body before parsing.
-        var xmlStart = xml.IndexOf(XmlEnvelopeStart, StringComparison.OrdinalIgnoreCase);
-        var xmlEnd = xml.IndexOf(XmlEnvelopeEnd, StringComparison.OrdinalIgnoreCase);
-        if (xmlStart >= 0 && xmlEnd > xmlStart)
-        {
-            xml = xml[(xmlStart + XmlEnvelopeStart.Length)..xmlEnd].Trim();
-        }
-
-        // Escape stray ampersands that aren't already part of an entity.
-        return Regex.Replace(xml, @"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)", "&amp;");
-    }
+    // Pinned by processor-scoped tests; the implementation lives in the shared parser.
+    internal static string SanitizeXml(string xml) => EdgarXmlSubmissionParser.SanitizeXml(xml);
 
     // Form 144 dates are US-format MM/dd/yyyy. Parse culture-independently so a non-Gregorian
     // host culture doesn't silently drop every date.

--- a/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
@@ -1,13 +1,12 @@
 using System.Globalization;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Errors.BusinessLogic;
-using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Contracts;
+using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
 
@@ -73,7 +72,15 @@ public class FormDFilingProcessor : IFilingProcessor
             return false;
         }
 
-        var root = await TryParseSubmission(content, filing, companyTicker);
+        var root = await EdgarXmlSubmissionParser.TryParseSubmission(
+            content,
+            filing,
+            companyTicker,
+            "Form D",
+            "FormD.ParseXml",
+            _logger,
+            _errorReporter
+        );
         if (root == null)
             return false;
 
@@ -101,49 +108,6 @@ public class FormDFilingProcessor : IFilingProcessor
         );
 
         return true;
-    }
-
-    private async Task<XElement> TryParseSubmission(
-        string content,
-        FilingData filing,
-        string companyTicker
-    )
-    {
-        var sanitized = SanitizeXml(content);
-
-        // Form D has only been filed as XML since 2008, so a submission without the
-        // <edgarSubmission> root is unexpected — skip quietly.
-        if (!sanitized.Contains("<edgarSubmission", StringComparison.OrdinalIgnoreCase))
-        {
-            _logger.LogDebug(
-                "Skipping non-XML Form D filing for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return null;
-        }
-
-        try
-        {
-            return XDocument.Parse(sanitized).Root;
-        }
-        catch (System.Xml.XmlException ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Malformed Form D XML for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            await _errorReporter.Report(
-                ErrorSource.DocumentScraper,
-                "FormD.ParseXml",
-                ex.Message,
-                ex.StackTrace,
-                $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
-            );
-            return null;
-        }
     }
 
     private static FormDFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
@@ -255,23 +219,8 @@ public class FormDFilingProcessor : IFilingProcessor
         return string.IsNullOrEmpty(value) ? null : value;
     }
 
-    private const string XmlEnvelopeStart = "<XML>";
-    private const string XmlEnvelopeEnd = "</XML>";
-
-    internal static string SanitizeXml(string xml)
-    {
-        // SEC filings wrap the actual XML inside an SGML envelope (one .txt holds the whole
-        // submission); pull out the <XML>...</XML> body before parsing.
-        var xmlStart = xml.IndexOf(XmlEnvelopeStart, StringComparison.OrdinalIgnoreCase);
-        var xmlEnd = xml.IndexOf(XmlEnvelopeEnd, StringComparison.OrdinalIgnoreCase);
-        if (xmlStart >= 0 && xmlEnd > xmlStart)
-        {
-            xml = xml[(xmlStart + XmlEnvelopeStart.Length)..xmlEnd].Trim();
-        }
-
-        // Escape stray ampersands that aren't already part of an entity.
-        return Regex.Replace(xml, @"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)", "&amp;");
-    }
+    // Pinned by processor-scoped tests; the implementation lives in the shared parser.
+    internal static string SanitizeXml(string xml) => EdgarXmlSubmissionParser.SanitizeXml(xml);
 
     // Returns (amount, isIndefinite). Form D reports offering amounts either as a dollar figure
     // or the literal "Indefinite"; the latter is stored as null and flagged.

--- a/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
@@ -1,13 +1,12 @@
 using System.Globalization;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Errors.BusinessLogic;
-using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Contracts;
+using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
 
@@ -74,7 +73,15 @@ public class NCenFilingProcessor : IFilingProcessor
             return false;
         }
 
-        var root = await TryParseSubmission(content, filing, companyTicker);
+        var root = await EdgarXmlSubmissionParser.TryParseSubmission(
+            content,
+            filing,
+            companyTicker,
+            "N-CEN",
+            "NCen.ParseXml",
+            _logger,
+            _errorReporter
+        );
         if (root == null)
             return false;
 
@@ -102,49 +109,6 @@ public class NCenFilingProcessor : IFilingProcessor
         );
 
         return true;
-    }
-
-    private async Task<XElement> TryParseSubmission(
-        string content,
-        FilingData filing,
-        string companyTicker
-    )
-    {
-        var sanitized = SanitizeXml(content);
-
-        // N-CEN has only ever been filed as XML, so a submission without the
-        // <edgarSubmission> root is unexpected — skip quietly.
-        if (!sanitized.Contains("<edgarSubmission", StringComparison.OrdinalIgnoreCase))
-        {
-            _logger.LogDebug(
-                "Skipping non-XML N-CEN filing for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return null;
-        }
-
-        try
-        {
-            return XDocument.Parse(sanitized).Root;
-        }
-        catch (System.Xml.XmlException ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Malformed N-CEN XML for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            await _errorReporter.Report(
-                ErrorSource.DocumentScraper,
-                "NCen.ParseXml",
-                ex.Message,
-                ex.StackTrace,
-                $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
-            );
-            return null;
-        }
     }
 
     private static NCenFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
@@ -387,23 +351,8 @@ public class NCenFilingProcessor : IFilingProcessor
         return trimmed.Equals(NotApplicable, StringComparison.OrdinalIgnoreCase) ? null : trimmed;
     }
 
-    private const string XmlEnvelopeStart = "<XML>";
-    private const string XmlEnvelopeEnd = "</XML>";
-
-    internal static string SanitizeXml(string xml)
-    {
-        // SEC filings wrap the actual XML inside an SGML envelope (one .txt holds the whole
-        // submission); pull out the <XML>...</XML> body before parsing.
-        var xmlStart = xml.IndexOf(XmlEnvelopeStart, StringComparison.OrdinalIgnoreCase);
-        var xmlEnd = xml.IndexOf(XmlEnvelopeEnd, StringComparison.OrdinalIgnoreCase);
-        if (xmlStart >= 0 && xmlEnd > xmlStart)
-        {
-            xml = xml[(xmlStart + XmlEnvelopeStart.Length)..xmlEnd].Trim();
-        }
-
-        // Escape stray ampersands that aren't already part of an entity.
-        return Regex.Replace(xml, @"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)", "&amp;");
-    }
+    // Pinned by processor-scoped tests; the implementation lives in the shared parser.
+    internal static string SanitizeXml(string xml) => EdgarXmlSubmissionParser.SanitizeXml(xml);
 
     internal static bool ParseYesNo(string value)
     {

--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -1,13 +1,12 @@
 using System.Globalization;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Errors.BusinessLogic;
-using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Contracts;
+using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
 
@@ -74,7 +73,15 @@ public class NportFilingProcessor : IFilingProcessor
             return false;
         }
 
-        var root = await TryParseSubmission(content, filing, companyTicker);
+        var root = await EdgarXmlSubmissionParser.TryParseSubmission(
+            content,
+            filing,
+            companyTicker,
+            "NPORT-P",
+            "Nport.ParseXml",
+            _logger,
+            _errorReporter
+        );
         if (root == null)
             return false;
 
@@ -102,49 +109,6 @@ public class NportFilingProcessor : IFilingProcessor
         );
 
         return true;
-    }
-
-    private async Task<XElement> TryParseSubmission(
-        string content,
-        FilingData filing,
-        string companyTicker
-    )
-    {
-        var sanitized = SanitizeXml(content);
-
-        // NPORT-P has only ever been filed as XML, so a submission without the
-        // <edgarSubmission> root is unexpected — skip quietly.
-        if (!sanitized.Contains("<edgarSubmission", StringComparison.OrdinalIgnoreCase))
-        {
-            _logger.LogDebug(
-                "Skipping non-XML NPORT-P filing for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return null;
-        }
-
-        try
-        {
-            return XDocument.Parse(sanitized).Root;
-        }
-        catch (System.Xml.XmlException ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Malformed NPORT-P XML for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            await _errorReporter.Report(
-                ErrorSource.DocumentScraper,
-                "Nport.ParseXml",
-                ex.Message,
-                ex.StackTrace,
-                $"ticker: {companyTicker}, accession: {filing.AccessionNumber}"
-            );
-            return null;
-        }
     }
 
     private static NportFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
@@ -264,23 +228,8 @@ public class NportFilingProcessor : IFilingProcessor
         return trimmed.Equals(NotApplicable, StringComparison.OrdinalIgnoreCase) ? null : trimmed;
     }
 
-    private const string XmlEnvelopeStart = "<XML>";
-    private const string XmlEnvelopeEnd = "</XML>";
-
-    internal static string SanitizeXml(string xml)
-    {
-        // SEC filings wrap the actual XML inside an SGML envelope (one .txt holds the whole
-        // submission); pull out the <XML>...</XML> body before parsing.
-        var xmlStart = xml.IndexOf(XmlEnvelopeStart, StringComparison.OrdinalIgnoreCase);
-        var xmlEnd = xml.IndexOf(XmlEnvelopeEnd, StringComparison.OrdinalIgnoreCase);
-        if (xmlStart >= 0 && xmlEnd > xmlStart)
-        {
-            xml = xml[(xmlStart + XmlEnvelopeStart.Length)..xmlEnd].Trim();
-        }
-
-        // Escape stray ampersands that aren't already part of an entity.
-        return Regex.Replace(xml, @"&(?!(amp|lt|gt|quot|apos|#\d+|#x[\da-fA-F]+);)", "&amp;");
-    }
+    // Pinned by processor-scoped tests; the implementation lives in the shared parser.
+    internal static string SanitizeXml(string xml) => EdgarXmlSubmissionParser.SanitizeXml(xml);
 
     internal static bool ParseYesNo(string value)
     {


### PR DESCRIPTION
## Summary

- The Form 144, Form D, N-CEN, and NPORT-P filing processors each carried near-identical XML submission parsing: a private `TryParseSubmission` (sanitize → require the `edgarSubmission` root → parse → log/report on failure) and a byte-identical `SanitizeXml` plus its envelope constants.
- Collapsed all four copies into one shared `EdgarXmlSubmissionParser` helper, parameterized by the form's display name and error-report context label. Behavior is unchanged — same return values, same rendered log text, same error reporting.

## Code changes

- `src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs` — new shared static helper holding `SanitizeXml` (envelope stripping + ampersand escaping) and `TryParseSubmission`.
- `src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs`, `FormDFilingProcessor.cs`, `NCenFilingProcessor.cs`, `NportFilingProcessor.cs` — call the shared helper, passing each form's display name and error context; removed the duplicated `TryParseSubmission` body, envelope constants, and now-unused usings. Each keeps a one-line `SanitizeXml` delegating shim because processor-scoped tests reference it directly.