### PR TITLE
feat(insider-trading): repair fat-fingered insider prices instead of just flagging

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
@@ -11,15 +11,18 @@ using Microsoft.Extensions.Logging;
 namespace Equibles.InsiderTrading.BusinessLogic;
 
 /// <summary>
-/// One-off recompute of <see cref="InsiderTransaction.IsPriceValid"/> across
-/// every row. Cross-checks the filer-reported <c>PricePerShare</c> against
-/// the Yahoo unadjusted close on the transaction date (most recent prior
-/// trading day if the transaction date fell on a weekend / holiday) and
-/// flips the flag according to <see cref="InsiderTransactionPriceValidator"/>.
+/// Evaluates the not-yet-checked insider transactions — those whose
+/// <see cref="InsiderTransaction.IsPriceValid"/> is still <c>null</c>. Each
+/// row's reported price is cross-checked against the Yahoo unadjusted close
+/// on the transaction date (most recent prior trading day for weekends /
+/// holidays) via <see cref="InsiderTransactionPriceValidator"/>; implausible
+/// rows are repaired (reported total ÷ shares) and the raw value preserved in
+/// <see cref="InsiderTransaction.ReportedPricePerShare"/>.
 ///
-/// Triggered from the backoffice maintenance dashboard after a parser fix
-/// lands. Idempotent and re-entrant — safe to click again. Iterates in
-/// batches with a progress callback so the UI can show an SSE-driven bar.
+/// Only null rows are touched, so a row is evaluated exactly once and re-runs
+/// don't re-scan the whole table. Rows with no usable close stay null and are
+/// retried on a later run. Triggered from the backoffice maintenance
+/// dashboard; iterates in batches with a progress callback for the SSE bar.
 /// </summary>
 [Service]
 public class InsiderTransactionPriceBackfillManager
