### PR TITLE
refactor(data): centralize LIKE escape character in LikePattern.EscapeChar

### DIFF
--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -21,10 +21,10 @@ public class CommonStockRepository : BaseRepository<CommonStock>
                 // rather than behaving as a wildcard.
                 var pattern = LikePattern.Contains(word);
                 query = query.Where(c =>
-                    EF.Functions.ILike(c.Ticker, pattern, "\\")
-                    || EF.Functions.ILike(c.Name, pattern, "\\")
-                    || EF.Functions.ILike(c.Description, pattern, "\\")
-                    || EF.Functions.ILike(c.Industry.Name, pattern, "\\")
+                    EF.Functions.ILike(c.Ticker, pattern, LikePattern.EscapeChar)
+                    || EF.Functions.ILike(c.Name, pattern, LikePattern.EscapeChar)
+                    || EF.Functions.ILike(c.Description, pattern, LikePattern.EscapeChar)
+                    || EF.Functions.ILike(c.Industry.Name, pattern, LikePattern.EscapeChar)
                 );
             }
         }

--- a/src/Equibles.Congress.Repositories/CongressMemberRepository.cs
+++ b/src/Equibles.Congress.Repositories/CongressMemberRepository.cs
@@ -18,6 +18,6 @@ public class CongressMemberRepository : BaseRepository<CongressMember>
     {
         // "Name contains the term"; escape so '%' / '_' / '\' in the query match literally.
         var pattern = LikePattern.Contains(search);
-        return GetAll().Where(m => EF.Functions.ILike(m.Name, pattern, "\\"));
+        return GetAll().Where(m => EF.Functions.ILike(m.Name, pattern, LikePattern.EscapeChar));
     }
 }

--- a/src/Equibles.Data/LikePattern.cs
+++ b/src/Equibles.Data/LikePattern.cs
@@ -2,15 +2,19 @@ namespace Equibles.Data;
 
 public static class LikePattern
 {
+    // The escape character baked into patterns by Escape/Contains; pass it as the
+    // EF.Functions.ILike escape argument so '\' '%' '_' match literally.
+    public const string EscapeChar = "\\";
+
     // Escapes LIKE metacharacters ('\' '%' '_') so user input matches literally rather
-    // than as wildcards. Use with EF.Functions.ILike(column, pattern, "\\").
+    // than as wildcards. Use with EF.Functions.ILike(column, pattern, LikePattern.EscapeChar).
     public static string Escape(string text)
     {
         return text.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
     }
 
     // Escapes LIKE metacharacters and wraps in % for a contains match.
-    // Use with EF.Functions.ILike(column, pattern, "\\").
+    // Use with EF.Functions.ILike(column, pattern, LikePattern.EscapeChar).
     public static string Contains(string text)
     {
         return $"%{Escape(text)}%";

--- a/src/Equibles.Errors.Repositories/ErrorRepository.cs
+++ b/src/Equibles.Errors.Repositories/ErrorRepository.cs
@@ -22,8 +22,8 @@ public class ErrorRepository : BaseRepository<Error>
         var pattern = LikePattern.Contains(search);
         return GetAll()
             .Where(e =>
-                EF.Functions.ILike(e.Context, pattern, "\\")
-                || EF.Functions.ILike(e.Message, pattern, "\\")
+                EF.Functions.ILike(e.Context, pattern, LikePattern.EscapeChar)
+                || EF.Functions.ILike(e.Message, pattern, LikePattern.EscapeChar)
             );
     }
 

--- a/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs
@@ -23,7 +23,7 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
     {
         // "Name contains the term"; escape so '%' / '_' / '\' match literally, matching SearchNameOrCik.
         var pattern = LikePattern.Contains(search);
-        return GetAll().Where(h => EF.Functions.ILike(h.Name, pattern, "\\"));
+        return GetAll().Where(h => EF.Functions.ILike(h.Name, pattern, LikePattern.EscapeChar));
     }
 
     // Typeahead variant: matches a CIK prefix as well as a name substring so the
@@ -37,8 +37,8 @@ public class InstitutionalHolderRepository : BaseRepository<InstitutionalHolder>
         var cikPrefix = $"{escaped}%";
         return GetAll()
             .Where(h =>
-                EF.Functions.ILike(h.Name, namePattern, "\\")
-                || EF.Functions.ILike(h.Cik, cikPrefix, "\\")
+                EF.Functions.ILike(h.Name, namePattern, LikePattern.EscapeChar)
+                || EF.Functions.ILike(h.Cik, cikPrefix, LikePattern.EscapeChar)
             );
     }
 

