### PR TITLE
feat(sec): backfill raw XBRL envelopes for previously-ingested documents

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260530180200_AddDocumentXbrlCaptureAttempts.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260530180200_AddDocumentXbrlCaptureAttempts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530180200_AddDocumentXbrlCaptureAttempts")]
+    partial class AddDocumentXbrlCaptureAttempts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260530180200_AddDocumentXbrlCaptureAttempts.cs
+++ b/src/Equibles.Migrations/Migrations/20260530180200_AddDocumentXbrlCaptureAttempts.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDocumentXbrlCaptureAttempts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "XbrlCaptureAttempts",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "XbrlCaptureAttempts", table: "Document");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -73,5 +73,14 @@ public class Document
     /// <summary>Size in bytes of the XBRL envelope before gzip compression. Null when none captured.</summary>
     public long? XbrlUncompressedSize { get; set; }
 
+    /// <summary>
+    /// How many times the backfill has tried (and failed to reach a terminal result) to
+    /// capture this document's XBRL. The backfill stops selecting a document once this hits
+    /// its retry ceiling, so a permanently-unfetchable filing can't starve the rest of the
+    /// queue. Only meaningful while <see cref="XbrlStatus"/> is
+    /// <see cref="XbrlCaptureStatus.NotChecked"/>.
+    /// </summary>
+    public int XbrlCaptureAttempts { get; set; }
+
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs
@@ -8,6 +8,17 @@ namespace Equibles.Sec.HostedService.Configuration;
 /// </summary>
 public class XbrlCaptureOptions
 {
-    /// <summary>Master switch — no capture happens unless this is true.</summary>
+    /// <summary>Master switch — no capture (forward or backfill) happens unless this is true.</summary>
     public bool Enabled { get; set; }
+
+    /// <summary>
+    /// When true (and <see cref="Enabled"/> is true), a background worker walks documents
+    /// ingested before capture and fills in their XBRL envelope. Separate from forward
+    /// capture so an operator can enable live capture first and opt into the historical
+    /// sweep — which re-fetches each pending filing's submission — deliberately.
+    /// </summary>
+    public bool BackfillEnabled { get; set; }
+
+    /// <summary>How many pending documents the backfill processes per cycle.</summary>
+    public int BackfillBatchSize { get; set; } = 100;
 }

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -20,12 +20,14 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IDocumentPersistenceService, DocumentPersistenceService>();
         services.AddScoped<ICompanySyncService, CompanySyncService>();
         services.AddScoped<XbrlEnvelopeCaptureService>();
+        services.AddScoped<XbrlBackfillService>();
         services.AddScoped<IDocumentScraper, DocumentScraper>();
 
         services.AddHostedService<SecScraperWorker>();
         services.AddHostedService<DocumentProcessorWorker>();
         services.AddHostedService<FtdScraperWorker>();
         services.AddHostedService<FormAdvScraperWorker>();
+        services.AddHostedService<XbrlBackfillWorker>();
 
         return services;
     }

--- a/src/Equibles.Sec.HostedService/Models/XbrlBackfillResult.cs
+++ b/src/Equibles.Sec.HostedService/Models/XbrlBackfillResult.cs
@@ -1,0 +1,11 @@
+namespace Equibles.Sec.HostedService.Models;
+
+/// <summary>Per-cycle tally of what the XBRL backfill did, for logging.</summary>
+public class XbrlBackfillResult
+{
+    public int Processed { get; set; }
+    public int Captured { get; set; }
+    public int NotPresent { get; set; }
+    public int Skipped { get; set; }
+    public int Failed { get; set; }
+}

--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -75,6 +75,12 @@ public class DocumentPersistenceService : IDocumentPersistenceService
         await transaction.CommitAsync(cancellationToken);
     }
 
+    public async Task UpdateXbrl(Document document, XbrlCaptureResult xbrl)
+    {
+        await ApplyXbrlCapture(document, xbrl ?? XbrlCaptureResult.NotChecked);
+        await _documentRepository.SaveChanges();
+    }
+
     // Stores the captured XBRL envelope as a gzip-compressed internal File and records its
     // type/sizes on the document. NotChecked/NotPresent only set the status — no File is
     // created — so the document either stays a backfill target or is marked terminally empty.

--- a/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
@@ -25,4 +25,11 @@ public interface IDocumentPersistenceService
         XbrlCaptureResult xbrl = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Applies a resolved XBRL capture result onto an already-persisted, tracked
