### PR TITLE
test(finra): add skipped repro for GH-3038 — GetLargestShortVolume culture-forks values

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Mcp.Tools;
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class ShortDataToolsGetLargestShortVolumeCultureInvarianceTests : ParadeDbMcpTestBase
+{
+    private ShortDataTools Sut() =>
+        new(
+            new DailyShortVolumeRepository(DbContext),
+            new ShortInterestRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<ShortDataTools>()
+        );
+
+    public ShortDataToolsGetLargestShortVolumeCultureInvarianceTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    // GetLargestShortVolume renders the Short Volume / Exempt / Total Volume cells as
+    // {r.ShortVolume:N0} etc. with culture-implicit specifiers, which honour the thread
+    // CurrentCulture. The established repo contract (the sibling GetShortVolume /
+    // GetShortInterest culture-invariance pins and the InvariantCulture call sites: "MCP
+    // markdown must not fork the separators by host locale") is byte-identical output on
+    // every host. de-DE swaps the thousand separator (5,000,000 → 5.000.000), forking the
+    // response — same bug class as #3013 / #3030 / #3035.
+    [Fact(
+        Skip = "GH-3038 — GetLargestShortVolume renders Short/Total Volume and Short % with host-locale separators, forking MCP output by culture"
+    )]
+    public async Task GetLargestShortVolume_UnderNonInvariantCulture_RendersShortVolumeCultureInvariantly()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "GME",
+            Name = "GameStop Corp",
+            Cik = "0001326380",
+        };
+        DbContext.Set<CommonStock>().Add(stock);
+        DbContext
+            .Set<DailyShortVolume>()
+            .Add(
+                new DailyShortVolume
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    Date = new DateOnly(2026, 4, 2),
+                    ShortVolume = 5_000_000,
+                    ShortExemptVolume = 0,
+                    TotalVolume = 8_000_000,
+                    Market = "ALL",
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var previous = CultureInfo.CurrentCulture;
+        string result;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            result = await Sut().GetLargestShortVolume();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+
+        // The volume cells (bare :N0) must render with en-US separators on every host
+        // locale; de-DE would produce 5.000.000 / 8.000.000.
+        result.Should().Contain("| 5,000,000 |");
+        result.Should().Contain("| 8,000,000 |");
+    }
+}


### PR DESCRIPTION
## Summary

- An adversarial culture-invariance test revealed that `GetLargestShortVolume` renders Short/Total Volume (`:N0`) and Short % (`:F1`) with culture-implicit specifiers, so under a comma-decimal host (e.g. `de-DE`) `5,000,000` renders as `5.000.000` and `62.5%` as `62,5%` — forking the LLM-facing MCP markdown by host locale.
- Same defect class as #3013 / #3030 / #3035; the last untreated tool in `ShortDataTools.cs`. The test is committed `[Skip]` — see GH-3038; un-skip it as part of the fix.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs` — new integration test (skipped, GH-3038) asserting `GetLargestShortVolume` renders volume cells with invariant separators under a `de-DE` thread culture.