### PR TITLE
fix(yahoo): clamp GetStockPrices maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -63,6 +63,12 @@ public class StockPriceTools
                     DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-data message,
+                // matching the sibling indicator tools' graceful degradation.
+                maxResults = Math.Max(0, maxResults);
+
                 var records = await _priceRepository
                     .GetByStock(stock, start, end)
                     .OrderByDescending(p => p.Date)

--- a/tests/Equibles.FunctionalTests/Tests/StockPricesNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StockPricesNegativeMaxResultsTests.cs
@@ -48,9 +48,7 @@ public class StockPricesNegativeMaxResultsTests : IClassFixture<McpServerAppFixt
         }
     }
 
-    [Fact(
-        Skip = "GH-2931 — GetStockPrices surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetStockPrices_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A client-supplied negative `maxResults` flowed into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` at the tool entry point so a non-positive cap yields zero rows and the existing no-data message, matching the sibling indicator tools.

## Code changes

- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — clamp `maxResults` to a non-negative value before it reaches `.Take(...)` in `GetStockPrices`.
- `tests/Equibles.FunctionalTests/Tests/StockPricesNegativeMaxResultsTests.cs` — un-skip the regression test pinning that a negative `maxResults` no longer returns the internal-error sentinel.

closes #2931