### PR TITLE
fix(indicators): avoid int overflow in ComputeStochastic %D warm-up guard

### DIFF
--- a/src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs
+++ b/src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs
@@ -256,7 +256,10 @@ public static class TechnicalIndicatorService
         var d = new List<decimal?>(count);
         for (var i = 0; i < count; i++)
         {
-            if (i < kPeriod - 1 + dPeriod - 1)
+            // Computed in long: kPeriod + dPeriod can exceed int.MaxValue, and an int
+            // overflow here would wrap the threshold negative so the guard never fires
+            // and the inner loop indexes %K out of range.
+            if (i < (long)kPeriod - 1 + dPeriod - 1)
             {
                 d.Add(null);
                 continue;

--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceStochasticHugeDPeriodTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceStochasticHugeDPeriodTests.cs
@@ -4,7 +4,7 @@ namespace Equibles.UnitTests.Web;
 
 public class TechnicalIndicatorServiceStochasticHugeDPeriodTests
 {
-    [Fact(Skip = "GH-2929 — ComputeStochastic warm-up guard overflows int for huge dPeriod")]
+    [Fact]
     public void ComputeStochastic_DPeriodLargerThanSeries_PercentDIsAllNull()
     {
         // Contract: %D is "null-padded at the start while the lookback window fills"; a


### PR DESCRIPTION
## Summary

`TechnicalIndicatorService.ComputeStochastic` threw `ArgumentOutOfRangeException` when `dPeriod` was large enough that the %D warm-up guard `kPeriod - 1 + dPeriod - 1` overflowed `int`. With `kPeriod = 3` and `dPeriod = int.MaxValue` the sum wrapped to `int.MinValue`, so the guard `i < int.MinValue` never fired and the inner loop indexed %K with a large negative index. This path is reachable from `GetStochasticOscillator`, which only rejects `dPeriod < 1` and has no upper bound.

Per the method's documented contract, a `dPeriod` larger than the series can never fill the lookback window, so every %D value must be `null`. Computing the threshold in `long` keeps that behavior instead of throwing.

## Code changes

- `src/Equibles.Yahoo.Repositories/TechnicalIndicatorService.cs` — compute the %D warm-up threshold in `long` (`(long)kPeriod - 1 + dPeriod - 1`) so the sum can't overflow.
- `tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceStochasticHugeDPeriodTests.cs` — un-skip the regression test that pins all-null %D for a `dPeriod` larger than the series.

closes #2929