### PR TITLE
ci: don't cancel in-progress runs on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,12 @@ permissions:
   contents: read
   checks: write
 
-# Cancel superseded runs on the same PR / branch so we don't burn CI minutes
-# on commits that have already been replaced.
+# Cancel superseded runs on the same PR so we don't burn CI minutes on commits
+# that have already been replaced. Pushes to main are never cancelled — each
+# merged commit gets its own completed run so the branch reliably shows status.
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,10 +9,10 @@ on:
     # Weekly scan on Monday 04:17 UTC — off-peak so we don't race CI.
     - cron: "17 4 * * 1"
 
-# Cancel superseded runs on the same PR / branch.
+# Cancel superseded runs on the same PR; let main pushes run to completion.
 concurrency:
   group: codeql-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   actions: read

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -11,10 +11,10 @@ permissions:
   contents: read
   checks: write
 
-# Cancel superseded runs on the same PR / branch.
+# Cancel superseded runs on the same PR; let main pushes run to completion.
 concurrency:
   group: functional-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   functional:


### PR DESCRIPTION
## Summary

CI on `main` has been perpetually showing a cancelled (red) status even though the build and tests pass. The cause is the concurrency config, not any test failure.

`cancel-in-progress: true` was applied to **both** PR commits and pushes to `main`, keyed on the branch ref (`ci-refs/heads/main` for main). With the current rapid merge cadence (a merged commit every 1–2 minutes), each new push to `main` cancelled the previous still-running run — which takes ~5 minutes — so **no main run ever reached completion** and the branch never displayed a green check.

Verified the underlying code is healthy: the full CI test filter passes locally on the latest `main` (`Equibles.UnitTests` 2365+ and `Equibles.IntegrationTests` 1807, 0 failures), and recent cancelled runs got through the unit suite (2366 passed, 0 failed) before being killed by a subsequent push.

## Code changes

Restrict `cancel-in-progress` to `pull_request` events in the three push-triggered workflows:

- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/functional.yml`

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

PRs still cancel superseded commits (saving CI minutes on rapid iteration); every merged commit on `main` now runs to completion, so the branch reliably reports status.