### PR TITLE
refactor(data): extract repeated latest-record-per-group LINQ into LatestPerGroup helper

### DIFF
--- a/src/Equibles.Data/Extensions/EnumerableLatestExtensions.cs
+++ b/src/Equibles.Data/Extensions/EnumerableLatestExtensions.cs
@@ -1,0 +1,22 @@
+namespace Equibles.Data.Extensions;
+
+public static class EnumerableLatestExtensions
+{
+    /// <summary>
+    /// Groups <paramref name="source"/> by <paramref name="keySelector"/> and returns the
+    /// single row with the highest <paramref name="dateSelector"/> value from each group —
+    /// the latest record per key. Runs in memory; call it after materialising an EF query,
+    /// never against an <see cref="IQueryable{T}"/> (the equivalent EF pattern must stay
+    /// inline so its expression tree still translates to SQL).
+    /// </summary>
+    public static IEnumerable<TSource> LatestPerGroup<TSource, TKey, TDate>(
+        this IEnumerable<TSource> source,
+        Func<TSource, TKey> keySelector,
+        Func<TSource, TDate> dateSelector
+    )
+    {
+        return source
+            .GroupBy(keySelector)
+            .Select(group => group.OrderByDescending(dateSelector).First());
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Core.AutoWiring;
 using Equibles.Data;
+using Equibles.Data.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Integrations.Sec.Contracts;
@@ -517,17 +518,18 @@ public class FinancialFactsImportService
     // keeping the latest-filed value.
     private static List<FinancialFact> CollapseToNaturalKey(List<FinancialFact> built) =>
         built
-            .GroupBy(f =>
-                (
-                    f.CommonStockId,
-                    f.FinancialConceptId,
-                    f.Unit,
-                    f.PeriodStart,
-                    f.PeriodEnd,
-                    f.AccessionNumber
-                )
+            .LatestPerGroup(
+                f =>
+                    (
+                        f.CommonStockId,
+                        f.FinancialConceptId,
+                        f.Unit,
+                        f.PeriodStart,
+                        f.PeriodEnd,
+                        f.AccessionNumber
+                    ),
+                f => f.FiledDate
             )
-            .Select(g => g.OrderByDescending(f => f.FiledDate).First())
             .ToList();
 
     private sealed class ParsedFact

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -3,6 +3,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.Extensions;
+using Equibles.Data.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
@@ -124,8 +125,8 @@ public class FinancialStatementTools
                 // Restatements re-emit the same concept; the latest-filed value
                 // is the currently-reported one.
                 var latestByConcept = facts
-                    .GroupBy(f => f.FinancialConceptId)
-                    .ToDictionary(g => g.Key, g => g.OrderByDescending(f => f.FiledDate).First());
+                    .LatestPerGroup(f => f.FinancialConceptId, f => f.FiledDate)
+                    .ToDictionary(f => f.FinancialConceptId);
 
                 return RenderStatementTable(
                     stock,

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -4,6 +4,7 @@ using Equibles.CommonStocks.Repositories;
 using Equibles.Congress.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Extensions;
+using Equibles.Data.Extensions;
 using Equibles.Finra.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
@@ -553,8 +554,8 @@ public class StockTabService
         // SEC re-emits a concept across filings (restatements); the latest-filed
         // value is the currently-reported one.
         var latestByConcept = facts
-            .GroupBy(f => f.FinancialConceptId)
-            .ToDictionary(g => g.Key, g => g.OrderByDescending(f => f.FiledDate).First());
+            .LatestPerGroup(f => f.FinancialConceptId, f => f.FiledDate)
+            .ToDictionary(f => f.FinancialConceptId);
 
         return statementLines
             .Select(line =>

--- a/src/Equibles.Yahoo.HostedService/Services/YahooStockPriceProvider.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooStockPriceProvider.cs
@@ -1,5 +1,6 @@
 using Equibles.Core.Contracts;
 using Equibles.Data;
+using Equibles.Data.Extensions;
 using Equibles.Yahoo.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -50,9 +51,7 @@ public class YahooStockPriceProvider : IStockPriceProvider
                 .ToListAsync(cancellationToken);
 
             // Pick the latest price per stock
-            var latestByStock = prices
-                .GroupBy(p => p.CommonStockId)
-                .Select(g => g.OrderByDescending(p => p.Date).First());
+            var latestByStock = prices.LatestPerGroup(p => p.CommonStockId, p => p.Date);
 
             foreach (var price in latestByStock)
             {


### PR DESCRIPTION
## Summary

- Four call sites independently re-implemented "pick the latest record per group key" with `.GroupBy(key).Select(g => g.OrderByDescending(date).First())` (or the `.ToDictionary` variant). Collapse them into one shared in-memory extension, `EnumerableLatestExtensions.LatestPerGroup`.
- Behaviour-preserving: every site already operated on a materialized collection, so the helper makes the identical LINQ-to-Objects calls. The EF `IQueryable` repository cases are deliberately left inline so their expression trees still translate to SQL.

## Code changes

- `src/Equibles.Data/Extensions/EnumerableLatestExtensions.cs` — new `LatestPerGroup(keySelector, dateSelector)` extension that returns the highest-by-date row per group; sits beside the existing `QueryableLatestExtensions`. Doc comment warns against `IQueryable` use.
- `src/Equibles.Yahoo.HostedService/Services/YahooStockPriceProvider.cs` — latest price per stock now via `LatestPerGroup`.
- `src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs` — `CollapseToNaturalKey` collapses to one row per natural key via `LatestPerGroup`.
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs` — latest-filed value per concept via `LatestPerGroup(...).ToDictionary(...)`.
- `src/Equibles.Web/Services/StockTabService.cs` — same latest-filed-per-concept rewrite.