### PR TITLE
fix(holdings): clamp GetMarketWide13FActivity maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -527,6 +527,11 @@ public class InstitutionalHoldingsTools
                 if (!ValidActivityBuckets.Contains(normalizedBucket))
                     return $"Unknown bucket. Use one of: {string.Join(", ", ValidActivityBuckets)}.";
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-data message.
+                maxResults = Math.Max(0, maxResults);
+
                 var (targetDate, previousDate, error) = await ResolveMarketActivityDates(
                     reportDate
                 );

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests.cs
@@ -19,9 +19,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResult
     )
         : base(fixture) { }
 
-    [Fact(
-        Skip = "GH-2999 — GetMarketWide13FActivity surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetMarketWide13FActivity_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         var prior = new DateOnly(2024, 9, 30);


### PR DESCRIPTION
## Summary

- A negative `maxResults` passed to the `GetMarketWide13FActivity` MCP tool flowed unclamped into EF Core's `.Take(maxResults)` for both the movers and churn leaderboards, becoming a negative SQL `LIMIT` that PostgreSQL rejects. The exception was swallowed and the caller received the generic internal-error sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` once at the tool entry point so a non-positive cap yields zero rows and the existing no-data message — matching the sibling MCP tools.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — clamp `maxResults` to a non-negative value at the start of `GetMarketWide13FActivity`, before it dispatches to the movers/churn render helpers.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityNegativeMaxResultsTests.cs` — un-skip the regression test that asserts a negative `maxResults` no longer surfaces the internal-error sentinel.

closes #2999