### PR TITLE
refactor(cboe): extract per-record staging loop into StageNewRecords

### DIFF
--- a/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
+++ b/src/Equibles.Cboe.HostedService/Services/CboeImportService.cs
@@ -151,26 +151,7 @@ public class CboeImportService : IImporter
                 break;
             }
 
-            foreach (var (productType, record) in dailyRecords)
-            {
-                var ratioType = MapProduct(productType);
-                if (record.Date <= latestPerType[ratioType])
-                    continue;
-
-                pending.Add(
-                    new CboePutCallRatio
-                    {
-                        RatioType = ratioType,
-                        Date = record.Date,
-                        CallVolume = record.CallVolume,
-                        PutVolume = record.PutVolume,
-                        TotalVolume = record.TotalVolume,
-                        PutCallRatio = record.PutCallRatio,
-                    }
-                );
-                perTypeInserts.TryGetValue(ratioType, out var n);
-                perTypeInserts[ratioType] = n + 1;
-            }
+            StageNewRecords(dailyRecords, latestPerType, pending, perTypeInserts);
 
             if (pending.Count >= InsertBatchSize)
                 await Flush();
@@ -191,6 +172,37 @@ public class CboeImportService : IImporter
                 ratioType,
                 count
             );
+        }
+    }
+
+    // Map each product's daily record to a CboePutCallRatio and stage the ones newer than
+    // what's already stored, tallying inserts per type. pending/perTypeInserts are mutated in place.
+    private static void StageNewRecords(
+        Dictionary<CboePutCallProductType, CboePutCallRecord> dailyRecords,
+        Dictionary<CboePutCallRatioType, DateOnly> latestPerType,
+        List<CboePutCallRatio> pending,
+        Dictionary<CboePutCallRatioType, int> perTypeInserts
+    )
+    {
+        foreach (var (productType, record) in dailyRecords)
+        {
+            var ratioType = MapProduct(productType);
+            if (record.Date <= latestPerType[ratioType])
+                continue;
+
+            pending.Add(
+                new CboePutCallRatio
+                {
+                    RatioType = ratioType,
+                    Date = record.Date,
+                    CallVolume = record.CallVolume,
+                    PutVolume = record.PutVolume,
+                    TotalVolume = record.TotalVolume,
+                    PutCallRatio = record.PutCallRatio,
+                }
+            );
+            perTypeInserts.TryGetValue(ratioType, out var n);
+            perTypeInserts[ratioType] = n + 1;
         }
     }
 


### PR DESCRIPTION
## Summary

- `ImportAllPutCallRatios` was 134 lines, interleaving the date-walk + download error-handling + batch-flushing skeleton with the inner per-product record mapping. Extracted that inner loop into a focused `StageNewRecords` helper so the import method reads as walk → download → stage → flush.
- Pure extract-method, behaviour-preserving: the loop body moved verbatim into a static helper that mutates the same `pending`/`perTypeInserts` collections; `MapProduct`, the latest-date dedup, and skip semantics are unchanged, and the outer Flush threshold is untouched.

## Code changes

- `src/Equibles.Cboe.HostedService/Services/CboeImportService.cs` — moved the per-record map/stage/tally loop out of `ImportAllPutCallRatios` into a new private static `StageNewRecords(dailyRecords, latestPerType, pending, perTypeInserts)`. No behaviour change.