### PR TITLE
fix(mcp): render ReadDocumentLines line counts with invariant culture

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -119,12 +119,12 @@ public class DocumentTextTools
 
                 if (startLine > endLine)
                 {
-                    return $"Invalid line range: {startLine} to {endLine} (document has {totalLines:N0} lines).";
+                    return $"Invalid line range: {startLine} to {endLine} (document has {McpFormat.WholeNumber(totalLines)} lines).";
                 }
 
                 var result = new StringBuilder();
                 result.AppendLine(
-                    $"{FormatDocumentHeader(document)} — lines {startLine:N0} to {endLine:N0} of {totalLines:N0}:"
+                    $"{FormatDocumentHeader(document)} — lines {McpFormat.WholeNumber(startLine)} to {McpFormat.WholeNumber(endLine)} of {McpFormat.WholeNumber(totalLines)}:"
                 );
                 result.AppendLine();
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadDocumentLinesCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadDocumentLinesCultureInvarianceTests.cs
@@ -27,7 +27,7 @@ public class DocumentTextToolsReadDocumentLinesCultureInvarianceTests : ParadeDb
     // the LLM-facing banner renders identically on every host. de-DE swaps the
     // thousand separator (1,500 -> 1.500), forking the response. Same bug class as
     // the fixed GetStockPrices volume cell and the GetLatestPrices repro (GH-3100).
-    [Fact(Skip = "GH-3110 — ReadDocumentLines forks line-count :N0 formatting by host locale")]
+    [Fact]
     public async Task ReadDocumentLines_UnderNonInvariantCulture_RendersLineCountsCultureInvariantly()
     {
         var content = string.Join("\n", Enumerable.Repeat("x", 1500)); // 1500 lines


### PR DESCRIPTION
## Summary

- `DocumentTextTools.ReadDocumentLines` built its line-range banner and invalid-range message with the culture-implicit `:N0` specifier on `startLine`/`endLine`/`totalLines`, which honour the thread `CurrentCulture` — so on a non-en-US host (e.g. de-DE) the LLM-facing markdown forked the thousand separator (`1.500` instead of `1,500`).
- Same MCP culture-fork bug class as the already-fixed `ListCompanyDocuments` (#3114) and `GetLatestPrices` (#3100); this banner in the SEC document module was missed.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs` — route the line counts in both render sites (banner + invalid-range message) through `McpFormat.WholeNumber`, matching the other MCP render sites; counts now render with invariant separators on every host locale.
- `tests/Equibles.IntegrationTests/Sec/DocumentTextToolsReadDocumentLinesCultureInvarianceTests.cs` — removed `Skip`; the test fails under de-DE on the old code and passes on the fix.

closes #3110