### PR TITLE
fix(insider-trading): restate per-ADS prices to per-ordinary on ADS rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Insider-trading values for companies listed via American Depositary Shares (ADS/ADR) are no longer overstated. These Form 4 filings report the share count in the issuer's underlying ordinary shares but quote the price per ADS, so the dashboard's shares × price read far too high — e.g. SaverOne (SVRE) appeared as an ~$8.6B insider buy when the real value was ~$200K. The price is now restated to a per-ordinary basis (from the filing's footnotes) whenever the share count is an exact multiple of the ADS ratio, leaving the as-filed price preserved. Existing rows are corrected on the next filing reprocess.
 - XBRL financial values wrapped in parentheses **and** carrying an explicit `sign="-"` are no longer double-negated — a parenthesised negative now resolves to a single negative value. PR #2819.
 - Financial tables with merged `rowspan`/`colspan` cells are expanded to a rectangular grid before parsing, so values land in the correct row and column. PR #2820.
 - CFTC Commitments-of-Traders ingestion looks up CSV columns by the headers cftc.gov actually ships rather than by fixed position, so a column reorder no longer mismaps positioning data. PR #2478.

--- a/src/Equibles.InsiderTrading.BusinessLogic/AdsRatioExtractor.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/AdsRatioExtractor.cs
@@ -1,0 +1,264 @@
+namespace Equibles.InsiderTrading.BusinessLogic;
+
+/// <summary>
+/// Detects the ADS/ADR "unit mismatch" in a Form 4 non-derivative row and
+/// returns the ordinary-shares-per-ADS ratio needed to make Shares × Price a
+/// real dollar value.
+///
+/// Background: for issuers listed via American Depositary Shares, some Form 4
+/// filers report the transaction in the issuer's <em>ordinary</em> shares (the
+/// share count) but quote <c>transactionPricePerShare</c> per <em>ADS</em> (the
+/// Nasdaq-traded unit). Shares (ordinary) × Price (per ADS) then overstates the
+/// value by the ADS ratio — e.g. SaverOne (SVRE): 2,501,582,400 ordinary shares
+/// × $3.45/ADS reads as $8.6B, when one ADS = 43,200 ordinary shares makes the
+/// real value ~$200K.
+///
+/// The ratio and the "price is per ADS" basis both live only in free-text
+/// footnotes, so this reads the row's resolved <c>Notes</c>. It corrects ONLY
+/// the unambiguous mismatch and leaves every other ADS style untouched:
+/// <list type="bullet">
+/// <item>The security title must denote ordinary/common shares, not the ADS
+/// itself — rows titled "ADSs" already pair an ADS count with an ADS price.</item>
+/// <item>A footnote must state the price is per ADS, and none may state the
+/// price was already converted to a per-ordinary figure.</item>
+/// <item>The share count must be an exact multiple of the ratio — proof it is
+/// the underlying ordinary count (ADS count × ratio), not an ADS count a filer
+/// mislabeled "ordinary shares". This arithmetic test, not the prose, is what
+/// separates the real bug from look-alikes (e.g. a filing whose row count is an
+/// ADS count would be <em>under</em>-valued if divided, so it is left alone).</item>
+/// </list>
+/// Pure and stateless.
+/// </summary>
+public static class AdsRatioExtractor
+{
+    // Title denotes the ADS itself → the count is already in ADS units, so the
+    // count and the per-ADS price are consistent and need no correction.
+    private static readonly string[] AdsTitleMarkers =
+    {
+        "american depositary",
+        "american depository",
+        "depositary share",
+        "depository share",
+        "depositary receipt",
+        "depository receipt",
+        " ads",
+        "(ads",
+        "adss",
+    };
+
+    // The price is quoted per ADS — the clause that makes Shares × Price mix units.
+    private static readonly string[] PerAdsPriceMarkers =
+    {
+        "per ads",
+        "per american depositary share",
+        "per american depositary receipt",
+        "price of each ads",
+        "per adr",
+    };
+
+    // The price was already restated to a per-ordinary figure → no correction.
+    private static readonly string[] AlreadyConvertedMarkers =
+    {
+        "per ordinary share",
+        "converted from price per ads",
+        "converted from the price per ads",
+        "divided by",
+        "derived from the price per ads",
+    };
+
+    private static readonly Dictionary<string, int> NumberWords = new(
+        StringComparer.OrdinalIgnoreCase
+    )
+    {
+        ["one"] = 1,
+        ["two"] = 2,
+        ["three"] = 3,
+        ["four"] = 4,
+        ["five"] = 5,
+        ["six"] = 6,
+        ["seven"] = 7,
+        ["eight"] = 8,
+        ["nine"] = 9,
+        ["ten"] = 10,
+        ["eleven"] = 11,
+        ["twelve"] = 12,
+        ["thirteen"] = 13,
+        ["fourteen"] = 14,
+        ["fifteen"] = 15,
+        ["sixteen"] = 16,
+        ["seventeen"] = 17,
+        ["eighteen"] = 18,
+        ["nineteen"] = 19,
+        ["twenty"] = 20,
+    };
+
+    // The token that opens a ratio clause: a bare "ads"/"adr", or the phrase
+    // "american depositary share/receipt" (handled in MatchAdsRepresents). Only
+    // the singular forms anchor — a plural "adss"/"adrs" tokenizes distinctly, so
+    // a total-count clause ("5,655,290 ADSs representing 33,931,740 Ordinary
+    // Shares") is never mistaken for the ratio.
+    private static readonly HashSet<string> AdsAnchorTokens = new(StringComparer.Ordinal)
+    {
+        "ads",
+        "adr",
+    };
+
+    private static readonly HashSet<string> RepresentsTokens = new(StringComparer.Ordinal)
+    {
+        "represents",
+        "representing",
+    };
+
+    public static bool TryGetOrdinarySharesPerAds(
+        string securityTitle,
+        IReadOnlyList<string> notes,
+        long shares,
+        out int ratio
+    )
+    {
+        ratio = 0;
+        if (notes == null || notes.Count == 0 || shares <= 0)
+            return false;
+
+        // The count must be ordinary/common shares, not the ADS itself.
+        if (TitleDenotesAds(securityTitle))
+            return false;
+
+        var pricePerAds = false;
+        var alreadyConverted = false;
+        int? parsedRatio = null;
+        foreach (var note in notes)
+        {
+            if (string.IsNullOrEmpty(note))
+                continue;
+            var lower = note.ToLowerInvariant();
+            if (PerAdsPriceMarkers.Any(marker => lower.Contains(marker)))
+                pricePerAds = true;
+            if (AlreadyConvertedMarkers.Any(marker => lower.Contains(marker)))
+                alreadyConverted = true;
+            parsedRatio ??= TryParseRatio(note);
+        }
+
+        // Need a per-ADS price, a ratio above 1, and no sign the price was
+        // already converted to per-ordinary.
+        if (!pricePerAds || alreadyConverted || parsedRatio is not > 1)
+            return false;
+
+        // The share count must be the underlying ordinary count: ADS count ×
+        // ratio is always an exact multiple of the ratio. A row that fails this
+        // is reporting an ADS count, so dividing the price would under-value it.
+        if (shares % parsedRatio.Value != 0)
+            return false;
+
+        ratio = parsedRatio.Value;
+        return true;
+    }
+
+    private static bool TitleDenotesAds(string securityTitle)
+    {
+        if (string.IsNullOrWhiteSpace(securityTitle))
+            return false;
+        var lower = securityTitle.ToLowerInvariant();
+        return AdsTitleMarkers.Any(marker => lower.Contains(marker));
+    }
+
+    // Scan the note for an "<ADS|ADR> represent(s|ing) N ... ordinary|common
+    // share(s)" clause and return N. The clause is anchored on the singular
+    // ADS/ADR token so a plural count clause ("5,655,290 ADSs representing
+    // 33,931,740 Ordinary Shares") never matches, and confirmed by the
+    // ordinary/common-share noun that follows so an unrelated number isn't read.
+    private static int? TryParseRatio(string note)
+    {
+        var tokens = Tokenize(note);
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            var afterRepresents = MatchAdsRepresents(tokens, i);
+            if (afterRepresents < 0)
+                continue;
+
+            // The ratio is the first number within a token or two of "represents".
+            var limit = Math.Min(tokens.Count, afterRepresents + 3);
+            for (var j = afterRepresents + 1; j < limit; j++)
+            {
+                var number = ParseNumberToken(tokens[j]);
+                if (number == null)
+                    continue;
+                if (OrdinaryShareNounFollows(tokens, j + 1))
+                    return number;
+                // A number that doesn't lead to the share noun isn't the ratio;
+                // give up on this anchor and look for the next one.
+                break;
+            }
+        }
+        return null;
+    }
+
+    // When tokens[i] opens an ADS/ADR anchor immediately followed by
+    // "represent(s|ing)", returns that verb's index; otherwise -1. Matches the
+    // bare "ads"/"adr" token or the "american depositary share/receipt" phrase.
+    private static int MatchAdsRepresents(IReadOnlyList<string> tokens, int i)
+    {
+        if (AdsAnchorTokens.Contains(tokens[i]))
+            return IsRepresents(tokens, i + 1) ? i + 1 : -1;
+
+        if (
+            tokens[i] == "american"
+            && i + 2 < tokens.Count
+            && (tokens[i + 1] == "depositary" || tokens[i + 1] == "depository")
+            && (tokens[i + 2] == "share" || tokens[i + 2] == "receipt")
+        )
+            return IsRepresents(tokens, i + 3) ? i + 3 : -1;
+
+        return -1;
+    }
+
+    private static bool IsRepresents(IReadOnlyList<string> tokens, int index) =>
+        index < tokens.Count && RepresentsTokens.Contains(tokens[index]);
+
+    // True when an "ordinary"/"common" token immediately followed by
+    // "share"/"shares" appears within a short window — the noun the ratio counts.
+    // The window skips over interveners like "Class A", "(5)", and "of the
+    // Company's" without letting an unrelated clause qualify.
+    private static bool OrdinaryShareNounFollows(IReadOnlyList<string> tokens, int start)
+    {
+        var limit = Math.Min(tokens.Count - 1, start + 6);
+        for (var i = start; i < limit; i++)
+        {
+            if (
+                (tokens[i] == "ordinary" || tokens[i] == "common")
+                && (tokens[i + 1] == "share" || tokens[i + 1] == "shares")
+            )
+                return true;
+        }
+        return false;
+    }
+
+    // Digits-with-commas ("43,200") or a number word ("twelve"). Null otherwise.
+    private static int? ParseNumberToken(string token)
+    {
+        if (token.Length == 0)
+            return null;
+        if (token.Any(char.IsDigit))
+            return int.TryParse(token.Replace(",", string.Empty), out var value) ? value : null;
+        return NumberWords.TryGetValue(token, out var word) ? word : null;
+    }
+
+    // Lowercase, split on whitespace, and reduce each token to letters/digits and
+    // the comma (kept for grouped numbers like "43,200"). Dropping the
+    // surrounding punctuation lets "(ADS)", "shares." and "Company's" tokenize
+    // cleanly, and leaves "ADSs" distinct from the "ads" anchor.
+    private static List<string> Tokenize(string note)
+    {
+        var raw = note.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
+        var tokens = new List<string>(raw.Length);
+        foreach (var word in raw)
+        {
+            var normalized = new string(
+                word.ToLowerInvariant().Where(c => char.IsLetterOrDigit(c) || c == ',').ToArray()
+            );
+            if (normalized.Length > 0)
+                tokens.Add(normalized);
+        }
+        return tokens;
+    }
+}

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -249,7 +249,8 @@ public class InsiderFilingReprocessManager
                 row.Shares,
                 row.SecurityKind,
                 row.SecurityTitle,
