### PR TITLE
Add explanatory intro to each stock data tab

### DIFF
--- a/src/Equibles.Web/Views/Shared/_TabIntro.cshtml
+++ b/src/Equibles.Web/Views/Shared/_TabIntro.cshtml
@@ -1,0 +1,7 @@
+@model string
+
+@* Short explanatory note at the top of a stock data tab — what the data is, where it comes from, and what it means. Always shown, including when the tab has no data. *@
+<div class="flex items-start gap-2 mb-4 text-sm text-base-content/60">
+    <icon name="information-circle" size="4" class="mt-0.5 shrink-0 text-base-content/40" />
+    <p class="max-w-3xl">@Model</p>
+</div>

--- a/src/Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml
@@ -1,6 +1,8 @@
 @using Equibles.Congress.Data.Models
 @model Equibles.Web.ViewModels.Stocks.CongressionalTradesTabViewModel
 
+<partial name="_TabIntro" model="@("Stock transactions by members of the U.S. Congress, disclosed under the STOCK Act. Lawmakers must report trades within 45 days, so the filing date can lag the trade itself.")" />
+
 @if (Model.Trades.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "building-library", Heading: "No Congressional Trades", Message: "No congressional trading data is available for this stock yet.")' />
 } else {

--- a/src/Equibles.Web/Views/Stocks/_DocumentsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_DocumentsTab.cshtml
@@ -1,6 +1,8 @@
 @using Equibles.Core.Extensions
 @model Equibles.Web.ViewModels.Stocks.DocumentsTabViewModel
 
+<partial name="_TabIntro" model="@("The company's filings as submitted to the SEC's EDGAR system — 10-K, 10-Q, 8-K, proxy statements and more — listed most recent first.")" />
+
 @if (Model.Documents.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "document-text", Heading: "No Documents Available", Message: "No SEC filings or earnings transcripts are available for this stock yet.")' />
 } else {

--- a/src/Equibles.Web/Views/Stocks/_ExemptOfferingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ExemptOfferingsTab.cshtml
@@ -1,5 +1,7 @@
 @model Equibles.Web.ViewModels.Stocks.ExemptOfferingsTabViewModel
 
+<partial name="_TabIntro" model="@("Private capital raises reported to the SEC on Form D under Regulation D, showing the offering size, amount sold, minimum investment and number of investors. Public operating companies rarely raise capital this way, so this page is often empty.")" />
+
 @if (Model.Filings.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "building-library", Heading: "No Exempt Offerings", Message: "No Form D exempt-offering notices are available for this stock yet.")' />
 } else {

--- a/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
@@ -2,6 +2,8 @@
 @using Equibles.Sec.FinancialFacts.Data.Enums
 @model Equibles.Web.ViewModels.Stocks.FinancialsTabViewModel
 
+<partial name="_TabIntro" model="@("Income-statement, balance-sheet and cash-flow figures extracted from the company's SEC filings — 10-K annual and 10-Q quarterly reports — and standardised for comparison across periods.")" />
+
 @if (!Model.HasData) {
     <partial name="_EmptyStateCard" model='(IconName: "document-text", Heading: "No Financial Data", Message: "No structured financial facts have been ingested for this stock yet.")' />
 } else {

--- a/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
@@ -1,5 +1,7 @@
 @model Equibles.Web.ViewModels.Stocks.FtdTabViewModel
 
+<partial name="_TabIntro" model="@("Fails to deliver — shares from a trade that were not delivered to the buyer by the settlement date — published by the SEC twice a month. Persistent fails can reflect settlement problems or naked short selling.")" />
+
 @if (Model.FailsToDeliver.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "exclamation-triangle", Heading: "No Fails to Deliver Data", Message: "No fails-to-deliver data is available for this stock yet.")' />
 } else {

--- a/src/Equibles.Web/Views/Stocks/_FundHoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FundHoldingsTab.cshtml
@@ -1,6 +1,8 @@
 @using System.Globalization
 @model Equibles.Web.ViewModels.Stocks.FundHoldingsTabViewModel
 
+<partial name="_TabIntro" model="@("Portfolio holdings reported by registered funds to the SEC on Form N-PORT — the individual securities a fund owns. Only mutual funds, ETFs and closed-end funds file N-PORT, so operating companies show no data.")" />
+
 @if (Model.Filing == null) {
     <partial name="_EmptyStateCard" model='(IconName: "chart-bar", Heading: "No Fund Holdings Data", Message: "No Form NPORT-P portfolio reports are available for this stock yet. Only registered investment companies — mutual funds and ETFs — file NPORT-P.")' />
 } else {

--- a/src/Equibles.Web/Views/Stocks/_FundOperationsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FundOperationsTab.cshtml
@@ -1,6 +1,8 @@
 @using Equibles.Core.Extensions
 @model Equibles.Web.ViewModels.Stocks.FundOperationsTabViewModel
 
+<partial name="_TabIntro" model="@("Operational details from a fund's annual SEC Form N-CEN — its registration type, reporting period and named service providers such as the adviser, custodian, transfer agent and auditor. Only registered investment companies — mutual funds, ETFs and closed-end funds — file N-CEN, so operating companies show no data.")" />
+
 @if (Model.Filings.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "building-library", Heading: "No Fund Operations Data", Message: "No Form N-CEN annual reports are available for this stock yet. Only registered investment companies — mutual funds, ETFs and closed-end funds — file N-CEN.")' />
 } else {

--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -38,6 +38,8 @@
 
 }
 
+<partial name="_TabIntro" model="@("Institutional ownership from SEC Form 13F filings. Investment managers with more than $100 million in U.S. equities must disclose their positions every quarter, within 45 days of quarter-end, so the holdings shown can lag the market by up to a quarter.")" />
+
 @if (Model.AvailableDates.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "building-office", Heading: "No Holdings Data", Message: "No institutional holdings data is available for this stock yet.")' />
 } else {

--- a/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
@@ -1,6 +1,8 @@
 @using Equibles.InsiderTrading.Data.Models
 @model Equibles.Web.ViewModels.Stocks.InsiderTradingTabViewModel
 
+<partial name="_TabIntro" model="@("Trades by corporate insiders — officers, directors and holders of more than 10% of the shares — disclosed to the SEC on Forms 3, 4 and 5. Form 4 must be filed within two business days of the trade.")" />
+
 @if (Model.Transactions.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "user", Heading: "No Insider Trading Data", Message: "No insider transactions are available for this stock yet.")' />
 } else {

--- a/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_PriceTab.cshtml
@@ -1,6 +1,8 @@
 @using Equibles.Yahoo.Repositories
 @model Equibles.Web.ViewModels.Stocks.PriceTabViewModel
 
+<partial name="_TabIntro" model="@("Daily open, high, low and close prices with derived technical indicators (moving averages, RSI and more). Price data syncs automatically from Yahoo Finance.")" />
+
 @if (Model.Prices.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "chart-bar", Heading: "No Price Data", Message: "No daily price data is available for this stock yet. Data syncs automatically from Yahoo Finance.")' />
 } else {

--- a/src/Equibles.Web/Views/Stocks/_ProposedSalesTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ProposedSalesTab.cshtml
@@ -1,5 +1,7 @@
 @model Equibles.Web.ViewModels.Stocks.ProposedSalesTabViewModel
 
+<partial name="_TabIntro" model="@("Notices of intent to sell restricted or control shares, filed with the SEC on Form 144 by insiders and affiliates. A Form 144 signals a planned sale — it does not confirm the shares were actually sold.")" />
+
 @if (Model.Filings.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "arrow-trending-down", Heading: "No Proposed Sales", Message: "No Form 144 proposed-sale notices are available for this stock yet.")' />
 } else {

--- a/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
@@ -1,5 +1,7 @@
 @model Equibles.Web.ViewModels.Stocks.ShortInterestTabViewModel
 
+<partial name="_TabIntro" model="@("Total shares sold short and not yet covered, reported to FINRA by broker-dealers and published twice a month (bi-monthly). Days to cover divides the short position by average daily volume; a high value (above 5) can signal short-squeeze potential.")" />
+
 @if (Model.ShortInterests.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "chart-bar", Heading: "No Short Interest Data", Message: "No short interest data is available for this stock yet.")' />
 } else {

--- a/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
@@ -1,5 +1,7 @@
 @model Equibles.Web.ViewModels.Stocks.ShortVolumeTabViewModel
 
+<partial name="_TabIntro" model="@("Daily short-sale volume published by FINRA from its trade-reporting facilities. It measures how many shares were sold short each day as a share of total volume — a daily flow, not the total outstanding short position.")" />
+
 @if (Model.ShortVolumes.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "arrow-trending-down", Heading: "No Short Volume Data", Message: "No daily short volume data is available for this stock yet.")' />
 } else {


### PR DESCRIPTION
## Summary

Each per-stock tab (Technicals, Institutional Holders, Short Volume, Short Interest, Fails to Deliver, Financials, SEC Filings, Insider Trades, Congressional Trades, Proposed Sales, Exempt Offerings, Fund Operations, Fund Holdings) now opens with a one- or two-sentence note describing what the data is, where it comes from, and what it means — for example, short interest is reported to FINRA by broker-dealers and published twice a month.

The note renders above the tab content and stays visible even when a tab has no data, so an empty page (e.g. Exempt Offerings or Fund Operations for an operating company) explains *why* it is empty rather than just showing a blank state.

## Code changes

- **`Views/Shared/_TabIntro.cshtml`** (new) — shared partial: an info-icon + muted paragraph, takes the note text as its string model.
- **`Views/Stocks/_*Tab.cshtml`** (12 files) — each renders `_TabIntro` with its data-source description, just above the existing empty-state check.