### PR TITLE
fix(sec): clamp GetExemptOfferings maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
@@ -49,10 +49,13 @@ public class FormDTools
                 if (stockError != null)
                     return stockError;
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
                 var filings = await _formDRepository
                     .GetByStock(stock)
                     .OrderByDescending(f => f.FilingDate)
-                    .Take(maxResults)
+                    .Take(Math.Max(0, maxResults))
                     .ToListAsync();
 
                 if (filings.Count == 0)

--- a/tests/Equibles.FunctionalTests/Tests/ExemptOfferingsNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/ExemptOfferingsNegativeMaxResultsTests.cs
@@ -51,9 +51,7 @@ public class ExemptOfferingsNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2978 — GetExemptOfferings surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetExemptOfferings_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A negative `maxResults` reached EF Core's `.Take(maxResults)` as a negative SQL `LIMIT`, which PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` before `.Take(...)`, matching the sibling MCP tools, so a non-positive cap yields zero rows and the existing no-results message.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/FormDTools.cs` — clamp `maxResults` to a non-negative lower bound before `.Take(...)` in `GetExemptOfferings`.
- `tests/Equibles.FunctionalTests/Tests/ExemptOfferingsNegativeMaxResultsTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2978