### PR TITLE
feat(insider-trading): capture Form 4 footnotes per transaction (parser v2)

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
@@ -35,6 +35,7 @@ public static class InsiderFilingParser
     )
     {
         var transactions = new List<InsiderTransaction>();
+        var footnotes = BuildFootnotes(root);
 
         void AddParsed(InsiderTransaction tx)
         {
@@ -55,10 +56,28 @@ public static class InsiderFilingParser
             if (table == null)
                 return;
             foreach (var txElement in table.Elements(txName))
-                AddParsed(ParseTransaction(txElement, owner, companyId, filing, isAmendment, kind));
+                AddParsed(
+                    ParseTransaction(
+                        txElement,
+                        owner,
+                        companyId,
+                        filing,
+                        isAmendment,
+                        kind,
+                        footnotes
+                    )
+                );
             foreach (var holdingElement in table.Elements(holdingName))
                 AddParsed(
-                    ParseHolding(holdingElement, owner, companyId, filing, isAmendment, kind)
+                    ParseHolding(
+                        holdingElement,
+                        owner,
+                        companyId,
+                        filing,
+                        isAmendment,
+                        kind,
+                        footnotes
+                    )
                 );
         }
 
@@ -111,7 +130,8 @@ public static class InsiderFilingParser
         Guid companyId,
         FilingData filing,
         bool isAmendment,
-        InsiderSecurityKind kind
+        InsiderSecurityKind kind,
+        IReadOnlyDictionary<string, string> footnotes
     )
     {
         string Wrapped(params string[] path) => GetWrappedValue(txElement, path);
@@ -147,6 +167,7 @@ public static class InsiderFilingParser
             IsAmendment = isAmendment,
             SecurityKind = kind,
             ParserVersion = InsiderTransaction.CurrentParserVersion,
+            Notes = ExtractNotes(txElement, footnotes),
         };
     }
 
@@ -156,7 +177,8 @@ public static class InsiderFilingParser
         Guid companyId,
         FilingData filing,
         bool isAmendment,
-        InsiderSecurityKind kind
+        InsiderSecurityKind kind,
+        IReadOnlyDictionary<string, string> footnotes
     )
     {
         var securityTitle = GetWrappedValue(holdingElement, "securityTitle")?.Trim();
@@ -183,7 +205,54 @@ public static class InsiderFilingParser
             IsAmendment = isAmendment,
             SecurityKind = kind,
             ParserVersion = InsiderTransaction.CurrentParserVersion,
+            Notes = ExtractNotes(holdingElement, footnotes),
         };
+    }
+
+    // Build the filing's footnote table: id → text. The <footnotes> block sits at
+    // the document root; transactions reference its entries by id. Returns an empty
+    // map when the filing has no footnotes.
+    private static Dictionary<string, string> BuildFootnotes(XElement root)
+    {
+        var footnotesElement = root.Element("footnotes");
+        if (footnotesElement == null)
+            return new Dictionary<string, string>();
+
+        var result = new Dictionary<string, string>();
+        foreach (var footnote in footnotesElement.Elements("footnote"))
+        {
+            var id = footnote.Attribute("id")?.Value;
+            var text = footnote.Value?.Trim();
+            if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(text))
+                continue;
+            // Last one wins on a duplicate id (shouldn't happen, but be deterministic).
+            result[id] = text;
+        }
+        return result;
+    }
+
+    // Resolve every footnote referenced anywhere within a transaction/holding
+    // element — Form 4 places <footnoteId id="Fx"/> on the row itself and on
+    // individual fields (price, shares, ownership). Collect them in document
+    // order, de-duplicated by id, and map to their text. Form 4 transactions are
+    // flat (siblings under their table), so this subtree holds only this row's
+    // references — never a sibling row's or the document-level <footnotes> block.
+    internal static List<string> ExtractNotes(
+        XElement element,
+        IReadOnlyDictionary<string, string> footnotes
+    )
+    {
+        var notes = new List<string>();
+        var seen = new HashSet<string>();
+        foreach (var reference in element.Descendants("footnoteId"))
+        {
+            var id = reference.Attribute("id")?.Value;
+            if (string.IsNullOrEmpty(id) || !seen.Add(id))
+                continue;
+            if (footnotes.TryGetValue(id, out var text) && !string.IsNullOrEmpty(text))
+                notes.Add(text);
+        }
+        return notes;
     }
 
     // "I" → Indirect, anything else (including "D" and absent) → Direct. The

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -204,19 +204,35 @@ public class InsiderFilingReprocessManager
         );
         // TransactionOrder is unique within a parse by construction, so a direct
         // dictionary is safe; a duplicate would be a parser bug worth surfacing.