-                close
+                close,
+                row.Notes
             );
             row.PricePerShare = evaluation.EffectivePrice;
             row.IsPriceValid = evaluation.IsPriceValid;

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceBackfillManager.cs
@@ -115,7 +115,8 @@ public class InsiderTransactionPriceBackfillManager
                     transaction.Shares,
                     transaction.SecurityKind,
                     transaction.SecurityTitle,
-                    close
+                    close,
+                    transaction.Notes
                 );
 
                 transaction.PricePerShare = evaluation.EffectivePrice;

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
@@ -85,13 +85,21 @@ public class InsiderTransactionPriceValidator
     /// Derivative classification uses the authoritative <paramref name="kind"/>
     /// (from the Form 4 table). Only when it's <see cref="InsiderSecurityKind.Unknown"/>
     /// (rows not yet reclassified) does it fall back to the title-keyword heuristic.
+    ///
+    /// <paramref name="notes"/> are the row's resolved footnotes. When they show
+    /// an ADS/ADR unit mismatch (an ordinary-share count priced per ADS), the
+    /// per-ADS price is first restated to per-ordinary via the ADS ratio so the
+    /// downstream Shares × EffectivePrice is a real value — see
+    /// <see cref="AdsRatioExtractor"/>. <paramref name="reportedPrice"/> stays the
+    /// as-filed (per-ADS) figure that the caller keeps in ReportedPricePerShare.
     /// </summary>
     public InsiderTransactionPriceEvaluation Evaluate(
         decimal reportedPrice,
         long shares,
         InsiderSecurityKind kind,
         string securityTitle,
-        decimal? unadjustedClose
+        decimal? unadjustedClose,
+        IReadOnlyList<string> notes = null
     )
     {
         // Zero/negative prices (holdings, sentinels) and derivatives need no
@@ -105,24 +113,40 @@ public class InsiderTransactionPriceValidator
             };
         }
 
