### PR TITLE
fix(sec): treat out-of-long-range Form ADV AUM as not reported instead of crashing the import

### DIFF
--- a/src/Equibles.Integrations.Sec/FormAdv/FormAdvCsvParser.cs
+++ b/src/Equibles.Integrations.Sec/FormAdv/FormAdvCsvParser.cs
@@ -130,7 +130,15 @@ public static class FormAdvCsvParser
             )
         )
         {
-            return (long)Math.Round(amount, MidpointRounding.AwayFromZero);
+            var rounded = Math.Round(amount, MidpointRounding.AwayFromZero);
+
+            // A figure with more digits than long can hold is still a valid decimal, so the
+            // narrowing cast would overflow and abort the whole streaming import. Treat an
+            // out-of-range AUM as "not reported" (null), consistent with a blank cell.
+            if (rounded < long.MinValue || rounded > long.MaxValue)
+                return null;
+
+            return (long)rounded;
         }
 
         return null;

--- a/tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumOverflowTests.cs
@@ -12,9 +12,7 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class FormAdvCsvParserParseAumOverflowTests
 {
-    [Fact(
-        Skip = "GH-2951 — ParseAum throws OverflowException casting an out-of-long-range AUM to long, aborting the import"
-    )]
+    [Fact]
     public void Parse_TotalAumLargerThanLongRange_TreatsCellAsNotReportedInsteadOfThrowing()
     {
         // 26 digits: within decimal's range but far beyond long.MaxValue (~9.2e18).


### PR DESCRIPTION
## Summary

- A Form ADV AUM cell with more digits than `long` can hold still parses as a `decimal`, so the narrowing cast in `ParseAum` threw `OverflowException` — aborting the entire streaming import over a single malformed cell in the untrusted SEC CSV.
- Bounds-check the rounded value and return `null` ("not reported") when it falls outside `long`'s range, consistent with how a blank cell is already handled.

## Code changes

- `src/Equibles.Integrations.Sec/FormAdv/FormAdvCsvParser.cs` — in `ParseAum`, round the parsed decimal, then return `null` if it is outside `[long.MinValue, long.MaxValue]` before the narrowing cast.
- `tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumOverflowTests.cs` — un-skip the regression test asserting a 26-digit AUM cell yields `TotalRegulatoryAum == null` instead of throwing.

closes #2951