### PR TITLE
test(mcp): pin McpToolExecutor.ParseDateRange unparseable start falls back to default

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/McpToolExecutorParseDateRangeFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpToolExecutorParseDateRangeFallbackTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Mcp;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class McpToolExecutorParseDateRangeFallbackTests
+{
+    // Contract: each bound "defaults to ..." when its text arg is absent or
+    // unusable. A client-supplied non-date string must degrade to the supplied
+    // defaultStart — never throw and never collapse to default(DateOnly)
+    // (0001-01-01). A valid end is supplied so the assertion stays deterministic
+    // and isolates the start-fallback branch the lone happy-path test never exercises.
+    [Fact]
+    public void ParseDateRange_UnparseableStart_FallsBackToDefaultStart()
+    {
+        var defaultStart = new DateOnly(2023, 6, 15);
+
+        var (start, end) = McpToolExecutor.ParseDateRange("not-a-date", "2024-03-31", defaultStart);
+
+        start.Should().Be(defaultStart);
+        end.Should().Be(new DateOnly(2024, 3, 31));
+    }
+}


### PR DESCRIPTION
## Summary

- `ParseDateRange` only had a single happy-path test; its fallback branches (absent / malformed input) were unexercised.
- Pins that a client-supplied non-date `startText` degrades to the supplied `defaultStart` — never throws, never collapses to `default(DateOnly)` (0001-01-01) — guarding the composition every MCP price/indicator tool relies on.

## Code changes

- `tests/Equibles.UnitTests/Mcp/McpToolExecutorParseDateRangeFallbackTests.cs` — new unit test asserting an unparseable start falls back to `defaultStart` while a valid end is parsed verbatim.