### PR TITLE
fix(congress): escape LIKE metacharacters in CongressMemberRepository.Search

### DIFF
--- a/src/Equibles.Congress.Repositories/CongressMemberRepository.cs
+++ b/src/Equibles.Congress.Repositories/CongressMemberRepository.cs
@@ -16,6 +16,10 @@ public class CongressMemberRepository : BaseRepository<CongressMember>
 
     public IQueryable<CongressMember> Search(string search)
     {
-        return GetAll().Where(m => EF.Functions.ILike(m.Name, $"%{search}%"));
+        // Escape LIKE metacharacters so '%' / '_' / '\' in the query match literally rather
+        // than as wildcards (a bare '_' would otherwise match every name, '%' the whole table),
+        // matching the "name contains the term" contract and the escaping used elsewhere.
+        var pattern = $"%{search.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_")}%";
+        return GetAll().Where(m => EF.Functions.ILike(m.Name, pattern, "\\"));
     }
 }

--- a/tests/Equibles.IntegrationTests/Web/CongressGlobalSearchWildcardEscapingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/CongressGlobalSearchWildcardEscapingTests.cs
@@ -42,9 +42,7 @@ public class CongressGlobalSearchWildcardEscapingTests
         return Task.CompletedTask;
     }
 
-    [Fact(
-        Skip = "GH-2918 — congress member search treats LIKE wildcards (_, %) as wildcards, not literals"
-    )]
+    [Fact]
     public async Task GlobalSearch_QueryIsBareUnderscore_DoesNotWildcardMatchMemberNamesWithoutUnderscore()
     {
         await _fixture.ResetAndSeedAsync(Seed);


### PR DESCRIPTION
## Summary

- `Search` spliced the raw query into an `ILIKE` pattern, so `_` and `%` behaved as wildcards — `_` matched every named member and `%` dumped the table, contradicting the "name contains the term" contract and exposing the global Congress search to wildcard injection.
- Escape `\`, `%`, `_` and pass the `\` escape char to `ILike`, matching the escaping used elsewhere.

## Code changes

- `src/Equibles.Congress.Repositories/CongressMemberRepository.cs` — escape LIKE metacharacters and pass the `\` escape char to `ILike`.
- `tests/Equibles.IntegrationTests/Web/CongressGlobalSearchWildcardEscapingTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2918