### PR TITLE
test(cboe): pin CboeClient.ParseVixCsv skips row with non-MM/dd/yyyy date

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CboeClientParseVixCsvDateUnparseableTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientParseVixCsvDateUnparseableTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Equibles.Integrations.Cboe;
+using Equibles.Integrations.Cboe.Models;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CboeClientParseVixCsvDateUnparseableTests
+{
+    private static readonly MethodInfo ParseVixCsvMethod = typeof(CboeClient).GetMethod(
+        "ParseVixCsv",
+        BindingFlags.NonPublic | BindingFlags.Static
+    )!;
+
+    [Fact]
+    public void ParseVixCsv_DateFieldNotMmDdYyyy_SkipsRowDoesNotPersistDefaultDate()
+    {
+        // Sibling pin to the Open/High/Low/Close arms. ParseVixCsv guards the
+        // DATE cell with DateOnly.TryParseExact("MM/dd/yyyy") and `continue`s
+        // on failure (CboeClient.cs:329-337) — a structurally distinct arm
+        // from the four decimal.TryParse cells. The row below carries five
+        // well-formed fields with valid OHLC, so only the date guard can
+        // reject it (an ISO "yyyy-MM-dd" date never matches the US exact
+        // format). Dropping that guard would leave `date` at default(DateOnly)
+        // (0001-01-01) and emit a bogus record, corrupting any time series
+        // keyed on the VIX date.
+        var csv = "DATE,OPEN,HIGH,LOW,CLOSE\n" + "2020-01-03,13.72,14.49,13.51,14.02\n";
+
+        var records = (List<CboeVixRecord>)ParseVixCsvMethod.Invoke(null, [csv])!;
+
+        records.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a sibling pin to the existing Open/High/Low/Close skip-arm tests for `CboeClient.ParseVixCsv`, covering the previously-untested DATE arm.
- The DATE cell is guarded by `DateOnly.TryParseExact("MM/dd/yyyy")` — a structurally distinct arm from the four `decimal.TryParse` cells — and `continue`s on failure. A row with a valid OHLC payload but an ISO `yyyy-MM-dd` date must be skipped, not emitted with a default `0001-01-01` date.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CboeClientParseVixCsvDateUnparseableTests.cs` — new unit test invoking the private `ParseVixCsv` via reflection (matching the established sibling-test pattern); feeds a header plus one well-formed-OHLC row whose date is not `MM/dd/yyyy`, and asserts the result is empty. Passes against current behavior, pinning the date guard against regression.