### PR TITLE
docs(guide): add how-to — view 13F trend charts

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -31,6 +31,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Browse investment advisers (SEC Form ADV)](how-to-browse-investment-advisers.md)
 - [Use the 13F holdings screener](how-to-use-holdings-screener.md)
 - [View quarterly holdings activity across the market](how-to-view-holdings-activity.md)
+- [View 13F trend charts](how-to-view-13f-trends.md)
 - [View the Double-Down Report](how-to-view-double-down-report.md)
 - [View the 13F Conviction Heat Map](how-to-view-conviction-heat-map.md)
 - [View the Smart Money Index](how-to-view-smart-money-index.md)

--- a/docs/guide/how-to-view-13f-trends.md
+++ b/docs/guide/how-to-view-13f-trends.md
@@ -1,0 +1,21 @@
+# View 13F trend charts
+
+This guide shows you how to use the 13F Trends page to see how institutional investing has shifted over time — total assets under management, how many funds and positions they report, and how their money is spread across market sectors.
+
+## Open the trends page
+
+1. Go to `http://localhost:8080` and click **More** in the top navigation, then **13F Trends** (or go directly to `http://localhost:8080/holdings/13f-trends`).
+
+2. The page draws its charts from each quarter's 13F snapshot. If you see a "No 13F data yet" message, the worker has not ingested a full quarter yet — check back after the initial sync.
+
+## Read the charts
+
+The page shows three charts, each plotting one quarter per point from oldest to newest.
+
+1. **Total Assets Under Management** — the combined dollar value (in billions) of every position reported across all 13F filers. Use it to see whether institutional money is growing or shrinking quarter over quarter.
+
+2. **Filers and Positions** — two lines on a shared timeline: how many institutions filed that quarter and how many total positions they reported. A dual axis keeps both readable even though the counts differ in scale.
+
+3. **Sector Allocation** — a stacked area chart showing how the total reported value splits across market sectors each quarter. Watch the bands grow or shrink to see money rotating between sectors over time.
+
+For the per-quarter buying and selling behind these trends, see [View quarterly holdings activity across the market](how-to-view-holdings-activity.md).


### PR DESCRIPTION
## Summary

- Adds a user-guide how-to for the 13F Trends page, which has its own navigation entry but no guide coverage.
- Explains how to open it and read the three charts: total assets under management, filer/position counts, and sector allocation over time.

## Code changes

- `docs/guide/how-to-view-13f-trends.md` — new how-to page.
- `docs/guide/README.md` — one TOC bullet under How-to guides linking the new page.