### PR TITLE
fix(sec): reject delimiter-only 'Item -' fragments in IsItemHeading

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -150,9 +150,27 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
         // SEC EDGAR renders "Item N" with a non-breaking space (U+00A0)
         // between word and number, so accept any Unicode whitespace after
         // "ITEM" — not just the literal U+0020 that StartsWith("ITEM ") demands.
-        return upperText.StartsWith("ITEM")
-            && upperText.Length > 5
-            && char.IsWhiteSpace(upperText[4]);
+        if (upperText.StartsWith("ITEM") && upperText.Length > 5 && char.IsWhiteSpace(upperText[4]))
+        {
+            var afterItem = upperText.Substring(5).Trim();
+            if (!string.IsNullOrEmpty(afterItem))
+            {
+                // Require a real item identifier after the separator (e.g. "1",
+                // "1A"). A delimiter-only fragment like "Item -" is a visual
+                // divider, not a heading. Mirrors IsPartHeading's guard against
+                // "Part -"; items use alphanumeric identifiers rather than words.
+                var tokens = afterItem.Split(
+                    [' ', '.', '-', ':'],
+                    StringSplitOptions.RemoveEmptyEntries
+                );
+                if (tokens.Length == 0)
+                    return false;
+                var firstWord = tokens[0];
+                return !string.IsNullOrEmpty(firstWord) && firstWord.Any(char.IsLetterOrDigit);
+            }
+        }
+
+        return false;
     }
 
     private bool IsItalicSpan(IElement span) => HasInlineCss(span, "font-style", "italic");

--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItemHeadingDelimiterOnlySuffixTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItemHeadingDelimiterOnlySuffixTests.cs
@@ -15,7 +15,7 @@ namespace Equibles.UnitTests.Sec.Normalizers;
 /// </summary>
 public class HeadingConversionStepIsItemHeadingDelimiterOnlySuffixTests
 {
-    [Fact(Skip = "GH-3129 — IsItemHeading promotes delimiter-only 'Item -' divider to a heading")]
+    [Fact]
     public void IsItemHeading_ItemFollowedByDelimiterOnlySuffix_ReturnsFalse()
     {
         var method = typeof(HeadingConversionStep).GetMethod(


### PR DESCRIPTION
## Summary

- `HeadingConversionStep.IsItemHeading` promoted any `Item <whitespace>…` span to an `<h2>` item heading without checking that a real item identifier followed the separator, so a visual divider like `Item -` was misclassified during SEC 10-K HTML normalization.
- Adds the symmetric guard its sibling `IsPartHeading` already has against `Part -`, and un-skips the GH-3129 regression test.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs` — after matching `ITEM` + whitespace, require a non-empty alphanumeric token after the separator; delimiter-only fragments now return `false`.
- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepIsItemHeadingDelimiterOnlySuffixTests.cs` — removed `Skip`; the test fails on the old code and passes on the fix.

closes #3129