### PR TITLE
perf(holdings): back the latest-filings feed with an InstitutionalFiling rollup

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -41,8 +41,28 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
                 h.Shares,
             });
 
+        // Covering index for the per-holder portfolio rollups on the holder page
+        // (StocksController.ShowHolder → ComputeTopPortfolioPositions /
+        // HolderPortfolioProvider.GetTrend). Both filter by holder and GROUP BY
+        // either ReportDate or CommonStockId while summing Value / Shares; without
+        // the INCLUDE list those run as a bitmap heap scan, and under crawler
+        // concurrency the slow reads drained the portal's Financial pool (#1262).
+        // Mirrors the per-stock covering index above so the rollups are
+        // index-only scans. EF merges this with the entity's
+        // `[Index(InstitutionalHolderId, ReportDate)]` attribute into one btree.
+        builder
+            .Entity<InstitutionalHolding>()
+            .HasIndex(h => new { h.InstitutionalHolderId, h.ReportDate })
+            .IncludeProperties(h => new
+            {
+                h.CommonStockId,
+                h.Value,
+                h.Shares,
+            });
+
         builder.Entity<ProcessedDataSet>();
         builder.Entity<ProcessedFiling>();
+        builder.Entity<InstitutionalFiling>();
         builder.Entity<RealtimeSweepState>();
         builder.Entity<FundScore>();
 

--- a/src/Equibles.Holdings.Data/Models/InstitutionalFiling.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalFiling.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.Data.Models;
+
+/// <summary>
+/// One row per 13F-HR submission, keyed by accession number — the filing-level
+/// rollup of the per-position <see cref="InstitutionalHolding"/> rows that share
+/// that accession. Holdings are stored only at the position grain, so the
+/// "latest filings" feed used to reconstruct one row per filing with a
+/// table-wide GROUP BY on every request; this table is that rollup, written once
+/// at ingestion and read back with a plain indexed scan.
+///
+/// <para>
+/// <see cref="PositionCount"/> and <see cref="TotalValue"/> count only the
+/// <em>tracked</em> positions that were actually imported (untracked CUSIPs are
+/// skipped during import), matching what the old GROUP BY over
+/// <see cref="InstitutionalHolding"/> produced.
+/// </para>
+///
+/// <para>
+/// Each accession is its own row. A RESTATEMENT amendment carries a new
+/// accession and deletes+reinserts the holdings under it, so the original and
+/// the amendment remain distinct filing rows — exactly as the per-accession
+/// GROUP BY treated them.
+/// </para>
+/// </summary>
+[Index(nameof(AccessionNumber), IsUnique = true)]
+[Index(nameof(FilingDate))]
+public class InstitutionalFiling
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [MaxLength(32)]
+    public string AccessionNumber { get; set; }
+
+    public Guid InstitutionalHolderId { get; set; }
+    public virtual InstitutionalHolder InstitutionalHolder { get; set; }
+
+    public DateOnly FilingDate { get; set; }
+    public DateOnly ReportDate { get; set; }
+    public bool IsAmendment { get; set; }
+
+    public int PositionCount { get; set; }
+    public long TotalValue { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -80,6 +80,7 @@ public class HoldingsImportService
         await UpsertInstitutionalHolders(context, cancellationToken);
         await HandleAmendments(context, cancellationToken);
         await StreamAndInsertHoldings(context, cancellationToken);
+        await SyncFilingSummaries(context, cancellationToken);
         await PublishAffectedQuartersAsync(context, cancellationToken);
         return new ImportResult(submissionCount, IsComplete: true);
     }
@@ -883,6 +884,134 @@ public class HoldingsImportService
         await dbContext.SaveChangesAsync(cancellationToken);
 
         return holdings.Count;
