### PR TITLE
test(sec): pin word ending in 'us' before $ is not US Dollars

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepWordEndingInUsDollarTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepWordEndingInUsDollarTests.cs
@@ -1,0 +1,31 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class CurrencyConsolidationStepWordEndingInUsDollarTests
+{
+    private readonly CurrencyConsolidationStep _sut = new();
+    private readonly HtmlParser _parser = new();
+
+    // Contract: only the exact "US" prefix denotes US Dollars ("US$"). A longer word
+    // that merely ends in "us" before the "$" (e.g. "PLUS$") is not US Dollars — the
+    // guard must match the FULL contiguous letter run, not just the trailing two chars.
+    // Guards the US$ exception against over-matching; the GH-3118 repro only covers the
+    // exact "US$" true positive. Oracle derived from the notation contract.
+    [Fact]
+    public void WordEndingInUsBeforeDollarSymbol_IsNotMistakenForUsDollars()
+    {
+        var html =
+            @"<html><body><table>
+  <tr><td>PLUS$</td><td></td><td>100</td></tr>
+  <tr><td>PLUS$</td><td></td><td>200</td></tr>
+</table></body></html>";
+
+        var doc = _parser.ParseDocument(html);
+
+        _sut.Execute(doc);
+
+        doc.QuerySelector("table + p em").Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- The US$ exception in `CurrencyConsolidationStep` (GH-3118) detects US Dollars only when the `$` is preceded by exactly the letters `US`. This pins that a longer word merely ending in `us` before the `$` (e.g. `PLUS$`) is NOT mistaken for US Dollars — guarding that the check matches the full contiguous letter run, not just the trailing two chars.
- The GH-3118 repro only covers the exact `US$` true positive; this is the over-match guard. The test passes against the current code.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/CurrencyConsolidationStepWordEndingInUsDollarTests.cs` — new unit test asserting a `PLUS$` column produces no "All values are in US Dollars." note.