### PR TITLE
refactor(sec): collapse three inline DateOnly.TryParse blocks onto ParseInvariantDateOr helper

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -282,16 +281,12 @@ public class SecEdgarClient : ISecEdgarClient
 
         foreach (var archiveFile in filings.Files)
         {
-            // Skip archive files whose date range is entirely outside the requested window
+            // Skip archive files whose date range is entirely outside the requested window.
+            // MaxValue/MinValue fallbacks make an unparseable date never trigger a skip,
+            // matching the prior behavior where a failed parse left the archive included.
             if (
                 fromDate.HasValue
-                && DateOnly.TryParse(
-                    archiveFile.FilingTo,
-                    CultureInfo.InvariantCulture,
-                    DateTimeStyles.None,
-                    out var archiveTo
-                )
-                && archiveTo < fromDate.Value
+                && ParseInvariantDateOr(archiveFile.FilingTo, DateOnly.MaxValue) < fromDate.Value
             )
             {
                 _logger.LogDebug(
@@ -304,13 +299,7 @@ public class SecEdgarClient : ISecEdgarClient
 
             if (
                 toDate.HasValue
-                && DateOnly.TryParse(
-                    archiveFile.FilingFrom,
-                    CultureInfo.InvariantCulture,
-                    DateTimeStyles.None,
-                    out var archiveFrom
-                )
-                && archiveFrom > toDate.Value
+                && ParseInvariantDateOr(archiveFile.FilingFrom, DateOnly.MinValue) > toDate.Value
             )
             {
                 _logger.LogDebug(
@@ -523,14 +512,7 @@ public class SecEdgarClient : ISecEdgarClient
             FormType = formType,
             CompanyName = company,
             Cik = cik,
-            DateFiled = DateOnly.TryParse(
-                dateFiled,
-                CultureInfo.InvariantCulture,
-                DateTimeStyles.None,
-                out var d
-            )
-                ? d
-                : fallbackDate,
+            DateFiled = ParseInvariantDateOr(dateFiled, fallbackDate),
             AccessionNumber = accession,
         };
         return true;


### PR DESCRIPTION
## Summary

- Three inline `DateOnly.TryParse(..., InvariantCulture, DateTimeStyles.None, ...)` blocks in `SecEdgarClient` duplicated the exact logic already encapsulated by the private `ParseInvariantDateOr` helper. This collapses all three onto the helper, removing 24 lines for 6.
- Behavior is preserved: the two archive-skip conditions use `DateOnly.MaxValue`/`DateOnly.MinValue` fallbacks so an unparseable date never triggers a skip — matching the prior short-circuit semantics where a failed parse left the archive included.

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — replace the `FilingTo`/`FilingFrom` skip-check parses and the `DateFiled` ternary with calls to `ParseInvariantDateOr`; drop the now-unused `using System.Globalization;` (remaining references are fully qualified).