### PR TITLE
fix(finra): render GetLargestShortVolume no-results threshold with InvariantCulture

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -272,7 +272,7 @@ public class ShortDataTools
                     .ToListAsync();
 
                 if (records.Count == 0)
-                    return $"No short volume data found for trading day {tradingDay:yyyy-MM-dd} with short volume >= {minShortVolume:N0}.";
+                    return $"No short volume data found for trading day {tradingDay:yyyy-MM-dd} with short volume >= {minShortVolume.ToString("N0", CultureInfo.InvariantCulture)}.";
 
                 var result = MarkdownTable.Start(
                     $"Largest short volume — trading day {tradingDay:yyyy-MM-dd}:",

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
@@ -34,9 +34,7 @@ public class ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests
     // the separators by host locale") is byte-identical output on every host. de-DE swaps the
     // thousand separator (1,000,000 → 1.000.000), forking the response — same bug class as the
     // sibling data-row cells and #3013 / #3030 / #3035 / #3043 / #3047.
-    [Fact(
-        Skip = "GH-3058 — GetLargestShortVolume renders the no-results minShortVolume threshold with the culture-implicit :N0, forking MCP output by host locale"
-    )]
+    [Fact]
     public async Task GetLargestShortVolume_NoResultsUnderNonInvariantCulture_RendersThresholdCultureInvariantly()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

- `GetLargestShortVolume`'s no-results message rendered the `minShortVolume` threshold with the culture-implicit `:N0`, forking its thousands separator by host locale (`1,000,000` on en-US, `1.000.000` on de-DE). MCP markdown must render byte-identically everywhere.
- Render the threshold with `N0` + `CultureInfo.InvariantCulture`, matching the data-row cells in the same tool.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — render the no-results `minShortVolume` threshold via `CultureInfo.InvariantCulture`.
- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs` — un-skip the committed regression test (fails on pre-fix code under de-DE, passes after).

closes #3058