### PR TITLE
refactor(sec): collapse duplicated XML element helpers into EdgarXmlSubmissionParser

### DIFF
--- a/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
+++ b/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
@@ -89,4 +89,27 @@ internal static class EdgarXmlSubmissionParser
             return null;
         }
     }
+
+    /// <summary>
+    /// First child element with the given local name (namespace-agnostic), or <c>null</c>.
+    /// EDGAR forms declare assorted default namespaces, so matching on the local name keeps
+    /// the navigation prefix-independent.
+    /// </summary>
+    internal static XElement El(XElement parent, string name) =>
+        parent?.Elements().FirstOrDefault(e => e.Name.LocalName == name);
+
+    /// <summary>
+    /// All child elements with the given local name (namespace-agnostic), never <c>null</c>.
+    /// </summary>
+    internal static IEnumerable<XElement> Els(XElement parent, string name) =>
+        parent?.Elements().Where(e => e.Name.LocalName == name) ?? [];
+
+    /// <summary>
+    /// Trimmed text of the named child element, or <c>null</c> when missing or empty.
+    /// </summary>
+    internal static string Val(XElement parent, string name)
+    {
+        var value = El(parent, name)?.Value?.Trim();
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
 }

--- a/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
@@ -10,6 +10,7 @@ using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Helpers;
 using Microsoft.EntityFrameworkCore;
+using static Equibles.Sec.HostedService.Helpers.EdgarXmlSubmissionParser;
 
 namespace Equibles.Sec.HostedService.Services;
 
@@ -169,20 +170,6 @@ public class Form144FilingProcessor : IFilingProcessor
             AmountSold = amount,
             GrossProceeds = grossProceeds,
         };
-    }
-
-    // ── XML helpers (namespace-agnostic: Form 144 declares a default xmlns) ──────────
-
-    private static XElement El(XElement parent, string name) =>
-        parent?.Elements().FirstOrDefault(e => e.Name.LocalName == name);
-
-    private static IEnumerable<XElement> Els(XElement parent, string name) =>
-        parent?.Elements().Where(e => e.Name.LocalName == name) ?? [];
-
-    private static string Val(XElement parent, string name)
-    {
-        var value = El(parent, name)?.Value?.Trim();
-        return string.IsNullOrEmpty(value) ? null : value;
     }
 
     // Pinned by processor-scoped tests; the implementation lives in the shared parser.

--- a/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
@@ -9,6 +9,7 @@ using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
+using static Equibles.Sec.HostedService.Helpers.EdgarXmlSubmissionParser;
 
 namespace Equibles.Sec.HostedService.Services;
 
@@ -203,20 +204,6 @@ public class FormDFilingProcessor : IFilingProcessor
 
         // Fall back to the submission form string ("D/A") when the flag is absent.
         return filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
-    }
-
-    // ── XML helpers (navigate by local name; Form D declares no namespace) ──────────
-
-    private static XElement El(XElement parent, string name) =>
-        parent?.Elements().FirstOrDefault(e => e.Name.LocalName == name);
-
-    private static IEnumerable<XElement> Els(XElement parent, string name) =>
-        parent?.Elements().Where(e => e.Name.LocalName == name) ?? [];
-
-    private static string Val(XElement parent, string name)
-    {
-        var value = El(parent, name)?.Value?.Trim();
-        return string.IsNullOrEmpty(value) ? null : value;
     }
 
     // Pinned by processor-scoped tests; the implementation lives in the shared parser.

--- a/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
@@ -9,6 +9,7 @@ using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
+using static Equibles.Sec.HostedService.Helpers.EdgarXmlSubmissionParser;
 
 namespace Equibles.Sec.HostedService.Services;
 
@@ -323,18 +324,6 @@ public class NCenFilingProcessor : IFilingProcessor
     }
 
     // ── XML helpers (navigate by local name; N-CEN declares the ncen namespace) ──────
-
-    private static XElement El(XElement parent, string name) =>
-        parent?.Elements().FirstOrDefault(e => e.Name.LocalName == name);
-
-    private static IEnumerable<XElement> Els(XElement parent, string name) =>
-        parent?.Elements().Where(e => e.Name.LocalName == name) ?? [];
-
-    private static string Val(XElement parent, string name)
-    {
-        var value = El(parent, name)?.Value?.Trim();
-        return string.IsNullOrEmpty(value) ? null : value;
-    }
 
     private static string Attr(XElement element, string name)
     {

--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -9,6 +9,7 @@ using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
+using static Equibles.Sec.HostedService.Helpers.EdgarXmlSubmissionParser;
 
 namespace Equibles.Sec.HostedService.Services;
 
@@ -200,18 +201,6 @@ public class NportFilingProcessor : IFilingProcessor
     }
 
     // ── XML helpers (navigate by local name; NPORT declares the nport namespace) ──────
-
-    private static XElement El(XElement parent, string name) =>
-        parent?.Elements().FirstOrDefault(e => e.Name.LocalName == name);
-
-    private static IEnumerable<XElement> Els(XElement parent, string name) =>
-        parent?.Elements().Where(e => e.Name.LocalName == name) ?? [];
-
-    private static string Val(XElement parent, string name)
-    {
-        var value = El(parent, name)?.Value?.Trim();
-        return string.IsNullOrEmpty(value) ? null : value;
-    }
 
     private static string Attr(XElement element, string name)
     {


### PR DESCRIPTION
## Summary

- The `El`/`Els`/`Val` XML element-navigation helpers were copied byte-for-byte across the four EDGAR issuer-feed filing processors (Form 144, Form D, N-CEN, NPORT-P).
- This consolidates them into the shared `EdgarXmlSubmissionParser`, which already houses the common SGML-envelope stripping and submission parsing for these forms.

## Code changes

- `Helpers/EdgarXmlSubmissionParser.cs` — added the namespace-agnostic `El`/`Els`/`Val` helpers (with documentation), alongside the existing shared parsing.
- `Services/Form144FilingProcessor.cs`, `Services/FormDFilingProcessor.cs`, `Services/NCenFilingProcessor.cs`, `Services/NportFilingProcessor.cs` — removed the local copies and reference the shared helpers via `using static`; call sites are unchanged.

Behavior-preserving: the helpers are byte-identical pure functions, so the relocated implementations produce identical results. Build is clean (0 warnings) and the four processor test suites (80 tests) plus the registration test stay green.