@@ -59,9 +62,13 @@ public class InsiderTransactionPriceBackfillManager
         Func<InsiderTransactionPriceBackfillResult, Task> onProgress = null
     )
     {
+        // Snapshot of the work-set size for the progress bar. The live parser
+        // may insert more null (pending) rows while this runs; those land
+        // behind the advancing cursor and are picked up on the next run, so
+        // Processed can briefly nudge past Total — harmless and self-correcting.
         var result = new InsiderTransactionPriceBackfillResult
         {
-            Total = await _transactionRepository.GetAll().CountAsync(),
+            Total = await _transactionRepository.GetAll().CountAsync(t => t.IsPriceValid == null),
         };
 
         if (result.Total == 0)
@@ -69,21 +76,27 @@ public class InsiderTransactionPriceBackfillManager
 
         _dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
 
-        // Keyset (cursor) pagination on Id. Postgres OFFSET scans and
-        // discards N rows before returning the M for that batch, so a
-        // Skip(N).Take(M) loop is O(N²) — the last batch in a 3M-row table
-        // is thousands of times slower than the first. Filtering by
-        // `Id > lastSeenId` instead lets the index seek straight to the
-        // next page, keeping every batch roughly the same speed and the
-        // whole pass O(N). Npgsql translates `Guid > Guid` to PostgreSQL's
-        // native `uuid > uuid` comparison.
-        var lastSeenId = Guid.Empty;
+        // Keyset (cursor) pagination on (TransactionDate, Id) over the
+        // unevaluated rows. Ordering by date — not the random Guid Id — keeps
+        // each batch inside a narrow date window, so FetchCloses pulls a small
+        // price range per batch instead of every stock's full history (the
+        // Id-ordered version scattered each batch across all dates, making
+        // FetchCloses load decades of prices at a time). The
+        // (IsPriceValid, TransactionDate) index backs both the filter and the
+        // order. Rows left pending (still null) fall behind the advancing
+        // cursor, so the run terminates; they're retried on the next run.
+        var lastDate = DateOnly.MinValue;
+        var lastId = Guid.Empty;
         while (true)
         {
             var batch = await _transactionRepository
                 .GetAll()
-                .Where(t => t.Id > lastSeenId)
-                .OrderBy(t => t.Id)
+                .Where(t => t.IsPriceValid == null)
+                .Where(t =>
+                    t.TransactionDate > lastDate || (t.TransactionDate == lastDate && t.Id > lastId)
+                )
+                .OrderBy(t => t.TransactionDate)
+                .ThenBy(t => t.Id)
                 .Take(BatchSize)
                 .ToListAsync();
 
@@ -97,32 +110,44 @@ public class InsiderTransactionPriceBackfillManager
                 var key = (transaction.CommonStockId, transaction.TransactionDate);
                 decimal? close = closes.TryGetValue(key, out var value) ? value : null;
 
-                var wasValid = transaction.IsPriceValid;
-                var nowValid = _validator.IsPlausible(
-                    transaction.PricePerShare,
+                var evaluation = _validator.Evaluate(
+                    transaction.ReportedPricePerShare,
+                    transaction.Shares,
                     transaction.SecurityTitle,
                     close
                 );
 
-                if (wasValid != nowValid)
-                {
-                    transaction.IsPriceValid = nowValid;
-                }
-                if (!nowValid)
-                    result.MarkedInvalid++;
+                transaction.PricePerShare = evaluation.EffectivePrice;
+                transaction.IsPriceValid = evaluation.IsPriceValid;
+
+                if (evaluation.IsPriceValid == null)
+                    result.Pending++;
+                else if (evaluation.WasRepaired)
+                    result.Repaired++;
+                else if (evaluation.IsPriceValid == true)
+                    result.Valid++;
                 else
-                    result.MarkedValid++;
+                    result.Invalid++;
             }
 
             await _transactionRepository.SaveChanges();
+
+            // Detach the saved batch so the change tracker doesn't grow to the
+            // full unevaluated set — otherwise every SaveChanges re-scans an
+            // ever-larger graph (quadratic) and memory balloons across the run.
+            _dbContext.ChangeTracker.Clear();
+
             result.Processed += batch.Count;
-            lastSeenId = batch[^1].Id;
+            lastDate = batch[^1].TransactionDate;
+            lastId = batch[^1].Id;
 
             _logger.LogInformation(
-                "Insider price backfill: processed {Processed}/{Total}, invalid={Invalid}",
+                "Insider price backfill: processed {Processed}/{Total}, repaired={Repaired}, invalid={Invalid}, pending={Pending}",
                 result.Processed,
                 result.Total,
-                result.MarkedInvalid
+                result.Repaired,
+                result.Invalid,
+                result.Pending
             );
 
             if (onProgress != null)

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
@@ -1,4 +1,5 @@
 using Equibles.Core.AutoWiring;
+using Equibles.InsiderTrading.BusinessLogic.Models;
 
 namespace Equibles.InsiderTrading.BusinessLogic;
 
@@ -60,6 +61,79 @@ public class InsiderTransactionPriceValidator
             return true;
 
         return pricePerShare <= unadjustedClose.Value * MaxPriceToCloseMultiplier;
+    }
+
+    /// <summary>
+    /// Full tri-state evaluation of a reported per-share price, plus the repair.
+    /// Pure — the caller supplies the close and persists the outcome.
+    ///
+    /// Differs from <see cref="IsPlausible"/> in two ways:
+    /// <list type="bullet">
+    /// <item>A missing close yields a <em>pending</em> result (null) instead of
+    /// valid, so the row is re-checked by a later recompute once the close
+    /// lands rather than being silently accepted.</item>
+    /// <item>An implausible real price is <em>repaired</em>: the per-share
+    /// field almost always holds the total transaction value, so dividing by
+    /// <paramref name="shares"/> recovers the unit price. Rows with no share
+    /// count can't be divided and stay flagged invalid.</item>
+    /// </list>
+    /// </summary>
+    public InsiderTransactionPriceEvaluation Evaluate(
+        decimal reportedPrice,
+        long shares,
+        string securityTitle,
+        decimal? unadjustedClose
+    )
+    {
+        // Zero/negative prices (holdings, sentinels) and derivatives need no
+        // close — they're valid as-is and never repaired.
+        if (reportedPrice <= 0m || IsDerivativeSecurity(securityTitle))
+        {
+            return new InsiderTransactionPriceEvaluation
+            {
+                IsPriceValid = true,
+                EffectivePrice = reportedPrice,
+            };
+        }
+
+        // A real price we can't yet check stays pending (null), not valid.
+        if (!unadjustedClose.HasValue || unadjustedClose.Value <= 0m)
+        {
+            return new InsiderTransactionPriceEvaluation
+            {
+                IsPriceValid = null,
+                EffectivePrice = reportedPrice,
+            };
+        }
+
+        // Plausible against the close — keep as filed.
+        if (reportedPrice <= unadjustedClose.Value * MaxPriceToCloseMultiplier)
+        {
+            return new InsiderTransactionPriceEvaluation
+            {
+                IsPriceValid = true,
+                EffectivePrice = reportedPrice,
+            };
+        }
+
+        // Implausible but unrepairable without a share count.
+        if (shares == 0)
+        {
+            return new InsiderTransactionPriceEvaluation
+            {
+                IsPriceValid = false,
+                EffectivePrice = reportedPrice,
+            };
+        }
+
+        // Implausible — repair by dividing the mis-entered total by the share
+        // count and accept the result as the per-share price.
+        return new InsiderTransactionPriceEvaluation
+        {
+            IsPriceValid = true,
+            EffectivePrice = reportedPrice / shares,
+            WasRepaired = true,
+        };
     }
 
     private static bool IsDerivativeSecurity(string securityTitle)

--- a/src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderTransactionPriceBackfillResult.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderTransactionPriceBackfillResult.cs
@@ -2,15 +2,28 @@ namespace Equibles.InsiderTrading.BusinessLogic.Models;
 
 public class InsiderTransactionPriceBackfillResult
 {
+    /// <summary>Rows that needed evaluating this run (IsPriceValid was null).</summary>
     public int Total { get; set; }
+
     public int Processed { get; set; }
-    public int MarkedInvalid { get; set; }
-    public int MarkedValid { get; set; }
+
+    /// <summary>Implausible rows repaired by dividing the reported total by Shares.</summary>
+    public int Repaired { get; set; }
+
+    /// <summary>Rows confirmed plausible — no change.</summary>
+    public int Valid { get; set; }
+
+    /// <summary>Implausible rows that couldn't be repaired (Shares == 0).</summary>
+    public int Invalid { get; set; }
+
+    /// <summary>Rows still without a usable close — left null for a later run.</summary>
+    public int Pending { get; set; }
 
     public string Summary =>
         Total == 0
-            ? "No insider transactions to scan."
-            : $"Scanned {Processed}/{Total} transactions. "
-                + $"Marked invalid: {MarkedInvalid}. "
-                + $"Marked valid: {MarkedValid}.";
+            ? "No unevaluated insider transactions to scan."
+            : $"Evaluated {Processed}/{Total} transactions. "
+                + $"Repaired: {Repaired}. Valid: {Valid}. "
+                + $"Invalid (no share count): {Invalid}. "
+                + $"Still pending (no close yet): {Pending}.";
 }

--- a/src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderTransactionPriceEvaluation.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderTransactionPriceEvaluation.cs
@@ -1,0 +1,25 @@
+namespace Equibles.InsiderTrading.BusinessLogic.Models;
+
+/// <summary>
+/// Outcome of evaluating one InsiderTransaction's reported per-share price
+/// against the market close. Mirrors the fields the caller persists onto the
+/// entity.
+/// </summary>
+public class InsiderTransactionPriceEvaluation
+{
+    /// <summary>
+    /// Resulting plausibility: <c>null</c> = pending (no usable close yet),
+    /// <c>true</c> = valid or repaired, <c>false</c> = implausible and not
+    /// repairable.
+    /// </summary>
+    public bool? IsPriceValid { get; set; }
+
+    /// <summary>
+    /// Per-share price to store: the reported value unchanged, or the
+    /// repaired value (<c>reported / shares</c>) when a fat-finger was fixed.
+    /// </summary>
+    public decimal EffectivePrice { get; set; }
+
+    /// <summary>True when <see cref="EffectivePrice"/> is a repaired value.</summary>
+    public bool WasRepaired { get; set; }
+}

--- a/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
+++ b/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
@@ -10,14 +10,9 @@ public class InsiderTradingModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<InsiderOwner>();
         builder.Entity<Form144Filing>();
         builder.Entity<Form144PriorSale>();
-        builder.Entity<InsiderTransaction>(entity =>
-        {
-            // SQL DEFAULT true so the column add doesn't backfill existing
-            // rows to false (which would hide every old row from the
-            // dashboard until the maintenance backfill runs). The parser
-            // explicitly sets this on new rows, so the default only ever
-            // applies to legacy data and to manually-inserted rows.
-            entity.Property(t => t.IsPriceValid).HasDefaultValue(true);
-        });
+        // IsPriceValid is intentionally left with no SQL default: a freshly
+        // inserted row is null ("not evaluated yet") until the parser (or a
+        // maintenance recompute) cross-checks it against the market close.
+        builder.Entity<InsiderTransaction>();
     }
 }

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -26,7 +26,24 @@ public class InsiderTransaction
     public TransactionCode TransactionCode { get; set; }
 
     public long Shares { get; set; }
