### PR TITLE
refactor(worker): extract repeated sync-start-date scope lookup into SyncStartDate helper

### DIFF
--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -7,7 +7,6 @@ using Equibles.Finra.Repositories;
 using Equibles.Integrations.Finra.Contracts;
 using Equibles.Integrations.Finra.Models;
 using Equibles.Worker;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
 namespace Equibles.Finra.HostedService.Services;
@@ -43,13 +42,12 @@ public class ShortVolumeImportService
 
     public async Task Import(CancellationToken cancellationToken)
     {
-        DateOnly startDate;
-        using (var scope = _scopeFactory.CreateScope())
-        {
-            var repo = scope.ServiceProvider.GetRequiredService<DailyShortVolumeRepository>();
-            var latestDate = await repo.GetLatestDate().FirstOrDefaultAsync(cancellationToken);
-            startDate = SyncDateResolver.Resolve(latestDate, _workerOptions);
-        }
+        var startDate = await SyncStartDate.Resolve<DailyShortVolumeRepository>(
+            _scopeFactory,
+            _workerOptions,
+            repo => repo.GetLatestDate(),
+            cancellationToken
+        );
 
         var endDate = DateOnly.FromDateTime(DateTime.UtcNow);
 

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -46,13 +46,12 @@ public class FtdImportService
 
     public async Task Import(CancellationToken cancellationToken)
     {
-        DateOnly startDate;
-        using (var scope = _scopeFactory.CreateScope())
-        {
-            var repo = scope.ServiceProvider.GetRequiredService<FailToDeliverRepository>();
-            var latestDate = await repo.GetLatestDate().FirstOrDefaultAsync(cancellationToken);
-            startDate = SyncDateResolver.Resolve(latestDate, _workerOptions);
-        }
+        var startDate = await SyncStartDate.Resolve<FailToDeliverRepository>(
+            _scopeFactory,
+            _workerOptions,
+            repo => repo.GetLatestDate(),
+            cancellationToken
+        );
 
         var fileNames = GetFileNames(startDate);
 

--- a/src/Equibles.Worker/SyncStartDate.cs
+++ b/src/Equibles.Worker/SyncStartDate.cs
@@ -1,0 +1,26 @@
+using Equibles.Core.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.Worker;
+
+public static class SyncStartDate
+{
+    /// <summary>
+    /// Resolves the next sync start date by reading the latest stored date from a repository
+    /// in a fresh DI scope and feeding it through <see cref="SyncDateResolver.Resolve"/>.
+    /// </summary>
+    public static async Task<DateOnly> Resolve<TRepository>(
+        IServiceScopeFactory scopeFactory,
+        WorkerOptions workerOptions,
+        Func<TRepository, IQueryable<DateOnly>> latestDateQuery,
+        CancellationToken cancellationToken
+    )
+        where TRepository : notnull
+    {
+        using var scope = scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<TRepository>();
+        var latestDate = await latestDateQuery(repo).FirstOrDefaultAsync(cancellationToken);
+        return SyncDateResolver.Resolve(latestDate, workerOptions);
+    }
+}

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -317,16 +317,16 @@ public class YahooPriceImportService
         CancellationToken cancellationToken
     )
     {
-        using var scope = _scopeFactory.CreateScope();
-        var repo = scope.ServiceProvider.GetRequiredService<DailyStockPriceRepository>();
-
-        var latestDate = await repo.GetAll()
-            .Where(p => p.CommonStockId == commonStockId)
-            .Select(p => p.Date)
-            .OrderByDescending(d => d)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        return SyncDateResolver.Resolve(latestDate, _workerOptions);
+        return await SyncStartDate.Resolve<DailyStockPriceRepository>(
+            _scopeFactory,
+            _workerOptions,
+            repo =>
+                repo.GetAll()
+                    .Where(p => p.CommonStockId == commonStockId)
+                    .Select(p => p.Date)
+                    .OrderByDescending(d => d),
+            cancellationToken
+        );
     }
 
     private HashSet<DateOnly> WarnAndCollectOverflowDates(


### PR DESCRIPTION
## Summary

- Three background scrapers each opened a DI scope, resolved a repository, read the latest stored date, and fed it through `SyncDateResolver.Resolve` — the same boilerplate repeated near-identically.
- Collapsed that into a single generic `SyncStartDate.Resolve<TRepository>(...)` helper in `Equibles.Worker`, with the per-scraper latest-date query passed as a lambda. Behavior is unchanged: same scope lifetime, same query, same resolution.

## Code changes

- `src/Equibles.Worker/SyncStartDate.cs` — new static helper: opens a DI scope, resolves `TRepository`, awaits the supplied `Func<TRepository, IQueryable<DateOnly>>` via `FirstOrDefaultAsync`, and returns `SyncDateResolver.Resolve(latestDate, options)`. Mirrors the existing `BatchPersister` helper idiom.
- `src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs` — replaced the inline scope+lookup with the helper (`repo => repo.GetLatestDate()`); dropped the now-unused EF Core using.
- `src/Equibles.Sec.HostedService/Services/FtdImportService.cs` — same replacement (`repo => repo.GetLatestDate()`).
- `src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs` — `GetSyncStartDate` now delegates to the helper, passing its per-stock latest-date query as the lambda.