### PR TITLE
fix(congress): render GetMemberTrades amount range with InvariantCulture so MCP output does not fork by locale

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -161,7 +161,10 @@ public class CongressTools
                 foreach (var t in trades)
                 {
                     var type = t.TransactionType.NameForHumans();
-                    var amount = $"${t.AmountFrom:N0}–${t.AmountTo:N0}";
+                    // Format with InvariantCulture so the MCP markdown does not fork the
+                    // separators by host locale (e.g. de-DE would render $1.000.000).
+                    var amount =
+                        $"${t.AmountFrom.ToString("N0", CultureInfo.InvariantCulture)}–${t.AmountTo.ToString("N0", CultureInfo.InvariantCulture)}";
                     result.AppendLine(
                         $"| {t.TransactionDate:yyyy-MM-dd} | {t.CommonStock.Ticker} | {type} | {amount} | {t.AssetName} | {t.OwnerType ?? "—"} |"
                     );

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberTradesCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberTradesCultureInvarianceTests.cs
@@ -30,9 +30,7 @@ public class CongressToolsGetMemberTradesCultureInvarianceTests : ParadeDbMcpTes
     // culture pin: "MCP markdown must not fork the separators by host locale") is byte-identical
     // output on every host. de-DE swaps the thousand separator (1,000,000 → 1.000.000), forking
     // the response — same bug class as #3013 / #3030 / #3035.
-    [Fact(
-        Skip = "GH-3043 — GetMemberTrades renders the amount range with host-locale separators, forking MCP output by culture"
-    )]
+    [Fact]
     public async Task GetMemberTrades_UnderNonInvariantCulture_RendersAmountCultureInvariantly()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

- `GetMemberTrades` built the Amount Range cell with raw `:N0` specifiers, so a comma-decimal host (e.g. `de-DE`) rendered `1,000,000` as `1.000.000`, forking the LLM-facing MCP markdown by host locale (same defect class as #3013 / #3030 / #3035 / #3038).
- Format both bounds with `CultureInfo.InvariantCulture`, matching the already-safe sibling `GetCongressionalTrades` in the same file.

## Code changes

- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — render the amount range via `ToString("N0", CultureInfo.InvariantCulture)` in `GetMemberTrades`.
- `tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberTradesCultureInvarianceTests.cs` — un-skip the regression test pinning invariant rendering under a `de-DE` thread culture.

closes #3043