### PR TITLE
fix(cftc): render GetLatestCftcData net positions with InvariantCulture

### DIFF
--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -156,10 +156,18 @@ public class CftcTools
                     var dateStr = McpFormat.OrDash(report?.ReportDate, "yyyy-MM-dd");
                     var oiStr = McpFormat.OrDash(report?.OpenInterest, "N0");
                     var commNet =
-                        report != null ? (report.CommLong - report.CommShort).ToString("N0") : "—";
+                        report != null
+                            ? (report.CommLong - report.CommShort).ToString(
+                                "N0",
+                                CultureInfo.InvariantCulture
+                            )
+                            : "—";
                     var nonCommNet =
                         report != null
-                            ? (report.NonCommLong - report.NonCommShort).ToString("N0")
+                            ? (report.NonCommLong - report.NonCommShort).ToString(
+                                "N0",
+                                CultureInfo.InvariantCulture
+                            )
                             : "—";
 
                     result.AppendLine(

--- a/tests/Equibles.IntegrationTests/Mcp/CftcToolsGetLatestCftcDataCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CftcToolsGetLatestCftcDataCultureInvarianceTests.cs
@@ -28,9 +28,7 @@ public class CftcToolsGetLatestCftcDataCultureInvarianceTests : ParadeDbMcpTestB
     // with a bare .ToString("N0"), which follows the thread CurrentCulture — under de-DE the
     // grouping separator becomes "." (1,460,000 → 1.460.000), forking the response. Same bug
     // class as the fixed Holdings render methods (#2628).
-    [Fact(
-        Skip = "GH-3013 — GetLatestCftcData renders Comm Net / Non-Comm Net with host-locale separators, forking MCP output by culture"
-    )]
+    [Fact]
     public async Task GetLatestCftcData_UnderNonInvariantCulture_RendersNetPositionsCultureInvariantly()
     {
         var contract = new CftcContract


### PR DESCRIPTION
## Summary

- `GetLatestCftcData` rendered the Comm Net / Non-Comm Net cells with a bare `.ToString("N0")`, honouring the thread `CurrentCulture` and forking the MCP markdown separators by host locale (de-DE → `1.460.000`).
- Render both net values with `CultureInfo.InvariantCulture`, matching every other cell and the sibling tools `GetCftcPositioning` / `GetVixHistory`.

## Code changes

- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs` — render Comm Net and Non-Comm Net with `CultureInfo.InvariantCulture`.
- `tests/Equibles.IntegrationTests/Mcp/CftcToolsGetLatestCftcDataCultureInvarianceTests.cs` — un-skip the committed regression test (fails on pre-fix code under de-DE, passes after).

closes #3013