### PR TITLE
fix(holdings): clamp SearchInstitutions maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -306,6 +306,11 @@ public class InstitutionalHoldingsTools
         return _runner.Execute(
             async () =>
             {
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
+                maxResults = Math.Max(0, maxResults);
+
                 var holders = await _holderRepository
                     .Search(query)
                     .OrderBy(h => h.Name)

--- a/tests/Equibles.FunctionalTests/Tests/SearchInstitutionsNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/SearchInstitutionsNegativeMaxResultsTests.cs
@@ -51,9 +51,7 @@ public class SearchInstitutionsNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2972 — SearchInstitutions surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task SearchInstitutions_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A negative `maxResults` reached EF Core's `.Take(maxResults)` as a negative SQL `LIMIT`, which PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` at the tool entry point, matching the already-fixed sibling tools in this file, so a non-positive cap yields zero rows and the existing no-results message.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — clamp `maxResults` to a non-negative lower bound before `.Take(...)` in `SearchInstitutions`.
- `tests/Equibles.FunctionalTests/Tests/SearchInstitutionsNegativeMaxResultsTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2972