### PR TITLE
refactor(views): extract repeated card/table wrapper into TableCard tag helper

### DIFF
--- a/src/Equibles.Web/TagHelpers/TableCardTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/TableCardTagHelper.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.Web.TagHelpers;
+
+// Wraps tabular content in the standard card + horizontal-scroll + zebra-table shell
+// used across the stock and profile views, so the shared markup lives in one place.
+[HtmlTargetElement("table-card")]
+public class TableCardTagHelper : TagHelper
+{
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        output.TagName = "div";
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.Attributes.SetAttribute("class", "card bg-base-100 shadow-sm");
+        output.PreContent.SetHtmlContent(
+            "<div class=\"overflow-x-auto\"><table class=\"table table-zebra table-sm\">"
+        );
+        output.PostContent.SetHtmlContent("</table></div>");
+    }
+}

--- a/src/Equibles.Web/Views/Profiles/Insider.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Insider.cshtml
@@ -14,9 +14,7 @@
     @if (Model.Transactions.Count == 0) {
         <div class="text-base-content/60 py-8">No reported transactions.</div>
     } else {
-        <div class="card bg-base-100 shadow-sm">
-            <div class="overflow-x-auto">
-                <table class="table table-zebra table-sm">
+        <table-card>
                     <thead>
                         <tr>
                             <th scope="col">Ticker</th>
@@ -39,8 +37,6 @@
                             </tr>
                         }
                     </tbody>
-                </table>
-            </div>
-        </div>
+                </table-card>
     }
 </div>

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -246,9 +246,7 @@
     @if (Model.Holdings.Count == 0) {
         <div class="text-base-content/60 py-8">No reported holdings.</div>
     } else {
-        <div class="card bg-base-100 shadow-sm">
-            <div class="overflow-x-auto">
-                <table class="table table-zebra table-sm">
+        <table-card>
                     <thead>
                         <tr>
                             <th scope="col">Ticker</th>
@@ -271,8 +269,6 @@
                             </tr>
                         }
                     </tbody>
-                </table>
-            </div>
-        </div>
+                </table-card>
     }
 </div>

--- a/src/Equibles.Web/Views/Profiles/Member.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Member.cshtml
@@ -11,9 +11,7 @@
     @if (Model.Trades.Count == 0) {
         <div class="text-base-content/60 py-8">No reported trades.</div>
     } else {
-        <div class="card bg-base-100 shadow-sm">
-            <div class="overflow-x-auto">
-                <table class="table table-zebra table-sm">
+        <table-card>
                     <thead>
                         <tr>
                             <th scope="col">Ticker</th>
@@ -36,8 +34,6 @@
                             </tr>
                         }
                     </tbody>
-                </table>
-            </div>
-        </div>
+                </table-card>
     }
 </div>

--- a/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
+++ b/src/Equibles.Web/Views/Stocks/ShowHolder.cshtml
@@ -81,9 +81,7 @@
             </div>
         }
 
-        <div class="card bg-base-100 shadow-sm">
-            <div class="overflow-x-auto">
-                <table class="table table-zebra table-sm">
+        <table-card>
                     <thead>
                         <tr>
                             <th scope="col">Report Date</th>
@@ -132,9 +130,7 @@
                             </tr>
                         }
                     </tbody>
-                </table>
-            </div>
-        </div>
+                </table-card>
 
         @if (chartHoldings.Count >= 2) {
             <partial name="_ChartJs" />

--- a/src/Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_CongressionalTradesTab.cshtml
@@ -6,9 +6,7 @@
 @if (Model.Trades.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "building-library", Heading: "No Congressional Trades", Message: "No congressional trading data is available for this stock yet.")' />
 } else {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="overflow-x-auto">
-            <table class="table table-zebra table-sm">
+    <table-card>
                 <thead>
                     <tr>
                         <th scope="col">Date</th>
@@ -36,9 +34,7 @@
                         </tr>
                     }
                 </tbody>
