### PR TITLE
fix(holdings): clamp negative maxResults in GetInstitutionPortfolio

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -251,7 +251,7 @@ public class InstitutionalHoldingsTools
                 var holdings = await _holdingRepository
                     .GetByHolder(holder, targetDate)
                     .OrderByDescending(h => h.Value)
-                    .Take(maxResults)
+                    .Take(Math.Max(0, maxResults))
                     .ToListAsync();
 
                 if (holdings.Count == 0)

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests.cs
@@ -27,9 +27,7 @@ public class InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResults
             NullLogger<InstitutionalHoldingsTools>()
         );
 
-    [Fact(
-        Skip = "GH-2994 — GetInstitutionPortfolio surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetInstitutionPortfolio_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

- A negative `maxResults` passed to the `GetInstitutionPortfolio` MCP tool reached PostgreSQL as a negative SQL `LIMIT`, which the engine rejects — the tool surfaced the executor's generic internal-error sentinel instead of degrading gracefully.
- Clamp the value with `Math.Max(0, maxResults)` so a negative cap yields an empty result, matching the sibling tools that already clamp.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — route `maxResults` through `Math.Max(0, maxResults)` before `.Take(...)` in `GetInstitutionPortfolio`.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetInstitutionPortfolioNegativeMaxResultsTests.cs` — un-skip the regression test; it fails on the unclamped code and passes after the fix.

closes #2994