### PR TITLE
test(mcp): pin McpFormat.WholeNumber invariant thousands separators under de-DE

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/McpFormatWholeNumberCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpFormatWholeNumberCultureInvarianceTests.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class McpFormatWholeNumberCultureInvarianceTests
+{
+    // Adversarial Lane A. Contract (from the XML doc on McpFormat.WholeNumber): a whole
+    // number MUST render with InvariantCulture grouping — ',' thousands separator —
+    // regardless of the host's thread CurrentCulture, so LLM-facing markdown does not fork
+    // the separators by deploy locale. de-DE is the canonical hostile locale used across the
+    // repo's culture pins: it swaps the group separator to '.', so a leak would render
+    // 1,234,567 as "1.234.567" — the exact MCP culture-forking regression this guards.
+    [Fact]
+    public void WholeNumber_UnderNonInvariantCulture_FormatsWithInvariantThousandsSeparators()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var result = McpFormat.WholeNumber(1_234_567L);
+
+            result
+                .Should()
+                .Be(
+                    "1,234,567",
+                    "McpFormat.WholeNumber passes CultureInfo.InvariantCulture so MCP markdown renders the same on every host locale; a non-invariant group separator forks LLM-consumed output by deploy locale"
+                );
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the documented culture-invariance contract of `McpFormat.WholeNumber<T>`: it must render thousands separators with `CultureInfo.InvariantCulture` regardless of the host's thread culture, so MCP markdown consumed by LLMs does not fork separators by deploy locale.
- `WholeNumber` was newly adopted across the CFTC and insider MCP tools but had no direct unit test — only its sibling `OrDash` was pinned. This closes that gap against the known MCP culture-forking regression class.

## Code changes

- `tests/Equibles.UnitTests/Mcp/McpFormatWholeNumberCultureInvarianceTests.cs` — new adversarial (Lane A) test running under `de-DE` and asserting `WholeNumber(1_234_567L)` renders `"1,234,567"` (invariant comma grouping), not the locale's `"1.234.567"`. Passes — confirms the invariant-culture guarantee and guards against a future drop of `InvariantCulture` from the helper.