-            </table>
-        </div>
-    </div>
+            </table-card>
 }
 
 @functions {

--- a/src/Equibles.Web/Views/Stocks/_DocumentsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_DocumentsTab.cshtml
@@ -6,9 +6,7 @@
 @if (Model.Documents.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "document-text", Heading: "No Documents Available", Message: "No SEC filings or earnings transcripts are available for this stock yet.")' />
 } else {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="overflow-x-auto">
-            <table class="table table-zebra table-sm">
+    <table-card>
                 <thead>
                     <tr>
                         <th scope="col">Type</th>
@@ -31,7 +29,5 @@
                         </tr>
                     }
                 </tbody>
-            </table>
-        </div>
-    </div>
+            </table-card>
 }

--- a/src/Equibles.Web/Views/Stocks/_ExemptOfferingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ExemptOfferingsTab.cshtml
@@ -5,9 +5,7 @@
 @if (Model.Filings.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "building-library", Heading: "No Exempt Offerings", Message: "No Form D exempt-offering notices are available for this stock yet.")' />
 } else {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="overflow-x-auto">
-            <table class="table table-zebra table-sm">
+    <table-card>
                 <thead>
                     <tr>
                         <th scope="col">Filed</th>
@@ -54,7 +52,5 @@
                         </tr>
                     }
                 </tbody>
-            </table>
-        </div>
-    </div>
+            </table-card>
 }

--- a/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FinancialsTab.cshtml
@@ -42,9 +42,7 @@
         </div>
     </div>
 
-    <div class="card bg-base-100 shadow-sm">
-        <div class="overflow-x-auto">
-            <table class="table table-zebra table-sm">
+    <table-card>
                 <thead>
                     <tr>
                         <th scope="col">Line Item</th>
@@ -83,9 +81,7 @@
                         </tr>
                     }
                 </tbody>
-            </table>
-        </div>
-    </div>
+            </table-card>
 
     <script>
     // Financials tab filters: changing the statement type or fiscal period

--- a/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FtdTab.cshtml
@@ -9,9 +9,7 @@
     <partial name="_ChartCard" model='("Fails to Deliver History", "ftd-chart", "Fails-to-deliver history", "h-[200px]", "mb-4")' />
 
     <!-- Table -->
-    <div class="card bg-base-100 shadow-sm">
-        <div class="overflow-x-auto">
-            <table class="table table-zebra table-sm">
+    <table-card>
                 <thead>
                     <tr>
                         <th scope="col">Settlement Date</th>
@@ -30,9 +28,7 @@
                         </tr>
                     }
                 </tbody>
-            </table>
-        </div>
-    </div>
+            </table-card>
 
     <partial name="_ChartJs" />
     <script>

--- a/src/Equibles.Web/Views/Stocks/_FundOperationsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_FundOperationsTab.cshtml
@@ -9,9 +9,7 @@
     var latest = Model.Filings[0];
     <div class="space-y-4">
         <!-- Annual N-CEN reports: the registrant's operational filings, newest first. -->
-        <div class="card bg-base-100 shadow-sm">
-            <div class="overflow-x-auto">
-                <table class="table table-zebra table-sm">
+        <table-card>
                     <thead>
                         <tr>
                             <th scope="col">Filed</th>
@@ -42,9 +40,7 @@
                             </tr>
                         }
                     </tbody>
-                </table>
-            </div>
-        </div>
+                </table-card>
 
         @if (latest.ServiceProviders.Count > 0) {
             <!-- Service providers named on the most recent report — who runs and services the fund. -->

--- a/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_InsiderTradingTab.cshtml
@@ -6,9 +6,7 @@
 @if (Model.Transactions.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "user", Heading: "No Insider Trading Data", Message: "No insider transactions are available for this stock yet.")' />
 } else {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="overflow-x-auto">
-            <table class="table table-zebra table-sm">
+    <table-card>
                 <thead>
                     <tr>
                         <th scope="col">Date</th>
@@ -63,7 +61,5 @@
                         </tr>
                     }
                 </tbody>
