### PR TITLE
refactor(mcp): route inline invariant-culture formatting through McpFormat.Invariant

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Globalization;
 using Equibles.Cboe.Data.Models;
 using Equibles.Cboe.Repositories;
 using Equibles.Core.Extensions;
@@ -137,7 +136,7 @@ public class CboeTools
                 foreach (var v in records.OrderBy(v => v.Date))
                 {
                     result.AppendLine(
-                        $"| {v.Date:yyyy-MM-dd} | {v.Open.ToString("F2", CultureInfo.InvariantCulture)} | {v.High.ToString("F2", CultureInfo.InvariantCulture)} | {v.Low.ToString("F2", CultureInfo.InvariantCulture)} | {v.Close.ToString("F2", CultureInfo.InvariantCulture)} |"
+                        $"| {v.Date:yyyy-MM-dd} | {McpFormat.Invariant(v.Open, "F2")} | {McpFormat.Invariant(v.High, "F2")} | {McpFormat.Invariant(v.Low, "F2")} | {McpFormat.Invariant(v.Close, "F2")} |"
                     );
                 }
 

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -89,7 +89,7 @@ public class ShortDataTools
                     var shortPct =
                         r.TotalVolume > 0 ? (double)r.ShortVolume / r.TotalVolume * 100 : 0;
                     result.AppendLine(
-                        $"| {r.Date:yyyy-MM-dd} | {McpFormat.WholeNumber(r.ShortVolume)} | {McpFormat.WholeNumber(r.ShortExemptVolume)} | {McpFormat.WholeNumber(r.TotalVolume)} | {shortPct.ToString("F1", CultureInfo.InvariantCulture)}% |"
+                        $"| {r.Date:yyyy-MM-dd} | {McpFormat.WholeNumber(r.ShortVolume)} | {McpFormat.WholeNumber(r.ShortExemptVolume)} | {McpFormat.WholeNumber(r.TotalVolume)} | {McpFormat.Invariant(shortPct, "F1")}% |"
                     );
                 }
 
@@ -278,7 +278,7 @@ public class ShortDataTools
                     // Render with InvariantCulture so the MCP markdown does not fork the
                     // separators by host locale (e.g. de-DE would render 5.000.000 / 62,5%).
                     result.AppendLine(
-                        $"| {r.CommonStock.Ticker} | {McpFormat.WholeNumber(r.ShortVolume)} | {McpFormat.WholeNumber(r.ShortExemptVolume)} | {McpFormat.WholeNumber(r.TotalVolume)} | {shortPct.ToString("F1", CultureInfo.InvariantCulture)}% |"
+                        $"| {r.CommonStock.Ticker} | {McpFormat.WholeNumber(r.ShortVolume)} | {McpFormat.WholeNumber(r.ShortExemptVolume)} | {McpFormat.WholeNumber(r.TotalVolume)} | {McpFormat.Invariant(shortPct, "F1")}% |"
                     );
                 }
 

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Globalization;
 using System.Text;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
@@ -89,7 +88,7 @@ public class FredTools
                     // Format with InvariantCulture so the MCP markdown does not fork the
                     // decimal separator by host locale (e.g. de-DE would render 5,25).
                     var valueStr = obs.Value.HasValue
-                        ? obs.Value.Value.ToString("G", CultureInfo.InvariantCulture)
+                        ? McpFormat.Invariant(obs.Value.Value, "G")
                         : "N/A";
                     result.AppendLine($"| {obs.Date:yyyy-MM-dd} | {valueStr} |");
                 }

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -148,7 +148,7 @@ public class InstitutionalHoldingsTools
                 $"| {i + 1} | {h.InstitutionalHolder.Name} | "
                     + $"{McpFormat.WholeNumber(h.Shares)} | "
                     + $"{FormatMillions(h.Value)} | "
-                    + $"{pct.ToString("F2", CultureInfo.InvariantCulture)}% |"
+                    + $"{McpFormat.Invariant(pct, "F2")}% |"
             );
         }
 
@@ -209,7 +209,7 @@ public class InstitutionalHoldingsTools
 
             var change =
                 previousShares > 0
