### PR TITLE
refactor(worker): collapse duplicated SEC contact-email gate into BaseScraperWorker helper

### DIFF
--- a/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
+++ b/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
@@ -52,17 +52,12 @@ public class Holdings13FRealtimeWorker : BaseScraperWorker
         _configuration = configuration;
     }
 
-    protected override bool ValidateConfiguration()
-    {
-        if (string.IsNullOrWhiteSpace(_configuration["Sec:ContactEmail"]))
-        {
-            Logger.LogWarning(
-                "13F real-time ingestion stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."
-            );
-            return false;
-        }
-        return true;
-    }
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(
+            _configuration,
+            "13F real-time ingestion",
+            treatWhitespaceAsAbsent: true
+        );
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {

--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -86,17 +86,8 @@ public class HoldingsScraperWorker : BaseScraperWorker
         }
     }
 
-    protected override bool ValidateConfiguration()
-    {
-        if (string.IsNullOrWhiteSpace(_configuration["Sec:ContactEmail"]))
-        {
-            Logger.LogWarning(
-                "Holdings Scraper stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."
-            );
-            return false;
-        }
-        return true;
-    }
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(_configuration, "Holdings Scraper", treatWhitespaceAsAbsent: true);
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {

--- a/src/Equibles.Sec.FinancialFacts.HostedService/FinancialFactsScraperWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/FinancialFactsScraperWorker.cs
@@ -40,17 +40,12 @@ public class FinancialFactsScraperWorker : BaseScraperWorker
         _configuration = configuration;
     }
 
-    protected override bool ValidateConfiguration()
-    {
-        if (string.IsNullOrWhiteSpace(_configuration["Sec:ContactEmail"]))
-        {
-            Logger.LogWarning(
-                "Financial facts scraper stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."
-            );
-            return false;
-        }
-        return true;
-    }
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(
+            _configuration,
+            "Financial facts scraper",
+            treatWhitespaceAsAbsent: true
+        );
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {

--- a/src/Equibles.Sec.HostedService/FormAdvScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/FormAdvScraperWorker.cs
@@ -33,17 +33,8 @@ public class FormAdvScraperWorker : BaseScraperWorker
         _configuration = configuration;
     }
 
-    protected override bool ValidateConfiguration()
-    {
-        if (string.IsNullOrEmpty(_configuration["Sec:ContactEmail"]))
-        {
-            Logger.LogWarning(
-                "Form ADV Scraper stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."
-            );
-            return false;
-        }
-        return true;
-    }
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(_configuration, "Form ADV Scraper", treatWhitespaceAsAbsent: false);
 
     protected override Task DoWork(CancellationToken stoppingToken) =>
         RunImport<FormAdvImportService>(stoppingToken);

--- a/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
@@ -37,17 +37,8 @@ public class FtdScraperWorker : BaseScraperWorker
         _configuration = configuration;
     }
 
-    protected override bool ValidateConfiguration()
-    {
-        if (string.IsNullOrEmpty(_configuration["Sec:ContactEmail"]))
-        {
-            Logger.LogWarning(
-                "FTD Scraper stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."
-            );
-            return false;
-        }
-        return true;
-    }
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(_configuration, "FTD Scraper", treatWhitespaceAsAbsent: false);
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {

--- a/src/Equibles.Sec.HostedService/SecScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/SecScraperWorker.cs
@@ -29,17 +29,12 @@ public class SecScraperWorker : BaseScraperWorker
         _configuration = configuration;
     }
 
-    protected override bool ValidateConfiguration()
-    {
-        if (string.IsNullOrEmpty(_configuration["Sec:ContactEmail"]))
-        {
-            Logger.LogWarning(
-                "SEC Filing Scraper stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."
-            );
-            return false;
-        }
-        return true;
-    }
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(
+            _configuration,
+            "SEC Filing Scraper",
+            treatWhitespaceAsAbsent: false
+        );
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {

--- a/src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs
@@ -50,17 +50,8 @@ public class XbrlBackfillWorker : BaseScraperWorker
         _configuration = configuration;
     }
 
