### PR TITLE
refactor(insider-trading-mcp): collapse three duplicated table renders onto MarkdownTable.Render

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -66,34 +66,28 @@ public class InsiderTradingTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                if (transactions.Count == 0)
-                    return $"No insider transactions found for {ticker}.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    transactions,
+                    $"No insider transactions found for {ticker}.",
                     $"Recent insider transactions for {stock.Name} ({ticker}):",
                     $"Showing {transactions.Count} most recent transactions",
                     "| Date | Insider | Role | Type | Shares | Price | Value | Owned After |",
-                    "|------|---------|------|------|--------|-------|-------|-------------|"
-                );
-
-                foreach (var t in transactions)
-                {
-                    var role = GetRole(t.InsiderOwner);
-                    var type = t.TransactionCode switch
+                    "|------|---------|------|------|--------|-------|-------|-------------|",
+                    t =>
                     {
-                        TransactionCode.Award => "Award",
-                        TransactionCode.Gift => "Gift",
-                        TransactionCode.Exercise => "Exercise",
-                        _ => t.AcquiredDisposed == AcquiredDisposed.Acquired ? "Buy" : "Sell",
-                    };
+                        var role = GetRole(t.InsiderOwner);
+                        var type = t.TransactionCode switch
+                        {
+                            TransactionCode.Award => "Award",
+                            TransactionCode.Gift => "Gift",
+                            TransactionCode.Exercise => "Exercise",
+                            _ => t.AcquiredDisposed == AcquiredDisposed.Acquired ? "Buy" : "Sell",
+                        };
 
-                    var value = t.Shares * t.PricePerShare;
-                    result.AppendLine(
-                        $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(t.Shares)} | ${McpFormat.Invariant(t.PricePerShare, "N2")} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(t.SharesOwnedAfter)} |"
-                    );
-                }
-
-                return result.ToString();
+                        var value = t.Shares * t.PricePerShare;
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.InsiderOwner.Name} | {role} | {type} | {McpFormat.WholeNumber(t.Shares)} | ${McpFormat.Invariant(t.PricePerShare, "N2")} | ${McpFormat.WholeNumber(value)} | {McpFormat.WholeNumber(t.SharesOwnedAfter)} |";
+                    }
+                );
             },
             "GetInsiderTransactions",
             $"ticker: {ticker}"
@@ -132,27 +126,21 @@ public class InsiderTradingTools
                     .Take(30)
                     .ToListAsync();
 
-                if (latestTransactions.Count == 0)
-                    return $"No insider ownership data found for {ticker}.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    latestTransactions,
+                    $"No insider ownership data found for {ticker}.",
                     $"Insider ownership summary for {stock.Name} ({ticker}):",
                     $"Showing {latestTransactions.Count} insiders with most recent data",
                     "| Insider | Role | Shares Owned | Last Transaction | Last Date |",
-                    "|---------|------|-------------|-----------------|-----------|"
+                    "|---------|------|-------------|-----------------|-----------|",
+                    t =>
+                    {
+                        var role = GetRole(t.InsiderOwner);
+                        var lastType = t.TransactionCode.ToString();
+                        var sharesOwned = McpFormat.WholeNumber(t.SharesOwnedAfter);
+                        return $"| {t.InsiderOwner.Name} | {role} | {sharesOwned} | {lastType} | {t.TransactionDate:yyyy-MM-dd} |";
+                    }
                 );
-
-                foreach (var t in latestTransactions)
-                {
-                    var role = GetRole(t.InsiderOwner);
-                    var lastType = t.TransactionCode.ToString();
-                    var sharesOwned = McpFormat.WholeNumber(t.SharesOwnedAfter);
-                    result.AppendLine(
-                        $"| {t.InsiderOwner.Name} | {role} | {sharesOwned} | {lastType} | {t.TransactionDate:yyyy-MM-dd} |"
-                    );
-                }
-
-                return result.ToString();
             },
             "GetInsiderOwnership",
             $"ticker: {ticker}"
