### PR TITLE
test(sec): pin HeadingConversionStep.IsItemHeading rejects delimiter-only 'Item -'

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItemHeadingDelimiterOnlySuffixTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItemHeadingDelimiterOnlySuffixTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+/// <summary>
+/// IsItemHeading classifies SEC 10-K "Item N" section headings: it should
+/// return true only when an item identifier (a number such as "1" / "1A")
+/// actually follows the word "Item". A fragment like "Item -" is a visual
+/// section divider with no item number, so the contract answer is false.
+/// Its sibling IsPartHeading is pinned to reject the exact parallel case
+/// ("Part -" -> false), proving the intended classification; this is the
+/// missing symmetric guarantee. Oracle derived from the SEC 10-K
+/// item-heading convention and the sibling's contract before reading the body.
+/// </summary>
+public class HeadingConversionStepIsItemHeadingDelimiterOnlySuffixTests
+{
+    [Fact(Skip = "GH-3129 — IsItemHeading promotes delimiter-only 'Item -' divider to a heading")]
+    public void IsItemHeading_ItemFollowedByDelimiterOnlySuffix_ReturnsFalse()
+    {
+        var method = typeof(HeadingConversionStep).GetMethod(
+            "IsItemHeading",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        var step = new HeadingConversionStep();
+
+        // "Item -" has no item identifier after the whitespace — it is a divider,
+        // not a numbered item heading. IsPartHeading rejects the parallel "Part -".
+        var result = (bool)method.Invoke(step, ["Item -"])!;
+
+        result
+            .Should()
+            .BeFalse(
+                "'Item -' carries no item identifier, so it is not a SEC 10-K item heading — mirroring IsPartHeading's rejection of 'Part -'"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped regression test pinning the intended contract of `HeadingConversionStep.IsItemHeading`: a delimiter-only fragment like `"Item -"` carries no item identifier and is not a SEC 10-K item heading.
- The test currently fails — skipped pending the fix in GH-3129. No production code is changed.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItemHeadingDelimiterOnlySuffixTests.cs` — new `[Fact(Skip = "GH-3129 …")]`. Asserts `IsItemHeading("Item -")` returns `false`, mirroring the sibling `IsPartHeading("Part -") == false` that is already pinned. `IsItemHeading` only checks for whitespace at index 4 and never verifies an identifier follows, so it currently promotes the `"Item -"` divider to an `<h2>` heading. Skipped — see GH-3129.