### PR TITLE
perf(holdings): materialise per-stock quarterly activity for the conviction heat map

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -101,6 +101,11 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<RealtimeSweepState>();
         builder.Entity<FundScore>();
 
+        // StockQuarterlyActivity carries its composite (CommonStockId, ReportDate)
+        // key and ReportDate index as attributes on the entity; no Fluent config
+        // is needed beyond registering it.
+        builder.Entity<StockQuarterlyActivity>();
+
         // AumQuarterlySnapshot uses ReportDate as the primary key. The [Key]
         // attribute can't be paired with [DatabaseGenerated(None)] without EF
         // also treating it as identity-by-convention on integral types, but the

--- a/src/Equibles.Holdings.Data/Models/StockQuarterlyActivity.cs
+++ b/src/Equibles.Holdings.Data/Models/StockQuarterlyActivity.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.Data.Models;
+
+// Per-(stock, quarter) materialisation of the cross-sectional 13F activity that
+// powers /holdings/conviction-heat-map. Deriving these live meant scanning two
+// quarters of InstitutionalHolding (~3.4M rows) plus ~3.4M correlated NOT-EXISTS
+// probes for the new/sold-out filer counts — ~30s on a cache miss, holding a
+// pooled connection the whole time (#1262). This table holds the same numbers
+// (one row per stock per quarter) so the heat map reads ~6k pre-aggregated rows
+// in quarter order instead.
+//
+// Rebuilt by HoldingsAggregateRefreshService.RebuildQuarter (drain worker), the
+// same DirtyAt-coalesced path that maintains AumQuarterlySnapshot — when a
+// quarter goes dirty its whole stock slice is recomputed against the prior
+// quarter and upserted. PreviousReportDate is null for the earliest quarter on
+// record (every filer then counts as new).
+[PrimaryKey(nameof(CommonStockId), nameof(ReportDate))]
+[Index(nameof(ReportDate))]
+public class StockQuarterlyActivity
+{
+    public Guid CommonStockId { get; set; }
+
+    public DateOnly ReportDate { get; set; }
+
+    public DateOnly? PreviousReportDate { get; set; }
+
+    public long CurrentShares { get; set; }
+    public long PreviousShares { get; set; }
+    public long CurrentValue { get; set; }
+    public long PreviousValue { get; set; }
+
+    public int CurrentFilerCount { get; set; }
+    public int PreviousFilerCount { get; set; }
+    public int NewFilerCount { get; set; }
+    public int SoldOutFilerCount { get; set; }
+
+    public DateTime ComputedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs
+++ b/src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs
@@ -134,14 +134,23 @@ public class AumSnapshotRebuildWorker : BackgroundService
         var snapshotQuarters = await dbContext
             .Set<AumQuarterlySnapshot>()
             .CountAsync(cancellationToken);
-        if (snapshotQuarters >= holdingQuarters)
+        // RebuildQuarter also materialises StockQuarterlyActivity, so a quarter
+        // isn't fully covered until both snapshots exist for it — otherwise a
+        // newly-added activity table would never backfill once AUM is complete.
+        var activityQuarters = await dbContext
+            .Set<StockQuarterlyActivity>()
+            .Select(s => s.ReportDate)
+            .Distinct()
+            .CountAsync(cancellationToken);
+        if (snapshotQuarters >= holdingQuarters && activityQuarters >= holdingQuarters)
         {
             return;
         }
 
         _logger.LogInformation(
-            "AUM snapshot coverage incomplete ({Snapshots}/{Holdings} quarters) — running backfill with {Timeout}s command timeout",
+            "Holdings snapshot coverage incomplete (AUM {Snapshots}, activity {Activity} of {Holdings} quarters) — running backfill with {Timeout}s command timeout",
             snapshotQuarters,
+            activityQuarters,
             holdingQuarters,
             BackfillCommandTimeout.TotalSeconds
         );

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -202,6 +202,7 @@ public class HoldingsAggregateRefreshService
 
         await UpsertAumSnapshot(dbContext, reportDate, cancellationToken);
         await UpsertSectorSnapshots(dbContext, reportDate, cancellationToken);
+        await UpsertStockActivitySnapshots(dbContext, reportDate, cancellationToken);
     }
 
     private static async Task UpsertAumSnapshot(
@@ -354,6 +355,149 @@ public class HoldingsAggregateRefreshService
         await dbContext
             .Set<SectorQuarterlySnapshot>()
             .Where(s => s.ReportDate == reportDate && !currentSectorIds.Contains(s.SectorId))
+            .ExecuteDeleteAsync(cancellationToken);
+    }
+
+    // Per-stock cross-sectional activity for the conviction heat map: current vs
+    // prior-quarter shares/value/filer counts plus the new/sold-out filer counts.
+    // Mirrors InstitutionalHoldingRepository.GetQuarterlyActivity and
+    // GetQuarterlyNewSoldOutPositions exactly — the same numbers the heat map used
+    // to derive live (a two-quarter scan + ~millions of correlated NOT-EXISTS
+    // probes), here computed once per dirty quarter and read back per row.
+    private static async Task UpsertStockActivitySnapshots(
+        EquiblesFinancialDbContext dbContext,
+        DateOnly reportDate,
+        CancellationToken cancellationToken
+    )
+    {
+        // The prior quarter on record. default(DateOnly) when this is the
+        // earliest — no holding row carries that date, so every "previous"
+        // predicate below is simply false and all current filers count as new.
+        var previousReportDate = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h => h.ReportDate < reportDate)
+            .Select(h => h.ReportDate)
+            .OrderByDescending(d => d)
+            .FirstOrDefaultAsync(cancellationToken);
+        var hasPrevious = previousReportDate != default;
+
+        var activity = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h => h.ReportDate == reportDate || h.ReportDate == previousReportDate)
+            .GroupBy(h => h.CommonStockId)
+            .Select(g => new
+            {
+                CommonStockId = g.Key,
+                CurrentShares = g.Sum(h => h.ReportDate == reportDate ? h.Shares : 0L),
+                PreviousShares = g.Sum(h => h.ReportDate == previousReportDate ? h.Shares : 0L),
+                CurrentValue = g.Sum(h => h.ReportDate == reportDate ? h.Value : 0L),
+                PreviousValue = g.Sum(h => h.ReportDate == previousReportDate ? h.Value : 0L),
+                CurrentFilerCount = g.Where(h => h.ReportDate == reportDate)
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+                PreviousFilerCount = g.Where(h => h.ReportDate == previousReportDate)
+                    .Select(h => h.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+            })
+            .ToListAsync(cancellationToken);
+
+        // Per-stock churn via two NOT-EXISTS subqueries, identical to
+        // GetQuarterlyNewSoldOutPositions. Keyed by stock so it merges with the
+        // activity rows above.
+        var churn = (
+            await dbContext
+                .Set<InstitutionalHolding>()
+                .Where(h => h.ReportDate == reportDate || h.ReportDate == previousReportDate)
+                .GroupBy(h => h.CommonStockId)
+                .Select(g => new
+                {
+                    CommonStockId = g.Key,
+                    NewFilerCount = g.Where(h =>
+                            h.ReportDate == reportDate
+                            && !dbContext
+                                .Set<InstitutionalHolding>()
+                                .Any(p =>
+                                    p.ReportDate == previousReportDate
+                                    && p.CommonStockId == h.CommonStockId
+                                    && p.InstitutionalHolderId == h.InstitutionalHolderId
+                                )
+                        )
+                        .Select(h => h.InstitutionalHolderId)
+                        .Distinct()
+                        .Count(),
+                    SoldOutFilerCount = g.Where(h =>
+                            h.ReportDate == previousReportDate
+                            && !dbContext
+                                .Set<InstitutionalHolding>()
+                                .Any(c =>
+                                    c.ReportDate == reportDate
+                                    && c.CommonStockId == h.CommonStockId
+                                    && c.InstitutionalHolderId == h.InstitutionalHolderId
+                                )
+                        )
+                        .Select(h => h.InstitutionalHolderId)
+                        .Distinct()
+                        .Count(),
+                })
+                .ToListAsync(cancellationToken)
+        ).ToDictionary(c => c.CommonStockId);
+
+        var computedAt = DateTime.UtcNow;
+        var rows = activity
+            .Select(a =>
+            {
+                churn.TryGetValue(a.CommonStockId, out var c);
+                return new StockQuarterlyActivity
+                {
+                    CommonStockId = a.CommonStockId,
+                    ReportDate = reportDate,
+                    PreviousReportDate = hasPrevious ? previousReportDate : null,
+                    CurrentShares = a.CurrentShares,
+                    PreviousShares = a.PreviousShares,
+                    CurrentValue = a.CurrentValue,
+                    PreviousValue = a.PreviousValue,
+                    CurrentFilerCount = a.CurrentFilerCount,
+                    PreviousFilerCount = a.PreviousFilerCount,
+                    NewFilerCount = c?.NewFilerCount ?? 0,
+                    SoldOutFilerCount = c?.SoldOutFilerCount ?? 0,
+                    ComputedAt = computedAt,
+                };
+            })
+            .ToList();
+
+        if (rows.Count > 0)
+        {
+            await dbContext
+                .Set<StockQuarterlyActivity>()
+                .UpsertRange(rows)
+                .On(a => new { a.CommonStockId, a.ReportDate })
+                .WhenMatched(
+                    (_, incoming) =>
+                        new StockQuarterlyActivity
+                        {
+                            PreviousReportDate = incoming.PreviousReportDate,
+                            CurrentShares = incoming.CurrentShares,
+                            PreviousShares = incoming.PreviousShares,
+                            CurrentValue = incoming.CurrentValue,
+                            PreviousValue = incoming.PreviousValue,
+                            CurrentFilerCount = incoming.CurrentFilerCount,
+                            PreviousFilerCount = incoming.PreviousFilerCount,
+                            NewFilerCount = incoming.NewFilerCount,
+                            SoldOutFilerCount = incoming.SoldOutFilerCount,
+                            ComputedAt = incoming.ComputedAt,
+                        }
+                )
+                .RunAsync(cancellationToken);
+        }
+
+        // Stocks with no exposure in either quarter — drop their stale rows for
+        // this quarter so the heat map can't render a phantom point.
+        var currentStockIds = rows.Select(r => r.CommonStockId).ToList();
+        await dbContext
+            .Set<StockQuarterlyActivity>()
+            .Where(s => s.ReportDate == reportDate && !currentStockIds.Contains(s.CommonStockId))
             .ExecuteDeleteAsync(cancellationToken);
     }
 }

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -168,6 +168,12 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             });
     }
 
