### PR TITLE
refactor(holdings): extract row dedup/merge into AddOrMergeHolding helper

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -669,25 +669,14 @@ public class HoldingsImportService
                 reportDate,
                 context
             );
-            var uniqueKey = BuildHoldingKey(holding);
-
-            if (holdingsMap.TryGetValue(uniqueKey, out var existing))
-            {
-                totalDuplicates++;
-                existing.Shares += holding.Shares;
-                existing.Value += holding.Value;
-                existing.VotingAuthSole += holding.VotingAuthSole;
-                existing.VotingAuthShared += holding.VotingAuthShared;
-                existing.VotingAuthNone += holding.VotingAuthNone;
-                existing.ManagerEntries.Add(managerEntry);
-            }
-            else
+            if (AddOrMergeHolding(holdingsMap, holding, managerEntry))
             {
                 if (valuePending)
                     totalPending++;
-
-                holding.ManagerEntries.Add(managerEntry);
-                holdingsMap[uniqueKey] = holding;
+            }
+            else
+            {
+                totalDuplicates++;
             }
         }
 
@@ -704,6 +693,34 @@ public class HoldingsImportService
             totalDuplicates,
             totalPending
         );
+    }
+
+    // Buffers a parsed row by its upsert key. A 13F holder can split one security
+    // across several otherManager codes, so the same key recurs within a filing;
+    // those rows accumulate into the in-memory position rather than overwriting it.
+    // Returns true when the row started a new position, false when it merged into
+    // an existing buffered one.
+    private static bool AddOrMergeHolding(
+        Dictionary<string, InstitutionalHolding> holdingsMap,
+        InstitutionalHolding holding,
+        HoldingManagerEntry managerEntry
+    )
+    {
+        var uniqueKey = BuildHoldingKey(holding);
+        if (holdingsMap.TryGetValue(uniqueKey, out var existing))
+        {
+            existing.Shares += holding.Shares;
+            existing.Value += holding.Value;
+            existing.VotingAuthSole += holding.VotingAuthSole;
+            existing.VotingAuthShared += holding.VotingAuthShared;
+            existing.VotingAuthNone += holding.VotingAuthNone;
+            existing.ManagerEntries.Add(managerEntry);
+            return false;
+        }
+
+        holding.ManagerEntries.Add(managerEntry);
+        holdingsMap[uniqueKey] = holding;
+        return true;
     }
 
     private static (


### PR DESCRIPTION
## Summary

- The streaming loop in `StreamAndInsertHoldings` inlined a non-obvious dedup/accumulation step: look up a row's upsert key, then either accumulate its fields into the buffered position (a 13F holder splitting a security across otherManager codes) or start a new one.
- Extracted that step into a named `AddOrMergeHolding` helper so the import loop reads as pure streaming control flow, and the merge semantics are documented in one place.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — moved the key-lookup + five-field accumulation + insert into a new `private static bool AddOrMergeHolding(...)` that returns true for a new position and false for a merge. The caller now increments `totalPending`/`totalDuplicates` based on the return value. Behavior is unchanged: same operations in the same order, identical counter totals.