### PR TITLE
fix(insider-trading): clamp GetInsiderTransactions maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -58,6 +58,11 @@ public class InsiderTradingTools
                 if (stockError != null)
                     return stockError;
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-data message.
+                maxResults = Math.Max(0, maxResults);
+
                 var transactions = await _transactionRepository
                     .GetByStock(stock)
                     .Include(t => t.InsiderOwner)

--- a/tests/Equibles.FunctionalTests/Tests/InsiderTransactionsNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/InsiderTransactionsNegativeMaxResultsTests.cs
@@ -54,9 +54,7 @@ public class InsiderTransactionsNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2949 — GetInsiderTransactions surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetInsiderTransactions_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         var stockId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

- A client-supplied negative `maxResults` flowed into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects (22023); the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully (same defect class as #2931 / #2941 / #2943 / #2945 / #2947).
- Clamp with `Math.Max(0, maxResults)` at the tool entry point so a non-positive cap yields zero rows and the existing no-data message. Scoped to `GetInsiderTransactions`; the siblings `GetProposedSales` (#2980) and `SearchInsiders` (#2964) are tracked separately.

## Code changes

- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — clamp `maxResults` to a non-negative value before it reaches `.Take(...)` in `GetInsiderTransactions`.
- `tests/Equibles.FunctionalTests/Tests/InsiderTransactionsNegativeMaxResultsTests.cs` — un-skip the regression test pinning that a negative `maxResults` no longer returns the internal-error sentinel.

closes #2949