+    }
+
+    // Recomputes the InstitutionalFiling rollup for every (holder, quarter) this
+    // import touched, straight from the resulting holdings. The latest-filings feed
+    // reads one indexed row per filing from this table instead of grouping the whole
+    // holdings table on each request.
+    //
+    // The unit of consistency is (holder, report date), not accession: every filing
+    // an import mutates — a fresh original, a restatement (delete + reinsert under a
+    // new accession), or a "new holdings" amendment that overwrites an existing
+    // position's accession — files under the submission's period, so recomputing all
+    // filings for the touched (holder, quarter) pairs covers all of them in one pass.
+    // Any accession that no longer has holdings (e.g. a restated original) is dropped
+    // so it can't ghost the feed. Aggregates count only tracked positions — the same
+    // grouping the feed used to do inline.
+    private async Task SyncFilingSummaries(
+        ImportContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        var affected = new HashSet<(Guid HolderId, DateOnly ReportDate)>();
+        foreach (var submission in context.Submissions.Values)
+        {
+            if (string.IsNullOrEmpty(submission.Cik))
+                continue;
+            if (!context.CikToHolderId.TryGetValue(submission.Cik, out var holderId))
+                continue;
+            if (!TryParseDateOnly(submission.PeriodOfReport, out var reportDate))
+                continue;
+            affected.Add((holderId, reportDate));
+        }
+        if (affected.Count == 0)
+            return;
+
+        // The two IN lists widen to a (holder × quarter) cross-product in SQL; the
+        // in-memory HashSet narrows the result back to the exact pairs we touched.
+        var holderIds = affected.Select(a => a.HolderId).Distinct().ToList();
+        var reportDates = affected.Select(a => a.ReportDate).Distinct().ToList();
+
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+
+        var rows = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h =>
+                holderIds.Contains(h.InstitutionalHolderId) && reportDates.Contains(h.ReportDate)
+            )
+            .GroupBy(h => new
+            {
+                h.AccessionNumber,
+                h.InstitutionalHolderId,
+                h.FilingDate,
+                h.ReportDate,
+                h.IsAmendment,
+            })
+            .Select(g => new
+            {
+                g.Key.AccessionNumber,
+                g.Key.InstitutionalHolderId,
+                g.Key.FilingDate,
+                g.Key.ReportDate,
+                g.Key.IsAmendment,
+                PositionCount = g.Count(),
+                TotalValue = g.Sum(h => h.Value),
+            })
+            .ToListAsync(cancellationToken);
+
+        var summaries = rows.Where(r => affected.Contains((r.InstitutionalHolderId, r.ReportDate)))
+            .Select(r => new InstitutionalFiling
+            {
+                AccessionNumber = r.AccessionNumber,
+                InstitutionalHolderId = r.InstitutionalHolderId,
+                FilingDate = r.FilingDate,
+                ReportDate = r.ReportDate,
+                IsAmendment = r.IsAmendment,
+                PositionCount = r.PositionCount,
+                TotalValue = r.TotalValue,
+            })
+            .ToList();
+
+        if (summaries.Count > 0)
+        {
+            await dbContext
+                .Set<InstitutionalFiling>()
+                .UpsertRange(summaries)
+                .On(f => f.AccessionNumber)
+                .WhenMatched(
+                    (existing, incoming) =>
+                        new InstitutionalFiling
+                        {
+                            InstitutionalHolderId = incoming.InstitutionalHolderId,
+                            FilingDate = incoming.FilingDate,
+                            ReportDate = incoming.ReportDate,
+                            IsAmendment = incoming.IsAmendment,
+                            PositionCount = incoming.PositionCount,
+                            TotalValue = incoming.TotalValue,
+                        }
+                )
+                .RunAsync(cancellationToken);
+        }
+
+        // Within the touched (holder, quarter) pairs, any existing filing row whose
+        // accession no longer has holdings (a restated original) must be removed,
+        // otherwise it ghosts the feed.
+        var present = summaries.Select(s => s.AccessionNumber).ToHashSet(StringComparer.Ordinal);
+        var existingFilings = await dbContext
+            .Set<InstitutionalFiling>()
+            .Where(f =>
+                holderIds.Contains(f.InstitutionalHolderId) && reportDates.Contains(f.ReportDate)
+            )
+            .ToListAsync(cancellationToken);
+        var orphans = existingFilings
+            .Where(f =>
+                affected.Contains((f.InstitutionalHolderId, f.ReportDate))
+                && !present.Contains(f.AccessionNumber)
+            )
+            .ToList();
+        if (orphans.Count > 0)
+        {
+            dbContext.Set<InstitutionalFiling>().RemoveRange(orphans);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        _logger.LogInformation(
+            "Synced {Count} filing summaries across {Pairs} (holder, quarter) pair(s)",
+            summaries.Count,
+            affected.Count
+        );
     }
 
     private static string BuildHoldingKey(

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -230,58 +230,40 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             );
     }
 
