### PR TITLE
fix(cboe): clamp GetPutCallRatios maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -60,6 +60,11 @@ public class CboeTools
                     DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-data message.
+                maxResults = Math.Max(0, maxResults);
+
                 var records = await _putCallRepository
                     .GetByType(ratioType, start, end)
                     .OrderByDescending(r => r.Date)

--- a/tests/Equibles.FunctionalTests/Tests/PutCallRatiosNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/PutCallRatiosNegativeMaxResultsTests.cs
@@ -50,9 +50,7 @@ public class PutCallRatiosNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2937 — GetPutCallRatios surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetPutCallRatios_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A client-supplied negative `maxResults` flowed into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully (same defect class as #2931 / #2933, the other tool in this file).
- Clamp with `Math.Max(0, maxResults)` at the tool entry point so a non-positive cap yields zero rows and the existing no-data message.

## Code changes

- `src/Equibles.Cboe.Mcp/Tools/CboeTools.cs` — clamp `maxResults` to a non-negative value before it reaches `.Take(...)` in `GetPutCallRatios`.
- `tests/Equibles.FunctionalTests/Tests/PutCallRatiosNegativeMaxResultsTests.cs` — un-skip the regression test pinning that a negative `maxResults` no longer returns the internal-error sentinel.

closes #2937