### PR TITLE
fix(sec): render negative USD facts as -$ instead of $-

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FactMarkdown.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FactMarkdown.cs
@@ -52,7 +52,11 @@ public static class FactMarkdown
             // pure / dimensionless / ratios — don't destroy the fraction.
             number = value.ToString("0.############", CultureInfo.InvariantCulture);
 
-        return isUsd ? "$" + number : number;
+        // Keep the sign outside the symbol so negatives read "-$1,234" rather
+        // than "$-1,234" (the universal convention .NET's own "C0" follows).
+        if (!isUsd)
+            return number;
+        return value < 0 ? "-$" + number.TrimStart('-') : "$" + number;
     }
 
     // A bare 3-letter currency code (USD already handled above): EUR, GBP, JPY…

--- a/tests/Equibles.UnitTests/Sec/FactMarkdownValueNegativeUsdTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownValueNegativeUsdTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// FactMarkdown.Value renders USD by concatenating "$" onto an already-signed
+/// number string, so a negative figure puts the dollar sign between the sign
+/// and the digits ("$-1,234,567"). Negative monetary facts are pervasive in
+/// SEC filings (net loss, accumulated deficit, negative free cash flow) and the
+/// XBRL parser already emits them from parenthesised values, so this malformed
+/// "$-" notation reaches the LLM. The sign must precede the currency symbol,
+/// matching the universal convention and .NET's own "C0" formatting.
+/// </summary>
+public class FactMarkdownValueNegativeUsdTests
+{
+    [Fact]
+    public void Value_NegativeUsdUnit_RendersSignBeforeDollarPrefix()
+    {
+        var result = FactMarkdown.Value(-1234567m, "USD");
+
+        result.Should().Be("-$1,234,567");
+    }
+}


### PR DESCRIPTION
## Summary

- `FactMarkdown.Value` concatenated `"$"` onto an already-signed number string, so a negative monetary fact rendered as `"$-1,234,567"` — the dollar sign landed between the sign and the digits.
- Negative figures are pervasive in SEC filings (net loss, accumulated deficit, negative free cash flow) and the XBRL parser already emits them from parenthesised values, so the malformed `$-` notation reached the LLM consuming the Markdown table.
- Reattach the sign outside the symbol so negatives read `"-$1,234,567"`, matching the universal currency convention and .NET's own `"C0"` formatting. Positive values are unaffected.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Mcp/Helpers/FactMarkdown.cs` — when the unit is USD and the value is negative, emit `"-$" + magnitude` instead of `"$" + signedNumber`; positive and non-USD paths unchanged.
- `tests/Equibles.UnitTests/Sec/FactMarkdownValueNegativeUsdTests.cs` — regression test asserting `Value(-1234567m, "USD") == "-$1,234,567"`.

closes #3262