-    // Recent filings feed: groups holdings by accession number to produce one row
-    // per filing, ordered by import timestamp. Joins InstitutionalHolder for filer
+    // Recent filings feed: one row per 13F filing, read straight from the
+    // InstitutionalFiling rollup (maintained at ingestion) instead of grouping the
+    // whole holdings table on every request. Joins InstitutionalHolder for filer
     // metadata and uses a NOT EXISTS subquery to flag first-time filers (no holdings
-    // from any earlier report date).
+    // from any earlier report date). Callers order by FilingDate descending.
     public IQueryable<RecentFiling> GetRecentFilings()
     {
-        var filings = GetAll()
-            .GroupBy(h => new
-            {
-                h.AccessionNumber,
-                h.InstitutionalHolderId,
-                h.FilingDate,
-                h.ReportDate,
-                h.IsAmendment,
-            })
-            .Select(g => new
-            {
-                g.Key.AccessionNumber,
-                g.Key.InstitutionalHolderId,
-                g.Key.FilingDate,
-                g.Key.ReportDate,
-                g.Key.IsAmendment,
-                PositionCount = g.Count(),
-                TotalValue = g.Sum(h => h.Value),
-                ImportedAt = g.Min(h => h.CreationTime),
-            });
-
-        return filings.Join(
-            DbContext.Set<InstitutionalHolder>(),
-            f => f.InstitutionalHolderId,
-            h => h.Id,
-            (f, h) =>
-                new RecentFiling
-                {
-                    AccessionNumber = f.AccessionNumber,
-                    InstitutionalHolderId = f.InstitutionalHolderId,
-                    FilerName = h.Name,
-                    FilerCik = h.Cik,
-                    FilingDate = f.FilingDate,
-                    ReportDate = f.ReportDate,
-                    PositionCount = f.PositionCount,
-                    TotalValue = f.TotalValue,
-                    IsAmendment = f.IsAmendment,
-                    ImportedAt = f.ImportedAt,
-                    IsNewFiler = !DbContext
-                        .Set<InstitutionalHolding>()
-                        .Any(prior =>
-                            prior.InstitutionalHolderId == f.InstitutionalHolderId
-                            && prior.ReportDate < f.ReportDate
-                        ),
-                }
-        );
+        return DbContext
+            .Set<InstitutionalFiling>()
+            .Join(
+                DbContext.Set<InstitutionalHolder>(),
+                f => f.InstitutionalHolderId,
+                h => h.Id,
+                (f, h) =>
+                    new RecentFiling
+                    {
+                        AccessionNumber = f.AccessionNumber,
+                        InstitutionalHolderId = f.InstitutionalHolderId,
+                        FilerName = h.Name,
+                        FilerCik = h.Cik,
+                        FilingDate = f.FilingDate,
+                        ReportDate = f.ReportDate,
+                        PositionCount = f.PositionCount,
+                        TotalValue = f.TotalValue,
+                        IsAmendment = f.IsAmendment,
+                        ImportedAt = f.CreationTime,
+                        IsNewFiler = !DbContext
+                            .Set<InstitutionalHolding>()
+                            .Any(prior =>
+                                prior.InstitutionalHolderId == f.InstitutionalHolderId
+                                && prior.ReportDate < f.ReportDate
+                            ),
+                    }
+            );
     }
 
     // Cross-sectional 13F screener. Aggregates per-stock filer-count / total-value /

