### PR TITLE
refactor(integrations): centralise duplicated exponential-backoff formula into RetryBackoff helper

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -6,6 +6,7 @@ using Equibles.Congress.Data.Models;
 using Equibles.Congress.HostedService.Models;
 using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Common.RateLimiter;
+using Equibles.Integrations.Common.Retry;
 using UglyToad.PdfPig;
 using UglyToad.PdfPig.Content;
 using static Equibles.Congress.HostedService.Services.DisclosureParsingHelper;
@@ -425,8 +426,8 @@ public partial class HouseDisclosureClient
         );
     }
 
-    private static TimeSpan ExponentialBackoff(int attempt) =>
-        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+    // Thin forwarder so existing reflection-based backoff tests still find the method.
+    private static TimeSpan ExponentialBackoff(int attempt) => RetryBackoff.Exponential(attempt);
 
     // Owner codes that prefix the asset text: SP (Spouse), JT (Joint), DC
     // (Dependent Child). Member-owned holdings leave the column blank.

--- a/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
@@ -2,6 +2,7 @@ using Equibles.Congress.Data.Models;
 using Equibles.Congress.HostedService.Models;
 using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Common.RateLimiter;
+using Equibles.Integrations.Common.Retry;
 using Newtonsoft.Json;
 using static Equibles.Congress.HostedService.Services.DisclosureParsingHelper;
 
@@ -275,8 +276,8 @@ public class SenateDisclosureClient : IAsyncDisposable
         );
     }
 
-    private static TimeSpan ExponentialBackoff(int attempt) =>
-        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+    // Thin forwarder so existing reflection-based backoff tests still find the method.
+    private static TimeSpan ExponentialBackoff(int attempt) => RetryBackoff.Exponential(attempt);
 
     public async ValueTask DisposeAsync()
     {

--- a/src/Equibles.Integrations.Cboe/CboeClient.cs
+++ b/src/Equibles.Integrations.Cboe/CboeClient.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Equibles.Integrations.Cboe.Contracts;
 using Equibles.Integrations.Cboe.Models;
 using Equibles.Integrations.Common.RateLimiter;
+using Equibles.Integrations.Common.Retry;
 using Microsoft.Extensions.Logging;
 
 namespace Equibles.Integrations.Cboe;
@@ -115,8 +116,8 @@ public class CboeClient : ICboeClient
         throw new HttpRequestException("Max retries exceeded for CBOE download");
     }
 
-    private static TimeSpan ExponentialBackoff(int attempt) =>
-        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+    // Thin forwarder so existing reflection-based backoff tests still find the method.
+    private static TimeSpan ExponentialBackoff(int attempt) => RetryBackoff.Exponential(attempt);
 
     private static Dictionary<CboePutCallProductType, CboePutCallRecord> ParseDailyPutCallPage(
         string html,

--- a/src/Equibles.Integrations.Cftc/CftcClient.cs
+++ b/src/Equibles.Integrations.Cftc/CftcClient.cs
@@ -6,6 +6,7 @@ using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Cftc.Contracts;
 using Equibles.Integrations.Cftc.Models;
 using Equibles.Integrations.Common.RateLimiter;
+using Equibles.Integrations.Common.Retry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -91,8 +92,8 @@ public class CftcClient : ICftcClient
         throw new HttpRequestException("Max retries exceeded for CFTC download");
     }
 
