### PR TITLE
test(web): add skipped repro for GH-2907 — stock search wildcard escaping

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/StocksControllerSearchWildcardEscapingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerSearchWildcardEscapingTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// End-to-end adversarial probe of the stock browser search box
+/// (<c>GET /Stocks?search=...</c> → <c>StocksController.Index</c> →
+/// <c>CommonStockRepository.Search</c>). The contract a search box promises is
+/// "match rows whose ticker/name/description/industry CONTAINS the typed term";
+/// the typed characters must be matched literally. <c>Search</c> splices the
+/// term straight into <c>EF.Functions.ILike(col, $"%{word}%")</c> without
+/// escaping LIKE metacharacters, so <c>_</c> (any single character) is honoured
+/// as a wildcard: a search for the literal underscore matches every stock whose
+/// columns hold at least one character. This test seeds two stocks that contain
+/// no underscore anywhere and asserts neither is returned for <c>?search=_</c>.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class StocksControllerSearchWildcardEscapingTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public StocksControllerSearchWildcardEscapingTests(WebHostFixture fixture) =>
+        _fixture = fixture;
+
+    [Fact(
+        Skip = "GH-2907 — CommonStockRepository.Search treats LIKE wildcards _ and % as wildcards instead of literals"
+    )]
+    public async Task Index_UnderscoreSearchTerm_DoesNotMatchStocksWithoutLiteralUnderscore()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "AAPL",
+                    Name = "Apple Inc",
+                    Description = "Consumer electronics maker",
+                    Cik = "0000320193",
+                }
+            );
+            db.Add(
+                new CommonStock
+                {
+                    Ticker = "MSFT",
+                    Name = "Microsoft Corporation",
+                    Description = "Enterprise software vendor",
+                    Cik = "0000789019",
+                }
+            );
+            await db.SaveChangesAsync();
+        });
+
+        var response = await _fixture.Client.GetAsync("/Stocks?search=_");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+
+        // Neither seeded name contains a literal underscore, so a literal-term
+        // search must return no rows. A wildcard-honouring '_' renders both.
+        html.Should().NotContain("Apple Inc");
+        html.Should().NotContain("Microsoft Corporation");
+    }
+}


### PR DESCRIPTION
## Summary

- The stock browser search box (`GET /Stocks?search=...`) splices the query into `EF.Functions.ILike` without escaping LIKE metacharacters, so a literal `_` or `%` is honoured as a wildcard — a search for `_` returns the whole table. Skipped — see GH-2907.
- Adds one functional end-to-end adversarial test that reproduces the defect through routing → controller → repository → rendered view. Same root cause as #2905 (adviser search), here on the platform's primary search surface.

## Code changes

- `tests/Equibles.IntegrationTests/Web/StocksControllerSearchWildcardEscapingTests.cs` — new `[Fact(Skip)]` regression test: seeds two stocks with no underscore in their fields, issues `GET /Stocks?search=_`, and asserts neither is rendered. Currently fails (bug reproduces); skipped until the LIKE-escaping fix lands, then un-skip as the guard.