### PR TITLE
test(media): pin GzipCompressor.Compress round-trips binary payloads

### DIFF
--- a/tests/Equibles.UnitTests/Media/GzipCompressorRoundTripTests.cs
+++ b/tests/Equibles.UnitTests/Media/GzipCompressorRoundTripTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Media.BusinessLogic;
+
+namespace Equibles.UnitTests.Media;
+
+// Lane B (coverage): GzipCompressor.Compress is otherwise unexercised. Its
+// contract is that a payload compressed here decompresses back byte-for-byte
+// (capture and replay share this codec), so pin the round-trip over a buffer
+// spanning every byte value 0-255 to guard binary fidelity against regression.
+public class GzipCompressorRoundTripTests
+{
+    [Fact]
+    public void Compress_ThenDecompress_RestoresEveryByteValue()
+    {
+        var original = new byte[256 * 4];
+        for (var i = 0; i < original.Length; i++)
+            original[i] = (byte)(i % 256);
+
+        var restored = GzipCompressor.Decompress(GzipCompressor.Compress(original));
+
+        restored.Should().Equal(original);
+    }
+}


### PR DESCRIPTION
## Summary

- `GzipCompressor.Compress` had no direct test coverage (only `Decompress` was exercised by the replay path). This pins its behavior so a future regression in the compression codec is caught.
- The two halves share a codec contract (capture compresses, replay decompresses), so the test asserts the round-trip identity rather than a brittle byte-for-byte snapshot of the compressed output.

## Code changes

- `tests/Equibles.UnitTests/Media/GzipCompressorRoundTripTests.cs` — new unit test compressing a 1 KB buffer that spans every byte value 0–255, then decompressing it, and asserting the result equals the original. Guards binary fidelity (no accidental text/encoding corruption) across the compress→decompress boundary.