### PR TITLE
refactor(yahoo-mcp): forward StockPriceTools.StartTable to shared MarkdownTable.Start

### DIFF
--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -443,15 +443,11 @@ public class StockPriceTools
         return (stock, records, null);
     }
 
-    private static StringBuilder StartTable(string title, string columnsRow, string separatorRow)
-    {
-        var sb = new StringBuilder();
-        sb.AppendLine(title);
-        sb.AppendLine();
-        sb.AppendLine(columnsRow);
-        sb.AppendLine(separatorRow);
-        return sb;
-    }
+    // Thin forwarder to the shared helper so the load-bearing title/blank/header/separator
+    // sequence lives in one documented place; kept as a named method so existing
+    // reflection-based pins still resolve it.
+    private static StringBuilder StartTable(string title, string columnsRow, string separatorRow) =>
+        MarkdownTable.Start(title, columnsRow, separatorRow);
 
     private static void AppendNewestFirstRows(
         StringBuilder result,


### PR DESCRIPTION
## Summary

- `StockPriceTools.StartTable` was a byte-for-byte reimplementation of the shared `MarkdownTable.Start(title, headerRow, separatorRow)` helper, duplicating the load-bearing title/blank-line/header/separator sequence that strict CommonMark renderers need to recognise a table.
- Routed `StartTable` through the shared helper so that invariant lives in one documented place, removing the drift risk of two independent copies.
- Behavior is unchanged: `MarkdownTable.Start` emits the identical four `AppendLine` calls in the same order; output is byte-identical.

## Code changes

- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — replaced the private `StartTable` method body with a delegating call to `MarkdownTable.Start`. Kept it as a named private method (not inlined) so the existing reflection-based pin (`StockPriceToolsStartTableBlankLineTests`) still resolves it; all six internal call sites are unaffected.