### PR TITLE
test(sec): pin EdgarXmlSubmissionParser.SanitizeXml escapes only stray ampersands

### DIFF
--- a/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserSanitizeXmlTests.cs
+++ b/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserSanitizeXmlTests.cs
@@ -1,0 +1,31 @@
+using System.Xml.Linq;
+using Equibles.Sec.HostedService.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class EdgarXmlSubmissionParserSanitizeXmlTests
+{
+    [Fact]
+    public void SanitizeXml_StrayAmpersandAmongValidEntities_EscapesOnlyStrayAndParsesAsXml()
+    {
+        // Contract: strip the <XML> envelope and escape STRAY ampersands so the payload parses
+        // as XML — without double-escaping the five XML predefined entities or numeric character
+        // references. Oracle derived from the XML spec, not the implementation: &amp; and &#38;
+        // both decode to '&', and the bare '&' in "AT&T" must survive as a literal '&'.
+        var submission =
+            "<SEC-HEADER>preamble</SEC-HEADER>\n"
+            + "<XML>\n"
+            + "<edgarSubmission><issuerName>Smith &amp; Co AT&T Tom &#38; Jerry</issuerName></edgarSubmission>\n"
+            + "</XML>\n"
+            + "<TRAILER>end</TRAILER>";
+
+        var sanitized = EdgarXmlSubmissionParser.SanitizeXml(submission);
+
+        var issuerName = XDocument
+            .Parse(sanitized)
+            .Root.Elements()
+            .First(e => e.Name.LocalName == "issuerName")
+            .Value;
+        issuerName.Should().Be("Smith & Co AT&T Tom & Jerry");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first unit test for `EdgarXmlSubmissionParser.SanitizeXml`, the shared SEC issuer-feed XML sanitizer (Form 144 / D / N-CEN / NPORT-P), which previously had no coverage.
- Pins the core contract: the `<XML>` SGML envelope is stripped and *stray* ampersands are escaped so the payload parses as XML, while the predefined XML entities and numeric character references are left intact (not double-escaped).

## Code changes

- `tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserSanitizeXmlTests.cs` — one fact feeding a realistic enveloped submission whose body mixes a stray `&` ("AT&T"), an existing `&amp;`, and a numeric reference `&#38;`. It sanitizes, then parses the result with `XDocument` and asserts the decoded text, falsifying three failure modes at once: envelope not stripped (multi-root parse error), stray `&` not escaped (parse error), and a valid entity double-escaped (literal text instead of `&`). The contract holds — behavior is pinned, no defect found.