### PR TITLE
fix: classify a 0-share current holding as Exited, not Reduced

### DIFF
--- a/src/Equibles.Holdings.Repositories/HolderQuarterlyActivityCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HolderQuarterlyActivityCalculator.cs
@@ -52,6 +52,8 @@ public static class HolderQuarterlyActivityCalculator
     {
         if (previousShares == 0)
             return StockPositionChangeType.Initiated;
+        if (currentShares == 0)
+            return StockPositionChangeType.Exited;
         if (currentShares == previousShares)
             return StockPositionChangeType.Unchanged;
         return currentShares > previousShares


### PR DESCRIPTION
## Summary

`HolderQuarterlyActivityCalculator.ClassifyChange` returned `Reduced` for a position that fell to 0 current shares (`0 < previous`). Whether a closed position landed in `Exited` or `Reduced` then depended on a filing-format quirk — a stock omitted from the current filing went to `Exited` (the second pass), but a current row reporting 0 shares went to `Reduced`. A 0-share holding is a full exit either way.

## Code changes

- `src/Equibles.Holdings.Repositories/HolderQuarterlyActivityCalculator.cs` — `ClassifyChange` now returns `Exited` when `currentShares == 0`, after the previous-only (`Initiated`) guard and before the increase/decrease comparison.