### PR TITLE
refactor(cftc): collapse sequential ParseDate TryParseExact calls into the BCL format-array overload

### DIFF
--- a/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
+++ b/src/Equibles.Cftc.HostedService/Services/CftcImportService.cs
@@ -321,33 +321,23 @@ public class CftcImportService : IImporter
             TradersCommShort = record.TradersCommShort,
         };
 
+    // CFTC report dates arrive as either ISO yyyy-MM-dd (modern feeds) or the
+    // legacy two-digit yyMMdd; TryParseExact tries each in order.
+    private static readonly string[] DateFormats = ["yyyy-MM-dd", "yyMMdd"];
+
     private static DateOnly? ParseDate(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
             return null;
 
-        if (
-            DateOnly.TryParseExact(
-                value.Trim(),
-                "yyyy-MM-dd",
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.None,
-                out var date
-            )
+        return DateOnly.TryParseExact(
+            value.Trim(),
+            DateFormats,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var date
         )
-            return date;
-
-        if (
-            DateOnly.TryParseExact(
-                value.Trim(),
-                "yyMMdd",
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.None,
-                out date
-            )
-        )
-            return date;
-
-        return null;
+            ? date
+            : null;
     }
 }


### PR DESCRIPTION
## Summary

- `CftcImportService.ParseDate` tried two date formats with two sequential single-format `DateOnly.TryParseExact` calls. Collapsed them into one call using the BCL's `string[]`-format overload, which tries each format in array order — behavior-identical and matches the existing `EdgarXmlSubmissionParser.ParseDate(value, formats)` idiom used by the Sec processors.
- No behavior change: same null/whitespace guard, same `Trim()`, same `InvariantCulture` and `DateTimeStyles.None`, same format precedence (`yyyy-MM-dd` then `yyMMdd`), same `DateOnly?` result for every input. The five existing `ParseDate` unit pins all pass.

## Code changes

- `src/Equibles.Cftc.HostedService/Services/CftcImportService.cs` — hoisted the accepted formats to a `static readonly string[] DateFormats` field and rewrote `ParseDate` to a single `TryParseExact` call over that array (12 insertions, 22 deletions).