@@ -181,27 +169,21 @@ public class InsiderTradingTools
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
-                if (filings.Count == 0)
-                    return $"No Form 144 proposed sales found for {ticker}.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    filings,
+                    $"No Form 144 proposed sales found for {ticker}.",
                     $"Recent proposed sales (Form 144) for {stock.Name} ({ticker}):",
                     $"Showing {filings.Count} most recent notices",
                     "| Filed | Seller | Relationship | Shares | Market Value | Approx. Sale Date | Broker |",
-                    "|-------|--------|--------------|--------|--------------|-------------------|--------|"
+                    "|-------|--------|--------------|--------|--------------|-------------------|--------|",
+                    f =>
+                    {
+                        var approxSaleDate =
+                            f.ApproxSaleDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
+                            ?? "-";
+                        return $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {approxSaleDate} | {f.BrokerName} |";
+                    }
                 );
-
-                foreach (var f in filings)
-                {
-                    var approxSaleDate =
-                        f.ApproxSaleDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
-                        ?? "-";
-                    result.AppendLine(
-                        $"| {f.FilingDate:yyyy-MM-dd} | {f.SellerName} | {f.RelationshipToIssuer} | {McpFormat.WholeNumber(f.SharesToBeSold)} | ${McpFormat.WholeNumber(f.AggregateMarketValue)} | {approxSaleDate} | {f.BrokerName} |"
-                    );
-                }
-
-                return result.ToString();
             },
             "GetProposedSales",
             $"ticker: {ticker}"

--- a/src/Equibles.Mcp/Helpers/MarkdownTable.cs
+++ b/src/Equibles.Mcp/Helpers/MarkdownTable.cs
@@ -54,6 +54,28 @@ public static class MarkdownTable
         return sb.ToString();
     }
 
+    // Subtitle-carrying variant of Render: same empty-check and one-row-per-item shape,
+    // but renders the title + subtitle header (with the load-bearing blank line) for the
+    // tools that show a "Showing N of M" line above the table.
+    public static string Render<T>(
+        IReadOnlyList<T> rows,
+        string emptyMessage,
+        string title,
+        string subtitle,
+        string headerRow,
+        string separatorRow,
+        Func<T, string> renderRow
+    )
+    {
+        if (rows.Count == 0)
+            return emptyMessage;
+
+        var sb = Start(title, subtitle, headerRow, separatorRow);
+        foreach (var row in rows)
+            sb.AppendLine(renderRow(row));
+        return sb.ToString();
+    }
+
     // Appends one markdown row per item in order, passing the 1-based rank and the item to
     // renderRow. Centralises the ranked-table loop so call sites don't repeat the `i + 1`
     // off-by-one and the `rows[i]` indexing.


### PR DESCRIPTION
## Summary

- The three `InsiderTradingTools` reads (`GetInsiderTransactions`, `GetInsiderOwnership`, `GetProposedSales`) each hand-rolled the same empty-check → `MarkdownTable.Start` → `foreach AppendLine` → `ToString` table-render block. This collapses them onto the shared `MarkdownTable.Render` helper, the same direction as the recent FINRA/search-result render consolidations.
- `MarkdownTable.Render` had no subtitle-carrying overload, which is why these "Showing N of M" tables stayed inline; this adds that overload so they can use it.
- Behavior-preserving: output is byte-identical (same `Start(title, subtitle, header, sep)` layout, row expressions copied verbatim, identical empty-message returns).

## Code changes

- `src/Equibles.Mcp/Helpers/MarkdownTable.cs` — adds a `Render<T>` overload that takes a `subtitle`, mirroring the existing `Render` but emitting the title + subtitle header (with the load-bearing blank line) via the 4-arg `Start`.
- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — migrates the three render methods onto the new overload, moving each per-row interpolation into the `renderRow` lambda and dropping the duplicated `StringBuilder` plumbing.