### PR TITLE
test(sec): pin EdgarXmlSubmissionParser.Clean N/A normalization

### DIFF
--- a/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserCleanTests.cs
+++ b/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserCleanTests.cs
@@ -1,0 +1,17 @@
+using Equibles.Sec.HostedService.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class EdgarXmlSubmissionParserCleanTests
+{
+    [Fact]
+    public void Clean_WhitespaceWrappedLowercaseNotApplicable_ReturnsNull()
+    {
+        // Contract (doc-comment): "Trimmed text with the 'N/A' placeholder and blanks normalized to
+        // null." A surrounding-whitespace, lowercase "n/a" must normalize to null — exercising both
+        // trim-before-compare and case-insensitive placeholder matching. Oracle from the contract.
+        var result = EdgarXmlSubmissionParser.Clean("  n/a  ");
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test pinning `EdgarXmlSubmissionParser.Clean` to its doc-comment contract: blanks and the `N/A` placeholder normalize to `null`.
- Uses a surrounding-whitespace, lowercase `n/a` to exercise both trim-before-compare and case-insensitive placeholder matching in a single input — guarding against a regression to ordinal (case-sensitive) comparison or compare-before-trim.

## Code changes

- `tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserCleanTests.cs` — new test: asserts `Clean("  n/a  ")` returns `null`. Behavior confirmed (passes); no production change.