### PR TITLE
fix(sec): treat a missing daily-index 403 as a non-trading day, not throttling

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.IO.Compression;
 using System.Net;
 using System.Net.Sockets;
 using System.Security.Authentication;
@@ -418,34 +419,57 @@ public class SecEdgarClient : ISecEdgarClient
         var url =
             $"{FilesBaseUrl}/Archives/edgar/daily-index/{date.Year}/QTR{quarter}/master.{date.ToString("yyyyMMdd", System.Globalization.CultureInfo.InvariantCulture)}.idx";
 
-        // A 403 on a PAST date is never a missing index (those always exist) —
-        // it's SEC throttling, so retry it as transient. For today/future dates a
-        // 403 means the index isn't published yet, so don't retry those.
-        var today = DateOnly.FromDateTime(DateTime.UtcNow);
-        var isPastDate = date < today;
+        // SEC has no index on non-trading days. SendWithRetryAsync retries only the
+        // recognizable rolling-window throttle page, so a 403 surfacing here is not a
+        // transient throttle — it is either a genuine "no index for this date" or an
+        // exhausted throttle, distinguished below. (A past date is NOT guaranteed to
+        // have an index: weekends and market holidays — e.g. Memorial Day — have none,
+        // and SEC's S3-backed Archives answer those with a 403, not a 404.)
         using var response = await SendWithRetryAsync(
             url,
             HttpCompletionOption.ResponseContentRead,
-            cancellationToken,
-            retryForbidden: isPastDate
+            cancellationToken
         );
 
-        // Weekend/holiday 404, or a 403 for a not-yet-published index (today or a
-        // future date), both mean "no index for this date" — skip it.
-        if (
-            response.StatusCode == HttpStatusCode.NotFound
-            || (response.StatusCode == HttpStatusCode.Forbidden && !isPastDate)
-        )
+        // Weekends typically 404 — unambiguously "no index for this date".
+        if (response.StatusCode == HttpStatusCode.NotFound)
         {
             _logger.LogInformation("No daily index published for {Date:yyyy-MM-dd}", date);
             return [];
         }
 
-        // A past-date 403 that survived the retries is SEC still throttling: that
-        // index always exists, so this is a real failure to fetch, not "no
-        // filings". Let it throw — the caller (DiscoverEntries) catches it per
-        // day and holds the sweep watermark back so the day is re-swept next
-        // cycle, rather than being silently skipped past.
+        if (response.StatusCode == HttpStatusCode.Forbidden)
+        {
+            // SEC compresses error bodies even without an Accept-Encoding request, so
+            // decode before inspecting; the raw bytes would be unreadable.
+            var body = await ReadDecodedBody(response, cancellationToken);
+
+            // NEVER skip a real throttle — that would silently drop a trading day's
+            // filings. The rolling-window page survived SendWithRetryAsync's retries,
+            // so SEC is still throttling: throw so the caller holds the sweep watermark
+            // and re-sweeps the day next cycle.
+            if (IsRateLimitThresholdPage(body))
+            {
+                response.EnsureSuccessStatusCode();
+            }
+
+            // ONLY skip when the body positively identifies a missing index object —
+            // the S3 AccessDenied / NoSuchKey served for a non-trading day (holiday or
+            // weekend). Skipping lets the sweep advance past it instead of looping.
+            if (IsMissingIndexError(body))
+            {
+                _logger.LogInformation(
+                    "No daily index published for {Date:yyyy-MM-dd} (non-trading day)",
+                    date
+                );
+                return [];
+            }
+
+            // Any other 403 is unrecognized: be conservative and treat it as a fetch
+            // failure rather than risk skipping a day that has filings.
+            response.EnsureSuccessStatusCode();
+        }
+
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
 
@@ -563,8 +587,7 @@ public class SecEdgarClient : ISecEdgarClient
     private async Task<HttpResponseMessage> SendWithRetryAsync(
         string url,
         HttpCompletionOption completionOption,
-        CancellationToken cancellationToken = default,
-        bool retryForbidden = false
+        CancellationToken cancellationToken = default
     )
     {
         for (var attempt = 0; attempt <= MaxRetries; attempt++)
@@ -626,19 +649,17 @@ public class SecEdgarClient : ISecEdgarClient
                 }
             }
 
