### PR TITLE
fix(cftc): clamp GetCftcPositioning maxResults to avoid internal error on negative value

### DIFF
--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -69,7 +69,7 @@ public class CftcTools
                 var reports = await _reportRepository
                     .GetByContract(contract, start, end)
                     .OrderByDescending(r => r.ReportDate)
-                    .Take(maxResults)
+                    .Take(Math.Max(0, maxResults))
                     .ToListAsync();
 
                 if (reports.Count == 0)

--- a/tests/Equibles.IntegrationTests/Mcp/CftcToolsGetCftcPositioningNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CftcToolsGetCftcPositioningNegativeMaxResultsTests.cs
@@ -20,9 +20,7 @@ public class CftcToolsGetCftcPositioningNegativeMaxResultsTests : ParadeDbMcpTes
             NullLogger<CftcTools>()
         );
 
-    [Fact(
-        Skip = "GH-2939 — negative maxResults becomes a negative SQL LIMIT and surfaces the internal-error sentinel"
-    )]
+    [Fact]
     public async Task GetCftcPositioning_NegativeMaxResults_DegradesGracefullyWithoutInternalError()
     {
         // Contract: maxResults is documented as "Maximum number of reports to return" — a


### PR DESCRIPTION
## Summary

- A negative `maxResults` passed to the `GetCftcPositioning` MCP tool flowed straight into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects. The exception was swallowed by the tool runner and the caller received the generic `An error occurred while executing GetCftcPositioning. Please try again.` sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` — matching the sibling MCP tools — so a non-positive cap yields zero rows and the existing friendly no-data message.

## Code changes

- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs` — clamp `maxResults` to a non-negative lower bound before `.Take()`.
- `tests/Equibles.IntegrationTests/Mcp/CftcToolsGetCftcPositioningNegativeMaxResultsTests.cs` — un-skip the regression test that calls `GetCftcPositioning(..., maxResults: -1)` and asserts the internal-error sentinel never surfaces (fails before the fix, passes after).

closes #2939