### PR TITLE
fix(insider): render reprocess Summary culture-invariantly

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderFilingReprocessResult.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderFilingReprocessResult.cs
@@ -28,7 +28,7 @@ public class InsiderFilingReprocessResult
     public int Failed { get; set; }
 
     public string Summary =>
-        $"Reprocessed {Processed:N0}/{Total:N0} filings "
-        + $"({Fetched:N0} fetched, {Reclassified:N0} rows reclassified, "
-        + $"{Repaired:N0} prices repaired, {Failed:N0} failed).";
+        FormattableString.Invariant(
+            $"Reprocessed {Processed:N0}/{Total:N0} filings ({Fetched:N0} fetched, {Reclassified:N0} rows reclassified, {Repaired:N0} prices repaired, {Failed:N0} failed)."
+        );
 }

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingReprocessResultSummaryCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingReprocessResultSummaryCultureInvarianceTests.cs
@@ -30,9 +30,7 @@ public class InsiderFilingReprocessResultSummaryCultureInvarianceTests
     // the body): Summary renders its counts culture-invariantly - the group
     // separator is always ',' regardless of host culture. de-DE is the
     // canonical non-invariant culture used by the repo's other culture pins.
-    [Fact(
-        Skip = "GH-3164 — Summary uses :N0 (CurrentCulture); forks log group separator by host locale"
-    )]
+    [Fact]
     public void Summary_LargeCountsUnderNonInvariantCulture_RendersWithInvariantGroupSeparator()
     {
         var result = new InsiderFilingReprocessResult


### PR DESCRIPTION
## Summary

- `InsiderFilingReprocessResult.Summary` built its operator-facing log string with plain interpolated `:N0` segments, which format with the thread `CurrentCulture`. On a non-invariant host (e.g. `de-DE`, dot group separator) a count of `1234` rendered as `1.234` instead of `1,234`, forking worker log output by host locale and breaking grep/awk triage.
- Fixes #3164.

## Code changes

- `src/Equibles.InsiderTrading.BusinessLogic/Models/InsiderFilingReprocessResult.cs` — wrap the `Summary` interpolation in `FormattableString.Invariant` so the group separator is always `,`, matching the repo's log-helper convention (`BaseScraperWorker.FormatInterval`, `FactMarkdown.Value`).
- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingReprocessResultSummaryCultureInvarianceTests.cs` — un-skip the committed regression test that pins invariant rendering under `de-DE`.