### PR TITLE
refactor(sec): extract duplicated SGML tag-value scan into SecSgmlEnvelope helper

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs
@@ -227,26 +227,6 @@ public static class SecDocumentEnvelopeParser
         return char.IsAsciiLetterOrDigit(ch) || ch == '.' || ch == '_' || ch == '-';
     }
 
-    private static bool TryExtractSgmlTagValue(string block, string tagName, out string value)
-    {
-        value = string.Empty;
-        var tagMarker = $"<{tagName}>";
-        var idx = block.IndexOf(tagMarker, StringComparison.OrdinalIgnoreCase);
-        if (idx == -1)
-            return false;
-
-        var valueStart = idx + tagMarker.Length;
-        var end = valueStart;
-        while (end < block.Length && block[end] != '\n' && block[end] != '\r' && block[end] != '<')
-        {
-            end++;
-        }
-
-        var raw = block.Substring(valueStart, end - valueStart).Trim();
-        if (raw.Length == 0)
-            return false;
-
-        value = raw.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)[0];
-        return true;
-    }
+    private static bool TryExtractSgmlTagValue(string block, string tagName, out string value) =>
+        SecSgmlEnvelope.TryGetTagValue(block, tagName, out value);
 }

--- a/src/Equibles.Sec.BusinessLogic/SecDocumentHtmlNormalizer.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecDocumentHtmlNormalizer.cs
@@ -120,26 +120,8 @@ public class SecDocumentHtmlNormalizer : ISecDocumentHtmlNormalizer
         return finalHtml.ToString();
     }
 
-    private static string ExtractSgmlTagValue(string block, string tagName)
-    {
-        var tagMarker = $"<{tagName}>";
-        var idx = block.IndexOf(tagMarker, StringComparison.OrdinalIgnoreCase);
-        if (idx == -1)
-            return null;
-
-        var valueStart = idx + tagMarker.Length;
-        var end = valueStart;
-        while (end < block.Length && block[end] != '\n' && block[end] != '\r' && block[end] != '<')
-        {
-            end++;
-        }
-
-        var raw = block.Substring(valueStart, end - valueStart).Trim();
-        if (string.IsNullOrEmpty(raw))
-            return null;
-
-        return raw.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)[0];
-    }
+    private static string ExtractSgmlTagValue(string block, string tagName) =>
+        SecSgmlEnvelope.TryGetTagValue(block, tagName, out var value) ? value : null;
 
     private static string ExtractInnerContent(string block, string tagName)
     {

--- a/src/Equibles.Sec.BusinessLogic/SecSgmlEnvelope.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecSgmlEnvelope.cs
@@ -1,0 +1,34 @@
+namespace Equibles.Sec.BusinessLogic;
+
+// Shared SGML-envelope reading primitives for SEC full-submission text. SEC filings wrap
+// their documents in an SGML envelope whose header tags (<TYPE>, <FILENAME>, ...) carry a
+// single-line value rather than a closing tag, so the value runs to the next line break or
+// angle bracket.
+internal static class SecSgmlEnvelope
+{
+    // Reads the single-line value of an SGML header tag (e.g. <FILENAME>edgar.htm). The value
+    // ends at the first line break or '<', is trimmed, and only its first whitespace-delimited
+    // token is returned — SEC sometimes appends a descriptive trailer after the bare value.
+    public static bool TryGetTagValue(string block, string tagName, out string value)
+    {
+        value = string.Empty;
+        var tagMarker = $"<{tagName}>";
+        var idx = block.IndexOf(tagMarker, StringComparison.OrdinalIgnoreCase);
+        if (idx == -1)
+            return false;
+
+        var valueStart = idx + tagMarker.Length;
+        var end = valueStart;
+        while (end < block.Length && block[end] != '\n' && block[end] != '\r' && block[end] != '<')
+        {
+            end++;
+        }
+
+        var raw = block.Substring(valueStart, end - valueStart).Trim();
+        if (raw.Length == 0)
+            return false;
+
+        value = raw.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)[0];
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary

- The single-line SGML header-tag scan (`<TYPE>`, `<FILENAME>`, …) used when reading SEC full-submission text was duplicated character-for-character in two parsers. This collapses it into one shared `SecSgmlEnvelope.TryGetTagValue` helper.
- Behavior-preserving: both original methods now delegate to the helper and keep their exact names, signatures, and null/`out`-param semantics.

## Code changes

- `src/Equibles.Sec.BusinessLogic/SecSgmlEnvelope.cs` — new internal helper holding the shared `TryGetTagValue` scan (same `OrdinalIgnoreCase` match, scan-to line-break/`<`, trim, empty→fail, first-token-only split).
- `src/Equibles.Sec.BusinessLogic/SecDocumentHtmlNormalizer.cs` — `ExtractSgmlTagValue` now delegates to the helper (`… ? value : null`), preserving its string/null contract.
- `src/Equibles.Sec.BusinessLogic/SecDocumentEnvelopeParser.cs` — `TryExtractSgmlTagValue` now forwards to the helper, preserving its `out`/bool contract.