### PR TITLE
refactor(mcp): route inline N0 invariant formatting through McpFormat.WholeNumber

### DIFF
--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -84,7 +84,7 @@ public class CftcTools
                 foreach (var r in reports.OrderBy(r => r.ReportDate))
                 {
                     result.AppendLine(
-                        $"| {r.ReportDate:yyyy-MM-dd} | {r.OpenInterest.ToString("N0", CultureInfo.InvariantCulture)} | {r.CommLong.ToString("N0", CultureInfo.InvariantCulture)} | {r.CommShort.ToString("N0", CultureInfo.InvariantCulture)} | {r.NonCommLong.ToString("N0", CultureInfo.InvariantCulture)} | {r.NonCommShort.ToString("N0", CultureInfo.InvariantCulture)} | {r.NonCommSpreads.ToString("N0", CultureInfo.InvariantCulture)} |"
+                        $"| {r.ReportDate:yyyy-MM-dd} | {McpFormat.WholeNumber(r.OpenInterest)} | {McpFormat.WholeNumber(r.CommLong)} | {McpFormat.WholeNumber(r.CommShort)} | {McpFormat.WholeNumber(r.NonCommLong)} | {McpFormat.WholeNumber(r.NonCommShort)} | {McpFormat.WholeNumber(r.NonCommSpreads)} |"
                     );
                 }
 

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Globalization;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Congress.Data.Models;
@@ -92,7 +91,7 @@ public class CongressTools
                     var position = t.CongressMember.Position.NameForHumans();
                     var type = t.TransactionType.NameForHumans();
                     var amount =
-                        $"${t.AmountFrom.ToString("N0", CultureInfo.InvariantCulture)}–${t.AmountTo.ToString("N0", CultureInfo.InvariantCulture)}";
+                        $"${McpFormat.WholeNumber(t.AmountFrom)}–${McpFormat.WholeNumber(t.AmountTo)}";
                     result.AppendLine(
                         $"| {t.TransactionDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {t.OwnerType ?? "—"} |"
                     );
@@ -161,7 +160,7 @@ public class CongressTools
                     // Format with InvariantCulture so the MCP markdown does not fork the
                     // separators by host locale (e.g. de-DE would render $1.000.000).
                     var amount =
-                        $"${t.AmountFrom.ToString("N0", CultureInfo.InvariantCulture)}–${t.AmountTo.ToString("N0", CultureInfo.InvariantCulture)}";
+                        $"${McpFormat.WholeNumber(t.AmountFrom)}–${McpFormat.WholeNumber(t.AmountTo)}";
                     result.AppendLine(
                         $"| {t.TransactionDate:yyyy-MM-dd} | {t.CommonStock.Ticker} | {type} | {amount} | {t.AssetName} | {t.OwnerType ?? "—"} |"
                     );

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -263,7 +263,7 @@ public class ShortDataTools
                     .ToListAsync();
 
                 if (records.Count == 0)
-                    return $"No short volume data found for trading day {tradingDay:yyyy-MM-dd} with short volume >= {minShortVolume.ToString("N0", CultureInfo.InvariantCulture)}.";
+                    return $"No short volume data found for trading day {tradingDay:yyyy-MM-dd} with short volume >= {McpFormat.WholeNumber(minShortVolume)}.";
 
                 var result = MarkdownTable.Start(
                     $"Largest short volume — trading day {tradingDay:yyyy-MM-dd}:",

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -678,7 +678,7 @@ public class InstitutionalHoldingsTools
             var count = normalizedBucket == "new-positions" ? r.NewFilerCount : r.SoldOutFilerCount;
             // Format with InvariantCulture so the MCP markdown does not fork the
             // separators by host locale (e.g. de-DE would render 1.000).
-            var countCell = count.ToString("N0", CultureInfo.InvariantCulture);
+            var countCell = McpFormat.WholeNumber(count);
             result.AppendLine($"| {i + 1} | {ticker} | {name} | {countCell} |");
         }
         return result.ToString();

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -94,7 +94,7 @@ public class InsiderTradingTools
 
                     var value = t.Shares * t.PricePerShare;
                     result.AppendLine(
-                        $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {t.Shares.ToString("N0", CultureInfo.InvariantCulture)} | ${t.PricePerShare.ToString("N2", CultureInfo.InvariantCulture)} | ${value.ToString("N0", CultureInfo.InvariantCulture)} | {t.SharesOwnedAfter.ToString("N0", CultureInfo.InvariantCulture)} |"
+                        $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(t.Shares)} | ${t.PricePerShare.ToString("N2", CultureInfo.InvariantCulture)} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(t.SharesOwnedAfter)} |"
                     );
                 }
 
