### PR TITLE
test(mcp): pin McpFormat.OrDash invariant-culture formatting under host locale

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/McpFormatOrDashCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpFormatOrDashCultureInvarianceTests.cs
@@ -1,0 +1,37 @@
+using System.Globalization;
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class McpFormatOrDashCultureInvarianceTests
+{
+    // Adversarial Lane A. Contract (from the XML doc on McpFormat.OrDash and the
+    // repo-wide MCP rule asserted by McpFormat's siblings): a non-null value MUST
+    // render with InvariantCulture separators — '.' decimal, ',' thousands —
+    // regardless of the host's thread CurrentCulture, so LLM-facing markdown does
+    // not fork the separators by deploy locale. de-DE is the canonical hostile
+    // locale used across the repo's culture pins: it swaps to '.' thousands and
+    // ',' decimal, so a leak would render 1,234,567.5 as "1.234.567,5".
+    [Fact]
+    public void OrDash_NonNullValueUnderNonInvariantCulture_FormatsWithInvariantSeparators()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var result = McpFormat.OrDash<decimal>(1_234_567.5m, "N1");
+
+            result
+                .Should()
+                .Be(
+                    "1,234,567.5",
+                    "McpFormat.OrDash passes CultureInfo.InvariantCulture so MCP markdown renders the same on every host locale; a non-invariant separator forks LLM-consumed output by deploy locale"
+                );
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the InvariantCulture guarantee on `McpFormat.OrDash` — the helper that keeps MCP markdown number formatting from forking by host locale. This branch of the helper was previously unpinned at the unit level (its non-null formatting path was only exercised indirectly by integration tests).
- Adversarially derived from the helper's contract: under a hostile host culture (de-DE, which swaps to `.` thousands / `,` decimal) the output must still use invariant separators. The test passes, confirming the helper honours its contract.

## Code changes

- `tests/Equibles.UnitTests/Mcp/McpFormatOrDashCultureInvarianceTests.cs` — new unit test forcing thread `CurrentCulture` to de-DE and asserting `OrDash(1_234_567.5m, "N1")` renders as `1,234,567.5`, guarding against a locale-dependent separator regression in LLM-facing output.