+    /// <see cref="Document"/> and saves — used by the backfill to fill in documents
+    /// ingested before capture was enabled.
+    /// </summary>
+    Task UpdateXbrl(Document document, XbrlCaptureResult xbrl);
 }

--- a/src/Equibles.Sec.HostedService/Services/XbrlBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/XbrlBackfillService.cs
@@ -17,6 +17,11 @@ namespace Equibles.Sec.HostedService.Services;
 /// </summary>
 public class XbrlBackfillService
 {
+    // After this many failed cycles a document is no longer selected, so a permanently
+    // unfetchable filing (deleted/superseded on EDGAR, unparseable) can't sit at the head of
+    // the newest-first queue and starve every older document behind it.
+    private const int MaxAttempts = 5;
+
     private readonly DocumentRepository _documentRepository;
     private readonly ISecEdgarClient _secEdgarClient;
     private readonly XbrlEnvelopeCaptureService _captureService;
@@ -50,11 +55,17 @@ public class XbrlBackfillService
             return result;
         }
 
-        // Only documents that came from a filing (an accession to re-fetch) qualify; legacy
-        // and paper-only rows have no accession. Newest first so recent filings fill in soonest.
+        // Only documents that came from a filing (an accession to re-fetch) and whose issuer
+        // has a CIK qualify; legacy/paper rows have neither. Documents that have exhausted
+        // their retry ceiling are dropped from the working set so they can't block the queue.
+        // Newest first so recent filings fill in soonest.
         var query = _documentRepository
             .GetByXbrlStatus(XbrlCaptureStatus.NotChecked)
-            .Where(d => d.AccessionNumber != null);
+            .Where(d =>
+                d.AccessionNumber != null
+                && d.CommonStock.Cik != null
+                && d.XbrlCaptureAttempts < MaxAttempts
+            );
 
         if (minReportingDate.HasValue)
         {
@@ -71,24 +82,23 @@ public class XbrlBackfillService
         {
             cancellationToken.ThrowIfCancellationRequested();
             result.Processed++;
+            // Count the attempt up front so a fetch/parse failure still advances the retry
+            // ceiling and the document eventually drops out of the working set.
+            document.XbrlCaptureAttempts++;
 
             try
             {
-                var cik = document.CommonStock?.Cik;
-                if (string.IsNullOrEmpty(cik))
-                {
-                    // Without a CIK the submission can't be located; leave NotChecked.
-                    result.Skipped++;
-                    continue;
-                }
-
                 var content = await _secEdgarClient.GetDocumentContent(
                     document.AccessionNumber,
-                    cik
+                    document.CommonStock.Cik
                 );
                 var capture = _captureService.Capture(
                     content,
-                    new FilingData { Cik = cik, AccessionNumber = document.AccessionNumber }
+                    new FilingData
+                    {
+                        Cik = document.CommonStock.Cik,
+                        AccessionNumber = document.AccessionNumber,
+                    }
                 );
                 await _persistenceService.UpdateXbrl(document, capture);
 
@@ -101,13 +111,16 @@ public class XbrlBackfillService
                         result.NotPresent++;
                         break;
                     default:
+                        // Successful fetch but extraction left it NotChecked — persisted with
+                        // the bumped attempt count by UpdateXbrl; retried until the ceiling.
                         result.Skipped++;
                         break;
                 }
             }
             catch (Exception ex)
             {
-                // Best-effort: leave the document NotChecked so a later cycle retries it.
+                // Best-effort: leave the document NotChecked so a later cycle retries it, but
+                // persist the bumped attempt count so it can't be retried forever.
                 result.Failed++;
                 _logger.LogWarning(
                     ex,
@@ -115,9 +128,24 @@ public class XbrlBackfillService
                     document.Id,
                     document.AccessionNumber
                 );
+                await PersistAttempt();
             }
         }
 
         return result;
