### PR TITLE
test(insider-trading): pin InsiderTransactionPriceValidator.Evaluate zero-close pending verdict

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorEvaluateZeroCloseTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorEvaluateZeroCloseTests.cs
@@ -1,0 +1,30 @@
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderTransactionPriceValidatorEvaluateZeroCloseTests
+{
+    private readonly InsiderTransactionPriceValidator _validator = new();
+
+    // Contract: a real (positive, non-derivative) price that can't yet be
+    // checked stays pending (IsPriceValid == null), not valid. A close on file
+    // of 0 — bad/sentinel data — is as unusable for validation as a missing
+    // close, so it must yield the same pending verdict rather than silently
+    // accepting or repairing the price.
+    [Fact]
+    public void Evaluate_CommonStockWithZeroClose_IsPending()
+    {
+        var result = _validator.Evaluate(
+            reportedPrice: 0.24m,
+            shares: 1000,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            unadjustedClose: 0m
+        );
+
+        result.IsPriceValid.Should().BeNull();
+        result.WasRepaired.Should().BeFalse();
+        result.EffectivePrice.Should().Be(0.24m);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the previously-uncovered branch in `InsiderTransactionPriceValidator.Evaluate` where the close is present but non-positive (`unadjustedClose.Value <= 0m`). Only the null-close pending case was covered.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorEvaluateZeroCloseTests.cs` — asserts a positive non-derivative price with a zero close yields a pending verdict (`IsPriceValid == null`, unrepaired, original price preserved), matching the documented "can't yet check → pending" contract.