### PR TITLE
fix(web): format ToStringWithSign with invariant culture

### DIFF
--- a/src/Equibles.Web/Extensions/SignedFormatting.cs
+++ b/src/Equibles.Web/Extensions/SignedFormatting.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Numerics;
 
 namespace Equibles.Web.Extensions;
@@ -5,5 +6,6 @@ namespace Equibles.Web.Extensions;
 public static class SignedFormatting
 {
     public static string ToStringWithSign<T>(this T value, string format)
-        where T : INumber<T> => (value > T.Zero ? "+" : "") + value.ToString(format, null);
+        where T : INumber<T> =>
+        (value > T.Zero ? "+" : "") + value.ToString(format, CultureInfo.InvariantCulture);
 }

--- a/tests/Equibles.UnitTests/Web/SignedFormattingToStringWithSignCultureTests.cs
+++ b/tests/Equibles.UnitTests/Web/SignedFormattingToStringWithSignCultureTests.cs
@@ -11,7 +11,7 @@ public class SignedFormattingToStringWithSignCultureTests
     // ToStringWithSign in a view must therefore use '.' as the decimal separator and
     // ',' as the grouping separator regardless of the host's thread culture, so the
     // figure reads the same next to its invariant-formatted neighbours.
-    [Fact(Skip = "GH-3171 — ToStringWithSign forks number formatting by host locale")]
+    [Fact]
     public void ToStringWithSign_UnderCommaDecimalCulture_UsesInvariantSeparators()
     {
         var original = CultureInfo.CurrentCulture;


### PR DESCRIPTION
## Summary

- `SignedFormatting.ToStringWithSign` rendered its value with `value.ToString(format, null)`, which uses the thread `CurrentCulture` for decimal/grouping separators. On a non-English host it emitted e.g. `+1.234,50` while every sibling formatter in `Equibles.Web` (`CompactNumberTagHelper`, `CsvExportService`, the export controllers) emits invariant `1,234.50` — inconsistent in shared views and wrong where a literal `%` is appended.
- Fixes #3171.

## Code changes

- `src/Equibles.Web/Extensions/SignedFormatting.cs` — pass `CultureInfo.InvariantCulture` instead of `null` to `value.ToString(format, ...)` so output is locale-independent.
- `tests/Equibles.UnitTests/Web/SignedFormattingToStringWithSignCultureTests.cs` — un-skip the committed regression test pinning invariant separators under `de-DE`.