### PR TITLE
refactor(cboe-mcp): collapse two duplicated table-render tails onto MarkdownTable.Render

### DIFF
--- a/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
+++ b/src/Equibles.Cboe.Mcp/Tools/CboeTools.cs
@@ -67,27 +67,21 @@ public class CboeTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                if (records.Count == 0)
-                    return $"No put/call ratio data found for {ratioType.NameForHumans()} in the specified date range.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    records.OrderBy(r => r.Date).ToList(),
+                    $"No put/call ratio data found for {ratioType.NameForHumans()} in the specified date range.",
                     $"CBOE {ratioType.NameForHumans()} Put/Call Ratios:",
                     "| Date | Call Volume | Put Volume | Total | P/C Ratio |",
-                    "|------|-----------|----------|-------|-----------|"
+                    "|------|-----------|----------|-------|-----------|",
+                    r =>
+                    {
+                        var callStr = McpFormat.OrDash(r.CallVolume, "N0");
+                        var putStr = McpFormat.OrDash(r.PutVolume, "N0");
+                        var totalStr = McpFormat.OrDash(r.TotalVolume, "N0");
+                        var ratioStr = McpFormat.OrDash(r.PutCallRatio, "F2");
+                        return $"| {r.Date:yyyy-MM-dd} | {callStr} | {putStr} | {totalStr} | {ratioStr} |";
+                    }
                 );
-
-                foreach (var r in records.OrderBy(r => r.Date))
-                {
-                    var callStr = McpFormat.OrDash(r.CallVolume, "N0");
-                    var putStr = McpFormat.OrDash(r.PutVolume, "N0");
-                    var totalStr = McpFormat.OrDash(r.TotalVolume, "N0");
-                    var ratioStr = McpFormat.OrDash(r.PutCallRatio, "F2");
-                    result.AppendLine(
-                        $"| {r.Date:yyyy-MM-dd} | {callStr} | {putStr} | {totalStr} | {ratioStr} |"
-                    );
-                }
-
-                return result.ToString();
             },
             "GetPutCallRatios",
             $"type: {type}"
@@ -124,23 +118,15 @@ public class CboeTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                if (records.Count == 0)
-                    return "No VIX data found in the specified date range.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    records.OrderBy(v => v.Date).ToList(),
+                    "No VIX data found in the specified date range.",
                     "CBOE Volatility Index (VIX):",
                     "| Date | Open | High | Low | Close |",
-                    "|------|------|------|-----|-------|"
-                );
-
-                foreach (var v in records.OrderBy(v => v.Date))
-                {
-                    result.AppendLine(
+                    "|------|------|------|-----|-------|",
+                    v =>
                         $"| {v.Date:yyyy-MM-dd} | {McpFormat.Invariant(v.Open, "F2")} | {McpFormat.Invariant(v.High, "F2")} | {McpFormat.Invariant(v.Low, "F2")} | {McpFormat.Invariant(v.Close, "F2")} |"
-                    );
-                }
-
-                return result.ToString();
+                );
             },
             "GetVixHistory",
             $"startDate: {startDate}"


### PR DESCRIPTION
## Summary

- The two CBOE MCP tools (`GetPutCallRatios`, `GetVixHistory`) each hand-built their result table with the same `MarkdownTable.Start` + manual `foreach`/`AppendLine`/`ToString` tail, guarded by an explicit empty-records check — the same duplication recently collapsed across the FINRA, insider-trading, and Yahoo tools.
- Routed both through the existing `MarkdownTable.Render` helper, which already encapsulates the empty-check → header → one-row-per-item shape, removing the repeated boilerplate.

## Code changes

- `src/Equibles.Cboe.Mcp/Tools/CboeTools.cs` — replaced the two inline table-render tails with calls to `MarkdownTable.Render`, passing the records pre-sorted ascending by date so the rendered output is byte-identical (same empty message, title, header/separator, ordering, and per-row formatting). Behavior-preserving; net 32 deletions / 18 insertions.