### PR TITLE
refactor(mcp): render whole numbers via McpFormat.WholeNumber in CFTC and insider tools

### DIFF
--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Globalization;
 using Equibles.Cftc.Data.Models;
 using Equibles.Cftc.Repositories;
 using Equibles.Core.Extensions;
@@ -157,17 +156,11 @@ public class CftcTools
                     var oiStr = McpFormat.OrDash(report?.OpenInterest, "N0");
                     var commNet =
                         report != null
-                            ? (report.CommLong - report.CommShort).ToString(
-                                "N0",
-                                CultureInfo.InvariantCulture
-                            )
+                            ? McpFormat.WholeNumber(report.CommLong - report.CommShort)
                             : "—";
                     var nonCommNet =
                         report != null
-                            ? (report.NonCommLong - report.NonCommShort).ToString(
-                                "N0",
-                                CultureInfo.InvariantCulture
-                            )
+                            ? McpFormat.WholeNumber(report.NonCommLong - report.NonCommShort)
                             : "—";
 
                     result.AppendLine(

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -146,12 +146,7 @@ public class InsiderTradingTools
                 {
                     var role = GetRole(t.InsiderOwner);
                     var lastType = t.TransactionCode.ToString();
-                    // Format with InvariantCulture so the MCP markdown does not fork the
-                    // separators by host locale (e.g. de-DE would render 7.654.321).
-                    var sharesOwned = t.SharesOwnedAfter.ToString(
-                        "N0",
-                        CultureInfo.InvariantCulture
-                    );
+                    var sharesOwned = McpFormat.WholeNumber(t.SharesOwnedAfter);
                     result.AppendLine(
                         $"| {t.InsiderOwner.Name} | {role} | {sharesOwned} | {lastType} | {t.TransactionDate:yyyy-MM-dd} |"
                     );


### PR DESCRIPTION
## Summary

- Three MCP tool methods hand-rolled `value.ToString("N0", CultureInfo.InvariantCulture)` for whole-number rendering while the rest of the same files already used the shared `McpFormat.WholeNumber` helper that does exactly that. This routes them through the one audited helper, so invariant-culture whole-number formatting is consistent across the MCP tools.
- Behavior-preserving: `McpFormat.WholeNumber<T>` is defined as `value.ToString("N0", CultureInfo.InvariantCulture)`, all three values are `long`, and the surrounding `report != null ? … : "—"` ternaries and placeholders are untouched. The existing CFTC and insider culture-invariance integration tests pass unchanged.

## Code changes

- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs` — replace two hand-rolled invariant `N0` formats (Comm Net / Non-Comm Net) with `McpFormat.WholeNumber`; drop the now-unused `System.Globalization` import.
- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — replace the hand-rolled invariant `N0` format for shares-owned with `McpFormat.WholeNumber`; remove the redundant comment whose reasoning already lives in the helper.