### PR TITLE
fix(sec): clamp GetFundOperations maxResults so a negative value no longer surfaces an internal error

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
@@ -50,11 +50,14 @@ public class NCenTools
                 if (stockError != null)
                     return stockError;
 
+                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
+                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
+                // so a non-positive cap yields zero rows and the existing no-results message.
                 var filings = await _nCenRepository
                     .GetByStock(stock)
                     .Include(f => f.ServiceProviders)
                     .OrderByDescending(f => f.FilingDate)
-                    .Take(maxResults)
+                    .Take(Math.Max(0, maxResults))
                     .ToListAsync();
 
                 if (filings.Count == 0)

--- a/tests/Equibles.FunctionalTests/Tests/GetFundOperationsNegativeMaxResultsTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/GetFundOperationsNegativeMaxResultsTests.cs
@@ -50,9 +50,7 @@ public class GetFundOperationsNegativeMaxResultsTests
         }
     }
 
-    [Fact(
-        Skip = "GH-2986 — GetFundOperations surfaces an internal error for a negative maxResults instead of degrading gracefully"
-    )]
+    [Fact]
     public async Task GetFundOperations_NegativeMaxResults_DoesNotSurfaceInternalError()
     {
         await _fixture.ResetAndSeedAsync(async db =>


### PR DESCRIPTION
## Summary

- A negative `maxResults` reached EF Core's `.Take(maxResults)` as a negative SQL `LIMIT`, which PostgreSQL rejects; the swallowed exception surfaced the generic internal-error sentinel instead of degrading gracefully.
- Clamp with `Math.Max(0, maxResults)` before `.Take(...)`, matching the sibling MCP tools, so a non-positive cap yields zero rows and the existing no-results message.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/NCenTools.cs` — clamp `maxResults` to a non-negative lower bound before `.Take(...)` in `GetFundOperations`.
- `tests/Equibles.FunctionalTests/Tests/GetFundOperationsNegativeMaxResultsTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2986