### PR TITLE
fix(web): guard pagination offset against Int32 overflow

### DIFF
--- a/src/Equibles.Web/Extensions/Pagination.cs
+++ b/src/Equibles.Web/Extensions/Pagination.cs
@@ -10,6 +10,12 @@ public static class Pagination
     // Skip((page-1)*pageSize), which PostgreSQL rejects (22023) and surfaces as HTTP 500.
     public static int ClampPage(int page) => page < 1 ? 1 : page;
 
-    public static IQueryable<T> Page<T>(this IQueryable<T> source, int page, int pageSize) =>
-        source.Skip((page - 1) * pageSize).Take(pageSize);
+    public static IQueryable<T> Page<T>(this IQueryable<T> source, int page, int pageSize)
+    {
+        // Compute the offset in long so a maximal client page can't overflow Int32 into a
+        // negative SQL OFFSET (PostgreSQL 22023 → HTTP 500); clamp to [0, int.MaxValue] so an
+        // absurd page simply falls past the end and renders an empty page.
+        var skip = (int)Math.Clamp((long)(page - 1) * pageSize, 0L, int.MaxValue);
+        return source.Skip(skip).Take(pageSize);
+    }
 }

--- a/tests/Equibles.FunctionalTests/Tests/AdvisersIndexPageOverflowTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/AdvisersIndexPageOverflowTests.cs
@@ -19,7 +19,7 @@ public class AdvisersIndexPageOverflowTests
         _playwright = playwright;
     }
 
-    [Fact(Skip = "GH-2924 — max-int page overflows Page() offset to negative, 500s")]
+    [Fact]
     public async Task Index_GetWithMaxIntPage_DoesNotReturnServerError()
     {
         // Contract: Pagination.ClampPage exists precisely so a client-supplied page value can

--- a/tests/Equibles.IntegrationTests/Web/AdvisersPaginationOverflowTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/AdvisersPaginationOverflowTests.cs
@@ -40,9 +40,7 @@ public class AdvisersPaginationOverflowTests
         return Task.CompletedTask;
     }
 
-    [Fact(
-        Skip = "GH-2920 — page=int.MaxValue overflows Skip((page-1)*pageSize) to a negative OFFSET, 500 instead of an empty page"
-    )]
+    [Fact]
     public async Task GetAdvisers_PageIsIntMaxValue_DoesNotOverflowToNegativeOffset()
     {
         await _fixture.ResetAndSeedAsync(Seed);


### PR DESCRIPTION
## Summary

- `Pagination.Page` computed `Skip((page - 1) * pageSize)` in unchecked `int` arithmetic, so a maximal client `page` (e.g. `?page=2147483647`) overflowed to a negative value → negative SQL `OFFSET` → PostgreSQL 22023 → HTTP 500. This is the exact failure `ClampPage`'s lower-bound floor was meant to prevent, slipping through via overflow.
- Compute the offset in `long` and clamp to `[0, int.MaxValue]` so an absurd page simply falls past the end and renders an empty page. Backs every paginated index (advisers, institutions, stocks, …).

Fixes both GH-2920 (advisers repro) and GH-2924 (generic), which are the same root cause.

## Code changes

- `src/Equibles.Web/Extensions/Pagination.cs` — compute `Skip` offset in `long`, clamped to `[0, int.MaxValue]`.
- `tests/Equibles.IntegrationTests/Web/AdvisersPaginationOverflowTests.cs` — un-skip the integration repro (`?page=int.MaxValue` → 200).
- `tests/Equibles.FunctionalTests/Tests/AdvisersIndexPageOverflowTests.cs` — un-skip the functional repro (no 5xx). Both fail on pre-fix code, pass after.

closes #2920
closes #2924