### PR TITLE
refactor(web): remove unused ComputeStats pass-through from EconomicDataController

### DIFF
--- a/src/Equibles.Web/Controllers/EconomicDataController.cs
+++ b/src/Equibles.Web/Controllers/EconomicDataController.cs
@@ -120,9 +120,6 @@ public class EconomicDataController : BaseController
         return View(viewModel);
     }
 
-    private static StatsSummary ComputeStats(double[] values, int decimals) =>
-        values.ComputeStats(decimals);
-
     private static string ExpandFrequency(string frequency) =>
         frequency?.Trim().ToUpperInvariant() switch
         {


### PR DESCRIPTION
## Summary

- `EconomicDataController` declared a private `ComputeStats(double[], int)` that only forwarded to the `StatisticsExtensions.ComputeStats` extension. Its sole stats call site already uses the extension directly (`chronological.ComputeStats(decimals: 4)`), so the method was unreferenced dead code.
- Removing it is behavior-preserving: the method is private, has no call sites, and is not reflected on by any test, so nothing observable changes.

## Code changes

- `src/Equibles.Web/Controllers/EconomicDataController.cs` — delete the dead private `ComputeStats` pass-through method (callers use the shared extension; `using Equibles.Web.Extensions` stays for the `ComputeStats`/`ComputeSma` extension calls).