### PR TITLE
refactor(integrations): collapse duplicated 429/5xx retry loop into HttpRetry.Send helper

### DIFF
--- a/src/Equibles.Integrations.Cboe/CboeClient.cs
+++ b/src/Equibles.Integrations.Cboe/CboeClient.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Net;
 using System.Text;
 using System.Text.Json;
 using Equibles.Integrations.Cboe.Contracts;
@@ -75,45 +74,28 @@ public class CboeClient : ICboeClient
 
     private async Task<string> DownloadWithRetry(string url)
     {
-        for (var attempt = 0; attempt <= MaxRetries; attempt++)
-        {
-            await _rateLimiter.WaitAsync();
-
-            using var response = await _httpClient.GetAsync(url);
-
-            if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
-            {
-                var delay = ExponentialBackoff(attempt);
+        using var response = await HttpRetry.Send(
+            () => _httpClient.GetAsync(url),
+            _rateLimiter,
+            MaxRetries,
+            "Max retries exceeded for CBOE download",
+            (attempt, delay) =>
                 _logger.LogWarning(
                     "CBOE rate limited (429), retrying in {Delay}s (attempt {Attempt}/{Max})",
                     delay.TotalSeconds,
                     attempt + 1,
                     MaxRetries
-                );
-                _rateLimiter.PauseFor(delay);
-                await Task.Delay(delay);
-                continue;
-            }
-
-            if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
-            {
-                var delay = ExponentialBackoff(attempt);
+                ),
+            (statusCode, attempt, delay) =>
                 _logger.LogWarning(
                     "CBOE server error ({StatusCode}), retrying in {Delay}s (attempt {Attempt}/{Max})",
-                    (int)response.StatusCode,
+                    statusCode,
                     delay.TotalSeconds,
                     attempt + 1,
                     MaxRetries
-                );
-                await Task.Delay(delay);
-                continue;
-            }
-
-            response.EnsureSuccessStatusCode();
-            return await response.Content.ReadAsStringAsync();
-        }
-
-        throw new HttpRequestException("Max retries exceeded for CBOE download");
+                )
+        );
+        return await response.Content.ReadAsStringAsync();
     }
 
     // Thin forwarder so existing reflection-based backoff tests still find the method.

--- a/src/Equibles.Integrations.Cftc/CftcClient.cs
+++ b/src/Equibles.Integrations.Cftc/CftcClient.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.IO.Compression;
-using System.Net;
 using System.Text;
 using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Cftc.Contracts;
@@ -43,53 +42,33 @@ public class CftcClient : ICftcClient
 
     private async Task<Stream> DownloadWithRetry(string url)
     {
-        for (var attempt = 0; attempt <= MaxRetries; attempt++)
-        {
-            await RateLimiter.WaitAsync();
-
-            var response = await _httpClient.GetAsync(
-                url,
-                HttpCompletionOption.ResponseHeadersRead
-            );
-
-            if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
-            {
-                var delay = ExponentialBackoff(attempt);
+        var response = await HttpRetry.Send(
+            () => _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead),
+            RateLimiter,
+            MaxRetries,
+            "Max retries exceeded for CFTC download",
+            (attempt, delay) =>
                 _logger.LogWarning(
                     "CFTC rate limited (429), retrying in {Delay}s (attempt {Attempt}/{Max})",
                     delay.TotalSeconds,
                     attempt + 1,
                     MaxRetries
-                );
-                RateLimiter.PauseFor(delay);
-                await Task.Delay(delay);
-                continue;
-            }
-
-            if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
-            {
-                var delay = ExponentialBackoff(attempt);
+                ),
+            (statusCode, attempt, delay) =>
                 _logger.LogWarning(
                     "CFTC server error ({StatusCode}), retrying in {Delay}s (attempt {Attempt}/{Max})",
-                    (int)response.StatusCode,
+                    statusCode,
                     delay.TotalSeconds,
                     attempt + 1,
                     MaxRetries
-                );
-                await Task.Delay(delay);
-                continue;
-            }
+                )
+        );
 
-            response.EnsureSuccessStatusCode();
-
-            // Copy to memory stream so we can use ZipArchive (requires seekable stream)
-            var memoryStream = new MemoryStream();
-            await response.Content.CopyToAsync(memoryStream);
-            memoryStream.Position = 0;
-            return memoryStream;
-        }
-
-        throw new HttpRequestException("Max retries exceeded for CFTC download");
+        // Copy to memory stream so we can use ZipArchive (requires seekable stream)
+        var memoryStream = new MemoryStream();
+        await response.Content.CopyToAsync(memoryStream);
+        memoryStream.Position = 0;
+        return memoryStream;
     }
 
     // Thin forwarder so existing reflection-based backoff tests still find the method.

