### PR TITLE
refactor(mcp): route duplicated result-limit clamp through shared McpLimit.Clamp

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -60,10 +60,7 @@ public class CboeTools
                     DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-data message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var records = await _putCallRepository
                     .GetByType(ratioType, start, end)
@@ -120,10 +117,7 @@ public class CboeTools
                     DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-data message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var records = await _vixRepository
                     .GetByDateRange(start, end)

--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -69,7 +69,7 @@ public class CftcTools
                 var reports = await _reportRepository
                     .GetByContract(contract, start, end)
                     .OrderByDescending(r => r.ReportDate)
-                    .Take(Math.Max(0, maxResults))
+                    .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
                 if (reports.Count == 0)
@@ -197,10 +197,7 @@ public class CftcTools
         return _runner.Execute(
             async () =>
             {
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var contracts = await _contractRepository
                     .Search(query)

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -70,10 +70,7 @@ public class CongressTools
                 var query = _tradeRepository.GetByStock(stock, start, end);
                 query = ApplyTransactionTypeFilter(query, transactionType);
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-data message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var trades = await query
                     .Include(t => t.CongressMember)
@@ -143,13 +140,10 @@ public class CongressTools
                     .Where(t => t.TransactionDate >= start && t.TransactionDate <= end);
                 query = ApplyTransactionTypeFilter(query, transactionType);
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
                 var trades = await query
                     .Include(t => t.CommonStock)
                     .OrderByDescending(t => t.TransactionDate)
-                    .Take(Math.Max(0, maxResults))
+                    .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
                 if (trades.Count == 0)
@@ -193,10 +187,7 @@ public class CongressTools
         return _runner.Execute(
             async () =>
             {
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var members = await _memberRepository
                     .Search(query.Trim())

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -68,10 +68,7 @@ public class ShortDataTools
 
                 query = query.Where(d => d.Date >= start && d.Date <= end);
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-data message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var records = await query
                     .OrderByDescending(d => d.Date)
@@ -120,10 +117,7 @@ public class ShortDataTools
         return _runner.Execute(
             async () =>
             {
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
@@ -199,12 +193,9 @@ public class ShortDataTools
                     query = query.Where(s => s.DaysToCover >= minDaysToCover);
                 }
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
                 var records = await query
                     .OrderByDescending(s => s.DaysToCover)
-                    .Take(Math.Max(0, maxResults))
+                    .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
                 if (records.Count == 0)
@@ -266,12 +257,9 @@ public class ShortDataTools
                     query = query.Where(d => d.ShortVolume >= minShortVolume);
                 }
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
                 var records = await query
                     .OrderByDescending(d => d.ShortVolume)
-                    .Take(Math.Max(0, maxResults))
+                    .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
                 if (records.Count == 0)

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -64,10 +64,7 @@ public class FredTools
                     DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-data message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var observations = await _observationRepository
                     .GetBySeries(series, start, end)
@@ -192,10 +189,7 @@ public class FredTools
         return _runner.Execute(
             async () =>
             {
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var series = await _seriesRepository
                     .Search(query)

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -92,10 +92,7 @@ public class InstitutionalHoldingsTools
                 var totalSharesAll = await allHoldings.SumAsync(h => h.Shares);
                 var totalValueAll = await allHoldings.SumAsync(h => h.Value);
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-data message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var holdings = await allHoldings
                     .OrderByDescending(h => h.Shares)
@@ -177,7 +174,7 @@ public class InstitutionalHoldingsTools
 
                 var reportDates = await _holdingRepository
                     .GetReportDatesByStock(stock)
-                    .Take(Math.Max(0, maxPeriods))
+                    .Take(McpLimit.Clamp(maxPeriods))
                     .ToListAsync();
 
                 if (reportDates.Count == 0)
@@ -256,7 +253,7 @@ public class InstitutionalHoldingsTools
                 var holdings = await _holdingRepository
                     .GetByHolder(holder, targetDate)
                     .OrderByDescending(h => h.Value)
-                    .Take(Math.Max(0, maxResults))
+                    .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
                 if (holdings.Count == 0)
@@ -306,10 +303,7 @@ public class InstitutionalHoldingsTools
         return _runner.Execute(
             async () =>
             {
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var holders = await _holderRepository
                     .Search(query)
@@ -537,10 +531,7 @@ public class InstitutionalHoldingsTools
                 if (!ValidActivityBuckets.Contains(normalizedBucket))
                     return $"Unknown bucket. Use one of: {string.Join(", ", ValidActivityBuckets)}.";
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-data message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var (targetDate, previousDate, error) = await ResolveMarketActivityDates(
                     reportDate
@@ -733,10 +724,7 @@ public class InstitutionalHoldingsTools
                         .OrderByDescending(a => a.CurrentFilerCount)
                         .ThenByDescending(a => a.CurrentValue),
                 };
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
-                var rows = await ranking.Take(Math.Max(0, maxResults)).ToListAsync();
+                var rows = await ranking.Take(McpLimit.Clamp(maxResults)).ToListAsync();
                 if (rows.Count == 0)
                     return $"No stocks were held by 13F filers as of {FormatDate(targetDate)}.";
 

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -58,10 +58,7 @@ public class InsiderTradingTools
                 if (stockError != null)
                     return stockError;
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-data message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var transactions = await _transactionRepository
                     .GetByStock(stock)
@@ -192,13 +189,10 @@ public class InsiderTradingTools
                 if (stockError != null)
                     return stockError;
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
                 var filings = await _form144Repository
                     .GetByStock(stock)
                     .OrderByDescending(f => f.FilingDate)
-                    .Take(Math.Max(0, maxResults))
+                    .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
                 if (filings.Count == 0)
@@ -244,10 +238,7 @@ public class InsiderTradingTools
         return _runner.Execute(
             async () =>
             {
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var insiders = await _ownerRepository.Search(query).Take(maxResults).ToListAsync();
 

--- a/src/Equibles.Mcp/Helpers/McpLimit.cs
+++ b/src/Equibles.Mcp/Helpers/McpLimit.cs
@@ -1,0 +1,9 @@
+namespace Equibles.Mcp.Helpers;
+
+public static class McpLimit
+{
+    // A negative result cap would flow into .Take(...) as a negative SQL LIMIT, which
+    // PostgreSQL rejects and surfaces as the internal-error sentinel. Clamping to non-negative
+    // makes a non-positive cap yield zero rows and the existing no-results message instead.
+    public static int Clamp(int maxResults) => Math.Max(0, maxResults);
+}

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -60,10 +60,7 @@ public class FailToDeliverTools
                     DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
                 );
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-data message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var records = await _ftdRepository
                     .GetByStock(stock)

--- a/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
@@ -48,13 +48,10 @@ public class FormDTools
                 if (stockError != null)
                     return stockError;
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
                 var filings = await _formDRepository
                     .GetByStock(stock)
                     .OrderByDescending(f => f.FilingDate)
-                    .Take(Math.Max(0, maxResults))
+                    .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
                 if (filings.Count == 0)

--- a/src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs
@@ -47,10 +47,7 @@ public class InvestmentAdviserTools
                 if (string.IsNullOrWhiteSpace(query))
                     return "Provide part of an adviser's name to search for.";
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var advisers = await _adviserRepository
                     .Search(query)

--- a/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
@@ -50,14 +50,11 @@ public class NCenTools
                 if (stockError != null)
                     return stockError;
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-results message.
                 var filings = await _nCenRepository
                     .GetByStock(stock)
                     .Include(f => f.ServiceProviders)
                     .OrderByDescending(f => f.FilingDate)
-                    .Take(Math.Max(0, maxResults))
+                    .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
                 if (filings.Count == 0)

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -63,11 +63,7 @@ public class StockPriceTools
                     DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
                 );
 
-                // A negative maxResults would flow into .Take(...) as a negative SQL LIMIT,
-                // which PostgreSQL rejects and surfaces as the internal-error sentinel. Clamp
-                // so a non-positive cap yields zero rows and the existing no-data message,
-                // matching the sibling indicator tools' graceful degradation.
-                maxResults = Math.Max(0, maxResults);
+                maxResults = McpLimit.Clamp(maxResults);
 
                 var records = await _priceRepository
                     .GetByStock(stock, start, end)


### PR DESCRIPTION
## Summary

- Twelve MCP tool classes each clamped the `maxResults`/`maxPeriods` cap with `Math.Max(0, …)` and carried a copy-pasted 3-line comment explaining the PostgreSQL negative-LIMIT hazard. The comment had drifted into three variants. This collapses all 27 clamps into one shared `McpLimit.Clamp` helper that holds the rationale once.
- Behavior-preserving: `McpLimit.Clamp(x)` is defined exactly as `Math.Max(0, x)`, so every call site computes an identical value; only duplicated comments are removed. Net −64 lines.

## Code changes

- `src/Equibles.Mcp/Helpers/McpLimit.cs` — new helper `Clamp(int maxResults) => Math.Max(0, maxResults)` carrying the negative-LIMIT WHY comment once (mirrors the `McpFormat` helper pattern).
- `src/Equibles.{Cboe,Cftc,Congress,Finra,Fred,Holdings,InsiderTrading,Sec,Yahoo}.Mcp/Tools/*.cs` (12 files) — replace each `Math.Max(0, maxResults)` / `Math.Max(0, maxPeriods)` with `McpLimit.Clamp(...)` and remove the now-redundant duplicated rationale comment.