-    private static TimeSpan ExponentialBackoff(int attempt) =>
-        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+    // Thin forwarder so existing reflection-based backoff tests still find the method.
+    private static TimeSpan ExponentialBackoff(int attempt) => RetryBackoff.Exponential(attempt);
 
     private async Task<List<CftcReportRecord>> ParseZipArchive(Stream zipStream)
     {

--- a/src/Equibles.Integrations.Common/Retry/RetryBackoff.cs
+++ b/src/Equibles.Integrations.Common/Retry/RetryBackoff.cs
@@ -1,0 +1,11 @@
+namespace Equibles.Integrations.Common.Retry;
+
+public static class RetryBackoff
+{
+    // Exponential backoff between HTTP retries: f(n) = 2^(n+1) seconds
+    // (f(0)=2s, f(1)=4s, f(2)=8s, f(3)=16s). The +1 shift starts the first
+    // retry at 2s — dropping it would halve every interval and turn an
+    // upstream throttle into a hard ban. Centralised so no client's copy drifts.
+    public static TimeSpan Exponential(int attempt) =>
+        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+}

--- a/src/Equibles.Integrations.Finra/FinraClient.cs
+++ b/src/Equibles.Integrations.Finra/FinraClient.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Common.RateLimiter;
+using Equibles.Integrations.Common.Retry;
 using Equibles.Integrations.Finra.Configuration;
 using Equibles.Integrations.Finra.Contracts;
 using Equibles.Integrations.Finra.Models;
@@ -332,8 +333,8 @@ public class FinraClient : IFinraClient
         throw new HttpRequestException("Max retries exceeded for FINRA API request");
     }
 
-    private static TimeSpan ExponentialBackoff(int attempt) =>
-        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+    // Thin forwarder so existing reflection-based backoff tests still find the method.
+    private static TimeSpan ExponentialBackoff(int attempt) => RetryBackoff.Exponential(attempt);
 
     // FINRA's API expects Gregorian ISO dates; InvariantCulture keeps the format
     // stable on non-Gregorian threads (e.g. ar-SA emits Hijri otherwise).

--- a/src/Equibles.Integrations.Fred/FredClient.cs
+++ b/src/Equibles.Integrations.Fred/FredClient.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Common.RateLimiter;
+using Equibles.Integrations.Common.Retry;
 using Equibles.Integrations.Fred.Configuration;
 using Equibles.Integrations.Fred.Contracts;
 using Equibles.Integrations.Fred.Models;
@@ -149,6 +150,6 @@ public class FredClient : IFredClient
         throw new HttpRequestException("Max retries exceeded for FRED API request");
     }
 
-    private static TimeSpan ExponentialBackoff(int attempt) =>
-        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+    // Thin forwarder so existing reflection-based backoff tests still find the method.
+    private static TimeSpan ExponentialBackoff(int attempt) => RetryBackoff.Exponential(attempt);
 }

--- a/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
+++ b/src/Equibles.Integrations.Yahoo/YahooFinanceClient.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Common.RateLimiter;
+using Equibles.Integrations.Common.Retry;
 using Equibles.Integrations.Yahoo.Contracts;
 using Equibles.Integrations.Yahoo.Models;
 using Equibles.Integrations.Yahoo.Models.Responses;
@@ -386,8 +387,8 @@ public class YahooFinanceClient : IYahooFinanceClient
         throw new HttpRequestException("Max retries exceeded for Yahoo Finance request");
     }
 
-    private static TimeSpan ExponentialBackoff(int attempt) =>
-        TimeSpan.FromSeconds(Math.Pow(2, attempt + 1));
+    // Thin forwarder so existing reflection-based backoff tests still find the method.
+    private static TimeSpan ExponentialBackoff(int attempt) => RetryBackoff.Exponential(attempt);
 
     private static async Task WaitForRetry(TimeSpan delay)
     {


### PR DESCRIPTION
## Summary

- Seven HTTP-retry clients each carried a byte-identical `ExponentialBackoff(int)` body — `TimeSpan.FromSeconds(Math.Pow(2, attempt + 1))` — so the retry-spacing formula could drift between clients with no single source of truth.
- Extracts the formula into one shared `RetryBackoff.Exponential` helper in `Equibles.Integrations.Common` (already referenced by all seven projects). Behaviour is identical: each retry interval is unchanged.

## Code changes

- `src/Equibles.Integrations.Common/Retry/RetryBackoff.cs` — new static helper holding the single `Exponential(int attempt)` backoff formula.
- `CftcClient`, `CboeClient`, `FinraClient`, `FredClient`, `YahooFinanceClient`, `HouseDisclosureClient`, `SenateDisclosureClient` — each client's private `ExponentialBackoff` is kept as a one-line forwarder to the shared helper (the existing reflection-based backoff tests pin these methods by name on each client type), plus the matching `using`.