### PR TITLE
chore(migrations): resync financial snapshot with ranking indexes + StockQuarterlyActivity

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260602100627_ResyncRankingIndexesAndStockActivity.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260602100627_ResyncRankingIndexesAndStockActivity.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260602100627_ResyncRankingIndexesAndStockActivity")]
+    partial class ResyncRankingIndexesAndStockActivity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260602100627_ResyncRankingIndexesAndStockActivity.cs
+++ b/src/Equibles.Migrations/Migrations/20260602100627_ResyncRankingIndexesAndStockActivity.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class ResyncRankingIndexesAndStockActivity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_TransactionDate",
+                table: "InsiderTransaction"
+            );
+
+            migrationBuilder.CreateTable(
+                name: "StockQuarterlyActivity",
+                columns: table => new
+                {
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ReportDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    PreviousReportDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    CurrentShares = table.Column<long>(type: "bigint", nullable: false),
+                    PreviousShares = table.Column<long>(type: "bigint", nullable: false),
+                    CurrentValue = table.Column<long>(type: "bigint", nullable: false),
+                    PreviousValue = table.Column<long>(type: "bigint", nullable: false),
+                    CurrentFilerCount = table.Column<int>(type: "integer", nullable: false),
+                    PreviousFilerCount = table.Column<int>(type: "integer", nullable: false),
+                    NewFilerCount = table.Column<int>(type: "integer", nullable: false),
+                    SoldOutFilerCount = table.Column<int>(type: "integer", nullable: false),
+                    ComputedAt = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey(
+                        "PK_StockQuarterlyActivity",
+                        x => new { x.CommonStockId, x.ReportDate }
+                    );
+                }
+            );
+
+            migrationBuilder
+                .CreateIndex(
+                    name: "IX_InstitutionalHolding_ReportDate_CommonStockId_Institutional~",
+                    table: "InstitutionalHolding",
+                    columns: new[] { "ReportDate", "CommonStockId", "InstitutionalHolderId" }
+                )
+                .Annotation("Npgsql:IndexInclude", new[] { "Shares", "Value" });
+
+            migrationBuilder
+                .CreateIndex(
+                    name: "IX_InstitutionalHolding_ReportDate_InstitutionalHolderId_Commo~",
+                    table: "InstitutionalHolding",
+                    columns: new[] { "ReportDate", "InstitutionalHolderId", "CommonStockId" }
+                )
+                .Annotation("Npgsql:IndexInclude", new[] { "Shares", "Value" });
+
+            migrationBuilder
+                .CreateIndex(
+                    name: "IX_InsiderTransaction_TransactionDate",
+                    table: "InsiderTransaction",
+                    column: "TransactionDate"
+                )
+                .Annotation(
+                    "Npgsql:IndexInclude",
+                    new[]
+                    {
+                        "Shares",
+                        "PricePerShare",
+                        "IsPriceValid",
+                        "SecurityKind",
+                        "SecurityTitle",
+                    }
+                );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockQuarterlyActivity_ReportDate",
+                table: "StockQuarterlyActivity",
+                column: "ReportDate"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "StockQuarterlyActivity");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_ReportDate_CommonStockId_Institutional~",
+                table: "InstitutionalHolding"
+            );
+
+            migrationBuilder.DropIndex(
+                name: "IX_InstitutionalHolding_ReportDate_InstitutionalHolderId_Commo~",
+                table: "InstitutionalHolding"
+            );
+
+            migrationBuilder.DropIndex(
+                name: "IX_InsiderTransaction_TransactionDate",
+                table: "InsiderTransaction"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InsiderTransaction_TransactionDate",
+                table: "InsiderTransaction",
+                column: "TransactionDate"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Four recent model changes landed config/entity-only and left the financial snapshot out of sync with the model — the standalone app (which applies migrations via `MigrateAsync`) would be missing the schema. Generate the migration that creates them:

- `StockQuarterlyActivity` table + `ReportDate` index (conviction heat map precompute)
- `(ReportDate, CommonStockId, InstitutionalHolderId) INCLUDE (Shares, Value)` — per-stock 13F rankings
- `(ReportDate, InstitutionalHolderId, CommonStockId) INCLUDE (Shares, Value)` — per-holder 13F rankings
- `InsiderTransaction(TransactionDate) INCLUDE (...)` — insider dashboard

`has-pending-model-changes` reports clean afterward. No code changes; migration only.

> Deploy note: the two InstitutionalHolding covering indexes build on a large table and briefly lock on apply.