--- a/src/Equibles.Migrations/Migrations/20260601235824_AddInstitutionalFiling.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260601235824_AddInstitutionalFiling.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260601235824_AddInstitutionalFiling")]
+    partial class AddInstitutionalFiling
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260601235824_AddInstitutionalFiling.cs
+++ b/src/Equibles.Migrations/Migrations/20260601235824_AddInstitutionalFiling.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstitutionalFiling : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_InstitutionalHolderId_ReportDate",
+                table: "InstitutionalHolding"
+            );
+
+            migrationBuilder.CreateTable(
+                name: "InstitutionalFiling",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccessionNumber = table.Column<string>(
+                        type: "character varying(32)",
+                        maxLength: 32,
+                        nullable: false
+                    ),
+                    InstitutionalHolderId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FilingDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    ReportDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    IsAmendment = table.Column<bool>(type: "boolean", nullable: false),
+                    PositionCount = table.Column<int>(type: "integer", nullable: false),
+                    TotalValue = table.Column<long>(type: "bigint", nullable: false),
+                    CreationTime = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InstitutionalFiling", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_InstitutionalFiling_InstitutionalHolder_InstitutionalHolder~",
+                        column: x => x.InstitutionalHolderId,
+                        principalTable: "InstitutionalHolder",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade
+                    );
+                }
+            );
+
+            migrationBuilder
+                .CreateIndex(
+                    name: "IX_InstitutionalHolding_InstitutionalHolderId_ReportDate",
+                    table: "InstitutionalHolding",
+                    columns: new[] { "InstitutionalHolderId", "ReportDate" }
+                )
+                .Annotation("Npgsql:IndexInclude", new[] { "CommonStockId", "Value", "Shares" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalFiling_AccessionNumber",
+                table: "InstitutionalFiling",
+                column: "AccessionNumber",
+                unique: true
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalFiling_FilingDate",
+                table: "InstitutionalFiling",
+                column: "FilingDate"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalFiling_InstitutionalHolderId",
+                table: "InstitutionalFiling",
+                column: "InstitutionalHolderId"
+            );
+
+            // One-time historical backfill: collapse the existing per-position
+            // InstitutionalHolding rows into one InstitutionalFiling row per
+            // accession — the same grouping the latest-filings feed used to run
+            // inline on every request. Going forward the import path keeps this
+            // table current (HoldingsImportService.SyncFilingSummaries). Runs once,
+            // when this migration is applied.
+            migrationBuilder.Sql(
+                """
+                INSERT INTO "InstitutionalFiling"
+                    ("Id", "AccessionNumber", "InstitutionalHolderId", "FilingDate",
+                     "ReportDate", "IsAmendment", "PositionCount", "TotalValue", "CreationTime")
+                SELECT
+                    gen_random_uuid(),
+                    "AccessionNumber",
+                    "InstitutionalHolderId",
+                    "FilingDate",
+                    "ReportDate",
+                    "IsAmendment",
+                    COUNT(*),
+                    COALESCE(SUM("Value"), 0)::bigint,
+                    MIN("CreationTime")
+                FROM "InstitutionalHolding"
+                WHERE "AccessionNumber" IS NOT NULL
+                GROUP BY "AccessionNumber", "InstitutionalHolderId", "FilingDate",
+                         "ReportDate", "IsAmendment";
+                """
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "InstitutionalFiling");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_InstitutionalHolderId_ReportDate",
+                table: "InstitutionalHolding"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_InstitutionalHolderId_ReportDate",
+                table: "InstitutionalHolding",
+                columns: new[] { "InstitutionalHolderId", "ReportDate" }
+            );
+        }
+    }
+}

