### PR TITLE
fix(finra): clamp GetLargestShortVolume maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -263,9 +263,12 @@ public class ShortDataTools
                     query = query.Where(d => d.ShortVolume >= minShortVolume);
                 }
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
                 var records = await query
                     .OrderByDescending(d => d.ShortVolume)
-                    .Take(maxResults)
+                    .Take(Math.Max(0, maxResults))
                     .ToListAsync();
 
                 if (records.Count == 0)

--- a/tests/Equibles.FunctionalTests/Tests/LargestShortVolumeNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/LargestShortVolumeNegativeMaxResultsTests.cs
@@ -52,9 +52,7 @@ public class LargestShortVolumeNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2974 — GetLargestShortVolume surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetLargestShortVolume_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A negative `maxResults` reached EF Core's `.Take(maxResults)` as a negative SQL `LIMIT`, which PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` before `.Take(...)`, matching the already-fixed sibling tools in this file, so a non-positive cap yields zero rows and the existing no-results message.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — clamp `maxResults` to a non-negative lower bound before `.Take(...)` in `GetLargestShortVolume`.
- `tests/Equibles.FunctionalTests/Tests/LargestShortVolumeNegativeMaxResultsTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2974