### PR TITLE
fix(fred): clamp GetEconomicIndicator maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -63,6 +63,11 @@ public class FredTools
                     DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-data message.
+                maxResults = Math.Max(0, maxResults);
+
                 var observations = await _observationRepository
                     .GetBySeries(series, start, end)
                     .OrderByDescending(o => o.Date)

--- a/tests/Equibles.FunctionalTests/Tests/EconomicIndicatorNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/EconomicIndicatorNegativeMaxResultsTests.cs
@@ -50,9 +50,7 @@ public class EconomicIndicatorNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2941 — GetEconomicIndicator surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetEconomicIndicator_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A client-supplied negative `maxResults` flowed into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully (same defect class as #2931 / #2933 / #2937).
- Clamp with `Math.Max(0, maxResults)` at the tool entry point so a non-positive cap yields zero rows and the existing no-data message. Scoped to `GetEconomicIndicator`; the sibling `SearchEconomicIndicators` is tracked separately as #2962.

## Code changes

- `src/Equibles.Fred.Mcp/Tools/FredTools.cs` — clamp `maxResults` to a non-negative value before it reaches `.Take(...)` in `GetEconomicIndicator`.
- `tests/Equibles.FunctionalTests/Tests/EconomicIndicatorNegativeMaxResultsTests.cs` — un-skip the regression test pinning that a negative `maxResults` no longer returns the internal-error sentinel.

closes #2941