### PR TITLE
test(sec): pin CsvRecordReader.Read lone-CR record terminator

### DIFF
--- a/tests/Equibles.UnitTests/Sec/CsvRecordReaderLoneCarriageReturnTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CsvRecordReaderLoneCarriageReturnTests.cs
@@ -1,0 +1,26 @@
+using Equibles.Integrations.Sec.FormAdv;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins the lone-CR record terminator the tokenizer documents but no existing test exercises:
+/// "Swallow the LF of a CRLF pair; a lone CR also ends the record." The existing pins cover LF
+/// and CRLF endings only, so the false arm of the CRLF look-ahead (a '\r' NOT followed by '\n',
+/// i.e. classic-Mac / mixed line endings) is unproven. Oracle derived from the documented
+/// contract before reading the switch body: each lone '\r' must close the current record exactly
+/// as '\n' does, yielding one record per line with no spurious empty trailing record. A
+/// regression that dropped the '\r' case — letting carriage returns fall through to the default
+/// arm and append into the field — would collapse this into a single record and fail loudly.
+/// </summary>
+public class CsvRecordReaderLoneCarriageReturnTests
+{
+    [Fact]
+    public void Read_LoneCarriageReturnLineEndings_SplitsOneRecordPerLine()
+    {
+        var records = CsvRecordReader.Read(new StringReader("a,b\rc,d\r")).ToList();
+
+        records.Should().HaveCount(2);
+        records[0].Should().Equal("a", "b");
+        records[1].Should().Equal("c", "d");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one adversarial unit test pinning the lone carriage-return (`\r`) record terminator that `CsvRecordReader.Read` documents — "a lone CR also ends the record" — but no existing test exercised.
- Existing pins cover LF and CRLF endings only, leaving the false arm of the CRLF look-ahead (a `\r` not followed by `\n`, i.e. classic-Mac / mixed line endings) unproven. The test confirms each lone `\r` closes the record exactly as `\n` does, with no spurious empty trailing record.

## Code changes

- `tests/Equibles.UnitTests/Sec/CsvRecordReaderLoneCarriageReturnTests.cs` — new test `Read_LoneCarriageReturnLineEndings_SplitsOneRecordPerLine`: feeds `"a,b\rc,d\r"` and asserts two records `[a,b]` and `[c,d]`. A regression that dropped the `\r` case (letting carriage returns append into the field) would collapse this to a single record and fail loudly.

No production code changed.