### PR TITLE
test(fred): add skipped repro for GH-2962 — SearchEconomicIndicators negative maxResults

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/SearchEconomicIndicatorsNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/SearchEconomicIndicatorsNegativeMaxResultsTests.cs
@@ -1,0 +1,92 @@
+using Equibles.Fred.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+/// <summary>
+/// Adversarial end-to-end test for the SearchEconomicIndicators MCP tool's <c>maxResults</c>
+/// parameter. The tool feeds the raw client value straight into EF Core's
+/// <c>.Take(maxResults)</c> over the deferred <see cref="IQueryable{T}"/> returned by
+/// <c>FredSeriesRepository.Search</c>, so a negative cap becomes a negative SQL <c>LIMIT</c>
+/// that PostgreSQL rejects (22023); the resulting exception is swallowed by the tool runner and
+/// the caller gets the generic internal-failure sentinel. The parameter contract ("Maximum
+/// number of results to return") makes a negative value nonsensical input that must degrade
+/// gracefully — never surface as the tool's internal error. Same defect class as
+/// SearchCongressMembers (GH-2957) and the rest of the unclamped <c>.Take(maxResults)</c>
+/// family; the FRED Search variant is the untested sibling.
+/// </summary>
+[Trait("Category", "Functional")]
+public class SearchEconomicIndicatorsNegativeMaxResultsTests
+    : IClassFixture<McpServerAppFixture>,
+        IAsyncLifetime
+{
+    private readonly McpServerAppFixture _fixture;
+    private McpClient _client;
+
+    public SearchEconomicIndicatorsNegativeMaxResultsTests(McpServerAppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var transport = new HttpClientTransport(
+            new HttpClientTransportOptions
+            {
+                Endpoint = new Uri($"{_fixture.BaseUrl.TrimEnd('/')}/mcp"),
+                TransportMode = HttpTransportMode.StreamableHttp,
+            }
+        );
+        _client = await McpClient.CreateAsync(transport);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_client is not null)
+        {
+            await _client.DisposeAsync();
+        }
+    }
+
+    [Fact(
+        Skip = "GH-2962 — SearchEconomicIndicators surfaces an internal error for a negative maxResults instead of degrading gracefully"
+    )]
+    public async Task SearchEconomicIndicators_NegativeMaxResults_DoesNotSurfaceInternalError()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Set<FredSeries>()
+                .Add(
+                    new FredSeries
+                    {
+                        SeriesId = "FEDFUNDS",
+                        Title = "Federal Funds Effective Rate",
+                        Category = FredSeriesCategory.InterestRates,
+                        Frequency = "Monthly",
+                        Units = "Percent",
+                        SeasonalAdjustment = "Not Seasonally Adjusted",
+                    }
+                );
+            await Task.CompletedTask;
+        });
+
+        var tools = await _client.ListToolsAsync();
+        var tool = tools.First(t => t.Name == "SearchEconomicIndicators");
+
+        // A negative record cap is invalid input for a "maximum number of results" parameter;
+        // the tool must degrade gracefully rather than let the value reach the database as a
+        // negative LIMIT. The generic "An error occurred while executing" sentinel means an
+        // internal exception leaked out — the behaviour this test forbids.
+        var result = await tool.CallAsync(
+            new Dictionary<string, object> { ["query"] = "FEDFUNDS", ["maxResults"] = -1 }
+        );
+
+        var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
+        text.Should().NotBeNull();
+        text.Should().NotContain("An error occurred while executing");
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial end-to-end test for the `SearchEconomicIndicators` MCP tool, proving it surfaces an internal error for a negative `maxResults` instead of degrading gracefully — skipped, see GH-2962.
- Same defect class as GH-2957 (SearchCongressMembers) and the rest of the unclamped `.Take(maxResults)` MCP-tool family: the negative value reaches the database as a negative SQL `LIMIT`, which PostgreSQL rejects, leaking the generic internal-failure sentinel.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/SearchEconomicIndicatorsNegativeMaxResultsTests.cs` — new functional test over the real MCP HTTP transport: seeds one `FredSeries`, calls the tool with `maxResults = -1`, and asserts the response does not contain the internal-error sentinel. Marked `[Fact(Skip = "GH-2962")]` until the tool clamps `maxResults`; un-skip as part of the fix.