@@ -215,7 +215,7 @@ public class InsiderTradingTools
                         f.ApproxSaleDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
                         ?? "-";
                     result.AppendLine(
-                        $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {f.SharesToBeSold.ToString("N0", CultureInfo.InvariantCulture)} | ${f.AggregateMarketValue.ToString("N0", CultureInfo.InvariantCulture)} | {approxSaleDate} | {f.BrokerName} |"
+                        $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {approxSaleDate} | {f.BrokerName} |"
                     );
                 }
 

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -82,7 +82,7 @@ public class FailToDeliverTools
                 {
                     var value = f.Quantity * f.Price;
                     result.AppendLine(
-                        $"| {f.SettlementDate:yyyy-MM-dd} | {f.Quantity.ToString("N0", CultureInfo.InvariantCulture)} | ${f.Price.ToString("F2", CultureInfo.InvariantCulture)} | ${value.ToString("N0", CultureInfo.InvariantCulture)} |"
+                        $"| {f.SettlementDate:yyyy-MM-dd} | {McpFormat.WholeNumber(f.Quantity)} | ${f.Price.ToString("F2", CultureInfo.InvariantCulture)} | ${McpFormat.WholeNumber(value)} |"
                     );
                 }
 

--- a/src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Globalization;
 using System.Text;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
@@ -142,10 +141,10 @@ public class InvestmentAdviserTools
     }
 
     private static string FormatAum(long? amount) =>
-        amount.HasValue ? $"${amount.Value.ToString("N0", CultureInfo.InvariantCulture)}" : "-";
+        amount.HasValue ? $"${McpFormat.WholeNumber(amount.Value)}" : "-";
 
     private static string FormatCount(int? count) =>
-        count.HasValue ? count.Value.ToString("N0", CultureInfo.InvariantCulture) : "-";
+        count.HasValue ? McpFormat.WholeNumber(count.Value) : "-";
 
     private static string FormatFeeStructure(FormAdvAdviser a)
     {

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -83,7 +83,7 @@ public class StockPriceTools
                 foreach (var p in records.OrderBy(p => p.Date))
                 {
                     result.AppendLine(
-                        $"| {p.Date:yyyy-MM-dd} | {p.Open.ToString("F2", CultureInfo.InvariantCulture)} | {p.High.ToString("F2", CultureInfo.InvariantCulture)} | {p.Low.ToString("F2", CultureInfo.InvariantCulture)} | {p.Close.ToString("F2", CultureInfo.InvariantCulture)} | {p.Volume.ToString("N0", CultureInfo.InvariantCulture)} |"
+                        $"| {p.Date:yyyy-MM-dd} | {p.Open.ToString("F2", CultureInfo.InvariantCulture)} | {p.High.ToString("F2", CultureInfo.InvariantCulture)} | {p.Low.ToString("F2", CultureInfo.InvariantCulture)} | {p.Close.ToString("F2", CultureInfo.InvariantCulture)} | {McpFormat.WholeNumber(p.Volume)} |"
                     );
                 }
 


### PR DESCRIPTION
## Summary

- The MCP tools already have a shared `McpFormat.WholeNumber<T>` helper (`value.ToString("N0", CultureInfo.InvariantCulture)`), but 8 tool files still inlined that exact call — several mixing both styles in the same file. This routes every inline whole-number invariant format through the helper, removing the duplication and hardening against the locale-dependent number-formatting bug class.
- Behavior-preserving: `McpFormat.WholeNumber` is defined as exactly the replaced expression, so rendered output is byte-identical. Only `"N0"` invariant calls were touched; `F2`/`N1`/`N2` inline calls were left as-is (no shared helper exists for them).

## Code changes

- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs`, `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs`, `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs`, `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs`, `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs`, `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — replace inline `ToString("N0", CultureInfo.InvariantCulture)` calls with `McpFormat.WholeNumber(...)`.
- `src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs`, `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — same replacement, plus drop the now-unused `using System.Globalization;` (these files had no other `CultureInfo` use).

## Verification

- `dotnet build Equibles.sln -c Release` — green.
- Unit tests: 2350 passed. MCP integration tests: 322 passed.
- Pre-existing and unrelated to this change (reproduce on clean `main`): 20 `InsiderTradingFilingProcessor` integration failures (a hosted-service DI registration gap) and one csharpier formatting failure in `StockPriceToolsGetStochasticOscillatorCultureInvarianceTests.cs`.