### PR TITLE
refactor(sec): collapse three duplicated filing repositories into SecFilingRepositoryBase

### DIFF
--- a/src/Equibles.Sec.Data/Contracts/IStockFiling.cs
+++ b/src/Equibles.Sec.Data/Contracts/IStockFiling.cs
@@ -1,0 +1,13 @@
+namespace Equibles.Sec.Data.Contracts;
+
+/// <summary>
+/// Shared shape for issuer-attributed SEC filings keyed by stock, accession number and
+/// filing date. Lets <c>SecFilingRepositoryBase&lt;TFiling&gt;</c> provide the common
+/// by-stock / by-accession / recent queries without duplicating them per filing type.
+/// </summary>
+public interface IStockFiling
+{
+    Guid CommonStockId { get; set; }
+    string AccessionNumber { get; set; }
+    DateOnly FilingDate { get; set; }
+}

--- a/src/Equibles.Sec.Data/Models/FormDFiling.cs
+++ b/src/Equibles.Sec.Data/Models/FormDFiling.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.Data.Contracts;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Sec.Data.Models;
@@ -15,7 +16,7 @@ namespace Equibles.Sec.Data.Models;
 [Index(nameof(CommonStockId), nameof(FilingDate))]
 [Index(nameof(AccessionNumber), IsUnique = true)]
 [Index(nameof(FilingDate))]
-public class FormDFiling
+public class FormDFiling : IStockFiling
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public Guid Id { get; set; } = Guid.NewGuid();

--- a/src/Equibles.Sec.Data/Models/NCenFiling.cs
+++ b/src/Equibles.Sec.Data/Models/NCenFiling.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.Data.Contracts;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Sec.Data.Models;
@@ -17,7 +18,7 @@ namespace Equibles.Sec.Data.Models;
 [Index(nameof(CommonStockId), nameof(FilingDate))]
 [Index(nameof(AccessionNumber), IsUnique = true)]
 [Index(nameof(FilingDate))]
-public class NCenFiling
+public class NCenFiling : IStockFiling
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public Guid Id { get; set; } = Guid.NewGuid();

--- a/src/Equibles.Sec.Data/Models/NportFiling.cs
+++ b/src/Equibles.Sec.Data/Models/NportFiling.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.Data.Contracts;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Sec.Data.Models;
@@ -17,7 +18,7 @@ namespace Equibles.Sec.Data.Models;
 [Index(nameof(CommonStockId), nameof(FilingDate))]
 [Index(nameof(AccessionNumber), IsUnique = true)]
 [Index(nameof(FilingDate))]
-public class NportFiling
+public class NportFiling : IStockFiling
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public Guid Id { get; set; } = Guid.NewGuid();

--- a/src/Equibles.Sec.Repositories/FormDFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/FormDFilingRepository.cs
@@ -1,26 +1,10 @@
-using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
 using Equibles.Sec.Data.Models;
 
 namespace Equibles.Sec.Repositories;
 
-public class FormDFilingRepository : BaseRepository<FormDFiling>
+public class FormDFilingRepository : SecFilingRepositoryBase<FormDFiling>
 {
     public FormDFilingRepository(EquiblesFinancialDbContext dbContext)
         : base(dbContext) { }
-
-    public IQueryable<FormDFiling> GetByStock(CommonStock stock)
-    {
-        return GetAll().Where(f => f.CommonStockId == stock.Id);
-    }
-
-    public IQueryable<FormDFiling> GetByAccessionNumber(string accessionNumber)
-    {
-        return GetAll().Where(f => f.AccessionNumber == accessionNumber);
-    }
-
-    public IQueryable<FormDFiling> GetRecent(DateOnly since)
-    {
-        return GetAll().Where(f => f.FilingDate >= since);
-    }
 }

--- a/src/Equibles.Sec.Repositories/NCenFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NCenFilingRepository.cs
@@ -1,26 +1,10 @@
-using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
 using Equibles.Sec.Data.Models;
 
 namespace Equibles.Sec.Repositories;
 
