### PR TITLE
refactor(holdings): collapse four duplicated rebalance-date clamps into RebalanceDateOf helper

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
@@ -173,15 +173,7 @@ public class FundScoringManager
         DateOnly? lastBeforeWindow = null;
         foreach (var date in reportDates)
         {
-            // Clamp the +45-day shift at the calendar's end so a far-future ReportDate
-            // (within RebalanceDelayDays of DateOnly.MaxValue) is treated as an out-of-window
-            // rebalance rather than overflowing AddDays — matching HoldingsBacktestCalculator
-            // and the HoldingsBacktestService / SmartMoneyIndexManager siblings.
-            var rebalance =
-                date.DayNumber
-                > DateOnly.MaxValue.DayNumber - HoldingsBacktestCalculator.RebalanceDelayDays
-                    ? DateOnly.MaxValue
-                    : date.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
+            var rebalance = HoldingsBacktestCalculator.RebalanceDateOf(date);
             if (rebalance < from)
                 lastBeforeWindow = date;
             else if (rebalance <= to)

--- a/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
@@ -223,11 +223,7 @@ public class SmartMoneyIndexManager
                 .ToList(),
         };
 
-        var from =
-            constructionDate.DayNumber
-            > DateOnly.MaxValue.DayNumber - HoldingsBacktestCalculator.RebalanceDelayDays
-                ? DateOnly.MaxValue
-                : constructionDate.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
+        var from = HoldingsBacktestCalculator.RebalanceDateOf(constructionDate);
 
         var stockIds = constituents.Select(c => c.CommonStockId).ToList();
 

--- a/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
@@ -13,6 +13,14 @@ public static class HoldingsBacktestCalculator
 
     public const decimal InitialValue = 100m;
 
+    // Shift a 13F ReportDate forward to its rebalance date (+RebalanceDelayDays). A ReportDate
+    // within RebalanceDelayDays of DateOnly.MaxValue would overflow the calendar, so cap the
+    // shift at MaxValue instead of throwing — a far-future date then reads as out-of-window.
+    public static DateOnly RebalanceDateOf(DateOnly reportDate) =>
+        reportDate.DayNumber > DateOnly.MaxValue.DayNumber - RebalanceDelayDays
+            ? DateOnly.MaxValue
+            : reportDate.AddDays(RebalanceDelayDays);
+
     // `priceOf` is expected to forward-fill the last-known close so weekends, holidays, and
     // post-delisting dates still yield a non-null value. The calculator does not maintain
     // its own price cache; if priceOf returns null for a held stock on a given day, that
@@ -45,15 +53,7 @@ public static class HoldingsBacktestCalculator
         }
 
         var ordered = snapshots
-            .Select(s =>
-                (
-                    Snapshot: s,
-                    RebalanceDate: s.ReportDate.DayNumber
-                    > DateOnly.MaxValue.DayNumber - RebalanceDelayDays
-                        ? DateOnly.MaxValue
-                        : s.ReportDate.AddDays(RebalanceDelayDays)
-                )
-            )
+            .Select(s => (Snapshot: s, RebalanceDate: RebalanceDateOf(s.ReportDate)))
             .OrderBy(x => x.RebalanceDate)
             .ToList();
 

--- a/src/Equibles.Web/Services/HoldingsBacktestService.cs
+++ b/src/Equibles.Web/Services/HoldingsBacktestService.cs
@@ -90,7 +90,7 @@ public class HoldingsBacktestService
         }
 
         var resolvedTo = to ?? DateOnly.FromDateTime(DateTime.UtcNow);
-        var firstRebalance = RebalanceDateOf(reportDates[0]);
+        var firstRebalance = HoldingsBacktestCalculator.RebalanceDateOf(reportDates[0]);
         var resolvedFrom = from ?? firstRebalance;
 
         var relevant = SelectRelevantSnapshotDates(reportDates, resolvedFrom, resolvedTo);
@@ -197,15 +197,6 @@ public class HoldingsBacktestService
         return options;
     }
 
-    // Shift a 13F ReportDate forward to its rebalance date (+45 days), mirroring the clamp in
-    // HoldingsBacktestCalculator: a ReportDate within RebalanceDelayDays of DateOnly.MaxValue
-    // would overflow the calendar, so cap the shift at MaxValue instead of throwing.
-    private static DateOnly RebalanceDateOf(DateOnly reportDate) =>
-        reportDate.DayNumber
-        > DateOnly.MaxValue.DayNumber - HoldingsBacktestCalculator.RebalanceDelayDays
-            ? DateOnly.MaxValue
-            : reportDate.AddDays(HoldingsBacktestCalculator.RebalanceDelayDays);
-
     // Select all snapshots whose rebalance date falls in [resolvedFrom, resolvedTo], plus the
     // latest one whose rebalance date precedes resolvedFrom so the simulation can open with an
     // initial portfolio.
@@ -219,7 +210,7 @@ public class HoldingsBacktestService
         DateOnly? lastBeforeWindow = null;
         foreach (var date in reportDates)
         {
-            var rebalance = RebalanceDateOf(date);
+            var rebalance = HoldingsBacktestCalculator.RebalanceDateOf(date);
             if (rebalance < resolvedFrom)
                 lastBeforeWindow = date;
             else if (rebalance <= resolvedTo)


### PR DESCRIPTION
## Summary

- The +45-day 13F rebalance-date clamp (`reportDate.DayNumber > DateOnly.MaxValue.DayNumber - RebalanceDelayDays ? DateOnly.MaxValue : reportDate.AddDays(RebalanceDelayDays)`) was copied verbatim in four places, with comments noting they had to stay in sync.
- Collapsed all four onto a single `HoldingsBacktestCalculator.RebalanceDateOf(DateOnly)` helper — the class that already owns `RebalanceDelayDays`. Behavior is identical; the four expressions were character-identical.

## Code changes

- `src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs` — add `public static DateOnly RebalanceDateOf(DateOnly)` and use it inside `Calculate`.
- `src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs` — replace inline clamp in `SelectRelevantSnapshotDates` with the helper.
- `src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs` — replace inline clamp with the helper.
- `src/Equibles.Web/Services/HoldingsBacktestService.cs` — drop the private `RebalanceDateOf` copy; route its two callers to the shared helper.