### PR TITLE
fix(holdings): clamp negative maxPeriods in GetOwnershipHistory

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -172,7 +172,7 @@ public class InstitutionalHoldingsTools
 
                 var reportDates = await _holdingRepository
                     .GetReportDatesByStock(stock)
-                    .Take(maxPeriods)
+                    .Take(Math.Max(0, maxPeriods))
                     .ToListAsync();
 
                 if (reportDates.Count == 0)

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests.cs
@@ -26,9 +26,7 @@ public class InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests :
             NullLogger<InstitutionalHoldingsTools>()
         );
 
-    [Fact(
-        Skip = "GH-2990 — GetOwnershipHistory surfaces an internal error for a negative maxPeriods instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetOwnershipHistory_NegativeMaxPeriods_DoesNotSurfaceInternalError()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

- `GetOwnershipHistory` forwarded a client-supplied `maxPeriods` straight into EF Core's `.Take(maxPeriods)`. A negative value reached PostgreSQL as a negative SQL `LIMIT`, which the engine rejects; the executor swallowed the error and returned the generic internal-failure sentinel to the caller.
- Clamp with `Math.Max(0, maxPeriods)` so the tool degrades gracefully to a no-data response, matching sibling tools.
- Fix lives in the shared `Equibles.Holdings.Mcp` package, so the commercial platform inherits it via the NuGet dependency — no separate change needed there.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — clamp `maxPeriods` to a non-negative floor before `.Take(...)`.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsOwnershipHistoryNegativeMaxPeriodsTests.cs` — un-skip the committed regression test (fails pre-fix, passes post-fix).

closes #2990