### PR TITLE
fix(cftc): clamp SearchCftcMarkets maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -189,6 +189,11 @@ public class CftcTools
         return _runner.Execute(
             async () =>
             {
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
+                maxResults = Math.Max(0, maxResults);
+
                 var contracts = await _contractRepository
                     .Search(query)
                     .OrderBy(c => c.Category)

--- a/tests/Equibles.FunctionalTests/Tests/SearchCftcMarketsNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/SearchCftcMarketsNegativeMaxResultsTests.cs
@@ -48,7 +48,7 @@ public class SearchCftcMarketsNegativeMaxResultsTests
         }
     }
 
-    [Fact(Skip = "GH-2968 — SearchCftcMarkets negative maxResults leaks internal-error sentinel")]
+    [Fact]
     public async Task SearchCftcMarkets_NegativeMaxResults_DoesNotLeakInternalErrorSentinel()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A negative `maxResults` passed to the `SearchCftcMarkets` MCP tool flowed into EF Core's `.Take(maxResults)` as a negative SQL `LIMIT`, which PostgreSQL rejects; the swallowed exception left the caller with the generic internal-error sentinel instead of graceful degradation.
- Clamp `maxResults` with `Math.Max(0, maxResults)` at the tool entry point — matching the sibling MCP tools — so a non-positive cap yields zero rows and the existing no-results message.
- Closes #2968.

## Code changes

- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs` — clamp `maxResults` to a non-negative lower bound before the query in `SearchCftcMarkets`.
- `tests/Equibles.FunctionalTests/Tests/SearchCftcMarketsNegativeMaxResultsTests.cs` — un-skip the committed regression test asserting the tool never leaks the internal-error sentinel on a negative `maxResults` (fails before, passes after).