+    }
+
+    // Saves the bumped attempt count after a fetch failure. Best-effort: a save failure here
+    // must not abort the rest of the batch.
+    private async Task PersistAttempt()
+    {
+        try
+        {
+            await _documentRepository.SaveChanges();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to persist XBRL backfill attempt count.");
+        }
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/XbrlBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/XbrlBackfillService.cs
@@ -1,0 +1,123 @@
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Fills in the raw XBRL envelope for documents ingested before capture was enabled. Each
+/// cycle takes a batch of <see cref="XbrlCaptureStatus.NotChecked"/> documents (newest first,
+/// bounded by the configured minimum sync date), re-fetches the filing submission, runs the
+/// same extraction as the live ingest path, and records the outcome. Per-document failures
+/// are swallowed so the document stays <c>NotChecked</c> and is retried next cycle.
+/// </summary>
+public class XbrlBackfillService
+{
+    private readonly DocumentRepository _documentRepository;
+    private readonly ISecEdgarClient _secEdgarClient;
+    private readonly XbrlEnvelopeCaptureService _captureService;
+    private readonly IDocumentPersistenceService _persistenceService;
+    private readonly ILogger<XbrlBackfillService> _logger;
+
+    public XbrlBackfillService(
+        DocumentRepository documentRepository,
+        ISecEdgarClient secEdgarClient,
+        XbrlEnvelopeCaptureService captureService,
+        IDocumentPersistenceService persistenceService,
+        ILogger<XbrlBackfillService> logger
+    )
+    {
+        _documentRepository = documentRepository;
+        _secEdgarClient = secEdgarClient;
+        _captureService = captureService;
+        _persistenceService = persistenceService;
+        _logger = logger;
+    }
+
+    public async Task<XbrlBackfillResult> Backfill(
+        int batchSize,
+        DateOnly? minReportingDate,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var result = new XbrlBackfillResult();
+        if (batchSize <= 0)
+        {
+            return result;
+        }
+
+        // Only documents that came from a filing (an accession to re-fetch) qualify; legacy
+        // and paper-only rows have no accession. Newest first so recent filings fill in soonest.
+        var query = _documentRepository
+            .GetByXbrlStatus(XbrlCaptureStatus.NotChecked)
+            .Where(d => d.AccessionNumber != null);
+
+        if (minReportingDate.HasValue)
+        {
+            query = query.Where(d => d.ReportingDate >= minReportingDate.Value);
+        }
+
+        var batch = await query
+            .Include(d => d.CommonStock)
+            .OrderByDescending(d => d.ReportingDate)
+            .Take(batchSize)
+            .ToListAsync(cancellationToken);
+
+        foreach (var document in batch)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            result.Processed++;
+
+            try
+            {
+                var cik = document.CommonStock?.Cik;
+                if (string.IsNullOrEmpty(cik))
+                {
+                    // Without a CIK the submission can't be located; leave NotChecked.
+                    result.Skipped++;
+                    continue;
+                }
+
+                var content = await _secEdgarClient.GetDocumentContent(
+                    document.AccessionNumber,
+                    cik
+                );
+                var capture = _captureService.Capture(
+                    content,
+                    new FilingData { Cik = cik, AccessionNumber = document.AccessionNumber }
+                );
+                await _persistenceService.UpdateXbrl(document, capture);
+
+                switch (capture.Status)
+                {
+                    case XbrlCaptureStatus.Captured:
+                        result.Captured++;
+                        break;
+                    case XbrlCaptureStatus.NotPresent:
+                        result.NotPresent++;
+                        break;
+                    default:
+                        result.Skipped++;
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                // Best-effort: leave the document NotChecked so a later cycle retries it.
+                result.Failed++;
+                _logger.LogWarning(
+                    ex,
+                    "XBRL backfill failed for document {DocumentId} ({Accession}); will retry.",
+                    document.Id,
+                    document.AccessionNumber
+                );
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs
@@ -1,0 +1,91 @@
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Worker;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Sec.HostedService;
+
+/// <summary>
+/// Backfills the raw XBRL envelope for documents ingested before capture was enabled. Runs
+/// alongside the live scraper (sharing the EDGAR request budget) and is gated on both the
+/// master capture switch and the dedicated backfill switch, so the historical sweep only
+/// runs when an operator opts in.
+/// </summary>
+public class XbrlBackfillWorker : BaseScraperWorker
+{
+    private readonly IConfiguration _configuration;
+    private readonly XbrlCaptureOptions _captureOptions;
+    private readonly WorkerOptions _workerOptions;
+
+    protected override string WorkerName => "XBRL backfill";
+    protected override TimeSpan SleepInterval => TimeSpan.FromMinutes(1);
+    protected override ErrorSource ErrorSource => ErrorSource.DocumentScraper;
+
+    // Yield to the live SEC scrapers at deploy time before spending the shared EDGAR budget
+    // on the historical sweep.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(10);
+
+    public XbrlBackfillWorker(
+        ILogger<XbrlBackfillWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<XbrlCaptureOptions> captureOptions,
+        IOptions<WorkerOptions> workerOptions,
+        IConfiguration configuration
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        _captureOptions = captureOptions.Value;
+        _workerOptions = workerOptions.Value;
+        _configuration = configuration;
+    }
+
+    protected override bool ValidateConfiguration()
+    {
+        if (string.IsNullOrEmpty(_configuration["Sec:ContactEmail"]))
+        {
+            Logger.LogWarning(
+                "XBRL backfill stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."
+            );
+            return false;
+        }
+        return true;
+    }
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        if (!_captureOptions.Enabled || !_captureOptions.BackfillEnabled)
+        {
+            Logger.LogDebug("XBRL backfill disabled; skipping cycle.");
+            return;
+        }
+
+        var minReportingDate = _workerOptions.MinSyncDate.HasValue
+            ? DateOnly.FromDateTime(_workerOptions.MinSyncDate.Value)
+            : (DateOnly?)null;
+
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var backfillService = scope.ServiceProvider.GetRequiredService<XbrlBackfillService>();
+        var result = await backfillService.Backfill(
+            _captureOptions.BackfillBatchSize,
+            minReportingDate,
+            stoppingToken
+        );
+
+        Logger.LogInformation(
+            "XBRL backfill cycle complete. Processed: {Processed}, Captured: {Captured}, "
+                + "NotPresent: {NotPresent}, Skipped: {Skipped}, Failed: {Failed}",
+            result.Processed,
+            result.Captured,
+            result.NotPresent,
+            result.Skipped,
+            result.Failed
+        );
+    }
+}

--- a/src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs
@@ -24,7 +24,11 @@ public class XbrlBackfillWorker : BaseScraperWorker
     private readonly WorkerOptions _workerOptions;
 
     protected override string WorkerName => "XBRL backfill";
-    protected override TimeSpan SleepInterval => TimeSpan.FromMinutes(1);
+
+    // A historical sweep, not a latency-sensitive job: a longer interval keeps it from
+    // re-querying and re-spending the shared EDGAR budget when the queue is drained or stuck
+    // on exhausted documents.
+    protected override TimeSpan SleepInterval => TimeSpan.FromMinutes(5);
     protected override ErrorSource ErrorSource => ErrorSource.DocumentScraper;
 
     // Yield to the live SEC scrapers at deploy time before spending the shared EDGAR budget

--- a/src/Equibles.Sec.Repositories/DocumentRepository.cs
+++ b/src/Equibles.Sec.Repositories/DocumentRepository.cs
@@ -45,6 +45,11 @@ public class DocumentRepository : BaseRepository<Document>
         return GetAll().Where(d => d.DocumentType == documentType);
     }
 
+    public IQueryable<Document> GetByXbrlStatus(XbrlCaptureStatus status)
+    {
+        return GetAll().Where(d => d.XbrlStatus == status);
+    }
+
     public async Task<Document> GetWithContent(Guid id)
     {
         return await GetAll().FirstOrDefaultAsync(d => d.Id == id);

--- a/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs
@@ -1,0 +1,160 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.Repositories;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Exercises <see cref="XbrlBackfillService"/> against real Postgres: pending
+/// (<see cref="XbrlCaptureStatus.NotChecked"/>) documents get their XBRL envelope filled in
+/// from the re-fetched submission, while the minimum-sync-date floor, the batch cap, and the
+/// "must have an accession" guard bound what is touched.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class XbrlBackfillServiceTests : ParadeDbMcpTestBase
+{
+    public XbrlBackfillServiceTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private const string InlineSubmission =
+        "<DOCUMENT>\n<TYPE>10-K\n<FILENAME>doc.htm\n<TEXT>\n"
+        + "<html xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\"><body><ix:nonFraction>1</ix:nonFraction></body></html>\n"
+        + "</TEXT>\n</DOCUMENT>";
+
+    private async Task<CommonStock> SeedCompany()
+    {
+        var apple = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        await using var seed = Fixture.CreateDbContext();
+        seed.Set<CommonStock>().Add(apple);
+        await seed.SaveChangesAsync();
+        return apple;
+    }
+
+    private async Task SeedDocument(Guid companyId, string accessionNumber, DateOnly reportingDate)
+    {
+        await using var seed = Fixture.CreateDbContext();
+        var content = new File
+        {
+            Id = Guid.NewGuid(),
+            Name = "content",
+            Extension = "txt",
+            ContentType = "text/plain",
+            Size = 4,
+            FileContent = new() { Bytes = "body"u8.ToArray() },
+        };
+        seed.Set<File>().Add(content);
+        seed.Set<Document>()
+            .Add(
+                new Document
+                {
+                    Id = Guid.NewGuid(),
+                    CommonStockId = companyId,
+                    Content = content,
+                    DocumentType = DocumentType.TenK,
+                    ReportingDate = reportingDate,
+                    ReportingForDate = reportingDate,
+                    AccessionNumber = accessionNumber,
+                    XbrlStatus = XbrlCaptureStatus.NotChecked,
+                }
+            );
+        await seed.SaveChangesAsync();
+    }
+
+    private XbrlBackfillService BuildSut(ISecEdgarClient secEdgarClient)
+    {
+        var repo = new DocumentRepository(DbContext);
+        var persistence = new DocumentPersistenceService(
+            repo,
+            new FileManager(new FileRepository(DbContext))
+        );
+        var capture = new XbrlEnvelopeCaptureService(
+            Options.Create(new XbrlCaptureOptions { Enabled = true }),
+            NullLogger<XbrlEnvelopeCaptureService>()
+        );
+        return new XbrlBackfillService(
+            repo,
+            secEdgarClient,
+            capture,
+            persistence,
+            NullLogger<XbrlBackfillService>()
+        );
+    }
+
+    private static ISecEdgarClient StubClient(string content)
+    {
+        var client = Substitute.For<ISecEdgarClient>();
+        client.GetDocumentContent(Arg.Any<string>(), Arg.Any<string>()).Returns(content);
+        return client;
+    }
+
+    [Fact]
+    public async Task Backfill_CapturesPendingDocumentsWithinBatch()
+    {
+        var company = await SeedCompany();
+        await SeedDocument(company.Id, "0000320193-24-000001", new DateOnly(2024, 2, 1));
+        await SeedDocument(company.Id, "0000320193-24-000002", new DateOnly(2024, 3, 1));
+        DbContext.ChangeTracker.Clear();
+
+        var result = await BuildSut(StubClient(InlineSubmission)).Backfill(batchSize: 10, null);
+
+        result.Captured.Should().Be(2);
+
+        await using var verify = Fixture.CreateDbContext();
+        var docs = await verify
+            .Set<Document>()
+            .Where(d => d.CommonStockId == company.Id)
+            .ToListAsync();
+        docs.Should().OnlyContain(d => d.XbrlStatus == XbrlCaptureStatus.Captured);
+        docs.Should().OnlyContain(d => d.XbrlContentId != null);
+        docs.Should().OnlyContain(d => d.XbrlType == XbrlType.InlineIxbrl);
+    }
+
+    [Fact]
+    public async Task Backfill_RespectsMinimumReportingDate()
+    {
+        var company = await SeedCompany();
+        await SeedDocument(company.Id, "0000320193-20-000001", new DateOnly(2020, 1, 1));
+        await SeedDocument(company.Id, "0000320193-24-000003", new DateOnly(2024, 1, 1));
+        DbContext.ChangeTracker.Clear();
+
+        var result = await BuildSut(StubClient(InlineSubmission))
+            .Backfill(batchSize: 10, minReportingDate: new DateOnly(2023, 1, 1));
+
+        result.Processed.Should().Be(1);
+
+        await using var verify = Fixture.CreateDbContext();
+        var stale = await verify
+            .Set<Document>()
+            .SingleAsync(d => d.AccessionNumber == "0000320193-20-000001");
+        stale.XbrlStatus.Should().Be(XbrlCaptureStatus.NotChecked);
+    }
+
+    [Fact]
+    public async Task Backfill_SkipsDocumentsWithoutAccession()
+    {
+        var company = await SeedCompany();
+        await SeedDocument(company.Id, accessionNumber: null, new DateOnly(2024, 1, 1));
+        DbContext.ChangeTracker.Clear();
+
+        var result = await BuildSut(StubClient(InlineSubmission)).Backfill(batchSize: 10, null);
+
+        result.Processed.Should().Be(0);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs
@@ -10,6 +10,7 @@ using Equibles.Sec.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 using File = Equibles.Media.Data.Models.File;
 
@@ -144,6 +145,41 @@ public class XbrlBackfillServiceTests : ParadeDbMcpTestBase
             .Set<Document>()
             .SingleAsync(d => d.AccessionNumber == "0000320193-20-000001");
         stale.XbrlStatus.Should().Be(XbrlCaptureStatus.NotChecked);
+    }
+
+    [Fact]
+    public async Task Backfill_PermanentlyFailingNewestDocument_DoesNotStarveOlderHealthyOne()
+    {
+        // A newer document that always fails to fetch must not block the older healthy one
+        // forever: after its retry ceiling it leaves the working set and the older one captures.
+        var company = await SeedCompany();
+        await SeedDocument(company.Id, "FAIL-NEWEST", new DateOnly(2024, 3, 1));
+        await SeedDocument(company.Id, "OK-OLDER", new DateOnly(2024, 1, 1));
+        DbContext.ChangeTracker.Clear();
+
+        var client = Substitute.For<ISecEdgarClient>();
+        client
+            .GetDocumentContent("FAIL-NEWEST", Arg.Any<string>())
+            .ThrowsAsync(new Exception("gone"));
+        client.GetDocumentContent("OK-OLDER", Arg.Any<string>()).Returns(InlineSubmission);
+        var sut = BuildSut(client);
+
+        // batchSize 1 means each cycle only the single newest pending doc is taken — the
+        // failing one, until it exhausts its attempts.
+        for (var cycle = 0; cycle < 6; cycle++)
+        {
+            await sut.Backfill(batchSize: 1, null);
+        }
+
+        await using var verify = Fixture.CreateDbContext();
+        var failing = await verify
+            .Set<Document>()
+            .SingleAsync(d => d.AccessionNumber == "FAIL-NEWEST");
+        var healthy = await verify
+            .Set<Document>()
+            .SingleAsync(d => d.AccessionNumber == "OK-OLDER");
+        failing.XbrlStatus.Should().Be(XbrlCaptureStatus.NotChecked);
+        healthy.XbrlStatus.Should().Be(XbrlCaptureStatus.Captured);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Follow-up to #2874. Adds the historical backfill: a background worker that fills in the raw XBRL envelope for `Document` rows ingested before capture was enabled (i.e. `XbrlStatus = NotChecked`).

Each cycle takes a batch of pending documents — newest first, bounded by the configured minimum sync date — re-fetches the filing submission, and runs the **same** extraction as the live ingest path (`XbrlEnvelopeCaptureService` over `SecDocumentEnvelopeParser`). A processed document ends up `Captured` or `NotPresent` (both terminal) and drops out of the pending set; per-document failures are swallowed, leaving it `NotChecked` for a later retry.

Design notes:
- **Opt-in, separate from forward capture.** Gated on a dedicated `XbrlCaptureOptions.BackfillEnabled` (in addition to the master `Enabled`), so an operator can enable live capture first and opt into the historical re-fetch — which re-downloads each pending filing — deliberately.
- **Respects the minimum sync date.** Only documents with `ReportingDate >= WorkerOptions.MinSyncDate` are touched — the same lower bound the live scraper uses (`Document.ReportingDate` is the filing date). No hard-coded era floor; the existing config governs it.
- **Runs alongside the live scraper**, sharing the rate-limited EDGAR client, and staggers its startup (10 min) so live ingest gets the request budget first. `BackfillBatchSize` (default 100) bounds per-cycle load.
- **Skips documents with no accession** (legacy/paper rows have nothing to re-fetch). The blank-`PrimaryDocument` inline fallback added in #2874 means backfilled documents — which don't carry the primary-doc name — still detect inline iXBRL.

## Code changes

- **`XbrlCaptureOptions`** — adds `BackfillEnabled` (default off) and `BackfillBatchSize` (default 100).
- **`XbrlBackfillService`** — queries `NotChecked` documents (accession present, date floor, newest first, batched), re-fetches the submission, captures, and applies the result; returns a per-cycle tally (`XbrlBackfillResult`).
- **`XbrlBackfillWorker`** (`BaseScraperWorker`) — gated on `Enabled && BackfillEnabled`, validates `Sec:ContactEmail`, passes the `MinSyncDate` floor.
- **`DocumentRepository.GetByXbrlStatus`** and **`IDocumentPersistenceService.UpdateXbrl`** — query + apply-to-existing-document update path (reuses the same gzip/`File` logic as `Save`).
- DI registration of the service + hosted worker.
- **Tests** — ParadeDB integration tests: captures pending documents within the batch, respects the minimum reporting date, skips accession-less documents.

## Testing

- New backfill integration tests green against ParadeDB (3 passed).
- `csharpier check` clean; full solution builds with no errors.