### PR TITLE
fix(holdings): clamp GetMostHeldStocks maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -733,7 +733,10 @@ public class InstitutionalHoldingsTools
                         .OrderByDescending(a => a.CurrentFilerCount)
                         .ThenByDescending(a => a.CurrentValue),
                 };
-                var rows = await ranking.Take(maxResults).ToListAsync();
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
+                var rows = await ranking.Take(Math.Max(0, maxResults)).ToListAsync();
                 if (rows.Count == 0)
                     return $"No stocks were held by 13F filers as of {FormatDate(targetDate)}.";
 

--- a/tests/Equibles.FunctionalTests/Tests/GetMostHeldStocksNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/GetMostHeldStocksNegativeMaxResultsTests.cs
@@ -53,9 +53,7 @@ public class GetMostHeldStocksNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2982 — GetMostHeldStocks surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetMostHeldStocks_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         var stockId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

- A negative `maxResults` reached EF Core's `.Take(maxResults)` on the cross-sectional 13F ranking as a negative SQL `LIMIT`, which PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` before `.Take(...)`, matching the sibling MCP tools, so a non-positive cap yields zero rows and the existing no-results message.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — clamp `maxResults` to a non-negative lower bound before `.Take(...)` in `GetMostHeldStocks`.
- `tests/Equibles.FunctionalTests/Tests/GetMostHeldStocksNegativeMaxResultsTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2982