### PR TITLE
test(sec): pin SecDocumentEnvelopeParser.TryExtractXbrlEnvelope captures an inline block missing its FILENAME tag

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserFallbackInlineMissingFilenameTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserFallbackInlineMissingFilenameTests.cs
@@ -1,0 +1,47 @@
+using Equibles.Sec.BusinessLogic;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentEnvelopeParserFallbackInlineMissingFilenameTests
+{
+    // Contract: the fallback-inline path must capture a block carrying inline ix: markers even
+    // when the primary name is missing or doesn't match — otherwise the filing is wrongly recorded
+    // as not-present. A block that omits its <FILENAME> tag entirely is the unguarded edge of that
+    // rule: detection must still succeed and the absent name must surface as a non-null empty
+    // string, not a lost fact or a throw.
+    [Fact]
+    public void TryExtractXbrlEnvelope_InlineBlockMissingFilenameTag_StillReturnsInlineWithEmptySource()
+    {
+        const string inlineBody =
+            "<html xmlns:ix=\"http://www.xbrl.org/2013/inlineXBRL\"><body>"
+            + "<ix:nonFraction>1</ix:nonFraction></body></html>";
+
+        // The block carries inline markers but has no <FILENAME>, and the primary name passed in
+        // matches nothing, so the named-primary fast path cannot fire.
+        var envelope = $"""
+            <SEC-DOCUMENT>
+            <DOCUMENT>
+            <TYPE>10-K
+            <SEQUENCE>1
+            <TEXT>
+            {inlineBody}
+            </TEXT>
+            </DOCUMENT>
+            </SEC-DOCUMENT>
+            """;
+
+        var found = SecDocumentEnvelopeParser.TryExtractXbrlEnvelope(
+            envelope,
+            primaryDocumentFileName: "acme-10k.htm",
+            out var type,
+            out var sourceFileName,
+            out var content
+        );
+
+        found.Should().BeTrue();
+        type.Should().Be(XbrlType.InlineIxbrl);
+        sourceFileName.Should().BeEmpty();
+        content.Should().Be(inlineBody);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins a previously untested edge of `SecDocumentEnvelopeParser.TryExtractXbrlEnvelope`: a `<DOCUMENT>` block that carries inline iXBRL markers but omits its `<FILENAME>` tag.
- The fallback-inline path is documented to cover filings whose primary-document name "is missing or doesn't match"; an absent FILENAME is the unguarded corner of that rule, and there was no test for it.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserFallbackInlineMissingFilenameTests.cs` — new unit test asserting that an inline block with no FILENAME is still detected as `InlineIxbrl`, returns the body content, and surfaces a non-null empty source filename rather than being lost as not-present or throwing on the absent name. Test passes against current behavior.