+
+    /// <summary>
+    /// Effective per-share price used by dashboards and sorts. Equals
+    /// <see cref="ReportedPricePerShare"/> for normal rows; diverges only
+    /// when a fat-fingered filing was repaired — see <see cref="IsPriceValid"/>.
+    /// </summary>
     public decimal PricePerShare { get; set; }
+
+    /// <summary>
+    /// The per-share price exactly as filed, before any repair. Always
+    /// populated, so the raw filing value is never lost. When a filer types
+    /// the total transaction value into the per-share field, the repair
+    /// recovers the unit price as <c>ReportedPricePerShare / Shares</c> and
+    /// stores it in <see cref="PricePerShare"/>, leaving this column holding
+    /// the original (bad) value for audit and reversibility.
+    /// </summary>
+    public decimal ReportedPricePerShare { get; set; }
+
     public AcquiredDisposed AcquiredDisposed { get; set; }
     public long SharesOwnedAfter { get; set; }
     public OwnershipNature OwnershipNature { get; set; }
@@ -46,14 +63,22 @@ public class InsiderTransaction
     public bool IsAmendment { get; set; }
 
     /// <summary>
-    /// False when the filer typed a bogus value into transactionPricePerShare —
-    /// most commonly the total transaction value instead of the per-share price.
-    /// Detected by cross-checking against the Yahoo unadjusted close on
-    /// TransactionDate. Dashboards filter on this so a single fat-fingered Form 4
-    /// doesn't drown out every other row when sorted by Shares × PricePerShare.
-    /// Default true — only rows we positively reject are flipped to false.
+    /// Tri-state price-plausibility flag, cross-checked against the Yahoo
+    /// unadjusted close on TransactionDate:
+    /// <list type="bullet">
+    /// <item><c>null</c> — not evaluated yet (no close available when the row
+    /// was ingested); a later maintenance recompute re-checks it once the
+    /// close exists.</item>
+    /// <item><c>true</c> — plausible, or repaired (see
+    /// <see cref="ReportedPricePerShare"/>).</item>
+    /// <item><c>false</c> — implausible and not repairable (<see cref="Shares"/>
+    /// is 0, so the mis-entered total can't be divided back to a unit price).</item>
+    /// </list>
+    /// Dashboards show a row unless this is positively <c>false</c>, so a
+    /// single fat-fingered Form 4 doesn't drown out every other row when
+    /// sorted by Shares × PricePerShare.
     /// </summary>
