### PR TITLE
docs(technical/hosts): correct AddMessaging wiring description

### DIFF
--- a/docs/technical/hosts.md
+++ b/docs/technical/hosts.md
@@ -62,4 +62,4 @@ Every host runs the same five steps described in [Architecture → Host composit
 4. `AutoWireServicesFrom<T>()` (once per assembly to wire)
 5. Host-specific registrations
 
-`AddMessaging()` as a *module* call must appear in the Web and MCP hosts; the Worker host pulls the same `MessagingModuleConfiguration` via `AddAllModules()` reflection because it references `Equibles.Messaging` directly. Either way the outbox tables end up in the EF model that owns the migration snapshot.
+`AddMessaging()` is a service registration from `Equibles.Messaging` (an `IServiceCollection` extension), not an `IModuleConfiguration` — so `AddAllModules()` never discovers it. The Web and Worker hosts call `builder.Services.AddMessaging(...)` directly; the MCP host does not. The MassTransit transport tables it relies on are part of the shared migration snapshot (the `AddMassTransitOutbox` migration), applied by the migrating host — `MigrateAsync` runs in the Web host.


### PR DESCRIPTION
## Summary

- Fixes an inaccurate description of how messaging is wired across hosts. The page referenced a `MessagingModuleConfiguration` class that does not exist, framed `AddMessaging()` as a module call pulled via `AddAllModules()` reflection, and named the wrong hosts.
- Corrected to match the code: `AddMessaging()` is an `IServiceCollection` extension from `Equibles.Messaging` (not an `IModuleConfiguration`, so `AddAllModules()` never discovers it); the Web and Worker hosts call it directly and the MCP host does not; the MassTransit tables come from the `AddMassTransitOutbox` migration in the shared snapshot, applied by the Web host via `MigrateAsync`.

## Code changes

- `docs/technical/hosts.md` — rewrite the messaging-wiring paragraph to match `MessagingServiceCollectionExtensions.AddMessaging`, the host `Program.cs` files, and the migration snapshot.