### PR TITLE
test(insider-trading): skipped repro for GH-3004 — MaxValue close overflow

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorMaxValueCloseTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorMaxValueCloseTests.cs
@@ -1,0 +1,26 @@
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderTransactionPriceValidatorMaxValueCloseTests
+{
+    private readonly InsiderTransactionPriceValidator _validator = new();
+
+    // Contract: IsPlausible classifies a reported price against the close and
+    // returns a bool — it must never throw for a valid decimal close. The
+    // ceiling check computes close * 10; a decimal.MaxValue close makes that
+    // product overflow, so an extreme-but-legal close must still yield a
+    // verdict (a price below any sane multiple of MaxValue is plausible),
+    // not an OverflowException leaking out of the validator.
+    [Fact(
+        Skip = "GH-3004 — IsPlausible throws OverflowException on a decimal.MaxValue close (close * 10 overflows)"
+    )]
+    public void IsPlausible_CommonStockWithMaxValueClose_DoesNotThrow()
+    {
+        var act = () => _validator.IsPlausible(100m, "Common Stock", decimal.MaxValue);
+
+        act.Should().NotThrow();
+        _validator.IsPlausible(100m, "Common Stock", decimal.MaxValue).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped regression test reproducing GH-3004: `InsiderTransactionPriceValidator.IsPlausible` throws `OverflowException` on a `decimal.MaxValue` close because the `close × 10` ceiling product overflows before the comparison.
- Test-only — no production change. Un-skip it as part of the fix for GH-3004.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorMaxValueCloseTests.cs` — new `[Fact(Skip = "GH-3004 …")]` asserting `IsPlausible` returns a verdict (does not throw) for an extreme-but-legal close. Skipped — see GH-3004.