### PR TITLE
test(sec): pin EdgarXmlSubmissionParser.Attr null-on-empty contract

### DIFF
--- a/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserAttrTests.cs
+++ b/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserAttrTests.cs
@@ -1,0 +1,21 @@
+using System.Xml.Linq;
+using Equibles.Sec.HostedService.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class EdgarXmlSubmissionParserAttrTests
+{
+    [Fact(Skip = "GH-3106 — Attr returns empty string instead of null for whitespace-only values")]
+    public void Attr_WhitespaceOnlyValue_ReturnsNull()
+    {
+        // Contract (from the doc-comment): "Trimmed value of the named attribute, or null when
+        // missing or empty." A whitespace-only value trims to empty, so the result must be null —
+        // matching the sibling Val helper, which callers chain through `?? default`. Oracle derived
+        // from the contract, not the body.
+        var element = new XElement("issuerStateCountry", new XAttribute("issuerCountry", "   "));
+
+        var result = EdgarXmlSubmissionParser.Attr(element, "issuerCountry");
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test pinning the documented contract of `EdgarXmlSubmissionParser.Attr`: a whitespace-only attribute value should return `null`, not an empty string.
- The test currently fails because `Attr` checks emptiness before trimming (unlike its sibling `Val`), so it is committed skipped pending the fix. Tracked in GH-3106.

## Code changes

- `tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserAttrTests.cs` — new unit test `Attr_WhitespaceOnlyValue_ReturnsNull`. Marked `[Fact(Skip = ...)]` because it reproduces a real defect — see GH-3106. Un-skip it as part of the fix.