### PR TITLE
test(finra): add skipped repro for GH-2966 — GetShortInterest negative maxResults

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/ShortInterestNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/ShortInterestNegativeMaxResultsTests.cs
@@ -1,0 +1,107 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Finra.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+/// <summary>
+/// Adversarial end-to-end test for the GetShortInterest MCP tool's <c>maxResults</c> parameter.
+/// Once a ticker resolves, GetShortInterest feeds the raw client value straight into EF Core's
+/// <c>.Take(maxResults)</c>, so a negative cap becomes a negative SQL <c>LIMIT</c> that
+/// PostgreSQL rejects; the resulting exception is swallowed and the caller gets the generic
+/// internal-failure sentinel. The parameter contract ("Maximum number of records to return")
+/// makes a negative value nonsensical input that must degrade gracefully — never surface as the
+/// tool's internal error. Same defect class as GH-2931 (GetStockPrices) and GH-2943
+/// (GetShortVolume), sibling MCP tools with the identical unclamped <c>.Take(maxResults)</c>.
+/// </summary>
+[Trait("Category", "Functional")]
+public class ShortInterestNegativeMaxResultsTests
+    : IClassFixture<McpServerAppFixture>,
+        IAsyncLifetime
+{
+    private readonly McpServerAppFixture _fixture;
+    private McpClient _client;
+
+    public ShortInterestNegativeMaxResultsTests(McpServerAppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var transport = new HttpClientTransport(
+            new HttpClientTransportOptions
+            {
+                Endpoint = new Uri($"{_fixture.BaseUrl.TrimEnd('/')}/mcp"),
+                TransportMode = HttpTransportMode.StreamableHttp,
+            }
+        );
+        _client = await McpClient.CreateAsync(transport);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_client is not null)
+        {
+            await _client.DisposeAsync();
+        }
+    }
+
+    [Fact(
+        Skip = "GH-2966 — GetShortInterest surfaces an internal error for a negative maxResults instead of degrading gracefully"
+    )]
+    public async Task GetShortInterest_NegativeMaxResults_DoesNotSurfaceInternalError()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            var stock = new CommonStock
+            {
+                Ticker = "GME",
+                Name = "GameStop Corp",
+                Cik = "0001326380",
+            };
+            db.Set<CommonStock>().Add(stock);
+            await db.SaveChangesAsync();
+
+            db.Set<ShortInterest>()
+                .Add(
+                    new ShortInterest
+                    {
+                        CommonStock = stock,
+                        CommonStockId = stock.Id,
+                        SettlementDate = new DateOnly(2026, 4, 15),
+                        CurrentShortPosition = 50_000_000,
+                        PreviousShortPosition = 49_000_000,
+                        ChangeInShortPosition = 1_000_000,
+                        AverageDailyVolume = 80_000_000,
+                        DaysToCover = 0.63m,
+                    }
+                );
+        });
+
+        var tools = await _client.ListToolsAsync();
+        var tool = tools.First(t => t.Name == "GetShortInterest");
+
+        // A negative record cap is invalid input for a "maximum number of records" parameter;
+        // the tool must degrade gracefully rather than let the value reach the database as a
+        // negative LIMIT. The generic "An error occurred while executing" sentinel means an
+        // internal exception leaked out — the behaviour this test forbids.
+        var result = await tool.CallAsync(
+            new Dictionary<string, object>
+            {
+                ["ticker"] = "GME",
+                ["startDate"] = "2026-03-01",
+                ["endDate"] = "2026-04-30",
+                ["maxResults"] = -1,
+            }
+        );
+
+        var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
+        text.Should().NotBeNull();
+        text.Should().NotContain("An error occurred while executing");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one skipped adversarial functional test reproducing GH-2966: the `GetShortInterest` MCP tool surfaces the generic internal-error sentinel ("An error occurred while executing GetShortInterest. Please try again.") when called with a negative `maxResults`, instead of degrading gracefully.
- Root cause: `maxResults` is fed straight into EF Core's `.Take(maxResults)` (`ShortDataTools.cs:134`) with no lower-bound clamp, so a negative value becomes a negative SQL `LIMIT` that PostgreSQL rejects. Same defect class as GH-2931 (GetStockPrices) and GH-2943 (GetShortVolume).

## Code changes

- `tests/Equibles.FunctionalTests/Tests/ShortInterestNegativeMaxResultsTests.cs` — new end-to-end test driving the real MCP server (Kestrel + ParadeDB), seeding a stock and one in-range short-interest row, then calling `GetShortInterest` with `maxResults: -1` and asserting the response does not contain the internal-error sentinel. Skipped (`Skip = "GH-2966 …"`) pending the production fix; un-skip as part of resolving GH-2966.