### PR TITLE
test(mcp): pin McpLimit.Clamp clamps int.MinValue cap to zero

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/McpLimitClampNegativeCapTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpLimitClampNegativeCapTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class McpLimitClampNegativeCapTests
+{
+    // Contract: McpLimit.Clamp exists so a negative result cap never reaches
+    // .Take(...) as a negative SQL LIMIT (PostgreSQL rejects it as an internal
+    // error). The documented promise is that a non-positive cap yields zero
+    // rows, i.e. the clamp returns a non-negative value — 0 for any negative
+    // input. int.MinValue is the extreme boundary: it must still clamp to 0,
+    // not overflow or pass a negative value through.
+    [Fact]
+    public void Clamp_IntMinValue_ReturnsZeroNotNegative()
+    {
+        var result = McpLimit.Clamp(int.MinValue);
+
+        result.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit test pinning that `McpLimit.Clamp` returns a non-negative cap, the guarantee MCP tools rely on to keep a negative result cap from reaching `.Take(...)` as a negative SQL LIMIT (which PostgreSQL rejects as an internal error).
- `McpLimit.Clamp` had no test coverage; this pins the extreme boundary so a future rewrite that drops the clamp surfaces here.

## Code changes

- `tests/Equibles.UnitTests/Mcp/McpLimitClampNegativeCapTests.cs` — new test asserting `Clamp(int.MinValue)` returns `0`, exercising the most adversarial negative input the clamp must absorb.