### PR TITLE
refactor(insider-trading-mcp): fold private StartTable into shared MarkdownTable.Start subtitle overload

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using System.Globalization;
-using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
@@ -70,7 +69,7 @@ public class InsiderTradingTools
                 if (transactions.Count == 0)
                     return $"No insider transactions found for {ticker}.";
 
-                var result = StartTable(
+                var result = MarkdownTable.Start(
                     $"Recent insider transactions for {stock.Name} ({ticker}):",
                     $"Showing {transactions.Count} most recent transactions",
                     "| Date | Insider | Role | Type | Shares | Price | Value | Owned After |",
@@ -136,7 +135,7 @@ public class InsiderTradingTools
                 if (latestTransactions.Count == 0)
                     return $"No insider ownership data found for {ticker}.";
 
-                var result = StartTable(
+                var result = MarkdownTable.Start(
                     $"Insider ownership summary for {stock.Name} ({ticker}):",
                     $"Showing {latestTransactions.Count} insiders with most recent data",
                     "| Insider | Role | Shares Owned | Last Transaction | Last Date |",
@@ -190,7 +189,7 @@ public class InsiderTradingTools
                 if (filings.Count == 0)
                     return $"No Form 144 proposed sales found for {ticker}.";
 
-                var result = StartTable(
+                var result = MarkdownTable.Start(
                     $"Recent proposed sales (Form 144) for {stock.Name} ({ticker}):",
                     $"Showing {filings.Count} most recent notices",
                     "| Filed | Seller | Relationship | Shares | Market Value | Approx. Sale Date | Broker |",
@@ -272,25 +271,6 @@ public class InsiderTradingTools
         if (owner.IsTenPercentOwner)
             roles.Add("10% Owner");
         return roles.Count > 0 ? string.Join(", ", roles) : "Insider";
-    }
-
-    // Builds the shared title + "Showing N…" subtitle preamble these tools emit before each
-    // markdown table. The blank line between subtitle and header row is load-bearing: strict
-    // CommonMark renderers need it to recognise the following rows as a table.
-    private static StringBuilder StartTable(
-        string title,
-        string subtitle,
-        string headerRow,
-        string separatorRow
-    )
-    {
-        var sb = new StringBuilder();
-        sb.AppendLine(title);
-        sb.AppendLine(subtitle);
-        sb.AppendLine();
-        sb.AppendLine(headerRow);
-        sb.AppendLine(separatorRow);
-        return sb;
     }
 
     // Thin forwarder so existing reflection-based normalization tests still find the method.

--- a/src/Equibles.Mcp/Helpers/MarkdownTable.cs
+++ b/src/Equibles.Mcp/Helpers/MarkdownTable.cs
@@ -13,4 +13,22 @@ public static class MarkdownTable
         sb.AppendLine(separatorRow);
         return sb;
     }
+
+    // The blank line between subtitle and header row is load-bearing: strict
+    // CommonMark renderers need it to recognise the following rows as a table.
+    public static StringBuilder Start(
+        string title,
+        string subtitle,
+        string headerRow,
+        string separatorRow
+    )
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(title);
+        sb.AppendLine(subtitle);
+        sb.AppendLine();
+        sb.AppendLine(headerRow);
+        sb.AppendLine(separatorRow);
+        return sb;
+    }
 }


### PR DESCRIPTION
## Summary

- The insider-trading MCP tools had a private `StartTable` helper whose body was identical to the shared `MarkdownTable.Start` plus one subtitle line — a duplicate of logic that already lives in the shared `Equibles.Mcp.Helpers.MarkdownTable` used across 15 tool files.
- Consolidates table-preamble building into the shared helper so there is one place that owns the load-bearing blank-line-before-header rule.

## Code changes

- `src/Equibles.Mcp/Helpers/MarkdownTable.cs` — add a `Start(title, subtitle, headerRow, separatorRow)` overload (title, subtitle, blank line, header, separator) alongside the existing 3-arg version; carry over the comment explaining why the blank line is required for strict CommonMark renderers.
- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — remove the now-redundant private `StartTable` method, repoint its three call sites to `MarkdownTable.Start`, and drop the now-unused `System.Text` import. Output is byte-for-byte identical (same `AppendLine` sequence and argument order).