-public class NCenFilingRepository : BaseRepository<NCenFiling>
+public class NCenFilingRepository : SecFilingRepositoryBase<NCenFiling>
 {
     public NCenFilingRepository(EquiblesFinancialDbContext dbContext)
         : base(dbContext) { }
-
-    public IQueryable<NCenFiling> GetByStock(CommonStock stock)
-    {
-        return GetAll().Where(f => f.CommonStockId == stock.Id);
-    }
-
-    public IQueryable<NCenFiling> GetByAccessionNumber(string accessionNumber)
-    {
-        return GetAll().Where(f => f.AccessionNumber == accessionNumber);
-    }
-
-    public IQueryable<NCenFiling> GetRecent(DateOnly since)
-    {
-        return GetAll().Where(f => f.FilingDate >= since);
-    }
 }

--- a/src/Equibles.Sec.Repositories/NportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NportFilingRepository.cs
@@ -1,28 +1,12 @@
-using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
 using Equibles.Sec.Data.Models;
 
 namespace Equibles.Sec.Repositories;
 
-public class NportFilingRepository : BaseRepository<NportFiling>
+public class NportFilingRepository : SecFilingRepositoryBase<NportFiling>
 {
     public NportFilingRepository(EquiblesFinancialDbContext dbContext)
         : base(dbContext) { }
-
-    public IQueryable<NportFiling> GetByStock(CommonStock stock)
-    {
-        return GetAll().Where(f => f.CommonStockId == stock.Id);
-    }
-
-    public IQueryable<NportFiling> GetByAccessionNumber(string accessionNumber)
-    {
-        return GetAll().Where(f => f.AccessionNumber == accessionNumber);
-    }
-
-    public IQueryable<NportFiling> GetRecent(DateOnly since)
-    {
-        return GetAll().Where(f => f.FilingDate >= since);
-    }
 
     public IQueryable<NportHolding> GetHoldings(NportFiling filing)
     {

--- a/src/Equibles.Sec.Repositories/SecFilingRepositoryBase.cs
+++ b/src/Equibles.Sec.Repositories/SecFilingRepositoryBase.cs
@@ -1,0 +1,31 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Sec.Data.Contracts;
+
+namespace Equibles.Sec.Repositories;
+
+/// <summary>
+/// Base repository for issuer-attributed SEC filings, providing the by-stock,
+/// by-accession-number and recent queries shared by every filing type.
+/// </summary>
+public abstract class SecFilingRepositoryBase<TFiling> : BaseRepository<TFiling>
+    where TFiling : class, IStockFiling
+{
+    protected SecFilingRepositoryBase(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<TFiling> GetByStock(CommonStock stock)
+    {
+        return GetAll().Where(f => f.CommonStockId == stock.Id);
+    }
+
+    public IQueryable<TFiling> GetByAccessionNumber(string accessionNumber)
+    {
+        return GetAll().Where(f => f.AccessionNumber == accessionNumber);
+    }
+
+    public IQueryable<TFiling> GetRecent(DateOnly since)
+    {
+        return GetAll().Where(f => f.FilingDate >= since);
+    }
+}


### PR DESCRIPTION
## Summary

- `FormDFilingRepository`, `NCenFilingRepository` and `NportFilingRepository` each carried an identical trio of query methods (`GetByStock`, `GetByAccessionNumber`, `GetRecent`). This collapses them into one shared generic base, removing the duplication and the drift risk that comes with it.
- Behavior-preserving: query predicates, public method signatures, and return types are unchanged; all callers compile as-is and the Sec integration suite passes.

## Code changes

- `src/Equibles.Sec.Data/Contracts/IStockFiling.cs` — new marker interface describing the shared shape of an issuer-attributed filing (`CommonStockId`, `AccessionNumber`, `FilingDate`).
- `src/Equibles.Sec.Repositories/SecFilingRepositoryBase.cs` — new generic base `SecFilingRepositoryBase<TFiling>` (constrained to `IStockFiling`) providing the three shared queries.
- `src/Equibles.Sec.Data/Models/{FormDFiling,NCenFiling,NportFiling}.cs` — implement `IStockFiling` (additive; properties already existed).
- `src/Equibles.Sec.Repositories/{FormDFilingRepository,NCenFilingRepository,NportFilingRepository}.cs` — inherit the base and drop the duplicated methods. `NportFilingRepository` keeps its filing-specific `GetHoldings`.