### PR TITLE
feat(insider-trading): capture raw filing XML and classify securities by table

### DIFF
--- a/src/Equibles.InsiderTrading.Data/Equibles.InsiderTrading.Data.csproj
+++ b/src/Equibles.InsiderTrading.Data/Equibles.InsiderTrading.Data.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\Equibles.CommonStocks.Data\Equibles.CommonStocks.Data.csproj" />
+    <ProjectReference Include="..\Equibles.Media.Data\Equibles.Media.Data.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
+++ b/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
@@ -10,6 +10,7 @@ public class InsiderTradingModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<InsiderOwner>();
         builder.Entity<Form144Filing>();
         builder.Entity<Form144PriorSale>();
+        builder.Entity<InsiderFiling>();
         // IsPriceValid is intentionally left with no SQL default: a freshly
         // inserted row is null ("not evaluated yet") until the parser (or a
         // maintenance recompute) cross-checks it against the market close.

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderFiling.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderFiling.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.InsiderTrading.Data.Models;
+
+/// <summary>
+/// One row per SEC Form 3/4/5 filing, holding the gzip-compressed raw ownership
+/// XML exactly as parsed. Keyed by <see cref="AccessionNumber"/> (the same key
+/// the transactions carry), so the filing's transactions can be re-derived from
+/// the stored XML without re-fetching from EDGAR.
+///
+/// This is what makes reprocessing cheap: when the parser changes (a bumped
+/// <see cref="InsiderTransaction.CurrentParserVersion"/>), stale transactions
+/// are re-parsed from the cached XML here — a local read, not a rate-limited
+/// network crawl.
+/// </summary>
+[Index(nameof(AccessionNumber), IsUnique = true)]
+[Index(nameof(CaptureStatus))]
+public class InsiderFiling
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// SEC accession number of the filing (globally unique, e.g.
+    /// 0000320193-24-000123). Matches <see cref="InsiderTransaction.AccessionNumber"/>.
+    /// </summary>
+    [Required]
+    [MaxLength(32)]
+    public string AccessionNumber { get; set; }
+
+    /// <summary>
+    /// The file holding the gzip-compressed ownership XML. Null when no XML was
+    /// captured (status <see cref="InsiderFilingCaptureStatus.NotChecked"/> or
+    /// <see cref="InsiderFilingCaptureStatus.NotPresent"/>). The stored
+    /// (compressed) size is <c>Content.Size</c>; the pre-compression size is
+    /// <see cref="UncompressedSize"/>.
+    /// </summary>
+    public Guid? ContentId { get; set; }
+    public virtual File Content { get; set; }
+
+    /// <summary>Size in bytes of the ownership XML before gzip compression. Null when none captured.</summary>
+    public long? UncompressedSize { get; set; }
+
+    public InsiderFilingCaptureStatus CaptureStatus { get; set; } =
+        InsiderFilingCaptureStatus.NotChecked;
+
+    /// <summary>
+    /// How many times a backfill has tried (and failed to reach a terminal
+    /// result) to capture this filing's XML. Lets a permanently-unfetchable
+    /// filing stop starving the backfill queue. Only meaningful while
+    /// <see cref="CaptureStatus"/> is <see cref="InsiderFilingCaptureStatus.NotChecked"/>.
+    /// </summary>
+    public int CaptureAttempts { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderFilingCaptureStatus.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderFilingCaptureStatus.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.InsiderTrading.Data.Models;
+
+/// <summary>
+/// Tracks whether the raw ownership XML for a Form 3/4/5 filing has been
+/// captured into an <see cref="InsiderFiling"/>. Mirrors the proven XBRL
+/// capture states on the SEC document: freshly-ingested filings are stored as
+/// <see cref="Captured"/>; <see cref="NotChecked"/> leaves a filing as a
+/// backfill target; <see cref="NotPresent"/> marks legacy pre-XML filings that
+/// have no ownership document to store.
+/// </summary>
+public enum InsiderFilingCaptureStatus
+{
+    [Display(Name = "Not checked")]
+    NotChecked = 0,
+
+    [Display(Name = "Captured")]
+    Captured = 1,
+
+    [Display(Name = "Not present")]
+    NotPresent = 2,
+}

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderSecurityKind.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderSecurityKind.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.InsiderTrading.Data.Models;
+
+/// <summary>
+/// Whether an insider transaction concerns the issuer's actual shares or a
+/// derivative instrument (option, warrant, convertible, etc.). Derived
+/// authoritatively from which Form 4 table the row was parsed from —
+/// <c>nonDerivativeTable</c> vs <c>derivativeTable</c> — not from the security
+/// title text. <see cref="Unknown"/> marks rows that predate this capture and
+/// haven't been reclassified yet.
+/// </summary>
+public enum InsiderSecurityKind
+{
+    [Display(Name = "Unknown")]
+    Unknown = 0,
+
+    [Display(Name = "Non-derivative")]
+    NonDerivative = 1,
+
+    [Display(Name = "Derivative")]
+    Derivative = 2,
+}

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -10,8 +10,19 @@ namespace Equibles.InsiderTrading.Data.Models;
 [Index(nameof(FilingDate))]
 [Index(nameof(TransactionDate))]
 [Index(nameof(IsPriceValid), nameof(TransactionDate))]
+[Index(nameof(SecurityKind), nameof(TransactionDate))]
+[Index(nameof(ParserVersion))]
 public class InsiderTransaction
 {
+    /// <summary>
+    /// Version of the parsing algorithm that produced this row. Bumped whenever
+    /// the parser starts extracting something new from the filing XML (a new
+    /// field, a corrected classification). Rows below this value can be
+    /// re-parsed from the cached <see cref="InsiderFiling"/> XML rather than
+    /// re-fetched from EDGAR. Rows ingested before versioning default to 0.
+    /// </summary>
+    public const int CurrentParserVersion = 1;
+
     public Guid Id { get; set; } = Guid.NewGuid();
 
     public Guid InsiderOwnerId { get; set; }
@@ -61,6 +72,21 @@ public class InsiderTransaction
     public int TransactionOrder { get; set; }
 
     public bool IsAmendment { get; set; }
+
+    /// <summary>
+    /// Whether this row concerns the issuer's actual shares or a derivative
+    /// instrument, taken from the Form 4 table it was parsed from (not the
+    /// title text). <see cref="InsiderSecurityKind.Unknown"/> for rows ingested
+    /// before this was captured; those are reclassified by a reprocess pass.
+    /// </summary>
+    public InsiderSecurityKind SecurityKind { get; set; } = InsiderSecurityKind.Unknown;
+
+    /// <summary>
+    /// Parsing-algorithm version that produced this row. See
+    /// <see cref="CurrentParserVersion"/>. Defaults to 0 for rows ingested
+    /// before versioning, which marks them for reprocessing.
+    /// </summary>
+    public int ParserVersion { get; set; }
 
     /// <summary>
     /// Tri-state price-plausibility flag, cross-checked against the Yahoo

--- a/src/Equibles.InsiderTrading.Repositories/InsiderFilingRepository.cs
+++ b/src/Equibles.InsiderTrading.Repositories/InsiderFilingRepository.cs
@@ -1,0 +1,15 @@
+using Equibles.Data;
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.InsiderTrading.Repositories;
+
+public class InsiderFilingRepository : BaseRepository<InsiderFiling>
+{
+    public InsiderFilingRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<InsiderFiling> GetByAccessionNumber(string accessionNumber)
+    {
+        return GetAll().Where(f => f.AccessionNumber == accessionNumber);
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260531012524_AddInsiderFilingAndSecurityKind.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260531012524_AddInsiderFilingAndSecurityKind.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260531012524_AddInsiderFilingAndSecurityKind")]
+    partial class AddInsiderFilingAndSecurityKind
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260531012524_AddInsiderFilingAndSecurityKind.cs
+++ b/src/Equibles.Migrations/Migrations/20260531012524_AddInsiderFilingAndSecurityKind.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInsiderFilingAndSecurityKind : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ParserVersion",
+                table: "InsiderTransaction",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0
+            );
+
+            migrationBuilder.AddColumn<int>(
+                name: "SecurityKind",
+                table: "InsiderTransaction",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0
+            );
+
+            migrationBuilder.CreateTable(
+                name: "InsiderFiling",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccessionNumber = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: false
+                    ),
+                    ContentId = table.Column<Guid>(type: "uuid", nullable: true),
+                    UncompressedSize = table.Column<long>(type: "bigint", nullable: true),
+                    CaptureStatus = table.Column<int>(type: "integer", nullable: false),
+                    CaptureAttempts = table.Column<int>(type: "integer", nullable: false),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InsiderFiling", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_InsiderFiling_File_ContentId",
+                        column: x => x.ContentId,
+                        principalTable: "File",
+                        principalColumn: "Id"
+                    );
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderTransaction_ParserVersion",
+                table: "InsiderTransaction",
+                column: "ParserVersion"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderTransaction_SecurityKind_TransactionDate",
+                table: "InsiderTransaction",
+                columns: new[] { "SecurityKind", "TransactionDate" }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderFiling_AccessionNumber",
+                table: "InsiderFiling",
+                column: "AccessionNumber",
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderFiling_CaptureStatus",
+                table: "InsiderFiling",
+                column: "CaptureStatus"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderFiling_ContentId",
+                table: "InsiderFiling",
+                column: "ContentId"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "InsiderFiling");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_ParserVersion",
+                table: "InsiderTransaction"
+            );
+
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_SecurityKind_TransactionDate",
+                table: "InsiderTransaction"
+            );
+
+            migrationBuilder.DropColumn(name: "ParserVersion", table: "InsiderTransaction");
+
+            migrationBuilder.DropColumn(name: "SecurityKind", table: "InsiderTransaction");
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -1,5 +1,4 @@
 using System.Data;
