### PR TITLE
fix(errors): escape LIKE metacharacters in ErrorRepository.Search

### DIFF
--- a/src/Equibles.Errors.Repositories/ErrorRepository.cs
+++ b/src/Equibles.Errors.Repositories/ErrorRepository.cs
@@ -18,10 +18,15 @@ public class ErrorRepository : BaseRepository<Error>
     {
         if (string.IsNullOrEmpty(search))
             return GetAll();
+        // Escape LIKE metacharacters so '%' / '_' / '\' in the query match literally rather
+        // than as wildcards (a bare '_' would otherwise match every row, '%' the whole table),
+        // matching the "Context or Message contains the term" contract and the escaping used
+        // elsewhere.
+        var pattern = $"%{search.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_")}%";
         return GetAll()
             .Where(e =>
-                EF.Functions.ILike(e.Context, $"%{search}%")
-                || EF.Functions.ILike(e.Message, $"%{search}%")
+                EF.Functions.ILike(e.Context, pattern, "\\")
+                || EF.Functions.ILike(e.Message, pattern, "\\")
             );
     }
 

--- a/tests/Equibles.IntegrationTests/Web/StatusControllerSearchWildcardTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StatusControllerSearchWildcardTests.cs
@@ -42,7 +42,7 @@ public class StatusControllerSearchWildcardTests
         return Task.CompletedTask;
     }
 
-    [Fact(Skip = "GH-2926 — /status error search treats _ and % as LIKE wildcards")]
+    [Fact]
     public async Task GetStatus_SearchIsBareUnderscore_DoesNotWildcardMatchErrorsWithoutUnderscore()
     {
         await _fixture.ResetAndSeedAsync(Seed);


### PR DESCRIPTION
## Summary

- `Search` spliced the raw query into two `ILIKE` patterns (Context, Message), so `_` and `%` behaved as wildcards — `_` matched every error with non-empty text and `%` dumped the table, contradicting the "Context or Message contains the term" contract and exposing the `/status` error search to wildcard injection.
- Escape `\`, `%`, `_` and pass the `\` escape char to both `ILike` calls, matching the escaping used elsewhere.

## Code changes

- `src/Equibles.Errors.Repositories/ErrorRepository.cs` — escape LIKE metacharacters and pass the `\` escape char to both `ILike` calls.
- `tests/Equibles.IntegrationTests/Web/StatusControllerSearchWildcardTests.cs` — un-skip the committed regression test (fails on pre-fix code, passes after).

closes #2926