### PR TITLE
docs(guide): add how-to — browse futures positioning

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -35,6 +35,7 @@ Task-focused recipes for someone who has Equibles running.
 - [View market-wide insider trading activity](how-to-view-insider-activity.md)
 - [Browse economic indicators](how-to-browse-economic-data.md)
 - [Browse market indicators (VIX and put/call ratios)](how-to-browse-market-indicators.md)
+- [Browse futures positioning (CFTC Commitments of Traders)](how-to-browse-futures.md)
 
 ## FAQ
 

--- a/docs/guide/how-to-browse-futures.md
+++ b/docs/guide/how-to-browse-futures.md
@@ -1,0 +1,42 @@
+# Browse futures positioning (CFTC Commitments of Traders)
+
+Use the Futures section of the web portal to view CFTC Commitments of Traders (COT) data — how commercial and non-commercial traders are positioned across futures markets.
+
+## Open the Futures overview
+
+1. Click **Futures** in the top navigation, or go to `http://localhost:8080/futures`.
+
+2. Contracts are grouped into categories:
+
+   | Category | Examples |
+   |----------|----------|
+   | **Agriculture** | Corn, wheat, soybeans, livestock |
+   | **Energy** | Crude oil, natural gas, gasoline |
+   | **Metals** | Gold, silver, copper |
+   | **Equity Indices** | S&P 500, Nasdaq, Dow futures |
+   | **Interest Rates** | Treasury notes and bonds, eurodollar |
+   | **Currencies** | Euro, yen, pound, and other FX futures |
+   | **Other** | Contracts that don't fit the categories above |
+
+3. Each row shows the contract code, market name, the latest commercial net and non-commercial net positions, and the report date. Click any contract to open its detail page.
+
+## View a contract's positioning
+
+1. From the overview, click a contract row, or go directly to a URL like `http://localhost:8080/futures/<market-code>` (for example, the code shown next to the market name).
+
+2. The detail page shows:
+
+   - **Latest positioning** — open interest, commercial net, non-commercial net, and spreads from the most recent weekly report.
+   - **Net positioning chart** — commercial net and non-commercial net positions plotted over the full report history.
+   - **Reports table** — every weekly report (date, open interest, commercial long/short, non-commercial long/short, spreads, and the change in open interest) in reverse chronological order.
+
+## What these numbers mean
+
+- **Commercial** traders are hedgers — producers and users of the underlying commodity (for example, a farmer or an airline). Their net position often moves opposite to price.
+- **Non-commercial** traders are large speculators (such as managed funds). A large net-long or net-short position signals where speculative money is leaning.
+- **Open interest** is the total number of outstanding contracts; rising open interest means new money is entering the market.
+- **Spreads** count non-commercial positions held simultaneously long and short across contract months.
+
+## If the pages are empty
+
+CFTC data is scraped automatically by the worker — no API key is required. After a fresh install, give the scrapers at least an hour to begin populating. Check ingestion progress on the [status page](how-to-view-status-and-errors.md).


### PR DESCRIPTION
## Summary

- Add a user-guide how-to for the Futures section of the web portal (CFTC Commitments of Traders), covering the overview, a contract's positioning detail page, and what the numbers mean — Expand lane, guide section.
- The Futures screen (`/futures`, served by `CftcController`) was the one browse-able portal section without a matching how-to alongside Economy and Market.

## Code changes

- `docs/guide/how-to-browse-futures.md` — new how-to: browse the futures overview by category, open a contract's COT detail page (latest positioning, net-positioning chart, reports table), and interpret commercial/non-commercial/open-interest/spreads.
- `docs/guide/README.md` — add the TOC bullet for the new how-to under How-to guides.