### PR TITLE
refactor(sec): extract shared issuer-feed filing pipeline into IssuerFeedFilingProcessor base

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
@@ -1,15 +1,11 @@
 using System.Globalization;
 using System.Xml.Linq;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.Errors.BusinessLogic;
 using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
-using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
-using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Helpers;
-using Microsoft.EntityFrameworkCore;
 using static Equibles.Sec.HostedService.Helpers.EdgarXmlSubmissionParser;
 
 namespace Equibles.Sec.HostedService.Services;
@@ -21,12 +17,9 @@ namespace Equibles.Sec.HostedService.Services;
 /// is attributed to the issuer's stock. The XML uses the same <c>edgar/ownership</c> namespace
 /// as Forms 3/4/5 but a different root (<c>edgarSubmission</c>) and flat (unwrapped) values.
 /// </summary>
-public class Form144FilingProcessor : IFilingProcessor
+public class Form144FilingProcessor
+    : IssuerFeedFilingProcessor<Form144Filing, Form144FilingRepository>
 {
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly ILogger<Form144FilingProcessor> _logger;
-    private readonly ErrorReporter _errorReporter;
-
     private static readonly string[] DateFormats = ["MM/dd/yyyy", "M/d/yyyy"];
 
     public Form144FilingProcessor(
@@ -34,80 +27,36 @@ public class Form144FilingProcessor : IFilingProcessor
         ILogger<Form144FilingProcessor> logger,
         ErrorReporter errorReporter
     )
-    {
-        _scopeFactory = scopeFactory;
-        _logger = logger;
-        _errorReporter = errorReporter;
-    }
+        : base(scopeFactory, logger, errorReporter) { }
 
-    public bool CanProcess(DocumentType documentType)
+    public override bool CanProcess(DocumentType documentType)
     {
         return documentType == DocumentType.Form144;
     }
 
-    public async Task<bool> Process(FilingData filing, CommonStock companyOutContext)
+    protected override string FormLabel => "Form 144";
+
+    protected override string ParseContext => "Form144.ParseXml";
+
+    protected override string RequiredSection => "formData";
+
+    protected override IQueryable<Form144Filing> GetByAccessionNumber(
+        Form144FilingRepository repository,
+        string accessionNumber
+    ) => repository.GetByAccessionNumber(accessionNumber);
+
+    protected override void LogImported(Form144Filing entity, string ticker, string accessionNumber)
     {
-        // Capture IDs from the outer-scope entity to avoid leaking untracked entities into inner scope.
-        var companyId = companyOutContext.Id;
-        var companyTicker = companyOutContext.Ticker;
-
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var secEdgarClient = scope.ServiceProvider.GetRequiredService<ISecEdgarClient>();
-        var repository = scope.ServiceProvider.GetRequiredService<Form144FilingRepository>();
-
-        var existing = await repository.GetByAccessionNumber(filing.AccessionNumber).AnyAsync();
-        if (existing)
-            return false;
-
-        var content = await secEdgarClient.GetDocumentContent(filing);
-        if (string.IsNullOrWhiteSpace(content))
-        {
-            _logger.LogWarning(
-                "Empty content for {Ticker} Form 144 - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return false;
-        }
-
-        var root = await EdgarXmlSubmissionParser.TryParseSubmission(
-            content,
-            filing,
-            companyTicker,
-            "Form 144",
-            "Form144.ParseXml",
-            _logger,
-            _errorReporter
-        );
-        if (root == null)
-            return false;
-
-        var entity = ParseFiling(root, companyId, filing);
-        if (entity == null)
-        {
-            _logger.LogWarning(
-                "Form 144 XML missing formData for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return false;
-        }
-
-        repository.Add(entity);
-        await repository.SaveChanges();
-
-        _logger.LogInformation(
+        Logger.LogInformation(
             "Imported Form 144 for {Ticker} ({Shares} shares, {Prior} prior sales) from {AccessionNumber}",
-            companyTicker,
+            ticker,
             entity.SharesToBeSold,
             entity.PriorSales.Count,
-            filing.AccessionNumber
+            accessionNumber
         );
-
-        return true;
     }
 
-    private static Form144Filing ParseFiling(XElement root, Guid companyId, FilingData filing)
+    protected override Form144Filing ParseFiling(XElement root, Guid companyId, FilingData filing)
     {
         var formData = El(root, "formData");
         if (formData == null)

--- a/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
@@ -1,14 +1,10 @@
 using System.Globalization;
 using System.Xml.Linq;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.Errors.BusinessLogic;
-using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
-using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.Repositories;
-using Microsoft.EntityFrameworkCore;
 using static Equibles.Sec.HostedService.Helpers.EdgarXmlSubmissionParser;
 
 namespace Equibles.Sec.HostedService.Services;
@@ -21,12 +17,8 @@ namespace Equibles.Sec.HostedService.Services;
 /// notice ("D") and its amendments ("D/A") are processed. The XML root is
 /// <c>edgarSubmission</c> with no default namespace, so elements are navigated by local name.
 /// </summary>
-public class FormDFilingProcessor : IFilingProcessor
+public class FormDFilingProcessor : IssuerFeedFilingProcessor<FormDFiling, FormDFilingRepository>
 {
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly ILogger<FormDFilingProcessor> _logger;
-    private readonly ErrorReporter _errorReporter;
-
     // Form D dates are ISO yyyy-MM-dd; accept the US MM/dd/yyyy fallback defensively.
     private static readonly string[] DateFormats = ["yyyy-MM-dd", "MM/dd/yyyy", "M/d/yyyy"];
 
@@ -37,81 +29,37 @@ public class FormDFilingProcessor : IFilingProcessor
         ILogger<FormDFilingProcessor> logger,
         ErrorReporter errorReporter
     )
-    {
-        _scopeFactory = scopeFactory;
-        _logger = logger;
-        _errorReporter = errorReporter;
-    }
+        : base(scopeFactory, logger, errorReporter) { }
 
-    public bool CanProcess(DocumentType documentType)
+    public override bool CanProcess(DocumentType documentType)
     {
         return documentType == DocumentType.FormD || documentType == DocumentType.FormDa;
     }
 
-    public async Task<bool> Process(FilingData filing, CommonStock companyOutContext)
+    protected override string FormLabel => "Form D";
+
+    protected override string ParseContext => "FormD.ParseXml";
+
+    protected override string RequiredSection => "offeringData";
+
+    protected override IQueryable<FormDFiling> GetByAccessionNumber(
+        FormDFilingRepository repository,
+        string accessionNumber
+    ) => repository.GetByAccessionNumber(accessionNumber);
+
+    protected override void LogImported(FormDFiling entity, string ticker, string accessionNumber)
     {
-        // Capture IDs from the outer-scope entity to avoid leaking untracked entities into inner scope.
-        var companyId = companyOutContext.Id;
-        var companyTicker = companyOutContext.Ticker;
-
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var secEdgarClient = scope.ServiceProvider.GetRequiredService<ISecEdgarClient>();
-        var repository = scope.ServiceProvider.GetRequiredService<FormDFilingRepository>();
-
-        var existing = await repository.GetByAccessionNumber(filing.AccessionNumber).AnyAsync();
-        if (existing)
-            return false;
-
-        var content = await secEdgarClient.GetDocumentContent(filing);
-        if (string.IsNullOrWhiteSpace(content))
-        {
-            _logger.LogWarning(
-                "Empty content for {Ticker} Form D - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return false;
-        }
-
-        var root = await EdgarXmlSubmissionParser.TryParseSubmission(
-            content,
-            filing,
-            companyTicker,
-            "Form D",
-            "FormD.ParseXml",
-            _logger,
-            _errorReporter
-        );
-        if (root == null)
-            return false;
-
-        var entity = ParseFiling(root, companyId, filing);
-        if (entity == null)
-        {
-            _logger.LogWarning(
-                "Form D XML missing offeringData for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return false;
-        }
-
-        repository.Add(entity);
-        await repository.SaveChanges();
-
-        _logger.LogInformation(
+        Logger.LogInformation(
             "Imported Form D for {Ticker} ({EntityName}, sold {Sold}, {Persons} related persons) from {AccessionNumber}",
-            companyTicker,
+            ticker,
             entity.EntityName,
             entity.TotalAmountSold,
             entity.RelatedPersons.Count,
-            filing.AccessionNumber
+            accessionNumber
         );
-
-        return true;
     }
 
-    private static FormDFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
+    protected override FormDFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
     {
         var offeringData = El(root, "offeringData");
         if (offeringData == null)

--- a/src/Equibles.Sec.HostedService/Services/IssuerFeedFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/IssuerFeedFilingProcessor.cs
@@ -1,0 +1,119 @@
+using System.Xml.Linq;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Contracts;
+using Equibles.Sec.HostedService.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Template-method base for filing processors that turn a single issuer-feed XML submission into one
+/// structured filing entity (Form 144, Form D, NPORT-P, N-CEN). The fixed pipeline — open a scope,
+/// skip an already-imported accession number, fetch and parse the submission, then persist — lives
+/// here; each form supplies only its labels, its accession lookup, its parse, and its success log line.
+/// </summary>
+public abstract class IssuerFeedFilingProcessor<TEntity, TRepository> : IFilingProcessor
+    where TEntity : class
+    where TRepository : BaseRepository<TEntity>
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ErrorReporter _errorReporter;
+
+    // Carries the concrete processor's log category, so messages emitted from this base keep the
+    // same SourceContext they had when the pipeline lived in each processor.
+    protected ILogger Logger { get; }
+
+    protected IssuerFeedFilingProcessor(
+        IServiceScopeFactory scopeFactory,
+        ILogger logger,
+        ErrorReporter errorReporter
+    )
+    {
+        _scopeFactory = scopeFactory;
+        Logger = logger;
+        _errorReporter = errorReporter;
+    }
+
+    public abstract bool CanProcess(DocumentType documentType);
+
+    // Human-readable form name used in log messages (e.g. "Form 144", "NPORT-P").
+    protected abstract string FormLabel { get; }
+
+    // Context key passed to the shared parser for error attribution (e.g. "Form144.ParseXml").
+    protected abstract string ParseContext { get; }
+
+    // Root element ParseFiling requires; named in the warning when the submission lacks it.
+    protected abstract string RequiredSection { get; }
+
+    protected abstract IQueryable<TEntity> GetByAccessionNumber(
+        TRepository repository,
+        string accessionNumber
+    );
+
+    protected abstract TEntity ParseFiling(XElement root, Guid companyId, FilingData filing);
+
+    protected abstract void LogImported(TEntity entity, string ticker, string accessionNumber);
+
+    public async Task<bool> Process(FilingData filing, CommonStock companyOutContext)
+    {
+        // Capture IDs from the outer-scope entity to avoid leaking untracked entities into inner scope.
+        var companyId = companyOutContext.Id;
+        var companyTicker = companyOutContext.Ticker;
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var secEdgarClient = scope.ServiceProvider.GetRequiredService<ISecEdgarClient>();
+        var repository = scope.ServiceProvider.GetRequiredService<TRepository>();
+
+        var existing = await GetByAccessionNumber(repository, filing.AccessionNumber).AnyAsync();
+        if (existing)
+            return false;
+
+        var content = await secEdgarClient.GetDocumentContent(filing);
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            Logger.LogWarning(
+                "Empty content for {Ticker} {Form} - {AccessionNumber}",
+                companyTicker,
+                FormLabel,
+                filing.AccessionNumber
+            );
+            return false;
+        }
+
+        var root = await EdgarXmlSubmissionParser.TryParseSubmission(
+            content,
+            filing,
+            companyTicker,
+            FormLabel,
+            ParseContext,
+            Logger,
+            _errorReporter
+        );
+        if (root == null)
+            return false;
+
+        var entity = ParseFiling(root, companyId, filing);
+        if (entity == null)
+        {
+            Logger.LogWarning(
+                "{Form} XML missing {Section} for {Ticker} - {AccessionNumber}",
+                FormLabel,
+                RequiredSection,
+                companyTicker,
+                filing.AccessionNumber
+            );
+            return false;
+        }
+
+        repository.Add(entity);
+        await repository.SaveChanges();
+
+        LogImported(entity, companyTicker, filing.AccessionNumber);
+
+        return true;
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
@@ -1,14 +1,10 @@
 using System.Globalization;
 using System.Xml.Linq;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.Errors.BusinessLogic;
-using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
-using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.Repositories;
-using Microsoft.EntityFrameworkCore;
 using static Equibles.Sec.HostedService.Helpers.EdgarXmlSubmissionParser;
 
 namespace Equibles.Sec.HostedService.Services;
@@ -22,12 +18,8 @@ namespace Equibles.Sec.HostedService.Services;
 /// <c>http://www.sec.gov/edgar/ncen</c> namespace, so elements are navigated by local name.
 /// Booleans are reported as "Y"/"N".
 /// </summary>
-public class NCenFilingProcessor : IFilingProcessor
+public class NCenFilingProcessor : IssuerFeedFilingProcessor<NCenFiling, NCenFilingRepository>
 {
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly ILogger<NCenFilingProcessor> _logger;
-    private readonly ErrorReporter _errorReporter;
-
     // N-CEN dates are ISO yyyy-MM-dd.
     private static readonly string[] DateFormats = ["yyyy-MM-dd"];
 
@@ -39,80 +31,37 @@ public class NCenFilingProcessor : IFilingProcessor
         ILogger<NCenFilingProcessor> logger,
         ErrorReporter errorReporter
     )
-    {
-        _scopeFactory = scopeFactory;
-        _logger = logger;
-        _errorReporter = errorReporter;
-    }
+        : base(scopeFactory, logger, errorReporter) { }
 
-    public bool CanProcess(DocumentType documentType)
+    public override bool CanProcess(DocumentType documentType)
     {
         return documentType == DocumentType.NCen || documentType == DocumentType.NCenA;
     }
 
-    public async Task<bool> Process(FilingData filing, CommonStock companyOutContext)
+    protected override string FormLabel => "N-CEN";
+
+    protected override string ParseContext => "NCen.ParseXml";
+
+    protected override string RequiredSection => "registrantInfo";
+
+    protected override IQueryable<NCenFiling> GetByAccessionNumber(
+        NCenFilingRepository repository,
+        string accessionNumber
+    ) => repository.GetByAccessionNumber(accessionNumber);
+
+    protected override void LogImported(NCenFiling entity, string ticker, string accessionNumber)
     {
-        var companyId = companyOutContext.Id;
-        var companyTicker = companyOutContext.Ticker;
-
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var secEdgarClient = scope.ServiceProvider.GetRequiredService<ISecEdgarClient>();
-        var repository = scope.ServiceProvider.GetRequiredService<NCenFilingRepository>();
-
-        var existing = await repository.GetByAccessionNumber(filing.AccessionNumber).AnyAsync();
-        if (existing)
-            return false;
-
-        var content = await secEdgarClient.GetDocumentContent(filing);
-        if (string.IsNullOrWhiteSpace(content))
-        {
-            _logger.LogWarning(
-                "Empty content for {Ticker} N-CEN - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return false;
-        }
-
-        var root = await EdgarXmlSubmissionParser.TryParseSubmission(
-            content,
-            filing,
-            companyTicker,
-            "N-CEN",
-            "NCen.ParseXml",
-            _logger,
-            _errorReporter
-        );
-        if (root == null)
-            return false;
-
-        var entity = ParseFiling(root, companyId, filing);
-        if (entity == null)
-        {
-            _logger.LogWarning(
-                "N-CEN XML missing registrantInfo for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return false;
-        }
-
-        repository.Add(entity);
-        await repository.SaveChanges();
-
-        _logger.LogInformation(
+        Logger.LogInformation(
             "Imported N-CEN for {Ticker} ({Registrant}, type {Type}, {Providers} service providers) from {AccessionNumber}",
-            companyTicker,
+            ticker,
             entity.RegistrantName,
             entity.InvestmentCompanyType,
             entity.ServiceProviders.Count,
-            filing.AccessionNumber
+            accessionNumber
         );
-
-        return true;
     }
 
-    private static NCenFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
+    protected override NCenFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
     {
         var headerData = El(root, "headerData");
         var filerInfo = El(headerData, "filerInfo");

--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -1,14 +1,10 @@
 using System.Globalization;
 using System.Xml.Linq;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.Errors.BusinessLogic;
-using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
-using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.Repositories;
-using Microsoft.EntityFrameworkCore;
 using static Equibles.Sec.HostedService.Helpers.EdgarXmlSubmissionParser;
 
 namespace Equibles.Sec.HostedService.Services;
@@ -22,12 +18,8 @@ namespace Equibles.Sec.HostedService.Services;
 /// <c>edgarSubmission</c> in the <c>http://www.sec.gov/edgar/nport</c> namespace, so elements are
 /// navigated by local name. Booleans are reported as "Y"/"N"; amounts are decimal strings.
 /// </summary>
-public class NportFilingProcessor : IFilingProcessor
+public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, NportFilingRepository>
 {
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly ILogger<NportFilingProcessor> _logger;
-    private readonly ErrorReporter _errorReporter;
-
     // NPORT dates are ISO yyyy-MM-dd.
     private static readonly string[] DateFormats = ["yyyy-MM-dd"];
 
@@ -39,80 +31,37 @@ public class NportFilingProcessor : IFilingProcessor
         ILogger<NportFilingProcessor> logger,
         ErrorReporter errorReporter
     )
-    {
-        _scopeFactory = scopeFactory;
-        _logger = logger;
-        _errorReporter = errorReporter;
-    }
+        : base(scopeFactory, logger, errorReporter) { }
 
-    public bool CanProcess(DocumentType documentType)
+    public override bool CanProcess(DocumentType documentType)
     {
         return documentType == DocumentType.NportP || documentType == DocumentType.NportPa;
     }
 
-    public async Task<bool> Process(FilingData filing, CommonStock companyOutContext)
+    protected override string FormLabel => "NPORT-P";
+
+    protected override string ParseContext => "Nport.ParseXml";
+
+    protected override string RequiredSection => "genInfo";
+
+    protected override IQueryable<NportFiling> GetByAccessionNumber(
+        NportFilingRepository repository,
+        string accessionNumber
+    ) => repository.GetByAccessionNumber(accessionNumber);
+
+    protected override void LogImported(NportFiling entity, string ticker, string accessionNumber)
     {
-        var companyId = companyOutContext.Id;
-        var companyTicker = companyOutContext.Ticker;
-
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var secEdgarClient = scope.ServiceProvider.GetRequiredService<ISecEdgarClient>();
-        var repository = scope.ServiceProvider.GetRequiredService<NportFilingRepository>();
-
-        var existing = await repository.GetByAccessionNumber(filing.AccessionNumber).AnyAsync();
-        if (existing)
-            return false;
-
-        var content = await secEdgarClient.GetDocumentContent(filing);
-        if (string.IsNullOrWhiteSpace(content))
-        {
-            _logger.LogWarning(
-                "Empty content for {Ticker} NPORT-P - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return false;
-        }
-
-        var root = await EdgarXmlSubmissionParser.TryParseSubmission(
-            content,
-            filing,
-            companyTicker,
-            "NPORT-P",
-            "Nport.ParseXml",
-            _logger,
-            _errorReporter
-        );
-        if (root == null)
-            return false;
-
-        var entity = ParseFiling(root, companyId, filing);
-        if (entity == null)
-        {
-            _logger.LogWarning(
-                "NPORT-P XML missing genInfo for {Ticker} - {AccessionNumber}",
-                companyTicker,
-                filing.AccessionNumber
-            );
-            return false;
-        }
-
-        repository.Add(entity);
-        await repository.SaveChanges();
-
-        _logger.LogInformation(
+        Logger.LogInformation(
             "Imported NPORT-P for {Ticker} ({Series}, net assets {NetAssets}, {Holdings} holdings) from {AccessionNumber}",
-            companyTicker,
+            ticker,
             entity.SeriesName,
             entity.NetAssets,
             entity.Holdings.Count,
-            filing.AccessionNumber
+            accessionNumber
         );
-
-        return true;
     }
 
-    private static NportFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
+    protected override NportFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
     {
         var headerData = El(root, "headerData");
         var formData = El(root, "formData");


### PR DESCRIPTION
## Summary

- The four single-entity SEC filing processors (`Form144FilingProcessor`, `FormDFilingProcessor`, `NportFilingProcessor`, `NCenFilingProcessor`) each carried a byte-identical `Process()` orchestration skeleton — open a scope, resolve the EDGAR client and a typed repository, skip already-imported accession numbers, fetch and parse the submission, persist, and log.
- That skeleton is now a single template-method base class, `IssuerFeedFilingProcessor<TEntity, TRepository>`. Each processor supplies only its form-specific labels, accession lookup, parse, and success-log line. Behavior is unchanged: same control flow, same return values, identical rendered log output, and the per-processor log category is preserved.

## Code changes

- `Services/IssuerFeedFilingProcessor.cs` — new generic base class holding the shared pipeline; exposes `FormLabel`, `ParseContext`, `RequiredSection`, `GetByAccessionNumber`, `ParseFiling`, and `LogImported` as the per-form extension points.
- `Services/Form144FilingProcessor.cs`, `FormDFilingProcessor.cs`, `NportFilingProcessor.cs`, `NCenFilingProcessor.cs` — drop the duplicated `Process()` body and inherit the base; `ParseFiling` becomes `protected override`; success/warning logging routed through the base. The two warning templates were de-duplicated into constant templates with structured placeholders whose substituted values reproduce the original literal text.