### PR TITLE
test(holdings): add skipped repro for GH-2999 — GetMarketWide13FActivity negative maxResults

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests.cs
@@ -1,0 +1,83 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests
+    : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests(
+        ParadeDbFixture fixture
+    )
+        : base(fixture) { }
+
+    [Fact(
+        Skip = "GH-2999 — GetMarketWide13FActivity surfaces an internal error for a negative maxResults instead of degrading gracefully"
+    )]
+    public async Task GetMarketWide13FActivity_NegativeMaxResults_DoesNotSurfaceInternalError()
+    {
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "C1",
+        };
+        var holder = new InstitutionalHolder { Cik = "1", Name = "Big Fund" };
+        DbContext.AddRange(aapl, holder);
+        DbContext.Add(MakeHolding(aapl, holder, prior, shares: 1_000, value: 1_000_000));
+        DbContext.Add(MakeHolding(aapl, holder, current, shares: 1_500, value: 1_500_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        // Contract: maxResults is "Maximum number of stocks to return"; a negative value
+        // is nonsensical input. It is forwarded unclamped into the EF Core
+        // GetQuarterlyActivity(...).Take(maxResults) query, so a negative cap reaches
+        // PostgreSQL as a negative LIMIT, which the engine rejects. The tool must degrade
+        // gracefully rather than leak the executor's internal-error sentinel to the caller.
+        var output = await sut.GetMarketWide13FActivity(bucket: "top-buys", maxResults: -1);
+
+        output.Should().NotContain("An error occurred while executing");
+    }
+
+    private InstitutionalHoldingsTools NewSut(Equibles.Data.EquiblesFinancialDbContext ctx) =>
+        new(
+            new InstitutionalHoldingRepository(ctx),
+            new InstitutionalHolderRepository(ctx),
+            new CommonStockRepository(ctx),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

- Adds an adversarial integration test asserting that `GetMarketWide13FActivity` degrades gracefully on a negative `maxResults` rather than surfacing the executor's internal-error sentinel.
- The test currently fails — it reproduces a real defect (negative `maxResults` reaches PostgreSQL as a negative SQL `LIMIT`). Committed as `[Skip]` — see GH-2999. Un-skip it as part of the fix.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests.cs` — new skipped regression test seeding two report dates and calling the `top-buys` bucket with `maxResults: -1`; asserts the output contains no internal-error sentinel.