### PR TITLE
docs(guide): add how-to — compare institutions with the overlap matrix

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -32,6 +32,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Use the 13F holdings screener](how-to-use-holdings-screener.md)
 - [View quarterly holdings activity across the market](how-to-view-holdings-activity.md)
 - [View the Smart Money Index](how-to-view-smart-money-index.md)
+- [Compare institutions with the overlap matrix](how-to-compare-institution-overlap.md)
 - [Check worker health and recent errors](how-to-view-status-and-errors.md)
 - [Search for stocks, filings, institutions, and more](how-to-search.md)
 - [View market-wide insider trading activity](how-to-view-insider-activity.md)

--- a/docs/guide/how-to-compare-institution-overlap.md
+++ b/docs/guide/how-to-compare-institution-overlap.md
@@ -1,0 +1,43 @@
+# Compare institutions with the overlap matrix
+
+This guide shows you how to use the Overlap Matrix page to see how many stock holdings two or more institutional investors share, so you can spot funds that move together or hold a common book.
+
+## Open the overlap matrix
+
+1. Go to `http://localhost:8080` and click **More** in the top navigation, then **Overlap Matrix** (or go directly to `http://localhost:8080/institutions/overlap-matrix`).
+
+2. The page opens with an empty picker prompting you to choose institutions.
+
+## Pick the institutions to compare
+
+1. Type an institution name or CIK number into the **Type an institution name or CIK** box. A CIK (Central Index Key) is the SEC's unique identifier for each filer.
+
+2. Choose a match from the suggestions. It becomes a chip above the search box. Repeat to add more — you can compare between 2 and 10 institutions at once.
+
+3. To remove an institution, click the **×** on its chip.
+
+4. Optionally pick a **Report date** to compare a specific 13F quarter. Leave it on the default to use the most recent quarter the chosen funds share.
+
+5. Click **Compare** to build the matrix.
+
+If you see "Pick at least 2 institutions", add another fund. If you see "No common report dates", the funds you chose never filed 13Fs for the same quarter — swap one out.
+
+## Read the matrix
+
+The page shows two tables.
+
+**Shared Ticker Counts** is the matrix itself. Each row and column is one institution:
+
+- A cell where a row and column meet shows how many stock tickers those two funds both hold. Darker cells mean more overlap.
+- A cell on the diagonal (a fund against itself), shaded grey, shows that fund's total number of positions.
+
+**Fund Summary** lists each selected institution with these columns:
+
+| Column | What it shows |
+|--------|---------------|
+| **Institution** | The fund's name, linking to its full profile. |
+| **CIK** | The fund's SEC Central Index Key. |
+| **Positions** | How many stock positions the fund reported that quarter. |
+| **Total Value ($M)** | The fund's total reported portfolio value, in millions of dollars. |
+
+Click any institution name in either table to open its full profile — see [Browse institutional portfolios and run a backtest](how-to-browse-institutions.md).


### PR DESCRIPTION
## Summary

- Adds a user-guide how-to for the Overlap Matrix page, which has its own navigation entry but no guide coverage.
- Explains how to pick 2–10 institutions with the typeahead picker, choose a report date, read the shared-ticker matrix (diagonal vs off-diagonal, colour intensity), and the fund summary table.

## Code changes

- `docs/guide/how-to-compare-institution-overlap.md` — new how-to page.
- `docs/guide/README.md` — one TOC bullet under How-to guides linking the new page.