### PR TITLE
fix(stocks): escape LIKE wildcards in stock search so _ and % match literally

### DIFF
--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -17,11 +17,14 @@ public class CommonStockRepository : BaseRepository<CommonStock>
         {
             foreach (var word in search.Split(" "))
             {
+                // Escape LIKE metacharacters so a typed '_' or '%' matches literally
+                // rather than behaving as a wildcard.
+                var pattern = LikePattern.Contains(word);
                 query = query.Where(c =>
-                    EF.Functions.ILike(c.Ticker, $"%{word}%")
-                    || EF.Functions.ILike(c.Name, $"%{word}%")
-                    || EF.Functions.ILike(c.Description, $"%{word}%")
-                    || EF.Functions.ILike(c.Industry.Name, $"%{word}%")
+                    EF.Functions.ILike(c.Ticker, pattern, "\\")
+                    || EF.Functions.ILike(c.Name, pattern, "\\")
+                    || EF.Functions.ILike(c.Description, pattern, "\\")
+                    || EF.Functions.ILike(c.Industry.Name, pattern, "\\")
                 );
             }
         }

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerSearchWildcardEscapingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerSearchWildcardEscapingTests.cs
@@ -24,9 +24,7 @@ public class StocksControllerSearchWildcardEscapingTests
     public StocksControllerSearchWildcardEscapingTests(WebHostFixture fixture) =>
         _fixture = fixture;
 
-    [Fact(
-        Skip = "GH-2907 — CommonStockRepository.Search treats LIKE wildcards _ and % as wildcards instead of literals"
-    )]
+    [Fact]
     public async Task Index_UnderscoreSearchTerm_DoesNotMatchStocksWithoutLiteralUnderscore()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- `CommonStockRepository.Search` spliced each typed word straight into `EF.Functions.ILike(col, $"%{word}%")` without escaping LIKE metacharacters, so a `_` was honoured as "any single character" and `%` as "any run" — a search for `_` matched every stock.
- Escape the term via the shared `LikePattern.Contains` helper and pass the explicit `"\\"` escape character, matching the sibling repositories that already do this.

## Code changes

- `src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs` — build the pattern with `LikePattern.Contains(word)` and call `EF.Functions.ILike(col, pattern, "\\")` for all four searched columns.
- `tests/Equibles.IntegrationTests/Web/StocksControllerSearchWildcardEscapingTests.cs` — un-skip the regression test asserting `?search=_` returns no stocks lacking a literal underscore.

closes #2907