### PR TITLE
test(finra): pin GetShortInterestSnapshot negative maxResults behavior

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/ShortInterestSnapshotNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/ShortInterestSnapshotNegativeMaxResultsTests.cs
@@ -1,0 +1,102 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Finra.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using FluentAssertions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+/// <summary>
+/// Adversarial end-to-end test for the GetShortInterestSnapshot MCP tool's <c>maxResults</c>
+/// parameter. After resolving the latest settlement date, GetShortInterestSnapshot feeds the raw
+/// client value straight into EF Core's <c>.Take(maxResults)</c>, so a negative cap becomes a
+/// negative SQL <c>LIMIT</c> that PostgreSQL rejects; the resulting exception is swallowed and the
+/// caller gets the generic internal-failure sentinel. The parameter contract ("Maximum number of
+/// results to return") makes a negative value nonsensical input that must degrade gracefully —
+/// never surface as the tool's internal error. Same defect class as GH-2931 (GetStockPrices),
+/// GH-2943 (GetShortVolume), GH-2966 (GetShortInterest), and GH-2974 (GetLargestShortVolume),
+/// sibling MCP tools with the identical unclamped <c>.Take(maxResults)</c>.
+/// </summary>
+[Trait("Category", "Functional")]
+public class ShortInterestSnapshotNegativeMaxResultsTests
+    : IClassFixture<McpServerAppFixture>,
+        IAsyncLifetime
+{
+    private readonly McpServerAppFixture _fixture;
+    private McpClient _client;
+
+    public ShortInterestSnapshotNegativeMaxResultsTests(McpServerAppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var transport = new HttpClientTransport(
+            new HttpClientTransportOptions
+            {
+                Endpoint = new Uri($"{_fixture.BaseUrl.TrimEnd('/')}/mcp"),
+                TransportMode = HttpTransportMode.StreamableHttp,
+            }
+        );
+        _client = await McpClient.CreateAsync(transport);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_client is not null)
+        {
+            await _client.DisposeAsync();
+        }
+    }
+
+    [Fact(
+        Skip = "GH-2984 — GetShortInterestSnapshot surfaces an internal error for a negative maxResults instead of degrading gracefully"
+    )]
+    public async Task GetShortInterestSnapshot_NegativeMaxResults_DoesNotSurfaceInternalError()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            var stock = new CommonStock
+            {
+                Ticker = "GME",
+                Name = "GameStop Corp",
+                Cik = "0001326380",
+            };
+            db.Set<CommonStock>().Add(stock);
+            await db.SaveChangesAsync();
+
+            // DaysToCover and a positive AverageDailyVolume satisfy the snapshot's filters so the
+            // row survives to the OrderByDescending(...).Take(maxResults) where the negative cap bites.
+            db.Set<ShortInterest>()
+                .Add(
+                    new ShortInterest
+                    {
+                        CommonStock = stock,
+                        CommonStockId = stock.Id,
+                        SettlementDate = new DateOnly(2026, 4, 15),
+                        CurrentShortPosition = 50_000_000,
+                        PreviousShortPosition = 49_000_000,
+                        ChangeInShortPosition = 1_000_000,
+                        AverageDailyVolume = 80_000_000,
+                        DaysToCover = 0.63m,
+                    }
+                );
+        });
+
+        var tools = await _client.ListToolsAsync();
+        var tool = tools.First(t => t.Name == "GetShortInterestSnapshot");
+
+        // A negative record cap is invalid input for a "maximum number of results" parameter;
+        // the tool must degrade gracefully rather than let the value reach the database as a
+        // negative LIMIT. The generic "An error occurred while executing" sentinel means an
+        // internal exception leaked out — the behaviour this test forbids.
+        var result = await tool.CallAsync(new Dictionary<string, object> { ["maxResults"] = -1 });
+
+        var text = result.Content.OfType<TextContentBlock>().FirstOrDefault()?.Text;
+        text.Should().NotBeNull();
+        text.Should().NotContain("An error occurred while executing");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an adversarial end-to-end test over the real MCP HTTP transport asserting `GetShortInterestSnapshot` does not surface an internal-error sentinel for a negative `maxResults`.
- The test currently fails (the tool feeds the unclamped negative cap into EF Core's `.Take(maxResults)` → negative SQL `LIMIT` → swallowed exception), so it ships `[Skip]` — see GH-2984. Un-skip it as part of the fix.

## Code changes

- `tests/Equibles.FunctionalTests/Tests/ShortInterestSnapshotNegativeMaxResultsTests.cs` — new functional test: seeds one `CommonStock` + one `ShortInterest` row (non-null `DaysToCover`, positive `AverageDailyVolume`), calls the `GetShortInterestSnapshot` tool with `maxResults = -1`, and asserts the response does not contain `An error occurred while executing`. Skipped pending the GH-2984 fix.