### PR TITLE
fix(insider-trading): reject negative-share repaired price in InsiderTransactionPriceValidator

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
@@ -122,8 +122,12 @@ public class InsiderTransactionPriceValidator
             };
         }
 
-        // Implausible but unrepairable without a share count.
-        if (shares == 0)
+        // Implausible but unrepairable without a positive share count. A zero
+        // count can't be divided; a negative one (a malformed/amended Form 4
+        // carries "-N" through long.TryParse) would only "repair" into a
+        // negative per-share price, which is never a real unit price — so it's
+        // rejected the same way.
+        if (shares <= 0)
         {
             return new InsiderTransactionPriceEvaluation
             {

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs
@@ -272,7 +272,7 @@ public class InsiderTransactionPriceValidatorTests
     // A recovered unit price is never negative; like the zero-shares case the
     // total can't be divided into a sensible unit price, so the row must be
     // rejected, not accepted as valid.
-    [Fact(Skip = "GH-2955 — Evaluate stamps a negative repaired price valid when shares < 0")]
+    [Fact]
     public void Evaluate_ImplausibleWithNegativeShares_IsNotAcceptedAsNegativePrice()
     {
         var result = _validator.Evaluate(


### PR DESCRIPTION
## Summary

- A malformed or amended Form 4 can carry a negative `transactionShares` through `long.TryParse` into `InsiderTransactionPriceValidator.Evaluate`. The implausible-price repair only guarded `shares == 0`, so a negative count divided the mis-entered total into a **negative** per-share price — then stamped `IsPriceValid = true` and `WasRepaired = true`, re-polluting the dashboard's `Shares × PricePerShare` sort the feature exists to clean.
- Widen the guard to `shares <= 0` so a negative count is rejected the same way as the zero-shares case (a recovered unit price is never negative).
- Shared `Equibles.InsiderTrading.BusinessLogic` module — the commercial portal consumes this same validator (no duplicate), so the fix flows there automatically.

## Code changes

- `src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs` — change the unrepairable-share-count guard from `shares == 0` to `shares <= 0`; expand the comment to explain the negative case.
- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorTests.cs` — un-skip the `Evaluate_ImplausibleWithNegativeShares_IsNotAcceptedAsNegativePrice` regression test.

closes #2955