### PR TITLE
fix(web): clamp backtest rebalance shift so a far-future 13F report date no longer 500s

### DIFF
--- a/src/Equibles.Web/Services/HoldingsBacktestService.cs
+++ b/src/Equibles.Web/Services/HoldingsBacktestService.cs
@@ -89,7 +89,7 @@ public class HoldingsBacktestService
         }
 
         var resolvedTo = to ?? DateOnly.FromDateTime(DateTime.UtcNow);
-        var firstRebalance = reportDates[0].AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
+        var firstRebalance = RebalanceDateOf(reportDates[0]);
         var resolvedFrom = from ?? firstRebalance;
 
         var relevant = SelectRelevantSnapshotDates(reportDates, resolvedFrom, resolvedTo);
@@ -196,6 +196,15 @@ public class HoldingsBacktestService
         return options;
     }
 
+    // Shift a 13F ReportDate forward to its rebalance date (+45 days), mirroring the clamp in
+    // HoldingsBacktestCalculator: a ReportDate within RebalanceDelayDays of DateOnly.MaxValue
+    // would overflow the calendar, so cap the shift at MaxValue instead of throwing.
+    private static DateOnly RebalanceDateOf(DateOnly reportDate) =>
+        reportDate.DayNumber
+        > DateOnly.MaxValue.DayNumber - HoldingsBacktestCalculator.RebalanceDelayDays
+            ? DateOnly.MaxValue
+            : reportDate.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
+
     // Select all snapshots whose rebalance date falls in [resolvedFrom, resolvedTo], plus the
     // latest one whose rebalance date precedes resolvedFrom so the simulation can open with an
     // initial portfolio.
@@ -209,7 +218,7 @@ public class HoldingsBacktestService
         DateOnly? lastBeforeWindow = null;
         foreach (var date in reportDates)
         {
-            var rebalance = date.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
+            var rebalance = RebalanceDateOf(date);
             if (rebalance < resolvedFrom)
                 lastBeforeWindow = date;
             else if (rebalance <= resolvedTo)

--- a/tests/Equibles.FunctionalTests/Tests/InstitutionsBacktestReportDateOverflowTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/InstitutionsBacktestReportDateOverflowTests.cs
@@ -23,7 +23,7 @@ public class InstitutionsBacktestReportDateOverflowTests
         _playwright = playwright;
     }
 
-    [Fact(Skip = "GH-2935 — backtest 500s on ReportDate.AddDays(45) overflow; un-skip when fixed")]
+    [Fact]
     public async Task Backtest_HolderWithFarFutureReportDate_DoesNotReturn500()
     {
         // Contract: the backtest page must respond gracefully for any holder that has 13F


### PR DESCRIPTION
## Summary

- The institution backtest page (`GET /institutions/{cik}/backtest`) returned HTTP 500 when a holder had a 13F snapshot whose `ReportDate` was within 45 days of `DateOnly.MaxValue`.
- `HoldingsBacktestService` shifted report dates forward by 45 days (the rebalance delay) with an unguarded `DateOnly.AddDays`, overflowing the calendar and throwing `ArgumentOutOfRangeException` before the calculator's own clamp was ever reached.

## Code changes

- `src/Equibles.Web/Services/HoldingsBacktestService.cs` — route both rebalance shifts (`reportDates[0]` in `Execute` and the per-snapshot shift in `SelectRelevantSnapshotDates`) through a new `RebalanceDateOf` helper that mirrors the clamp `HoldingsBacktestCalculator` already applies (`DayNumber` guard → cap at `DateOnly.MaxValue`). The page now renders a graceful no-data result instead of a 500.
- `tests/Equibles.FunctionalTests/Tests/InstitutionsBacktestReportDateOverflowTests.cs` — un-skipped the committed regression test; it fails on the unfixed code (500) and passes with the clamp.

Closes #2935.