### PR TITLE
docs(guide/use-holdings-screener): fix non-existent Holdings nav instruction

### DIFF
--- a/docs/guide/how-to-use-holdings-screener.md
+++ b/docs/guide/how-to-use-holdings-screener.md
@@ -4,7 +4,7 @@ The holdings screener lets you filter the full universe of U.S. stocks by instit
 
 ## Open the screener
 
-1. Go to `http://localhost:8080` and click **Holdings** in the top navigation, then **Screener** (or go directly to `http://localhost:8080/holdings/screener`).
+1. Go to `http://localhost:8080/holdings/screener` in your browser.
 
 2. The screener needs at least two 13F report dates to work. If you see a warning that data isn't available yet, the worker is still backfilling 13F filings — check back in an hour or so.
 


### PR DESCRIPTION
## Summary

- Fixes a stale navigation instruction: the screener guide told readers to click **Holdings** in the top navigation, then **Screener**, but there is no Holdings menu and no Screener nav entry.
- The screener is reached directly at `/holdings/screener`. Simplified the step to open it by URL.

## Code changes

- `docs/guide/how-to-use-holdings-screener.md` — replace the non-existent Holdings → Screener nav path with the direct URL.