### PR TITLE
fix(mcp): render ListCompanyDocuments Lines column with invariant culture

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -171,7 +171,7 @@ public class RagSearchTools
                 foreach (var doc in documents)
                 {
                     result.AppendLine(
-                        $"{doc.Id} | {doc.DocumentType} | {doc.ReportingDate:yyyy-MM-dd} | {doc.ReportingForDate:yyyy-MM-dd} | {doc.LineCount:N0}"
+                        $"{doc.Id} | {doc.DocumentType} | {doc.ReportingDate:yyyy-MM-dd} | {doc.ReportingForDate:yyyy-MM-dd} | {McpFormat.WholeNumber(doc.LineCount)}"
                     );
                 }
 

--- a/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsListCompanyDocumentsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsListCompanyDocumentsCultureInvarianceTests.cs
@@ -44,9 +44,7 @@ public class RagSearchToolsListCompanyDocumentsCultureInvarianceTests : ParadeDb
     // (RagSearchTools.cs:174), which honours the thread CurrentCulture — de-DE swaps the thousand
     // separator (1,500 -> 1.500), forking the response by host locale. Same bug class as the
     // already-pinned ReadDocumentLines (GH-3110) and GetLatestPrices (GH-3100) repros.
-    [Fact(
-        Skip = "GH-3114 — ListCompanyDocuments forks the Lines column :N0 formatting by host locale"
-    )]
+    [Fact]
     public async Task ListCompanyDocuments_UnderNonInvariantCulture_RendersLineCountCultureInvariantly()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

- `RagSearchTools.ListCompanyDocuments` built the Lines cell with the culture-implicit `:N0` specifier, which honours the thread `CurrentCulture` — so on a non-en-US host (e.g. de-DE) the LLM-facing markdown forked the thousand separator (`1.500` instead of `1,500`).
- Same MCP culture-fork bug class as the already-fixed `ReadDocumentLines` (#3110 sibling) and `GetLatestPrices` (#3100); this tool was not yet covered.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs` — route `doc.LineCount` through `McpFormat.WholeNumber`, matching the other MCP render sites; the Lines column now renders with invariant separators on every host locale.
- `tests/Equibles.IntegrationTests/Mcp/RagSearchToolsListCompanyDocumentsCultureInvarianceTests.cs` — removed `Skip`; the test fails under de-DE on the old code and passes on the fix.

closes #3114