### PR TITLE
refactor(finra): extract bulk-vs-filtered fetch selection into FetchMissingRecords

### DIFF
--- a/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
@@ -164,23 +164,13 @@ public class ShortInterestImportService
             if (missingStockIds.Count == 0)
                 return -1;
 
-            List<ShortInterestRecord> records;
-            var useBulkFetch =
-                missingStockIds.Count == trackedStockIds.Count
-                || missingStockIds.Count > filteredFetchThreshold;
-
-            if (useBulkFetch)
-            {
-                records = await _finraClient.GetShortInterest(date);
-            }
-            else
-            {
-                var missingSymbols = missingStockIds
-                    .Where(id => reverseMap.ContainsKey(id))
-                    .Select(id => reverseMap[id])
-                    .ToList();
-                records = await _finraClient.GetShortInterest(date, missingSymbols);
-            }
+            var records = await FetchMissingRecords(
+                date,
+                missingStockIds,
+                trackedStockIds,
+                reverseMap,
+                filteredFetchThreshold
+            );
 
             if (records.Count == 0)
             {
@@ -237,6 +227,30 @@ public class ShortInterestImportService
             );
             return 0;
         }
+    }
+
+    // Fetch this date's short-interest rows: a single bulk request when most/all tracked
+    // stocks are missing, or a symbol-filtered request when only a few need backfilling.
+    private Task<List<ShortInterestRecord>> FetchMissingRecords(
+        DateOnly date,
+        HashSet<Guid> missingStockIds,
+        HashSet<Guid> trackedStockIds,
+        Dictionary<Guid, string> reverseMap,
+        int filteredFetchThreshold
+    )
+    {
+        var useBulkFetch =
+            missingStockIds.Count == trackedStockIds.Count
+            || missingStockIds.Count > filteredFetchThreshold;
+
+        if (useBulkFetch)
+            return _finraClient.GetShortInterest(date);
+
+        var missingSymbols = missingStockIds
+            .Where(id => reverseMap.ContainsKey(id))
+            .Select(id => reverseMap[id])
+            .ToList();
+        return _finraClient.GetShortInterest(date, missingSymbols);
     }
 
     // tickerMap was built at the start of Import and goes stale if CompanySyncService


### PR DESCRIPTION
## Summary

- `ImportDate` was 98 lines, mixing the choice of fetch strategy (one bulk request vs a symbol-filtered request) with the surrounding existing-row check, dedup, and persistence. Extracted that decision into a focused `FetchMissingRecords` helper so the method reads as check → fetch → map → persist.
- Pure extract-method, behaviour-preserving: the threshold decision and both `GetShortInterest` calls move verbatim; the helper returns the task so any `HttpRequestException` still surfaces at the caller's `await` inside the same try/catch.

## Code changes

- `src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs` — moved the bulk-vs-filtered fetch selection out of `ImportDate` into a new private `FetchMissingRecords(date, missingStockIds, trackedStockIds, reverseMap, filteredFetchThreshold)`. No behaviour change.