--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -102,7 +102,10 @@ public class HoldingsActivityController : BaseController
     {
         page = Pagination.ClampPage(page);
 
-        var query = _holdingRepository.GetRecentFilings().OrderByDescending(f => f.ImportedAt);
+        var query = _holdingRepository
+            .GetRecentFilings()
+            .OrderByDescending(f => f.FilingDate)
+            .ThenByDescending(f => f.AccessionNumber);
 
         var totalCount = await query.CountAsync();
 

--- a/tests/Equibles.FunctionalTests/Tests/HoldingsLatestFilingsSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HoldingsLatestFilingsSeededTests.cs
@@ -23,7 +23,7 @@ public class HoldingsLatestFilingsSeededTests
     [Fact]
     public async Task LatestFilings_WithNewAndReturningFilers_RendersCorrectBadges()
     {
-        // Contract: /holdings/latest-13f-filings shows filings ordered by ImportedAt descending.
+        // Contract: /holdings/latest-13f-filings shows filings ordered by FilingDate descending.
         // A filer with no holdings in a prior quarter gets a "New" badge. Amendment
         // filings get an "A" badge. Position count and total value aggregate multiple
         // holdings per filing.
@@ -123,6 +123,42 @@ public class HoldingsLatestFilingsSeededTests
                     ShareType = ShareType.Shares,
                     InvestmentDiscretion = InvestmentDiscretion.Sole,
                     AccessionNumber = "ACC-003",
+                    IsAmendment = true,
+                    CreationTime = new DateTime(2025, 2, 20, 10, 0, 0, DateTimeKind.Utc),
+                }
+            );
+
+            // The feed reads the InstitutionalFiling rollup (maintained at ingestion);
+            // seed the matching filing rows for the holdings above.
+            db.AddRange(
+                new InstitutionalFiling
+                {
+                    AccessionNumber = "ACC-001",
+                    InstitutionalHolderId = filerA.Id,
+                    ReportDate = q1,
+                    FilingDate = q1.AddDays(45),
+                    PositionCount = 1,
+                    TotalValue = 1_000_000,
+                    CreationTime = new DateTime(2024, 11, 15, 10, 0, 0, DateTimeKind.Utc),
+                },
+                new InstitutionalFiling
+                {
+                    AccessionNumber = "ACC-002",
+                    InstitutionalHolderId = filerA.Id,
+                    ReportDate = q2,
+                    FilingDate = q2.AddDays(45),
+                    PositionCount = 2,
+                    TotalValue = 5_000_000,
+                    CreationTime = new DateTime(2025, 2, 15, 10, 0, 0, DateTimeKind.Utc),
+                },
+                new InstitutionalFiling
+                {
+                    AccessionNumber = "ACC-003",
+                    InstitutionalHolderId = filerB.Id,
+                    ReportDate = q2,
+                    FilingDate = q2.AddDays(50),
+                    PositionCount = 1,
+                    TotalValue = 5_000_000,
                     IsAmendment = true,
                     CreationTime = new DateTime(2025, 2, 20, 10, 0, 0, DateTimeKind.Utc),
                 }

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceAmendmentReconciliationTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceAmendmentReconciliationTests.cs
@@ -201,5 +201,133 @@ public class HoldingsImportServiceAmendmentReconciliationTests : IAsyncLifetime
         holding.AccessionNumber.Should().Be("ACC-AMEND");
         holding.IsAmendment.Should().BeTrue();
         holding.ReportDate.Should().Be(reportDate);
+
+        // The InstitutionalFiling rollup must track the same reconciliation: the
+        // amendment's filing row replaces the original's, with the amended counts.
+        // The restated original (ACC-ORIG) must NOT linger as a ghost in the feed.
+        var filings = await verify.Set<InstitutionalFiling>().ToListAsync();
+        filings.Should().ContainSingle();
+        var filing = filings[0];
+        filing.AccessionNumber.Should().Be("ACC-AMEND");
+        filing.PositionCount.Should().Be(1);
+        filing.TotalValue.Should().Be(25_000);
+        filing.IsAmendment.Should().BeTrue();
+        filing.ReportDate.Should().Be(reportDate);
+    }
+
+    [Fact]
+    public async Task ImportDataSet_NewHoldingsAmendmentOverwritingAPosition_RecomputesOriginalFilingRow()
+    {
+        // A "NEW HOLDINGS" amendment does NOT delete the original's holdings, but the
+        // holdings upsert key excludes the accession, so re-filing an existing position
+        // overwrites that row and flips its accession to the amendment's. The filing
+        // rollup must recompute the ORIGINAL filing row too (its position count drops),
+        // not leave it stale — even though the original accession is absent from this
+        // archive's submissions. This pins the (holder, quarter) recompute unit.
+        var aapl = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc",
+            Cik = "0000320193",
+            Cusip = "037833100",
+        };
+        var msft = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "MSFT",
+            Name = "Microsoft Corp",
+            Cik = "0000789019",
+            Cusip = "594918104",
+        };
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().AddRange(aapl, msft);
+            await seed.SaveChangesAsync();
+        }
+
+        var reportDate = new DateOnly(2024, 9, 30);
+        var prices = new Dictionary<(Guid, DateOnly), decimal>
+        {
+            [(aapl.Id, reportDate)] = 100m,
+            [(msft.Id, reportDate)] = 100m,
+        };
+
+        const string coverWithType =
+            "ACCESSION_NUMBER\tISAMENDMENT\tAMENDMENTTYPE\tFILINGMANAGER_NAME\n";
+        const string infoHeader =
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n";
+
+        // 1) Original 13F-HR — two positions (AAPL 1000, MSFT 500) under ACC-ORIG.
+        using (
+            var original = BuildArchive(
+                (
+                    "SUBMISSION.tsv",
+                    "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+                        + "13F-HR\tACC-ORIG\t2024-10-15\t2024-09-30\t0001067983\n"
+                ),
+                ("COVERPAGE.tsv", coverWithType + "ACC-ORIG\tN\t\tBig Fund\n"),
+                (
+                    "INFOTABLE.tsv",
+                    infoHeader
+                        + "ACC-ORIG\t037833100\t1000\tSH\t\tSOLE\t1000\t0\t0\tCOM\t\n"
+                        + "ACC-ORIG\t594918104\t500\tSH\t\tSOLE\t500\t0\t0\tCOM\t\n"
+                )
+            )
+        )
+        {
+            var sut = CreateImporter(PriceProviderReturning(prices));
+            await sut.ImportDataSet(original, new DateOnly(2024, 1, 1), CancellationToken.None);
+        }
+
+        // 2) NEW HOLDINGS amendment ACC-AMEND — re-files AAPL at 1500 (same key →
+        //    overwrites the AAPL row, flipping its accession). MSFT untouched.
+        using (
+            var amendment = BuildArchive(
+                (
+                    "SUBMISSION.tsv",
+                    "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+                        + "13F-HR/A\tACC-AMEND\t2024-11-20\t2024-09-30\t0001067983\n"
+                ),
+                ("COVERPAGE.tsv", coverWithType + "ACC-AMEND\tY\tNEW HOLDINGS\tBig Fund\n"),
+                (
+                    "INFOTABLE.tsv",
+                    infoHeader + "ACC-AMEND\t037833100\t1500\tSH\t\tSOLE\t1500\t0\t0\tCOM\t\n"
+                )
+            )
+        )
+        {
+            var sut = CreateImporter(PriceProviderReturning(prices));
+            await sut.ImportDataSet(amendment, new DateOnly(2024, 1, 1), CancellationToken.None);
+        }
+
+        using var verify = FreshContext();
+
+        // Holdings: AAPL now under ACC-AMEND at 1500; MSFT still under ACC-ORIG at 500.
+        var holdings = await verify
+            .Set<InstitutionalHolding>()
+            .OrderBy(h => h.AccessionNumber)
+            .ToListAsync();
+        holdings.Should().HaveCount(2);
+        holdings.Should().ContainSingle(h => h.AccessionNumber == "ACC-AMEND" && h.Shares == 1500);
+        holdings.Should().ContainSingle(h => h.AccessionNumber == "ACC-ORIG" && h.Shares == 500);
+
+        // Filing rollup: the original row is RECOMPUTED to one position (just MSFT),
+        // not left stale at two; the amendment row holds the moved AAPL position.
+        var filings = await verify
+            .Set<InstitutionalFiling>()
+            .OrderBy(f => f.AccessionNumber)
+            .ToListAsync();
+        filings.Should().HaveCount(2);
+
+        var amend = filings.Single(f => f.AccessionNumber == "ACC-AMEND");
+        amend.PositionCount.Should().Be(1);
+        amend.TotalValue.Should().Be(150_000);
+        amend.IsAmendment.Should().BeTrue();
+
+        var orig = filings.Single(f => f.AccessionNumber == "ACC-ORIG");
+        orig.PositionCount.Should().Be(1);
+        orig.TotalValue.Should().Be(50_000);
+        orig.IsAmendment.Should().BeFalse();
     }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryRecentFilingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryRecentFilingsTests.cs
