### PR TITLE
test(commonstocks): pin TickerNormalizer.Normalize culture-invariant uppercasing

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/TickerNormalizerNormalizeCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/TickerNormalizerNormalizeCultureInvarianceTests.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+using Equibles.CommonStocks.Data.Helpers;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class TickerNormalizerNormalizeCultureInvarianceTests
+{
+    // Contract: Normalize is the canonical ticker form for case-insensitive lookups and
+    // upper-cases with the INVARIANT culture so a host's locale can't fork the mapping.
+    // Under tr-TR a culture-sensitive ToUpper maps lowercase 'i' to the dotted capital 'İ'
+    // (U+0130); the canonical form of "visa" must stay ASCII "VISA" on every host, or the
+    // same ticker keys to two different strings depending on where the process runs.
+    [Fact]
+    public void Normalize_LowercaseIUnderTurkishCulture_UppercasesToAsciiInvariantly()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+
+            var result = TickerNormalizer.Normalize("visa");
+
+            result.Should().Be("VISA");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test pinning that `TickerNormalizer.Normalize` upper-cases tickers with the invariant culture, so case-insensitive ticker lookups never fork by the host's locale.
- Guards the documented Turkish dotless-i contract: under `tr-TR` a culture-sensitive uppercasing maps `i` to the dotted capital `İ` (U+0130), which would key the same ticker to two different strings depending on where the process runs. The method was previously untested.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/TickerNormalizerNormalizeCultureInvarianceTests.cs` — new test that sets `CurrentCulture` to `tr-TR`, normalizes `"visa"`, and asserts the result is ASCII `"VISA"` (restoring the culture in a `finally`). Passes against the current `ToUpperInvariant` implementation; would fail if it regressed to a culture-sensitive `ToUpper`.