### PR TITLE
fix: match HTML/text filename extensions case-insensitively

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/SecDocumentHtmlNormalizer.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecDocumentHtmlNormalizer.cs
@@ -105,9 +105,9 @@ public class SecDocumentHtmlNormalizer : ISecDocumentHtmlNormalizer
             if (string.IsNullOrEmpty(filename))
                 continue;
             if (
-                !filename.EndsWith(".htm")
-                && !filename.EndsWith(".html")
-                && !filename.EndsWith(".txt")
+                !filename.EndsWith(".htm", StringComparison.OrdinalIgnoreCase)
+                && !filename.EndsWith(".html", StringComparison.OrdinalIgnoreCase)
+                && !filename.EndsWith(".txt", StringComparison.OrdinalIgnoreCase)
             )
                 continue;
 


### PR DESCRIPTION
## Summary

`SecDocumentHtmlNormalizer.ExtractAndFilterDocuments` filtered each `<DOCUMENT>` block's FILENAME extension with the default case-sensitive `EndsWith`. A document whose FILENAME ended in an uppercase `.HTM`/`.HTML`/`.TXT` was rejected and silently dropped — for a single-document filing the entire body was lost.

File extensions are case-insensitive, and the sibling `SecDocumentEnvelopeParser` already matches `.PDF` with `OrdinalIgnoreCase`. This makes the HTML/text path consistent.

## Code changes

- `src/Equibles.Sec.BusinessLogic/SecDocumentHtmlNormalizer.cs` — the three `.htm`/`.html`/`.txt` `EndsWith` checks now pass `StringComparison.OrdinalIgnoreCase`.