### PR TITLE
refactor(mcp): extract repeated search-result table tail into MarkdownTable.Render helper

### DIFF
--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -199,23 +199,14 @@ public class CftcTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                if (contracts.Count == 0)
-                    return $"No contracts found matching '{query}'.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    contracts,
+                    $"No contracts found matching '{query}'.",
                     $"CFTC contracts matching '{query}':",
                     "| Market Code | Name | Category |",
-                    "|-------------|------|----------|"
+                    "|-------------|------|----------|",
+                    c => $"| {c.MarketCode} | {c.MarketName} | {c.Category.NameForHumans()} |"
                 );
-
-                foreach (var c in contracts)
-                {
-                    result.AppendLine(
-                        $"| {c.MarketCode} | {c.MarketName} | {c.Category.NameForHumans()} |"
-                    );
-                }
-
-                return result.ToString();
             },
             "SearchCftcMarkets",
             $"query: {query}"

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -194,21 +194,14 @@ public class CongressTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                if (members.Count == 0)
-                    return $"No congress members found matching '{query}'.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    members,
+                    $"No congress members found matching '{query}'.",
                     $"Congress members matching '{query}':",
                     "| Name | Position |",
-                    "|------|----------|"
+                    "|------|----------|",
+                    m => $"| {m.Name} | {m.Position.NameForHumans()} |"
                 );
-
-                foreach (var m in members)
-                {
-                    result.AppendLine($"| {m.Name} | {m.Position.NameForHumans()} |");
-                }
-
-                return result.ToString();
             },
             "SearchCongressMembers",
             $"query: {query}"

--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -194,23 +194,14 @@ public class FredTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                if (series.Count == 0)
-                    return $"No series found matching '{query}'.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    series,
+                    $"No series found matching '{query}'.",
                     $"Economic indicators matching '{query}':",
                     "| Series ID | Title | Category | Frequency | Units |",
-                    "|-----------|-------|----------|-----------|-------|"
+                    "|-----------|-------|----------|-----------|-------|",
+                    s => $"| {s.SeriesId} | {s.Title} | {s.Category} | {s.Frequency} | {s.Units} |"
                 );
-
-                foreach (var s in series)
-                {
-                    result.AppendLine(
-                        $"| {s.SeriesId} | {s.Title} | {s.Category} | {s.Frequency} | {s.Units} |"
-                    );
-                }
-
-                return result.ToString();
             },
             "SearchEconomicIndicators",
             $"query: {query}"

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -305,23 +305,14 @@ public class InstitutionalHoldingsTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                if (holders.Count == 0)
-                    return $"No institutions found matching '{query}'.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    holders,
+                    $"No institutions found matching '{query}'.",
                     $"Institutions matching '{query}':",
                     "| Institution | CIK | City | State/Country |",
-                    "|------------|-----|------|--------------|"
+                    "|------------|-----|------|--------------|",
+                    h => $"| {h.Name} | {h.Cik} | {h.City ?? "—"} | {h.StateOrCountry ?? "—"} |"
                 );
-
-                foreach (var h in holders)
-                {
-                    result.AppendLine(
-                        $"| {h.Name} | {h.Cik} | {h.City ?? "—"} | {h.StateOrCountry ?? "—"} |"
-                    );
-                }
-
-                return result.ToString();
             },
             "SearchInstitutions",
             $"query: {query}"

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -224,30 +224,24 @@ public class InsiderTradingTools
 
                 var insiders = await _ownerRepository.Search(query).Take(maxResults).ToListAsync();
 
-                if (insiders.Count == 0)
-                    return $"No insiders found matching '{query}'.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    insiders,
+                    $"No insiders found matching '{query}'.",
                     $"Insiders matching '{query}':",
                     "| Name | CIK | Role | Location |",
-                    "|------|-----|------|----------|"
+                    "|------|-----|------|----------|",
+                    insider =>
+                    {
+                        var role = GetRole(insider);
+                        var location = string.Join(
+                            ", ",
+                            new[] { insider.City, insider.StateOrCountry }.Where(s =>
+                                !string.IsNullOrEmpty(s)
+                            )
+                        );
+                        return $"| {insider.Name} | {insider.OwnerCik} | {role} | {location} |";
+                    }
                 );
