### PR TITLE
test(web): pin Html.Json escapes angle brackets to block script breakout

### DIFF
--- a/tests/Equibles.UnitTests/Web/HtmlExtensionsJsonScriptBreakoutTests.cs
+++ b/tests/Equibles.UnitTests/Web/HtmlExtensionsJsonScriptBreakoutTests.cs
@@ -1,0 +1,30 @@
+using System.Text.Encodings.Web;
+using Equibles.Web.Extensions;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Web;
+
+public class HtmlExtensionsJsonScriptBreakoutTests
+{
+    // Contract: Html.Json<T> emits its result through HtmlString (raw, unencoded)
+    // for embedding inside a Razor <script> block, so the serialized JSON itself
+    // must be safe in that context. A string value containing "</script>" must not
+    // survive verbatim — the '<' has to be escaped (<) or it closes the host
+    // <script> element and turns serialized model data into stored XSS.
+    [Fact]
+    public void Json_StringContainingScriptClosingTag_EscapesAngleBrackets()
+    {
+        var html = Substitute.For<IHtmlHelper>();
+
+        var content = html.Json("</script><script>alert(1)</script>");
+
+        using var writer = new StringWriter();
+        content.WriteTo(writer, HtmlEncoder.Default);
+        var rendered = writer.ToString();
+
+        rendered.Should().NotContain("<");
+        rendered.Should().Contain("\\u003C");
+    }
+}


### PR DESCRIPTION
## Summary

`HtmlExtensions.Json<T>` serializes a model value and emits it through `HtmlString` (raw, unencoded) so views can embed it inside a Razor `<script>` block. Because the output is rendered unescaped, the serialized JSON itself must be safe in that context — a string value containing `</script>` must not survive verbatim, or it closes the host `<script>` element and turns serialized model data into stored XSS.

The helper had no direct test. This adds one pinning that guarantee: a string carrying `</script><script>alert(1)</script>` is serialized with its angle brackets escaped (`<`), so no literal `<` reaches the page. The test passes against the current implementation (the default `System.Text.Json` encoder escapes HTML-sensitive characters); it would fail if the helper were ever switched to a relaxed/unsafe JSON encoder.

## Code changes

- `tests/Equibles.UnitTests/Web/HtmlExtensionsJsonScriptBreakoutTests.cs` — new unit test rendering the helper's output and asserting the script-closing tag is neutralized via `<` escaping.