### PR TITLE
refactor(cftc): extract existing-report-key lookup into LoadExistingReportKeys

### DIFF
--- a/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
+++ b/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
@@ -198,21 +198,7 @@ public class CftcImportService : IImporter
         var minDate = allDates.Min();
         var maxDate = allDates.Max();
 
-        HashSet<(Guid, DateOnly)> existingKeys;
-        using (var scope = _scopeFactory.CreateScope())
-        {
-            var reportRepo =
-                scope.ServiceProvider.GetRequiredService<CftcPositionReportRepository>();
-            existingKeys = (
-                await reportRepo
-                    .GetAll()
-                    .Where(r => r.ReportDate >= minDate && r.ReportDate <= maxDate)
-                    .Select(r => new { r.CftcContractId, r.ReportDate })
-                    .ToListAsync(cancellationToken)
-            )
-                .Select(r => (r.CftcContractId, r.ReportDate))
-                .ToHashSet();
-        }
+        var existingKeys = await LoadExistingReportKeys(minDate, maxDate, cancellationToken);
 
         var totalInserted = await BatchPersister.Persist<
             CftcPositionReport,
@@ -248,6 +234,27 @@ public class CftcImportService : IImporter
             year,
             totalInserted
         );
+    }
+
+    // Load the (contract, date) keys already stored within the date window so the import
+    // can skip rows that would collide with existing data.
+    private async Task<HashSet<(Guid, DateOnly)>> LoadExistingReportKeys(
+        DateOnly minDate,
+        DateOnly maxDate,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var reportRepo = scope.ServiceProvider.GetRequiredService<CftcPositionReportRepository>();
+        return (
+            await reportRepo
+                .GetAll()
+                .Where(r => r.ReportDate >= minDate && r.ReportDate <= maxDate)
+                .Select(r => new { r.CftcContractId, r.ReportDate })
+                .ToListAsync(cancellationToken)
+        )
+            .Select(r => (r.CftcContractId, r.ReportDate))
+            .ToHashSet();
     }
 
     private async Task UpdateContractMetadata(


### PR DESCRIPTION
## Summary

- `ImportYear` was 101 lines, inlining a scope-bound database read (the windowed existing-key lookup with its range filter, anonymous projection, and tuple rehydration) amid the download/filter/persist orchestration. Pulled that read into a focused `LoadExistingReportKeys` helper so the import flow reads as download → filter → load contracts → load existing keys → persist.
- Pure extract-method, behaviour-preserving: the query, the `using` scope lifetime, and the `(contractId, date)` tuple conversion move verbatim; the result is assigned exactly as before.

## Code changes

- `src/Equibles.Cftc.HostedService/Services/CftcImportService.cs` — moved the existing-report-key window lookup out of `ImportYear` into a new private `LoadExistingReportKeys(minDate, maxDate, cancellationToken)`. No behaviour change.