-    public bool IsPriceValid { get; set; } = true;
+    public bool? IsPriceValid { get; set; }
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Migrations/Migrations/20260530212704_AddInsiderTransactionReportedPrice.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260530212704_AddInsiderTransactionReportedPrice.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260530212704_AddInsiderTransactionReportedPrice")]
+    partial class AddInsiderTransactionReportedPrice
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260530212704_AddInsiderTransactionReportedPrice.cs
+++ b/src/Equibles.Migrations/Migrations/20260530212704_AddInsiderTransactionReportedPrice.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInsiderTransactionReportedPrice : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsPriceValid",
+                table: "InsiderTransaction",
+                type: "boolean",
+                nullable: true,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldDefaultValue: true
+            );
+
+            // Reset previously-flagged rows to "not evaluated yet" (null) so
+            // the maintenance recompute re-checks and repairs them under the
+            // new logic. Rows that were valid stay valid.
+            migrationBuilder.Sql(
+                "UPDATE \"InsiderTransaction\" SET \"IsPriceValid\" = NULL WHERE \"IsPriceValid\" = false;"
+            );
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "ReportedPricePerShare",
+                table: "InsiderTransaction",
+                type: "numeric",
+                nullable: false,
+                defaultValue: 0m
+            );
+
+            // Backfill the as-filed price for every existing row. No repairs
+            // have been applied yet, so the original equals the current
+            // PricePerShare; this keeps ReportedPricePerShare non-null.
+            migrationBuilder.Sql(
+                "UPDATE \"InsiderTransaction\" SET \"ReportedPricePerShare\" = \"PricePerShare\";"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "ReportedPricePerShare", table: "InsiderTransaction");
+
+            // Collapse the tri-state back to a non-null bool: pending (null)
+            // rows revert to the original default (true) before the column is
+            // made NOT NULL again.
+            migrationBuilder.Sql(
+                "UPDATE \"InsiderTransaction\" SET \"IsPriceValid\" = true WHERE \"IsPriceValid\" IS NULL;"
+            );
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsPriceValid",
+                table: "InsiderTransaction",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldNullable: true
+            );
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -339,6 +339,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 AccessionNumber = filing.AccessionNumber,
                 SecurityTitle = "No Securities Owned",
                 TransactionOrder = 0,
