### PR TITLE
docs(technical/modules): add SEC fund and Form D filing entities

### DIFF
--- a/docs/technical/modules.md
+++ b/docs/technical/modules.md
@@ -6,7 +6,7 @@ Index of the financial-domain modules in `src/`. Each row is one logical domain;
 
 | Module | Source | Key entities (`*.Data`) | Scraper (`*.HostedService`) | MCP tools (`*.Mcp`) |
 |---|---|---|---|---|
-| **SEC** ([`Equibles.Sec.*`](../../src/Equibles.Sec.Data)) | SEC EDGAR | `Document` (10-K / 10-Q / 8-K + Form 3/4), `FailToDeliver`, `Chunks/*` | `SecScraperWorker`, `DocumentProcessorWorker`, `FtdScraperWorker` | `Equibles.Sec.Mcp` |
+| **SEC** ([`Equibles.Sec.*`](../../src/Equibles.Sec.Data)) | SEC EDGAR | `Document` (10-K / 10-Q / 8-K + Form 3/4), `FailToDeliver`, `Chunks/*`, `FormDFiling` (Reg D exempt offerings), `NportFiling` (fund holdings), `NCenFiling` (fund operations) | `SecScraperWorker`, `DocumentProcessorWorker`, `FtdScraperWorker` | `Equibles.Sec.Mcp` |
 | **SEC Financial Facts** ([`Equibles.Sec.FinancialFacts.*`](../../src/Equibles.Sec.FinancialFacts.Data)) | SEC EDGAR XBRL | `FinancialFact`, `FinancialConcept`, `FinancialFactDimension` | `FinancialFactsScraperWorker` | `Equibles.Sec.FinancialFacts.Mcp` |
 | **Holdings** ([`Equibles.Holdings.*`](../../src/Equibles.Holdings.Data)) | SEC 13F-HR | `InstitutionalHolder`, `InstitutionalHolding`, `ProcessedDataSet`, `ProcessedFiling`, `HoldingManagerEntry` | `HoldingsScraperWorker` (bulk), `Holdings13FRealtimeWorker` (per-filing) | `Equibles.Holdings.Mcp` |
 | **Insider Trading** ([`Equibles.InsiderTrading.*`](../../src/Equibles.InsiderTrading.Data)) | SEC Form 3 / 4 | `InsiderOwner`, `InsiderTransaction` (with `TransactionCode`, `AcquiredDisposed`, `OwnershipNature` enums) | piggy-backs on SEC — `InsiderTradingFilingProcessor` runs inside `DocumentProcessorWorker` (no scraper project of its own) | `Equibles.InsiderTrading.Mcp` |


### PR DESCRIPTION
## Summary

- List the SEC module's newer filing entities — Maintain lane (missing doc for a data dimension), technical section.
- The SEC row's "Key entities" omitted `FormDFiling`, `NportFiling`, and `NCenFiling` — real entities in `Equibles.Sec.Data/Models` backing the portal's Exempt Offerings, Fund Holdings, and Fund Operations tabs.

## Code changes

- `docs/technical/modules.md` — add `FormDFiling` (Reg D exempt offerings), `NportFiling` (fund holdings), `NCenFiling` (fund operations) to the SEC module's key-entities cell.