### PR TITLE
fix: do not classify a letter-prefixed dollar (C$, A$) as US Dollars

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs
@@ -107,10 +107,26 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
     {
         foreach (var (code, (symbol, _)) in CurrencyMap)
         {
-            if (text.Contains(symbol) || CurrencyCodeRegexes[code].IsMatch(text))
+            if (ContainsCurrencySymbol(text, symbol) || CurrencyCodeRegexes[code].IsMatch(text))
                 return code;
         }
         return null;
+    }
+
+    // A symbol immediately preceded by a letter is a different currency's
+    // prefixed symbol (e.g. "C$", "A$", "HK$", "NZ$"), not this one — so a
+    // Canadian/Australian/HK dollar cell is not mistaken for US Dollars,
+    // mirroring the boundary-careful currency-code match above.
+    private static bool ContainsCurrencySymbol(string text, string symbol)
+    {
+        var index = text.IndexOf(symbol, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            if (index == 0 || !char.IsLetter(text[index - 1]))
+                return true;
+            index = text.IndexOf(symbol, index + symbol.Length, StringComparison.Ordinal);
+        }
+        return false;
     }
 
     private void ProcessCurrencyColumnsForConsolidation(


### PR DESCRIPTION
## Summary

`CurrencyConsolidationStep.DetectCurrency` matched a currency *symbol* with a naive substring `Contains`, so USD's `$` matched a Canadian-dollar cell written `C$1,000` (as 40-F/MJDS and 20-F filings do). The step then stamped "All values are in US Dollars." onto Canadian/Australian/HK-dollar financials. The same method already matches currency *codes* boundary-carefully (a word-boundary regex, so `USDA`/`USDC` aren't mistaken for USD) — the symbol match is now equally careful.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs` — symbol detection now rejects a symbol immediately preceded by a letter (`C$`, `A$`, `HK$`, `NZ$`), so `$1,000` stays USD while a letter-prefixed dollar does not.