### PR TITLE
fix(sec): reject whitespace-only SEC contact email in all SEC scraper workers

### DIFF
--- a/src/Equibles.Sec.HostedService/FormAdvScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/FormAdvScraperWorker.cs
@@ -34,7 +34,7 @@ public class FormAdvScraperWorker : BaseScraperWorker
     }
 
     protected override bool ValidateConfiguration() =>
-        ValidateSecContactEmail(_configuration, "Form ADV Scraper", treatWhitespaceAsAbsent: false);
+        ValidateSecContactEmail(_configuration, "Form ADV Scraper", treatWhitespaceAsAbsent: true);
 
     protected override Task DoWork(CancellationToken stoppingToken) =>
         RunImport<FormAdvImportService>(stoppingToken);

--- a/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
@@ -38,7 +38,7 @@ public class FtdScraperWorker : BaseScraperWorker
     }
 
     protected override bool ValidateConfiguration() =>
-        ValidateSecContactEmail(_configuration, "FTD Scraper", treatWhitespaceAsAbsent: false);
+        ValidateSecContactEmail(_configuration, "FTD Scraper", treatWhitespaceAsAbsent: true);
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {

--- a/src/Equibles.Sec.HostedService/SecScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/SecScraperWorker.cs
@@ -33,7 +33,7 @@ public class SecScraperWorker : BaseScraperWorker
         ValidateSecContactEmail(
             _configuration,
             "SEC Filing Scraper",
-            treatWhitespaceAsAbsent: false
+            treatWhitespaceAsAbsent: true
         );
 
     protected override async Task DoWork(CancellationToken stoppingToken)

--- a/src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/XbrlBackfillWorker.cs
@@ -51,7 +51,7 @@ public class XbrlBackfillWorker : BaseScraperWorker
     }
 
     protected override bool ValidateConfiguration() =>
