### PR TITLE
fix(web): ComputeSma yields null on a non-finite window instead of throwing

### DIFF
--- a/src/Equibles.Web/Extensions/StatisticsExtensions.cs
+++ b/src/Equibles.Web/Extensions/StatisticsExtensions.cs
@@ -24,10 +24,7 @@ public static class StatisticsExtensions
     public static List<decimal?> ComputeSma(this double[] values, int period, int digits)
     {
         var sma = values.MovingAverage(period);
-        return sma.Select(
-                (v, i) => i < period - 1 ? (decimal?)null : (decimal?)Math.Round(v, digits)
-            )
-            .ToList();
+        return sma.Select((v, i) => i < period - 1 ? (decimal?)null : v.SafeRound(digits)).ToList();
     }
 
     public static StatsSummary ComputeStats(this double[] values, int decimals)

--- a/tests/Equibles.UnitTests/Web/StatisticsExtensionsComputeSmaNonFiniteWindowTests.cs
+++ b/tests/Equibles.UnitTests/Web/StatisticsExtensionsComputeSmaNonFiniteWindowTests.cs
@@ -17,9 +17,7 @@ public class StatisticsExtensionsComputeSmaNonFiniteWindowTests
     // ComputeSma pins only feed finite, in-range inputs, so this unprotected region
     // (which the ComputeSmaPeriodLargerThanInput comment itself flags as a hazard)
     // escapes them.
-    [Fact(
-        Skip = "GH-2922 — ComputeSma throws OverflowException on a non-finite window instead of yielding null like SafeRound"
-    )]
+    [Fact]
     public void ComputeSma_FullWindowAveragesToNonFinite_ReturnsNullInsteadOfThrowing()
     {
         double[] values = [1.0, 2.0, double.NaN];


### PR DESCRIPTION
## Summary

- `ComputeSma` cast each full-window moving average straight to `decimal` via `(decimal?)Math.Round(v, digits)`. A full-window position whose average is non-finite (`NaN`/`±Infinity`) — or a finite value outside `decimal`'s range — threw `OverflowException`, crashing the SMA chart overlay.
- Its sibling `SafeRound` in the same file guards exactly this hazard and returns `null`; the two disagreed on the same input. Route the per-position cast through `SafeRound` so a non-finite window yields `null` instead of throwing.

## Code changes

- `src/Equibles.Web/Extensions/StatisticsExtensions.cs` — `ComputeSma` now rounds each full-window value via `v.SafeRound(digits)` instead of the raw `(decimal?)Math.Round(...)` cast, mirroring the existing `ComputeStats` path.
- `tests/Equibles.UnitTests/Web/StatisticsExtensionsComputeSmaNonFiniteWindowTests.cs` — un-skipped the committed regression test pinning `[1, 2, NaN]` → `[null, 1.5, null]`.

closes #2922