### PR TITLE
refactor(congress-mcp): collapse two duplicated table-render tails onto MarkdownTable.Render

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -77,27 +77,21 @@ public class CongressTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                if (trades.Count == 0)
-                    return $"No congressional trades found for {stock.Ticker} in the specified date range.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    trades,
+                    $"No congressional trades found for {stock.Ticker} in the specified date range.",
                     $"Congressional trades for {stock.Ticker} ({stock.Name}):",
                     "| Date | Member | Position | Type | Amount Range | Owner |",
-                    "|------|--------|----------|------|-------------|-------|"
+                    "|------|--------|----------|------|-------------|-------|",
+                    t =>
+                    {
+                        var position = t.CongressMember.Position.NameForHumans();
+                        var type = t.TransactionType.NameForHumans();
+                        var amount =
+                            $"${McpFormat.WholeNumber(t.AmountFrom)}–${McpFormat.WholeNumber(t.AmountTo)}";
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {t.OwnerType ?? "—"} |";
+                    }
                 );
-
-                foreach (var t in trades)
-                {
-                    var position = t.CongressMember.Position.NameForHumans();
-                    var type = t.TransactionType.NameForHumans();
-                    var amount =
-                        $"${McpFormat.WholeNumber(t.AmountFrom)}–${McpFormat.WholeNumber(t.AmountTo)}";
-                    result.AppendLine(
-                        $"| {t.TransactionDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {t.OwnerType ?? "—"} |"
-                    );
-                }
-
-                return result.ToString();
             },
             "GetCongressionalTrades",
             $"ticker: {ticker}"
@@ -145,28 +139,22 @@ public class CongressTools
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
-                if (trades.Count == 0)
-                    return $"No trades found for {member.Name} ({member.Position.NameForHumans()}) in the specified date range.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    trades,
+                    $"No trades found for {member.Name} ({member.Position.NameForHumans()}) in the specified date range.",
                     $"Trades by {member.Name} ({member.Position.NameForHumans()}):",
                     "| Date | Ticker | Type | Amount Range | Asset | Owner |",
-                    "|------|--------|------|-------------|-------|-------|"
+                    "|------|--------|------|-------------|-------|-------|",
+                    t =>
+                    {
+                        var type = t.TransactionType.NameForHumans();
+                        // Format with InvariantCulture so the MCP markdown does not fork the
+                        // separators by host locale (e.g. de-DE would render $1.000.000).
+                        var amount =
+                            $"${McpFormat.WholeNumber(t.AmountFrom)}–${McpFormat.WholeNumber(t.AmountTo)}";
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.CommonStock.Ticker} | {type} | {amount} | {t.AssetName} | {t.OwnerType ?? "—"} |";
+                    }
                 );
-
-                foreach (var t in trades)
-                {
-                    var type = t.TransactionType.NameForHumans();
-                    // Format with InvariantCulture so the MCP markdown does not fork the
-                    // separators by host locale (e.g. de-DE would render $1.000.000).
-                    var amount =
-                        $"${McpFormat.WholeNumber(t.AmountFrom)}–${McpFormat.WholeNumber(t.AmountTo)}";
-                    result.AppendLine(
-                        $"| {t.TransactionDate:yyyy-MM-dd} | {t.CommonStock.Ticker} | {type} | {amount} | {t.AssetName} | {t.OwnerType ?? "—"} |"
-                    );
-                }
-
-                return result.ToString();
             },
             "GetMemberTrades",
             $"memberName: {memberName}"


### PR DESCRIPTION
## Summary

- `GetCongressionalTrades` and `GetMemberTrades` each hand-rolled the same empty-check → header → one-row-per-item → `ToString` sequence that the shared `MarkdownTable.Render` helper already centralises (and that `SearchCongressMembers` in the same file already uses).
- Collapsing both onto `MarkdownTable.Render` removes the duplicated table tail with no change to the rendered output.

## Code changes

- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — replaced the two manual `MarkdownTable.Start` + `foreach`/`AppendLine` + `ToString` blocks with `MarkdownTable.Render` calls, passing the already-materialised `trades` list, the empty-result message, and the row formatter. The InvariantCulture note on the amount formatting is preserved inside the `GetMemberTrades` row formatter. Output is byte-identical (same empty message, same iteration order, same row strings).