### PR TITLE
fix(congress): clamp GetMemberTrades maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -143,10 +143,13 @@ public class CongressTools
                     .Where(t => t.TransactionDate >= start && t.TransactionDate <= end);
                 query = ApplyTransactionTypeFilter(query, transactionType);
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
                 var trades = await query
                     .Include(t => t.CommonStock)
                     .OrderByDescending(t => t.TransactionDate)
-                    .Take(maxResults)
+                    .Take(Math.Max(0, maxResults))
                     .ToListAsync();
 
                 if (trades.Count == 0)

--- a/tests/Equibles.FunctionalTests/Tests/GetMemberTradesNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/GetMemberTradesNegativeMaxResultsTests.cs
@@ -54,9 +54,7 @@ public class GetMemberTradesNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2976 — GetMemberTrades surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetMemberTrades_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         var stockId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

- A negative `maxResults` reached EF Core's `.Take(maxResults)` as a negative SQL `LIMIT`, which PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` before `.Take(...)`, matching the sibling MCP tools, so a non-positive cap yields zero rows and the existing no-results message.

## Code changes

- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — clamp `maxResults` to a non-negative lower bound before `.Take(...)` in `GetMemberTrades`.
- `tests/Equibles.FunctionalTests/Tests/GetMemberTradesNegativeMaxResultsTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2976