### PR TITLE
test(sec): pin StripPrefix returns local name for prefixed/unprefixed QNames

### DIFF
--- a/tests/Equibles.UnitTests/Sec/XbrlValueParserStripPrefixLocalNameTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlValueParserStripPrefixLocalNameTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+public class XbrlValueParserStripPrefixLocalNameTests
+{
+    // The two primary StripPrefix paths (the empty-local-name → null edge is pinned
+    // separately): a prefixed QName returns just the local name, and an unprefixed
+    // name (no colon) passes through unchanged. Concept-tagged measures arrive both
+    // ways — "us-gaap:Assets" from a namespaced taxonomy and a bare local name from a
+    // default-namespace document — so both must resolve to the same concept token.
+    [Fact]
+    public void StripPrefix_PrefixedAndUnprefixedQNames_ReturnTheLocalName()
+    {
+        XbrlValueParser.StripPrefix("us-gaap:Assets").Should().Be("Assets");
+        XbrlValueParser.StripPrefix("Assets").Should().Be("Assets");
+    }
+}


### PR DESCRIPTION
## Summary

- `XbrlValueParser.StripPrefix` had only its empty-local-name edge (`"iso4217:"` → null) pinned. Its two primary paths — a prefixed QName returning the local name, and an unprefixed name passing through unchanged — were unexercised.
- Pins both: `"us-gaap:Assets"` → `"Assets"` and `"Assets"` → `"Assets"`, so the same concept token resolves whether the measure arrives namespaced or bare.

## Code changes

- `tests/Equibles.UnitTests/Sec/XbrlValueParserStripPrefixLocalNameTests.cs` — new unit test covering the two previously-zero-hit StripPrefix paths. No production changes.