-
-                foreach (var insider in insiders)
-                {
-                    var role = GetRole(insider);
-                    var location = string.Join(
-                        ", ",
-                        new[] { insider.City, insider.StateOrCountry }.Where(s =>
-                            !string.IsNullOrEmpty(s)
-                        )
-                    );
-                    result.AppendLine(
-                        $"| {insider.Name} | {insider.OwnerCik} | {role} | {location} |"
-                    );
-                }
-
-                return result.ToString();
             },
             "SearchInsiders",
             $"query: {query}"

--- a/src/Equibles.Mcp/Helpers/MarkdownTable.cs
+++ b/src/Equibles.Mcp/Helpers/MarkdownTable.cs
@@ -32,6 +32,28 @@ public static class MarkdownTable
         return sb;
     }
 
+    // Renders rows as a markdown table, or returns emptyMessage verbatim when there are none.
+    // Centralises the search-result table shape (empty check → header → one row per item)
+    // repeated across the MCP search tools. Callers materialise the query first so this helper
+    // stays free of any data-access dependency.
+    public static string Render<T>(
+        IReadOnlyList<T> rows,
+        string emptyMessage,
+        string title,
+        string headerRow,
+        string separatorRow,
+        Func<T, string> renderRow
+    )
+    {
+        if (rows.Count == 0)
+            return emptyMessage;
+
+        var sb = Start(title, headerRow, separatorRow);
+        foreach (var row in rows)
+            sb.AppendLine(renderRow(row));
+        return sb.ToString();
+    }
+
     // Appends one markdown row per item in order, passing the 1-based rank and the item to
     // renderRow. Centralises the ranked-table loop so call sites don't repeat the `i + 1`
     // off-by-one and the `rows[i]` indexing.

--- a/src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs
@@ -53,23 +53,15 @@ public class InvestmentAdviserTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                if (advisers.Count == 0)
-                    return $"No investment advisers found matching \"{query}\".";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    advisers,
+                    $"No investment advisers found matching \"{query}\".",
                     $"Investment advisers matching \"{query}\" ({advisers.Count} shown, largest by assets first):",
                     "| CRD | Name | Location | Regulatory AUM | Employees |",
-                    "|-----|------|----------|----------------|-----------|"
-                );
-
-                foreach (var a in advisers)
-                {
-                    result.AppendLine(
+                    "|-----|------|----------|----------------|-----------|",
+                    a =>
                         $"| {a.Crd} | {a.LegalName ?? "-"} | {FormatLocation(a)} | {FormatAum(a.TotalRegulatoryAum)} | {FormatCount(a.NumberOfEmployees)} |"
-                    );
-                }
-
-                return result.ToString();
+                );
             },
             "SearchInvestmentAdvisers",
             $"query: {query}"


### PR DESCRIPTION
## Summary

- Six MCP search tools each repeated the same search-result table tail: an empty-results check, `MarkdownTable.Start(...)`, a `foreach` appending one markdown row per item, and `ToString()`. This collapses that duplicated scaffold into a single generic `MarkdownTable.Render<T>` helper.
- Behavior-preserving: each call site passes the same empty message, title, header, separator, and per-row expression, so the rendered output is byte-identical. Queries are still materialized at the call site, so the helper stays free of any data-access dependency.

## Code changes

- `src/Equibles.Mcp/Helpers/MarkdownTable.cs` — add `Render<T>(rows, emptyMessage, title, headerRow, separatorRow, renderRow)` that returns the empty message when there are no rows, otherwise builds the table via the existing `Start` overload and one row per item.
- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs`, `src/Equibles.Congress.Mcp/Tools/CongressTools.cs`, `src/Equibles.Fred.Mcp/Tools/FredTools.cs`, `src/Equibles.Sec.Mcp/Tools/InvestmentAdviserTools.cs`, `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs`, `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — replace the inline empty-check + table-building loop with a `MarkdownTable.Render(...)` call.