### PR TITLE
test(holdings): pin FundScoringManager.SelectRelevantSnapshotDates MaxValue ReportDate overflow

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/FundScoringManagerSelectRelevantSnapshotDatesMaxValueReportDateTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundScoringManagerSelectRelevantSnapshotDatesMaxValueReportDateTests.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Equibles.Holdings.BusinessLogic;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Contract (class summary): FundScoringManager "mirror[s] the on-demand backtest in the web
+/// portal's HoldingsBacktestService". Its sibling there — and SmartMoneyIndexManager in this same
+/// module — both clamp the +45-day rebalance shift at DateOnly.MaxValue precisely because a
+/// ReportDate within RebalanceDelayDays of the calendar's end would overflow AddDays. ScoreHolder
+/// also promises to "return ... null when there isn't enough data to simulate", i.e. graceful
+/// degradation on bad inputs, never a thrown exception.
+///
+/// SelectRelevantSnapshotDates here calls reportDate.AddDays(45) with no such clamp, so a
+/// far-future ReportDate throws ArgumentOutOfRangeException instead of being treated like any
+/// other out-of-window snapshot. The clamped sibling resolves MaxValue's rebalance to MaxValue,
+/// which sits after a normal window's upper bound and is simply excluded — so the expected result
+/// is the in-window snapshot alone, with no throw.
+/// </summary>
+public class FundScoringManagerSelectRelevantSnapshotDatesMaxValueReportDateTests
+{
+    [Fact(Skip = "GH-3221 — FundScoringManager.SelectRelevantSnapshotDates throws on a MaxValue ReportDate")]
+    public void SelectRelevantSnapshotDates_ReportDateAtMaxValue_ExcludesItWithoutThrowing()
+    {
+        var method = typeof(FundScoringManager).GetMethod(
+            "SelectRelevantSnapshotDates",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var from = new DateOnly(2020, 1, 1);
+        var to = new DateOnly(2023, 1, 1);
+        // Ascending, as the caller passes them. The far-future date's rebalance lands beyond `to`.
+        IReadOnlyList<DateOnly> reportDates = [new DateOnly(2021, 6, 1), DateOnly.MaxValue];
+
+        var result = (List<DateOnly>)method.Invoke(null, [reportDates, from, to]);
+
+        result.Should().ContainSingle().Which.Should().Be(new DateOnly(2021, 6, 1));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one adversarial unit test for `FundScoringManager.SelectRelevantSnapshotDates`, which shifts a 13F `ReportDate` forward by `RebalanceDelayDays` (45) via a raw `AddDays` — with no `DateOnly.MaxValue` clamp.
- Both sibling implementations (`HoldingsBacktestService.RebalanceDateOf` in the web portal and `SmartMoneyIndexManager` in this module) clamp that shift at `DateOnly.MaxValue`; this copy diverges and throws `ArgumentOutOfRangeException` on a near-`MaxValue` report date, breaking `ScoreHolder`'s "return null when there isn't enough data" graceful contract.
- The test is committed **skipped — see GH-3221**; un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Holdings/FundScoringManagerSelectRelevantSnapshotDatesMaxValueReportDateTests.cs` — new `[Fact(Skip = "GH-3221 ...")]`. Invokes the private static method by reflection with `reportDates = [2021-06-01, DateOnly.MaxValue]` over a normal window and asserts it returns the single in-window snapshot without throwing (the contract-correct, clamped behavior). Currently reproduces the overflow at `FundScoringManager.cs:176`. No production code changed.