### PR TITLE
test(holdings): pin BacktestPriceLoader.ForwardFill returns null for a stock absent from the price map

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/BacktestPriceLoaderForwardFillMissingStockTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/BacktestPriceLoaderForwardFillMissingStockTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using Equibles.Holdings.BusinessLogic;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class BacktestPriceLoaderForwardFillMissingStockTests
+{
+    // The dictionary overload is the load-bearing entry point the calculator actually calls
+    // (priceOf: (stockId, date) => ForwardFill(pricesByStock, stockId, date)). pricesByStock is
+    // built by GroupBy, so it only ever holds keys for stocks that had price rows in the window —
+    // a held constituent with no loaded prices is simply absent. HoldingsBacktestCalculator's
+    // contract is that priceOf returns null for such a stock so the position is excluded that day,
+    // never that it throws. A refactor to the `[]` indexer would raise KeyNotFoundException and
+    // abort the whole simulation. Pass a stockId absent from the map and assert null, not a throw.
+    [Fact]
+    public void ForwardFill_StockIdAbsentFromPriceMap_ReturnsNullWithoutThrowing()
+    {
+        var loaderType = typeof(FundScoringManager).Assembly.GetType(
+            "Equibles.Holdings.BusinessLogic.BacktestPriceLoader"
+        );
+        var priceRowType = loaderType.GetNestedType("PriceRow");
+        var mapType = typeof(Dictionary<,>).MakeGenericType(
+            typeof(Guid),
+            priceRowType.MakeArrayType()
+        );
+        var emptyMap = Activator.CreateInstance(mapType);
+
+        var forwardFill = loaderType
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m =>
+                m.Name == "ForwardFill"
+                && m.GetParameters().Length == 3
+                && m.GetParameters()[0].ParameterType == mapType
+            );
+
+        var result = (decimal?)
+            forwardFill.Invoke(null, [emptyMap, Guid.NewGuid(), new DateOnly(2025, 1, 20)]);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the look-ahead-safety contract of `BacktestPriceLoader.ForwardFill`'s dictionary overload — the load-bearing entry point the backtest calculator calls via `priceOf`.
- `pricesByStock` is built by `GroupBy`, so it only holds keys for stocks that had price rows in the window. A held constituent with no loaded prices is simply absent; the calculator's contract is that `priceOf` returns null for such a stock (position excluded that day), never that it throws.
- Guards against a regression to the `[]` indexer, which would raise `KeyNotFoundException` and abort the whole simulation.

## Code changes

- `tests/Equibles.UnitTests/Holdings/BacktestPriceLoaderForwardFillMissingStockTests.cs` — new unit test invoking the 3-arg overload with a stock id absent from an empty price map and asserting the result is null rather than a throw.