### PR TITLE
fix(mcp): render GetLatestPrices Close/Volume with invariant culture

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -153,7 +153,7 @@ public class StockPriceTools
                     }
 
                     result.AppendLine(
-                        $"| {ticker} | {price.Date:yyyy-MM-dd} | {price.Close:F2} | {price.Volume:N0} |"
+                        $"| {ticker} | {price.Date:yyyy-MM-dd} | {McpFormat.Invariant(price.Close, "F2")} | {McpFormat.WholeNumber(price.Volume)} |"
                     );
                 }
 

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesCultureInvarianceTests.cs
@@ -29,7 +29,7 @@ public class StockPriceToolsGetLatestPricesCultureInvarianceTests : ParadeDbMcpT
     // cells with the culture-implicit specifiers, which honour the thread
     // CurrentCulture — so de-DE swaps the decimal point and thousand separator,
     // forking the response. Same bug class as the already-fixed GetStockPrices (#2628).
-    [Fact(Skip = "GH-3100 — GetLatestPrices renders Close/Volume with culture-implicit specifiers")]
+    [Fact]
     public async Task GetLatestPrices_UnderNonInvariantCulture_RendersCloseAndVolumeCultureInvariantly()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

- `StockPriceTools.GetLatestPrices` rendered its Close (`:F2`) and Volume (`:N0`) cells with culture-implicit specifiers, which honour the thread `CurrentCulture` — so on a non-en-US host (e.g. de-DE) the LLM-facing markdown forked the decimal point and thousand separator (`150,00` / `1.234.567`).
- Same bug class already fixed across the MCP tools; the sibling `GetStockPrices` (#2628) was fixed but `GetLatestPrices` was missed.

## Code changes

- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — format the Close/Volume cells via `McpFormat.Invariant` / `McpFormat.WholeNumber`, matching the already-fixed sibling; numbers now render with invariant separators on every host locale.
- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetLatestPricesCultureInvarianceTests.cs` — removed `Skip`; the test fails under de-DE on the old code and passes on the fix.

closes #3100