### PR TITLE
test(sec): pin XbrlValueParser.ParseDecimals preserves negative decimals

### DIFF
--- a/tests/Equibles.UnitTests/Sec/XbrlValueParserParseDecimalsNegativeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlValueParserParseDecimalsNegativeTests.cs
@@ -1,0 +1,19 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+public class XbrlValueParserParseDecimalsNegativeTests
+{
+    // XBRL allows a negative @decimals (e.g. "-3" = reported accurate to the nearest
+    // thousand). The sign carries meaning, so the parser must preserve it rather than
+    // reject or absolutise it the way a "decimal places must be >= 0" assumption would.
+    [Fact]
+    public void ParseDecimals_NegativeIntegerDecimals_PreservesSign()
+    {
+        var result = XbrlValueParser.ParseDecimals("-3");
+
+        result.Should().Be(-3);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test pinning that `XbrlValueParser.ParseDecimals` preserves a negative `@decimals` value (e.g. `"-3"` → `-3`), the XBRL convention for values reported accurate to the nearest power of ten above the unit (thousands, millions).
- `XbrlValueParser` is the shared parsing primitive used by both `StandaloneXbrlParser` and `InlineXbrlParser`; it had no direct unit coverage. This guards the primitive against a refactor that assumes precision must be non-negative and would strip or absolutise the sign.

## Code changes

- `tests/Equibles.UnitTests/Sec/XbrlValueParserParseDecimalsNegativeTests.cs` — new test `ParseDecimals_NegativeIntegerDecimals_PreservesSign` asserting `ParseDecimals("-3")` returns `-3`.