### PR TITLE
test(sec): pin TryExtractXbrlEnvelope prefers a non-primary inline block over a standalone .INS instance

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserFallbackInlineBeatsStandaloneTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserFallbackInlineBeatsStandaloneTests.cs
@@ -1,0 +1,64 @@
+using Equibles.Sec.BusinessLogic;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentEnvelopeParserFallbackInlineBeatsStandaloneTests
+{
+    private const string InlineBody =
+        "<html xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\"><body><ix:nonFraction>1</ix:nonFraction></body></html>";
+
+    private const string PlainBody = "<html><body>no inline xbrl here</body></html>";
+
+    private const string InstanceBody = "<xbrl>standalone instance</xbrl>";
+
+    [Fact]
+    public void TryExtractXbrlEnvelope_PlainPrimaryWithSeparateInlineBlockAndInstance_PrefersFallbackInlineOverStandalone()
+    {
+        // Contract: when the named primary carries no inline XBRL, a non-primary
+        // block that does carry inline markers must win over a standalone .INS
+        // instance — the post-loop order checks the inline fallback first. The
+        // failure mode this guards is wrongly returning StandaloneXbrl.
+        var envelope = $"""
+            <SEC-DOCUMENT>
+            <DOCUMENT>
+            <TYPE>10-K
+            <SEQUENCE>1
+            <FILENAME>acme-10k.htm
+            <TEXT>
+            {PlainBody}
+            </TEXT>
+            </DOCUMENT>
+            <DOCUMENT>
+            <TYPE>EX-99.1
+            <SEQUENCE>2
+            <FILENAME>acme-ex99.htm
+            <TEXT>
+            {InlineBody}
+            </TEXT>
+            </DOCUMENT>
+            <DOCUMENT>
+            <TYPE>EX-101.INS
+            <SEQUENCE>7
+            <FILENAME>acme-20201231.xml
+            <TEXT>
+            {InstanceBody}
+            </TEXT>
+            </DOCUMENT>
+            </SEC-DOCUMENT>
+            """;
+
+        var found = SecDocumentEnvelopeParser.TryExtractXbrlEnvelope(
+            envelope,
+            "acme-10k.htm",
+            out var type,
+            out var sourceFileName,
+            out var content
+        );
+
+        found.Should().BeTrue();
+        type.Should().Be(XbrlType.InlineIxbrl);
+        sourceFileName.Should().Be("acme-ex99.htm");
+        content.Should().Be(InlineBody);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one unit test pinning an untested precedence path in `SecDocumentEnvelopeParser.TryExtractXbrlEnvelope`.
- Existing tests cover named-primary inline, inline-over-instance, plain-primary→standalone, blank-primary fallback, and the empty cases — but not the case where the named primary is plain *and* a separate non-primary block carries inline markers *while* a standalone `.INS` instance is also present.
- The parser's contract resolves inline-fallback before standalone; this guards against a regression that would wrongly return `StandaloneXbrl` for such a filing.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserFallbackInlineBeatsStandaloneTests.cs` — one `[Fact]` building a three-block SGML envelope (plain primary `acme-10k.htm`, inline exhibit `acme-ex99.htm`, standalone `EX-101.INS`) and asserting the result is `InlineIxbrl` sourced from the exhibit block, not the standalone instance.