### PR TITLE
refactor(stocks): extract duplicated ticker normalization into TickerNormalizer.Normalize

### DIFF
--- a/src/Equibles.CommonStocks.Data/Helpers/TickerNormalizer.cs
+++ b/src/Equibles.CommonStocks.Data/Helpers/TickerNormalizer.cs
@@ -1,0 +1,8 @@
+namespace Equibles.CommonStocks.Data.Helpers;
+
+public static class TickerNormalizer
+{
+    // Canonical ticker form for case-insensitive lookups. Upper-cases with the invariant
+    // culture so a host's locale (e.g. Turkish dotless-i) can't fork the mapping.
+    public static string Normalize(string ticker) => ticker.Trim().ToUpperInvariant();
+}

--- a/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
+++ b/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Data.Models;
 
 namespace Equibles.CommonStocks.Repositories.Extensions;
@@ -9,7 +10,7 @@ public static class CommonStockRepositoryExtensions
         string ticker
     )
     {
-        var stock = await repository.GetByTicker(ticker.Trim().ToUpperInvariant());
+        var stock = await repository.GetByTicker(TickerNormalizer.Normalize(ticker));
         return stock == null ? (null, $"Stock '{ticker}' not found.") : (stock, null);
     }
 }

--- a/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
@@ -62,7 +63,7 @@ public class FundScoringManager
         string benchmarkTicker = DefaultBenchmark
     )
     {
-        benchmarkTicker = benchmarkTicker.Trim().ToUpperInvariant();
+        benchmarkTicker = TickerNormalizer.Normalize(benchmarkTicker);
 
         var benchmarkStock = await _stockRepository.GetByTicker(benchmarkTicker);
         if (benchmarkStock == null)

--- a/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
@@ -64,7 +65,7 @@ public class SmartMoneyIndexManager
     )
     {
         topFunds = Math.Max(1, topFunds);
-        benchmarkTicker = benchmarkTicker.Trim().ToUpperInvariant();
+        benchmarkTicker = TickerNormalizer.Normalize(benchmarkTicker);
 
         var result = new SmartMoneyIndexResult
         {

--- a/src/Equibles.Web/Controllers/SearchController.cs
+++ b/src/Equibles.Web/Controllers/SearchController.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Search;
 using Equibles.Search.Abstractions;
@@ -60,7 +61,7 @@ public class SearchController : BaseController
         if (string.IsNullOrWhiteSpace(q))
             return null;
 
-        return await _commonStockRepository.GetByTicker(q.Trim().ToUpperInvariant());
+        return await _commonStockRepository.GetByTicker(TickerNormalizer.Normalize(q));
     }
 
     // Results-only fragment for instant (as-you-type) search. instant-search.js fetches this

--- a/src/Equibles.Web/Services/HoldingsBacktestService.cs
+++ b/src/Equibles.Web/Services/HoldingsBacktestService.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Holdings.Repositories;
@@ -56,7 +57,7 @@ public class HoldingsBacktestService
             Cik = cik,
             Benchmark = string.IsNullOrWhiteSpace(benchmark)
                 ? DefaultBenchmark
-                : benchmark.Trim().ToUpperInvariant(),
+                : TickerNormalizer.Normalize(benchmark),
             RequestedFrom = from,
             RequestedTo = to,
         };


### PR DESCRIPTION
## Summary

- Five call sites independently normalized tickers with the same inline expression `x.Trim().ToUpperInvariant()`. Collapsed them into a single shared `TickerNormalizer.Normalize` helper.
- Behavior-preserving: the helper body is exactly `ticker.Trim().ToUpperInvariant()` (same trim/upper order, invariant culture, and null behavior); every call site is a token-for-token substitution.

## Code changes

- `src/Equibles.CommonStocks.Data/Helpers/TickerNormalizer.cs` — new shared helper; `Normalize` trims and upper-cases with the invariant culture so a host's locale can't fork the mapping.
- `src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs` — route `ResolveByTicker` through the helper.
- `src/Equibles.Web/Controllers/SearchController.cs` — route `ResolveExactTicker` through the helper.
- `src/Equibles.Web/Services/HoldingsBacktestService.cs` — route benchmark normalization through the helper.
- `src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs` — route benchmark-ticker normalization through the helper.
- `src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs` — route benchmark-ticker normalization through the helper.