### PR TITLE
fix(holdings): clamp GetTopHolders maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -92,6 +92,11 @@ public class InstitutionalHoldingsTools
                 var totalSharesAll = await allHoldings.SumAsync(h => h.Shares);
                 var totalValueAll = await allHoldings.SumAsync(h => h.Value);
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-data message.
+                maxResults = Math.Max(0, maxResults);
+
                 var holdings = await allHoldings
                     .OrderByDescending(h => h.Shares)
                     .Take(maxResults)

--- a/tests/Equibles.FunctionalTests/Tests/GetTopHoldersNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/GetTopHoldersNegativeMaxResultsTests.cs
@@ -52,9 +52,7 @@ public class GetTopHoldersNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2959 — GetTopHolders surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetTopHolders_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         var stockId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

- A client-supplied negative `maxResults` flowed into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully (same defect class as #2931 / #2943 / #2949 / #2957).
- Clamp with `Math.Max(0, maxResults)` at the tool entry point so a non-positive cap yields zero rows and the existing no-data message. Scoped to `GetTopHolders`; the sibling `GetMostHeldStocks` (#2982) is tracked separately.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — clamp `maxResults` to a non-negative value before it reaches `.Take(...)` in `GetTopHolders`.
- `tests/Equibles.FunctionalTests/Tests/GetTopHoldersNegativeMaxResultsTests.cs` — un-skip the regression test pinning that a negative `maxResults` no longer returns the internal-error sentinel.

closes #2959