### PR TITLE
test(sec): pin FactMarkdown.Value negative per-share USD rendering

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FactMarkdownValueNegativePerShareUsdTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FactMarkdownValueNegativePerShareUsdTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Sec.FinancialFacts.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// FactMarkdown.Value's contract layers three independent promises that a
+/// negative USD/shares fact (e.g. basic loss per share) triggers at once:
+/// per-share units render at cents precision, USD is "$"-prefixed, and the
+/// sign precedes the currency symbol. Existing tests pin each axis in
+/// isolation (positive USD/shares, positive bare USD, negative whole USD) but
+/// never their intersection, so the negative-sign reattachment is unverified
+/// on the cents-precision branch. Pin "-$1.50".
+/// </summary>
+public class FactMarkdownValueNegativePerShareUsdTests
+{
+    [Fact]
+    public void Value_NegativePerShareUsdUnit_RendersSignBeforeDollarWithCents()
+    {
+        var result = FactMarkdown.Value(-1.5m, "USD/shares");
+
+        result.Should().Be("-$1.50");
+    }
+}


### PR DESCRIPTION
## Summary

- `FactMarkdown.Value` layers three independent rules that a negative USD/shares fact (basic loss per share) triggers at once: cents precision for per-share units, `$` prefix for USD, and sign before the symbol.
- Existing tests pin each axis in isolation but never their intersection, leaving the negative-sign reattachment unverified on the cents-precision branch. This pins `Value(-1.5m, "USD/shares") == "-$1.50"`.

## Code changes

- `tests/Equibles.UnitTests/Sec/FactMarkdownValueNegativePerShareUsdTests.cs` — new regression test asserting negative per-share USD renders with the sign before the dollar and two decimal places.