### PR TITLE
fix(migrations): add migration syncing snapshot with model to fix CI

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260602100233_SyncModelSnapshot.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260602100233_SyncModelSnapshot.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260602100233_SyncModelSnapshot")]
+    partial class SyncModelSnapshot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260602100233_SyncModelSnapshot.cs
+++ b/src/Equibles.Migrations/Migrations/20260602100233_SyncModelSnapshot.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncModelSnapshot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_TransactionDate",
+                table: "InsiderTransaction");
+
+            migrationBuilder.CreateTable(
+                name: "StockQuarterlyActivity",
+                columns: table => new
+                {
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ReportDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    PreviousReportDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    CurrentShares = table.Column<long>(type: "bigint", nullable: false),
+                    PreviousShares = table.Column<long>(type: "bigint", nullable: false),
+                    CurrentValue = table.Column<long>(type: "bigint", nullable: false),
+                    PreviousValue = table.Column<long>(type: "bigint", nullable: false),
+                    CurrentFilerCount = table.Column<int>(type: "integer", nullable: false),
+                    PreviousFilerCount = table.Column<int>(type: "integer", nullable: false),
+                    NewFilerCount = table.Column<int>(type: "integer", nullable: false),
+                    SoldOutFilerCount = table.Column<int>(type: "integer", nullable: false),
+                    ComputedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StockQuarterlyActivity", x => new { x.CommonStockId, x.ReportDate });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_ReportDate_CommonStockId_Institutional~",
+                table: "InstitutionalHolding",
+                columns: new[] { "ReportDate", "CommonStockId", "InstitutionalHolderId" })
+                .Annotation("Npgsql:IndexInclude", new[] { "Shares", "Value" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_ReportDate_InstitutionalHolderId_Commo~",
+                table: "InstitutionalHolding",
+                columns: new[] { "ReportDate", "InstitutionalHolderId", "CommonStockId" })
+                .Annotation("Npgsql:IndexInclude", new[] { "Shares", "Value" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderTransaction_TransactionDate",
+                table: "InsiderTransaction",
+                column: "TransactionDate")
+                .Annotation("Npgsql:IndexInclude", new[] { "Shares", "PricePerShare", "IsPriceValid", "SecurityKind", "SecurityTitle" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockQuarterlyActivity_ReportDate",
+                table: "StockQuarterlyActivity",
+                column: "ReportDate");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StockQuarterlyActivity");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_ReportDate_CommonStockId_Institutional~",
+                table: "InstitutionalHolding");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_ReportDate_InstitutionalHolderId_Commo~",
+                table: "InstitutionalHolding");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_TransactionDate",
+                table: "InsiderTransaction");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderTransaction_TransactionDate",
+                table: "InsiderTransaction",
+                column: "TransactionDate");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

CI and Functional Tests have been red on `main` because the `EquiblesFinancialDbContext` model carried pending changes that were never captured in a migration. EF Core raised `PendingModelChangesWarning` during migration validation, which failed every DB-booting integration and functional test at fixture setup.

The model had drifted from the migration snapshot in three places:
- the `StockQuarterlyActivity` table (new entity, never migrated)
- two covering indexes on `InstitutionalHolding` (`ReportDate, CommonStockId, InstitutionalHolderId` and `ReportDate, InstitutionalHolderId, CommonStockId`, both INCLUDE `Shares, Value`)
- INCLUDE columns added to the `InsiderTransaction.TransactionDate` index (`Shares, PricePerShare, IsPriceValid, SecurityKind, SecurityTitle`)

## Code changes

- `20260602100233_SyncModelSnapshot.cs` / `.Designer.cs` — new migration creating the missing table and indexes.
- `EquiblesDbContextModelSnapshot.cs` — regenerated so the snapshot matches the model.

A second `migrations add` after this change produces an empty migration, confirming no remaining drift. The previously-failing `SectorTaxonomyTests` integration class passes locally against a real ParadeDB container.
