### PR TITLE
test(sec): pin FactMarkdown.Value negative USD rendering (skipped, GH-3262)

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownValueNegativeUsdTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownValueNegativeUsdTests.cs
@@ -1,0 +1,26 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Value(decimal, string) renders a USD monetary fact with a "$" prefix as a
+/// grouped whole number. Negative monetary figures are pervasive in SEC facts
+/// (net loss, accumulated deficit, negative free cash flow) and the XBRL
+/// parser already emits them — parenthesised values like "(1,234)" parse to a
+/// negative decimal that then flows straight into this renderer. Every
+/// existing FactMarkdown.Value test uses a positive input, so the negative
+/// path is unpinned. The contract promises standard currency rendering, and
+/// the universal convention (matched by .NET's own currency formatting) places
+/// the sign before the symbol: "-$1,234,567". Pin that so a negative net-loss
+/// figure isn't handed to the LLM as malformed currency.
+/// </summary>
+public class FactMarkdownValueNegativeUsdTests
+{
+    [Fact(Skip = "GH-3262 — negative USD renders as \"$-1,234,567\" not \"-$1,234,567\"")]
+    public void Value_NegativeUsdUnit_RendersSignBeforeDollarPrefix()
+    {
+        var result = FactMarkdown.Value(-1234567m, "USD");
+
+        result.Should().Be("-$1,234,567");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a unit test pinning how `FactMarkdown.Value(decimal, string)` should render a negative USD monetary value. Negative monetary facts (net loss, accumulated deficit, negative free cash flow) are pervasive in SEC filings and the XBRL parser already emits them, yet every existing `FactMarkdownValue*` test uses a positive input — the negative path was unpinned.

The test currently **fails**, so it is committed `[Skip]` pending the fix tracked in #3262: negative USD renders as `$-1,234,567` (symbol wedged between sign and digits) instead of the conventional `-$1,234,567`. Remove the `Skip` as part of fixing #3262.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownValueNegativeUsdTests.cs` — new file, one `[Fact(Skip = "GH-3262 …")]` asserting `Value(-1234567m, "USD") == "-$1,234,567"`. Skipped — see #3262.