### PR TITLE
fix(holdings): open backtest at requested from using active prior snapshot

### DIFF
--- a/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
@@ -57,11 +57,13 @@ public static class HoldingsBacktestCalculator
             .OrderBy(x => x.RebalanceDate)
             .ToList();
 
-        // First snapshot whose rebalance date is on or after `from`. If none — the window
-        // sits after the latest filing; fall back to the most recent prior snapshot so the
-        // simulation still has a portfolio to mark to market.
-        var firstIdx = ordered.FindIndex(x => x.RebalanceDate >= from);
-        var snapshotIdx = firstIdx < 0 ? ordered.Count - 1 : firstIdx;
+        // The snapshot active at `from`: the latest whose rebalance date is on or before
+        // `from`, so the simulation opens at `from` with the portfolio that had actually
+        // matured by then (marking it to market until the next rebalance date inside the
+        // window). If `from` precedes every rebalance date, no filing has matured yet —
+        // open at the earliest snapshot's rebalance date instead.
+        var priorIdx = ordered.FindLastIndex(x => x.RebalanceDate <= from);
+        var snapshotIdx = priorIdx < 0 ? 0 : priorIdx;
 
         var startDate = ordered[snapshotIdx].RebalanceDate;
         if (startDate < from)

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorWindowBetweenTwoRebalancesTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorWindowBetweenTwoRebalancesTests.cs
@@ -8,9 +8,7 @@ public class HoldingsBacktestCalculatorWindowBetweenTwoRebalancesTests
     private static readonly Guid StockOld = Guid.Parse("11111111-1111-1111-1111-111111111111");
     private static readonly Guid StockNew = Guid.Parse("22222222-2222-2222-2222-222222222222");
 
-    [Fact(
-        Skip = "GH-3193 — Calculate skips the active prior snapshot when `from` falls between two rebalance dates"
-    )]
+    [Fact]
     public void Calculate_FromBetweenTwoRebalances_OpensAtRequestedFromWithPriorSnapshot()
     {
         // Contract: HoldingsBacktestService.SelectRelevantSnapshotDates deliberately feeds the


### PR DESCRIPTION
## Summary

- `HoldingsBacktestCalculator.Calculate` chose its opening snapshot with `FindIndex(rebalance >= from)`. When `from` fell strictly between two snapshots' rebalance dates, that skipped the older (already-matured) snapshot and selected the newer one — so the simulation opened at the newer rebalance date instead of at `from`, silently dropping the leading `[from, newerRebalance)` segment and never marking the portfolio actually active at `from` to market.
- `HoldingsBacktestService.SelectRelevantSnapshotDates` deliberately feeds that prior snapshot in, so this is reachable from the holder backtest page whenever the window starts partway through a quarter.
- Fixes #3193.

## Code changes

- `src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs` — select the snapshot active at `from` (latest whose rebalance date ≤ `from`, via `FindLastIndex`), falling back to the earliest when `from` precedes every rebalance date. The existing start-date clamp then opens the window at `from` with the prior portfolio, matching the single-snapshot case.
- `tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorWindowBetweenTwoRebalancesTests.cs` — un-skip the committed regression test (`StartDate == from` and first point at `from` when `from` sits between two rebalance dates).