### PR TITLE
test(sec): pin CurrencyConsolidationStep leaves foreign C$ columns unlabelled

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepForeignDollarPrefixedSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepForeignDollarPrefixedSymbolTests.cs
@@ -1,0 +1,33 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class CurrencyConsolidationStepForeignDollarPrefixedSymbolTests
+{
+    private readonly CurrencyConsolidationStep _sut = new();
+    private readonly HtmlParser _parser = new();
+
+    // Contract (ContainsCurrencySymbol doc): "A symbol immediately preceded by a letter is a
+    // different currency's prefixed symbol (e.g. C$, A$, HK$, NZ$), not this one — so a
+    // Canadian/Australian/HK dollar cell is not mistaken for US Dollars." A "C$" currency column
+    // must therefore be left alone: no consolidation, and no "All values are in US Dollars." note.
+    // Oracle derived from the contract; this pins the positive side of the letter-prefix guard
+    // (the GH-3118 repro only covers the "US$" false negative).
+    [Fact]
+    public void ForeignDollarPrefixedSymbolColumn_IsNotMistakenForUsDollars()
+    {
+        var html =
+            @"<html><body><table>
+  <tr><td>C$</td><td></td><td>100</td></tr>
+  <tr><td>C$</td><td></td><td>200</td></tr>
+</table></body></html>";
+
+        var doc = _parser.ParseDocument(html);
+
+        _sut.Execute(doc);
+
+        doc.QuerySelector("table + p em").Should().BeNull();
+        doc.QuerySelectorAll("td").Select(td => td.TextContent).Should().Contain("C$");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the positive side of `CurrencyConsolidationStep`'s letter-prefix currency guard: a `C$` (Canadian dollar) column must not be mistaken for US Dollars.
- Closes a coverage gap on the `ContainsCurrencySymbol` letter-prefix branch, which until now was only exercised by the skipped GH-3118 repro (the `US$` false-negative). This test passes today and guards the documented intent against regression.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepForeignDollarPrefixedSymbolTests.cs` — new unit test: a table whose currency column holds `C$` cells is left unchanged by `Execute` — no "All values are in US Dollars." note is appended and the `C$` column is retained. Oracle derived from the `ContainsCurrencySymbol` contract ("a symbol immediately preceded by a letter is a different currency's prefixed symbol … not mistaken for US Dollars").