-                    ? $"{((double)(totalShares - previousShares) / previousShares * 100).ToString("+0.0;-0.0", CultureInfo.InvariantCulture)}%"
+                    ? $"{McpFormat.Invariant((double)(totalShares - previousShares) / previousShares * 100, "+0.0;-0.0")}%"
                     : "—";
 
             result.AppendLine(
@@ -1291,7 +1291,7 @@ public class InstitutionalHoldingsTools
         {
             var x = rowsWithConsensus[i];
             result.AppendLine(
-                $"| {i + 1} | {x.Row.Ticker} | {x.Row.Name} | {x.HeldBy}/{holders.Count} | {(x.Row.CombinedValue / 1_000_000m).ToString("N1", CultureInfo.InvariantCulture)} |"
+                $"| {i + 1} | {x.Row.Ticker} | {x.Row.Name} | {x.HeldBy}/{holders.Count} | {McpFormat.Invariant(x.Row.CombinedValue / 1_000_000m, "N1")} |"
             );
         }
         return result.ToString();
@@ -1341,21 +1341,20 @@ public class InstitutionalHoldingsTools
     // Signed $millions with one decimal place, invariant culture (matches FormatMillions
     // and the rest of this file; MCP markdown must not fork the separators by host locale).
     private static string FormatSignedMillions(decimal value) =>
-        (value / 1_000_000m).ToString("+#,##0.0;-#,##0.0;0.0", CultureInfo.InvariantCulture);
+        McpFormat.Invariant(value / 1_000_000m, "+#,##0.0;-#,##0.0;0.0");
 
     // Raw dollar values rendered in $millions with one decimal place, invariant culture.
     private static string FormatMillions(decimal value) =>
-        (value / 1_000_000m).ToString("N1", CultureInfo.InvariantCulture);
+        McpFormat.Invariant(value / 1_000_000m, "N1");
 
     // Percentages rendered with one decimal place in invariant culture; callers append the
     // literal `%`. Keeps the separator stable across host locales like the other helpers.
     private static string FormatPercent<T>(T value)
-        where T : INumber<T> => value.ToString("F1", CultureInfo.InvariantCulture);
+        where T : INumber<T> => McpFormat.Invariant(value, "F1");
 
     // yyyy-MM-dd dates rendered in invariant culture so the MCP markdown stays Gregorian ISO
     // regardless of the host calendar/locale (LLMs consume these dates as ISO).
-    private static string FormatDate(DateOnly date) =>
-        date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+    private static string FormatDate(DateOnly date) => McpFormat.Invariant(date, "yyyy-MM-dd");
 
     private async Task<(
         InstitutionalHolder Holder,

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -94,7 +94,7 @@ public class InsiderTradingTools
 
                     var value = t.Shares * t.PricePerShare;
                     result.AppendLine(
-                        $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(t.Shares)} | ${t.PricePerShare.ToString("N2", CultureInfo.InvariantCulture)} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(t.SharesOwnedAfter)} |"
+                        $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(t.Shares)} | ${McpFormat.Invariant(t.PricePerShare, "N2")} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(t.SharesOwnedAfter)} |"
                     );
                 }
 

--- a/src/Equibles.Mcp/Helpers/McpFormat.cs
+++ b/src/Equibles.Mcp/Helpers/McpFormat.cs
@@ -18,4 +18,9 @@ public static class McpFormat
     // by host locale.
     public static string WholeNumber<T>(T value)
         where T : INumber<T> => value.ToString("N0", CultureInfo.InvariantCulture);
+
+    // Non-nullable companion to OrDash: formats a value with the given format string in
+    // invariant culture so MCP markdown does not fork the separators by host locale.
+    public static string Invariant<T>(T value, string format)
+        where T : IFormattable => value.ToString(format, CultureInfo.InvariantCulture);
 }

--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -1,11 +1,11 @@
 using System.ComponentModel;
-using System.Globalization;
 using System.Text;
 using Equibles.Core.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.Repositories;
 using Microsoft.Extensions.Logging;
@@ -161,7 +161,7 @@ public class DocumentTextTools
     }
 
     private static string FormatDocumentHeader(Document document) =>
