### PR TITLE
test(holdings): add skipped repro for GH-2994 — GetInstitutionPortfolio negative maxResults

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests.cs
@@ -1,0 +1,83 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests
+    : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests(
+        ParadeDbFixture fixture
+    )
+        : base(fixture) { }
+
+    private InstitutionalHoldingsTools Sut() =>
+        new(
+            new InstitutionalHoldingRepository(DbContext),
+            new InstitutionalHolderRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<InstitutionalHoldingsTools>()
+        );
+
+    [Fact(
+        Skip = "GH-2994 — GetInstitutionPortfolio surfaces an internal error for a negative maxResults instead of degrading gracefully"
+    )]
+    public async Task GetInstitutionPortfolio_NegativeMaxResults_DoesNotSurfaceInternalError()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+        };
+        var holder = new InstitutionalHolder
+        {
+            Cik = "0001067983",
+            Name = "Berkshire Hathaway Inc",
+            City = "Omaha",
+            StateOrCountry = "NE",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.Set<InstitutionalHolder>().Add(holder);
+        await DbContext.SaveChangesAsync();
+
+        DbContext
+            .Set<InstitutionalHolding>()
+            .Add(
+                new InstitutionalHolding
+                {
+                    CommonStockId = stock.Id,
+                    CommonStock = stock,
+                    InstitutionalHolderId = holder.Id,
+                    InstitutionalHolder = holder,
+                    ReportDate = new DateOnly(2024, 3, 31),
+                    FilingDate = new DateOnly(2024, 5, 15),
+                    Shares = 10_000,
+                    Value = 1_000_000,
+                    ShareType = ShareType.Shares,
+                    InvestmentDiscretion = InvestmentDiscretion.Sole,
+                    AccessionNumber = "0000000000-24-000001",
+                    TitleOfClass = "COM",
+                    Cusip = "037833100",
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        // Contract: maxResults is "Maximum number of holdings to return"; a negative
+        // value is nonsensical input. It is forwarded unclamped into EF Core's
+        // GetByHolder(...).Take(maxResults), so a negative cap reaches PostgreSQL as a
+        // negative LIMIT, which the engine rejects. The tool must degrade gracefully
+        // rather than leak the executor's internal-error sentinel to the caller.
+        var result = await Sut().GetInstitutionPortfolio("Berkshire", maxResults: -1);
+
+        result.Should().NotContain("An error occurred while executing");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped regression test reproducing GH-2994: `GetInstitutionPortfolio` forwards a negative `maxResults` straight into EF Core's `.Take(maxResults)`, which reaches PostgreSQL as a negative `LIMIT` and surfaces the executor's internal-error sentinel instead of degrading gracefully.
- Same defect class as the already-filed sibling tools (#2959, #2982, #2990). Test is `[Skip]` until the production clamp lands — see GH-2994.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests.cs` — skipped repro asserting the tool does not return the internal-error sentinel for `maxResults: -1`.