### PR TITLE
fix(congress): clamp GetCongressionalTrades maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -70,6 +70,11 @@ public class CongressTools
                 var query = _tradeRepository.GetByStock(stock, start, end);
                 query = ApplyTransactionTypeFilter(query, transactionType);
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-data message.
+                maxResults = Math.Max(0, maxResults);
+
                 var trades = await query
                     .Include(t => t.CongressMember)
                     .OrderByDescending(t => t.TransactionDate)

--- a/tests/Equibles.FunctionalTests/Tests/CongressionalTradesNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/CongressionalTradesNegativeMaxResultsTests.cs
@@ -54,9 +54,7 @@ public class CongressionalTradesNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2947 — GetCongressionalTrades surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetCongressionalTrades_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         var stockId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

- A client-supplied negative `maxResults` flowed into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects (22023); the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully (same defect class as #2931 / #2933 / #2941 / #2943 / #2945).
- Clamp with `Math.Max(0, maxResults)` at the tool entry point so a non-positive cap yields zero rows and the existing no-data message. Scoped to `GetCongressionalTrades`; the siblings `GetMemberTrades` (#2976) and `SearchCongressMembers` (#2957) are tracked separately.

## Code changes

- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — clamp `maxResults` to a non-negative value before it reaches `.Take(...)` in `GetCongressionalTrades`.
- `tests/Equibles.FunctionalTests/Tests/CongressionalTradesNegativeMaxResultsTests.cs` — un-skip the regression test pinning that a negative `maxResults` no longer returns the internal-error sentinel.

closes #2947