-    protected override bool ValidateConfiguration()
-    {
-        if (string.IsNullOrEmpty(_configuration["Sec:ContactEmail"]))
-        {
-            Logger.LogWarning(
-                "XBRL backfill stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file."
-            );
-            return false;
-        }
-        return true;
-    }
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(_configuration, "XBRL backfill", treatWhitespaceAsAbsent: false);
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {

--- a/src/Equibles.Worker/BaseScraperWorker.cs
+++ b/src/Equibles.Worker/BaseScraperWorker.cs
@@ -3,6 +3,7 @@ using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Messaging.Contracts.Activity;
 using MassTransit;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -227,6 +228,39 @@ public abstract class BaseScraperWorker : BackgroundService
         StartupDelay > TimeSpan.Zero ? Task.Delay(StartupDelay, stoppingToken) : Task.CompletedTask;
 
     protected virtual bool ValidateConfiguration() => true;
+
+    /// <summary>
+    /// Startup gate shared by every SEC-EDGAR-backed scraper: SEC 403-bans a
+    /// source whose User-Agent carries no contact email, so a worker with no
+    /// usable <c>Sec:ContactEmail</c> must not loop uselessly. Logs a warning and
+    /// returns false when the value is absent; returns true otherwise.
+    /// </summary>
+    /// <param name="treatWhitespaceAsAbsent">
+    /// When true a whitespace-only value also fails the gate (its User-Agent
+    /// would carry no real contact). Workers disagree on this today — the SEC
+    /// scrapers accept whitespace while the Holdings/financial-facts scrapers
+    /// reject it — so callers pass their current behavior explicitly to keep it.
+    /// </param>
+    protected bool ValidateSecContactEmail(
+        IConfiguration configuration,
+        string label,
+        bool treatWhitespaceAsAbsent
+    )
+    {
+        var email = configuration["Sec:ContactEmail"];
+        var absent = treatWhitespaceAsAbsent
+            ? string.IsNullOrWhiteSpace(email)
+            : string.IsNullOrEmpty(email);
+        if (absent)
+        {
+            Logger.LogWarning(
+                "{Label} stopped: SEC_CONTACT_EMAIL not configured. Set it in your .env file.",
+                label
+            );
+            return false;
+        }
+        return true;
+    }
 
     protected abstract Task DoWork(CancellationToken stoppingToken);
 }


### PR DESCRIPTION
## Summary

- Seven scraper workers each carried a near-identical `ValidateConfiguration` override that read `Sec:ContactEmail` and logged the same "not configured" warning. Collapse that duplication into one shared `ValidateSecContactEmail` helper on `BaseScraperWorker`.
- Behavior-preserving: each worker keeps its exact original predicate via a `treatWhitespaceAsAbsent` flag, and the warning renders byte-for-byte identically. The `IsNullOrEmpty`/`IsNullOrWhiteSpace` inconsistency between workers is deliberately preserved here and tracked separately in #3135.

## Code changes

- `src/Equibles.Worker/BaseScraperWorker.cs` — add `protected ValidateSecContactEmail(IConfiguration, string label, bool treatWhitespaceAsAbsent)`: reads `Sec:ContactEmail`, selects `IsNullOrWhiteSpace` (flag true) or `IsNullOrEmpty` (flag false), logs the shared warning, returns false when absent.
- `SecScraperWorker`, `FtdScraperWorker`, `XbrlBackfillWorker`, `FormAdvScraperWorker` — replace the override body with a one-line call passing `treatWhitespaceAsAbsent: false` (preserves their original `IsNullOrEmpty` check).
- `HoldingsScraperWorker`, `Holdings13FRealtimeWorker`, `FinancialFactsScraperWorker` — replace the override body with a one-line call passing `treatWhitespaceAsAbsent: true` (preserves their original `IsNullOrWhiteSpace` check).

Net: −77 / +60 lines. Build, unit tests (2357), affected integration tests (20), and `csharpier check` all green.