### PR TITLE
refactor(holdings): collapse five duplicated safe-percentage calcs into Percentage.Of helper

### DIFF
--- a/src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/FundOverlapCalculator.cs
@@ -57,12 +57,11 @@ public static class FundOverlapCalculator
 
         result.UnionPositionCount = allStockIds.Count;
         result.IntersectionPositionCount = intersectionCount;
-        result.JaccardSimilarityPercent =
-            allStockIds.Count > 0 ? (double)intersectionCount / allStockIds.Count * 100.0 : 0;
-        result.DollarWeightedOverlapPercent =
-            dollarWeightedDenominator > 0
-                ? (double)dollarWeightedNumerator / dollarWeightedDenominator * 100.0
-                : 0;
+        result.JaccardSimilarityPercent = Percentage.Of(intersectionCount, allStockIds.Count);
+        result.DollarWeightedOverlapPercent = Percentage.Of(
+            dollarWeightedNumerator,
+            dollarWeightedDenominator
+        );
 
         result.Rows = result.Rows.OrderByDescending(r => r.CombinedValue).ToList();
         return result;

--- a/src/Equibles.Holdings.Repositories/HolderQuarterlyActivityCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HolderQuarterlyActivityCalculator.cs
@@ -78,8 +78,7 @@ public static class HolderQuarterlyActivityCalculator
             PreviousShares = previous?.Shares ?? 0,
             PreviousValue = previous?.Value ?? 0,
             ChangeType = changeType,
-            PercentOfPortfolio =
-                totalCurrentValue > 0 ? (double)current.Value / totalCurrentValue * 100.0 : 0,
+            PercentOfPortfolio = Percentage.Of(current.Value, totalCurrentValue),
         };
     }
 

--- a/src/Equibles.Holdings.Repositories/IndustryAllocationCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/IndustryAllocationCalculator.cs
@@ -39,8 +39,7 @@ public static class IndustryAllocationCalculator
                     IndustryName = industryName,
                     PositionCount = perStock.Count,
                     TotalValue = industryValue,
-                    PercentOfPortfolio =
-                        totalValue > 0 ? (double)industryValue / totalValue * 100.0 : 0,
+                    PercentOfPortfolio = Percentage.Of(industryValue, totalValue),
                 };
             })
             // Unclassified always last, even if its value would otherwise rank it higher.

--- a/src/Equibles.Holdings.Repositories/Models/DoubleDownPosition.cs
+++ b/src/Equibles.Holdings.Repositories/Models/DoubleDownPosition.cs
@@ -14,6 +14,5 @@ public class DoubleDownPosition
     public long PreviousValue { get; set; }
 
     public long DeltaShares => CurrentShares - PreviousShares;
-    public double PctChange =>
-        PreviousShares > 0 ? (double)DeltaShares / PreviousShares * 100.0 : 0;
+    public double PctChange => Percentage.Of(DeltaShares, PreviousShares);
 }

--- a/src/Equibles.Holdings.Repositories/Percentage.cs
+++ b/src/Equibles.Holdings.Repositories/Percentage.cs
@@ -1,0 +1,7 @@
+namespace Equibles.Holdings.Repositories;
+
+public static class Percentage
+{
+    // Guard the divide so a zero (or empty) total yields 0% rather than NaN/Infinity.
+    public static double Of(double value, double total) => total > 0 ? value / total * 100.0 : 0;
+}


### PR DESCRIPTION
## Summary

- Five places in `Equibles.Holdings.Repositories` hand-rolled the same guarded percentage calculation `denom > 0 ? (double)num / denom * 100.0 : 0`. This collapses them into a single `Percentage.Of(value, total)` helper, removing the repeated divide-by-zero guard and matching the existing root static-helper pattern (`CombinedQuarterHelper`).
- Behavior-preserving: every operand is `long`/`int` (exact when widened to `double`), so each site yields the same `double`. Verified by the existing value-based calculator unit tests (2411/2411 pass) and an independent equivalence review of all five sites.

## Code changes

- `src/Equibles.Holdings.Repositories/Percentage.cs` — new static helper `Percentage.Of(double value, double total)` returning `total > 0 ? value / total * 100.0 : 0`.
- `HolderQuarterlyActivityCalculator.cs` — `PercentOfPortfolio` now calls `Percentage.Of(current.Value, totalCurrentValue)`.
- `FundOverlapCalculator.cs` — `JaccardSimilarityPercent` and `DollarWeightedOverlapPercent` now call `Percentage.Of(...)`.
- `IndustryAllocationCalculator.cs` — `PercentOfPortfolio` now calls `Percentage.Of(industryValue, totalValue)`.
- `Models/DoubleDownPosition.cs` — `PctChange` now calls `Percentage.Of(DeltaShares, PreviousShares)`.