-using System.IO.Compression;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Media.BusinessLogic;
@@ -92,7 +91,7 @@ public class DocumentPersistenceService : IDocumentPersistenceService
             return;
         }
 
-        var compressed = Compress(xbrl.RawBytes);
+        var compressed = GzipCompressor.Compress(xbrl.RawBytes);
         // File.Name is capped at 256 chars; EDGAR document names are bare short tokens, but
         // guard against a pathological envelope value so the insert can never overflow.
         var name =
@@ -110,15 +109,5 @@ public class DocumentPersistenceService : IDocumentPersistenceService
         document.XbrlType = xbrl.Type;
         document.XbrlUncompressedSize = xbrl.RawBytes.Length;
         document.XbrlStatus = XbrlCaptureStatus.Captured;
-    }
-
-    private static byte[] Compress(byte[] raw)
-    {
-        using var output = new MemoryStream();
-        using (var gzip = new GZipStream(output, CompressionLevel.Optimal))
-        {
-            gzip.Write(raw, 0, raw.Length);
-        }
-        return output.ToArray();
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/GzipCompressor.cs
+++ b/src/Equibles.Sec.HostedService/Services/GzipCompressor.cs
@@ -1,0 +1,20 @@
+using System.IO.Compression;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Gzip helper shared by the SEC ingest services that cache raw filing payloads
+/// (the XBRL envelope on a document, the ownership XML on an insider filing).
+/// </summary>
+internal static class GzipCompressor
+{
+    public static byte[] Compress(byte[] raw)
+    {
+        using var output = new MemoryStream();
+        using (var gzip = new GZipStream(output, CompressionLevel.Optimal))
+        {
+            gzip.Write(raw, 0, raw.Length);
+        }
+        return output.ToArray();
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Equibles.CommonStocks.Data.Models;
@@ -9,6 +10,7 @@ using Equibles.InsiderTrading.Data.Models;
 using Equibles.InsiderTrading.Repositories;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
+using Equibles.Media.BusinessLogic;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Contracts;
 using Equibles.Yahoo.Repositories;
@@ -53,6 +55,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         var ownerRepository = scope.ServiceProvider.GetRequiredService<InsiderOwnerRepository>();
         var transactionRepository =
             scope.ServiceProvider.GetRequiredService<InsiderTransactionRepository>();
+        var filingRepository = scope.ServiceProvider.GetRequiredService<InsiderFilingRepository>();
+        var fileManager = scope.ServiceProvider.GetRequiredService<IFileManager>();
         var dailyStockPriceRepository =
             scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
         var priceValidator =
@@ -85,6 +89,10 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             return false;
 
         var isAmendment = filing.Form.Contains("/A", StringComparison.OrdinalIgnoreCase);
+
+        // Cache the raw ownership XML so the filing can be re-parsed locally
+        // when the parser changes, without re-fetching from EDGAR.
+        await CaptureFilingXml(root, filing, filingRepository, fileManager);
 
         var transactions = ParseAllTransactions(root, owner, companyId, filing, isAmendment);
 
@@ -156,21 +164,83 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             transactions.Add(tx);
         }
 
-        void WalkTable(string tableName, string txName, string holdingName)
+        void WalkTable(
+            string tableName,
+            string txName,
+            string holdingName,
+            InsiderSecurityKind kind
+        )
         {
             var table = root.Element(tableName);
             if (table == null)
                 return;
             foreach (var txElement in table.Elements(txName))
-                AddParsed(ParseTransaction(txElement, owner, companyId, filing, isAmendment));
+                AddParsed(ParseTransaction(txElement, owner, companyId, filing, isAmendment, kind));
             foreach (var holdingElement in table.Elements(holdingName))
-                AddParsed(ParseHolding(holdingElement, owner, companyId, filing, isAmendment));
+                AddParsed(
+                    ParseHolding(holdingElement, owner, companyId, filing, isAmendment, kind)
+                );
         }
 
-        WalkTable("nonDerivativeTable", "nonDerivativeTransaction", "nonDerivativeHolding");
-        WalkTable("derivativeTable", "derivativeTransaction", "derivativeHolding");
+        // The table a row lives in is the authoritative security classification —
+        // nonDerivativeTable holds the issuer's actual shares, derivativeTable
+        // holds options/warrants/convertibles/etc.
+        WalkTable(
+            "nonDerivativeTable",
+            "nonDerivativeTransaction",
+            "nonDerivativeHolding",
+            InsiderSecurityKind.NonDerivative
+        );
+        WalkTable(
+            "derivativeTable",
+            "derivativeTransaction",
+            "derivativeHolding",
+            InsiderSecurityKind.Derivative
+        );
 
         return transactions;
+    }
+
+    // Stores the parsed ownership XML as a gzip-compressed internal File so the
+    // filing can be re-parsed locally if the parser changes, without re-fetching
+    // from EDGAR. root.ToString() re-serializes the already-parsed (well-formed,
+    // SGML-envelope-stripped) document, so the stored payload is guaranteed
+    // re-parseable. The File and InsiderFiling are added to the shared context
+    // here; the caller's SaveChanges persists them alongside the transactions.
+    private static async Task CaptureFilingXml(
+        XElement root,
+        FilingData filing,
+        InsiderFilingRepository filingRepository,
+        IFileManager fileManager
+    )
+    {
+        // A filing is only processed when its transactions don't yet exist, but
+        // guard against a duplicate filing row so the unique accession index
+        // can't be violated by a re-run.
+        var alreadyCaptured = await filingRepository
+            .GetByAccessionNumber(filing.AccessionNumber)
+            .AnyAsync();
+        if (alreadyCaptured)
+            return;
+
+        var rawBytes = Encoding.UTF8.GetBytes(root.ToString(SaveOptions.DisableFormatting));
+        var compressed = GzipCompressor.Compress(rawBytes);
+        var file = await fileManager.SaveInternalFile(
+            compressed,
+            filing.AccessionNumber,
+            "gz",
+            "application/gzip"
+        );
+
+        filingRepository.Add(
+            new InsiderFiling
+            {
+                AccessionNumber = filing.AccessionNumber,
+                Content = file,
+                UncompressedSize = rawBytes.Length,
+                CaptureStatus = InsiderFilingCaptureStatus.Captured,
+            }
+        );
     }
 
     private async Task<XElement> TryParseOwnershipRoot(
@@ -341,6 +411,9 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 TransactionOrder = 0,
                 // 0-price holding sentinel: nothing to validate or repair.
                 IsPriceValid = true,
+                // No security exists on a noSecuritiesOwned filing, so SecurityKind
+                // stays Unknown by design — there is no table to classify it from.
+                ParserVersion = InsiderTransaction.CurrentParserVersion,
             }
         );
         await transactionRepository.SaveChanges();
