### PR TITLE
feat(sec): default XBRL capture + backfill on; smaller insider reprocess batch

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -31,7 +31,11 @@ namespace Equibles.InsiderTrading.BusinessLogic;
 [Service]
 public class InsiderFilingReprocessManager
 {
-    private const int BatchSize = 200;
+    // Small batches so progress is committed often: the work-set is drained per batch
+    // and SaveChanges runs once per batch, so a smaller size means a throttled or
+    // interrupted run still persists what it managed to fetch rather than losing a
+    // large in-flight batch.
+    private const int BatchSize = 32;
     private const int CloseLookbackDays = 10;
 
     // After this many failed fetch/parse attempts a filing is marked NotPresent and

--- a/src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs
@@ -2,22 +2,22 @@ namespace Equibles.Sec.HostedService.Configuration;
 
 /// <summary>
 /// Controls whether the raw XBRL envelope is captured onto each <c>Document</c> at
-/// filing-ingest time. Off by default: capture only runs once an operator has reviewed
-/// the storage-sizing implications and explicitly enables it. The envelope is read from
-/// the submission already fetched for ingest, so capture adds no extra EDGAR round-trip.
+/// filing-ingest time. On by default: forward capture reads the envelope from the
+/// submission already fetched for ingest, so it adds no extra EDGAR round-trip. An
+/// operator can still disable it where the storage-sizing implications aren't wanted.
 /// </summary>
 public class XbrlCaptureOptions
 {
     /// <summary>Master switch — no capture (forward or backfill) happens unless this is true.</summary>
-    public bool Enabled { get; set; }
+    public bool Enabled { get; set; } = true;
 
     /// <summary>
     /// When true (and <see cref="Enabled"/> is true), a background worker walks documents
     /// ingested before capture and fills in their XBRL envelope. Separate from forward
-    /// capture so an operator can enable live capture first and opt into the historical
-    /// sweep — which re-fetches each pending filing's submission — deliberately.
+    /// capture so an operator can disable the historical sweep — which re-fetches each
+    /// pending filing's submission and so spends the shared EDGAR budget — independently.
     /// </summary>
-    public bool BackfillEnabled { get; set; }
+    public bool BackfillEnabled { get; set; } = true;
 
     /// <summary>How many pending documents the backfill processes per cycle.</summary>
     public int BackfillBatchSize { get; set; } = 32;


### PR DESCRIPTION
## Summary

Two worker-side changes so the SEC document and insider pipelines actually do their historical work out of the box, instead of sitting idle behind opt-in flags.

- **XBRL capture/backfill default on.** `XbrlCaptureOptions.Enabled` and `BackfillEnabled` now default `true`. Forward capture reads the envelope from the submission already fetched for ingest (no extra EDGAR round-trip); the backfill is a one-time historical sweep that self-terminates once every eligible document is captured or retry-exhausted.
- **Smaller insider reprocess batch.** `InsiderFilingReprocessManager.BatchSize` 200 → 32. The work-set is drained per batch and `SaveChanges` runs once per batch, so a smaller size means a throttled or interrupted run persists what it managed to fetch rather than losing a large in-flight batch.

## Code changes

- `src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs` — `Enabled` and `BackfillEnabled` default `true`; docstrings updated to reflect the on-by-default posture and that backfill can be disabled independently.
- `src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs` — `BatchSize` 200 → 32 with a comment explaining the commit-frequency tradeoff.