### PR TITLE
test(sec): add skipped repro for GH-3182 — XbrlValueParser.ParseDecimals

### DIFF
--- a/tests/Equibles.UnitTests/Sec/XbrlValueParserParseDecimalsArabicCultureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlValueParserParseDecimalsArabicCultureTests.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class XbrlValueParserParseDecimalsArabicCultureTests
+{
+    // The XBRL @decimals attribute is an xs:integer (or "INF") per the XBRL 2.1 spec;
+    // its value is an ASCII integer that must parse identically on any host. A negative
+    // value carries meaning ("-6" = reported accurate to the nearest million), so the
+    // parser must return -6 regardless of the host's CurrentCulture.
+    //
+    // ParseDecimals reaches the value through int.TryParse(string, out int) — the
+    // overload that matches the leading sign against NumberFormatInfo.CurrentInfo.
+    // NegativeSign rather than the ASCII hyphen. Under Arabic cultures (ar-SA's
+    // NegativeSign is U+061C) the ASCII "-" no longer matches, so "-6" fails to parse
+    // and the method returns null, silently dropping the rounding-scale metadata for a
+    // valid filing. Every other numeric parse in the codebase pins
+    // CultureInfo.InvariantCulture; this one does not.
+    [Fact(
+        Skip = "GH-3182 — ParseDecimals uses the culture-sensitive int.TryParse overload, so a negative @decimals returns null on non-invariant-culture hosts"
+    )]
+    public void ParseDecimals_NegativeValueUnderArabicCulture_PreservesTheInteger()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+
+            var result = XbrlValueParser.ParseDecimals("-6");
+
+            result.Should().Be(-6);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a skipped regression test reproducing GH-3182: `XbrlValueParser.ParseDecimals` reads the XBRL `@decimals` attribute with the culture-sensitive `int.TryParse(string, out int)` overload, so a negative value (`"-6"`) fails to parse on hosts whose `CurrentCulture` has a non-hyphen negative sign (every Arabic culture, e.g. `ar-SA` where `NegativeSign` is U+061C), returning `null` and silently dropping the rounding-scale metadata.
- The existing pin #3177 asserts `ParseDecimals("-3") == -3` but runs under the invariant test culture, so it never exercises this fork. This test attacks the host-culture axis under `ar-SA` and fails until the parser pins `CultureInfo.InvariantCulture` like every other numeric parse in the codebase.

## Code changes

- `tests/Equibles.UnitTests/Sec/XbrlValueParserParseDecimalsArabicCultureTests.cs` — new unit test, marked `[Fact(Skip)]` (skipped — see GH-3182). Sets the thread culture to `ar-SA`, calls `ParseDecimals("-6")`, and asserts `-6`. Un-skip when the parser is fixed.
- No production code changed.