### PR TITLE
fix(sec): clamp SearchInvestmentAdvisers maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs
@@ -47,6 +47,11 @@ public class InvestmentAdviserTools
                 if (string.IsNullOrWhiteSpace(query))
                     return "Provide part of an adviser's name to search for.";
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
+                maxResults = Math.Max(0, maxResults);
+
                 var advisers = await _adviserRepository
                     .Search(query)
                     .Take(maxResults)

--- a/tests/Equibles.FunctionalTests/Tests/SearchInvestmentAdvisersNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/SearchInvestmentAdvisersNegativeMaxResultsTests.cs
@@ -52,9 +52,7 @@ public class SearchInvestmentAdvisersNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2970 — SearchInvestmentAdvisers surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task SearchInvestmentAdvisers_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A negative `maxResults` reached EF Core's `.Take(maxResults)` as a negative SQL `LIMIT`, which PostgreSQL rejects (22023); the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` at the tool entry point, matching the already-fixed sibling Search tools (GH-2964 `SearchInsiders`, GH-2957 `SearchCongressMembers`), so a non-positive cap yields zero rows and the existing no-results message.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs` — clamp `maxResults` to a non-negative lower bound before `.Take(...)`.
- `tests/Equibles.FunctionalTests/Tests/SearchInvestmentAdvisersNegativeMaxResultsTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2970