### PR TITLE
fix(holdings): clamp FundScoringManager rebalance shift at DateOnly.MaxValue

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
@@ -173,7 +173,15 @@ public class FundScoringManager
         DateOnly? lastBeforeWindow = null;
         foreach (var date in reportDates)
         {
-            var rebalance = date.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
+            // Clamp the +45-day shift at the calendar's end so a far-future ReportDate
+            // (within RebalanceDelayDays of DateOnly.MaxValue) is treated as an out-of-window
+            // rebalance rather than overflowing AddDays — matching HoldingsBacktestCalculator
+            // and the HoldingsBacktestService / SmartMoneyIndexManager siblings.
+            var rebalance =
+                date.DayNumber
+                > DateOnly.MaxValue.DayNumber - HoldingsBacktestCalculator.RebalanceDelayDays
+                    ? DateOnly.MaxValue
+                    : date.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
             if (rebalance < from)
                 lastBeforeWindow = date;
             else if (rebalance <= to)

--- a/tests/Equibles.UnitTests/Holdings/FundScoringManagerSelectRelevantSnapshotDatesMaxValueReportDateTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundScoringManagerSelectRelevantSnapshotDatesMaxValueReportDateTests.cs
@@ -19,7 +19,7 @@ namespace Equibles.UnitTests.Holdings;
 /// </summary>
 public class FundScoringManagerSelectRelevantSnapshotDatesMaxValueReportDateTests
 {
-    [Fact(Skip = "GH-3221 — FundScoringManager.SelectRelevantSnapshotDates throws on a MaxValue ReportDate")]
+    [Fact]
     public void SelectRelevantSnapshotDates_ReportDateAtMaxValue_ExcludesItWithoutThrowing()
     {
         var method = typeof(FundScoringManager).GetMethod(


### PR DESCRIPTION
## Summary

- `FundScoringManager.SelectRelevantSnapshotDates` shifted each `ReportDate` forward by `RebalanceDelayDays` (45) with a bare `AddDays`, unlike its siblings (`HoldingsBacktestCalculator`, `HoldingsBacktestService.RebalanceDateOf`, `SmartMoneyIndexManager`) which clamp at `DateOnly.MaxValue`. A `ReportDate` within 45 days of the calendar's end threw `ArgumentOutOfRangeException` out of `AddDays`, propagating through `RunBacktest`/`ScoreHolder` and aborting scoring for that holder — instead of the documented graceful degradation (return null when there isn't enough data).
- Fixes #3221.

## Code changes

- `src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs` — clamp the rebalance shift at `DateOnly.MaxValue` inline (same guard the calculator uses); the far-future rebalance then sits past the window's upper bound and is excluded.
- `tests/Equibles.UnitTests/Holdings/FundScoringManagerSelectRelevantSnapshotDatesMaxValueReportDateTests.cs` — un-skip the committed regression test pinning that a `MaxValue` `ReportDate` is excluded without throwing.