### PR TITLE
refactor(sec): replace hand-rolled FYE min-search loop with Where + MinBy

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
@@ -74,20 +74,10 @@ internal static class FiscalPeriodResolver
         // The fiscal year containing periodEnd is the one whose FYE is on or
         // after periodEnd within roughly twelve months — ranks the matched
         // year correctly even when the quarter closes a few days late.
-        DateOnly endingFye = default;
-        var endingFyeFound = false;
-        foreach (var candidate in candidates)
-        {
-            if (candidate.DayNumber < periodEnd.DayNumber)
-                continue;
-            if (!endingFyeFound || candidate.DayNumber < endingFye.DayNumber)
-            {
-                endingFye = candidate;
-                endingFyeFound = true;
-            }
-        }
-        if (!endingFyeFound)
+        var matches = candidates.Where(c => c.DayNumber >= periodEnd.DayNumber).ToList();
+        if (matches.Count == 0)
             return null;
+        var endingFye = matches.MinBy(c => c.DayNumber);
         if (endingFye.DayNumber - periodEnd.DayNumber > AnnualMaxDays)
             return null;
 


### PR DESCRIPTION
## Summary

- Simplify the fiscal-year-end selection in `FiscalPeriodResolver.Resolve` by replacing a hand-rolled min-search loop (with a mutable found-flag) with a `Where` filter plus `MinBy`, matching the `MinBy` idiom already used by `ClosestTo` in the same file.
- Behaviour-preserving: same partition (`DayNumber >= periodEnd.DayNumber`), same first-among-ties minimum selection, and the `matches.Count == 0` guard reproduces the prior `return null` path without ever calling `MinBy` on an empty sequence.

## Code changes

- `src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs` — replace the 12-line foreach/flag min-search that picked the smallest-`DayNumber` fiscal-year-end on or after `periodEnd` with `candidates.Where(...).ToList()` + `MinBy(c => c.DayNumber)`, guarded by an empty-set check.