### PR TITLE
refactor(sec): collapse duplicated Attr/Clean XML helpers into EdgarXmlSubmissionParser

### DIFF
--- a/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
+++ b/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
@@ -17,6 +17,9 @@ internal static class EdgarXmlSubmissionParser
     private const string XmlEnvelopeStart = "<XML>";
     private const string XmlEnvelopeEnd = "</XML>";
 
+    // Optional fields the filer leaves blank are reported as the literal "N/A"; treat as absent.
+    private const string NotApplicable = "N/A";
+
     /// <summary>
     /// Strips the SGML envelope and escapes stray ampersands so the payload parses as XML.
     /// </summary>
@@ -111,5 +114,25 @@ internal static class EdgarXmlSubmissionParser
     {
         var value = El(parent, name)?.Value?.Trim();
         return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    /// <summary>
+    /// Trimmed value of the named attribute (namespace-agnostic), or <c>null</c> when missing or empty.
+    /// </summary>
+    internal static string Attr(XElement element, string name)
+    {
+        var value = element?.Attributes().FirstOrDefault(a => a.Name.LocalName == name)?.Value;
+        return string.IsNullOrEmpty(value) ? null : value.Trim();
+    }
+
+    /// <summary>
+    /// Trimmed text with the "N/A" placeholder and blanks normalized to <c>null</c>.
+    /// </summary>
+    internal static string Clean(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        var trimmed = value.Trim();
+        return trimmed.Equals(NotApplicable, StringComparison.OrdinalIgnoreCase) ? null : trimmed;
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
@@ -23,9 +23,6 @@ public class NCenFilingProcessor : IssuerFeedFilingProcessor<NCenFiling, NCenFil
     // N-CEN dates are ISO yyyy-MM-dd.
     private static readonly string[] DateFormats = ["yyyy-MM-dd"];
 
-    // Optional fields the filer leaves blank are reported as the literal "N/A"; treat as absent.
-    private const string NotApplicable = "N/A";
-
     public NCenFilingProcessor(
         IServiceScopeFactory scopeFactory,
         ILogger<NCenFilingProcessor> logger,
@@ -253,23 +250,6 @@ public class NCenFilingProcessor : IssuerFeedFilingProcessor<NCenFiling, NCenFil
             return submissionType.Contains("/A", StringComparison.OrdinalIgnoreCase);
 
         return filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
-    }
-
-    // ── XML helpers (navigate by local name; N-CEN declares the ncen namespace) ──────
-
-    private static string Attr(XElement element, string name)
-    {
-        var value = element?.Attributes().FirstOrDefault(a => a.Name.LocalName == name)?.Value;
-        return string.IsNullOrEmpty(value) ? null : value.Trim();
-    }
-
-    // Normalize the "N/A" placeholder and blanks to null.
-    private static string Clean(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return null;
-        var trimmed = value.Trim();
-        return trimmed.Equals(NotApplicable, StringComparison.OrdinalIgnoreCase) ? null : trimmed;
     }
 
     // Pinned by processor-scoped tests; the implementation lives in the shared parser.

--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -23,9 +23,6 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
     // NPORT dates are ISO yyyy-MM-dd.
     private static readonly string[] DateFormats = ["yyyy-MM-dd"];
 
-    // Optional identifiers the filer leaves blank are reported as the literal "N/A"; treat as absent.
-    private const string NotApplicable = "N/A";
-
     public NportFilingProcessor(
         IServiceScopeFactory scopeFactory,
         ILogger<NportFilingProcessor> logger,
@@ -147,23 +144,6 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
             return submissionType.Contains("/A", StringComparison.OrdinalIgnoreCase);
 
         return filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
-    }
-
-    // ── XML helpers (navigate by local name; NPORT declares the nport namespace) ──────
-
-    private static string Attr(XElement element, string name)
-    {
-        var value = element?.Attributes().FirstOrDefault(a => a.Name.LocalName == name)?.Value;
-        return string.IsNullOrEmpty(value) ? null : value.Trim();
-    }
-
-    // Normalize the "N/A" placeholder and blanks to null.
-    private static string Clean(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return null;
-        var trimmed = value.Trim();
-        return trimmed.Equals(NotApplicable, StringComparison.OrdinalIgnoreCase) ? null : trimmed;
     }
 
     // Pinned by processor-scoped tests; the implementation lives in the shared parser.


### PR DESCRIPTION
## Summary

- `NCenFilingProcessor` and `NportFilingProcessor` each carried byte-identical private `Attr` and `Clean` XML/value helpers (plus the `NotApplicable = "N/A"` constant they share). This completes the earlier consolidation that moved `El`/`Els`/`Val` into the shared `EdgarXmlSubmissionParser`, removing the last duplicated navigation/normalization helpers between the two sibling processors.
- Behaviour-preserving: the helper bodies and the `NotApplicable` value are unchanged, both processors already `using static EdgarXmlSubmissionParser`, so the existing call sites now resolve to the identical shared implementation.

## Code changes

- `Helpers/EdgarXmlSubmissionParser.cs` — added `internal static Attr(...)` and `Clean(...)` alongside `El`/`Els`/`Val`, plus the `NotApplicable` constant.
- `Services/NCenFilingProcessor.cs` — removed the local `Attr`/`Clean` helpers, the `NotApplicable` constant, and the now-orphaned XML-helpers comment header.
- `Services/NportFilingProcessor.cs` — same removal.