### PR TITLE
refactor(mcp): collapse duplicated UTC date-range defaults into McpToolExecutor factories

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -56,7 +56,7 @@ public class CboeTools
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
+                    McpToolExecutor.UtcMonthsAgo(3)
                 );
 
                 maxResults = McpLimit.Clamp(maxResults);
@@ -113,7 +113,7 @@ public class CboeTools
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
+                    McpToolExecutor.UtcMonthsAgo(3)
                 );
 
                 maxResults = McpLimit.Clamp(maxResults);

--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -63,7 +63,7 @@ public class CftcTools
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                    McpToolExecutor.UtcYearsAgo(1)
                 );
 
                 var reports = await _reportRepository

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -63,7 +63,7 @@ public class CongressTools
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                    McpToolExecutor.UtcYearsAgo(1)
                 );
 
                 var query = _tradeRepository.GetByStock(stock, start, end);
@@ -131,7 +131,7 @@ public class CongressTools
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                    McpToolExecutor.UtcYearsAgo(1)
                 );
 
                 var query = _tradeRepository

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -63,7 +63,7 @@ public class ShortDataTools
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
+                    McpToolExecutor.UtcMonthsAgo(3)
                 );
 
                 query = query.Where(d => d.Date >= start && d.Date <= end);
@@ -128,7 +128,7 @@ public class ShortDataTools
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                    McpToolExecutor.UtcYearsAgo(1)
                 );
 
                 query = query.Where(s => s.SettlementDate >= start && s.SettlementDate <= end);

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -60,7 +60,7 @@ public class FredTools
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                    McpToolExecutor.UtcYearsAgo(1)
                 );
 
                 maxResults = McpLimit.Clamp(maxResults);

--- a/src/Equibles.Mcp/McpToolExecutor.cs
+++ b/src/Equibles.Mcp/McpToolExecutor.cs
@@ -16,6 +16,12 @@ public static class McpToolExecutor
             ? parsed
             : fallback;
 
+    public static DateOnly UtcMonthsAgo(int months) =>
+        DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-months));
+
+    public static DateOnly UtcYearsAgo(int years) =>
+        DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-years));
+
     public static (DateOnly Start, DateOnly End) ParseDateRange(
         string startText,
         string endText,

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -56,7 +56,7 @@ public class FailToDeliverTools
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-3))
+                    McpToolExecutor.UtcMonthsAgo(3)
                 );
 
                 maxResults = McpLimit.Clamp(maxResults);

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -59,7 +59,7 @@ public class StockPriceTools
                 var (start, end) = McpToolExecutor.ParseDateRange(
                     startDate,
                     endDate,
-                    DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-1))
+                    McpToolExecutor.UtcYearsAgo(1)
                 );
 
                 maxResults = McpLimit.Clamp(maxResults);
@@ -425,7 +425,7 @@ public class StockPriceTools
         var (start, end) = McpToolExecutor.ParseDateRange(
             startDate,
             endDate,
-            DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-6))
+            McpToolExecutor.UtcMonthsAgo(6)
         );
 
         var records = await _priceRepository


### PR DESCRIPTION
## Summary

- The MCP tools repeated the expression `DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(-N))` / `AddYears(-N)` 11 times across 7 tool classes to build the default start of a query date range.
- Extract that into two named factory methods on `McpToolExecutor` (`UtcMonthsAgo` / `UtcYearsAgo`), beside the existing `ParseDateRange` / `ParseDateOr` date helpers, and route every call site through them. Behavior-preserving — each factory body is the same expression it replaces.

## Code changes

- `src/Equibles.Mcp/McpToolExecutor.cs` — add `UtcMonthsAgo(int)` and `UtcYearsAgo(int)` static factories returning today's UTC date shifted back by the given period.
- `src/Equibles.Cboe.Mcp/Tools/CboeTools.cs`, `Equibles.Cftc.Mcp/Tools/CftcTools.cs`, `Equibles.Congress.Mcp/Tools/CongressTools.cs`, `Equibles.Finra.Mcp/Tools/ShortDataTools.cs`, `Equibles.Fred.Mcp/Tools/FredTools.cs`, `Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs`, `Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — replace the inline `DateOnly.FromDateTime(DateTime.UtcNow.Add…)` default-start expressions with the corresponding factory call.