### PR TITLE
fix(sec): detect US$ notation as US Dollars in CurrencyConsolidationStep

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs
@@ -116,17 +116,38 @@ internal class CurrencyConsolidationStep : IHtmlNormalizationStep
     // A symbol immediately preceded by a letter is a different currency's
     // prefixed symbol (e.g. "C$", "A$", "HK$", "NZ$"), not this one — so a
     // Canadian/Australian/HK dollar cell is not mistaken for US Dollars,
-    // mirroring the boundary-careful currency-code match above.
+    // mirroring the boundary-careful currency-code match above. The one
+    // exception is "US$": the "US" prefix is the standard, unambiguous
+    // notation for US Dollars, so it must NOT be dropped as foreign.
     private static bool ContainsCurrencySymbol(string text, string symbol)
     {
         var index = text.IndexOf(symbol, StringComparison.Ordinal);
         while (index >= 0)
         {
-            if (index == 0 || !char.IsLetter(text[index - 1]))
+            if (
+                index == 0
+                || !char.IsLetter(text[index - 1])
+                || IsUsDollarPrefix(text, index, symbol)
+            )
                 return true;
             index = text.IndexOf(symbol, index + symbol.Length, StringComparison.Ordinal);
         }
         return false;
+    }
+
+    // "US$" denotes US Dollars, not a foreign prefixed symbol: the "$" is
+    // preceded by exactly the letters "US". Returns true only for that case.
+    private static bool IsUsDollarPrefix(string text, int symbolIndex, string symbol)
+    {
+        if (symbol != "$")
+            return false;
+
+        var start = symbolIndex;
+        while (start > 0 && char.IsLetter(text[start - 1]))
+            start--;
+
+        return text.AsSpan(start, symbolIndex - start)
+            .Equals("US", StringComparison.OrdinalIgnoreCase);
     }
 
     private void ProcessCurrencyColumnsForConsolidation(

--- a/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepUsDollarPrefixedSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepUsDollarPrefixedSymbolTests.cs
@@ -17,9 +17,7 @@ public class CurrencyConsolidationStepUsDollarPrefixedSymbolTests
     // (C$, A$, HK$, NZ$) — but it also drops the legitimate "US$": the "$" is preceded
     // by the letter "S" (excluded), and the standalone "USD" code is absent, so the
     // cell falls through both detection arms and the column is never labelled.
-    [Fact(
-        Skip = "GH-3118 — CurrencyConsolidationStep does not detect the \"US$\" notation as US Dollars"
-    )]
+    [Fact]
     public void UsDollarPrefixedSymbolColumnFollowedByEmptyColumn_AddsUsDollarsNote()
     {
         var html =


### PR DESCRIPTION
## Summary

- `CurrencyConsolidationStep.ContainsCurrencySymbol` dropped any `$` immediately preceded by a letter as a foreign prefixed symbol (`C$`, `A$`, `HK$`, `NZ$`). That also discarded the legitimate `US$` notation — the `$` is preceded by `S`, and the standalone `USD` code is absent — so a `US$` column was never consolidated and no currency note was emitted.
- `US$` is the standard, unambiguous way to write US Dollars in SEC filings (foreign private issuers / prospectuses), equivalent to the already-handled `$` and `USD` cells.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/CurrencyConsolidationStep.cs` — let a `$` through the letter-prefix guard when its immediately-preceding letters are exactly `US` (new `IsUsDollarPrefix` helper); other letter prefixes (`C`, `A`, `HK`, `NZ`) stay excluded.
- `tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepUsDollarPrefixedSymbolTests.cs` — removed `Skip`; the test fails on the old code and passes on the fix. All existing foreign-prefix pins remain green.

closes #3118