### PR TITLE
fix(sec): point Form ADV importer at the SEC's current download URL

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FormAdvImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FormAdvImportService.cs
@@ -28,7 +28,7 @@ namespace Equibles.Sec.HostedService.Services;
 public class FormAdvImportService : IImporter
 {
     private const string BaseUrl =
-        "https://www.sec.gov/files/investment/data/information-about-registered-investment-advisers-and-exempt-reporting-advisers";
+        "https://www.sec.gov/files/investment/data/other/information-about-registered-investment-advisers-exempt-reporting-advisers";
     private const int MonthsToProbe = 4;
     private const int UpsertBatchSize = 1000;
 


### PR DESCRIPTION
## Summary

The Form ADV scraper raised `FormAdvImport.NoSnapshot` — "No Form ADV snapshot found in the last 4 months — SEC URL or schedule may have changed". It was the URL: the SEC moved the bulk Form ADV download. It now lives under a `/other/` path segment, and the folder name dropped `-and-`:

- Old: `.../data/information-about-registered-investment-advisers-and-exempt-reporting-advisers/iaMMDDYY.zip`
- New: `.../data/other/information-about-registered-investment-advisers-exempt-reporting-advisers/iaMMDDYY.zip`

The old path 404s for every month, so all four monthly probes failed and the false alarm fired.

## Code changes

- `FormAdvImportService.BaseUrl`: updated to the current SEC path. Filename pattern (`iaMMDDYY.zip`) and probe logic are unchanged.

## Verification

Checked against the live SEC: the old URL returns 404 for recent months (e.g. May and April 2026) while the new URL returns the expected ~5 MB zip. Build clean; the existing Form ADV unit + integration tests (15) pass; csharpier clean.