### PR TITLE
fix(migrations): dedupe accession in InstitutionalFiling backfill

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260601235824_AddInstitutionalFiling.cs
+++ b/src/Equibles.Migrations/Migrations/20260601235824_AddInstitutionalFiling.cs
@@ -83,25 +83,46 @@ namespace Equibles.Migrations.Migrations
             // inline on every request. Going forward the import path keeps this
             // table current (HoldingsImportService.SyncFilingSummaries). Runs once,
             // when this migration is applied.
+            //
+            // AccessionNumber is unique on InstitutionalFiling, but a few accessions
+            // appear under more than one (holder, filing-date) group in the historical
+            // holdings (e.g. the same accession attributed to two holder ids). Grouping
+            // by those columns alone would emit several rows for one accession and
+            // violate the unique index, so DISTINCT ON keeps exactly one row per
+            // accession — the largest group, deterministically — mirroring the runtime
+            // upsert's one-row-per-accession (.On(AccessionNumber)) outcome.
             migrationBuilder.Sql(
                 """
                 INSERT INTO "InstitutionalFiling"
                     ("Id", "AccessionNumber", "InstitutionalHolderId", "FilingDate",
                      "ReportDate", "IsAmendment", "PositionCount", "TotalValue", "CreationTime")
-                SELECT
+                SELECT DISTINCT ON (grouped."AccessionNumber")
                     gen_random_uuid(),
-                    "AccessionNumber",
-                    "InstitutionalHolderId",
-                    "FilingDate",
-                    "ReportDate",
-                    "IsAmendment",
-                    COUNT(*),
-                    COALESCE(SUM("Value"), 0)::bigint,
-                    MIN("CreationTime")
-                FROM "InstitutionalHolding"
-                WHERE "AccessionNumber" IS NOT NULL
-                GROUP BY "AccessionNumber", "InstitutionalHolderId", "FilingDate",
-                         "ReportDate", "IsAmendment";
+                    grouped."AccessionNumber",
+                    grouped."InstitutionalHolderId",
+                    grouped."FilingDate",
+                    grouped."ReportDate",
+                    grouped."IsAmendment",
+                    grouped."PositionCount",
+                    grouped."TotalValue",
+                    grouped."CreationTime"
+                FROM (
+                    SELECT
+                        "AccessionNumber",
+                        "InstitutionalHolderId",
+                        "FilingDate",
+                        "ReportDate",
+                        "IsAmendment",
+                        COUNT(*) AS "PositionCount",
+                        COALESCE(SUM("Value"), 0)::bigint AS "TotalValue",
+                        MIN("CreationTime") AS "CreationTime"
+                    FROM "InstitutionalHolding"
+                    WHERE "AccessionNumber" IS NOT NULL
+                    GROUP BY "AccessionNumber", "InstitutionalHolderId", "FilingDate",
+                             "ReportDate", "IsAmendment"
+                ) AS grouped
+                ORDER BY grouped."AccessionNumber", grouped."PositionCount" DESC,
+                         grouped."InstitutionalHolderId";
                 """
             );
         }


### PR DESCRIPTION
## Summary

The `AddInstitutionalFiling` migration's one-time backfill aborts on data where a single filing's holdings are split across two `InstitutionalHolder` rows for the same filer (the CIK was historically stored both zero-padded and unpadded). The backfill groups holdings by `(AccessionNumber, InstitutionalHolderId, FilingDate, ReportDate, IsAmendment)` and inserts one row per group, but `InstitutionalFiling` has a **unique index on `AccessionNumber` alone** — so a split filing produces two rows for one accession and trips `23505 duplicate key`, rolling the whole migration back.

## Code changes

- `src/Equibles.Migrations/Migrations/20260601235824_AddInstitutionalFiling.cs` — wrap the grouped backfill query in `DISTINCT ON ("AccessionNumber")` with a deterministic `ORDER BY` (largest group wins), so exactly one row per accession is inserted. This mirrors the runtime `HoldingsImportService.SyncFilingSummaries` upsert, which already collapses to one row per accession via `.On(f => f.AccessionNumber)`. Schema, indexes, and the Designer/snapshot are unchanged — only the backfill DML.