### PR TITLE
feat(insider-trading): reprocess insider filings automatically in the worker

### DIFF
--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -20,6 +20,7 @@ public sealed class ErrorSource
     public static readonly ErrorSource CftcScraper = new("CftcScraper");
     public static readonly ErrorSource CboeScraper = new("CboeScraper");
     public static readonly ErrorSource TranscriptScraper = new("TranscriptScraper");
+    public static readonly ErrorSource InsiderTradingReprocess = new("InsiderTradingReprocess");
     public static readonly ErrorSource Other = new("Other");
 
     public static IEnumerable<ErrorSource> GetAll() =>
@@ -38,6 +39,7 @@ public sealed class ErrorSource
             CftcScraper,
             CboeScraper,
             TranscriptScraper,
+            InsiderTradingReprocess,
             Other,
         ];
 

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -70,7 +70,8 @@ public class InsiderFilingReprocessManager
     }
 
     public async Task<InsiderFilingReprocessResult> Run(
-        Func<InsiderFilingReprocessResult, Task> onProgress = null
+        Func<InsiderFilingReprocessResult, Task> onProgress = null,
+        CancellationToken cancellationToken = default
     )
     {
         // Snapshot of the work-set for the progress bar. The live ingest worker may
@@ -97,7 +98,7 @@ public class InsiderFilingReprocessManager
         // run still terminates; they're retried on the next run (string ordering would
         // be collation-dependent, so a textual keyset is deliberately avoided).
         var failedThisRun = new HashSet<string>();
-        while (true)
+        while (!cancellationToken.IsCancellationRequested)
         {
             var accessions = await _transactionRepository
                 .GetAll()
@@ -106,13 +107,15 @@ public class InsiderFilingReprocessManager
                 .Select(t => t.AccessionNumber)
                 .Distinct()
                 .Take(BatchSize)
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
 
             if (accessions.Count == 0)
                 break;
 
             foreach (var accession in accessions)
             {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
                 try
                 {
                     await ReprocessFiling(accession, result);

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<FtdScraperWorker>();
         services.AddHostedService<FormAdvScraperWorker>();
         services.AddHostedService<XbrlBackfillWorker>();
+        services.AddHostedService<InsiderFilingReprocessWorker>();
 
         return services;
     }

--- a/src/Equibles.Sec.HostedService/InsiderFilingReprocessWorker.cs
+++ b/src/Equibles.Sec.HostedService/InsiderFilingReprocessWorker.cs
@@ -1,0 +1,55 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Sec.HostedService;
+
+/// <summary>
+/// Continuously brings insider transactions up to the current parser version.
+/// Each cycle drains every filing whose rows sit below
+/// <see cref="Equibles.InsiderTrading.Data.Models.InsiderTransaction.CurrentParserVersion"/>
+/// — re-deriving security kind, price validity, and footnotes from the cached
+/// ownership XML, fetching and caching that XML from EDGAR the first time a filing
+/// is seen. The work is version-driven and resumable, so it survives restarts and
+/// automatically re-enrolls every filing after a parser-version bump — no manual
+/// trigger needed.
+///
+/// Runs in the worker process so it shares the single SEC rate-limiter with the
+/// other EDGAR scrapers (rather than competing as a separate process), and starts
+/// after a stagger so it doesn't contend for the request budget at deploy time.
+/// </summary>
+public class InsiderFilingReprocessWorker : BaseScraperWorker
+{
+    protected override string WorkerName => "Insider filing reprocess";
+    protected override ErrorSource ErrorSource => ErrorSource.InsiderTradingReprocess;
+
+    // Once the backlog is drained each cycle finds nothing and idles; a periodic
+    // re-check is only meaningful to pick up rows left pending after a transient
+    // failure or a future parser-version bump.
+    protected override TimeSpan SleepInterval => TimeSpan.FromHours(6);
+
+    // Stagger past deploy so the initial EDGAR burst doesn't collide with the
+    // other SEC scrapers starting at the same time.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(5);
+
+    public InsiderFilingReprocessWorker(
+        ILogger<InsiderFilingReprocessWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter
+    )
+        : base(logger, scopeFactory, errorReporter) { }
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var manager = scope.ServiceProvider.GetRequiredService<InsiderFilingReprocessManager>();
+
+        var result = await manager.Run(cancellationToken: stoppingToken);
+
+        if (result.Processed > 0)
+            Logger.LogInformation("Insider filing reprocess cycle: {Summary}", result.Summary);
+    }
+}


### PR DESCRIPTION
## Summary

Makes insider-filing reprocessing **automatic**, as the parser-version design always intended. Until now the reprocess engine could only be triggered by the backoffice "Reprocess filings" button — an SSE job in the web request that dies on redeploy or tab-close and competes with the worker for SEC's rate budget from a separate process. This adds a background worker that drains the backlog on its own.

`InsiderFilingReprocessWorker` (a `BaseScraperWorker`) each cycle reprocesses every filing whose rows are below `InsiderTransaction.CurrentParserVersion` — re-deriving `SecurityKind`, price validity, and `Notes` from the cached ownership XML, and fetching+caching that XML from EDGAR the first time a filing is seen (so filings without a saved original get captured too). Because it's version-driven and resumable:
- it survives restarts (no progress lost — it picks up where the version filter leaves off),
- it needs no manual trigger, and
- a future `CurrentParserVersion` bump re-enrolls every filing automatically.

Running it in the **worker process** is the key fix for the problems hit in practice: it shares the single in-process SEC rate-limiter with the other EDGAR scrapers (no cross-process contention / 403 storms), and a 5-minute startup stagger keeps it off the request budget at deploy time.

## Code changes

- **`InsiderFilingReprocessWorker`** (new, Sec.HostedService) — `DoWork` runs `InsiderFilingReprocessManager.Run` to drain the backlog; `SleepInterval` 6h (idles once drained), `StartupDelay` 5m.
- **`InsiderFilingReprocessManager.Run`** — now takes a `CancellationToken` (second optional arg, non-breaking) and observes it at the batch and per-filing boundaries so the cycle stops promptly on shutdown and resumes next start.
- **`ErrorSource.InsiderTradingReprocess`** — new source for the worker's error reporting.
- Registered via `AddSecWorker`.

The backoffice "Reprocess filings" button stays as a manual "run now" trigger.

## Tests

- Full unit suite green: 2346 passing (incl. `ErrorSourceTests`, `BaseScraperWorker` tests).