### PR TITLE
refactor(mcp): adopt MarkdownTable.Start for hand-rolled table headers

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1133,13 +1133,11 @@ public class InstitutionalHoldingsTools
         int maxResults
     )
     {
-        var result = new StringBuilder();
-        result.AppendLine(
-            $"Portfolio overlap — **{holder1.Name}** vs **{holder2.Name}** as of {FormatDate(selected)}"
+        var result = MarkdownTable.Start(
+            $"Portfolio overlap — **{holder1.Name}** vs **{holder2.Name}** as of {FormatDate(selected)}",
+            "| Metric | Value |",
+            "|--------|-------|"
         );
-        result.AppendLine();
-        result.AppendLine("| Metric | Value |");
-        result.AppendLine("|--------|-------|");
         result.AppendLine($"| Union positions | {FormatWholeNumber(overlap.UnionPositionCount)} |");
         result.AppendLine(
             $"| Shared positions | {FormatWholeNumber(overlap.IntersectionPositionCount)} |"

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -10,6 +10,7 @@ using Equibles.Errors.Data.Models;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
@@ -234,11 +235,11 @@ public class InsiderTradingTools
                 if (insiders.Count == 0)
                     return $"No insiders found matching '{query}'.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"Insiders matching '{query}':");
-                result.AppendLine();
-                result.AppendLine("| Name | CIK | Role | Location |");
-                result.AppendLine("|------|-----|------|----------|");
+                var result = MarkdownTable.Start(
+                    $"Insiders matching '{query}':",
+                    "| Name | CIK | Role | Location |",
+                    "|------|-----|------|----------|"
+                );
 
                 foreach (var insider in insiders)
                 {

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -247,13 +247,11 @@ public class FinancialFactsTools
     )
     {
         var basis = asOriginallyReported ? "as originally reported" : "latest restated";
-        var result = new StringBuilder();
-        result.AppendLine(
-            $"{concept} for {stock.Ticker} ({FactMarkdown.Cell(stock.Name)}) — {basis}:"
+        var result = MarkdownTable.Start(
+            $"{concept} for {stock.Ticker} ({FactMarkdown.Cell(stock.Name)}) — {basis}:",
+            "| Period End | FY | Period | Value | Unit | Form | Filed | Accession |",
+            "|-----------|---:|--------|------:|------|------|-------|-----------|"
         );
-        result.AppendLine();
-        result.AppendLine("| Period End | FY | Period | Value | Unit | Form | Filed | Accession |");
-        result.AppendLine("|-----------|---:|--------|------:|------|------|-------|-----------|");
         foreach (var f in perPeriod)
         {
             result.AppendLine(


### PR DESCRIPTION
## Summary

- Three MCP tool renderers hand-rolled the same four-line markdown-table preamble (`new StringBuilder()` + title + blank + header + separator) that the shared `MarkdownTable.Start` helper already encapsulates and that 25 other call sites use.
- Consolidate those three sites onto `MarkdownTable.Start` to remove the duplicated boilerplate and keep table headers consistent. Output is byte-identical — the helper's body is exactly the replaced sequence.

## Code changes

- `FinancialFactsTools.cs` — `RenderFactHistoryTable` preamble now uses `MarkdownTable.Start`.
- `InstitutionalHoldingsTools.cs` — `RenderOverlapTable` preamble now uses `MarkdownTable.Start`.
- `InsiderTradingTools.cs` — `SearchInsiders` table preamble now uses `MarkdownTable.Start`; added `using Equibles.Mcp.Helpers`.