### PR TITLE
fix(finra): guard short-volume import against CommonStock disappearing mid-cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - House congressional PTR PDFs are parsed via page geometry so Representatives land in the right columns. PR #2530.
 - SEC Form 4 transaction-code mapping corrected (I/W). PR #2469.
 - Investment-adviser name search treats LIKE wildcards (`%`, `_`) in the query as literal characters, so a search containing them no longer matches unintended advisers. Issue #2905 (PR #3010).
+- The FINRA daily short-volume scraper now guards against the parent `CommonStock` disappearing between the per-cycle ticker-map read and the per-batch write — the same guard already applied to the Yahoo, FTD, and FinancialFacts scrapers. A cold-start tick alongside `CompanySyncService` could otherwise trip `FK_*_CommonStock_CommonStockId` and fail the entire insert batch (poisoning rows for surviving stocks too); stale IDs are now re-validated against the live `CommonStock` table per batch and dropped with a warning so the surviving rows still persist. Issue #3288 (follow-up to #1591).
 
 ### Security
 

--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -110,8 +110,10 @@ public class ShortVolumeImportService
                 async batch =>
                 {
                     using var scope = _scopeFactory.CreateScope();
-                    var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
-                    var repo = scope.ServiceProvider.GetRequiredService<DailyShortVolumeRepository>();
+                    var stockRepo =
+                        scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+                    var repo =
+                        scope.ServiceProvider.GetRequiredService<DailyShortVolumeRepository>();
 
                     // tickerMap was built at the start of Import and can go stale if CompanySyncService
                     // hard-deletes/replaces a stock in parallel. Re-validate each batch against the
@@ -123,7 +125,9 @@ public class ShortVolumeImportService
                         .Select(s => s.Id)
                         .ToHashSetAsync(cancellationToken);
 
-                    var validBatch = batch.Where(b => liveStockIds.Contains(b.CommonStockId)).ToList();
+                    var validBatch = batch
+                        .Where(b => liveStockIds.Contains(b.CommonStockId))
+                        .ToList();
                     var dropped = batch.Count - validBatch.Count;
                     if (dropped > 0)
                     {

--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
@@ -7,6 +8,7 @@ using Equibles.Finra.Repositories;
 using Equibles.Integrations.Finra.Contracts;
 using Equibles.Integrations.Finra.Models;
 using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
 namespace Equibles.Finra.HostedService.Services;
@@ -79,12 +81,16 @@ public class ShortVolumeImportService
                 continue;
             }
 
-            await ImportSingleDay(currentDate, tickerMap);
+            await ImportSingleDay(currentDate, tickerMap, cancellationToken);
             currentDate = currentDate.AddDays(1);
         }
     }
 
-    private async Task ImportSingleDay(DateOnly date, IReadOnlyDictionary<string, Guid> tickerMap)
+    private async Task ImportSingleDay(
+        DateOnly date,
+        IReadOnlyDictionary<string, Guid> tickerMap,
+        CancellationToken cancellationToken
+    )
     {
         try
         {
@@ -98,10 +104,43 @@ public class ShortVolumeImportService
 
             var aggregated = AggregateVolumesByStock(records, tickerMap, date);
 
-            var totalInserted = await BatchPersister.Persist<
-                DailyShortVolume,
-                DailyShortVolumeRepository
-            >(aggregated.Values, InsertBatchSize, _scopeFactory);
+            var totalInserted = await BatchPersister.Persist(
+                aggregated.Values,
+                InsertBatchSize,
+                async batch =>
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+                    var repo = scope.ServiceProvider.GetRequiredService<DailyShortVolumeRepository>();
+
+                    // tickerMap was built at the start of Import and can go stale if CompanySyncService
+                    // hard-deletes/replaces a stock in parallel. Re-validate each batch against the
+                    // current CommonStock table so dangling-FK inserts don't poison the whole batch.
+                    var batchStockIds = batch.Select(b => b.CommonStockId).Distinct().ToList();
+                    var liveStockIds = await stockRepo
+                        .GetAll()
+                        .Where(s => batchStockIds.Contains(s.Id))
+                        .Select(s => s.Id)
+                        .ToHashSetAsync(cancellationToken);
+
+                    var validBatch = batch.Where(b => liveStockIds.Contains(b.CommonStockId)).ToList();
+                    var dropped = batch.Count - validBatch.Count;
+                    if (dropped > 0)
+                    {
+                        _logger.LogWarning(
+                            "Dropped {Dropped} short volume rows for {Date} referencing CommonStockIds no longer in the database",
+                            dropped,
+                            date
+                        );
+                    }
+
+                    if (validBatch.Count == 0)
+                        return;
+
+                    repo.AddRange(validBatch);
+                    await repo.SaveChanges();
+                }
+            );
 
             _logger.LogInformation(
                 "Imported {Count} short volume records for {Date}",


### PR DESCRIPTION
## What

Extends the stale-`CommonStockId` foreign-key guard from #1591 (Yahoo, FTD, FinancialFacts scrapers) to the **FINRA daily short-volume scraper** (`ShortVolumeImportService`), which was left out of that fix's scope.

## Why

`Import()` builds the ticker → `CommonStockId` map once at the start of a cycle. If `CompanySyncService` hard-deletes or replaces a `CommonStock` between that read and the per-batch write (common during cold-start while the universe is still populating), the now-stale `CommonStockId` trips `FK_*_CommonStock_CommonStockId` and fails the **entire insert batch** — poisoning rows for surviving stocks too.

Observed on a local deployment: 5 `An error occurred while saving the entity changes` failures recorded against `FinraScraper`, clustered in a cold-start window — the same mechanism #1591 describes.

## How

`ImportSingleDay` now re-validates each batch against the live `CommonStock` table before persisting, drops only the stale IDs (logging a warning with the count), and saves the survivors. Mirrors the guard already in place for the other three scrapers. Also threads `CancellationToken` through `ImportSingleDay`.

## Testing

- `dotnet build src/Equibles.Finra.HostedService` — green (0 warnings, 0 errors).
- Verified against the live FINRA importer locally: short-volume backfill completes without the batch-poisoning failures.

Closes #3288. Follow-up to #1591.
