### PR TITLE
refactor(mcp): reuse shared MarkdownTable.Start for inline table-head builders

### DIFF
--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Text;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -74,14 +73,12 @@ public class FredTools
                 if (observations.Count == 0)
                     return $"No observations found for {series.SeriesId} ({series.Title}) in the specified date range.";
 
-                var result = new StringBuilder();
-                result.AppendLine($"{series.Title} ({series.SeriesId})");
-                result.AppendLine(
-                    $"Units: {series.Units} | Frequency: {series.Frequency} | Seasonal Adj: {series.SeasonalAdjustment}"
+                var result = MarkdownTable.Start(
+                    $"{series.Title} ({series.SeriesId})",
+                    $"Units: {series.Units} | Frequency: {series.Frequency} | Seasonal Adj: {series.SeasonalAdjustment}",
+                    "| Date | Value |",
+                    "|------|-------|"
                 );
-                result.AppendLine();
-                result.AppendLine("| Date | Value |");
-                result.AppendLine("|------|-------|");
 
                 foreach (var obs in observations.OrderBy(o => o.Date))
                 {

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -127,18 +127,14 @@ public class InstitutionalHoldingsTools
         List<InstitutionalHolding> holdings
     )
     {
-        var result = new StringBuilder();
-        result.AppendLine(
-            $"Top institutional holders of {stock.Name} ({ticker}) as of {FormatDate(targetDate)}:"
-        );
-        result.AppendLine(
+        var result = MarkdownTable.Start(
+            $"Top institutional holders of {stock.Name} ({ticker}) as of {FormatDate(targetDate)}:",
             $"Showing {holdings.Count} of {totalInstitutions} institutions. Total: "
                 + $"{McpFormat.WholeNumber(totalSharesAll)} shares, "
-                + $"${FormatMillions(totalValueAll)}M value"
+                + $"${FormatMillions(totalValueAll)}M value",
+            "| # | Institution | Shares | Value ($M) | % of Total |",
+            "|---|------------|--------|-----------|-----------|"
         );
-        result.AppendLine();
-        result.AppendLine("| # | Institution | Shares | Value ($M) | % of Total |");
-        result.AppendLine("|---|------------|--------|-----------|-----------|");
 
         for (var i = 0; i < holdings.Count; i++)
         {


### PR DESCRIPTION
## Summary

- Two MCP tools built their markdown table headers inline with a fresh `StringBuilder` and a fixed sequence of `AppendLine` calls, duplicating the logic already provided by the shared `MarkdownTable.Start` helper — and both files already used that helper elsewhere, so the inline blocks were inconsistent holdouts.
- Route both through `MarkdownTable.Start(title, subtitle, header, separator)` so table-head construction lives in one place. Output is byte-identical (same lines, same order, same single blank line).

## Code changes

- `src/Equibles.Fred.Mcp/Tools/FredTools.cs` — replace the inline economic-indicator table head with `MarkdownTable.Start`; drop the now-unused `using System.Text;`.
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — replace the inline top-holders table head with `MarkdownTable.Start` (`StringBuilder` is still used elsewhere, so its import stays).

Verified by full unit (2360) and integration (1798) suites passing, including the FredTools and GetTopHolders tests that assert exact rendered table output.