### PR TITLE
test(sec): add skipped repro for GH-2951 — FormAdvCsvParser.ParseAum long overflow

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumOverflowTests.cs
@@ -1,0 +1,29 @@
+using Equibles.Integrations.Sec.FormAdv;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Adversarial pin for <see cref="FormAdvCsvParser"/>'s AUM parsing. The parser is documented as
+/// defensive — it nulls a field it cannot represent ("Returns null for a blank cell") and skips
+/// unkeyable rows — so one malformed cell in the untrusted SEC CSV must never abort the whole
+/// streaming import. A figure with more digits than <see cref="long"/> can hold still parses as a
+/// <see cref="decimal"/>, so the narrowing cast to long can overflow; the contract requires that
+/// to degrade to "not reported" (null), not throw.
+/// </summary>
+public class FormAdvCsvParserParseAumOverflowTests
+{
+    [Fact(
+        Skip = "GH-2951 — ParseAum throws OverflowException casting an out-of-long-range AUM to long, aborting the import"
+    )]
+    public void Parse_TotalAumLargerThanLongRange_TreatsCellAsNotReportedInsteadOfThrowing()
+    {
+        // 26 digits: within decimal's range but far beyond long.MaxValue (~9.2e18).
+        var csv = "Organization CRD#,5F(2)(c)\n" + "12345,99999999999999999999999999\n";
+
+        var advisers = FormAdvCsvParser.Parse(new StringReader(csv)).ToList();
+
+        advisers.Should().ContainSingle();
+        advisers[0].Crd.Should().Be(12345);
+        advisers[0].TotalRegulatoryAum.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- An adversarial test discovered that `FormAdvCsvParser.ParseAum` throws `System.OverflowException` when an assets-under-management cell parses as a `decimal` but exceeds `long` range, aborting the entire Form ADV streaming import on a single malformed cell from the untrusted SEC bulk CSV.
- The parser is documented and built to be defensive (nulls fields it cannot represent, skips unkeyable rows), so an unrepresentable AUM value should degrade to "not reported" (null), not crash. See GH-2951.

## Code changes

- `tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumOverflowTests.cs` — adds one `[Fact]`, committed skipped — see GH-2951. It parses a 26-digit AUM cell and asserts the row is returned with `TotalRegulatoryAum == null` instead of throwing. Un-skip it as part of the fix. No production code changed.