### PR TITLE
refactor(views): extract repeated badge-strip markup into BadgeStripTagHelper

### DIFF
--- a/src/Equibles.Web/TagHelpers/BadgeStripTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/BadgeStripTagHelper.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.Web.TagHelpers;
+
+// Wraps a horizontal strip of muted metadata badges (the gap-3 flex row that sits
+// above a card's stats/body). Centralises the class combo so the three Profiles
+// summary cards don't drift apart.
+[HtmlTargetElement("badge-strip")]
+public class BadgeStripTagHelper : TagHelper
+{
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var inner = await output.GetChildContentAsync();
+
+        output.TagName = "div";
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.Attributes.Clear();
+        output.Attributes.SetAttribute(
+            "class",
+            "flex flex-wrap items-center gap-3 mb-3 text-xs text-base-content/60"
+        );
+
+        output.Content.SetHtmlContent(inner);
+    }
+}

--- a/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml
@@ -35,14 +35,14 @@
         var overlap = Model.Overlap;
         <div class="card bg-base-100 shadow-sm mb-6" data-testid="combined-summary">
             <div class="card-body p-4">
-                <div class="flex flex-wrap items-center gap-3 mb-3 text-xs text-base-content/60">
+                <badge-strip>
                     <span class="badge badge-ghost">Report date: @overlap.ReportDate.ToString("MMM dd, yyyy")</span>
                     <span class="badge badge-ghost">@overlap.Funds.Count funds combined</span>
                     <span class="badge badge-ghost">@overlap.UnionPositionCount unique stocks</span>
                     @if (overlap.IntersectionPositionCount > 0) {
                         <span class="badge badge-success">@overlap.IntersectionPositionCount held by all</span>
                     }
-                </div>
+                </badge-strip>
                 <ul class="text-sm text-base-content/70 list-disc list-inside">
                     @foreach (var fund in overlap.Funds) {
                         <li>@fund.HolderName <span class="text-xs text-base-content/50">CIK @fund.HolderCik</span> — @fund.PositionCount positions, $@fund.TotalValue.ToString("N0")</li>

--- a/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
@@ -35,12 +35,12 @@
         <!-- Overlap summary header. -->
         <div class="card bg-base-100 shadow-sm mb-6" data-testid="compare-overlap-summary">
             <div class="card-body p-4">
-                <div class="flex flex-wrap items-center gap-3 mb-3 text-xs text-base-content/60">
+                <badge-strip>
                     <span class="badge badge-ghost">Report date: @overlap.ReportDate.ToString("MMM dd, yyyy")</span>
                     @if (Model.CommonReportDates.Count > 1) {
                         <span class="badge badge-ghost">@Model.CommonReportDates.Count common quarters</span>
                     }
-                </div>
+                </badge-strip>
                 <div class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200 w-full">
                     <stat-tile title="Union positions">@overlap.UnionPositionCount.ToString("N0")</stat-tile>
                     <stat-tile title="Shared positions">@overlap.IntersectionPositionCount.ToString("N0")</stat-tile>

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -49,13 +49,13 @@
         <!-- Portfolio summary header — derived from the latest report date for this holder. -->
         <div class="card bg-base-100 shadow-sm mb-8" data-testid="institution-summary">
             <div class="card-body p-4">
-                <div class="flex flex-wrap items-center gap-3 mb-3 text-xs text-base-content/60">
+                <badge-strip>
                     <span class="badge badge-ghost">Latest: @Model.Summary.LatestReportDate.Value.ToString("MMM dd, yyyy")</span>
                     @if (Model.Summary.PreviousReportDate.HasValue) {
                         <span class="badge badge-ghost">Prior: @Model.Summary.PreviousReportDate.Value.ToString("MMM dd, yyyy")</span>
                     }
                     <span class="badge badge-ghost">Quarters reported: @Model.Summary.QuartersReported</span>
-                </div>
+                </badge-strip>
                 <div class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200 w-full">
                     <stat-tile title="Reported AUM"><compactable-number value="@Model.Summary.ReportedAum" prefix="$" /></stat-tile>
                     <stat-tile title="# Positions"><compactable-number value="@Model.Summary.PositionCount" /></stat-tile>


### PR DESCRIPTION
## Summary

- The metadata badge-strip wrapper `<div class="flex flex-wrap items-center gap-3 mb-3 text-xs text-base-content/60">…</div>` was duplicated identically across three Profiles summary cards. Extracted it into a reusable `<badge-strip>` Tag Helper so the styling lives in one place and the three views can't drift apart.
- Behavior-preserving: the Tag Helper emits the exact same opening `<div>` with the same class string and renders its child badges unchanged, so the rendered HTML is identical.

## Code changes

- `src/Equibles.Web/TagHelpers/BadgeStripTagHelper.cs` — new Tag Helper targeting `<badge-strip>`; clears attributes, sets the badge-strip class, and passes child content through verbatim (mirrors the existing `StatTileTagHelper` pattern).
- `src/Equibles.Web/Views/Profiles/Institution.cshtml` — replaced the literal badge-strip div with `<badge-strip>`.
- `src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml` — same replacement.
- `src/Equibles.Web/Views/Profiles/CombinedInstitutions.cshtml` — same replacement.

Verified: Web build clean, 10 Profiles view-rendering integration tests pass, CSharpier check clean.