### PR TITLE
fix(fred): render GetEconomicIndicator values with InvariantCulture so MCP output does not fork by locale

### DIFF
--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using System.Text;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
@@ -88,7 +89,11 @@ public class FredTools
 
                 foreach (var obs in observations.OrderBy(o => o.Date))
                 {
-                    var valueStr = obs.Value.HasValue ? obs.Value.Value.ToString("G") : "N/A";
+                    // Format with InvariantCulture so the MCP markdown does not fork the
+                    // decimal separator by host locale (e.g. de-DE would render 5,25).
+                    var valueStr = obs.Value.HasValue
+                        ? obs.Value.Value.ToString("G", CultureInfo.InvariantCulture)
+                        : "N/A";
                     result.AppendLine($"| {obs.Date:yyyy-MM-dd} | {valueStr} |");
                 }
 

--- a/tests/Equibles.IntegrationTests/Mcp/FredToolsGetEconomicIndicatorCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FredToolsGetEconomicIndicatorCultureInvarianceTests.cs
@@ -27,9 +27,7 @@ public class FredToolsGetEconomicIndicatorCultureInvarianceTests : ParadeDbMcpTe
     // "MCP markdown must not fork the separators by host locale") is that LLM-facing
     // markdown renders identically on every host. de-DE swaps the decimal separator
     // (5.25 → 5,25), forking the response — same bug class as #3013 / the VIX render.
-    [Fact(
-        Skip = "GH-3030 — GetEconomicIndicator renders observation values with host-locale separators, forking MCP output by culture"
-    )]
+    [Fact]
     public async Task GetEconomicIndicator_UnderNonInvariantCulture_RendersValueCultureInvariantly()
     {
         var series = new FredSeries


### PR DESCRIPTION
## Summary

- `GetEconomicIndicator` formatted observation values with the culture-implicit `.ToString("G")`, so a comma-decimal host (e.g. `de-DE`) rendered `5.25` as `5,25`, forking the LLM-facing MCP markdown by host locale (same defect class as #3013 and the `McpFormat.OrDash` / `GetVixHistory` invariant-culture call sites).
- Format the value with `CultureInfo.InvariantCulture` so the output is identical on every host.

## Code changes

- `src/Equibles.Fred.Mcp/Tools/FredTools.cs` — render the observation value via `ToString("G", CultureInfo.InvariantCulture)` (adds the `System.Globalization` using).
- `tests/Equibles.IntegrationTests/Mcp/FredToolsGetEconomicIndicatorCultureInvarianceTests.cs` — un-skip the regression test pinning invariant rendering under a `de-DE` thread culture.

closes #3030