### PR TITLE
fix(finra): clamp GetShortVolume maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -68,6 +68,11 @@ public class ShortDataTools
 
                 query = query.Where(d => d.Date >= start && d.Date <= end);
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-data message.
+                maxResults = Math.Max(0, maxResults);
+
                 var records = await query
                     .OrderByDescending(d => d.Date)
                     .Take(maxResults)

--- a/tests/Equibles.FunctionalTests/Tests/ShortVolumeNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/ShortVolumeNegativeMaxResultsTests.cs
@@ -49,9 +49,7 @@ public class ShortVolumeNegativeMaxResultsTests : IClassFixture<McpServerAppFixt
         }
     }
 
-    [Fact(
-        Skip = "GH-2943 — GetShortVolume surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetShortVolume_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A client-supplied negative `maxResults` flowed into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects (22023); the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully (same defect class as #2931 / #2933 / #2937 / #2941 / #2962).
- Clamp with `Math.Max(0, maxResults)` at the tool entry point so a non-positive cap yields zero rows and the existing no-data message. Scoped to `GetShortVolume`; the sibling tools in this file are tracked separately (#2966 / #2974 / #2984).

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — clamp `maxResults` to a non-negative value before it reaches `.Take(...)` in `GetShortVolume`.
- `tests/Equibles.FunctionalTests/Tests/ShortVolumeNegativeMaxResultsTests.cs` — un-skip the regression test pinning that a negative `maxResults` no longer returns the internal-error sentinel.

closes #2943