### PR TITLE
test(insider): pin ParseLong is culture-invariant for negative integers

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseLongCultureTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseLongCultureTests.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserParseLongCultureTests
+{
+    // Adversarial: ParseLong first tries the culture-sensitive long.TryParse(string, out long)
+    // overload, which matches a leading sign against CurrentCulture.NegativeSign, not the ASCII
+    // hyphen — the same fork class as GH-3182 (XbrlValueParser). The SEC ownership XML carries
+    // ASCII signed integers, and a negative share count is a real input (malformed/amended Form 4,
+    // already pinned in the validator's negative-shares test). The contract: a share count parses
+    // identically on any host culture. Here ar-SA (NegativeSign = U+061C) is the canonical
+    // non-hyphen culture; ParseLong must still recover -1000 via its invariant ParseDecimal
+    // fallback, never silently collapse to 0.
+    [Fact]
+    public void ParseLong_NegativeIntegerUnderArabicCulture_PreservesTheValue()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+
+            InsiderFilingParser
+                .ParseLong("-1000")
+                .Should()
+                .Be(
+                    -1000,
+                    "a Form 4 share count is ASCII and locale-independent; a non-hyphen "
+                        + "NegativeSign must not fork the parse (cf. GH-3182)"
+                );
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `InsiderFilingParser.ParseLong` first tries the culture-sensitive `long.TryParse(string, out long)` overload, which matches a leading sign against `CurrentCulture.NegativeSign` rather than the ASCII hyphen — the same fork class as #3182. SEC ownership XML carries ASCII signed integers, and a negative share count is a real input (malformed/amended Form 4). The parse is only saved from forking by host locale by its invariant `ParseDecimal` fallback.
- This pins that contract: a share count parses identically on any host culture. Under `ar-SA` (NegativeSign = U+061C), `ParseLong("-1000")` must still recover `-1000`, never silently collapse to `0`.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseLongCultureTests.cs` — new unit test asserting `ParseLong("-1000")` returns `-1000` under a non-hyphen negative-sign culture. Guards against a future regression that drops the invariant fallback. No production changes.