### PR TITLE
fix(holdings): render GetMarketWide13FActivity churn count with InvariantCulture so MCP output does not fork by locale

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -680,7 +680,10 @@ public class InstitutionalHoldingsTools
             var r = rows[i];
             var (ticker, name) = ResolveStockCells(stocks, r.CommonStockId);
             var count = normalizedBucket == "new-positions" ? r.NewFilerCount : r.SoldOutFilerCount;
-            result.AppendLine($"| {i + 1} | {ticker} | {name} | {count:N0} |");
+            // Format with InvariantCulture so the MCP markdown does not fork the
+            // separators by host locale (e.g. de-DE would render 1.000).
+            var countCell = count.ToString("N0", CultureInfo.InvariantCulture);
+            result.AppendLine($"| {i + 1} | {ticker} | {name} | {countCell} |");
         }
         return result.ToString();
     }

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvarianceTests.cs
@@ -26,9 +26,7 @@ public class InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvar
     // the separators by host locale") is byte-identical output on every host. A mega-cap can have
     // 1,000+ filers initiating in a quarter; under de-DE that renders 1.000, forking the response
     // — same bug class as #3013 / #3030 / #3035 / #3043 / #3047.
-    [Fact(
-        Skip = "GH-3053 — GetMarketWide13FActivity churn leaderboard renders the filer count with host-locale separators, forking MCP output by culture"
-    )]
+    [Fact]
     public async Task GetMarketWide13FActivity_ChurnUnderNonInvariantCulture_RendersFilerCountCultureInvariantly()
     {
         var prior = new DateOnly(2024, 9, 30);


### PR DESCRIPTION
## Summary

- The churn leaderboard (new-positions / sold-out-positions) rendered the filer-count cell with raw `:N0`, so a comma-decimal host (e.g. `de-DE`) rendered `1,000` as `1.000`, forking the LLM-facing MCP markdown by host locale (mega-caps realistically have 1,000+ filers in a quarter; same defect class as #3013 / #3030 / #3035 / #3043 / #3047).
- Format the count with `CultureInfo.InvariantCulture`, matching the movers buckets in the same tool.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — render the churn filer count via `ToString("N0", CultureInfo.InvariantCulture)`.
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetMarketWide13FActivityChurnCultureInvarianceTests.cs` — un-skip the regression test pinning invariant rendering of the churn count under a `de-DE` thread culture.

closes #3053