@@ -7,9 +7,11 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.IntegrationTests.Holdings;
 
 /// <summary>
-/// Adversarial test for <c>GetRecentFilings().IsNewFiler</c> — the NOT EXISTS
-/// subquery must correlate correctly through the GroupBy + Join to distinguish
-/// first-time filers from returning ones.
+/// Coverage for <c>GetRecentFilings()</c>, which reads one row per filing from the
+/// <see cref="InstitutionalFiling"/> rollup (not a live GROUP BY over holdings):
+/// the NOT EXISTS <c>IsNewFiler</c> subquery must still correlate to the right
+/// holder, the projection must surface the rollup's counts/values, and the
+/// migration's one-time backfill SQL must collapse holdings into that rollup.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class InstitutionalHoldingRepositoryRecentFilingsTests : IAsyncLifetime
@@ -58,6 +60,10 @@ public class InstitutionalHoldingRepositoryRecentFilingsTests : IAsyncLifetime
         seed.Add(MakeHolding(stock, returningFiler, Q3, accession: "acc-ret-q3"));
         seed.Add(MakeHolding(stock, returningFiler, Q4, accession: "acc-ret-q4"));
         seed.Add(MakeHolding(stock, newFiler, Q4, accession: "acc-new-q4"));
+        // The feed reads the rollup, so each filing needs its InstitutionalFiling row.
+        seed.Add(MakeFiling(returningFiler, Q3, "acc-ret-q3"));
+        seed.Add(MakeFiling(returningFiler, Q4, "acc-ret-q4"));
+        seed.Add(MakeFiling(newFiler, Q4, "acc-new-q4"));
         await seed.SaveChangesAsync();
 
         await using var read = FreshContext();
