### PR TITLE
fix(finra): clamp GetShortInterest maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -120,6 +120,11 @@ public class ShortDataTools
         return _runner.Execute(
             async () =>
             {
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
+                maxResults = Math.Max(0, maxResults);
+
                 var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;

--- a/tests/Equibles.FunctionalTests/Tests/ShortInterestNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/ShortInterestNegativeMaxResultsTests.cs
@@ -51,9 +51,7 @@ public class ShortInterestNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2966 — GetShortInterest surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetShortInterest_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A negative `maxResults` passed to the `GetShortInterest` MCP tool flowed straight into EF Core's `.Take(maxResults)`, producing a negative SQL `LIMIT` that PostgreSQL rejects (22023). The exception was swallowed and the caller received the generic internal-error sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` once at the entry point, matching the sibling MCP tools, so a non-positive cap yields zero rows and the existing no-results message.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — clamp `maxResults` to a non-negative lower bound at the start of `GetShortInterest`'s execution block.
- `tests/Equibles.FunctionalTests/Tests/ShortInterestNegativeMaxResultsTests.cs` — un-skip the pre-committed regression test; it fails on unfixed code (internal-error sentinel) and passes after the clamp.

closes #2966