### PR TITLE
chore(sec): default XBRL backfill batch size to 32

### DIFF
--- a/src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs
@@ -20,5 +20,5 @@ public class XbrlCaptureOptions
     public bool BackfillEnabled { get; set; }
 
     /// <summary>How many pending documents the backfill processes per cycle.</summary>
-    public int BackfillBatchSize { get; set; } = 100;
+    public int BackfillBatchSize { get; set; } = 32;
 }


### PR DESCRIPTION
Lower the default `XbrlCaptureOptions.BackfillBatchSize` from 100 to 32 — a gentler per-cycle cap for the historical XBRL backfill. The backfill still persists one document at a time; this only bounds how many a single worker cycle processes before yielding the shared EDGAR budget.