-        var kindByOrder = parsed.ToDictionary(t => t.TransactionOrder, t => t.SecurityKind);
+        var parsedByOrder = parsed.ToDictionary(t => t.TransactionOrder);
+
+        // The re-parse should reproduce the stored rows exactly. If the counts
+        // diverge, some stored rows won't map to a parsed row — they keep their
+        // prior data but are still advanced to the current version. Rare, but log
+        // it so the assumption is observable across a full backlog reprocess.
+        if (rows.Count != parsed.Count)
+        {
+            _logger.LogWarning(
+                "Insider reprocess: {AccessionNumber} has {StoredCount} stored rows but re-parsed {ParsedCount}; unmatched rows keep prior data",
+                accession,
+                rows.Count,
+                parsed.Count
+            );
+        }
 
         var closes = await FetchCloses(first.CommonStockId, rows);
 
         foreach (var row in rows)
         {
-            if (
-                kindByOrder.TryGetValue(row.TransactionOrder, out var kind)
-                && row.SecurityKind != kind
-            )
+            if (parsedByOrder.TryGetValue(row.TransactionOrder, out var reparsed))
             {
-                row.SecurityKind = kind;
-                result.Reclassified++;
+                if (row.SecurityKind != reparsed.SecurityKind)
+                {
+                    row.SecurityKind = reparsed.SecurityKind;
+                    result.Reclassified++;
+                }
+                // Re-derive footnotes (added in parser v2); cheap to always copy.
+                row.Notes = reparsed.Notes;
             }
 
             decimal? close = closes.TryGetValue(row.TransactionDate, out var value) ? value : null;

--- a/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
+++ b/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
@@ -15,5 +15,14 @@ public class InsiderTradingModuleConfiguration : Equibles.Data.IFinancialModule
         // inserted row is null ("not evaluated yet") until the parser (or a
         // maintenance recompute) cross-checks it against the market close.
         builder.Entity<InsiderTransaction>();
+        // Notes is a NOT NULL text[]; default existing rows to an empty array so
+        // the column can be added without a backfill (the reprocess pass fills it).
+        // IsRequired is explicit because nullable reference types are off, so EF
+        // would otherwise treat the collection as optional.
+        builder
+            .Entity<InsiderTransaction>()
+            .Property(t => t.Notes)
+            .IsRequired()
+            .HasDefaultValueSql("'{}'");
     }
 }

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -20,8 +20,10 @@ public class InsiderTransaction
     /// field, a corrected classification). Rows below this value can be
     /// re-parsed from the cached <see cref="InsiderFiling"/> XML rather than
     /// re-fetched from EDGAR. Rows ingested before versioning default to 0.
+    ///
+    /// History: v1 added SecurityKind; v2 added <see cref="Notes"/> (footnotes).
     /// </summary>
-    public const int CurrentParserVersion = 1;
+    public const int CurrentParserVersion = 2;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 
@@ -87,6 +89,15 @@ public class InsiderTransaction
     /// before versioning, which marks them for reprocessing.
     /// </summary>
     public int ParserVersion { get; set; }
