### PR TITLE
fix(finra): render GetShortInterestSnapshot values with InvariantCulture so MCP output does not fork by locale

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -212,8 +212,12 @@ public class ShortDataTools
                 {
                     var changeStr = FormatSignedChange(r.ChangeInShortPosition);
                     var advStr = McpFormat.OrDash(r.AverageDailyVolume, "N0");
+                    // Render with InvariantCulture so the MCP markdown does not fork the
+                    // separators by host locale (e.g. de-DE would render 1.234.567 / 12,3).
+                    var shortPositionStr = FormatWholeNumber(r.CurrentShortPosition);
+                    var dtcStr = McpFormat.OrDash(r.DaysToCover, "F1");
                     result.AppendLine(
-                        $"| {r.CommonStock.Ticker} | {r.CurrentShortPosition:N0} | {changeStr} | {advStr} | {r.DaysToCover:F1} |"
+                        $"| {r.CommonStock.Ticker} | {shortPositionStr} | {changeStr} | {advStr} | {dtcStr} |"
                     );
                 }
 

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
@@ -31,9 +31,7 @@ public class ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests : Para
     // must not fork the separators by host locale") is byte-identical output on every host.
     // de-DE swaps the separators (1,234,567 → 1.234.567), forking the response — same bug
     // class as #3013 / #3030.
-    [Fact(
-        Skip = "GH-3035 — GetShortInterestSnapshot renders Short Position / Days to Cover with host-locale separators, forking MCP output by culture"
-    )]
+    [Fact]
     public async Task GetShortInterestSnapshot_UnderNonInvariantCulture_RendersShortPositionCultureInvariantly()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

- `GetShortInterestSnapshot` rendered the Short Position (`:N0`) and Days to Cover (`:F1`) cells with culture-implicit specifiers, so a comma-decimal host (e.g. `de-DE`) rendered `1,234,567` as `1.234.567` and `12.3` as `12,3`, forking the LLM-facing MCP markdown by host locale (same defect class as #3013 / #3030).
- Route both cells through the file's existing `InvariantCulture` helpers (`FormatWholeNumber`, `McpFormat.OrDash`), matching the already-safe sibling tools.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — render Short Position via `FormatWholeNumber` and Days to Cover via `McpFormat.OrDash(..., "F1")` in `GetShortInterestSnapshot`.
- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs` — un-skip the regression test pinning invariant rendering under a `de-DE` thread culture.

closes #3035