### PR TITLE
fix(sec): parse XBRL @decimals with invariant culture

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/XbrlValueParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/XbrlValueParser.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
 
 // Engine-agnostic XBRL value-parsing primitives shared by StandaloneXbrlParser
@@ -22,6 +24,13 @@ internal static class XbrlValueParser
             return null;
         if (string.Equals(decimalsAttribute, "INF", StringComparison.OrdinalIgnoreCase))
             return int.MaxValue;
-        return int.TryParse(decimalsAttribute, out var value) ? value : null;
+        return int.TryParse(
+            decimalsAttribute,
+            NumberStyles.Integer,
+            CultureInfo.InvariantCulture,
+            out var value
+        )
+            ? value
+            : null;
     }
 }

--- a/tests/Equibles.UnitTests/Sec/XbrlValueParserParseDecimalsArabicCultureTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlValueParserParseDecimalsArabicCultureTests.cs
@@ -17,9 +17,7 @@ public class XbrlValueParserParseDecimalsArabicCultureTests
     // and the method returns null, silently dropping the rounding-scale metadata for a
     // valid filing. Every other numeric parse in the codebase pins
     // CultureInfo.InvariantCulture; this one does not.
-    [Fact(
-        Skip = "GH-3182 — ParseDecimals uses the culture-sensitive int.TryParse overload, so a negative @decimals returns null on non-invariant-culture hosts"
-    )]
+    [Fact]
     public void ParseDecimals_NegativeValueUnderArabicCulture_PreservesTheInteger()
     {
         var original = CultureInfo.CurrentCulture;


### PR DESCRIPTION
## Summary

- `XbrlValueParser.ParseDecimals` read the `@decimals` attribute via the culture-sensitive `int.TryParse(string, out int)` overload, which matches a leading sign against `NumberFormatInfo.CurrentInfo.NegativeSign` rather than the ASCII hyphen. The XBRL `@decimals` value is an `xs:integer` (always ASCII) and a negative value is valid and common (`-6` = accurate to the nearest million). On a host whose `CurrentCulture` has a non-hyphen negative sign (e.g. `ar-SA`, U+061C), `-6` failed to parse and the rounding-scale metadata was silently dropped.
- Fixes #3182.

## Code changes

- `src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/XbrlValueParser.cs` — parse `@decimals` with `NumberStyles.Integer` + `CultureInfo.InvariantCulture`, matching every other numeric parse in the codebase.
- `tests/Equibles.UnitTests/Sec/XbrlValueParserParseDecimalsArabicCultureTests.cs` — un-skip the committed regression test pinning `ParseDecimals("-6") == -6` under `ar-SA`.