### PR TITLE
fix(insider-trading): escape LIKE metacharacters in InsiderOwnerRepository.Search

### DIFF
--- a/src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs
+++ b/src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs
@@ -25,8 +25,12 @@ public class InsiderOwnerRepository : BaseRepository<InsiderOwner>
         var query = GetAll();
         foreach (var token in tokens)
         {
-            var t = token;
-            query = query.Where(o => EF.Functions.ILike(o.Name, $"%{t}%"));
+            // Escape LIKE metacharacters so '%' / '_' / '\' in a token match literally rather
+            // than as wildcards (a bare '_' would otherwise match every name, '%' the whole
+            // table). A fresh local per iteration keeps the closure capture correct.
+            var pattern =
+                $"%{token.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_")}%";
+            query = query.Where(o => EF.Functions.ILike(o.Name, pattern, "\\"));
         }
 
         return query;

--- a/tests/Equibles.IntegrationTests/Web/InsidersGlobalSearchWildcardEscapingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/InsidersGlobalSearchWildcardEscapingTests.cs
@@ -47,9 +47,7 @@ public class InsidersGlobalSearchWildcardEscapingTests
         return Task.CompletedTask;
     }
 
-    [Fact(
-        Skip = "GH-2915 — insider search treats LIKE wildcards (_, %) as wildcards, not literals"
-    )]
+    [Fact]
     public async Task GlobalSearch_QueryIsBareUnderscore_DoesNotWildcardMatchInsiderNamesWithoutUnderscore()
     {
         await _fixture.ResetAndSeedAsync(Seed);


### PR DESCRIPTION
## Summary

- `Search` split the query into tokens and spliced each raw token into an `ILIKE` pattern, so `_` and `%` behaved as wildcards — `_` matched every named owner and `%` dumped the table, contradicting the "name contains the term" contract and exposing the global Insiders search to wildcard injection.
- Escape `\`, `%`, `_` per token and pass the `\` escape char to `ILike`, matching the escaping used elsewhere (`InstitutionalHolderRepository`).

## Code changes

- `src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs` — escape LIKE metacharacters per token and pass the `\` escape char to `ILike`.
- `tests/Equibles.IntegrationTests/Web/InsidersGlobalSearchWildcardEscapingTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2915