### PR TITLE
test(insider-trading): add skipped repro for GH-2980 — GetProposedSales negative maxResults

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/ProposedSalesNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/ProposedSalesNegativeMaxResultsTests.cs
@@ -1,0 +1,106 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using Equibles.InsiderTrading.Data.Models;
+using FluentAssertions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+/// <summary>
+/// Adversarial end-to-end test for the GetProposedSales MCP tool's <c>maxResults</c> parameter.
+/// Once a ticker resolves, GetProposedSales feeds the raw client value straight into EF Core's
+/// <c>.Take(maxResults)</c>, so a negative cap becomes a negative SQL <c>LIMIT</c> that
+/// PostgreSQL rejects; the exception is swallowed and the caller gets the generic
+/// internal-failure sentinel. The parameter contract ("Maximum number of notices to return")
+/// makes a negative value nonsensical input that must degrade gracefully — never surface as the
+/// tool's internal error. Same defect class as GH-2931 (GetStockPrices) and GH-2978
+/// (GetExemptOfferings), sibling MCP tools with the identical unclamped <c>.Take(maxResults)</c>.
+/// </summary>
+[Trait("Category", "Functional")]
+public class ProposedSalesNegativeMaxResultsTests
+    : IClassFixture<McpServerAppFixture>,
+        IAsyncLifetime
+{
+    private readonly McpServerAppFixture _fixture;
+    private McpClient _client;
+
+    public ProposedSalesNegativeMaxResultsTests(McpServerAppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var transport = new HttpClientTransport(
+            new HttpClientTransportOptions
+            {
+                Endpoint = new Uri($"{_fixture.BaseUrl.TrimEnd('/')}/mcp"),
+                TransportMode = HttpTransportMode.StreamableHttp,
+            }
+        );
+        _client = await McpClient.CreateAsync(transport);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_client is not null)
+        {
+            await _client.DisposeAsync();
+        }
+    }
+
+    [Fact(
+        Skip = "GH-2980 — GetProposedSales surfaces an internal error for a negative maxResults instead of degrading gracefully"
+    )]
+    public async Task GetProposedSales_NegativeMaxResults_DoesNotSurfaceInternalError()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            var stock = new CommonStock
+            {
+                Ticker = "AAPL",
+                Name = "Apple Inc",
+                Cik = "0000320193",
+            };
+            db.Set<CommonStock>().Add(stock);
+            await db.SaveChangesAsync();
+
+            db.Set<Form144Filing>()
+                .Add(
+                    new Form144Filing
+                    {
+                        CommonStock = stock,
+                        CommonStockId = stock.Id,
+                        AccessionNumber = "0000320193-26-000001",
+                        FilingDate = new DateOnly(2026, 4, 1),
+                        SellerName = "Jane Affiliate",
+                        RelationshipToIssuer = "Director",
+                        SecurityClassTitle = "Common",
+                        BrokerName = "Charles Schwab & Co., Inc.",
+                        SharesToBeSold = 10_000,
+                        AggregateMarketValue = 3_000_000m,
+                        SharesOutstanding = 14_687_356_000,
+                        ApproxSaleDate = new DateOnly(2026, 4, 7),
+                        SecuritiesExchangeName = "NASDAQ",
+                    }
+                );
+        });
+
+        var tools = await _client.ListToolsAsync();
+        var tool = tools.First(t => t.Name == "GetProposedSales");
+
+        // A negative notice cap is invalid input for a "maximum number of notices" parameter;
+        // the tool must degrade gracefully rather than let the value reach the database as a
+        // negative LIMIT. The generic "An error occurred while executing" sentinel means an
+        // internal exception leaked out — the behaviour this test forbids.
+        var result = await tool.CallAsync(
+            new Dictionary<string, object> { ["ticker"] = "AAPL", ["maxResults"] = -1 }
+        );
+
+        var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
+        text.Should().NotBeNull();
+        text.Should().NotContain("An error occurred while executing");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an adversarial end-to-end test proving `GetProposedSales` leaks the generic internal-error sentinel when called with a negative `maxResults`, instead of degrading gracefully. The negative value reaches EF Core's `.Take(maxResults)` and becomes a negative SQL `LIMIT` that PostgreSQL rejects.
- Committed `[Skip]` against GH-2980 — un-skip it as part of the fix. No production code changed.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/ProposedSalesNegativeMaxResultsTests.cs` — new functional test over the real MCP HTTP transport (`McpServerAppFixture` + `McpClient`): seeds one `CommonStock` (AAPL) plus a linked `Form144Filing`, calls `GetProposedSales` with `maxResults = -1`, and asserts the response does not contain the internal-error sentinel. Skipped — see GH-2980.