### PR TITLE
test(data): pin LikePattern.Contains escapes user wildcards but keeps wrapping wildcards

### DIFF
--- a/tests/Equibles.UnitTests/Data/LikePatternContainsTests.cs
+++ b/tests/Equibles.UnitTests/Data/LikePatternContainsTests.cs
@@ -1,0 +1,24 @@
+using Equibles.Data;
+
+namespace Equibles.UnitTests.Data;
+
+public class LikePatternContainsTests
+{
+    // Adversarial Lane A. LikePattern.Contains is the LIKE-injection guard behind
+    // every typeahead search in the app (CommonStockRepository, InsiderOwnerRepository,
+    // InstitutionalHolderRepository, CongressMemberRepository, FormAdvAdviserRepository,
+    // ErrorRepository, InstitutionsController, …). Its contract: "escapes LIKE
+    // metacharacters and wraps in % for a contains match." The load-bearing security
+    // property is that a '%' the USER typed must come back escaped ("\%" — a literal
+    // percent), while only the two wrapping '%' stay live wildcards. If escaping were
+    // dropped or applied after the wrap, "50%" would yield "%50%%": the middle '%'
+    // becomes a wildcard and the query matches every row — a typeahead that leaks the
+    // whole table. The single assertion pins exactly that distinction.
+    [Fact]
+    public void Contains_InputWithUserPercent_EscapesUserPercentButKeepsWrappingWildcards()
+    {
+        var result = LikePattern.Contains("50%");
+
+        result.Should().Be("%50\\%%");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a focused unit test pinning `LikePattern.Contains`, the LIKE-injection guard behind every typeahead search (CommonStock, InsiderOwner, InstitutionalHolder, CongressMember, FormAdvAdviser, Error repositories, and the Institutions controller). It had no direct test — the only existing LIKE test pins the older private `InstitutionalHolderRepository.EscapeLikePattern`.
- The test locks the load-bearing security property: a `%` the user typed comes back escaped (`\%`, a literal percent) while only the two wrapping `%` stay live wildcards, so a search for `50%` cannot degrade into a match-everything query.

## Code changes

- `tests/Equibles.UnitTests/Data/LikePatternContainsTests.cs` — new test: `Contains("50%")` must equal `%50\%%`. Passing, confirming the current behavior is correct.