+                // 0-price holding sentinel: nothing to validate or repair.
+                IsPriceValid = true,
             }
         );
         await transactionRepository.SaveChanges();
@@ -347,12 +349,13 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
     // Filer-reported transactionPricePerShare is unvalidated by EDGAR — some
     // filings dump the total transaction value (or a placeholder like the
     // share count) into that field, which then explodes the dashboard's
-    // Shares × Price sort. Cross-check against Yahoo's unadjusted close on
-    // the TransactionDate (most recent prior trading day for weekends/
-    // holidays) and flip the flag accordingly. If the Yahoo feed hasn't
-    // caught up yet for a freshly-filed transaction date, leave the default
-    // (true) — the backoffice backfill button re-evaluates everything once
-    // the close is available.
+    // Shares × Price sort. Preserve the as-filed value in ReportedPricePerShare,
+    // then cross-check against Yahoo's unadjusted close on the TransactionDate
+    // (most recent prior trading day for weekends/holidays): plausible rows
+    // stay as filed, implausible rows are repaired (total ÷ shares). If the
+    // Yahoo feed hasn't caught up yet, IsPriceValid is left null (pending) —
+    // the backoffice maintenance recompute re-evaluates it once the close
+    // exists, rather than silently accepting it as valid.
     private static async Task ApplyPriceValidity(
         List<InsiderTransaction> transactions,
         Guid companyId,
@@ -379,11 +382,20 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 .Where(p => p.Date <= transaction.TransactionDate)
                 .Select(p => (decimal?)p.Close)
                 .FirstOrDefault();
-            transaction.IsPriceValid = priceValidator.IsPlausible(
-                transaction.PricePerShare,
+
+            // Capture the as-filed price first; both this path and the backfill
+            // manager evaluate from ReportedPricePerShare so the "reported is
+            // the source of truth" invariant holds regardless of ordering.
+            transaction.ReportedPricePerShare = transaction.PricePerShare;
+
+            var evaluation = priceValidator.Evaluate(
+                transaction.ReportedPricePerShare,
+                transaction.Shares,
                 transaction.SecurityTitle,
                 close
             );
+            transaction.PricePerShare = evaluation.EffectivePrice;
+            transaction.IsPriceValid = evaluation.IsPriceValid;
         }
     }
 

--- a/src/Equibles.Web/Controllers/InsiderActivityController.cs
+++ b/src/Equibles.Web/Controllers/InsiderActivityController.cs
@@ -92,7 +92,9 @@ public class InsiderActivityController : BaseController
         Expression<Func<InsiderTransaction, TRow>> projection
     ) =>
         source
-            .Where(t => t.IsPriceValid)
+            // Show valid and not-yet-evaluated (null) rows; hide only rows
+            // positively rejected as implausible.
+            .Where(t => t.IsPriceValid != false)
             .OrderByDescending(t => t.Shares * t.PricePerShare)
             .Take(InsiderDashboardViewModel.RowCap)
             .Select(projection)

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTransactionPriceBackfillManagerRunTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTransactionPriceBackfillManagerRunTests.cs
@@ -13,10 +13,11 @@ namespace Equibles.IntegrationTests.InsiderTrading;
 /// <summary>
 /// End-to-end pin for the backfill manager's core recompute loop, which needs a
 /// real relational provider (it calls Database.SetCommandTimeout, unsupported by
