### PR TITLE
test(web): pin SelectRelevantSnapshotDates clamps a MaxValue report date

### DIFF
--- a/tests/Equibles.UnitTests/Web/HoldingsBacktestServiceSelectRelevantSnapshotsMaxValueReportDateTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsBacktestServiceSelectRelevantSnapshotsMaxValueReportDateTests.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+/// <summary>
+/// Per-snapshot sibling to the rebalance-date overflow guard. SelectRelevantSnapshotDates
+/// shifts each ReportDate forward to its rebalance date (+45 days); a ReportDate within
+/// RebalanceDelayDays of DateOnly.MaxValue would overflow the calendar with an unguarded
+/// AddDays. The contract is that any stored snapshot must be classified gracefully — never
+/// throw — so the page can render a "no data" result. With a normal requested window, the
+/// clamped rebalance date (MaxValue) sits past resolvedTo and the snapshot is simply dropped.
+/// </summary>
+public class HoldingsBacktestServiceSelectRelevantSnapshotsMaxValueReportDateTests
+{
+    private static readonly MethodInfo SelectRelevantSnapshotDatesMethod =
+        typeof(HoldingsBacktestService).GetMethod(
+            "SelectRelevantSnapshotDates",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    [Fact]
+    public void SelectRelevantSnapshotDates_ReportDateAtMaxValue_DoesNotThrowAndDropsOutOfWindowSnapshot()
+    {
+        var resolvedFrom = new DateOnly(2024, 1, 1);
+        var resolvedTo = new DateOnly(2024, 12, 31);
+        IReadOnlyList<DateOnly> reportDates = [DateOnly.MaxValue];
+
+        var result =
+            (List<DateOnly>)
+                SelectRelevantSnapshotDatesMethod.Invoke(
+                    null,
+                    [reportDates, resolvedFrom, resolvedTo]
+                );
+
+        // Rebalance clamps to MaxValue, which is after resolvedTo: out of window, not an
+        // opener — so nothing is selected, and no overflow is thrown along the way.
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a focused unit pin for the per-snapshot rebalance-date overflow clamp in `HoldingsBacktestService.SelectRelevantSnapshotDates` (the second call site hardened in the GH-2935 fix).
- The functional test covers the overflow end-to-end; this pins the per-snapshot classification at the unit level — a `ReportDate` of `DateOnly.MaxValue` must clamp gracefully (no `ArgumentOutOfRangeException`) and, with a normal requested window, drop out of window.

## Code changes

- `tests/Equibles.UnitTests/Web/HoldingsBacktestServiceSelectRelevantSnapshotsMaxValueReportDateTests.cs` — new reflection-based unit test asserting `SelectRelevantSnapshotDates([DateOnly.MaxValue], …)` returns empty without throwing.