-            </table>
-        </div>
-    </div>
+            </table-card>
 }

--- a/src/Equibles.Web/Views/Stocks/_ProposedSalesTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ProposedSalesTab.cshtml
@@ -5,9 +5,7 @@
 @if (Model.Filings.Count == 0) {
     <partial name="_EmptyStateCard" model='(IconName: "arrow-trending-down", Heading: "No Proposed Sales", Message: "No Form 144 proposed-sale notices are available for this stock yet.")' />
 } else {
-    <div class="card bg-base-100 shadow-sm">
-        <div class="overflow-x-auto">
-            <table class="table table-zebra table-sm">
+    <table-card>
                 <thead>
                     <tr>
                         <th scope="col">Filed</th>
@@ -38,7 +36,5 @@
                         </tr>
                     }
                 </tbody>
-            </table>
-        </div>
-    </div>
+            </table-card>
 }

--- a/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortInterestTab.cshtml
@@ -9,9 +9,7 @@
     <partial name="_ChartCard" model='("Short Interest History", "short-interest-chart", "Short interest history", "h-[200px]", "mb-4")' />
 
     <!-- Table -->
-    <div class="card bg-base-100 shadow-sm">
-        <div class="overflow-x-auto">
-            <table class="table table-zebra table-sm">
+    <table-card>
                 <thead>
                     <tr>
                         <th scope="col">Settlement Date</th>
@@ -42,9 +40,7 @@
                         </tr>
                     }
                 </tbody>
-            </table>
-        </div>
-    </div>
+            </table-card>
 
     <partial name="_ChartJs" />
     <script>

--- a/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_ShortVolumeTab.cshtml
@@ -9,9 +9,7 @@
     <partial name="_ChartCard" model='("Short Volume (Last 90 Days)", "short-volume-chart", "Daily short volume history", "h-[200px]", "mb-4")' />
 
     <!-- Table -->
-    <div class="card bg-base-100 shadow-sm">
-        <div class="overflow-x-auto">
-            <table class="table table-zebra table-sm">
+    <table-card>
                 <thead>
                     <tr>
                         <th scope="col">Date</th>
@@ -33,9 +31,7 @@
                         </tr>
                     }
                 </tbody>
-            </table>
-        </div>
-    </div>
+            </table-card>
 
     <partial name="_ChartJs" />
     <script>


### PR DESCRIPTION
## Summary

- The same `card > overflow-x-auto > table table-zebra table-sm` wrapper markup was duplicated byte-for-byte across 14 stock and profile views. This collapses it into a single reusable `<table-card>` tag helper, so the shared shell lives in one place.
- Purely behavior-preserving: the tag helper emits identical HTML; only the wrapper markup is centralized.

## Code changes

- `src/Equibles.Web/TagHelpers/TableCardTagHelper.cs` — new tag helper that renders `<div class="card bg-base-100 shadow-sm"><div class="overflow-x-auto"><table class="table table-zebra table-sm">…</table></div></div>` around its child content. Mirrors the existing `EmptyTableRowTagHelper` convention; auto-registered via `@addTagHelper *, Equibles.Web`.
- 14 views — replaced the inline three-level wrapper with `<table-card>…thead/tbody…</table-card>`: the eight Stocks tab partials (`_DocumentsTab`, `_ProposedSalesTab`, `_ExemptOfferingsTab`, `_CongressionalTradesTab`, `_InsiderTradingTab`, `_ShortInterestTab`, `_ShortVolumeTab`, `_FtdTab`), `_FinancialsTab`, `_FundOperationsTab`, `ShowHolder`, and the `Profiles` Insider/Institution/Member pages. Inner table contents and surrounding siblings (charts, scripts, filters) are unchanged.