### PR TITLE
docs(guide): add how-to — view the Double-Down Report

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -31,6 +31,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Browse investment advisers (SEC Form ADV)](how-to-browse-investment-advisers.md)
 - [Use the 13F holdings screener](how-to-use-holdings-screener.md)
 - [View quarterly holdings activity across the market](how-to-view-holdings-activity.md)
+- [View the Double-Down Report](how-to-view-double-down-report.md)
 - [View the Smart Money Index](how-to-view-smart-money-index.md)
 - [Compare institutions with the overlap matrix](how-to-compare-institution-overlap.md)
 - [Check worker health and recent errors](how-to-view-status-and-errors.md)

--- a/docs/guide/how-to-view-double-down-report.md
+++ b/docs/guide/how-to-view-double-down-report.md
@@ -1,0 +1,35 @@
+# View the Double-Down Report
+
+This guide shows you how to use the Double-Down Report to find positions where an institution sharply increased its stake in a stock from one quarter to the next — a sign of growing conviction.
+
+## Open the report
+
+1. Go to `http://localhost:8080` and click **More** in the top navigation, then **Double-Down Report** (or go directly to `http://localhost:8080/holdings/double-down-report`).
+
+2. The report compares each institution's holdings against the previous quarter, so it needs at least two quarters of 13F data. If you see a "Not enough data" message, the worker is still backfilling — check back after the initial sync.
+
+## Choose the quarter and threshold
+
+1. Use the **Report Date** dropdown to pick which quarter to analyze. The report compares it against the previous quarter. The dropdown also offers a combined view that aggregates the latest filings across institutions.
+
+2. Use the **Min % Increase** box to set how large a share-count jump counts as a "double down". It defaults to 50%, meaning a position only appears if the institution grew its share count by at least 50% versus the prior quarter. Raise it to see only the most aggressive additions; lower it to widen the net.
+
+3. Submit the form to refresh the table.
+
+## Read the table
+
+Positions are ranked by the size of the increase, largest first, 100 per page. Each row shows one institution's increase in one stock:
+
+| Column | What it shows |
+|--------|---------------|
+| **Institution** | The fund that increased its position. |
+| **Stock** | The stock it added to. |
+| **Prior Shares** | Shares held in the previous quarter. |
+| **Current Shares** | Shares held in the selected quarter. |
+| **Change** | The percentage increase in share count between the two quarters. |
+| **Prior Value** | The position's reported dollar value in the previous quarter. |
+| **Current Value** | The position's reported dollar value in the selected quarter. |
+
+If no rows appear, no position met your threshold for that quarter — lower the **Min % Increase** value and try again.
+
+For the broader buying-and-selling picture across the whole market, see [View quarterly holdings activity across the market](how-to-view-holdings-activity.md).


### PR DESCRIPTION
## Summary

- Adds a user-guide how-to for the Double-Down Report page, which has its own navigation entry but no guide coverage.
- Explains how to open it, pick a quarter, set the Min % Increase threshold (default 50%), and read the ranked table of institutions that sharply grew a position quarter over quarter.

## Code changes

- `docs/guide/how-to-view-double-down-report.md` — new how-to page.
- `docs/guide/README.md` — one TOC bullet under How-to guides linking the new page.