### PR TITLE
test(sec): pin XbrlValueParser.StripPrefix returns null for empty local name

### DIFF
--- a/tests/Equibles.UnitTests/Sec/XbrlValueParserStripPrefixEmptyLocalNameTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlValueParserStripPrefixEmptyLocalNameTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+public class XbrlValueParserStripPrefixEmptyLocalNameTests
+{
+    // A measure QName carrying a prefix but no local name (e.g. "iso4217:") is
+    // unresolvable, so the contract promises null rather than an empty string.
+    // Returning "" here would let a blank unit flow into a parsed fact instead
+    // of the fact being dropped.
+    [Fact]
+    public void StripPrefix_PrefixWithEmptyLocalName_ReturnsNull()
+    {
+        var result = XbrlValueParser.StripPrefix("iso4217:");
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test pinning `XbrlValueParser.StripPrefix` to return `null` (not an empty string) for a measure QName that carries a prefix but no local name, e.g. `iso4217:`.
- This behaviour gates XBRL unit/measure resolution: returning `""` would let a blank unit flow into a parsed fact instead of the fact being dropped. The method previously had no direct test.

## Code changes

- `tests/Equibles.UnitTests/Sec/XbrlValueParserStripPrefixEmptyLocalNameTests.cs` — new test asserting `StripPrefix("iso4217:")` is `null`.