### PR TITLE
test(mcp): pin McpFormat.OrDash null value returns em-dash placeholder

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/McpFormatOrDashNullTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpFormatOrDashNullTests.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class McpFormatOrDashNullTests
+{
+    // Adversarial Lane A. Contract (XML doc on McpFormat.OrDash): "Formats a nullable
+    // value with the given format string, OR the em-dash placeholder when null." The
+    // null branch is the unexercised half of OrDash — its sibling test only covers a
+    // present value. A correct impl must short-circuit on null and return exactly the
+    // placeholder (U+2014), independent of the format string passed in. The format
+    // below is a marker that would appear in the output if the null guard ever leaked
+    // and applied it as a custom numeric format; the assertion that we get a bare
+    // em-dash proves it did not. A hostile host locale (de-DE) is pinned to show the
+    // placeholder is culture-independent too.
+    [Fact]
+    public void OrDash_NullValue_ReturnsEmDashPlaceholderRegardlessOfFormat()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var result = McpFormat.OrDash<decimal>(null, @"\L\E\A\K");
+
+            result
+                .Should()
+                .Be(
+                    "—",
+                    "OrDash promises the em-dash placeholder for a null value, short-circuiting before the format string is ever applied"
+                );
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the null branch of `McpFormat.OrDash`, the previously unexercised half of the helper — its existing test only covered a present value, leaving the documented null placeholder behavior unverified.
- Guards the contract that a null nullable value renders as the em-dash placeholder (U+2014), short-circuiting before the format string is applied, independent of host locale.

## Code changes

- `tests/Equibles.UnitTests/Mcp/McpFormatOrDashNullTests.cs` — new unit test asserting `OrDash<decimal>(null, ...)` returns `"—"` regardless of the format string passed and under a hostile thread culture (de-DE).