### PR TITLE
docs: update README and changelog for recent features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Explanatory intro on every stock data tab — each tab on the stock page (price, holdings, short interest, short volume, fails-to-deliver, financials, SEC documents, insider trading, proposed sales, fund holdings, fund operations, exempt offerings, congressional trades) now opens with a short description of what the data is and where it comes from, rendered via a shared `_TabIntro` partial. PR #3165.
 - Investment advisers (SEC Form ADV) — browse SEC-registered investment advisers at `/advisers` (name search, ranked largest-by-assets, paginated) with a per-firm profile at `/advisers/{crd}` showing regulatory assets under management (discretionary / non-discretionary / total), main office, employee count and fee structure. Data comes from the SEC's bulk Form ADV download, refreshed monthly by a background worker and keyed by Organization CRD number. Two MCP tools expose the same data to assistants: `SearchInvestmentAdvisers` (by name) and `GetInvestmentAdviser` (full profile by CRD). Issue #1866 (PRs #2867, #2868, #2869, #2870, #2871).
 - Fund portfolio holdings (SEC Form NPORT) — parses funds' monthly portfolio filings in the worker, exposes a fund's holdings via MCP, and adds a "Fund holdings" tab to the stock page listing the largest positions with value and percentage of net assets (capped, showing the largest N of M). Issue #1868 (PRs #2860, #2861, #2862, #2863).
 - Registered-fund annual operations (SEC Form N-CEN) — parses N-CEN filings in the worker, exposes them via MCP, and adds a "Fund operations" tab to the stock page surfacing each tracked fund/ETF's service providers (auditor, custodian, transfer agent, principal underwriter, etc.). Issue #1869 (PRs #2856, #2857, #2858, #2859).
@@ -41,6 +42,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - **No transactional outbox in OSS standalone.** `AddMessaging` no longer registers the EF outbox and gains a `configureBus` hook so a host can opt a context into one. OSS consumers must therefore be idempotent (no inbox/dedup ships). `CommonStockManager.SetCusip` now publishes **after** `SaveChanges` to avoid phantom events on rollback. PR #2258.
 - **Holdings snapshot rebuilds are now throttled and coalesced.** `Filings13FImportedConsumer` no longer rebuilds the AUM/sector snapshots inline — it marks the affected quarter dirty via a new `DirtyAt` timestamp on `AumQuarterlySnapshot`. A new `AumSnapshotDrainWorker` ticks every 5 minutes and rebuilds any quarter whose dirty flag has been set for more than an hour, using optimistic-concurrency clear so a consumer event landing mid-rebuild isn't lost. During 13F filing-season burst windows hundreds of imports per day for the same quarter now produce one rebuild per cooldown window instead of one per import. The daily safety-net `AumSnapshotRebuildWorker` is narrowed to the four most recent quarters (older quarters are effectively frozen — amendments trigger their own consumer event). First-boot backfill of every quarter is unchanged.
 - Holdings stats and trends pages (`/holdings/stats`, `/holdings/trends`) now read the per-quarter snapshots instead of recomputing aggregates on each request. PR #2479.
+- Per-stock quarterly 13F activity backing the conviction heat map is now materialized by the snapshot worker instead of recomputed per request, so the heat map renders from precomputed rows. PR #3238.
 
 ### Fixed
 
@@ -55,6 +57,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - CBOE put/call ingestion switched to the daily-page scraper and now persists incrementally so a cold start populates. PRs #2526, #2751.
 - House congressional PTR PDFs are parsed via page geometry so Representatives land in the right columns. PR #2530.
 - SEC Form 4 transaction-code mapping corrected (I/W). PR #2469.
+- Investment-adviser name search treats LIKE wildcards (`%`, `_`) in the query as literal characters, so a search containing them no longer matches unintended advisers. Issue #2905 (PR #3010).
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ See [`docs/`](docs/README.md) for the user guide and technical documentation.
 | Domain | Data Source | Description |
 |--------|------------|-------------|
 | **SEC Filings** | SEC EDGAR | 10-K, 10-Q, 8-K annual/quarterly/current reports with full-text search |
+| **Financial Statements** | SEC XBRL | Parsed income statement, balance sheet, and cash flow facts per fiscal period |
 | **Holdings** | SEC 13F-HR | Institutional ownership — who owns what, how much, and trend over time |
-| **Insider Trading** | SEC Form 3/4 | Director, officer, and 10% owner transactions |
+| **Fund Filings** | SEC NPORT / N-CEN / Form D | Fund portfolio holdings, registered-fund operations (service providers), and exempt offerings (private placements) |
+| **Investment Advisers** | SEC Form ADV | SEC-registered advisers — assets under management, main office, employee count, fee structure |
+| **Insider Trading** | SEC Form 3/4/144 | Director, officer, and 10% owner transactions, plus proposed (Form 144) sales |
 | **Congressional Trading** | House/Senate disclosures | Stock trades by members of Congress |
 | **Short Data** | SEC / FINRA | Fails-to-deliver (SEC), daily short volume and short interest (FINRA) |
 | **Economic Indicators** | FRED (Federal Reserve) | Interest rates, inflation, employment, GDP, yield spreads, and more |
@@ -152,9 +155,11 @@ Database migrations are applied automatically on startup. Review the [changelog]
 
 The web portal at `http://localhost:8080` provides a browser-based interface for exploring data:
 