-        ValidateSecContactEmail(_configuration, "XBRL backfill", treatWhitespaceAsAbsent: false);
+        ValidateSecContactEmail(_configuration, "XBRL backfill", treatWhitespaceAsAbsent: true);
 
     protected override async Task DoWork(CancellationToken stoppingToken)
     {

--- a/tests/Equibles.UnitTests/Sec/FormAdvScraperWorkerWhitespaceEmailTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormAdvScraperWorkerWhitespaceEmailTests.cs
@@ -1,0 +1,50 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Sec.HostedService;
+using Equibles.Sec.HostedService.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FormAdvScraperWorkerWhitespaceEmailTests
+{
+    [Fact]
+    public void ValidateConfiguration_SecContactEmailWhitespaceOnly_ReturnsFalse()
+    {
+        // Contract: a whitespace-only Sec:ContactEmail yields a User-Agent with no real
+        // contact (SEC 403-bans an unidentified source), so the gate must reject it just
+        // like an unset value — matching the FinancialFacts/Holdings workers.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { ["Sec:ContactEmail"] = "   " })
+            .Build();
+        var sut = new TestableFormAdvScraperWorker(
+            Substitute.For<ILogger<FormAdvScraperWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new FormAdvScraperOptions()),
+            config
+        );
+
+        sut.InvokeValidateConfiguration().Should().BeFalse();
+    }
+
+    private sealed class TestableFormAdvScraperWorker : FormAdvScraperWorker
+    {
+        public TestableFormAdvScraperWorker(
+            ILogger<FormAdvScraperWorker> logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            IOptions<FormAdvScraperOptions> options,
+            IConfiguration configuration
+        )
+            : base(logger, scopeFactory, errorReporter, options, configuration) { }
+
+        public bool InvokeValidateConfiguration() => ValidateConfiguration();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FtdScraperWorkerWhitespaceEmailTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdScraperWorkerWhitespaceEmailTests.cs
@@ -1,0 +1,58 @@
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Sec.HostedService;
+using Equibles.Sec.HostedService.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FtdScraperWorkerWhitespaceEmailTests
+{
+    [Fact]
+    public void ValidateConfiguration_SecContactEmailWhitespaceOnly_ReturnsFalse()
+    {
+        // Contract: a whitespace-only Sec:ContactEmail yields a User-Agent with no real
+        // contact (SEC 403-bans an unidentified source), so the gate must reject it just
+        // like an unset value — matching the FinancialFacts/Holdings workers.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { ["Sec:ContactEmail"] = "   " })
+            .Build();
+        var sut = new TestableFtdScraperWorker(
+            Substitute.For<ILogger<FtdScraperWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new FtdScraperOptions()),
+            config
+        );
+
+        sut.InvokeValidateConfiguration().Should().BeFalse();
+    }
+
+    private sealed class TestableFtdScraperWorker : FtdScraperWorker
+    {
+        public TestableFtdScraperWorker(
+            ILogger<FtdScraperWorker> logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            IOptions<FtdScraperOptions> options,
+            IConfiguration configuration
+        )
+            : base(
+                logger,
+                scopeFactory,
+                errorReporter,
+                options,
+                Options.Create(new WorkerOptions()),
+                configuration
+            ) { }
+
+        public bool InvokeValidateConfiguration() => ValidateConfiguration();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/SecScraperWorkerWhitespaceEmailTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecScraperWorkerWhitespaceEmailTests.cs
@@ -1,0 +1,46 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Sec.HostedService;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecScraperWorkerWhitespaceEmailTests
+{
+    [Fact]
+    public void ValidateConfiguration_SecContactEmailWhitespaceOnly_ReturnsFalse()
+    {
+        // Contract: a whitespace-only Sec:ContactEmail yields a User-Agent with no real
+        // contact (SEC 403-bans an unidentified source), so the gate must reject it just
+        // like an unset value — matching the FinancialFacts/Holdings workers.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { ["Sec:ContactEmail"] = "   " })
+            .Build();
+        var sut = new TestableSecScraperWorker(
+            Substitute.For<ILogger<SecScraperWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            config
+        );
+
+        sut.InvokeValidateConfiguration().Should().BeFalse();
+    }
+
+    private sealed class TestableSecScraperWorker : SecScraperWorker
+    {
+        public TestableSecScraperWorker(
+            ILogger<SecScraperWorker> logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            IConfiguration configuration
+        )
+            : base(logger, scopeFactory, errorReporter, configuration) { }
+
+        public bool InvokeValidateConfiguration() => ValidateConfiguration();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/XbrlBackfillWorkerWhitespaceEmailTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlBackfillWorkerWhitespaceEmailTests.cs
@@ -1,0 +1,58 @@
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Sec.HostedService;
+using Equibles.Sec.HostedService.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+public class XbrlBackfillWorkerWhitespaceEmailTests
+{
+    [Fact]
+    public void ValidateConfiguration_SecContactEmailWhitespaceOnly_ReturnsFalse()
+    {
+        // Contract: a whitespace-only Sec:ContactEmail yields a User-Agent with no real
+        // contact (SEC 403-bans an unidentified source), so the gate must reject it just
+        // like an unset value — matching the FinancialFacts/Holdings workers.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { ["Sec:ContactEmail"] = "   " })
+            .Build();
+        var sut = new TestableXbrlBackfillWorker(
+            Substitute.For<ILogger<XbrlBackfillWorker>>(),
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new XbrlCaptureOptions()),
+            config
+        );
+
+        sut.InvokeValidateConfiguration().Should().BeFalse();
+    }
+
+    private sealed class TestableXbrlBackfillWorker : XbrlBackfillWorker
+    {
+        public TestableXbrlBackfillWorker(
+            ILogger<XbrlBackfillWorker> logger,
+            IServiceScopeFactory scopeFactory,
+            ErrorReporter errorReporter,
+            IOptions<XbrlCaptureOptions> captureOptions,
+            IConfiguration configuration
+        )
+            : base(
+                logger,
+                scopeFactory,
+                errorReporter,
+                captureOptions,
+                Options.Create(new WorkerOptions()),
+                configuration
+            ) { }
+
+        public bool InvokeValidateConfiguration() => ValidateConfiguration();
+    }
+}


### PR DESCRIPTION
## Summary

- `SecScraperWorker`, `FtdScraperWorker`, `XbrlBackfillWorker` and `FormAdvScraperWorker` passed `treatWhitespaceAsAbsent: false` to the shared startup gate, so a whitespace-only `Sec:ContactEmail` (e.g. `"   "`) let them start and hit SEC with an unidentified User-Agent — looping into silent 403 bans — while the Holdings/financial-facts workers correctly refused to start.
- Unifies the four SEC-EDGAR-backed workers with the documented contract (whitespace-only treated as unset), matching `FinancialFactsScraperWorkerWhitespaceEmailTests`.

## Code changes

- `src/Equibles.Sec.HostedService/{SecScraperWorker,FtdScraperWorker,XbrlBackfillWorker,FormAdvScraperWorker}.cs` — pass `treatWhitespaceAsAbsent: true` to `ValidateSecContactEmail` so a whitespace-only contact email is rejected like an unset one.
- `tests/Equibles.UnitTests/Sec/{SecScraperWorker,FtdScraperWorker,XbrlBackfillWorker,FormAdvScraperWorker}WhitespaceEmailTests.cs` — four new unit tests asserting each worker's `ValidateConfiguration()` returns `false` for a whitespace-only email; each fails on the old code and passes on the fix.

closes #3135