### PR TITLE
refactor(mcp): extract duplicated FormatWholeNumber helpers into McpFormat.WholeNumber

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -92,7 +92,7 @@ public class ShortDataTools
                     var shortPct =
                         r.TotalVolume > 0 ? (double)r.ShortVolume / r.TotalVolume * 100 : 0;
                     result.AppendLine(
-                        $"| {r.Date:yyyy-MM-dd} | {FormatWholeNumber(r.ShortVolume)} | {FormatWholeNumber(r.ShortExemptVolume)} | {FormatWholeNumber(r.TotalVolume)} | {shortPct.ToString("F1", CultureInfo.InvariantCulture)}% |"
+                        $"| {r.Date:yyyy-MM-dd} | {McpFormat.WholeNumber(r.ShortVolume)} | {McpFormat.WholeNumber(r.ShortExemptVolume)} | {McpFormat.WholeNumber(r.TotalVolume)} | {shortPct.ToString("F1", CultureInfo.InvariantCulture)}% |"
                     );
                 }
 
@@ -159,7 +159,7 @@ public class ShortDataTools
                     var advStr = McpFormat.OrDash(r.AverageDailyVolume, "N0");
                     var dtcStr = McpFormat.OrDash(r.DaysToCover, "F1");
                     result.AppendLine(
-                        $"| {r.SettlementDate:yyyy-MM-dd} | {FormatWholeNumber(r.CurrentShortPosition)} | {changeStr} | {advStr} | {dtcStr} |"
+                        $"| {r.SettlementDate:yyyy-MM-dd} | {McpFormat.WholeNumber(r.CurrentShortPosition)} | {changeStr} | {advStr} | {dtcStr} |"
                     );
                 }
 
@@ -222,7 +222,7 @@ public class ShortDataTools
                     var advStr = McpFormat.OrDash(r.AverageDailyVolume, "N0");
                     // Render with InvariantCulture so the MCP markdown does not fork the
                     // separators by host locale (e.g. de-DE would render 1.234.567 / 12,3).
-                    var shortPositionStr = FormatWholeNumber(r.CurrentShortPosition);
+                    var shortPositionStr = McpFormat.WholeNumber(r.CurrentShortPosition);
                     var dtcStr = McpFormat.OrDash(r.DaysToCover, "F1");
                     result.AppendLine(
                         $"| {r.CommonStock.Ticker} | {shortPositionStr} | {changeStr} | {advStr} | {dtcStr} |"
@@ -290,7 +290,7 @@ public class ShortDataTools
                     // Render with InvariantCulture so the MCP markdown does not fork the
                     // separators by host locale (e.g. de-DE would render 5.000.000 / 62,5%).
                     result.AppendLine(
-                        $"| {r.CommonStock.Ticker} | {FormatWholeNumber(r.ShortVolume)} | {FormatWholeNumber(r.ShortExemptVolume)} | {FormatWholeNumber(r.TotalVolume)} | {shortPct.ToString("F1", CultureInfo.InvariantCulture)}% |"
+                        $"| {r.CommonStock.Ticker} | {McpFormat.WholeNumber(r.ShortVolume)} | {McpFormat.WholeNumber(r.ShortExemptVolume)} | {McpFormat.WholeNumber(r.TotalVolume)} | {shortPct.ToString("F1", CultureInfo.InvariantCulture)}% |"
                     );
                 }
 
@@ -301,11 +301,8 @@ public class ShortDataTools
         );
     }
 
-    private static string FormatWholeNumber(long value) =>
-        value.ToString("N0", CultureInfo.InvariantCulture);
-
     private static string FormatSignedChange(long change) =>
-        change >= 0 ? $"+{FormatWholeNumber(change)}" : FormatWholeNumber(change);
+        change >= 0 ? $"+{McpFormat.WholeNumber(change)}" : McpFormat.WholeNumber(change);
 
     // Thin forwarder so existing reflection-based normalization tests still find the method.
     private Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker) =>

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -136,7 +136,7 @@ public class InstitutionalHoldingsTools
         );
         result.AppendLine(
             $"Showing {holdings.Count} of {totalInstitutions} institutions. Total: "
-                + $"{FormatWholeNumber(totalSharesAll)} shares, "
+                + $"{McpFormat.WholeNumber(totalSharesAll)} shares, "
                 + $"${FormatMillions(totalValueAll)}M value"
         );
         result.AppendLine();