+    // Precomputed per-stock activity + churn for a quarter, maintained by
+    // HoldingsAggregateRefreshService. The conviction heat map reads this instead
+    // of deriving GetQuarterlyActivity + GetQuarterlyNewSoldOutPositions live.
+    public IQueryable<StockQuarterlyActivity> GetStockActivitySnapshots(DateOnly reportDate) =>
+        DbContext.Set<StockQuarterlyActivity>().Where(s => s.ReportDate == reportDate);
+
     // Double-down report: per-(holder, stock) positions where the share-count
     // increase from the prior quarter exceeds a given percentage threshold,
     // ranked by conviction (largest % increase first). Joins holder + stock


### PR DESCRIPTION
Adds a StockQuarterlyActivity table (one row per stock per quarter: current/prior shares, value, filer counts + new/sold-out filer counts), maintained by the existing per-quarter rebuild path (HoldingsAggregateRefreshService + drain worker + DirtyAt). The conviction heat map can then read ~6k pre-aggregated rows instead of deriving them live (a two-quarter scan + millions of correlated NOT-EXISTS probes, ~30s/miss). Computation mirrors GetQuarterlyActivity + GetQuarterlyNewSoldOutPositions exactly. Backfill gate waits for activity coverage too.

Consumed by the commercial portal (EquiblesCommercial#1286).