### PR TITLE
refactor(sec): share filing-processor ParseDate logic via EdgarXmlSubmissionParser

### DIFF
--- a/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
+++ b/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Equibles.Errors.BusinessLogic;
@@ -134,5 +135,25 @@ internal static class EdgarXmlSubmissionParser
             return null;
         var trimmed = value.Trim();
         return trimmed.Equals(NotApplicable, StringComparison.OrdinalIgnoreCase) ? null : trimmed;
+    }
+
+    /// <summary>
+    /// Parses a date against the supplied exact formats in invariant culture, or <c>null</c> when
+    /// blank or unparseable. Callers pass their form's accepted <paramref name="formats"/>, which
+    /// differ per submission type.
+    /// </summary>
+    internal static DateOnly? ParseDate(string value, string[] formats)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        return DateOnly.TryParseExact(
+            value.Trim(),
+            formats,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var parsed
+        )
+            ? parsed
+            : null;
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
@@ -126,20 +126,8 @@ public class Form144FilingProcessor
 
     // Form 144 dates are US-format MM/dd/yyyy. Parse culture-independently so a non-Gregorian
     // host culture doesn't silently drop every date.
-    internal static DateOnly? ParseDate(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return null;
-        return DateOnly.TryParseExact(
-            value.Trim(),
-            DateFormats,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.None,
-            out var parsed
-        )
-            ? parsed
-            : null;
-    }
+    internal static DateOnly? ParseDate(string value) =>
+        EdgarXmlSubmissionParser.ParseDate(value, DateFormats);
 
     internal static long ParseLong(string value)
     {

--- a/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
@@ -168,20 +168,8 @@ public class FormDFilingProcessor : IssuerFeedFilingProcessor<FormDFiling, FormD
         return (ParseLong(value), false);
     }
 
-    internal static DateOnly? ParseDate(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return null;
-        return DateOnly.TryParseExact(
-            value.Trim(),
-            DateFormats,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.None,
-            out var parsed
-        )
-            ? parsed
-            : null;
-    }
+    internal static DateOnly? ParseDate(string value) =>
+        EdgarXmlSubmissionParser.ParseDate(value, DateFormats);
 
     internal static bool ParseBool(string value)
     {

--- a/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Xml.Linq;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Models;
@@ -260,18 +259,6 @@ public class NCenFilingProcessor : IssuerFeedFilingProcessor<NCenFiling, NCenFil
         return value != null && value.Trim().Equals("Y", StringComparison.OrdinalIgnoreCase);
     }
 
-    internal static DateOnly? ParseDate(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return null;
-        return DateOnly.TryParseExact(
-            value.Trim(),
-            DateFormats,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.None,
-            out var parsed
-        )
-            ? parsed
-            : null;
-    }
+    internal static DateOnly? ParseDate(string value) =>
+        EdgarXmlSubmissionParser.ParseDate(value, DateFormats);
 }

--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -154,20 +154,8 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
         return value != null && value.Trim().Equals("Y", StringComparison.OrdinalIgnoreCase);
     }
 
-    internal static DateOnly? ParseDate(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return null;
-        return DateOnly.TryParseExact(
-            value.Trim(),
-            DateFormats,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.None,
-            out var parsed
-        )
-            ? parsed
-            : null;
-    }
+    internal static DateOnly? ParseDate(string value) =>
+        EdgarXmlSubmissionParser.ParseDate(value, DateFormats);
 
     internal static decimal ParseDecimal(string value)
     {


### PR DESCRIPTION
## Summary

- Four SEC filing processors (Form 144, Form D, N-CEN, NPORT-P) each carried a byte-identical `ParseDate(string)` body that differed only in the `DateFormats` array it closed over. This moves the shared parsing logic into `EdgarXmlSubmissionParser` — the existing home for cross-processor EDGAR parsing — and leaves each processor with a thin forwarder passing its own formats.
- Behavior-preserving: the shared method's logic is identical to each inlined body, and every forwarder passes that processor's own `DateFormats`, so accepted formats and results are unchanged per form. The per-processor `ParseDate(string)` signature is kept (it is pinned by integration tests). Net −28 lines.

## Code changes

- `src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs` — add `ParseDate(string value, string[] formats)` holding the shared null/whitespace guard + `DateOnly.TryParseExact` (invariant culture) logic; add `using System.Globalization`.
- `src/Equibles.Sec.HostedService/Services/{Form144,FormD,NCen,Nport}FilingProcessor.cs` — replace the duplicated `ParseDate` body with a one-line forwarder to the shared method, passing each processor's own `DateFormats` (arrays unchanged). Removed the now-unused `System.Globalization` import from `NCenFilingProcessor`.