### PR TITLE
fix(insider-trading): clamp GetProposedSales maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -192,10 +192,13 @@ public class InsiderTradingTools
                 if (stockError != null)
                     return stockError;
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
                 var filings = await _form144Repository
                     .GetByStock(stock)
                     .OrderByDescending(f => f.FilingDate)
-                    .Take(maxResults)
+                    .Take(Math.Max(0, maxResults))
                     .ToListAsync();
 
                 if (filings.Count == 0)

--- a/tests/Equibles.FunctionalTests/Tests/ProposedSalesNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/ProposedSalesNegativeMaxResultsTests.cs
@@ -51,9 +51,7 @@ public class ProposedSalesNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2980 — GetProposedSales surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetProposedSales_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A negative `maxResults` reached EF Core's `.Take(maxResults)` as a negative SQL `LIMIT`, which PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` before `.Take(...)`, matching the sibling MCP tools (including `SearchInsiders` in this same file), so a non-positive cap yields zero rows and the existing no-results message.

## Code changes

- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — clamp `maxResults` to a non-negative lower bound before `.Take(...)` in `GetProposedSales`.
- `tests/Equibles.FunctionalTests/Tests/ProposedSalesNegativeMaxResultsTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2980