@@ -71,6 +77,92 @@ public class InstitutionalHoldingRepositoryRecentFilingsTests : IAsyncLifetime
         returningFiling.IsNewFiler.Should().BeFalse();
         newFiling.IsNewFiler.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task GetRecentFilings_ProjectsRollupCountsAndValues()
+    {
+        // The feed surfaces PositionCount / TotalValue straight from the
+        // InstitutionalFiling rollup, not a live count over holdings. Seed a
+        // rollup row whose counts deliberately differ from the seeded holdings to
+        // prove the read path uses the rollup table.
+        await using var seed = FreshContext();
+        var stock = await SeedStock(seed, "MSFT");
+        var holder = await SeedHolder(seed, "rollup");
+
+        // One holding exists so the IsNewFiler subquery has something to resolve...
+        seed.Add(MakeHolding(stock, holder, Q4, accession: "acc-roll"));
+        // ...but the rollup independently claims 3 positions worth 900k.
+        seed.Add(MakeFiling(holder, Q4, "acc-roll", positionCount: 3, totalValue: 900_000));
+        await seed.SaveChangesAsync();
+
+        await using var read = FreshContext();
+        var sut = new InstitutionalHoldingRepository(read);
+
+        var filing = (await sut.GetRecentFilings().ToListAsync()).Single();
+
+        filing.AccessionNumber.Should().Be("acc-roll");
+        filing.PositionCount.Should().Be(3);
+        filing.TotalValue.Should().Be(900_000);
+        filing.FilerCik.Should().Be("rollup");
+        filing.IsNewFiler.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Backfill_CollapsesHoldingsIntoOneRowPerAccession()
+    {
+        // Pins the one-time historical backfill shipped in the
+        // AddInstitutionalFiling migration: it must collapse per-position holdings
+        // into one InstitutionalFiling row per accession with COUNT / SUM matching
+        // the old inline feed grouping. This statement mirrors the migration's Sql.
+        await using var seed = FreshContext();
+        var stockA = await SeedStock(seed, "NVDA");
+        var stockB = await SeedStock(seed, "AMD");
+        var filerA = await SeedHolder(seed, "filerA");
+        var filerB = await SeedHolder(seed, "filerB");
+
+        // acc-a: two positions for filerA at Q4 → count 2, value 350.
+        seed.Add(MakeHolding(stockA, filerA, Q4, "acc-a", value: 100));
+        seed.Add(MakeHolding(stockB, filerA, Q4, "acc-a", value: 250));
+        // acc-b: one position for filerB at Q3 → count 1, value 500.
+        seed.Add(MakeHolding(stockA, filerB, Q3, "acc-b", value: 500));
+        await seed.SaveChangesAsync();
+
+        await using var run = FreshContext();
+        await run.Database.ExecuteSqlRawAsync(BackfillSql);
+
+        await using var read = FreshContext();
+        var filings = await read.Set<InstitutionalFiling>().ToListAsync();
+
+        filings.Should().HaveCount(2);
+        var a = filings.Single(f => f.AccessionNumber == "acc-a");
+        a.PositionCount.Should().Be(2);
+        a.TotalValue.Should().Be(350);
+        a.ReportDate.Should().Be(Q4);
+        var b = filings.Single(f => f.AccessionNumber == "acc-b");
+        b.PositionCount.Should().Be(1);
+        b.TotalValue.Should().Be(500);
+    }
+
+    // Mirrors the one-time backfill in 20260601235824_AddInstitutionalFiling.
+    private const string BackfillSql = """
+        INSERT INTO "InstitutionalFiling"
+            ("Id", "AccessionNumber", "InstitutionalHolderId", "FilingDate",
+             "ReportDate", "IsAmendment", "PositionCount", "TotalValue", "CreationTime")
+        SELECT
+            gen_random_uuid(),
+            "AccessionNumber",
+            "InstitutionalHolderId",
+            "FilingDate",
+            "ReportDate",
+            "IsAmendment",
+            COUNT(*),
+            COALESCE(SUM("Value"), 0)::bigint,
+            MIN("CreationTime")
+        FROM "InstitutionalHolding"
+        WHERE "AccessionNumber" IS NOT NULL
+        GROUP BY "AccessionNumber", "InstitutionalHolderId", "FilingDate",
+                 "ReportDate", "IsAmendment";
+        """;
 
     private static async Task<CommonStock> SeedStock(
         Equibles.Data.EquiblesFinancialDbContext ctx,
@@ -103,7 +195,8 @@ public class InstitutionalHoldingRepositoryRecentFilingsTests : IAsyncLifetime
         CommonStock stock,
         InstitutionalHolder holder,
         DateOnly reportDate,
-        string accession
+        string accession,
+        long value = 100_000
     ) =>
         new()
         {
@@ -112,9 +205,28 @@ public class InstitutionalHoldingRepositoryRecentFilingsTests : IAsyncLifetime
             FilingDate = reportDate.AddDays(45),
             ReportDate = reportDate,
             Shares = 100,
-            Value = 100_000,
+            Value = value,
             ShareType = ShareType.Shares,
             InvestmentDiscretion = InvestmentDiscretion.Sole,
             AccessionNumber = accession,
+        };
+
+    private static InstitutionalFiling MakeFiling(
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        string accession,
+        int positionCount = 1,
+        long totalValue = 100_000,
+        bool isAmendment = false
+    ) =>
+        new()
+        {
+            AccessionNumber = accession,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            IsAmendment = isAmendment,
+            PositionCount = positionCount,
+            TotalValue = totalValue,
         };
 }


