### PR TITLE
test(insider): add skipped repro for GH-3164 — InsiderFilingReprocessResult.Summary

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingReprocessResultSummaryCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingReprocessResultSummaryCultureInvarianceTests.cs
@@ -1,0 +1,67 @@
+using System.Globalization;
+using Equibles.InsiderTrading.BusinessLogic.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingReprocessResultSummaryCultureInvarianceTests
+{
+    // Adversarial Lane A. InsiderFilingReprocessResult.Summary is an
+    // operator-facing log helper: it is consumed only by
+    //   Logger.LogInformation("Insider filing reprocess cycle: {Summary}", result.Summary)
+    // in InsiderFilingReprocessWorker.
+    //
+    // The repo's established convention for log/render helpers is
+    // CultureInfo.InvariantCulture (cf. BaseScraperWorker.FormatInterval's
+    // culture-invariance pins and FactMarkdown.Value, which thread invariant
+    // through every ToString). Summary's body, however, uses plain
+    // interpolated `:N0` segments:
+    //     $"Reprocessed {Processed:N0}/{Total:N0} filings ..."
+    // which, per the C# spec, format with formatProvider=null - defaulting to
+    // thread CurrentCulture.
+    //
+    // The bug class (same one tracked across the repo's other culture pins):
+    // under a non-invariant CurrentCulture with a dot group separator (de-DE),
+    // a count of 1234 renders as "1.234" instead of the invariant "1,234".
+    // Production impact: log lines fork by host locale - "1.234 fetched" on a
+    // de-DE host vs "1,234 fetched" elsewhere - breaking grep/awk operator
+    // triage and any log-parsing pipeline that keys on the group separator.
+    //
+    // The contract / oracle (derived from the repo convention before reading
+    // the body): Summary renders its counts culture-invariantly - the group
+    // separator is always ',' regardless of host culture. de-DE is the
+    // canonical non-invariant culture used by the repo's other culture pins.
+    [Fact(
+        Skip = "GH-3164 — Summary uses :N0 (CurrentCulture); forks log group separator by host locale"
+    )]
+    public void Summary_LargeCountsUnderNonInvariantCulture_RendersWithInvariantGroupSeparator()
+    {
+        var result = new InsiderFilingReprocessResult
+        {
+            Processed = 1234,
+            Total = 5678,
+            Fetched = 9012,
+            Reclassified = 3456,
+            Repaired = 7890,
+            Failed = 2345,
+        };
+
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            result
+                .Summary.Should()
+                .Be(
+                    "Reprocessed 1,234/5,678 filings (9,012 fetched, 3,456 rows reclassified, "
+                        + "7,890 prices repaired, 2,345 failed).",
+                    "log helpers in this repo are culture-invariant (cf. BaseScraperWorker.FormatInterval, "
+                        + "FactMarkdown.Value); a non-invariant group separator forks operator log output by host locale"
+                );
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial unit test for `InsiderFilingReprocessResult.Summary` that discovered a culture-forking defect: the summary string formats its counts with `:N0` (which defaults to thread `CurrentCulture`), so on a `de-DE` host a count of `1234` logs as `1.234` instead of the invariant `1,234`. This forks operator log output by host locale — skipped, see GH-3164.
- The expected behavior follows the repo's established log-helper convention (culture-invariant, cf. `BaseScraperWorker.FormatInterval`, `FactMarkdown.Value`).

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingReprocessResultSummaryCultureInvarianceTests.cs` — new `[Fact(Skip = "GH-3164 …")]` regression test. Pins the culture-invariant group separator under `de-DE`; un-skip it when GH-3164 is fixed. No production code changed.