### PR TITLE
fix(insider-trading): render GetInsiderOwnership shares with InvariantCulture so MCP output does not fork by locale

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -158,8 +158,14 @@ public class InsiderTradingTools
                 {
                     var role = GetRole(t.InsiderOwner);
                     var lastType = t.TransactionCode.ToString();
+                    // Format with InvariantCulture so the MCP markdown does not fork the
+                    // separators by host locale (e.g. de-DE would render 7.654.321).
+                    var sharesOwned = t.SharesOwnedAfter.ToString(
+                        "N0",
+                        CultureInfo.InvariantCulture
+                    );
                     result.AppendLine(
-                        $"| {t.InsiderOwner.Name} | {role} | {t.SharesOwnedAfter:N0} | {lastType} | {t.TransactionDate:yyyy-MM-dd} |"
+                        $"| {t.InsiderOwner.Name} | {role} | {sharesOwned} | {lastType} | {t.TransactionDate:yyyy-MM-dd} |"
                     );
                 }
 

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderOwnershipCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderOwnershipCultureInvarianceTests.cs
@@ -31,9 +31,7 @@ public class InsiderTradingToolsGetInsiderOwnershipCultureInvarianceTests : Para
     // culture pin: "MCP markdown must not fork the separators by host locale") is byte-identical
     // output on every host. de-DE swaps the thousand separator (7,654,321 → 7.654.321), forking
     // the response — same bug class as #3013 / #3030 / #3035 / #3043.
-    [Fact(
-        Skip = "GH-3047 — GetInsiderOwnership renders Shares Owned with host-locale separators, forking MCP output by culture"
-    )]
+    [Fact]
     public async Task GetInsiderOwnership_UnderNonInvariantCulture_RendersSharesOwnedCultureInvariantly()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

- `GetInsiderOwnership` rendered the Shares Owned cell with raw `:N0`, so a comma-decimal host (e.g. `de-DE`) rendered `7,654,321` as `7.654.321`, forking the LLM-facing MCP markdown by host locale (same defect class as #3013 / #3030 / #3035 / #3043).
- Format Shares Owned with `CultureInfo.InvariantCulture`, matching the already-safe sibling tools `GetInsiderTransactions` and `GetProposedSales` in the same file. `InsiderTradingTools.cs` is now fully culture-safe.

## Code changes

- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — render the Shares Owned cell via `ToString("N0", CultureInfo.InvariantCulture)` in `GetInsiderOwnership`.
- `tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsGetInsiderOwnershipCultureInvarianceTests.cs` — un-skip the regression test pinning invariant rendering under a `de-DE` thread culture.

closes #3047