### PR TITLE
fix(holdings): escape LIKE metacharacters in the institutions city filter

### DIFF
--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -97,7 +97,12 @@ public class InstitutionsController : BaseController
         }
         if (!string.IsNullOrWhiteSpace(city))
         {
-            holders = holders.Where(h => EF.Functions.ILike(h.City, $"%{city.Trim()}%"));
+            // Escape LIKE metacharacters so '%' / '_' / '\' in the city term match literally
+            // rather than as wildcards (a bare '_' or '%' would otherwise dump the table),
+            // matching the "city contains" intent and the escaping used elsewhere.
+            var cityPattern =
+                $"%{city.Trim().Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_")}%";
+            holders = holders.Where(h => EF.Functions.ILike(h.City, cityPattern, "\\"));
         }
 
         var joined = holders.GroupJoin(

--- a/tests/Equibles.IntegrationTests/Web/InstitutionsControllerCityFilterWildcardTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/InstitutionsControllerCityFilterWildcardTests.cs
@@ -51,7 +51,7 @@ public class InstitutionsControllerCityFilterWildcardTests
         return Task.CompletedTask;
     }
 
-    [Fact(Skip = "GH-2913: institution city filter treats _ or % as LIKE wildcards")]
+    [Fact]
     public async Task GetInstitutions_CityIsBareUnderscore_DoesNotWildcardMatchCitiesWithoutUnderscore()
     {
         await _fixture.ResetAndSeedAsync(Seed);


### PR DESCRIPTION
## Summary

- The `/institutions` city filter spliced the raw term into an `ILIKE` pattern, so `_` and `%` behaved as wildcards — `city=_` matched every institution with a non-empty city and `%` dumped the table, contradicting the literal "city contains" intent.
- Escape `\`, `%`, `_` and pass the `\` escape char to `ILike`, matching the escaping used by `InstitutionalHolderRepository`.

## Code changes

- `src/Equibles.Web/Controllers/InstitutionsController.cs` — escape LIKE metacharacters in the city term and pass the `\` escape char to `ILike`.
- `tests/Equibles.IntegrationTests/Web/InstitutionsControllerCityFilterWildcardTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2913