@@ -404,7 +477,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         InsiderOwner owner,
         Guid companyId,
         FilingData filing,
-        bool isAmendment
+        bool isAmendment,
+        InsiderSecurityKind kind
     )
     {
         string Wrapped(params string[] path) => GetWrappedValue(txElement, path);
@@ -438,6 +512,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             SecurityTitle = securityTitle,
             AccessionNumber = filing.AccessionNumber,
             IsAmendment = isAmendment,
+            SecurityKind = kind,
+            ParserVersion = InsiderTransaction.CurrentParserVersion,
         };
     }
 
@@ -446,7 +522,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         InsiderOwner owner,
         Guid companyId,
         FilingData filing,
-        bool isAmendment
+        bool isAmendment,
+        InsiderSecurityKind kind
     )
     {
         var securityTitle = GetWrappedValue(holdingElement, "securityTitle")?.Trim();
@@ -471,6 +548,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             SecurityTitle = securityTitle,
             AccessionNumber = filing.AccessionNumber,
             IsAmendment = isAmendment,
+            SecurityKind = kind,
+            ParserVersion = InsiderTransaction.CurrentParserVersion,
         };
     }
 

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCultureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCultureTests.cs
@@ -61,7 +61,10 @@ public class InsiderTradingFilingProcessorParseTransactionCultureTests
             )!;
 
             var result = (InsiderTransaction)
