### PR TITLE
docs(guide/browse-economic-data): fix Economy nav label to Economic Data

### DIFF
--- a/docs/guide/how-to-browse-economic-data.md
+++ b/docs/guide/how-to-browse-economic-data.md
@@ -8,7 +8,7 @@ You need a [FRED API key](how-to-set-up-fred-api-key.md) configured. Without it,
 
 ## Open the Economy index
 
-1. Click **Economy** in the top navigation, or go to `http://localhost:8080/EconomicData`.
+1. Click **More** in the top navigation, then **Economic Data** (or go to `http://localhost:8080/EconomicData`).
 
 2. You'll see indicators organized by category (e.g., Interest Rates, Inflation, Employment, GDP). Each row shows:
 


### PR DESCRIPTION
## Summary

- Fixes a screen-label mismatch: the guide told readers to click **Economy** in the top navigation, but there is no such item — the page is reached via **More → Economic Data**.
- The nav link, page title, and heading all read "Economic Data". Updated the step to match.

## Code changes

- `docs/guide/how-to-browse-economic-data.md` — correct the navigation instruction to **More → Economic Data**.