-        $"{document.CommonStock.Name} ({document.CommonStock.Ticker}) {document.DocumentType} filed {document.ReportingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
+        $"{document.CommonStock.Name} ({document.CommonStock.Ticker}) {document.DocumentType} filed {McpFormat.Invariant(document.ReportingDate, "yyyy-MM-dd")}";
 
     private static string HighlightKeyword(string line, string keyword)
     {

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Globalization;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -82,7 +81,7 @@ public class FailToDeliverTools
                 {
                     var value = f.Quantity * f.Price;
                     result.AppendLine(
-                        $"| {f.SettlementDate:yyyy-MM-dd} | {McpFormat.WholeNumber(f.Quantity)} | ${f.Price.ToString("F2", CultureInfo.InvariantCulture)} | ${McpFormat.WholeNumber(value)} |"
+                        $"| {f.SettlementDate:yyyy-MM-dd} | {McpFormat.WholeNumber(f.Quantity)} | ${McpFormat.Invariant(f.Price, "F2")} | ${McpFormat.WholeNumber(value)} |"
                     );
                 }
 

--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Globalization;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -86,9 +85,7 @@ public class NportTools
         );
     }
 
-    private static string FormatAmount(decimal value) =>
-        value.ToString("N2", CultureInfo.InvariantCulture);
+    private static string FormatAmount(decimal value) => McpFormat.Invariant(value, "N2");
 
-    private static string FormatPercent(decimal value) =>
-        value.ToString("N2", CultureInfo.InvariantCulture) + "%";
+    private static string FormatPercent(decimal value) => McpFormat.Invariant(value, "N2") + "%";
 }

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Globalization;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
@@ -83,7 +82,7 @@ public class StockPriceTools
                 foreach (var p in records.OrderBy(p => p.Date))
                 {
                     result.AppendLine(
-                        $"| {p.Date:yyyy-MM-dd} | {p.Open.ToString("F2", CultureInfo.InvariantCulture)} | {p.High.ToString("F2", CultureInfo.InvariantCulture)} | {p.Low.ToString("F2", CultureInfo.InvariantCulture)} | {p.Close.ToString("F2", CultureInfo.InvariantCulture)} | {McpFormat.WholeNumber(p.Volume)} |"
+                        $"| {p.Date:yyyy-MM-dd} | {McpFormat.Invariant(p.Open, "F2")} | {McpFormat.Invariant(p.High, "F2")} | {McpFormat.Invariant(p.Low, "F2")} | {McpFormat.Invariant(p.Close, "F2")} | {McpFormat.WholeNumber(p.Volume)} |"
                     );
                 }
 
@@ -388,7 +387,7 @@ public class StockPriceTools
                 );
 
                 var result = StartTable(
-                    $"Bollinger Bands (period={period}, stdDev={stdDev.ToString("0.#", CultureInfo.InvariantCulture)}) for {stock.Ticker} ({stock.Name}):",
+                    $"Bollinger Bands (period={period}, stdDev={McpFormat.Invariant(stdDev, "0.#")}) for {stock.Ticker} ({stock.Name}):",
                     "| Date | Close | Lower | Middle | Upper |",
                     "|------|-------|-------|--------|-------|"
                 );


### PR DESCRIPTION
## Summary

- The `McpFormat` helper centralizes invariant-culture number formatting so MCP markdown output does not fork separators by host locale. It already had `OrDash` (nullable) and `WholeNumber`, but non-nullable values were still formatted with inline `value.ToString("<fmt>", CultureInfo.InvariantCulture)` calls scattered across the tool projects.
- Add a non-nullable companion `Invariant<T>(T value, string format)` and route every inline occurrence through it, mirroring the earlier consolidation of `N0` formatting through `WholeNumber`.
- Behavior is unchanged: `Invariant` is literally `value.ToString(format, CultureInfo.InvariantCulture)`, so every call site produces byte-identical output. Two sites with different shapes were intentionally left as-is — a parameterless `ToString(InvariantCulture)` (no format string) and a nullable `?.ToString(...)` (whose null handling differs).

## Code changes

- `src/Equibles.Mcp/Helpers/McpFormat.cs` — add `Invariant<T>(T value, string format) where T : IFormattable`.
- `src/Equibles.Cboe.Mcp/Tools/CboeTools.cs`, `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs`, `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs`, `src/Equibles.Sec.Mcp/Tools/NportTools.cs`, `src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs`, `src/Equibles.Fred.Mcp/Tools/FredTools.cs`, `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs`, `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs`, `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — replace inline invariant-culture `ToString` calls with `McpFormat.Invariant`, and drop the now-unused `using System.Globalization;` where it became orphaned.