@@ -149,7 +149,7 @@ public class InstitutionalHoldingsTools
             var pct = totalSharesAll > 0 ? (double)h.Shares / totalSharesAll * 100 : 0;
             result.AppendLine(
                 $"| {i + 1} | {h.InstitutionalHolder.Name} | "
-                    + $"{FormatWholeNumber(h.Shares)} | "
+                    + $"{McpFormat.WholeNumber(h.Shares)} | "
                     + $"{FormatMillions(h.Value)} | "
                     + $"{pct.ToString("F2", CultureInfo.InvariantCulture)}% |"
             );
@@ -216,7 +216,7 @@ public class InstitutionalHoldingsTools
                     : "—";
 
             result.AppendLine(
-                $"| {FormatDate(date)} | {FormatWholeNumber(institutionCount)} | {FormatWholeNumber(totalShares)} | {FormatMillions(totalValue)} | {change} |"
+                $"| {FormatDate(date)} | {McpFormat.WholeNumber(institutionCount)} | {McpFormat.WholeNumber(totalShares)} | {FormatMillions(totalValue)} | {change} |"
             );
 
             previousShares = totalShares;
@@ -286,7 +286,7 @@ public class InstitutionalHoldingsTools
             var h = holdings[i];
             result.AppendLine(
                 $"| {i + 1} | {h.CommonStock.Ticker} | {h.CommonStock.Name} | "
-                    + $"{FormatWholeNumber(h.Shares)} | "
+                    + $"{McpFormat.WholeNumber(h.Shares)} | "
                     + $"{FormatMillions(h.Value)} |"
             );
         }
@@ -512,7 +512,7 @@ public class InstitutionalHoldingsTools
             {
                 var m = rows[i];
                 sb.AppendLine(
-                    $"| {i + 1} | {m.Name} | {FormatSignedShares(m.DeltaShares)} | {FormatSignedMillions(m.DeltaValue)} | {FormatWholeNumber(m.PreviousShares)} → {FormatWholeNumber(m.CurrentShares)} |"
+                    $"| {i + 1} | {m.Name} | {FormatSignedShares(m.DeltaShares)} | {FormatSignedMillions(m.DeltaValue)} | {McpFormat.WholeNumber(m.PreviousShares)} → {McpFormat.WholeNumber(m.CurrentShares)} |"
                 );
             }
         }
@@ -771,7 +771,7 @@ public class InstitutionalHoldingsTools
         var result = new StringBuilder();
         result.AppendLine($"Most-held 13F stocks as of {FormatDate(targetDate)}");
         result.AppendLine(
-            $"vs prior quarter {FormatDate(previousDate)} · {FormatWholeNumber(universeFilers)} filers in the 13F universe"
+            $"vs prior quarter {FormatDate(previousDate)} · {McpFormat.WholeNumber(universeFilers)} filers in the 13F universe"
         );
         result.AppendLine($"Sorted by: {sort}");
         result.AppendLine();
@@ -788,7 +788,7 @@ public class InstitutionalHoldingsTools
             var pct = universeFilers > 0 ? (double)r.CurrentFilerCount / universeFilers * 100.0 : 0;
             var deltaFilers = r.CurrentFilerCount - r.PreviousFilerCount;
             result.AppendLine(
-                $"| {i + 1} | {ticker} | {name} | {FormatWholeNumber(r.CurrentFilerCount)} | {FormatSignedShares(deltaFilers)} | {FormatMillions(r.CurrentValue)} | {FormatSignedMillions(r.DeltaValue)} | {FormatPercent(pct)}% |"
+                $"| {i + 1} | {ticker} | {name} | {McpFormat.WholeNumber(r.CurrentFilerCount)} | {FormatSignedShares(deltaFilers)} | {FormatMillions(r.CurrentValue)} | {FormatSignedMillions(r.DeltaValue)} | {FormatPercent(pct)}% |"
             );
         }
         return result.ToString();
@@ -856,8 +856,8 @@ public class InstitutionalHoldingsTools
         result.AppendLine();
         result.AppendLine("| Metric | Value |");
         result.AppendLine("|--------|-------|");
