### PR TITLE
test(sec): pin EdgarXmlSubmissionParser.ParseDate culture-invariant slash parsing

### DIFF
--- a/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserParseDateTests.cs
+++ b/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserParseDateTests.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using Equibles.Sec.HostedService.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class EdgarXmlSubmissionParserParseDateTests
+{
+    [Fact]
+    public void ParseDate_SlashFormatUnderNonInvariantCulture_ParsesViaInvariantSeparator()
+    {
+        // Contract: parse against the supplied exact formats in INVARIANT culture. The '/' in
+        // "MM/dd/yyyy" (the format real Form 144 / Form D filings use) is the culture's DateSeparator
+        // placeholder — under de-DE that separator is '.', so a literal-slash value would fail to
+        // match unless parsing is pinned to invariant. Oracle: the doc-comment, not the body.
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var result = EdgarXmlSubmissionParser.ParseDate("03/15/2024", ["MM/dd/yyyy"]);
+
+            result.Should().Be(new DateOnly(2024, 3, 15));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test pinning `EdgarXmlSubmissionParser.ParseDate` to invariant-culture parsing for the slash date formats real Form 144 / Form D filings use (`MM/dd/yyyy`).
- The `/` in an exact format string is the culture's `DateSeparator` placeholder; under a non-invariant `CurrentCulture` (e.g. de-DE, separator `.`) a literal-slash value would fail to match unless parsing is pinned to invariant. The test runs under de-DE and asserts the date still parses, guarding against a future regression away from `CultureInfo.InvariantCulture`.

## Code changes

- `tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserParseDateTests.cs` — new test: pins `ParseDate("03/15/2024", ["MM/dd/yyyy"])` to `2024-03-15` while `CurrentCulture` is de-DE. Behavior confirmed (passes); no production change.