### PR TITLE
fix(cboe): clamp GetVixHistory maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -115,6 +115,11 @@ public class CboeTools
                     DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-data message.
+                maxResults = Math.Max(0, maxResults);
+
                 var records = await _vixRepository
                     .GetByDateRange(start, end)
                     .OrderByDescending(v => v.Date)

--- a/tests/Equibles.FunctionalTests/Tests/VixHistoryNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/VixHistoryNegativeMaxResultsTests.cs
@@ -47,9 +47,7 @@ public class VixHistoryNegativeMaxResultsTests : IClassFixture<McpServerAppFixtu
         }
     }
 
-    [Fact(
-        Skip = "GH-2933 — GetVixHistory surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetVixHistory_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A client-supplied negative `maxResults` flowed into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully (same defect class as #2931).
- Clamp with `Math.Max(0, maxResults)` at the tool entry point so a non-positive cap yields zero rows and the existing no-data message.

## Code changes

- `src/Equibles.Cboe.Mcp/Tools/CboeTools.cs` — clamp `maxResults` to a non-negative value before it reaches `.Take(...)` in `GetVixHistory`.
- `tests/Equibles.FunctionalTests/Tests/VixHistoryNegativeMaxResultsTests.cs` — un-skip the regression test pinning that a negative `maxResults` no longer returns the internal-error sentinel.

closes #2933