### PR TITLE
test(sec): pin FormAdvCsvParser.ParseAum below-long-range AUM degrades to not reported

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumUnderflowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumUnderflowTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Integrations.Sec.FormAdv;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Twin of <see cref="FormAdvCsvParserParseAumOverflowTests"/> for the negative end of the range.
+/// ParseAum is documented as defensive — it nulls a field it cannot represent — so a figure more
+/// negative than <see cref="long"/>.MinValue (still a valid decimal) must degrade to "not reported"
+/// (null) rather than overflow the narrowing cast and abort the whole streaming import.
+/// </summary>
+public class FormAdvCsvParserParseAumUnderflowTests
+{
+    [Fact]
+    public void Parse_TotalAumBelowLongRange_TreatsCellAsNotReportedInsteadOfThrowing()
+    {
+        // 26-digit negative: within decimal's range but far below long.MinValue (~-9.2e18).
+        var csv = "Organization CRD#,5F(2)(c)\n" + "12345,-99999999999999999999999999\n";
+
+        var advisers = FormAdvCsvParser.Parse(new StringReader(csv)).ToList();
+
+        advisers.Should().ContainSingle();
+        advisers[0].Crd.Should().Be(12345);
+        advisers[0].TotalRegulatoryAum.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- The Form ADV AUM overflow fix (#3019) guards both ends of `long`'s range, but only the positive overflow path had a regression test. This pins the negative twin.
- Asserts a 26-digit negative AUM cell (a valid decimal far below `long.MinValue`) yields `TotalRegulatoryAum == null` rather than overflowing the narrowing cast and aborting the import. Passes against current code.

## Code changes

- `tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumUnderflowTests.cs` — new unit test exercising the `rounded < long.MinValue` branch of `ParseAum`.