-/// the in-memory provider used elsewhere). Contract: Run cross-checks every
-/// transaction's PricePerShare against the unadjusted close on its transaction
-/// date and flips IsPriceValid per the validator (>10x close = invalid), tallying
-/// MarkedInvalid / MarkedValid.
+/// the in-memory provider used elsewhere). Contract: Run evaluates only the
+/// not-yet-checked rows (IsPriceValid == null), cross-checks each reported price
+/// against the unadjusted close on its transaction date, repairs implausible
+/// rows (reported total ÷ shares) while preserving ReportedPricePerShare, and
+/// tallies Repaired / Valid / Invalid / Pending.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class InsiderTransactionPriceBackfillManagerRunTests : ParadeDbMcpTestBase
@@ -25,7 +26,7 @@ public class InsiderTransactionPriceBackfillManagerRunTests : ParadeDbMcpTestBas
         : base(fixture) { }
 
     [Fact]
-    public async Task Run_RecomputesValidity_FlipsImplausiblePriceAndKeepsPlausible()
+    public async Task Run_RepairsImplausiblePrice_AndKeepsPlausible()
     {
         var date = new DateOnly(2024, 6, 14);
         var stock = new CommonStock
@@ -76,14 +77,104 @@ public class InsiderTransactionPriceBackfillManagerRunTests : ParadeDbMcpTestBas
 
         result.Total.Should().Be(2);
         result.Processed.Should().Be(2);
-        result.MarkedInvalid.Should().Be(1);
-        result.MarkedValid.Should().Be(1);
+        result.Repaired.Should().Be(1);
+        result.Valid.Should().Be(1);
+        result.Invalid.Should().Be(0);
+        result.Pending.Should().Be(0);
 
         await using var verify = Fixture.CreateDbContext();
         var bad = await verify.Set<InsiderTransaction>().FindAsync(implausible.Id);
         var ok = await verify.Set<InsiderTransaction>().FindAsync(plausible.Id);
-        bad!.IsPriceValid.Should().BeFalse("$50,000 on a $50 close exceeds the 10x ceiling");
-        ok!.IsPriceValid.Should().BeTrue("$55 on a $50 close is within the 10x ceiling");
+
+        // Repaired: $50,000 on a $50 close exceeds the 10x ceiling, so the
+        // mis-entered total is divided by the 1,000 shares back to $50/share.
+        bad!.IsPriceValid.Should().BeTrue();
+        bad.PricePerShare.Should().Be(50m);
+        bad.ReportedPricePerShare.Should().Be(50_000m, "the as-filed value is preserved");
+
+        // Plausible: $55 on a $50 close is within the ceiling — untouched.
+        ok!.IsPriceValid.Should().BeTrue();
+        ok.PricePerShare.Should().Be(55m);
+        ok.ReportedPricePerShare.Should().Be(55m);
+    }
+
+    [Fact]
+    public async Task Run_NoClose_StaysPending_AndZeroShares_IsInvalidNotRepaired()
+    {
+        var date = new DateOnly(2024, 6, 14);
+        var priced = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        // Second stock has no DailyStockPrice on file → no usable close.
+        var unpriced = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "NONE",
+            Name = "Unlisted Co.",
+            Cik = "0000000001",
+        };
+        var owner = new InsiderOwner
+        {
+            Id = Guid.NewGuid(),
+            OwnerCik = "0001",
+            Name = "Jane Insider",
+            City = "Cupertino",
+            StateOrCountry = "CA",
+            IsDirector = true,
+        };
+        // Implausible ($50,000 on a $50 close) but 0 shares → can't divide.
+        var unrepairable = Transaction(priced, owner, date, 50_000m, "ACC-ZERO", shares: 0);
+        // Real price, no close on file → must stay pending (null), not valid.
+        var pending = Transaction(unpriced, owner, date, 12.34m, "ACC-PENDING");
+
+        DbContext.Add(priced);
+        DbContext.Add(unpriced);
+        DbContext.Add(owner);
+        DbContext.Add(
+            new DailyStockPrice
+            {
+                CommonStockId = priced.Id,
+                Date = date,
+                Close = 50m,
+            }
+        );
+        DbContext.Add(unrepairable);
+        DbContext.Add(pending);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var runCtx = Fixture.CreateDbContext();
+        var manager = new InsiderTransactionPriceBackfillManager(
+            new InsiderTransactionRepository(runCtx),
+            new DailyStockPriceRepository(runCtx),
+            new InsiderTransactionPriceValidator(),
+            runCtx,
+            NullLogger<InsiderTransactionPriceBackfillManager>()
+        );
+
+        var result = await manager.Run();
+
+        result.Total.Should().Be(2);
+        result.Repaired.Should().Be(0);
+        result.Valid.Should().Be(0);
+        result.Invalid.Should().Be(1);
+        result.Pending.Should().Be(1);
+
+        await using var verify = Fixture.CreateDbContext();
+        var zero = await verify.Set<InsiderTransaction>().FindAsync(unrepairable.Id);
+        var pend = await verify.Set<InsiderTransaction>().FindAsync(pending.Id);
+
+        // Unrepairable: positively rejected, price left as filed.
+        zero!.IsPriceValid.Should().BeFalse();
+        zero.PricePerShare.Should().Be(50_000m);
+
+        // Pending: no close yet, so it stays null for a later run to retry.
+        pend!.IsPriceValid.Should().BeNull();
+        pend.PricePerShare.Should().Be(12.34m);
     }
 
     private static InsiderTransaction Transaction(
@@ -91,7 +182,8 @@ public class InsiderTransactionPriceBackfillManagerRunTests : ParadeDbMcpTestBas
         InsiderOwner owner,
         DateOnly date,
         decimal pricePerShare,
-        string accession
+        string accession,
+        long shares = 1000
     ) =>
         new()
         {
@@ -101,8 +193,11 @@ public class InsiderTransactionPriceBackfillManagerRunTests : ParadeDbMcpTestBas
             FilingDate = date,
             TransactionDate = date,
             TransactionCode = TransactionCode.Purchase,
-            Shares = 1000,
+            Shares = shares,
             PricePerShare = pricePerShare,
+            // As-filed value, always populated by the migration / ingest;
+            // IsPriceValid left null so Run treats the row as unevaluated.
+            ReportedPricePerShare = pricePerShare,
             AcquiredDisposed = AcquiredDisposed.Acquired,
             SharesOwnedAfter = 5000,
             OwnershipNature = OwnershipNature.Direct,

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs
@@ -119,4 +119,89 @@ public class InsiderTransactionPriceValidatorTests
 
         result.Should().BeTrue();
     }