+
+    /// <summary>
+    /// Footnotes attached to this transaction in the Form 4 filing, resolved to
+    /// their text. A Form 4 references footnotes by id (<c>footnoteId</c>) on the
+    /// transaction itself or on individual fields; this collects every footnote
+    /// referenced anywhere within the row, de-duplicated, in document order.
+    /// Empty when the filing annotated nothing. Stored as a Postgres array.
+    /// </summary>
+    public List<string> Notes { get; set; } = [];
 
     /// <summary>
     /// Tri-state price-plausibility flag, cross-checked against the Yahoo

--- a/src/Equibles.Migrations/Migrations/20260531122502_AddInsiderTransactionNotes.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260531122502_AddInsiderTransactionNotes.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260531122502_AddInsiderTransactionNotes")]
+    partial class AddInsiderTransactionNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260531122502_AddInsiderTransactionNotes.cs
+++ b/src/Equibles.Migrations/Migrations/20260531122502_AddInsiderTransactionNotes.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInsiderTransactionNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<List<string>>(
+                name: "Notes",
+                table: "InsiderTransaction",
+                type: "text[]",
+                nullable: false,
+                defaultValueSql: "'{}'"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "Notes", table: "InsiderTransaction");
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserFootnotesTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserFootnotesTests.cs
@@ -1,0 +1,107 @@
+using System.Xml.Linq;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserFootnotesTests
+{
+    // Form 4 references footnotes by id both on the transaction itself and on
+    // individual fields (price, shares, ownership). ParseTransactions must resolve
+    // every reference within a row to its text, in document order, de-duplicated,
+    // ignoring footnotes the row doesn't reference.
+    private static List<InsiderTransaction> ParseAll(XElement root)
+    {
+        var owner = new InsiderOwner { OwnerCik = "0000000001", Name = "Owner" };
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000000000-26-000001",
+            Form = "4",
+            FilingDate = new DateOnly(2026, 1, 5),
+            ReportDate = new DateOnly(2026, 1, 2),
+        };
+        return InsiderFilingParser.ParseTransactions(root, owner, Guid.NewGuid(), filing, false);
+    }
+
+    [Fact]
+    public void ParseTransactions_ResolvesPerFieldAndRowFootnotes_InOrderDeduped()
+    {
+        var root = new XElement(
+            "ownershipDocument",
+            new XElement(
+                "nonDerivativeTable",
+                new XElement(
+                    "nonDerivativeTransaction",
+                    new XElement("securityTitle", new XElement("value", "Common Stock")),
+                    new XElement("transactionDate", new XElement("value", "2026-01-02")),
+                    new XElement("transactionCoding", new XElement("transactionCode", "P")),
+                    new XElement(
+                        "transactionAmounts",
+                        new XElement("transactionShares", new XElement("value", "1000")),
+                        new XElement(
+                            "transactionPricePerShare",
+                            new XElement("value", "10"),
+                            new XElement("footnoteId", new XAttribute("id", "F1"))
+                        )
+                    ),
+                    // Row-level footnote.
+                    new XElement("footnoteId", new XAttribute("id", "F2")),
+                    new XElement(
+                        "postTransactionAmounts",
+                        new XElement(
+                            "sharesOwnedFollowingTransaction",
+                            new XElement("value", "1000"),
+                            // Duplicate reference to F1 — must collapse to one note.
+                            new XElement("footnoteId", new XAttribute("id", "F1"))
+                        )
+                    )
+                )
+            ),
+            new XElement(
+                "footnotes",
+                new XElement(
+                    "footnote",
+                    new XAttribute("id", "F1"),
+                    "Price is a weighted average."
+                ),
+                new XElement("footnote", new XAttribute("id", "F2"), "Shares held in a trust."),
+                new XElement("footnote", new XAttribute("id", "F3"), "Unreferenced note.")
+            )
+        );
+
+        var transactions = ParseAll(root);
+
+        transactions.Should().HaveCount(1);
+        transactions[0]
+            .Notes.Should()
+            .Equal("Price is a weighted average.", "Shares held in a trust.");
+    }
+
+    [Fact]
+    public void ParseTransactions_NoFootnotes_NotesIsEmpty()
+    {
+        var root = new XElement(
+            "ownershipDocument",
+            new XElement(
+                "nonDerivativeTable",
+                new XElement(
+                    "nonDerivativeTransaction",
+                    new XElement("securityTitle", new XElement("value", "Common Stock")),
+                    new XElement("transactionDate", new XElement("value", "2026-01-02")),
+                    new XElement("transactionCoding", new XElement("transactionCode", "P")),
+                    new XElement(
+                        "transactionAmounts",
+                        new XElement("transactionShares", new XElement("value", "1000")),
+                        new XElement("transactionPricePerShare", new XElement("value", "10"))
+                    )
+                )
+            )
+        );
+
+        var transactions = ParseAll(root);
+
+        transactions.Should().HaveCount(1);
+        transactions[0].Notes.Should().BeEmpty();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCultureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InsiderTradingFilingProcessorParseTransactionCultureTests.cs
@@ -59,7 +59,15 @@ public class InsiderTradingFilingProcessorParseTransactionCultureTests
             var result = (InsiderTransaction)
                 method.Invoke(
                     null,
-                    [tx, owner, Guid.NewGuid(), filing, false, InsiderSecurityKind.NonDerivative]
+                    [
+                        tx,
+                        owner,
+                        Guid.NewGuid(),
+                        filing,
+                        false,
+                        InsiderSecurityKind.NonDerivative,
+                        new Dictionary<string, string>(),
+                    ]
                 );
 
             result.Should().NotBeNull();


### PR DESCRIPTION
## Summary

Captures the footnotes a Form 4 attaches to each insider transaction. A filing references footnotes by id (`<footnoteId id="Fx"/>`) on the transaction element and on individual fields (price, shares, ownership); the document root carries a `<footnotes>` block of id→text. This resolves every reference within a row to its text — in document order, de-duplicated — and stores them on the new `InsiderTransaction.Notes` (Postgres `text[]`).

This is the second use of the parser-version mechanism: `CurrentParserVersion` is bumped 1→2, so the existing reprocess pass re-derives `Notes` for every stored row from the cached ownership XML (alongside `SecurityKind`), and new ingests populate it directly. No new backfill machinery — the version bump re-enrolls every filing automatically.

## Code changes

- **`InsiderTransaction.Notes`** — `List<string>` mapped to `text[]`, `IsRequired` + `HasDefaultValueSql("'{}'")` (NRT is off, so required is explicit). `CurrentParserVersion` → 2.
- **`InsiderFilingParser`** — `BuildFootnotes(root)` builds the id→text map (skips blank/idless); `ExtractNotes(element, footnotes)` walks the row's subtree for every `<footnoteId>`, dedups by id preserving document order, resolves to text. `ParseTransaction`/`ParseHolding` set `Notes`.
- **`InsiderFilingReprocessManager`** — copies the re-parsed `Notes` onto the stored row (mapped by `TransactionOrder`) during reprocess, and logs a warning if stored/parsed counts diverge.
- **Migration `AddInsiderTransactionNotes`** — adds the `Notes text[] NOT NULL DEFAULT '{}'` column (metadata-only on PostgreSQL 11+, no rewrite/backfill).

## Tests

- New unit tests for footnote resolution: per-field + row-level references, de-dup of a repeated id, document order, an unreferenced footnote ignored, and the no-footnotes case.
- Full unit suite green: 2345 passing.

## Notes

- Existing rows gain `Notes` when the backoffice "Reprocess filings" pass runs (it now does kind + price + notes in one pass — the v1 backlog hadn't been run yet, so going straight to v2 means a single crawl does everything).