### PR TITLE
refactor(cftc): collapse three nullable-number parse helpers into generic Parse<T>

### DIFF
--- a/src/Equibles.Integrations.Cftc/CftcClient.cs
+++ b/src/Equibles.Integrations.Cftc/CftcClient.cs
@@ -253,30 +253,19 @@ public class CftcClient : ICftcClient
         return string.IsNullOrEmpty(value) ? null : value;
     }
 
-    private static long? ParseLong(string value)
-    {
-        if (value == null)
-            return null;
-        return long.TryParse(value.Replace(",", ""), CultureInfo.InvariantCulture, out var result)
-            ? result
-            : null;
-    }
+    private static long? ParseLong(string value) => Parse<long>(value, stripCommas: true);
 
-    private static decimal? ParseDecimal(string value)
-    {
-        if (value == null)
-            return null;
-        return decimal.TryParse(value, CultureInfo.InvariantCulture, out var result)
-            ? result
-            : null;
-    }
+    // CFTC monetary columns carry no thousands separators, so commas are left intact here.
+    private static decimal? ParseDecimal(string value) => Parse<decimal>(value, stripCommas: false);
 
-    private static int? ParseInt(string value)
+    private static int? ParseInt(string value) => Parse<int>(value, stripCommas: true);
+
+    private static T? Parse<T>(string value, bool stripCommas)
+        where T : struct, IParsable<T>
     {
         if (value == null)
             return null;
-        return int.TryParse(value.Replace(",", ""), CultureInfo.InvariantCulture, out var result)
-            ? result
-            : null;
+        var text = stripCommas ? value.Replace(",", "") : value;
+        return T.TryParse(text, CultureInfo.InvariantCulture, out var result) ? result : null;
     }
 }


### PR DESCRIPTION
## Summary

- `CftcClient` had three near-identical private helpers — `ParseLong`, `ParseDecimal`, `ParseInt` — that differed only in target type and whether thousands-separator commas were stripped before parsing.
- Collapsed the shared logic into a single generic `Parse<T>(string value, bool stripCommas)` constrained to `struct, IParsable<T>`, keeping the three named methods as one-line delegators so behavior and reflection-pinned signatures stay identical.

## Code changes

- `src/Equibles.Integrations.Cftc/CftcClient.cs` — replaced the three duplicated parse bodies with delegators to a new generic `Parse<T>` helper. `ParseLong`/`ParseInt` pass `stripCommas: true`; `ParseDecimal` passes `stripCommas: false` (monetary columns carry no separators), making the previously implicit comma-stripping asymmetry an explicit, documented parameter. Null-guard and `InvariantCulture` parsing are unchanged.