### PR TITLE
fix(finra): clamp GetShortInterestSnapshot maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -199,9 +199,12 @@ public class ShortDataTools
                     query = query.Where(s => s.DaysToCover >= minDaysToCover);
                 }
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
                 var records = await query
                     .OrderByDescending(s => s.DaysToCover)
-                    .Take(maxResults)
+                    .Take(Math.Max(0, maxResults))
                     .ToListAsync();
 
                 if (records.Count == 0)

--- a/tests/Equibles.FunctionalTests/Tests/ShortInterestSnapshotNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/ShortInterestSnapshotNegativeMaxResultsTests.cs
@@ -52,9 +52,7 @@ public class ShortInterestSnapshotNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2984 — GetShortInterestSnapshot surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetShortInterestSnapshot_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A negative `maxResults` reached EF Core's `.Take(maxResults)` on the snapshot ranking as a negative SQL `LIMIT`, which PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` before `.Take(...)`, matching the sibling MCP tools, so a non-positive cap yields zero rows and the existing no-results message.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — clamp `maxResults` to a non-negative lower bound before `.Take(...)` in `GetShortInterestSnapshot`.
- `tests/Equibles.FunctionalTests/Tests/ShortInterestSnapshotNegativeMaxResultsTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2984