### PR TITLE
perf(holdings): ReportDate-leading covering index for per-stock 13F rankings

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -60,6 +60,24 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
                 h.Shares,
             });
 
+        // Covering index for the per-stock 13F ranking pages (Most-Held Stocks,
+        // Last-Quarter Movers): WHERE ReportDate = <quarter> GROUP BY CommonStockId
+        // with COUNT(DISTINCT InstitutionalHolderId) and SUM(Shares)/SUM(Value).
+        // Leading with ReportDate lets the quarter filter seek; rows then arrive
+        // ordered by (CommonStockId, InstitutionalHolderId) so the grouped
+        // aggregate + distinct count run as an index-only scan with no sort. The
+        // per-stock covering index above leads with CommonStockId and so can't
+        // serve this ReportDate-first ranking scan over the whole quarter.
+        builder
+            .Entity<InstitutionalHolding>()
+            .HasIndex(h => new
+            {
+                h.ReportDate,
+                h.CommonStockId,
+                h.InstitutionalHolderId,
+            })
+            .IncludeProperties(h => new { h.Shares, h.Value });
+
         builder.Entity<ProcessedDataSet>();
         builder.Entity<ProcessedFiling>();
         builder.Entity<InstitutionalFiling>();

--- a/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
+++ b/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
@@ -24,5 +24,28 @@ public class InsiderTradingModuleConfiguration : Equibles.Data.IFinancialModule
             .Property(t => t.Notes)
             .IsRequired()
             .HasDefaultValueSql("'{}'");
+
+        // Covering index for the insider-trading dashboard's "top by dollar
+        // volume" queries (run three times per page: buys, sells, biggest).
+        // Each filters a ~90-day TransactionDate window, drops invalid-price and
+        // derivative rows, then orders by Shares * PricePerShare. The date window
+        // is the only selective filter, but the planner was choosing a full seq
+        // scan over the plain [Index(TransactionDate)] btree; the INCLUDE columns
+        // let the window resolve as an index-only scan (no heap fetch for the
+        // filter/sort fields), turning an ~805ms scan into ~90ms. Postgres-specific
+        // INCLUDE isn't expressible via the [Index] attribute, so it lives here;
+        // EF merges it with the entity's [Index(TransactionDate)] attribute into a
+        // single btree with the INCLUDE list attached.
+        builder
+            .Entity<InsiderTransaction>()
+            .HasIndex(t => t.TransactionDate)
+            .IncludeProperties(t => new
+            {
+                t.Shares,
+                t.PricePerShare,
+                t.IsPriceValid,
+                t.SecurityKind,
+                t.SecurityTitle,
+            });
     }
 }


### PR DESCRIPTION
(ReportDate, CommonStockId, InstitutionalHolderId) INCLUDE (Shares, Value) so the per-stock ranking pages' WHERE ReportDate=<quarter> GROUP BY CommonStockId scans run index-only with no sort (~1.3s → ~1.4ms). Model config only.

Stacked on the insider index branch. Shipped via EquiblesCommercial#1299.