### PR TITLE
fix(sec): clamp GetFailsToDeliver maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -60,6 +60,11 @@ public class FailToDeliverTools
                     DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-data message.
+                maxResults = Math.Max(0, maxResults);
+
                 var records = await _ftdRepository
                     .GetByStock(stock)
                     .Where(f => f.SettlementDate >= start && f.SettlementDate <= end)

--- a/tests/Equibles.FunctionalTests/Tests/FailsToDeliverNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/FailsToDeliverNegativeMaxResultsTests.cs
@@ -50,9 +50,7 @@ public class FailsToDeliverNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2945 — GetFailsToDeliver surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetFailsToDeliver_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A client-supplied negative `maxResults` flowed into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully (same defect class as #2931 / #2933 / #2941 / #2943).
- Clamp with `Math.Max(0, maxResults)` at the tool entry point so a non-positive cap yields zero rows and the existing no-data message.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs` — clamp `maxResults` to a non-negative value before it reaches `.Take(...)` in `GetFailsToDeliver`.
- `tests/Equibles.FunctionalTests/Tests/FailsToDeliverNegativeMaxResultsTests.cs` — un-skip the regression test pinning that a negative `maxResults` no longer returns the internal-error sentinel.

closes #2945