+
+    // Evaluate — full tri-state + repair. Unlike IsPlausible, a missing close
+    // is *pending* (null), not an automatic pass: the row gets re-checked once
+    // the close lands instead of being silently accepted.
+    [Fact]
+    public void Evaluate_CommonStockWithNullClose_IsPending()
+    {
+        var result = _validator.Evaluate(
+            0.24m,
+            shares: 1000,
+            "Common Stock",
+            unadjustedClose: null
+        );
+
+        result.IsPriceValid.Should().BeNull();
+        result.WasRepaired.Should().BeFalse();
+        result.EffectivePrice.Should().Be(0.24m);
+    }
+
+    // The bug this feature exists to fix — filer typed the total transaction
+    // value ($24,035,774.40) into the per-share field. Divide by the share
+    // count to recover the unit price, and mark it valid.
+    [Fact]
+    public void Evaluate_TotalValueInPriceField_RepairsByDividingByShares()
+    {
+        var result = _validator.Evaluate(
+            reportedPrice: 24_035_774.40m,
+            shares: 100_149_893, // 24,035,774.40 / 0.24
+            securityTitle: "Common Stock",
+            unadjustedClose: 0.24m
+        );
+
+        result.IsPriceValid.Should().BeTrue();
+        result.WasRepaired.Should().BeTrue();
+        result.EffectivePrice.Should().Be(24_035_774.40m / 100_149_893);
+    }
+
+    // Implausible but no share count to divide by — can't repair, so it's
+    // positively rejected (the only thing dashboards hide).
+    [Fact]
+    public void Evaluate_ImplausibleWithZeroShares_IsInvalidNotRepaired()
+    {
+        var result = _validator.Evaluate(50_000m, shares: 0, "Common Stock", unadjustedClose: 50m);
+
+        result.IsPriceValid.Should().BeFalse();
+        result.WasRepaired.Should().BeFalse();
+        result.EffectivePrice.Should().Be(50_000m);
+    }
+
+    [Fact]
+    public void Evaluate_PlausiblePrice_IsValidUnchanged()
+    {
+        var result = _validator.Evaluate(55m, shares: 1000, "Common Stock", unadjustedClose: 50m);
+
+        result.IsPriceValid.Should().BeTrue();
+        result.WasRepaired.Should().BeFalse();
+        result.EffectivePrice.Should().Be(55m);
+    }
+
+    // Derivatives carry the instrument's own price; never repaired, valid even
+    // far above the underlying close and even with no close on file.
+    [Fact]
+    public void Evaluate_DerivativeWayAboveClose_IsValidUnchanged()
+    {
+        var result = _validator.Evaluate(
+            50_000m,
+            shares: 1000,
+            "Stock Option (Right to Buy)",
+            unadjustedClose: 50m
+        );
+
+        result.IsPriceValid.Should().BeTrue();
+        result.WasRepaired.Should().BeFalse();
+        result.EffectivePrice.Should().Be(50_000m);
+    }
+
+    [Fact]
+    public void Evaluate_ZeroPrice_IsValidWithoutClose()
+    {
+        var result = _validator.Evaluate(0m, shares: 0, "Common Stock", unadjustedClose: null);
+
+        result.IsPriceValid.Should().BeTrue();
+        result.WasRepaired.Should().BeFalse();
+        result.EffectivePrice.Should().Be(0m);
+    }
 }


