### PR TITLE
docs(technical/modules): correct Equibles.Messaging — no EF outbox

### DIFF
--- a/docs/technical/modules.md
+++ b/docs/technical/modules.md
@@ -27,7 +27,7 @@ These do not own a financial-domain dataset; they support every other module.
 | `Equibles.Errors.*` | `Error` entity + `ErrorManager` + `ErrorReporter` — captures scraper/MCP/HostedService failures for the Status dashboard. |
 | `Equibles.Media.*` | `File` storage abstraction for raw documents (PDFs, HTML, ZIPs). |
 | `Equibles.Search` + `Equibles.Search.Abstractions` | `ISearchProvider` contract + assembly-scoped discovery via `AddEquiblesSearch()`. Each domain module that wants to participate ships a provider class. |
-| `Equibles.Messaging` | MassTransit configuration (Postgres SQL transport + EF outbox). |
+| `Equibles.Messaging` | MassTransit configuration on the Postgres SQL transport; OSS ships no transactional outbox — events publish directly and consumers are idempotent. |
 | `Equibles.Plugins` | Optional plugin assembly loader called as the very first startup step in every host. |
 
 ## Module nuances


### PR DESCRIPTION
## Summary

- Fix an incorrect messaging description in the modules doc — Maintain lane, technical section.
- The cross-cutting-modules table said `Equibles.Messaging` is "Postgres SQL transport + EF outbox". OSS ships no transactional outbox (the EF model snapshot has no outbox tables; events publish directly via `IPublishEndpoint`). Same correction as the recent hosts-doc fix.

## Code changes

- `docs/technical/modules.md` — drop the false "+ EF outbox" claim from the `Equibles.Messaging` row; state the actual OSS behaviour (Postgres SQL transport, direct publish, idempotent consumers).