### PR TITLE
docs(technical/web-portal): refresh current stock-tab list

### DIFF
--- a/docs/technical/web-portal.md
+++ b/docs/technical/web-portal.md
@@ -9,7 +9,7 @@ Most user-facing data lives under `~/Stocks/{ticker}/{tab}`. The tab pattern is 
 The trio:
 
 - **Controller action** in [`StocksController`](../../src/Equibles.Web/Controllers/StocksController.cs) — one action per tab.
-- Current tabs: `Price`, `Holdings`, `ShortVolume`, `ShortInterest`, `Ftd`, `Documents`, `InsiderTrading`, `CongressionalTrades`, `Financials`.
+- Current tabs: `Price`, `Holdings`, `ShortVolume`, `ShortInterest`, `Ftd`, `Financials`, `Documents`, `InsiderTrading`, `ProposedSales`, `ExemptOfferings`, `FundOperations`, `FundHoldings`, `CongressionalTrades`.
 - Each action resolves the ticker, calls the matching `StockTabService.LoadXxxTab(stock, ...)`, stashes the result in `ViewData["TabViewModel"]`, and returns the shared `Show.cshtml` view.
 - **Service method** on [`StockTabService`](../../src/Equibles.Web/Services/StockTabService.cs) — `Task<XxxTabViewModel> LoadXxxTab(CommonStock stock, …)`.
 - The service is the only place that talks to repositories for tab data; all query composition lives here.


### PR DESCRIPTION
## Summary

- Fix a stale tab list in the web-portal doc — Maintain lane, technical section.
- The "Current tabs" line listed nine tabs; `StocksController` now has thirteen actions. Added the four missing ones (`ProposedSales`, `ExemptOfferings`, `FundOperations`, `FundHoldings`) in controller source order.

## Code changes

- `docs/technical/web-portal.md` — complete the current-tabs list to match `StocksController`'s per-tab actions.