### PR TITLE
style(tests): fix CSharpier formatting on stochastic oscillator culture test

### DIFF
--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetStochasticOscillatorCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetStochasticOscillatorCultureInvarianceTests.cs
@@ -29,7 +29,9 @@ public class StockPriceToolsGetStochasticOscillatorCultureInvarianceTests : Para
     // the culture-implicit :F2 specifier, so de-DE renders the decimal comma — forking the
     // response and making one column disagree with the next. Same bug class as GetLatestPrices
     // (#3100) and the already-fixed GetStockPrices (#2628).
-    [Fact(Skip = "GH-3103 — GetStochasticOscillator renders the Close column with a culture-implicit specifier")]
+    [Fact(
+        Skip = "GH-3103 — GetStochasticOscillator renders the Close column with a culture-implicit specifier"
+    )]
     public async Task GetStochasticOscillator_UnderNonInvariantCulture_RendersCloseCultureInvariantly()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

CI's CSharpier format check was failing on `main`: `StockPriceToolsGetStochasticOscillatorCultureInvarianceTests.cs` had an unformatted `[Fact(Skip = ...)]` attribute that CSharpier wants wrapped across multiple lines.

## Code changes

- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetStochasticOscillatorCultureInvarianceTests.cs` — applied `csharpier format` (wraps the long `[Fact(Skip = ...)]` attribute onto multiple lines). No behavior change.