+        // ADS/ADR unit normalization: when the footnotes show the price is per
+        // ADS but the share count is the underlying ordinary count, restate the
+        // price to per-ordinary so it matches the count. Everything below works
+        // on this base price; the as-filed per-ADS value is preserved by the
+        // caller in ReportedPricePerShare.
+        var basePrice = reportedPrice;
+        if (
+            AdsRatioExtractor.TryGetOrdinarySharesPerAds(
+                securityTitle,
+                notes,
+                shares,
+                out var ratio
+            )
+        )
+            basePrice = reportedPrice / ratio;
+
         // A real price we can't yet check stays pending (null), not valid.
         if (!unadjustedClose.HasValue || unadjustedClose.Value <= 0m)
         {
             return new InsiderTransactionPriceEvaluation
             {
                 IsPriceValid = null,
-                EffectivePrice = reportedPrice,
+                EffectivePrice = basePrice,
             };
         }
 
         // Plausible against the close — keep as filed. Divide rather than
         // multiply the close so a near-decimal.MaxValue close can't overflow.
-        if (reportedPrice / MaxPriceToCloseMultiplier <= unadjustedClose.Value)
+        if (basePrice / MaxPriceToCloseMultiplier <= unadjustedClose.Value)
         {
             return new InsiderTransactionPriceEvaluation
             {
                 IsPriceValid = true,
-                EffectivePrice = reportedPrice,
+                EffectivePrice = basePrice,
             };
         }
 
