### PR TITLE
fix(finra): render GetLargestShortVolume values with InvariantCulture so MCP output does not fork by locale

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -276,8 +276,10 @@ public class ShortDataTools
                 {
                     var shortPct =
                         r.TotalVolume > 0 ? (double)r.ShortVolume / r.TotalVolume * 100 : 0;
+                    // Render with InvariantCulture so the MCP markdown does not fork the
+                    // separators by host locale (e.g. de-DE would render 5.000.000 / 62,5%).
                     result.AppendLine(
-                        $"| {r.CommonStock.Ticker} | {r.ShortVolume:N0} | {r.ShortExemptVolume:N0} | {r.TotalVolume:N0} | {shortPct:F1}% |"
+                        $"| {r.CommonStock.Ticker} | {FormatWholeNumber(r.ShortVolume)} | {FormatWholeNumber(r.ShortExemptVolume)} | {FormatWholeNumber(r.TotalVolume)} | {shortPct.ToString("F1", CultureInfo.InvariantCulture)}% |"
                     );
                 }
 

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
@@ -31,9 +31,7 @@ public class ShortDataToolsGetLargestShortVolumeCultureInvarianceTests : ParadeD
     // markdown must not fork the separators by host locale") is byte-identical output on
     // every host. de-DE swaps the thousand separator (5,000,000 → 5.000.000), forking the
     // response — same bug class as #3013 / #3030 / #3035.
-    [Fact(
-        Skip = "GH-3038 — GetLargestShortVolume renders Short/Total Volume and Short % with host-locale separators, forking MCP output by culture"
-    )]
+    [Fact]
     public async Task GetLargestShortVolume_UnderNonInvariantCulture_RendersShortVolumeCultureInvariantly()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

- `GetLargestShortVolume` rendered the volume cells (`:N0`) and Short % (`:F1`) with culture-implicit specifiers, so a comma-decimal host (e.g. `de-DE`) rendered `5,000,000` as `5.000.000` and `62.5%` as `62,5%`, forking the LLM-facing MCP markdown by host locale (same defect class as #3013 / #3030 / #3035).
- Route the volumes through `FormatWholeNumber` and the percentage through `InvariantCulture`, matching the already-safe `GetShortVolume`. `ShortDataTools.cs` is now fully culture-safe.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — render Short/Exempt/Total Volume via `FormatWholeNumber` and Short % via `ToString("F1", CultureInfo.InvariantCulture)` in `GetLargestShortVolume`.
- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs` — un-skip the regression test pinning invariant rendering under a `de-DE` thread culture.

closes #3038