-- **Stocks** — Browse and search all tracked companies, view price charts with technical indicators (SMA, EMA, RSI, MACD), institutional holdings, short data, SEC filings, insider trading, and congressional trades per stock
-- **Institutions** — Browse institutional holders (hedge funds, asset managers), view detailed profiles with portfolio breakdowns, industry allocation, quarterly activity, backtesting, and side-by-side comparisons. Includes a holdings screener with filters (filer count, value, float %, industry) and CSV export
+- **Stocks** — Browse and search all tracked companies, view price charts with technical indicators (SMA, EMA, RSI, MACD, Bollinger Bands), golden/death-cross and price-streak badges, performance versus SPY, plus per-stock tabs for institutional holdings, short data, SEC filings, financial statements, insider trading, proposed (Form 144) sales, fund holdings (NPORT), fund operations (N-CEN), exempt offerings (Form D), and congressional trades
+- **Institutions** — Browse institutional holders (hedge funds, asset managers), view detailed profiles with portfolio breakdowns, industry allocation, quarterly activity, backtesting, and side-by-side comparisons. Filers are scored on risk-adjusted performance (alpha vs. a benchmark) and a Smart Money Index page aggregates the highest-scoring funds into a consensus signal. Includes a holdings screener with filters (filer count, value, float %, location, AUM/position-count, industry) and CSV export
+- **Advisers** — Browse SEC-registered investment advisers (`/advisers`), ranked by assets under management, with per-firm profiles (regulatory AUM, main office, employee count, fee structure)
 - **Insider Trading** — Dashboard showing the top insider buys, sells, and biggest transactions over the last 90 days
+- **Short Activity** — Most-shorted leaderboard (`/most-shorted`, ranked by FINRA short interest) and largest daily short volume (`/short-volume`), each with a date selector, server-side sort, and pagination
 - **Economy** — Browse FRED economic indicators grouped by category (interest rates, inflation, employment, GDP, etc.) with charts and statistics
 - **Futures** — CFTC Commitments of Traders positioning data for 30+ futures contracts (commodities, indices, currencies) with commercial/non-commercial position charts
 - **Market** — CBOE market indicators: VIX volatility index with OHLC charts, put/call ratios (equity, index, total, VIX, ETP)
@@ -165,14 +170,15 @@ The web portal at `http://localhost:8080` provides a browser-based interface for
 
 The MCP server exposes financial data tools for AI assistants (Claude, ChatGPT, etc.):
 
-- **Institutional Holdings** — Top holders, ownership history, institution portfolios, institution search
-- **Insider Trading** — Insider transactions, ownership summary, insider search
+- **Institutional Holdings** — Top holders, ownership history, institution portfolios and summary, sector allocation, quarterly activity, most-held stocks, consensus holdings, fund overlap, market-wide 13F activity, institution search
+- **Insider Trading** — Insider transactions, ownership summary, proposed (Form 144) sales, insider search
 - **Congressional Trading** — Trades for a ticker, trades by one member, member search
 - **SEC Documents** — Full-text search, semantic search, document browsing, keyword search within filings
 - **Financial Statements** — XBRL fact time series per ticker, cross-ticker fact comparison, full income statement / balance sheet / cash flow per fiscal period
-- **Short Data** — Daily short volume, bi-monthly short interest, and the latest short-interest snapshot across tickers
+- **Fund & Adviser Filings** — Fund portfolio holdings (NPORT), registered-fund operations (N-CEN), exempt offerings (Form D), and SEC-registered investment-adviser lookup and search (Form ADV)
+- **Short Data** — Daily short volume, market-wide largest daily short volume, bi-monthly short interest, and the latest short-interest snapshot across tickers
 - **Economic Indicators** — FRED data lookup, latest macro snapshot, indicator search across categories
-- **Stock Prices** — Daily OHLCV history with adjusted close, latest close across one or more tickers, and on-demand technical indicators (EMA, Stochastic Oscillator, Average True Range, On-Balance Volume)
+- **Stock Prices** — Daily OHLCV history with adjusted close, latest close across one or more tickers, and on-demand technical indicators (EMA, Stochastic Oscillator, Average True Range, On-Balance Volume, Bollinger Bands)
 - **Futures Positioning** — COT positioning data, latest snapshot across all contracts, contract search
 - **Market Indicators** — VIX historical data, put/call ratios by type (equity, index, total, VIX, ETP)
 


### PR DESCRIPTION
## Summary

- The README had drifted from the shipped feature set — entire areas now in the `[Unreleased]` changelog (SEC fund/adviser filings, most-shorted/short-volume pages, fund scoring, Smart Money Index, several MCP tools) were undocumented. Brought the three drifted sections current.
- The changelog stopped at PR #2871; several user-facing PRs merged afterward were missing. Added the notable ones, verified against git history.

## Code changes

- `README.md` — expanded **What's Included** (added Financial Statements, Fund Filings, Investment Advisers rows; Form 3/4/144); **Web Portal** (new stock tabs, Bollinger Bands, SPY benchmark, Advisers and Short Activity pages, fund scoring + Smart Money Index); **MCP Server** (Fund & Adviser Filings group, proposed sales, largest short volume, Bollinger Bands, expanded institutional-holdings tools).
- `CHANGELOG.md` — **Added**: stock-tab intros (#3165); **Changed**: per-stock quarterly-activity materialization for the conviction heat map (#3238); **Fixed**: investment-adviser name search escapes LIKE wildcards as literals (#2905 / #3010).