### PR TITLE
refactor(views): extract repeated sort-select markup into _SortSelect partial

### DIFF
--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -92,12 +92,7 @@
                            aria-label="Maximum total dollar value" placeholder="Max $" />
                 </div>
             </label>
-            <label class="form-control">
-                <span class="label-text text-sm mb-1">Sort by</span>
-                <select name="sort" class="select select-bordered" aria-label="Sort institutions">
-                    <partial name="_SortOptions" model='(Html.GetEnumSelectList<InstitutionSort>(), (int)Model.Sort)' />
-                </select>
-            </label>
+            <partial name="_SortSelect" model='(Html.GetEnumSelectList<InstitutionSort>(), (int)Model.Sort, "institutions")' />
             <button type="submit" class="btn btn-primary">Apply</button>
             @if (hasFilters) {
                 <a asp-action="Index" class="btn btn-ghost">Clear</a>

--- a/src/Equibles.Web/Views/Shared/_SortSelect.cshtml
+++ b/src/Equibles.Web/Views/Shared/_SortSelect.cshtml
@@ -1,0 +1,12 @@
+@using Microsoft.AspNetCore.Mvc.Rendering
+@model (IEnumerable<SelectListItem> Options, int Selected, string AriaLabel)
+
+@* Filter-bar "Sort by" control shared across the browser index pages (stocks, institutions,
+   short volume, most shorted). Wraps the enum-backed sort <select> and delegates its option
+   list to _SortOptions so the selected-option matching stays in one place. *@
+<label class="form-control">
+    <span class="label-text text-sm mb-1">Sort by</span>
+    <select name="sort" class="select select-bordered" aria-label="Sort @Model.AriaLabel">
+        <partial name="_SortOptions" model="(Model.Options, Model.Selected)" />
+    </select>
+</label>

--- a/src/Equibles.Web/Views/ShortActivity/MostShorted.cshtml
+++ b/src/Equibles.Web/Views/ShortActivity/MostShorted.cshtml
@@ -44,12 +44,7 @@
                     }
                 </select>
             </label>
-            <label class="form-control">
-                <span class="label-text text-sm mb-1">Sort by</span>
-                <select name="sort" class="select select-bordered" aria-label="Sort stocks">
-                    <partial name="_SortOptions" model='(Html.GetEnumSelectList<MostShortedSort>(), (int)Model.Sort)' />
-                </select>
-            </label>
+            <partial name="_SortSelect" model='(Html.GetEnumSelectList<MostShortedSort>(), (int)Model.Sort, "stocks")' />
             <button type="submit" class="btn btn-primary">Apply</button>
             @if (filterRoute.ContainsKey("sort")) {
                 <a asp-action="MostShorted" asp-route-date="@Model.SelectedDate?.ToString("yyyy-MM-dd")" class="btn btn-ghost">Reset sort</a>

--- a/src/Equibles.Web/Views/ShortVolume/Index.cshtml
+++ b/src/Equibles.Web/Views/ShortVolume/Index.cshtml
@@ -44,12 +44,7 @@
                     }
                 </select>
             </label>
-            <label class="form-control">
-                <span class="label-text text-sm mb-1">Sort by</span>
-                <select name="sort" class="select select-bordered" aria-label="Sort stocks">
-                    <partial name="_SortOptions" model='(Html.GetEnumSelectList<ShortVolumeSort>(), (int)Model.Sort)' />
-                </select>
-            </label>
+            <partial name="_SortSelect" model='(Html.GetEnumSelectList<ShortVolumeSort>(), (int)Model.Sort, "stocks")' />
             <button type="submit" class="btn btn-primary">Apply</button>
             @if (filterRoute.ContainsKey("sort")) {
                 <a asp-action="Index" asp-route-date="@Model.SelectedDate?.ToString("yyyy-MM-dd")" class="btn btn-ghost">Reset sort</a>

--- a/src/Equibles.Web/Views/Stocks/Index.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Index.cshtml
@@ -32,12 +32,7 @@
                        aria-label="Search stocks by ticker or name"
                        placeholder="Ticker or name..." />
             </label>
-            <label class="form-control">
-                <span class="label-text text-sm mb-1">Sort by</span>
-                <select name="sort" class="select select-bordered" aria-label="Sort stocks">
-                    <partial name="_SortOptions" model='(Html.GetEnumSelectList<StockSort>(), (int)Model.Sort)' />
-                </select>
-            </label>
+            <partial name="_SortSelect" model='(Html.GetEnumSelectList<StockSort>(), (int)Model.Sort, "stocks")' />
             <label class="form-control">
                 <span class="label-text text-sm mb-1">Min market cap ($)</span>
                 <input type="number" name="minMarketCap" value="@Model.MinMarketCap"


### PR DESCRIPTION
## Summary

- The filter-bar "Sort by" control was duplicated byte-for-byte across four browser index views (Stocks, Institutions, Short Volume, Most Shorted), differing only by the sort enum type and the aria-label noun.
- Collapsed those four blocks into a single shared `_SortSelect` partial that composes the existing `_SortOptions` partial, so the wrapper markup lives in one place.

## Code changes

- `src/Equibles.Web/Views/Shared/_SortSelect.cshtml` — new shared partial; renders the `label`/`select` wrapper and delegates its option list to `_SortOptions`. Model is `(IEnumerable<SelectListItem> Options, int Selected, string AriaLabel)`.
- `src/Equibles.Web/Views/Stocks/Index.cshtml`, `Institutions/Index.cshtml`, `ShortVolume/Index.cshtml`, `ShortActivity/MostShorted.cshtml` — replaced the inline sort-select block with a `_SortSelect` partial call, passing each view's enum select list, current sort, and aria-label noun.

Rendered HTML is unchanged (same `name="sort"`, classes, option list, and per-view aria-label). Verified by the existing view-rendering and sort integration tests.