### PR TITLE
fix(finra): render GetShortInterestSnapshot no-results threshold with InvariantCulture

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -205,7 +205,7 @@ public class ShortDataTools
                     .ToListAsync();
 
                 if (records.Count == 0)
-                    return $"No short interest data found for settlement date {latestDate:yyyy-MM-dd} with days to cover >= {minDaysToCover}.";
+                    return $"No short interest data found for settlement date {latestDate:yyyy-MM-dd} with days to cover >= {minDaysToCover.ToString(CultureInfo.InvariantCulture)}.";
 
                 var result = MarkdownTable.Start(
                     $"Short interest snapshot — settlement date {latestDate:yyyy-MM-dd}:",

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
@@ -35,9 +35,7 @@ public class ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTes
     )
         : base(fixture) { }
 
-    [Fact(
-        Skip = "GH-3068 — GetShortInterestSnapshot renders the no-results minDaysToCover threshold with host-locale separators, forking MCP output by culture"
-    )]
+    [Fact]
     public async Task GetShortInterestSnapshot_NoResultsUnderNonInvariantCulture_RendersThresholdCultureInvariantly()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

- `GetShortInterestSnapshot`'s no-results message interpolated the `minDaysToCover` threshold as a bare decimal, forking its separator by host locale (`2.5` on en-US, `2,5` on de-DE). MCP markdown must render byte-identically everywhere.
- Format the threshold with `CultureInfo.InvariantCulture`, matching the table-rendering path in the same tool and the established repo contract.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — render the no-results `minDaysToCover` threshold via `CultureInfo.InvariantCulture`.
- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs` — un-skip the committed regression test (fails on pre-fix code under de-DE, passes after).

closes #3068