### PR TITLE
test(yahoo): pin PriceReturnCalculator January MTD/YTD year-boundary anchor

### DIFF
--- a/tests/Equibles.UnitTests/Yahoo/PriceReturnCalculatorMonthToDateJanuaryTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/PriceReturnCalculatorMonthToDateJanuaryTests.cs
@@ -1,0 +1,33 @@
+using Equibles.Yahoo.Repositories;
+
+namespace Equibles.UnitTests.Yahoo;
+
+public class PriceReturnCalculatorMonthToDateJanuaryTests
+{
+    // Contract: MonthToDate anchors on the last close strictly before the first day of the
+    // latest bar's month. When the latest bar falls in January that month-start threshold is
+    // Jan 1, so the anchor must reach across the year boundary to the prior December's final
+    // close — the very same bar YearToDate anchors on. The two windows therefore have to
+    // coincide in January. Existing MTD coverage only spans an in-year (April→May) anchor, so
+    // this pins the year-boundary arm the month-start threshold computation relies on.
+    [Fact]
+    public void Compute_LatestBarInJanuary_MonthToDateAnchorsOnPriorDecemberCloseLikeYearToDate()
+    {
+        var dates = new List<DateOnly>
+        {
+            new(2024, 12, 30),
+            new(2024, 12, 31),
+            new(2025, 1, 2),
+            new(2025, 1, 3),
+            new(2025, 1, 6),
+        };
+        // Dec 31, 2024 close (100) is both the prior-month-end and prior-year-end anchor;
+        // latest close 125 → (125 / 100 - 1) * 100 = 25%.
+        var closes = new List<decimal> { 90m, 100m, 110m, 120m, 125m };
+
+        var result = PriceReturnCalculator.Compute(dates, closes);
+
+        result.MonthToDate.Should().Be(25m);
+        result.MonthToDate.Should().Be(result.YearToDate);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one unit test pinning that, when the latest bar falls in January, `PriceReturnCalculator.Compute` anchors month-to-date on the prior December's final close — crossing the year boundary — and so coincides exactly with year-to-date.
- Existing MTD coverage only spans an in-year (April→May) anchor; this exercises the year-boundary arm the month-start threshold (`new DateOnly(year, 1, 1)`) depends on. Behavior confirmed correct — the test passes as a pinned guarantee.

## Code changes

- `tests/Equibles.UnitTests/Yahoo/PriceReturnCalculatorMonthToDateJanuaryTests.cs` — new `[Fact]` building a Dec 2024→Jan 2025 close series and asserting `MonthToDate == 25%` and `MonthToDate == YearToDate`.