### PR DESCRIPTION
## Summary

Form 4 filers sometimes type the **total transaction value** into the per-share price field, producing trillion-dollar per-share values that dominate the Shares × Price insider dashboards. Until now these rows were only *flagged* (`IsPriceValid = false`) and hidden — the bad price stayed in the row.

This repairs the recoverable ones. When a reported price is implausible against the Yahoo unadjusted close (>10×) and a share count is present, the mis-entered total is divided by the shares to recover the unit price. The original as-filed value is preserved in a new `ReportedPricePerShare` column for audit and reversibility.

`IsPriceValid` becomes **tri-state** (nullable):
- `null` — not evaluated yet (no close available at ingest); a later recompute retries it.
- `true` — plausible, or repaired.
- `false` — implausible and unrepairable (no share count to divide by).

The maintenance recompute now processes **only** the `null` rows, keyset-paginated by `(TransactionDate, Id)` and clearing the change tracker per batch. A row is evaluated exactly once, so re-runs no longer rescan the whole table (this also fixes the prior full-history price scan that made the recompute take ~hours). Rows with no usable close stay pending and are retried on a later run.

## Code changes

- **`InsiderTransaction`** — `IsPriceValid` is now `bool?`; new `ReportedPricePerShare` (NOT NULL) holds the as-filed price.
- **`InsiderTransactionPriceValidator.Evaluate`** — new pure tri-state evaluation + repair (missing close ⇒ pending; implausible & shares>0 ⇒ divide & valid; implausible & shares==0 ⇒ false; else valid). `IsPlausible` is unchanged.
- **`InsiderTransactionPriceBackfillManager.Run`** — processes only `IsPriceValid == null`, keyset by `(TransactionDate, Id)`, clears the change tracker per batch, tallies Repaired/Valid/Invalid/Pending.
- **`InsiderTradingFilingProcessor.ApplyPriceValidity`** — sets `ReportedPricePerShare`, uses `Evaluate`, leaves `IsPriceValid` null when no close.
- **`InsiderActivityController`** — read filter `IsPriceValid != false` (shows valid + not-yet-evaluated, hides only positively rejected).
- **Migration** — adds `ReportedPricePerShare`, copies `PricePerShare` into it for all existing rows, makes `IsPriceValid` nullable, and resets existing `false` rows to `null` so they get repaired. (Uses two data-only `UPDATE`s — a column-to-column copy and a flag reset can't be expressed without SQL.)
- **Tests** — `Evaluate` unit tests (pending / repair / unrepairable / valid / derivative / zero); backfill integration tests for repair+valid and pending+invalid.

## Notes

- Forward-only: `Down` collapses the tri-state back to bool and drops the repaired/original values.
- Repair is applied to **all** flagged rows with a share count, preserving the original — so a non-"total in per-share" error is also divided, but the as-filed value is never lost.
