### PR TITLE
refactor(sec-mcp): replace hand-rolled keyword-match loop in SearchDocumentKeyword with Range/Where/Take

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs
@@ -46,15 +46,11 @@ public class DocumentTextTools
                 if (error != null)
                     return error;
 
-                var matches = new List<int>();
-
-                for (var i = 0; i < lines.Length && matches.Count < maxResults; i++)
-                {
-                    if (lines[i].Contains(keyword, StringComparison.OrdinalIgnoreCase))
-                    {
-                        matches.Add(i);
-                    }
-                }
+                var matches = Enumerable
+                    .Range(0, lines.Length)
+                    .Where(i => lines[i].Contains(keyword, StringComparison.OrdinalIgnoreCase))
+                    .Take(maxResults)
+                    .ToList();
 
                 if (matches.Count == 0)
                 {


### PR DESCRIPTION
## Summary

- Replace the manual index `for` loop that collected matching line indices in `SearchDocumentKeyword` with an equivalent `Enumerable.Range(...).Where(...).Take(maxResults).ToList()` expression.
- Behavior-preserving: same line indices in the same order, the same `maxResults` cap (including `maxResults <= 0` and empty input), and `matches` stays a `List<int>` so downstream count/iteration are unaffected.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/DocumentTextTools.cs` — `SearchDocumentKeyword`: swap the hand-rolled loop (compound `i < lines.Length && matches.Count < maxResults` termination) for `Range/Where/Take`, whose lazy `Take` short-circuits exactly like the old `matches.Count < maxResults` break. Existing unit and integration tests for this tool pass unchanged.