### PR TITLE
fix(sec): register InsiderFilingRepository and IFileManager in insider processor tests

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorMalformedOwnershipXmlTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorMalformedOwnershipXmlTests.cs
@@ -9,6 +9,7 @@ using Equibles.InsiderTrading.Repositories;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
@@ -48,6 +49,8 @@ public class InsiderTradingFilingProcessorMalformedOwnershipXmlTests
             (typeof(ISecEdgarClient), secClient),
             (typeof(InsiderOwnerRepository), new InsiderOwnerRepository(dbContext)),
             (typeof(InsiderTransactionRepository), new InsiderTransactionRepository(dbContext)),
+            (typeof(InsiderFilingRepository), new InsiderFilingRepository(dbContext)),
+            (typeof(IFileManager), Substitute.For<IFileManager>()),
             (typeof(ErrorManager), new ErrorManager(new ErrorRepository(dbContext))),
             (typeof(DailyStockPriceRepository), new DailyStockPriceRepository(dbContext)),
             (typeof(InsiderTransactionPriceValidator), new InsiderTransactionPriceValidator())

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -10,6 +10,7 @@ using Equibles.InsiderTrading.Repositories;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
 using Equibles.Messaging;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
@@ -310,16 +311,20 @@ public class InsiderTradingFilingProcessorTests
 
         var ownerRepo = new InsiderOwnerRepository(dbContext);
         var txRepo = new InsiderTransactionRepository(dbContext);
+        var filingRepo = new InsiderFilingRepository(dbContext);
         var errorRepo = new ErrorRepository(dbContext);
         var errorManager = new ErrorManager(errorRepo);
         var dailyStockPriceRepo = new DailyStockPriceRepository(dbContext);
         var priceValidator = new InsiderTransactionPriceValidator();
         var secClient = Substitute.For<ISecEdgarClient>();
+        var fileManager = Substitute.For<IFileManager>();
 
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(ISecEdgarClient), secClient),
             (typeof(InsiderOwnerRepository), ownerRepo),
             (typeof(InsiderTransactionRepository), txRepo),
+            (typeof(InsiderFilingRepository), filingRepo),
+            (typeof(IFileManager), fileManager),
             (typeof(ErrorManager), errorManager),
             (typeof(DailyStockPriceRepository), dailyStockPriceRepo),
             (typeof(InsiderTransactionPriceValidator), priceValidator)


### PR DESCRIPTION
## Summary

The build-and-test CI job has been red on `main`: every `InsiderTradingFilingProcessorTests.Process_*` integration test (and `InsiderTradingFilingProcessorMalformedOwnershipXmlTests`) threw:

```
System.InvalidOperationException : No service for type 'Equibles.InsiderTrading.Repositories.InsiderFilingRepository' has been registered.
```

`InsiderTradingFilingProcessor.Process` resolves `InsiderFilingRepository` and `IFileManager` from the request scope (added alongside raw-filing-XML capture in #2910), but the test scope factories were never updated to register them, so resolution failed before any assertion ran.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs` — register a real `InsiderFilingRepository` (over the test `dbContext`) and a substitute `IFileManager` in `CreateProcessorWithDeps`.
- `tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorMalformedOwnershipXmlTests.cs` — same two registrations in its scope factory.

All 68 `InsiderTradingFilingProcessor*` integration tests now pass locally; build and CSharpier are clean.