-            // SEC serves its "Request Rate Threshold Exceeded" throttle page with
-            // a 403 (not a 429), so a burst that trips the rolling-window limit
-            // arrives as a Forbidden carrying that HTML body. Back off and retry
-            // it like a 429 — otherwise callers that read 403 as "no resource"
-            // silently discard real data. Callers that know a 403 can only mean
-            // throttling (retryForbidden: e.g. a past-dated daily index, which
-            // always exists) retry every Forbidden; otherwise we retry only when
-            // the body is the recognizable throttle page, leaving a genuine 403
-            // (not-yet-published index, access-restricted path) to fall through.
+            // SEC serves its "Request Rate Threshold Exceeded" throttle page with a
+            // 403 (not a 429), so a burst that trips the rolling-window limit arrives
+            // as a Forbidden carrying that HTML body. Back off and retry it like a 429.
+            // Decode first: SEC gzips bodies even when none was requested, so the raw
+            // bytes would not match the page. A genuine 403 (a non-trading-day index,
+            // an access-restricted path) is not the throttle page, so it falls through
+            // for the caller to classify.
             if (response.StatusCode == HttpStatusCode.Forbidden && attempt < MaxRetries)
             {
-                var body = await response.Content.ReadAsStringAsync(cancellationToken);
-                if (retryForbidden || IsRateLimitThresholdPage(body))
+                var body = await ReadDecodedBody(response, cancellationToken);
+                if (IsRateLimitThresholdPage(body))
                 {
                     var delay = GetRetryDelay(response, attempt);
 
@@ -720,6 +741,51 @@ public class SecEdgarClient : ISecEdgarClient
     private static bool IsRateLimitThresholdPage(string body) =>
         !string.IsNullOrEmpty(body)
         && body.Contains("Request Rate Threshold Exceeded", StringComparison.OrdinalIgnoreCase);
+
+    // The SEC Archives are served from S3, which returns these error codes in the
+    // body when the requested index object does not exist — the signature of a
+    // non-trading day (weekend or market holiday) that legitimately has no filings.
+    private static bool IsMissingIndexError(string body) =>
+        !string.IsNullOrEmpty(body)
+        && (
+            body.Contains("AccessDenied", StringComparison.OrdinalIgnoreCase)
+            || body.Contains("NoSuchKey", StringComparison.OrdinalIgnoreCase)
+        );
+
+    // Reads a response body, transparently decompressing per Content-Encoding. The
+    // SEC HttpClient does not enable automatic decompression, yet SEC's S3-backed
+    // Archives gzip error bodies even when no Accept-Encoding was requested, so the
+    // raw string would be binary garbage. Successful payloads are uncompressed and
+    // pass straight through.
+    private static async Task<string> ReadDecodedBody(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken
+    )
+    {
+        var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+
+        // Content-Encoding tokens are case-insensitive per RFC 9110, and gzip is also
+        // spelled x-gzip — match loosely so a non-trading-day body never slips through
+        // undecoded and gets misread as binary garbage.
+        bool HasEncoding(string token) =>
+            response.Content.Headers.ContentEncoding.Any(e =>
+                e.Contains(token, StringComparison.OrdinalIgnoreCase)
+            );
+
+        Stream stream = new MemoryStream(bytes);
+        if (HasEncoding("gzip"))
+            stream = new GZipStream(stream, CompressionMode.Decompress);
+        else if (HasEncoding("deflate"))
+            stream = new DeflateStream(stream, CompressionMode.Decompress);
+        else if (HasEncoding("br"))
+            stream = new BrotliStream(stream, CompressionMode.Decompress);
+
+        await using (stream)
+        using (var reader = new StreamReader(stream))
+        {
+            return await reader.ReadToEndAsync(cancellationToken);
+        }
+    }
 
     private static List<CompanyInfo> ParseCompaniesFromResponse(CompanyTickersResponse response)
     {

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientGetDailyIndexThrottleRetryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientGetDailyIndexThrottleRetryTests.cs
@@ -1,5 +1,7 @@
+using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Text;
 using Equibles.Integrations.Sec;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -7,17 +9,28 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Equibles.UnitTests.Sec;
 
 /// <summary>
-/// Pins GetDailyIndex's 403 handling (GH-2222). A daily index for a PAST date
-/// always exists, so a 403 there is SEC throttling — it must be retried
-/// regardless of the response body, and if throttling persists the day is
-/// skipped (logged) rather than crashing the whole sweep. For today/future
-/// dates a 403 means "not yet published" and must not be retried.
+/// Pins GetDailyIndex's 403 handling. SEC has no index on non-trading days
+/// (weekends and market holidays such as Memorial Day) and answers those from its
+/// S3-backed Archives with a 403 carrying an AccessDenied/NoSuchKey body — for
+/// PAST dates included. That must be skipped so the sweep advances. A 403 carrying
+/// the rolling-window throttle page must NEVER be skipped (that would silently drop
+/// a trading day's filings) — it is retried, then surfaced if it persists. Any
+/// other, unrecognized 403 is treated conservatively as a fetch failure, not "no
+/// filings".
 /// </summary>
 public class SecEdgarClientGetDailyIndexThrottleRetryTests
 {
     private const string MasterIndexBody =
         "CIK|Company Name|Form Type|Date Filed|File Name\n"
         + "933478|VANGUARD FIDUCIARY TRUST CO|13F-HR|20200102|edgar/data/933478/0000933478-20-000004.txt\n";
+
+    private const string ThrottlePageBody =
+        "<html><head><title>Request Rate Threshold Exceeded</title></head></html>";
+
+    // The S3 error body SEC returns for a date that has no index object.
+    private const string AccessDeniedBody =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>";
 
     private static SecEdgarClient BuildClient(HttpMessageHandler handler)
     {
@@ -34,11 +47,13 @@ public class SecEdgarClientGetDailyIndexThrottleRetryTests
     }
 
     [Fact]
-    public async Task GetDailyIndex_PastDateForbiddenThenSuccess_RetriesRegardlessOfBodyAndParses()
+    public async Task GetDailyIndex_ThrottlePageThenSuccess_RetriesAndParses()
     {
-        // Empty 403 body — proves the retry is driven by the past-date rule, not
-        // by recognizing the throttle page (real throttle 403s can be body-less).
-        var handler = new SequencedHandler(() => Forbidden(body: ""), () => Ok(MasterIndexBody));
+        // The rolling-window throttle page is retryable; the next attempt succeeds.
+        var handler = new SequencedHandler(
+            () => Forbidden(ThrottlePageBody),
+            () => Ok(MasterIndexBody)
+        );
         var sut = BuildClient(handler);
 
         var result = await sut.GetDailyIndex(new DateOnly(2020, 1, 2));
@@ -49,13 +64,12 @@ public class SecEdgarClientGetDailyIndexThrottleRetryTests
     }
 
     [Fact]
-    public async Task GetDailyIndex_PastDateThrottlePersists_ThrowsAfterRetries()
+    public async Task GetDailyIndex_ThrottlePagePersists_ThrowsAfterRetriesNeverSkips()
     {
-        // Every attempt is throttled. A past-date index always exists, so a
-        // persistent 403 is a real fetch failure, not "no filings": it must be
-        // retried and then surfaced (the caller catches it per day and holds the
-        // sweep watermark back), never silently returned as empty.
-        var handler = new SequencedHandler(() => Forbidden(body: ""));
+        // Every attempt is throttled. A persistent throttle is a real fetch failure,
+        // not "no filings": it must be retried and then surfaced (the caller catches
+        // it per day and holds the sweep watermark back), never silently skipped.
+        var handler = new SequencedHandler(() => Forbidden(ThrottlePageBody));
         var sut = BuildClient(handler);
 
         var act = async () => await sut.GetDailyIndex(new DateOnly(2020, 1, 2));
@@ -65,17 +79,90 @@ public class SecEdgarClientGetDailyIndexThrottleRetryTests
     }
 
     [Fact]
-    public async Task GetDailyIndex_FutureDateForbidden_ReturnsEmptyWithoutRetry()
+    public async Task GetDailyIndex_PastDateMissingIndex_ReturnsEmptyWithoutRetry()
     {
-        // A future date's index isn't published yet: 403 means "no index", not
-        // throttling, so it must not be retried.
-        var handler = new SequencedHandler(() => Forbidden(body: ""));
+        // Memorial Day 2026-05-25 (a PAST date when swept) has no index — SEC answers
+        // with an AccessDenied 403. It must be skipped, not retried as throttling.
+        var handler = new SequencedHandler(() => Forbidden(AccessDeniedBody));
         var sut = BuildClient(handler);
 
-        var result = await sut.GetDailyIndex(new DateOnly(2099, 1, 1));
+        var result = await sut.GetDailyIndex(new DateOnly(2026, 5, 25));
+
+        result.Should().BeEmpty();
+        handler.CallCount.Should().Be(1); // not retried
+    }
+
+    [Fact]
+    public async Task GetDailyIndex_GzippedMissingIndex_DecodesBodyAndReturnsEmpty()
+    {
+        // SEC gzip-compresses its S3 error bodies even without an Accept-Encoding
+        // request, so the missing-index 403 must be decoded before it can be told
+        // apart from a throttle. The raw bytes would never match either signature.
+        var handler = new SequencedHandler(() => GzippedForbidden(AccessDeniedBody));
+        var sut = BuildClient(handler);
+
+        var result = await sut.GetDailyIndex(new DateOnly(2026, 5, 25));
 
         result.Should().BeEmpty();
         handler.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetDailyIndex_GzippedThrottlePagePersists_RetriesAndThrows()
+    {
+        // A throttle page must be recognized even when gzip-compressed, so it is
+        // backed off and retried — never skipped, and never thrown on the first try.
+        var handler = new SequencedHandler(() => GzippedForbidden(ThrottlePageBody));
+        var sut = BuildClient(handler);
+
+        var act = async () => await sut.GetDailyIndex(new DateOnly(2020, 1, 2));
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        handler.CallCount.Should().BeGreaterThan(1); // retried, not skipped
+    }
+
+    [Fact]
+    public async Task GetDailyIndex_NoSuchKeyMissingIndex_ReturnsEmpty()
+    {
+        // S3 also returns NoSuchKey (not only AccessDenied) for a missing index object.
+        const string noSuchKey =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>";
+        var handler = new SequencedHandler(() => Forbidden(noSuchKey));
+        var sut = BuildClient(handler);
+
+        var result = await sut.GetDailyIndex(new DateOnly(2026, 5, 25));
+
+        result.Should().BeEmpty();
+        handler.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetDailyIndex_NotFound_ReturnsEmpty()
+    {
+        // Weekends typically 404 — unambiguously "no index for this date".
+        var handler = new SequencedHandler(() => new HttpResponseMessage(HttpStatusCode.NotFound));
+        var sut = BuildClient(handler);
+
+        var result = await sut.GetDailyIndex(new DateOnly(2020, 1, 4));
+
+        result.Should().BeEmpty();
+        handler.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetDailyIndex_UnrecognizedForbidden_ThrowsRatherThanSkip()
+    {
+        // A 403 that is neither the throttle page nor a recognizable missing-index
+        // error is ambiguous: treat it as a fetch failure rather than risk skipping a
+        // day that has filings.
+        var handler = new SequencedHandler(() => Forbidden("something unexpected"));
+        var sut = BuildClient(handler);
+
+        var act = async () => await sut.GetDailyIndex(new DateOnly(2020, 1, 2));
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        handler.CallCount.Should().Be(1); // not the throttle page → not retried
     }
 
     private static HttpResponseMessage Ok(string body) =>
@@ -88,6 +175,23 @@ public class SecEdgarClientGetDailyIndexThrottleRetryTests
             Content = new StringContent(body),
         };
         // Retry-After: 0 keeps retrying tests fast and avoids a real backoff pause.
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.Zero);
+        return response;
+    }
+
+    private static HttpResponseMessage GzippedForbidden(string body)
+    {
+        using var output = new MemoryStream();
+        using (var gzip = new GZipStream(output, CompressionMode.Compress, leaveOpen: true))
+        {
+            var bytes = Encoding.UTF8.GetBytes(body);
+            gzip.Write(bytes, 0, bytes.Length);
+        }
+
+        var content = new ByteArrayContent(output.ToArray());
+        content.Headers.ContentEncoding.Add("gzip");
+
+        var response = new HttpResponseMessage(HttpStatusCode.Forbidden) { Content = content };
         response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.Zero);
         return response;
     }


### PR DESCRIPTION
## Summary

The SEC realtime sweep stalls for hours, starving Form 4 and XBRL downloads. `SecEdgarClient.GetDailyIndex` assumed a 403 on a past date was always throttling ("the index always exists") and retried every past-date 403 with exponential backoff up to 5 minutes plus a **global** `RateLimiter.PauseFor()` that freezes all six SEC workers.

But market holidays have **no** daily index, and SEC's S3-backed Archives answer those with a genuine 403 — a gzipped `AccessDenied` — for past dates too. So the sweep hit Memorial Day (2026-05-25), looped on it forever holding its watermark, and drained the shared EDGAR budget. Verified directly: `master.20260522.idx` (Fri) → 200, `master.20260526.idx` (Tue) → 200, `master.20260525.idx` (Mon) → 403; the IP is not throttled.

## Code changes

`src/Equibles.Integrations.Sec/SecEdgarClient.cs`:
- `GetDailyIndex` now classifies a 403 by its **decoded** body: throttle page (`IsRateLimitThresholdPage`) → throw so the caller holds the watermark (**never skipped**); S3 `AccessDenied`/`NoSuchKey` (`IsMissingIndexError`) → skip the non-trading day so the sweep advances; any other 403 → throw (conservative).
- Added `ReadDecodedBody` (gzip/deflate/brotli, case-insensitive) — SEC gzips error bodies even with no `Accept-Encoding`, so the raw bytes would never match either signature. The retry loop now decodes too, so a compressed throttle page is still recognized and backed off.
- Dropped the now-unused `retryForbidden` flag.

## Tests

Rewrote `SecEdgarClientGetDailyIndexThrottleRetryTests` to the correct contract (8 tests, all green): throttle-then-success retries+parses; persistent throttle (plain **and** gzipped) retries then throws — never skips; past-date missing index (plain + gzipped + NoSuchKey) skips without retry; 404 skips; unrecognized 403 throws.