### PR TITLE
refactor(search): route duplicated LIKE-escape through the shared LikePattern helper

### DIFF
--- a/src/Equibles.Congress.Repositories/CongressMemberRepository.cs
+++ b/src/Equibles.Congress.Repositories/CongressMemberRepository.cs
@@ -16,10 +16,8 @@ public class CongressMemberRepository : BaseRepository<CongressMember>
 
     public IQueryable<CongressMember> Search(string search)
     {
-        // Escape LIKE metacharacters so '%' / '_' / '\' in the query match literally rather
-        // than as wildcards (a bare '_' would otherwise match every name, '%' the whole table),
-        // matching the "name contains the term" contract and the escaping used elsewhere.
-        var pattern = $"%{search.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_")}%";
+        // "Name contains the term"; escape so '%' / '_' / '\' in the query match literally.
+        var pattern = LikePattern.Contains(search);
         return GetAll().Where(m => EF.Functions.ILike(m.Name, pattern, "\\"));
     }
 }

--- a/src/Equibles.Data/LikePattern.cs
+++ b/src/Equibles.Data/LikePattern.cs
@@ -2,11 +2,17 @@ namespace Equibles.Data;
 
 public static class LikePattern
 {
+    // Escapes LIKE metacharacters ('\' '%' '_') so user input matches literally rather
+    // than as wildcards. Use with EF.Functions.ILike(column, pattern, "\\").
+    public static string Escape(string text)
+    {
+        return text.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
+    }
+
     // Escapes LIKE metacharacters and wraps in % for a contains match.
     // Use with EF.Functions.ILike(column, pattern, "\\").
     public static string Contains(string text)
     {
-        var escaped = text.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
-        return $"%{escaped}%";
+        return $"%{Escape(text)}%";
     }
 }

--- a/src/Equibles.Errors.Repositories/ErrorRepository.cs
+++ b/src/Equibles.Errors.Repositories/ErrorRepository.cs
@@ -18,11 +18,8 @@ public class ErrorRepository : BaseRepository<Error>
     {
         if (string.IsNullOrEmpty(search))
             return GetAll();
-        // Escape LIKE metacharacters so '%' / '_' / '\' in the query match literally rather
-        // than as wildcards (a bare '_' would otherwise match every row, '%' the whole table),
-        // matching the "Context or Message contains the term" contract and the escaping used
-        // elsewhere.
-        var pattern = $"%{search.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_")}%";
+        // "Context or Message contains the term"; escape so '%' / '_' / '\' match literally.
+        var pattern = LikePattern.Contains(search);
         return GetAll()
             .Where(e =>
                 EF.Functions.ILike(e.Context, pattern, "\\")

--- a/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
@@ -21,10 +21,8 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
 
     public IQueryable<InstitutionalHolder> Search(string search)
     {
-        // Escape LIKE metacharacters so '%' / '_' / '\\' in the query match literally
-        // rather than behaving as wildcards (e.g. "_" would otherwise match every name),
-        // matching the documented "name contains the term" contract and SearchNameOrCik.
-        var pattern = $"%{EscapeLikePattern(search)}%";
+        // "Name contains the term"; escape so '%' / '_' / '\' match literally, matching SearchNameOrCik.
+        var pattern = LikePattern.Contains(search);
         return GetAll().Where(h => EF.Functions.ILike(h.Name, pattern, "\\"));
     }
 
@@ -44,8 +42,8 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
             );
     }
 
-    private static string EscapeLikePattern(string input) =>
-        input.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
+    // Local alias over the shared escaper, kept so SearchNameOrCik reads as one concept.
+    private static string EscapeLikePattern(string input) => LikePattern.Escape(input);
 
     // Distinct non-empty state/country codes across the filer universe, used to
     // populate the location filter dropdown on the institutions index so the user

--- a/src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs
+++ b/src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs
@@ -25,11 +25,8 @@ public class InsiderOwnerRepository : BaseRepository<InsiderOwner>
         var query = GetAll();
         foreach (var token in tokens)
         {
-            // Escape LIKE metacharacters so '%' / '_' / '\' in a token match literally rather
-            // than as wildcards (a bare '_' would otherwise match every name, '%' the whole
-            // table). A fresh local per iteration keeps the closure capture correct.
-            var pattern =
-                $"%{token.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_")}%";
+            // A fresh local per iteration keeps the closure capture correct.
+            var pattern = LikePattern.Contains(token);
             query = query.Where(o => EF.Functions.ILike(o.Name, pattern, "\\"));
         }
 

--- a/src/Equibles.Sec.Repositories/FormAdvAdviserRepository.cs
+++ b/src/Equibles.Sec.Repositories/FormAdvAdviserRepository.cs
@@ -25,11 +25,7 @@ public class FormAdvAdviserRepository : BaseRepository<FormAdvAdviser>
             return GetAll().Where(a => false);
         }
 
-        var trimmed = term.Trim();
-        // Escape LIKE metacharacters so "_" and "%" in the query match literally
-        // rather than acting as wildcards; pair with an explicit ESCAPE clause.
-        var escaped = trimmed.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
-        var pattern = $"%{escaped}%";
+        var pattern = LikePattern.Contains(term.Trim());
         return GetAll()
             .Where(a =>
                 EF.Functions.ILike(a.LegalName, pattern, "\\")

--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -97,11 +97,8 @@ public class InstitutionsController : BaseController
         }
         if (!string.IsNullOrWhiteSpace(city))
         {
-            // Escape LIKE metacharacters so '%' / '_' / '\' in the city term match literally
-            // rather than as wildcards (a bare '_' or '%' would otherwise dump the table),
-            // matching the "city contains" intent and the escaping used elsewhere.
-            var cityPattern =
-                $"%{city.Trim().Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_")}%";
+            // "City contains"; escape so '%' / '_' / '\' in the city term match literally.
+            var cityPattern = LikePattern.Contains(city.Trim());
             holders = holders.Where(h => EF.Functions.ILike(h.City, cityPattern, "\\"));
         }
 


### PR DESCRIPTION
## Summary

- The LIKE-metacharacter escape `text.Replace("\\","\\\\").Replace("%","\\%").Replace("_","\\_")` had been copied inline into six `Search` methods/filters across modules. This consolidates every copy onto the existing shared `Equibles.Data.LikePattern` helper.
- Behavior is unchanged: `LikePattern.Contains(x)` produces the same `%…%` contains pattern as each inline expression, and a new `LikePattern.Escape(x)` returns the bare escaped string for the CIK-prefix case in the institutions typeahead. Trim/Split semantics and null/empty guards at each call site are untouched.

## Code changes

- `src/Equibles.Data/LikePattern.cs` — add `Escape(text)` (bare escape) and have `Contains` delegate to it; the escape chain now lives in one place.
- `src/Equibles.Congress.Repositories/CongressMemberRepository.cs`, `src/Equibles.Errors.Repositories/ErrorRepository.cs`, `src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs`, `src/Equibles.Sec.Repositories/FormAdvAdviserRepository.cs`, `src/Equibles.Web/Controllers/InstitutionsController.cs` — replace the inline escape with `LikePattern.Contains(...)`.
- `src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs` — `Search` uses `LikePattern.Contains`; the private `EscapeLikePattern` becomes a thin alias over `LikePattern.Escape`, still used by `SearchNameOrCik`.