-        result.AppendLine($"| Reported AUM | ${FormatWholeNumber(summary.ReportedAum)} |");
-        result.AppendLine($"| # Positions | {FormatWholeNumber(summary.PositionCount)} |");
+        result.AppendLine($"| Reported AUM | ${McpFormat.WholeNumber(summary.ReportedAum)} |");
+        result.AppendLine($"| # Positions | {McpFormat.WholeNumber(summary.PositionCount)} |");
         result.AppendLine(
             $"| Top 10 concentration | {FormatPercent(summary.Top10ConcentrationPercent)}% |"
         );
@@ -903,7 +903,7 @@ public class InstitutionalHoldingsTools
         {
             var s = slices[i];
             result.AppendLine(
-                $"| {i + 1} | {s.IndustryName} | {FormatWholeNumber(s.PositionCount)} | {FormatMillions(s.TotalValue)} | {FormatPercent(s.PercentOfPortfolio)}% |"
+                $"| {i + 1} | {s.IndustryName} | {McpFormat.WholeNumber(s.PositionCount)} | {FormatMillions(s.TotalValue)} | {FormatPercent(s.PercentOfPortfolio)}% |"
             );
         }
         return result.ToString();
@@ -1068,7 +1068,7 @@ public class InstitutionalHoldingsTools
         {
             var r = rows[i];
             result.AppendLine(
-                $"| {i + 1} | {r.Ticker} | {r.Name} | {FormatWholeNumber(r.PreviousShares)} | {FormatWholeNumber(r.CurrentShares)} | {FormatSignedShares(r.DeltaShares)} | {FormatSignedMillions(r.DeltaValue)} |"
+                $"| {i + 1} | {r.Ticker} | {r.Name} | {McpFormat.WholeNumber(r.PreviousShares)} | {McpFormat.WholeNumber(r.CurrentShares)} | {FormatSignedShares(r.DeltaShares)} | {FormatSignedMillions(r.DeltaValue)} |"
             );
         }
         result.AppendLine();
@@ -1159,9 +1159,11 @@ public class InstitutionalHoldingsTools
             "| Metric | Value |",
             "|--------|-------|"
         );
-        result.AppendLine($"| Union positions | {FormatWholeNumber(overlap.UnionPositionCount)} |");
         result.AppendLine(
-            $"| Shared positions | {FormatWholeNumber(overlap.IntersectionPositionCount)} |"
+            $"| Union positions | {McpFormat.WholeNumber(overlap.UnionPositionCount)} |"
+        );
+        result.AppendLine(
+            $"| Shared positions | {McpFormat.WholeNumber(overlap.IntersectionPositionCount)} |"
         );
         result.AppendLine(
             $"| Jaccard similarity | {FormatPercent(overlap.JaccardSimilarityPercent)}% |"
@@ -1190,7 +1192,7 @@ public class InstitutionalHoldingsTools
             var a = row.Slices[0];
             var b = row.Slices[1];
             result.AppendLine(
-                $"| {i + 1} | {row.Ticker} | {row.Name} | {(a.Shares > 0 ? FormatWholeNumber(a.Shares) : "—")} | {(a.Value > 0 ? FormatPercent(a.PercentOfPortfolio) + "%" : "—")} | {(b.Shares > 0 ? FormatWholeNumber(b.Shares) : "—")} | {(b.Value > 0 ? FormatPercent(b.PercentOfPortfolio) + "%" : "—")} | {FormatMillions(row.CombinedValue)} |"
+                $"| {i + 1} | {row.Ticker} | {row.Name} | {(a.Shares > 0 ? McpFormat.WholeNumber(a.Shares) : "—")} | {(a.Value > 0 ? FormatPercent(a.PercentOfPortfolio) + "%" : "—")} | {(b.Shares > 0 ? McpFormat.WholeNumber(b.Shares) : "—")} | {(b.Value > 0 ? FormatPercent(b.PercentOfPortfolio) + "%" : "—")} | {FormatMillions(row.CombinedValue)} |"
             );
         }
         return result.ToString();
@@ -1343,15 +1345,10 @@ public class InstitutionalHoldingsTools
         return (s?.Ticker ?? "—", s?.Name ?? "Unknown");
     }
 