@@ -136,7 +160,7 @@ public class InsiderTransactionPriceValidator
             return new InsiderTransactionPriceEvaluation
             {
                 IsPriceValid = false,
-                EffectivePrice = reportedPrice,
+                EffectivePrice = basePrice,
             };
         }
 
@@ -145,7 +169,7 @@ public class InsiderTransactionPriceValidator
         return new InsiderTransactionPriceEvaluation
         {
             IsPriceValid = true,
-            EffectivePrice = reportedPrice / shares,
+            EffectivePrice = basePrice / shares,
             WasRepaired = true,
         };
     }

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -21,9 +21,12 @@ public class InsiderTransaction
     /// re-parsed from the cached <see cref="InsiderFiling"/> XML rather than
     /// re-fetched from EDGAR. Rows ingested before versioning default to 0.
     ///
-    /// History: v1 added SecurityKind; v2 added <see cref="Notes"/> (footnotes).
+    /// History: v1 added SecurityKind; v2 added <see cref="Notes"/> (footnotes);
+    /// v3 restates per-ADS prices on ADS/ADR rows to per-ordinary so Shares ×
+    /// PricePerShare is a real value (re-evaluated from the footnotes — see
+    /// <see cref="ReportedPricePerShare"/>).
     /// </summary>
-    public const int CurrentParserVersion = 2;
+    public const int CurrentParserVersion = 3;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -416,7 +416,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 transaction.Shares,
                 transaction.SecurityKind,
                 transaction.SecurityTitle,
