### PR TITLE
test(holdings): add skipped repro for GH-2990 — GetOwnershipHistory negative maxPeriods

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests.cs
@@ -1,0 +1,82 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests(
+        ParadeDbFixture fixture
+    )
+        : base(fixture) { }
+
+    private InstitutionalHoldingsTools Sut() =>
+        new(
+            new InstitutionalHoldingRepository(DbContext),
+            new InstitutionalHolderRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<InstitutionalHoldingsTools>()
+        );
+
+    [Fact(
+        Skip = "GH-2990 — GetOwnershipHistory surfaces an internal error for a negative maxPeriods instead of degrading gracefully"
+    )]
+    public async Task GetOwnershipHistory_NegativeMaxPeriods_DoesNotSurfaceInternalError()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+        };
+        var holder = new InstitutionalHolder
+        {
+            Cik = "0001067983",
+            Name = "Berkshire Hathaway Inc",
+            City = "Omaha",
+            StateOrCountry = "NE",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<InstitutionalHolder>().Add(holder);
+        await DbContext.SaveChangesAsync();
+
+        DbContext
+            .Set<InstitutionalHolding>()
+            .Add(
+                new InstitutionalHolding
+                {
+                    CommonStockId = stock.Id,
+                    CommonStock = stock,
+                    InstitutionalHolderId = holder.Id,
+                    InstitutionalHolder = holder,
+                    ReportDate = new DateOnly(2024, 3, 31),
+                    FilingDate = new DateOnly(2024, 5, 15),
+                    Shares = 10_000,
+                    Value = 1_000_000,
+                    ShareType = ShareType.Shares,
+                    InvestmentDiscretion = InvestmentDiscretion.Sole,
+                    AccessionNumber = "0000000000-24-000001",
+                    TitleOfClass = "COM",
+                    Cusip = "037833100",
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        // Contract: maxPeriods is "Maximum number of quarterly periods to return"; a
+        // negative value is nonsensical input. It is forwarded unclamped into EF Core's
+        // GetReportDatesByStock(stock).Take(maxPeriods), so a negative cap would reach
+        // PostgreSQL as a negative LIMIT. The tool must degrade gracefully rather than
+        // leak the executor's internal-error sentinel to the caller.
+        var result = await Sut().GetOwnershipHistory("AAPL", maxPeriods: -1);
+
+        result.Should().NotContain("An error occurred while executing");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one adversarial integration test reproducing GH-2990: the `GetOwnershipHistory` MCP tool forwards a client-supplied negative `maxPeriods` unclamped into EF Core's `.Take(maxPeriods)`, so the value reaches PostgreSQL as a negative SQL `LIMIT`; the exception is swallowed and the caller receives the generic internal-error sentinel instead of degrading gracefully.
- The test is committed `[Skip]` — it fails today because the bug is real. Un-skip it as part of the fix. See GH-2990: https://github.com/daniel3303/Equibles/issues/2990

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests.cs` (new) — seeds one stock + holder + holding, calls `GetOwnershipHistory("AAPL", maxPeriods: -1)` on the ParadeDB-backed harness, and asserts the result does not contain the executor's internal-error sentinel. Marked `[Fact(Skip = "GH-2990 …")]` since it documents an unfixed defect. Test-only; no production code changed.