### PR TITLE
test(web): pin InstitutionsController.Search limit upper-clamp at 50

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/InstitutionsControllerSearchLimitClampTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/InstitutionsControllerSearchLimitClampTests.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using System.Text.Json;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Adversarial: the /institutions/search typeahead clamps limit to an upper bound
+/// of 50. An over-large client limit (1000) against 60 matching holders must NOT
+/// over-fetch — the JSON array must contain at most the clamp (≤50) rows.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class InstitutionsControllerSearchLimitClampTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public InstitutionsControllerSearchLimitClampTests(WebHostFixture fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    public async Task GetSearch_LimitAboveUpperClamp_ReturnsAtMostFiftyRows()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            for (var i = 0; i < 60; i++)
+            {
+                db.Add(
+                    new InstitutionalHolder
+                    {
+                        Cik = (9000000000L + i).ToString(),
+                        Name = $"Capital Partners {i:D2}",
+                        City = "Boston",
+                        StateOrCountry = "MA",
+                    }
+                );
+            }
+
+            await db.SaveChangesAsync();
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions/search?q=Capital&limit=1000");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetArrayLength().Should().BeLessThanOrEqualTo(50);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one adversarial end-to-end integration test for the `/institutions/search` typeahead endpoint, exercising the real HTTP pipeline against a ParadeDB-backed host.
- Pins the contract that an over-large client `limit` must not over-fetch: the controller clamps `limit` to 50, so even with 60 matching holders and `limit=1000` the JSON array returns at most 50 rows.

## Code changes

- `tests/Equibles.IntegrationTests/Web/InstitutionsControllerSearchLimitClampTests.cs` — new `[Fact]` seeding 60 matching `InstitutionalHolder` rows, requesting `?q=Capital&limit=1000`, and asserting the response array length is ≤ 50. Verifies the upper clamp (a gap not covered by the existing case-insensitive-match test). Test-only; no production code touched.