### PR TITLE
fix(sec): return null for whitespace-only attribute values in EdgarXmlSubmissionParser.Attr

### DIFF
--- a/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
+++ b/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
@@ -122,8 +122,11 @@ internal static class EdgarXmlSubmissionParser
     /// </summary>
     internal static string Attr(XElement element, string name)
     {
-        var value = element?.Attributes().FirstOrDefault(a => a.Name.LocalName == name)?.Value;
-        return string.IsNullOrEmpty(value) ? null : value.Trim();
+        var value = element
+            ?.Attributes()
+            .FirstOrDefault(a => a.Name.LocalName == name)
+            ?.Value?.Trim();
+        return string.IsNullOrEmpty(value) ? null : value;
     }
 
     /// <summary>

--- a/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserAttrTests.cs
+++ b/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserAttrTests.cs
@@ -5,7 +5,7 @@ namespace Equibles.UnitTests.Sec;
 
 public class EdgarXmlSubmissionParserAttrTests
 {
-    [Fact(Skip = "GH-3106 — Attr returns empty string instead of null for whitespace-only values")]
+    [Fact]
     public void Attr_WhitespaceOnlyValue_ReturnsNull()
     {
         // Contract (from the doc-comment): "Trimmed value of the named attribute, or null when


### PR DESCRIPTION
## Summary

- `EdgarXmlSubmissionParser.Attr` returned an empty string instead of `null` for whitespace-only attribute values, contradicting its doc-comment and diverging from the sibling `Val` helper.
- Callers chain the result through `?? default` and null-tolerant helpers, so the empty string slipped past and was stored as empty data (e.g. an empty country code in the N-CEN / NPORT processors).

## Code changes

- `src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs` — trim the attribute value before the null/empty check (mirroring `Val`), so a whitespace-only value normalizes to `null`.
- `tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserAttrTests.cs` — un-skipped the regression test pinning the `null` contract for a whitespace-only attribute.

closes #3106