### PR TITLE
fix(insider-trading): clamp SearchInsiders maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -241,6 +241,11 @@ public class InsiderTradingTools
         return _runner.Execute(
             async () =>
             {
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
+                maxResults = Math.Max(0, maxResults);
+
                 var insiders = await _ownerRepository.Search(query).Take(maxResults).ToListAsync();
 
                 if (insiders.Count == 0)

--- a/tests/Equibles.FunctionalTests/Tests/SearchInsidersNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/SearchInsidersNegativeMaxResultsTests.cs
@@ -51,9 +51,7 @@ public class SearchInsidersNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2964 — SearchInsiders surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task SearchInsiders_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A client-supplied negative `maxResults` flowed into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects (22023); the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully (same defect class as #2949 / #2957 and the rest of the unclamped `.Take(maxResults)` family).
- Clamp with `Math.Max(0, maxResults)` at the tool entry point so a non-positive cap yields zero rows and the existing no-results message. `InsiderTradingTools.cs` is now fully clamped.

## Code changes

- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — clamp `maxResults` to a non-negative value before it reaches `.Take(...)` in `SearchInsiders`.
- `tests/Equibles.FunctionalTests/Tests/SearchInsidersNegativeMaxResultsTests.cs` — un-skip the regression test pinning that a negative `maxResults` no longer returns the internal-error sentinel.

closes #2964