-                close
+                close,
+                transaction.Notes
             );
             transaction.PricePerShare = evaluation.EffectivePrice;
             transaction.IsPriceValid = evaluation.IsPriceValid;

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/AdsRatioExtractorTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/AdsRatioExtractorTests.cs
@@ -1,0 +1,193 @@
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+// Cases are drawn from real Form 4 footnote styles across many ADS/ADR issuers
+// (SaverOne, Adaptimmune, GW Pharmaceuticals, Avadel, Moatable, Taiwan
+// Semiconductor) plus the foreign-issuer ordinary-shares-direct negative class
+// (Freightos). The extractor must restate ONLY the unambiguous mismatch — an
+// ordinary-share count priced per ADS — and leave every other style alone.
+public class AdsRatioExtractorTests
+{
+    public static IEnumerable<object[]> Cases()
+    {
+        // SaverOne (SVRE): ordinary count priced per ADS, comma-grouped ratio.
+        // 2,501,582,400 / 43,200 = 57,907 (exact) → corrected.
+        yield return new object[]
+        {
+            "Ordinary Shares",
+            new[]
+            {
+                "The price reported is the price per American Depositary Share (\"ADS\") acquired in an open-market transaction on The Nasdaq Stock Market LLC. Each ADS represents 43,200 ordinary shares of the Issuer pursuant to the ADS ratio effective February 25, 2026. The Reporting Person acquired 57,907 ADSs on April 9, 2026 at $3.45, all per ADS, resulting in the underlying ordinary shares reported.",
+            },
+            2_501_582_400L,
+            43_200,
+        };
+
+        // Adaptimmune (ADAP): ordinary count priced per ADS, digit ratio. The
+        // total-count clause ("...representing 33,931,740 Ordinary Shares") must
+        // NOT be read as the ratio. 33,931,740 / 6 = 5,655,290 (exact).
+        yield return new object[]
+        {
+            "Ordinary Shares",
+            new[]
+            {
+                "These Ordinary Shares are held through American Depositary Shares (\"ADS\") of the Issuer. Each ADS represents 6 Ordinary Shares.",
+                "The reporting persons sold 5,655,290 ADSs representing 33,931,740 Ordinary Shares.",
+                "The price reported in Column 4 is the price per ADS sold by the reporting persons.",
+            },
+            33_931_740L,
+            6,
+        };
+
+        // Number-word ratio ("twelve") with an explicit per-ADS price. 240 / 12 exact.
+        yield return new object[]
+        {
+            "Ordinary Shares",
+            new[]
+            {
+                "Price reported is per ADS.",
+                "Each ADS represents twelve ordinary shares of the Issuer.",
+            },
+            240L,
+            12,
+        };
+
+        // "five (5)" word-plus-parenthetical, "Common Shares". 500 / 5 exact.
+        yield return new object[]
+        {
+            "Common Shares",
+            new[]
+            {
+                "The reported price is the price of each ADS.",
+                "Each American Depositary Share represents five (5) Common Shares.",
+            },
+            500L,
+            5,
+        };
+
+        // ADR token (not "ADS") with a per-ADR price. 400 / 4 exact.
+        yield return new object[]
+        {
+            "Ordinary Shares",
+            new[]
+            {
+                "The price reported is per ADR.",
+                "Each ADR represents 4 ordinary shares of the issuer.",
+            },
+            400L,
+            4,
+        };
+
+        // "of the Company's" possessive between the ratio and "ordinary shares".
+        // 5,000 / 1,000 exact.
+        yield return new object[]
+        {
+            "Ordinary Shares",
+            new[]
+            {
+                "Price reported is per ADS.",
+                "Each ADS represents 1,000 of the Company's ordinary shares.",
+            },
+            5_000L,
+            1_000,
+        };
+
+        // NEGATIVE — GW Pharmaceuticals: price already converted to per-ordinary.
+        yield return new object[]
+        {
+            "Ordinary Shares",
+            new[]
+            {
+                "Each ADS represents twelve ordinary shares of the Issuer.",
+                "Converted from price per ADS. The price reported in Column 4 is a weighted average price per ordinary share ($140.0338 per ADS).",
+            },
+            93_468L,
+            0,
+        };
+
+        // NEGATIVE — Avadel: the row is titled in ADS units, so count and price
+        // are already consistent (and the ratio is 1 anyway).
+        yield return new object[]
+        {
+            "ADSs",
+            new[]
+            {
+                "The issuer's \"ADSs\" are American Depositary Shares, with each ADS representing one ordinary share, nominal value $0.01 per share, of the issuer; ADSs may be represented by American Depositary Receipts.",
+            },
+            70_000L,
+            0,
+        };
+
+        // NEGATIVE — Moatable: per-ADS price + ordinary title, but the share
+        // count is the ADS count (59,168 / 45 is not whole) → the arithmetic
+        // gate refuses to divide, which would otherwise under-value the row.
+        yield return new object[]
+        {
+            "Class A Ordinary Shares",
+            new[]
+            {
+                "The reported price is the price of each ADS purchased, the price was paid in USD. Each ADS represents 45 Class A Ordinary Shares.",
+            },
+            59_168L,
+            0,
+        };
+
+        // NEGATIVE — Taiwan Semiconductor: ratio footnote present, but the priced
+        // row is per common share (FX-translated), not per ADS.
+        yield return new object[]
+        {
+            "Common Shares (2330.TW)",
+            new[]
+            {
+                "Each American Depositary Share represents five (5) Common Shares.",
+                "The price was translated from the average purchase price of NT$1,837.2789 in New Taiwan dollars, at the rate of NT$31.748 to US$1.",
+            },
+            88L,
+            0,
+        };
+
+        // NEGATIVE — Freightos: foreign issuer listing ordinary shares directly
+        // (no ADS wrapper). Looks like the bug — ordinary title — but no ADS
+        // footnote at all, so it must never be touched.
+        yield return new object[]
+        {
+            "Ordinary Shares",
+            new[]
+            {
+                "The transaction reported in this row consists of a sale-to-cover on behalf of the Reporting Person to cover tax liability for vesting of restricted share units.",
+            },
+            17_898L,
+            0,
+        };
+
+        // NEGATIVE — Form 3 holding: no footnotes at all.
+        yield return new object[]
+        {
+            "Ordinary Shares",
+            System.Array.Empty<string>(),
+            6_418_828_800L,
+            0,
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void TryGetOrdinarySharesPerAds_AcrossFilingStyles_MatchesExpectedRatio(
+        string securityTitle,
+        string[] notes,
+        long shares,
+        int expectedRatio
+    )
+    {
+        var corrected = AdsRatioExtractor.TryGetOrdinarySharesPerAds(
+            securityTitle,
+            notes,
+            shares,
+            out var ratio
+        );
+
+        corrected.Should().Be(expectedRatio != 0);
+        ratio.Should().Be(expectedRatio);
+    }
+}

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorAdsTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorAdsTests.cs
@@ -1,0 +1,76 @@
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+// The ADS/ADR unit-mismatch correction wired through the price evaluator: a
+// per-ADS price on an ordinary-share count is restated to per-ordinary so
+// Shares × EffectivePrice is a real dollar value, while the as-filed per-ADS
+// figure (ReportedPricePerShare) is left for the caller to preserve.
+public class InsiderTransactionPriceValidatorAdsTests
+{
+    private readonly InsiderTransactionPriceValidator _validator = new();
+
+    private static readonly string[] SvreNotes =
+    {
+        "The price reported is the price per American Depositary Share (\"ADS\") acquired in an open-market transaction on The Nasdaq Stock Market LLC. Each ADS represents 43,200 ordinary shares of the Issuer pursuant to the ADS ratio effective February 25, 2026. The Reporting Person acquired 57,907 ADSs on April 9, 2026 at $3.45, all per ADS, resulting in the underlying ordinary shares reported.",
+    };
+
+    // The headline case: 2,501,582,400 ordinary × $3.45/ADS read as $8.6B; with
+    // 1 ADS = 43,200 ordinary the effective per-ordinary price restates the value
+    // to ~$200K. Close ($3.45, the ADS price) is well above the per-ordinary
+    // price, so the row is plausible and never spuriously "repaired".
+    [Fact]
+    public void Evaluate_PerAdsPriceOnOrdinaryCount_RestatesPriceToPerOrdinary()
+    {
+        var evaluation = _validator.Evaluate(
+            reportedPrice: 3.45m,
+            shares: 2_501_582_400L,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Ordinary Shares",
+            unadjustedClose: 3.45m,
+            notes: SvreNotes
+        );
+
+        evaluation.IsPriceValid.Should().BeTrue();
+        evaluation.WasRepaired.Should().BeFalse();
+        evaluation.EffectivePrice.Should().Be(3.45m / 43_200);
+        (evaluation.EffectivePrice * 2_501_582_400L).Should().BeApproximately(199_779.6m, 1m);
+    }
+
+    // Without the footnotes the evaluator can't know the price is per ADS, so it
+    // leaves the value untouched — the correction is footnote-driven, not
+    // inferred from the numbers.
+    [Fact]
+    public void Evaluate_PerAdsPriceWithoutNotes_LeavesPriceUnchanged()
+    {
+        var evaluation = _validator.Evaluate(
+            reportedPrice: 3.45m,
+            shares: 2_501_582_400L,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Ordinary Shares",
+            unadjustedClose: 3.45m,
+            notes: null
+        );
+
+        evaluation.EffectivePrice.Should().Be(3.45m);
+    }
+
+    // A plain domestic common-stock sale must be unaffected by the new notes
+    // path — no ADS footnote, price stays as filed.
+    [Fact]
+    public void Evaluate_PlainCommonStock_IsUnaffectedByAdsPath()
+    {
+        var evaluation = _validator.Evaluate(
+            reportedPrice: 50m,
+            shares: 1_000L,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            unadjustedClose: 49m,
+            notes: new[] { "Represents shares withheld to cover taxes." }
+        );
+
+        evaluation.IsPriceValid.Should().BeTrue();
+        evaluation.EffectivePrice.Should().Be(50m);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the insider-trading dashboard showing an ~$8.6B insider buy for SaverOne (SVRE). For companies listed via American Depositary Shares, Form 4 filings report the share count in the issuer's underlying ordinary shares but quote `transactionPricePerShare` per ADS, so `Shares × Price` overstates the value by the ADS ratio (SVRE: 2,501,582,400 ordinary × $3.45/ADS = $8.6B; one ADS = 43,200 ordinary makes the real value ~$200K). The data faithfully matches EDGAR — this is a derived-value unit mismatch, not a parsing bug.

## Code changes

- **`AdsRatioExtractor`** (new, pure): detects the mismatch from a row's resolved footnotes and returns the ordinary-shares-per-ADS ratio. Gated to the unambiguous case only — ordinary/common security title, a footnote stating the price is per ADS, no footnote showing it was already converted, an extractable ratio, and a share count that is an exact multiple of that ratio. That last arithmetic check (`shares % ratio == 0`) is what proves the count is the underlying ordinary count rather than a mislabeled ADS count, and is what keeps the inverse case (where dividing would *under*-value) untouched. Implemented as a small token scanner (no regex).
- **`InsiderTransactionPriceValidator.Evaluate`**: gains a `notes` parameter; when the mismatch is detected it restates the per-ADS price to per-ordinary before the existing plausibility/repair logic. The as-filed per-ADS price is preserved by callers in `ReportedPricePerShare`; only the effective `PricePerShare` moves.
- Wired `Notes` through the three evaluation call sites (ingest processor, reprocess manager, price backfill manager).
- Bumped `InsiderTransaction.CurrentParserVersion` 2 → 3 so a reprocess pass re-evaluates existing rows. No schema change (the ratio is re-derived from the footnotes already captured at v2).
- Tests: `AdsRatioExtractorTests` (corpus-driven across SaverOne, Adaptimmune, GW Pharmaceuticals, Avadel, Moatable, Taiwan Semiconductor, an ADR token, and foreign-issuer ordinary-direct negatives) and `InsiderTransactionPriceValidatorAdsTests`.

## Verification

- [x] `dotnet build` clean locally
- [x] `dotnet test` (insider/Sec unit tests) passes locally — 39 ADS/validator tests + 116 insider/Sec tests green
- [x] `dotnet csharpier check` clean on changed files
- [x] CHANGELOG.md updated under `## [Unreleased]` › Fixed

## Notes for reviewers

- The correction is footnote-driven and conservative: anything ambiguous is left exactly as filed. ADS rows in the *derivative* table (e.g. Sequans) aren't corrected, but the dashboard excludes derivatives anyway.
- Existing rows correct on the next reprocess pass (parser v3); prod rows are currently at version 0 with empty footnotes, so the reprocess also folds in the pending v2 footnote capture.