### PR TITLE
test(sec): pin XbrlBackfillService retry ceiling on the skipped path

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs
@@ -183,6 +183,53 @@ public class XbrlBackfillServiceTests : ParadeDbMcpTestBase
     }
 
     [Fact]
+    public async Task Backfill_PerpetuallySkippedDocument_DropsOutAfterRetryCeiling()
+    {
+        // Contract: a document fetched successfully but whose extraction leaves it NotChecked
+        // (the "Skipped" outcome) must be bounded by the same retry ceiling (5) as a failing
+        // fetch — its bumped attempt count is persisted via UpdateXbrl each cycle, so after the
+        // ceiling it leaves the working set and can't starve older documents. Guards against the
+        // attempt counter being advanced only on the exception path.
+        var company = await SeedCompany();
+        await SeedDocument(company.Id, "SKIP-ME", new DateOnly(2024, 1, 1));
+        DbContext.ChangeTracker.Clear();
+
+        var repo = new DocumentRepository(DbContext);
+        var persistence = new DocumentPersistenceService(
+            repo,
+            new FileManager(new FileRepository(DbContext))
+        );
+        // Capture disabled => every fetched submission resolves to NotChecked (the Skipped branch).
+        var capture = new XbrlEnvelopeCaptureService(
+            Options.Create(new XbrlCaptureOptions { Enabled = false }),
+            NullLogger<XbrlEnvelopeCaptureService>()
+        );
+        var sut = new XbrlBackfillService(
+            repo,
+            StubClient(InlineSubmission),
+            capture,
+            persistence,
+            NullLogger<XbrlBackfillService>()
+        );
+
+        // Five cycles consume the five allowed attempts, each leaving the document Skipped.
+        for (var cycle = 0; cycle < 5; cycle++)
+        {
+            var cycleResult = await sut.Backfill(batchSize: 1, null);
+            cycleResult.Skipped.Should().Be(1);
+        }
+
+        // Sixth cycle: the document has hit the ceiling and is no longer selected.
+        var afterCeiling = await sut.Backfill(batchSize: 1, null);
+        afterCeiling.Processed.Should().Be(0);
+
+        await using var verify = Fixture.CreateDbContext();
+        var doc = await verify.Set<Document>().SingleAsync(d => d.AccessionNumber == "SKIP-ME");
+        doc.XbrlStatus.Should().Be(XbrlCaptureStatus.NotChecked);
+        doc.XbrlCaptureAttempts.Should().Be(5);
+    }
+
+    [Fact]
     public async Task Backfill_SkipsDocumentsWithoutAccession()
     {
         var company = await SeedCompany();


### PR DESCRIPTION
## Summary

- Adds one integration test pinning a previously-untested behavior of the XBRL backfill: a document that is fetched successfully but whose extraction leaves it unchecked (the "skipped" outcome) is bounded by the same retry ceiling (5 attempts) as a document that fails to fetch.
- Only the exception/failed path's starvation-relief behavior was covered before; this guards against the attempt counter being advanced only on the failure path, which would let a perpetually-skipped document sit at the head of the newest-first queue and starve older documents forever.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs` — new `Backfill_PerpetuallySkippedDocument_DropsOutAfterRetryCeiling` fact. Runs the service against real Postgres with capture disabled so every fetch resolves to the skipped branch, runs five cycles (each leaving the document skipped), and asserts the sixth cycle no longer selects it, with the persisted attempt count capped at 5 and status still unchecked. Test passes — behavior confirmed.