### PR TITLE
fix: keep a table cell holding an image/link beside a whitespace span

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs
@@ -166,11 +166,20 @@ internal class TableNormalizationStep : IHtmlNormalizationStep
         return IsOnlyWhitespaceSpan(cellHtml);
     }
 
+    // Meaningful non-text content: an element that carries data without any text
+    // (a logo/signature/checkmark <img>, a linked <a href>, a form <input>, …).
+    private const string MeaningfulNonSpanSelector =
+        "img, a[href], input, svg, object, embed, iframe, video, audio, canvas, picture";
+
     private bool IsOnlyWhitespaceSpan(string html)
     {
         var tempDoc = _parser.ParseDocument(html);
         var spans = tempDoc.QuerySelectorAll("span").ToList();
-        return spans.Count > 0 && spans.All(span => !IsMeaningfulText(span.TextContent.Trim()));
+        if (spans.Count == 0 || spans.Any(span => IsMeaningfulText(span.TextContent.Trim())))
+            return false;
+        // A whitespace span beside a text-free <img>/<a href>/<input> is NOT "only
+        // whitespace spans" — the cell still holds meaningful content and must be kept.
+        return tempDoc.QuerySelectorAll(MeaningfulNonSpanSelector).Length == 0;
     }
 
     private void RemoveEmptyColumns(IElement table)


### PR DESCRIPTION
## Summary

`TableNormalizationStep.IsOnlyWhitespaceSpan` judged a cell's emptiness from its `<span>` children only. A cell containing a whitespace `<span>` next to a text-free `<img>` (logo/signature/checkmark) or `<a href>` was therefore reported empty, and `RemoveEmptyColumns`/`RemoveEmptyRows` silently dropped its image/link. SEC HTML wraps content in styling spans everywhere, so this triggers often.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/TableNormalizationStep.cs` — a cell counts as whitespace-spans only when it ALSO has no meaningful non-span element (`img, a[href], input, svg, object, embed, iframe, video, audio, canvas, picture`). Same span-only blind spot `ListConversionStep` already documented.