-                method.Invoke(processor, [tx, owner, Guid.NewGuid(), filing, false]);
+                method.Invoke(
+                    processor,
+                    [tx, owner, Guid.NewGuid(), filing, false, InsiderSecurityKind.NonDerivative]
+                );
 
             result.Should().NotBeNull();
             result!.TransactionDate.Should().Be(new DateOnly(2024, 2, 1));

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSecurityKindTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorSecurityKindTests.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+using System.Xml.Linq;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InsiderTradingFilingProcessorSecurityKindTests
+{
+    // ParseAllTransactions is the method that walks the two Form 4 tables. The
+    // table a row sits in is the AUTHORITATIVE security classification — the
+    // non-derivative table holds the issuer's actual shares, the derivative
+    // table holds options/warrants/convertibles. This pins that each row is
+    // tagged from its source table rather than from the (unreliable) title
+    // text, and that every parsed row is stamped with the current parser
+    // version so the reprocessing pipeline can find stale rows.
+    private static readonly MethodInfo ParseAllTransactionsMethod =
+        typeof(InsiderTradingFilingProcessor).GetMethod(
+            "ParseAllTransactions",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+    private static List<InsiderTransaction> ParseAll(XElement root)
+    {
+        // ParseAllTransactions uses none of the constructor dependencies, so
+        // nulls are safe for exercising the pure table-walk logic.
+        var processor = new InsiderTradingFilingProcessor(null, null, null);
+        var owner = new InsiderOwner { OwnerCik = "0000000001", Name = "Test Owner" };
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000000000-26-000001",
+            Form = "4",
+            FilingDate = new DateOnly(2026, 1, 5),
+            ReportDate = new DateOnly(2026, 1, 2),
+        };
+
+        return (List<InsiderTransaction>)
+            ParseAllTransactionsMethod.Invoke(
+                processor,
+                [root, owner, Guid.NewGuid(), filing, false]
+            );
+    }
+
+    private static XElement Transaction(string securityTitle) =>
+        new(
+            "nonDerivativeTransaction",
+            new XElement("securityTitle", new XElement("value", securityTitle)),
+            new XElement("transactionDate", new XElement("value", "2026-01-02")),
+            new XElement("transactionCoding", new XElement("transactionCode", "P")),
+            new XElement(
+                "transactionAmounts",
+                new XElement("transactionShares", new XElement("value", "1000")),
+                new XElement("transactionPricePerShare", new XElement("value", "10"))
+            )
+        );
+
+    private static XElement DerivativeTransaction(string securityTitle) =>
+        new XElement(Transaction(securityTitle)) { Name = "derivativeTransaction" };
+
+    [Fact]
+    public void ParseAllTransactions_TagsRowsFromTheirSourceTable_NotTheTitleText()
+    {
+        // A "Common Stock" row that lives in the derivative table (e.g. the
+        // common-stock underlying a converted note) must classify as Derivative
+        // from its table, and a deliberately option-titled row in the
+        // non-derivative table must classify as NonDerivative — proving the
+        // classification follows the table, never the title keywords.
+        var root = new XElement(
+            "ownershipDocument",
+            new XElement("nonDerivativeTable", Transaction("Common Stock")),
+            new XElement("derivativeTable", DerivativeTransaction("Common Stock"))
+        );
+
+        var transactions = ParseAll(root);
+
+        transactions.Should().HaveCount(2);
+        transactions[0].SecurityKind.Should().Be(InsiderSecurityKind.NonDerivative);
+        transactions[1].SecurityKind.Should().Be(InsiderSecurityKind.Derivative);
+    }
+
+    [Fact]
+    public void ParseAllTransactions_StampsEveryRowWithCurrentParserVersion()
+    {
+        var root = new XElement(
+            "ownershipDocument",
+            new XElement("nonDerivativeTable", Transaction("Common Stock")),
+            new XElement("derivativeTable", DerivativeTransaction("Stock Option (Right to Buy)"))
+        );
+
+        var transactions = ParseAll(root);
+
+        transactions
+            .Should()
+            .OnlyContain(t => t.ParserVersion == InsiderTransaction.CurrentParserVersion);
+    }
+}


