### PR TITLE
test(sec): pin FormAdvAdviserRepository.Search literal-underscore containment

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/FormAdvAdviserRepositorySearchLiteralUnderscoreTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FormAdvAdviserRepositorySearchLiteralUnderscoreTests.cs
@@ -1,0 +1,55 @@
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Adversarial guard on <see cref="FormAdvAdviserRepository.Search"/>'s "name CONTAINS term"
+/// contract for the literal-underscore case. A term with an underscore must match a name that
+/// contains that literal underscore (the escape must not break legitimate matches) AND must
+/// exclude a name that only matches when "_" is honoured as a LIKE single-character wildcard.
+/// Runs on ParadeDB because EF.Functions.ILike has no in-memory translation.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FormAdvAdviserRepositorySearchLiteralUnderscoreTests : ParadeDbMcpTestBase
+{
+    public FormAdvAdviserRepositorySearchLiteralUnderscoreTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task Search_TermWithUnderscore_MatchesLiteralUnderscoreOnly()
+    {
+        DbContext
+            .Set<FormAdvAdviser>()
+            .AddRange(
+                new FormAdvAdviser
+                {
+                    Crd = 410,
+                    LegalName = "A_B CAPITAL",
+                    PrimaryBusinessName = "A_B",
+                    TotalRegulatoryAum = 1_000_000L,
+                    ReportDate = new DateOnly(2022, 4, 1),
+                },
+                new FormAdvAdviser
+                {
+                    Crd = 420,
+                    LegalName = "AXB CAPITAL",
+                    PrimaryBusinessName = "AXB",
+                    TotalRegulatoryAum = 2_000_000L,
+                    ReportDate = new DateOnly(2022, 4, 1),
+                }
+            );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+        var sut = new FormAdvAdviserRepository(DbContext);
+
+        var results = await sut.Search("A_B").ToListAsync();
+
+        // Contract is literal containment: the underscore matches only the name that literally
+        // contains it (CRD 410), never the wildcard-only match "AXB CAPITAL" (CRD 420).
+        results.Select(a => a.Crd).Should().Equal(410);
+    }
+}


### PR DESCRIPTION
## Summary

Adds one adversarial integration test guarding `FormAdvAdviserRepository.Search`'s "name contains term" contract for the literal-underscore case, following the GH-2905 wildcard-escaping fix. The merged GH-2905 regression test only proved a bare `_` no longer wildcard-matches names without an underscore (the exclusion direction). This pins the direction the fix must not break: a term containing an underscore must still match a name that contains that literal underscore.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/FormAdvAdviserRepositorySearchLiteralUnderscoreTests.cs` — seeds `A_B CAPITAL` (literal underscore) and `AXB CAPITAL` (matches only if `_` is treated as a wildcard), searches `A_B`, and asserts only `A_B CAPITAL` is returned. Confirms the escape both suppresses wildcard behaviour and preserves legitimate literal matches. Runs on the ParadeDB harness because `EF.Functions.ILike` has no in-memory translation.

## Verification

- Test passes against current `main` (Passed: 1, Failed: 0).