### PR TITLE
test(sec): pin FormAdvCsvParser.ParseAum rounds a half-dollar away from zero

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumMidpointRoundingTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumMidpointRoundingTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Integrations.Sec.FormAdv;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FormAdvCsvParserParseAumMidpointRoundingTests
+{
+    // ParseAum converts a fractional AUM figure to whole dollars. A half-dollar
+    // is the ambiguous case: a caller reading "100.50" as dollars expects the
+    // half to round up to 101. The integer part here (100) is even, so the
+    // default banker's rounding (ToEven) would instead round DOWN to 100 — this
+    // input therefore pins the away-from-zero contract and fails if the rounding
+    // mode is ever dropped to the Math.Round default.
+    [Fact]
+    public void Parse_AumWithHalfDollar_RoundsAwayFromZero()
+    {
+        var csv = "Organization CRD#,5F(2)(c)\n777,100.50\n";
+        using var reader = new StringReader(csv);
+
+        var adviser = FormAdvCsvParser.Parse(reader).Single();
+
+        adviser.TotalRegulatoryAum.Should().Be(101L);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `FormAdvCsvParser.ParseAum` rounds a half-dollar AUM figure away from zero (up), the behavior a caller reading whole dollars expects.
- The existing record-replay cassette only carries `.00` figures, so the midpoint rounding mode was never exercised; this closes that gap.

## Code changes

- `tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumMidpointRoundingTests.cs` — new unit test parsing an in-memory CSV whose total-AUM cell is `100.50`, asserting it maps to `101`. The integer part (100) is even, so a switch to the `Math.Round` default (banker's / to-even) would round down to `100` and fail the test — making this a guard against an accidental rounding-mode regression.