### PR TITLE
refactor(sec-mcp): collapse two duplicated table-render tails onto MarkdownTable.Render

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -68,24 +68,18 @@ public class FailToDeliverTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                if (records.Count == 0)
-                    return $"No FTD data found for {stock.Ticker} in the specified date range.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    records.OrderBy(f => f.SettlementDate).ToList(),
+                    $"No FTD data found for {stock.Ticker} in the specified date range.",
                     $"Fails-to-deliver for {stock.Ticker} ({stock.Name}):",
                     "| Settlement Date | Quantity | Price | Value |",
-                    "|----------------|---------|-------|-------|"
+                    "|----------------|---------|-------|-------|",
+                    f =>
+                    {
+                        var value = f.Quantity * f.Price;
+                        return $"| {f.SettlementDate:yyyy-MM-dd} | {McpFormat.WholeNumber(f.Quantity)} | ${McpFormat.Invariant(f.Price, "F2")} | ${McpFormat.WholeNumber(value)} |";
+                    }
                 );
-
-                foreach (var f in records.OrderBy(f => f.SettlementDate))
-                {
-                    var value = f.Quantity * f.Price;
-                    result.AppendLine(
-                        $"| {f.SettlementDate:yyyy-MM-dd} | {McpFormat.WholeNumber(f.Quantity)} | ${McpFormat.Invariant(f.Price, "F2")} | ${McpFormat.WholeNumber(value)} |"
-                    );
-                }
-
-                return result.ToString();
             },
             "GetFailsToDeliver",
             $"ticker: {ticker}"

--- a/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FormDTools.cs
@@ -54,23 +54,15 @@ public class FormDTools
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
-                if (filings.Count == 0)
-                    return $"No Form D exempt offerings found for {ticker}.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    filings,
+                    $"No Form D exempt offerings found for {ticker}.",
                     $"Recent exempt offerings (Form D) for {stock.Name} ({ticker}) — showing {filings.Count} most recent notices:",
                     "| Filed | Amendment | Industry | Offering Amount | Sold | Min. Investment | Investors | Exemptions |",
-                    "|-------|-----------|----------|-----------------|------|-----------------|-----------|------------|"
-                );
-
-                foreach (var f in filings)
-                {
-                    result.AppendLine(
+                    "|-------|-----------|----------|-----------------|------|-----------------|-----------|------------|",
+                    f =>
                         $"| {f.FilingDate:yyyy-MM-dd} | {(f.IsAmendment ? "Yes" : "No")} | {f.IndustryGroup ?? "-"} | {FormatAmount(f.TotalOfferingAmount, f.IsOfferingAmountIndefinite)} | ${McpFormat.WholeNumber(f.TotalAmountSold)} | ${McpFormat.WholeNumber(f.MinimumInvestmentAccepted)} | {McpFormat.WholeNumber(f.TotalNumberAlreadyInvested)} | {f.FederalExemptions ?? "-"} |"
-                    );
-                }
-
-                return result.ToString();
+                );
             },
             "GetExemptOfferings",
             $"ticker: {ticker}"


### PR DESCRIPTION
## Summary

- Two SEC MCP tools hand-rolled the same markdown-table tail (`empty-check` → `MarkdownTable.Start` → `foreach` append → `ToString`) that the shared `MarkdownTable.Render` helper already encapsulates.
- Routed both onto `MarkdownTable.Render`, matching the recent collapses in the FINRA, CFTC, and insider-trading MCP tools. Output is byte-identical.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs` — replaced the manual empty-check + `Start`/`foreach`/`ToString` block with `MarkdownTable.Render`, passing the ascending-sorted records list and folding the "no data" message into the helper's empty-message argument.
- `src/Equibles.Sec.Mcp/Tools/FormDTools.cs` — same collapse onto `MarkdownTable.Render`; the title's `filings.Count` interpolation stays safe on an empty list (materialized `List`, no element access).

Behavior preserved: `MarkdownTable.Render(rows, msg, …)` is defined as exactly `if (rows.Count == 0) return msg; else Start(…)+foreach+ToString`, so each replacement is line-for-line equivalent. Build and the full unit suite (2411 tests) are green; csharpier check passes.