### PR TITLE
test(insider-trading): add skipped repro for GH-2955 — Evaluate accepts negative repaired price

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs
@@ -204,4 +204,25 @@ public class InsiderTransactionPriceValidatorTests
         result.WasRepaired.Should().BeFalse();
         result.EffectivePrice.Should().Be(0m);
     }
+
+    // Shares comes straight from ParseLong (long.TryParse), which accepts "-N",
+    // so a malformed / amended Form 4 can carry a negative share count into
+    // Evaluate. The repair only guards shares == 0, so reportedPrice / shares
+    // becomes a NEGATIVE per-share price — yet it's stamped valid + repaired.
+    // A recovered unit price is never negative; like the zero-shares case the
+    // total can't be divided into a sensible unit price, so the row must be
+    // rejected, not accepted as valid.
+    [Fact(Skip = "GH-2955 — Evaluate stamps a negative repaired price valid when shares < 0")]
+    public void Evaluate_ImplausibleWithNegativeShares_IsNotAcceptedAsNegativePrice()
+    {
+        var result = _validator.Evaluate(
+            reportedPrice: 50_000m,
+            shares: -1000,
+            securityTitle: "Common Stock",
+            unadjustedClose: 50m
+        );
+
+        result.IsPriceValid.Should().NotBe(true);
+        result.EffectivePrice.Should().BeGreaterThanOrEqualTo(0m);
+    }
 }


### PR DESCRIPTION
## Summary

- Adversarial unit test for `InsiderTransactionPriceValidator.Evaluate` that exposes a real defect: when an implausible reported price is "repaired" and the share count is negative, the division yields a negative per-share price that is wrongly stamped `IsPriceValid = true` / `WasRepaired = true`.
- Negative shares is reachable from real input — `InsiderTradingFilingProcessor.ParseLong` uses `long.TryParse`, which accepts `"-N"`, so a malformed Form 4 flows an unclamped negative count into `Evaluate`.
- Committed skipped — see GH-2955. Un-skip as part of the fix (widen the `shares == 0` guard to `shares <= 0`).

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs` — adds `Evaluate_ImplausibleWithNegativeShares_IsNotAcceptedAsNegativePrice`, marked `[Fact(Skip = "GH-2955 …")]`, asserting the row is not accepted as valid and the effective price is never negative.