### PR TITLE
docs(technical/scrapers): refresh HoldingsRescanSignal mechanism reference

### DIFF
--- a/docs/technical/scrapers.md
+++ b/docs/technical/scrapers.md
@@ -123,8 +123,8 @@ The cursor pattern means re-running is cheap (a single query for `max(date)` per
 
 In-process pub/sub between modules:
 
-- [`HoldingsRescanSignal`](../../src/Equibles.Holdings.HostedService/HoldingsRescanSignal.cs) — singleton with an internal `TaskCompletionSource` queue.
-- `StockCusipChangedConsumer` (MassTransit) calls `HoldingsRescanSignal.Signal()` after invalidating processed data.
+- [`HoldingsRescanSignal`](../../src/Equibles.Holdings.HostedService/HoldingsRescanSignal.cs) — singleton wrapping a `SemaphoreSlim(0, 1)`; repeated requests coalesce to a single pending rescan.
+- `StockCusipChangedConsumer` (MassTransit) calls `HoldingsRescanSignal.RequestRescan()` after invalidating processed data.
 - `HoldingsScraperWorker.WaitForNextCycle` races the signal against its 24h timer and wakes on whichever fires first.
 - Pattern is reusable. Add a singleton with the same async-signal shape (`WaitAsync` / `Signal`) when one module's events should wake another module's worker.
 


### PR DESCRIPTION
## Summary

- Fixes a stale code reference: the in-process pub/sub section described `HoldingsRescanSignal` as wrapping a `TaskCompletionSource` queue and called its method `Signal()`.
- The code uses a coalescing `SemaphoreSlim(0, 1)` and the method is `RequestRescan()`. Corrected both.

## Code changes

- `docs/technical/scrapers.md` — update the `HoldingsRescanSignal` mechanism and method name to match `HoldingsRescanSignal.cs` and `StockCusipChangedConsumer`.