### PR TITLE
test(fred): add skipped repro for GH-2941 — GetEconomicIndicator negative maxResults

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/EconomicIndicatorNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/EconomicIndicatorNegativeMaxResultsTests.cs
@@ -1,0 +1,103 @@
+using Equibles.Fred.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+/// <summary>
+/// Adversarial end-to-end test for the GetEconomicIndicator MCP tool's <c>maxResults</c> parameter.
+/// GetEconomicIndicator feeds the raw client value straight into EF Core's <c>.Take(maxResults)</c>,
+/// so a negative cap becomes a negative SQL <c>LIMIT</c> that PostgreSQL rejects; the resulting
+/// exception is swallowed and the caller gets the generic internal-failure sentinel. The parameter
+/// contract ("Maximum number of observations to return") makes a negative value nonsensical input
+/// that must degrade gracefully — never surface as the tool's internal error. Same defect class and
+/// identical <c>.Take(maxResults)</c> pattern as GetVixHistory (GH-2933), GetPutCallRatios (GH-2937),
+/// and GetStockPrices (GH-2931).
+/// </summary>
+[Trait("Category", "Functional")]
+public class EconomicIndicatorNegativeMaxResultsTests
+    : IClassFixture<McpServerAppFixture>,
+        IAsyncLifetime
+{
+    private readonly McpServerAppFixture _fixture;
+    private McpClient _client;
+
+    public EconomicIndicatorNegativeMaxResultsTests(McpServerAppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var transport = new HttpClientTransport(
+            new HttpClientTransportOptions
+            {
+                Endpoint = new Uri($"{_fixture.BaseUrl.TrimEnd('/')}/mcp"),
+                TransportMode = HttpTransportMode.StreamableHttp,
+            }
+        );
+        _client = await McpClient.CreateAsync(transport);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_client is not null)
+        {
+            await _client.DisposeAsync();
+        }
+    }
+
+    [Fact(
+        Skip = "GH-2941 — GetEconomicIndicator surfaces an internal error for a negative maxResults instead of degrading gracefully"
+    )]
+    public async Task GetEconomicIndicator_NegativeMaxResults_DoesNotSurfaceInternalError()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            var series = new FredSeries
+            {
+                SeriesId = "FEDFUNDS",
+                Title = "Federal Funds Effective Rate",
+                Category = FredSeriesCategory.InterestRates,
+                Frequency = "Monthly",
+                Units = "Percent",
+                SeasonalAdjustment = "Not Seasonally Adjusted",
+            };
+            db.Set<FredSeries>().Add(series);
+            db.Set<FredObservation>()
+                .Add(
+                    new FredObservation
+                    {
+                        FredSeries = series,
+                        Date = new DateOnly(2026, 4, 1),
+                        Value = 5.33m,
+                    }
+                );
+            await Task.CompletedTask;
+        });
+
+        var tools = await _client.ListToolsAsync();
+        var tool = tools.First(t => t.Name == "GetEconomicIndicator");
+
+        // A negative observation cap is invalid input for a "maximum number of records" parameter;
+        // the tool must degrade gracefully rather than let the value reach the database as a
+        // negative LIMIT. The generic "An error occurred while executing" sentinel means an
+        // internal exception leaked out — the behaviour this test forbids.
+        var result = await tool.CallAsync(
+            new Dictionary<string, object>
+            {
+                ["seriesId"] = "FEDFUNDS",
+                ["startDate"] = "2026-03-01",
+                ["endDate"] = "2026-04-30",
+                ["maxResults"] = -1,
+            }
+        );
+
+        var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
+        text.Should().NotBeNull();
+        text.Should().NotContain("An error occurred while executing");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial end-to-end test for the `GetEconomicIndicator` MCP tool over the real MCP HTTP transport. It binds the client `maxResults` straight into EF Core's `.Take(maxResults)`; a negative value becomes a negative SQL `LIMIT` that PostgreSQL rejects, the catch-all swallows the exception, and the caller gets the generic internal-error sentinel instead of degrading gracefully.
- The test reproduces the defect (it fails against current `main`) and is committed `[Skip]` pending the fix — see GH-2941. Same defect class as GH-2933 (GetVixHistory), GH-2937 (GetPutCallRatios), GH-2931 (GetStockPrices).

## Code changes

- `tests/Equibles.FunctionalTests/Tests/EconomicIndicatorNegativeMaxResultsTests.cs` — new functional test: seeds one `FredSeries` + one `FredObservation`, calls `GetEconomicIndicator` with `maxResults: -1`, and asserts the response does not contain the internal-error sentinel. Skipped (`Skip = "GH-2941 — ..."`); un-skip as part of the fix. No production code changed.