### PR TITLE
fix(sec): treat LIKE wildcards in adviser name search as literals

### DIFF
--- a/src/Equibles.Sec.Repositories/FormAdvAdviserRepository.cs
+++ b/src/Equibles.Sec.Repositories/FormAdvAdviserRepository.cs
@@ -26,10 +26,14 @@ public class FormAdvAdviserRepository : BaseRepository<FormAdvAdviser>
         }
 
         var trimmed = term.Trim();
+        // Escape LIKE metacharacters so "_" and "%" in the query match literally
+        // rather than acting as wildcards; pair with an explicit ESCAPE clause.
+        var escaped = trimmed.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
+        var pattern = $"%{escaped}%";
         return GetAll()
             .Where(a =>
-                EF.Functions.ILike(a.LegalName, $"%{trimmed}%")
-                || EF.Functions.ILike(a.PrimaryBusinessName, $"%{trimmed}%")
+                EF.Functions.ILike(a.LegalName, pattern, "\\")
+                || EF.Functions.ILike(a.PrimaryBusinessName, pattern, "\\")
             )
             // Coalesce so advisers that did not report assets sort last rather than first
             // (Postgres orders NULL highest under a plain DESC).

--- a/tests/Equibles.IntegrationTests/Web/AdvisersSearchWildcardEscapingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/AdvisersSearchWildcardEscapingTests.cs
@@ -48,9 +48,7 @@ public class AdvisersSearchWildcardEscapingTests
         return Task.CompletedTask;
     }
 
-    [Fact(
-        Skip = "GH-2905 — adviser search treats LIKE wildcards (_, %) as wildcards, not literals"
-    )]
+    [Fact]
     public async Task GetAdvisers_QueryIsBareUnderscore_DoesNotWildcardMatchNamesWithoutUnderscore()
     {
         await _fixture.ResetAndSeedAsync(Seed);


### PR DESCRIPTION
## Summary

`FormAdvAdviserRepository.Search` is documented to match advisers whose legal or primary business name *contains* the supplied term, but it spliced the raw term straight into an `ILIKE` pattern (`%{term}%`) without escaping LIKE metacharacters. Because `_` matches any single character and `%` matches any run of characters, a query containing them did not search for those literals: searching for `_` matched every adviser with a non-empty name, and `%` returned the entire advisers table. Closes #2905.

## Code changes

- `src/Equibles.Sec.Repositories/FormAdvAdviserRepository.cs` — escape `\`, `%` and `_` in the trimmed term (backslash first) and match with an explicit `ESCAPE '\'` clause via the three-argument `EF.Functions.ILike` overload, so wildcard characters are matched literally. Behaviour for ordinary terms is unchanged.
- `tests/Equibles.IntegrationTests/Web/AdvisersSearchWildcardEscapingTests.cs` — un-skip the existing regression test that drives `/advisers?q=_` through the real router, controller, ParadeDB and view, asserting that names without a literal underscore are not returned.

## Verification

- Regression test fails on the pre-fix code (`Failed: 1, Passed: 0`, "an unescaped '_' must not wildcard-match a name with no literal underscore") and passes after the fix.
- All Advisers integration tests green (`Passed: 9, Failed: 0`).