--- a/src/Equibles.Integrations.Common/Retry/HttpRetry.cs
+++ b/src/Equibles.Integrations.Common/Retry/HttpRetry.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using Equibles.Integrations.Common.RateLimiter;
+
+namespace Equibles.Integrations.Common.Retry;
+
+public static class HttpRetry
+{
+    // Shared 429/5xx retry loop for the simple integration clients (FRED, CFTC,
+    // CBOE): wait on the rate limiter, send, and on a throttle (429) or server
+    // error (5xx) back off via RetryBackoff and retry up to maxRetries. The first
+    // successful response is returned undisposed for the caller to read; responses
+    // from retried attempts are disposed here. Only a 429 pauses the shared limiter
+    // (a 5xx is not a rate-limit signal). Clients that layer auth refresh,
+    // Retry-After, or transient-network handling on top (FINRA, Yahoo, SEC) keep
+    // their own loops.
+    public static async Task<HttpResponseMessage> Send(
+        Func<Task<HttpResponseMessage>> send,
+        IRateLimiter rateLimiter,
+        int maxRetries,
+        string exhaustedMessage,
+        Action<int, TimeSpan> onRateLimited,
+        Action<int, int, TimeSpan> onServerError
+    )
+    {
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
+        {
+            await rateLimiter.WaitAsync();
+
+            var response = await send();
+
+            if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < maxRetries)
+            {
+                var delay = RetryBackoff.Exponential(attempt);
+                onRateLimited(attempt, delay);
+                rateLimiter.PauseFor(delay);
+                response.Dispose();
+                await Task.Delay(delay);
+                continue;
+            }
+
+            if ((int)response.StatusCode >= 500 && attempt < maxRetries)
+            {
+                var delay = RetryBackoff.Exponential(attempt);
+                onServerError((int)response.StatusCode, attempt, delay);
+                response.Dispose();
+                await Task.Delay(delay);
+                continue;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return response;
+        }
+
+        throw new HttpRequestException(exhaustedMessage);
+    }
+}

--- a/src/Equibles.Integrations.Fred/FredClient.cs
+++ b/src/Equibles.Integrations.Fred/FredClient.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Equibles.Core.AutoWiring;
 using Equibles.Integrations.Common.RateLimiter;
 using Equibles.Integrations.Common.Retry;
@@ -109,45 +108,28 @@ public class FredClient : IFredClient
 
     private async Task<string> SendWithRetry(string url)
     {
-        for (var attempt = 0; attempt <= MaxRetries; attempt++)
-        {
-            await RateLimiter.WaitAsync();
-
-            using var response = await _httpClient.GetAsync(url);
-
-            if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
-            {
-                var delay = ExponentialBackoff(attempt);
+        using var response = await HttpRetry.Send(
+            () => _httpClient.GetAsync(url),
+            RateLimiter,
+            MaxRetries,
+            "Max retries exceeded for FRED API request",
+            (attempt, delay) =>
                 _logger.LogWarning(
                     "FRED rate limited (429), retrying in {Delay}s (attempt {Attempt}/{Max})",
                     delay.TotalSeconds,
                     attempt + 1,
                     MaxRetries
-                );
-                RateLimiter.PauseFor(delay);
-                await Task.Delay(delay);
-                continue;
-            }
-
-            if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
-            {
-                var delay = ExponentialBackoff(attempt);
+                ),
+            (statusCode, attempt, delay) =>
                 _logger.LogWarning(
                     "FRED server error ({StatusCode}), retrying in {Delay}s (attempt {Attempt}/{Max})",
-                    (int)response.StatusCode,
+                    statusCode,
                     delay.TotalSeconds,
                     attempt + 1,
                     MaxRetries
-                );
-                await Task.Delay(delay);
-                continue;
-            }
-
-            response.EnsureSuccessStatusCode();
-            return await response.Content.ReadAsStringAsync();
-        }
-
-        throw new HttpRequestException("Max retries exceeded for FRED API request");
+                )
+        );
+        return await response.Content.ReadAsStringAsync();
     }
 
     // Thin forwarder so existing reflection-based backoff tests still find the method.


### PR DESCRIPTION
## Summary

- FredClient, CftcClient, and CboeClient each carried a near-identical attempt loop for retrying throttled (429) and server-error (5xx) HTTP responses with exponential backoff. This collapses that shared control flow into one `HttpRetry.Send` helper in `Equibles.Integrations.Common.Retry`, continuing the earlier centralisation of `RetryBackoff`.
- Behaviour-preserving: each client keeps its own send call, response handling, rate limiter, log messages, and exhausted-retry message; only the loop scaffolding moves. Clients with extra concerns (FINRA auth refresh, Yahoo session refresh, SEC Retry-After / transient-network handling) intentionally keep their own loops.

## Code changes

- `src/Equibles.Integrations.Common/Retry/HttpRetry.cs` — new shared helper running the 429/5xx retry loop: waits on the rate limiter, sends, pauses the limiter only on 429, backs off via `RetryBackoff`, disposes retried responses, and returns the first successful response undisposed for the caller to read.
- `src/Equibles.Integrations.Fred/FredClient.cs` — `SendWithRetry` now delegates to `HttpRetry.Send`; dropped the now-unused `System.Net` import.
- `src/Equibles.Integrations.Cftc/CftcClient.cs` — `DownloadWithRetry` now delegates to `HttpRetry.Send` (preserving `HttpCompletionOption.ResponseHeadersRead` and the memory-stream copy); dropped the unused `System.Net` import.
- `src/Equibles.Integrations.Cboe/CboeClient.cs` — `DownloadWithRetry` now delegates to `HttpRetry.Send` (using the injected rate limiter); dropped the unused `System.Net` import.

The per-client `ExponentialBackoff` forwarders are retained so the existing reflection-based backoff tests still resolve. Existing retry-behaviour tests (CFTC 503/429, CBOE 429/5xx/404) and the full unit suite pass.