### PR TITLE
test(insider-trading): pin InsiderFilingParser.ExtractNotes skips malformed and dangling footnote refs

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserExtractNotesDanglingReferencesTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserExtractNotesDanglingReferencesTests.cs
@@ -1,0 +1,29 @@
+using System.Xml.Linq;
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserExtractNotesDanglingReferencesTests
+{
+    // Contract (per ExtractNotes' doc): resolve every referenced footnote to its text,
+    // in document order, de-duplicated by id. A real filing can carry malformed or
+    // dangling references — a <footnoteId> with no id, an empty id, or an id with no
+    // matching <footnote> entry. None of those resolve to text, so each must be dropped
+    // without throwing while a following well-formed reference still resolves.
+    [Fact]
+    public void ExtractNotes_MalformedAndDanglingReferences_AreSkippedAndValidStillResolves()
+    {
+        var footnotes = new Dictionary<string, string> { ["F1"] = "Shares held in a trust." };
+        var row = new XElement(
+            "nonDerivativeTransaction",
+            new XElement("footnoteId"), // missing id attribute
+            new XElement("footnoteId", new XAttribute("id", "")), // empty id
+            new XElement("footnoteId", new XAttribute("id", "F9")), // id absent from the map
+            new XElement("footnoteId", new XAttribute("id", "F1")) // the only resolvable one
+        );
+
+        var notes = InsiderFilingParser.ExtractNotes(row, footnotes);
+
+        notes.Should().Equal("Shares held in a trust.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one unit test pinning `InsiderFilingParser.ExtractNotes` behavior on malformed/dangling footnote references, a real-world input not previously covered (existing footnote tests only exercise well-formed references through `ParseTransactions`).
- Confirms the documented contract — resolve referenced footnotes to text, in document order, de-duplicated by id — holds when a row carries broken references.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserExtractNotesDanglingReferencesTests.cs` — new test feeding a row with a `<footnoteId>` lacking an id attribute, one with an empty id, and one referencing an id absent from the footnotes map, interleaved before a single resolvable reference. Asserts each broken reference is dropped without throwing while the valid one still resolves to its text.