### PR TITLE
fix(mcp): render indicator-tool Close/Volume columns with invariant culture

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -220,7 +220,7 @@ public class StockPriceTools
                     {
                         var kCell = McpFormat.OrDash(k[i], "F2");
                         var dCell = McpFormat.OrDash(d[i], "F2");
-                        return $"| {records[i].Date:yyyy-MM-dd} | {records[i].Close:F2} | {kCell} | {dCell} |";
+                        return $"| {records[i].Date:yyyy-MM-dd} | {McpFormat.Invariant(records[i].Close, "F2")} | {kCell} | {dCell} |";
                     }
                 );
 
@@ -279,7 +279,7 @@ public class StockPriceTools
                     i =>
                     {
                         var atrCell = McpFormat.OrDash(atr[i], "F4");
-                        return $"| {records[i].Date:yyyy-MM-dd} | {records[i].Close:F2} | {atrCell} |";
+                        return $"| {records[i].Date:yyyy-MM-dd} | {McpFormat.Invariant(records[i].Close, "F2")} | {atrCell} |";
                     }
                 );
 
@@ -333,7 +333,7 @@ public class StockPriceTools
                     records.Count,
                     maxResults,
                     i =>
-                        $"| {records[i].Date:yyyy-MM-dd} | {records[i].Close:F2} | {records[i].Volume:N0} | {obv[i]:N0} |"
+                        $"| {records[i].Date:yyyy-MM-dd} | {McpFormat.Invariant(records[i].Close, "F2")} | {McpFormat.WholeNumber(records[i].Volume)} | {McpFormat.WholeNumber(obv[i])} |"
                 );
 
                 return result.ToString();
@@ -401,7 +401,7 @@ public class StockPriceTools
                         var lowerCell = McpFormat.OrDash(lower[i], "F2");
                         var middleCell = McpFormat.OrDash(middle[i], "F2");
                         var upperCell = McpFormat.OrDash(upper[i], "F2");
-                        return $"| {records[i].Date:yyyy-MM-dd} | {records[i].Close:F2} | {lowerCell} | {middleCell} | {upperCell} |";
+                        return $"| {records[i].Date:yyyy-MM-dd} | {McpFormat.Invariant(records[i].Close, "F2")} | {lowerCell} | {middleCell} | {upperCell} |";
                     }
                 );
 

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetAverageTrueRangeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetAverageTrueRangeCultureInvarianceTests.cs
@@ -30,9 +30,7 @@ public class StockPriceToolsGetAverageTrueRangeCultureInvarianceTests : ParadeDb
     // response and making one column disagree with the next. Same bug class as
     // GetStochasticOscillator (#3103, which enumerates this method at StockPriceTools.cs:283)
     // and GetLatestPrices (#3100).
-    [Fact(
-        Skip = "GH-3103 — GetAverageTrueRange renders the Close column with a culture-implicit specifier"
-    )]
+    [Fact]
     public async Task GetAverageTrueRange_UnderNonInvariantCulture_RendersCloseCultureInvariantly()
     {
         var stock = new CommonStock

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetBollingerBandsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetBollingerBandsCultureInvarianceTests.cs
@@ -30,9 +30,7 @@ public class StockPriceToolsGetBollingerBandsCultureInvarianceTests : ParadeDbMc
     // forking the response and making the Close column disagree with the band columns. Same bug
     // class as GetStochasticOscillator / GetAverageTrueRange / GetOnBalanceVolume (#3103, the
     // "sibling indicator tools") and GetLatestPrices (#3100).
-    [Fact(
-        Skip = "GH-3103 — GetBollingerBands renders the Close column with a culture-implicit specifier"
-    )]
+    [Fact]
     public async Task GetBollingerBands_UnderNonInvariantCulture_RendersCloseCultureInvariantly()
     {
         var stock = new CommonStock

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetOnBalanceVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetOnBalanceVolumeCultureInvarianceTests.cs
@@ -29,9 +29,7 @@ public class StockPriceToolsGetOnBalanceVolumeCultureInvarianceTests : ParadeDbM
     // (StockPriceTools.cs:337), so de-DE renders the decimal comma — forking the response by
     // host locale. Same bug class and sibling tool enumerated in GH-3103 (alongside the
     // already-pinned GetStochasticOscillator (#3104) and GetAverageTrueRange (#3108)).
-    [Fact(
-        Skip = "GH-3103 — GetOnBalanceVolume renders the Close column with a culture-implicit specifier"
-    )]
+    [Fact]
     public async Task GetOnBalanceVolume_UnderNonInvariantCulture_RendersCloseCultureInvariantly()
     {
         var stock = new CommonStock

--- a/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetStochasticOscillatorCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGetStochasticOscillatorCultureInvarianceTests.cs
@@ -29,9 +29,7 @@ public class StockPriceToolsGetStochasticOscillatorCultureInvarianceTests : Para
     // the culture-implicit :F2 specifier, so de-DE renders the decimal comma — forking the
     // response and making one column disagree with the next. Same bug class as GetLatestPrices
     // (#3100) and the already-fixed GetStockPrices (#2628).
-    [Fact(
-        Skip = "GH-3103 — GetStochasticOscillator renders the Close column with a culture-implicit specifier"
-    )]
+    [Fact]
     public async Task GetStochasticOscillator_UnderNonInvariantCulture_RendersCloseCultureInvariantly()
     {
         var stock = new CommonStock


### PR DESCRIPTION
## Summary

- `GetStochasticOscillator`, `GetAverageTrueRange`, `GetOnBalanceVolume` and `GetBollingerBands` rendered their Close column (and OBV's Volume/OBV cells) with the culture-implicit `:F2`/`:N0` specifiers, which honour the thread `CurrentCulture`. On a non-en-US host (e.g. de-DE) the Close column forked (`123,45`) while the adjacent invariant indicator cells showed `123.45` — columns disagreed within the same row and the LLM-facing markdown differed by host locale.
- Same MCP culture-fork bug class as the already-fixed `GetStockPrices`/`GetLatestPrices`; this sweep covers the four sibling indicator tools.

## Code changes

- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — route the Close cells (and OBV's Volume/OBV cells) through `McpFormat.Invariant` / `McpFormat.WholeNumber` across the four indicator tools; all numeric cells now render with invariant separators on every host locale.
- `tests/Equibles.IntegrationTests/Mcp/StockPriceToolsGet{StochasticOscillator,AverageTrueRange,OnBalanceVolume,BollingerBands}CultureInvarianceTests.cs` — removed `Skip` on the four GH-3103 repros; each fails under de-DE on the old code and passes on the fix.

closes #3103