### PR TITLE
fix(fred): clamp SearchEconomicIndicators maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -192,6 +192,11 @@ public class FredTools
         return _runner.Execute(
             async () =>
             {
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
+                maxResults = Math.Max(0, maxResults);
+
                 var series = await _seriesRepository
                     .Search(query)
                     .OrderBy(s => s.Category)

--- a/tests/Equibles.FunctionalTests/Tests/SearchEconomicIndicatorsNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/SearchEconomicIndicatorsNegativeMaxResultsTests.cs
@@ -52,9 +52,7 @@ public class SearchEconomicIndicatorsNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2962 — SearchEconomicIndicators surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task SearchEconomicIndicators_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A client-supplied negative `maxResults` flowed into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully (same defect class as #2941 and the other clamped tools).
- Clamp with `Math.Max(0, maxResults)` at the tool entry point so a non-positive cap yields zero rows and the existing no-results message. `FredTools.cs` is now fully clamped across all three tools.

## Code changes

- `src/Equibles.Fred.Mcp/Tools/FredTools.cs` — clamp `maxResults` to a non-negative value before it reaches `.Take(...)` in `SearchEconomicIndicators`.
- `tests/Equibles.FunctionalTests/Tests/SearchEconomicIndicatorsNegativeMaxResultsTests.cs` — un-skip the regression test pinning that a negative `maxResults` no longer returns the internal-error sentinel.

closes #2962