### PR TITLE
test(web): add skipped repro for GH-2935 — backtest report-date overflow

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/InstitutionsBacktestReportDateOverflowTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/InstitutionsBacktestReportDateOverflowTests.cs
@@ -1,0 +1,80 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using Equibles.Holdings.Data.Models;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class InstitutionsBacktestReportDateOverflowTests
+{
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public InstitutionsBacktestReportDateOverflowTests(
+        WebAppFixture web,
+        PlaywrightFixture playwright
+    )
+    {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact(Skip = "GH-2935 — backtest 500s on ReportDate.AddDays(45) overflow; un-skip when fixed")]
+    public async Task Backtest_HolderWithFarFutureReportDate_DoesNotReturn500()
+    {
+        // Contract: the backtest page must respond gracefully for any holder that has 13F
+        // snapshots, whatever their stored report dates. The shift to the rebalance date
+        // (ReportDate + 45 days) must not overflow the calendar. HoldingsBacktestCalculator
+        // already clamps this exact arithmetic (DayNumber guard / DateOnly.MaxValue), so a
+        // snapshot whose ReportDate is within 45 days of DateOnly.MaxValue should yield a
+        // "no data" page, never an HTTP 500.
+        var stockId = Guid.NewGuid();
+        var filerCik = "0001067983";
+
+        await _web.ResetAndSeedAsync(async db =>
+        {
+            // Benchmark stock must exist so Execute proceeds past the benchmark lookup and
+            // reaches the rebalance-date computation.
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "SPY",
+                    Name = "SPDR S&P 500 ETF Trust",
+                    Cik = "0000884394",
+                }
+            );
+
+            var filer = new InstitutionalHolder { Cik = filerCik, Name = "Berkshire Hathaway Inc" };
+            db.Add(filer);
+
+            db.Add(
+                new InstitutionalHolding
+                {
+                    CommonStockId = stockId,
+                    InstitutionalHolderId = filer.Id,
+                    // ReportDate within 45 days of DateOnly.MaxValue: ReportDate.AddDays(45)
+                    // pushes past 9999-12-31 and throws ArgumentOutOfRangeException unless clamped.
+                    ReportDate = DateOnly.MaxValue,
+                    FilingDate = new DateOnly(2025, 2, 14),
+                    Value = 5_000_000,
+                    Shares = 200,
+                    ShareType = ShareType.Shares,
+                    InvestmentDiscretion = InvestmentDiscretion.Sole,
+                }
+            );
+
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync($"/institutions/{filerCik}/backtest");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().NotBe(500);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped functional regression test reproducing GH-2935: `GET /institutions/{cik}/backtest` returns HTTP 500 when a holder's 13F snapshot has a report date within 45 days of the calendar maximum.
- Root cause: `HoldingsBacktestService.Execute` shifts the report date to its rebalance date via `ReportDate.AddDays(45)` (`src/Equibles.Web/Services/HoldingsBacktestService.cs:92`, also `:212`) without the overflow clamp the sibling `HoldingsBacktestCalculator` already applies (`:36-39`, `:51-54`), so the +45-day shift overflows the calendar and throws.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/InstitutionsBacktestReportDateOverflowTests.cs` — new functional test. Seeds a holder, a benchmark stock, and one holding with `ReportDate = DateOnly.MaxValue`, then asserts the backtest page does not return 500. Currently fails (returns 500) so it ships `[Fact(Skip = ...)]` — skipped, see GH-2935. Un-skip as part of the fix. No production code changed.