### PR TITLE
fix(congress): clamp SearchCongressMembers maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -190,6 +190,11 @@ public class CongressTools
         return _runner.Execute(
             async () =>
             {
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
+                maxResults = Math.Max(0, maxResults);
+
                 var members = await _memberRepository
                     .Search(query.Trim())
                     .OrderBy(m => m.Name)

--- a/tests/Equibles.FunctionalTests/Tests/SearchCongressMembersNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/SearchCongressMembersNegativeMaxResultsTests.cs
@@ -52,9 +52,7 @@ public class SearchCongressMembersNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2957 — SearchCongressMembers surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task SearchCongressMembers_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A client-supplied negative `maxResults` flowed into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects (22023); the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully (same defect class as #2947 and the rest of the unclamped `.Take(maxResults)` family).
- Clamp with `Math.Max(0, maxResults)` at the tool entry point so a non-positive cap yields zero rows and the existing no-results message. `CongressTools.cs` is now fully clamped across all three tools.

## Code changes

- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — clamp `maxResults` to a non-negative value before it reaches `.Take(...)` in `SearchCongressMembers`.
- `tests/Equibles.FunctionalTests/Tests/SearchCongressMembersNegativeMaxResultsTests.cs` — un-skip the regression test pinning that a negative `maxResults` no longer returns the internal-error sentinel.

closes #2957