### PR TITLE
refactor(holdings): route remaining manual safe-percentage calcs through Percentage.Of

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -140,7 +140,7 @@ public class InstitutionalHoldingsTools
             holdings,
             (rank, h) =>
             {
-                var pct = totalSharesAll > 0 ? (double)h.Shares / totalSharesAll * 100 : 0;
+                var pct = Percentage.Of(h.Shares, totalSharesAll);
                 return $"| {rank} | {h.InstitutionalHolder.Name} | "
                     + $"{McpFormat.WholeNumber(h.Shares)} | "
                     + $"{FormatMillions(h.Value)} | "
@@ -769,8 +769,7 @@ public class InstitutionalHoldingsTools
             (rank, r) =>
             {
                 var (ticker, name) = ResolveStockCells(stocks, r.CommonStockId);
-                var pct =
-                    universeFilers > 0 ? (double)r.CurrentFilerCount / universeFilers * 100.0 : 0;
+                var pct = Percentage.Of(r.CurrentFilerCount, universeFilers);
                 var deltaFilers = r.CurrentFilerCount - r.PreviousFilerCount;
                 return $"| {rank} | {ticker} | {name} | {McpFormat.WholeNumber(r.CurrentFilerCount)} | {FormatSignedShares(deltaFilers)} | {FormatMillions(r.CurrentValue)} | {FormatSignedMillions(r.DeltaValue)} | {FormatPercent(pct)}% |";
             }

--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -285,8 +285,7 @@ public class HoldingsActivityController : BaseController
                     PreviousFilerCount = r.PreviousFilerCount,
                     CurrentValue = r.CurrentValue,
                     PreviousValue = r.PreviousValue,
-                    PercentOfUniverse =
-                        universe > 0 ? (double)r.CurrentFilerCount / universe * 100.0 : 0,
+                    PercentOfUniverse = Percentage.Of(r.CurrentFilerCount, universe),
                 };
             })
             .ToList();
@@ -455,16 +454,12 @@ public class HoldingsActivityController : BaseController
         var newFilers = churn?.NewFilerCount ?? 0;
         var soldOut = churn?.SoldOutFilerCount ?? 0;
 
-        var netConviction =
-            activity.CurrentFilerCount > 0
-                ? (double)(newFilers - soldOut) / activity.CurrentFilerCount * 100.0
-                : 0;
+        var netConviction = Percentage.Of(newFilers - soldOut, activity.CurrentFilerCount);
         var retention =
             activity.PreviousFilerCount > 0
                 ? (1.0 - (double)soldOut / activity.PreviousFilerCount) * 100.0
                 : 0;
-        var universePct =
-            totalFilers > 0 ? (double)activity.CurrentFilerCount / totalFilers * 100.0 : 0;
+        var universePct = Percentage.Of(activity.CurrentFilerCount, totalFilers);
 
         var score = netConviction + retention + universePct;
 


### PR DESCRIPTION
## Summary

- Follow-up to the earlier Percentage.Of extraction: five manual `total > 0 ? (double)value / total * 100 : 0` calculations were still inline in the holdings most-held / heat-map paths.
- Routes them through the existing `Percentage.Of` helper so every safe-percentage calc shares one guarded implementation.
- Behaviour-preserving: each site operates on already-materialised data, the int/long arguments widen to double identically, and `* 100` vs `* 100.0` yield the same double, so the rendered percentages are unchanged.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — top-holders `% of Total` and most-held `% of 13F Universe` now call `Percentage.Of`.
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — most-held `PercentOfUniverse` and the heat-map `netConviction` / `universePct` scores now call `Percentage.Of` (the `retention` formula has a different shape and is left as-is).