### PR TITLE
fix(insider-trading): avoid decimal overflow in InsiderTransactionPriceValidator close ceiling

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
@@ -61,7 +61,10 @@ public class InsiderTransactionPriceValidator
         if (!unadjustedClose.HasValue || unadjustedClose.Value <= 0m)
             return true;
 
-        return pricePerShare <= unadjustedClose.Value * MaxPriceToCloseMultiplier;
+        // Compare via division rather than close * multiplier: an extreme-but-
+        // legal close (near decimal.MaxValue) overflows the product, and this
+        // method must always return a verdict, never throw.
+        return pricePerShare / MaxPriceToCloseMultiplier <= unadjustedClose.Value;
     }
 
     /// <summary>
@@ -112,8 +115,9 @@ public class InsiderTransactionPriceValidator
             };
         }
 
-        // Plausible against the close — keep as filed.
-        if (reportedPrice <= unadjustedClose.Value * MaxPriceToCloseMultiplier)
+        // Plausible against the close — keep as filed. Divide rather than
+        // multiply the close so a near-decimal.MaxValue close can't overflow.
+        if (reportedPrice / MaxPriceToCloseMultiplier <= unadjustedClose.Value)
         {
             return new InsiderTransactionPriceEvaluation
             {

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorMaxValueCloseTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorMaxValueCloseTests.cs
@@ -13,14 +13,35 @@ public class InsiderTransactionPriceValidatorMaxValueCloseTests
     // product overflow, so an extreme-but-legal close must still yield a
     // verdict (a price below any sane multiple of MaxValue is plausible),
     // not an OverflowException leaking out of the validator.
-    [Fact(
-        Skip = "GH-3004 — IsPlausible throws OverflowException on a decimal.MaxValue close (close * 10 overflows)"
-    )]
+    [Fact]
     public void IsPlausible_CommonStockWithMaxValueClose_DoesNotThrow()
     {
         var act = () => _validator.IsPlausible(100m, "Common Stock", decimal.MaxValue);
 
         act.Should().NotThrow();
         _validator.IsPlausible(100m, "Common Stock", decimal.MaxValue).Should().BeTrue();
+    }
+
+    // Evaluate shares the same close * 10 ceiling check (the plausible-against-
+    // close branch), so a decimal.MaxValue close overflows there too. The
+    // contract is to return a verdict — a price far below any sane multiple of
+    // a MaxValue close is valid as filed, not an OverflowException.
+    [Fact]
+    public void Evaluate_CommonStockWithMaxValueClose_DoesNotThrow()
+    {
+        var act = () =>
+            _validator.Evaluate(
+                reportedPrice: 100m,
+                shares: 10,
+                kind: InsiderSecurityKind.NonDerivative,
+                securityTitle: "Common Stock",
+                unadjustedClose: decimal.MaxValue
+            );
+
+        act.Should().NotThrow();
+        var evaluation = act();
+        evaluation.IsPriceValid.Should().Be(true);
+        evaluation.EffectivePrice.Should().Be(100m);
+        evaluation.WasRepaired.Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Summary

- `InsiderTransactionPriceValidator` decided plausibility by comparing the reported per-share price against `close * 10`. A close at or near `decimal.MaxValue` overflowed that product and threw `OverflowException` out of a method whose contract is to return a verdict.
- Rearranged both the `IsPlausible` and `Evaluate` ceiling checks to divide the price by the multiplier instead — algebraically equivalent for the positive values that reach this point, and incapable of overflowing.

## Code changes

- `src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs` — replaced `price <= close * MaxPriceToCloseMultiplier` with `price / MaxPriceToCloseMultiplier <= close` in both `IsPlausible` and `Evaluate`.
- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorMaxValueCloseTests.cs` — un-skipped the GH-3004 repro for `IsPlausible` and added a matching `Evaluate` repro; both fail on the pre-fix product overflow and pass after.

closes #3004