### PR TITLE
test(web): add skipped repro for GH-3171 — SignedFormatting.ToStringWithSign locale fork

### DIFF
--- a/tests/Equibles.UnitTests/Web/SignedFormattingToStringWithSignCultureTests.cs
+++ b/tests/Equibles.UnitTests/Web/SignedFormattingToStringWithSignCultureTests.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class SignedFormattingToStringWithSignCultureTests
+{
+    // Contract: numeric output across Equibles.Web is invariant-formatted (every
+    // sibling formatter — CompactNumberTagHelper, CsvExportService, the export
+    // controllers — passes CultureInfo.InvariantCulture). A value rendered through
+    // ToStringWithSign in a view must therefore use '.' as the decimal separator and
+    // ',' as the grouping separator regardless of the host's thread culture, so the
+    // figure reads the same next to its invariant-formatted neighbours.
+    [Fact(Skip = "GH-3171 — ToStringWithSign forks number formatting by host locale")]
+    public void ToStringWithSign_UnderCommaDecimalCulture_UsesInvariantSeparators()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            (1234.5).ToStringWithSign("N2").Should().Be("+1,234.50");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped regression test capturing a locale-forking defect in `SignedFormatting.ToStringWithSign` — it renders numbers with the host thread culture instead of invariant, so on a comma-decimal host (e.g. de-DE) a view emits `+1.234,50` while every sibling formatter in `Equibles.Web` emits `1,234.50`. Tracked in GH-3171.
- No production code changed — the test ships `[Skip]` until the fix lands.

## Code changes

- `tests/Equibles.UnitTests/Web/SignedFormattingToStringWithSignCultureTests.cs` — new unit test asserting `(1234.5).ToStringWithSign("N2")` yields invariant separators (`+1,234.50`) under de-DE culture. Marked `[Fact(Skip = "GH-3171 …")]`; un-skip as part of the production fix (pass `CultureInfo.InvariantCulture` instead of `null`).