--- a/src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs
+++ b/src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs
@@ -27,7 +27,7 @@ public class InsiderOwnerRepository : BaseRepository<InsiderOwner>
         {
             // A fresh local per iteration keeps the closure capture correct.
             var pattern = LikePattern.Contains(token);
-            query = query.Where(o => EF.Functions.ILike(o.Name, pattern, "\\"));
+            query = query.Where(o => EF.Functions.ILike(o.Name, pattern, LikePattern.EscapeChar));
         }
 
         return query;

--- a/src/Equibles.Sec.Repositories/FormAdvAdviserRepository.cs
+++ b/src/Equibles.Sec.Repositories/FormAdvAdviserRepository.cs
@@ -28,8 +28,8 @@ public class FormAdvAdviserRepository : BaseRepository<FormAdvAdviser>
         var pattern = LikePattern.Contains(term.Trim());
         return GetAll()
             .Where(a =>
-                EF.Functions.ILike(a.LegalName, pattern, "\\")
-                || EF.Functions.ILike(a.PrimaryBusinessName, pattern, "\\")
+                EF.Functions.ILike(a.LegalName, pattern, LikePattern.EscapeChar)
+                || EF.Functions.ILike(a.PrimaryBusinessName, pattern, LikePattern.EscapeChar)
             )
             // Coalesce so advisers that did not report assets sort last rather than first
             // (Postgres orders NULL highest under a plain DESC).

--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -99,7 +99,9 @@ public class InstitutionsController : BaseController
         {
             // "City contains"; escape so '%' / '_' / '\' in the city term match literally.
             var cityPattern = LikePattern.Contains(city.Trim());
-            holders = holders.Where(h => EF.Functions.ILike(h.City, cityPattern, "\\"));
+            holders = holders.Where(h =>
+                EF.Functions.ILike(h.City, cityPattern, LikePattern.EscapeChar)
+            );
         }
 
         var joined = holders.GroupJoin(


### PR DESCRIPTION
## Summary

- The LIKE escape character `\` was hand-repeated as the magic string literal `"\\"` across 14 `EF.Functions.ILike(column, pattern, "\\")` call sites in 8 files.
- Named it once as `public const string EscapeChar = "\\"` on the existing `LikePattern` class — the class that already builds the search patterns via `Escape`/`Contains` — so the escape argument and pattern construction live together.
- Behavior-preserving: a `const string` inlines to the identical literal at every call site, so EF Core emits byte-identical SQL. Build, lint (csharpier), and the full unit (2373) + integration (1808) suites pass, including every search wildcard-escaping test.

## Code changes

- `src/Equibles.Data/LikePattern.cs` — add `EscapeChar` constant; update the two doc comments to reference it.
- `src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs` — replace 4 literals.
- `src/Equibles.Holdings.Repositories/InstitutionalHolderRepository.cs` — replace 3 literals.
- `src/Equibles.Sec.Repositories/FormAdvAdviserRepository.cs` — replace 2 literals.
- `src/Equibles.Errors.Repositories/ErrorRepository.cs` — replace 2 literals.
- `src/Equibles.InsiderTrading.Repositories/InsiderOwnerRepository.cs` — replace 1 literal.
- `src/Equibles.Congress.Repositories/CongressMemberRepository.cs` — replace 1 literal.
- `src/Equibles.Web/Controllers/InstitutionsController.cs` — replace 1 literal.