-    // Whole numbers (share counts, position counts, whole-dollar amounts) rendered with
-    // thousands separators in invariant culture, matching the other invariant cells.
-    private static string FormatWholeNumber<T>(T value)
-        where T : INumber<T> => value.ToString("N0", CultureInfo.InvariantCulture);
-
     // Raw dollar values rendered in $millions with an explicit leading +/- sign.
     // `+` for positive deltas; N0 already emits `-` for negatives.
     private static string FormatSignedShares<T>(T value)
-        where T : INumber<T> => (value > T.Zero ? "+" : "") + FormatWholeNumber(value);
+        where T : INumber<T> => (value > T.Zero ? "+" : "") + McpFormat.WholeNumber(value);
 
     // Signed $millions with one decimal place, invariant culture (matches FormatMillions
     // and the rest of this file; MCP markdown must not fork the separators by host locale).

--- a/src/Equibles.Mcp/Helpers/McpFormat.cs
+++ b/src/Equibles.Mcp/Helpers/McpFormat.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Numerics;
 
 namespace Equibles.Mcp.Helpers;
 
@@ -11,4 +12,10 @@ public static class McpFormat
     public static string OrDash<T>(T? value, string format)
         where T : struct, IFormattable =>
         value.HasValue ? value.Value.ToString(format, CultureInfo.InvariantCulture) : Dash;
+
+    // Whole numbers (share counts, position counts, whole-dollar amounts) rendered with
+    // thousands separators in invariant culture so MCP markdown does not fork the separators
+    // by host locale.
+    public static string WholeNumber<T>(T value)
+        where T : INumber<T> => value.ToString("N0", CultureInfo.InvariantCulture);
 }

--- a/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Globalization;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -70,7 +69,7 @@ public class FormDTools
                 foreach (var f in filings)
                 {
                     result.AppendLine(
-                        $"| {f.FilingDate:yyyy-MM-dd} | {(f.IsAmendment ? "Yes" : "No")} | {f.IndustryGroup ?? "-"} | {FormatAmount(f.TotalOfferingAmount, f.IsOfferingAmountIndefinite)} | ${FormatWholeNumber(f.TotalAmountSold)} | ${FormatWholeNumber(f.MinimumInvestmentAccepted)} | {FormatWholeNumber(f.TotalNumberAlreadyInvested)} | {f.FederalExemptions ?? "-"} |"
+                        $"| {f.FilingDate:yyyy-MM-dd} | {(f.IsAmendment ? "Yes" : "No")} | {f.IndustryGroup ?? "-"} | {FormatAmount(f.TotalOfferingAmount, f.IsOfferingAmountIndefinite)} | ${McpFormat.WholeNumber(f.TotalAmountSold)} | ${McpFormat.WholeNumber(f.MinimumInvestmentAccepted)} | {McpFormat.WholeNumber(f.TotalNumberAlreadyInvested)} | {f.FederalExemptions ?? "-"} |"
                     );
                 }
 
@@ -85,9 +84,6 @@ public class FormDTools
     {
         if (isIndefinite)
             return "Indefinite";
-        return amount.HasValue ? $"${FormatWholeNumber(amount.Value)}" : "-";
+        return amount.HasValue ? $"${McpFormat.WholeNumber(amount.Value)}" : "-";
     }
-
-    private static string FormatWholeNumber(long value) =>
-        value.ToString("N0", CultureInfo.InvariantCulture);
 }


### PR DESCRIPTION
## Summary

- Three MCP tool classes each defined a private `FormatWholeNumber` helper that rendered a number with `"N0"` and `CultureInfo.InvariantCulture` — the same invariant-culture formatting `McpFormat` already centralizes. This collapses them into one shared generic helper.
- Behavior is preserved: the new `McpFormat.WholeNumber<T>(T value) where T : INumber<T>` produces identical output to all three removed definitions; the generic constraint subsumes the previous `long` overloads.

## Code changes

- `src/Equibles.Mcp/Helpers/McpFormat.cs` — add `WholeNumber<T>` (mirrors the existing `OrDash` invariant-culture pattern); add `using System.Numerics`.
- `src/Equibles.Sec.Mcp/Tools/FormDTools.cs` — remove the local `FormatWholeNumber`, repoint call sites, drop the now-unused `System.Globalization` import.
- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — remove the local `FormatWholeNumber`, repoint call sites (including `FormatSignedChange`).
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — remove the local generic `FormatWholeNumber`, repoint call sites (including `FormatSignedShares`).