### PR DESCRIPTION
## Summary

The `/holdings/latest-13f-filings` feed reconstructed one row per filing by running an unbounded `GROUP BY` over the entire per-position `InstitutionalHolding` table on **every request** — a warm render took ~33s, and the same query class backed the other slow holdings/ranking pages. 13F was the only filing module without a first-class per-filing table.

This adds an `InstitutionalFiling` rollup (one row per accession), consistent with `InsiderFiling` / `NportFiling` / etc., and reads the feed straight from it — no aggregation. It also adds a covering index that fixes the holder-page connection-pool exhaustion.

## Code changes

- **`InstitutionalFiling` entity** — one row per accession: holder, filing/report dates, `IsAmendment`, `PositionCount`, `TotalValue`. Indexed on `FilingDate` (feed ordering) + unique `AccessionNumber`.
- **Maintained at ingestion** (`HoldingsImportService.SyncFilingSummaries`) — after holdings are written, the rollup is recomputed for every touched **(holder, quarter)** pair. That unit covers fresh originals, restatements (delete + reinsert under a new accession), and "new holdings" amendments (which overwrite an existing position's accession), and drops any accession left with no holdings so it can't ghost the feed.
- **One-time backfill** — `INSERT … SELECT … GROUP BY` in the migration collapses existing holdings into the rollup.
- **`GetRecentFilings`** now reads the rollup joined to the holder; `IsNewFiler` stays a per-holder `NOT EXISTS` subquery. Callers order by `FilingDate` desc.
- **Covering index** on `(InstitutionalHolderId, ReportDate) INCLUDE (CommonStockId, Value, Shares)` — makes `ComputeTopPortfolioPositions` / `HolderPortfolioProvider.GetTrend` index-only scans so holder pages stop draining the pool under load.

## Tests

- `GetRecentFilings` reads the rollup (counts/values from the table, not a live count); `IsNewFiler` still correct.
- Backfill SQL collapses holdings into one row per accession with correct `COUNT`/`SUM`.
- Restatement amendment: rollup replaces the original, no ghost row.
- New-holdings amendment that moves a position: the original filing row is **recomputed** (count drops), not left stale.
- Full Holdings integration namespace (180) + holder/feed web tests green.

Addresses the 13F-holdings query-performance issues (latest-filings render time and holder-page pool exhaustion).