### PR DESCRIPTION
## Summary

Insider transactions are currently classified as derivative vs non-derivative only by matching keywords in the security title, which misses real cases (restricted stock units, phantom stock, oddly-worded convertible notes) and mis-tags others. The Form 4 filing already states this authoritatively: a row lives in either `<nonDerivativeTable>` (the issuer's actual shares) or `<derivativeTable>` (options, warrants, convertibles). The parser walks both tables but discarded which one a row came from.

This change records that authoritative classification, and lays the groundwork to cheaply reprocess existing data when the parser improves:

- **`SecurityKind`** on each transaction, set from the source table (not the title text) — non-derivative, derivative, or unknown.
- **`ParserVersion`** stamped on every parsed row, so rows produced by an older parser can be found and reprocessed.
- **Raw ownership XML cached per filing**, gzip-compressed, in a new `InsiderFiling` entity. Reprocessing can then re-parse locally instead of re-fetching ~1M filings from EDGAR. Form 4 ownership XML averages ~7 KB (~1.2 KB gzipped), so the full corpus is on the order of a gigabyte.

Existing rows default to `SecurityKind = Unknown` and `ParserVersion = 0`, which marks them for a later reprocessing pass (added separately).

## Code changes

- `InsiderSecurityKind` — new enum (Unknown / NonDerivative / Derivative).
- `InsiderFilingCaptureStatus` — new enum mirroring the document XBRL-capture states.
- `InsiderFiling` — new per-accession entity holding the gzipped ownership XML (FK to a Media `File`), uncompressed size, capture status and attempts. Unique on `AccessionNumber`. Registered in the module configuration; `InsiderFilingRepository` added.
- `InsiderTransaction` — adds `SecurityKind`, `ParserVersion`, a `CurrentParserVersion` constant, and indexes on `(SecurityKind, TransactionDate)` and `ParserVersion`.
- `InsiderTradingFilingProcessor` — passes the source table's kind into `ParseTransaction`/`ParseHolding`, stamps `ParserVersion` on every row (including the no-securities sentinel), and caches the parsed ownership XML via `CaptureFilingXml`. The capture and the transactions persist in one `SaveChanges`.
- `GzipCompressor` — gzip helper extracted from `DocumentPersistenceService` and shared with the new capture path.
- `Equibles.InsiderTrading.Data` now references `Equibles.Media.Data` for the `File` type.
- Migration `AddInsiderFilingAndSecurityKind` — new columns (defaults 0) and the `InsiderFiling` table.

## Tests

- New unit tests pin that rows are classified from their source table (not the title) and that every parsed row carries the current parser version.
- Full unit suite green: 2330 passing.