### PR TITLE
test(holdings): seed snapshot rows for the heat-map tests broken by #3268

### DIFF
--- a/tests/Equibles.FunctionalTests/Tests/HoldingsHeatMapSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HoldingsHeatMapSeededTests.cs
@@ -54,6 +54,27 @@ public class HoldingsHeatMapSeededTests
                 db.Add(MakeHolding(stockId, filer.Id, latest, 150, 1_500_000));
             }
 
+            // The single-quarter heat map renders from the materialised
+            // StockQuarterlyActivity snapshot (#1262), not the live holdings, so
+            // the qualifying stock has to be present there for the bubble chart
+            // and top-scorers table to populate.
+            db.Add(
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stockId,
+                    ReportDate = latest,
+                    PreviousReportDate = prior,
+                    CurrentShares = 450,
+                    PreviousShares = 300,
+                    CurrentValue = 4_500_000,
+                    PreviousValue = 3_000_000,
+                    CurrentFilerCount = 3,
+                    PreviousFilerCount = 3,
+                    NewFilerCount = 0,
+                    SoldOutFilerCount = 0,
+                }
+            );
+
             await Task.CompletedTask;
         });
 

--- a/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerHeatMapFilerThresholdTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsActivityControllerHeatMapFilerThresholdTests.cs
@@ -9,7 +9,11 @@ namespace Equibles.IntegrationTests.Web;
 /// Pins the conviction-heat-map's filer-count floor: the action keeps only
 /// stocks with CurrentFilerCount >= 3 (noise reduction), so a thinly-held stock
 /// with 2 filers must be excluded while a 3-filer stock appears. Exercises the
-/// otherwise-untested heat-map body (activity query + score computation + render).
+/// otherwise-untested heat-map body (snapshot query + score computation + render).
+///
+/// The single-quarter view reads the materialised StockQuarterlyActivity snapshot
+/// (#1262), so the filer counts are seeded there; the holdings rows only supply
+/// the available-report-dates list and the total-filer universe count.
 /// </summary>
 [Collection(WebHostCollection.Name)]
 public class HoldingsActivityControllerHeatMapFilerThresholdTests
@@ -54,13 +58,21 @@ public class HoldingsActivityControllerHeatMapFilerThresholdTests
                 db.Add(h);
             }
 
-            // Two distinct quarters so the heat map has a prior to compare against.
+            // Two distinct quarters so the heat map has a prior to compare against
+            // and the available-dates list clears its >= 2 minimum.
             db.Add(MakeHolding(aaplId, holders[0].Id, prior, 100, 180_000));
             // Current quarter: AAPL held by 3 filers (qualifies), MSFT by 2 (below floor).
             for (var i = 0; i < 3; i++)
                 db.Add(MakeHolding(aaplId, holders[i].Id, current, 100, 200_000));
             for (var i = 0; i < 2; i++)
                 db.Add(MakeHolding(msftId, holders[i].Id, current, 50, 100_000));
+
+            // The single-quarter heat map renders from the materialised snapshot,
+            // so the qualifying/below-floor split lives in these rows.
+            db.AddRange(
+                MakeSnapshot(aaplId, current, prior, filerCount: 3, value: 200_000),
+                MakeSnapshot(msftId, current, prior, filerCount: 2, value: 100_000)
+            );
             await Task.CompletedTask;
         });
 
@@ -71,6 +83,28 @@ public class HoldingsActivityControllerHeatMapFilerThresholdTests
         html.Should().Contain("AAPL"); // 3 filers -> kept
         html.Should().NotContain("MSFT"); // 2 filers -> below the >=3 floor, dropped
     }
+
+    private static StockQuarterlyActivity MakeSnapshot(
+        Guid stockId,
+        DateOnly reportDate,
+        DateOnly previousReportDate,
+        int filerCount,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            ReportDate = reportDate,
+            PreviousReportDate = previousReportDate,
+            CurrentShares = 100 * filerCount,
+            PreviousShares = 0,
+            CurrentValue = value,
+            PreviousValue = 0,
+            CurrentFilerCount = filerCount,
+            PreviousFilerCount = 0,
+            NewFilerCount = filerCount,
+            SoldOutFilerCount = 0,
+        };
 
     private static InstitutionalHolding MakeHolding(
         Guid stockId,


### PR DESCRIPTION
## Summary

CI on `main` went red after #3268 switched the single-quarter conviction heat map to render from the materialised `StockQuarterlyActivity` snapshot. Two pre-existing tests still seeded only `InstitutionalHolding` rows, so the snapshot table was empty and the page rendered no points:

- `HoldingsActivityControllerHeatMapFilerThresholdTests.HeatMap_StockBelowThreeFilers_ExcludedWhileQualifyingStockShown` (integration) — `AAPL` containment assertion failed.
- `HoldingsHeatMapSeededTests.HeatMap_WithThreeFilersAcrossTwoQuarters_RendersChartAndTable` (functional) — bubble chart / top-scorers table not visible.

These were stale tests pinning the old live-derivation behaviour, not a regression in the shipped fix.

## Code changes

- `HoldingsActivityControllerHeatMapFilerThresholdTests` — seed `StockQuarterlyActivity` snapshot rows carrying the qualifying/below-floor split (AAPL 3 filers, MSFT 2 filers); the holdings rows stay to supply the available-dates list and total-filer universe count.
- `HoldingsHeatMapSeededTests` — add the matching snapshot row for the qualifying stock so the chart and table populate.

Both tests now pass locally.
