### PR TITLE
fix(holdings): escape LIKE metacharacters in InstitutionalHolderRepository.Search

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
@@ -21,7 +21,11 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
 
     public IQueryable<InstitutionalHolder> Search(string search)
     {
-        return GetAll().Where(h => EF.Functions.ILike(h.Name, $"%{search}%"));
+        // Escape LIKE metacharacters so '%' / '_' / '\\' in the query match literally
+        // rather than behaving as wildcards (e.g. "_" would otherwise match every name),
+        // matching the documented "name contains the term" contract and SearchNameOrCik.
+        var pattern = $"%{EscapeLikePattern(search)}%";
+        return GetAll().Where(h => EF.Functions.ILike(h.Name, pattern, "\\"));
     }
 
     // Typeahead variant: matches a CIK prefix as well as a name substring so the

--- a/tests/Equibles.IntegrationTests/Web/InstitutionsSearchWildcardEscapingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/InstitutionsSearchWildcardEscapingTests.cs
@@ -47,9 +47,7 @@ public class InstitutionsSearchWildcardEscapingTests
         return Task.CompletedTask;
     }
 
-    [Fact(
-        Skip = "GH-2911 — institution name search treats LIKE wildcards (_, %) as wildcards, not literals"
-    )]
+    [Fact]
     public async Task GetInstitutions_SearchIsBareUnderscore_DoesNotWildcardMatchNamesWithoutUnderscore()
     {
         await _fixture.ResetAndSeedAsync(Seed);


### PR DESCRIPTION
## Summary

- `Search` spliced the raw term into an `ILIKE` pattern, so `_` and `%` behaved as wildcards — searching `_` matched every named holder and `%` dumped the whole table, contradicting the documented "name contains the term" contract and exposing `/institutions?search=...` to wildcard injection.
- Escape the term via the existing `EscapeLikePattern` and pass the `\` escape char to `ILike`, matching the sibling `SearchNameOrCik`.

## Code changes

- `src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs` — escape LIKE metacharacters in `Search` and pass the `\` escape char to `ILike`.
- `tests/Equibles.IntegrationTests/Web/InstitutionsSearchWildcardEscapingTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2911