### PR TITLE
test(insider): pin AdsRatioExtractor 1:1 ADS ratio leaves row untouched

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/AdsRatioExtractorRatioOfOneTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/AdsRatioExtractorRatioOfOneTests.cs
@@ -1,0 +1,29 @@
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class AdsRatioExtractorRatioOfOneTests
+{
+    [Fact]
+    public void TryGetOrdinarySharesPerAds_OneToOneRatioPricedPerAds_LeavesRowUntouched()
+    {
+        // Contract: a 1:1 ADS issuer already has Shares (ordinary) == Shares (ADS),
+        // so Shares x Price (per ADS) is correct and must NOT be rescaled. The
+        // docstring requires "a ratio above 1"; here the title is ordinary (not the
+        // ADS itself) and the price is per ADS, so the only thing barring a
+        // correction is the ratio of exactly one.
+        var corrected = AdsRatioExtractor.TryGetOrdinarySharesPerAds(
+            "Ordinary Shares",
+            new[]
+            {
+                "The reported price is per ADS.",
+                "Each ADS represents one ordinary share of the Issuer.",
+            },
+            70_000L,
+            out var ratio
+        );
+
+        corrected.Should().BeFalse();
+        ratio.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the rule that `AdsRatioExtractor.TryGetOrdinarySharesPerAds` only rescales a Form 4 row when the ordinary-shares-per-ADS ratio is **above 1**.
- The existing suite never isolated this: its only 1:1 case (Avadel) is rejected earlier on an ADS-denoting title, so the `ratio > 1` guard combined with an ordinary title was untested.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/AdsRatioExtractorRatioOfOneTests.cs` — new unit test: an ordinary-titled, per-ADS-priced row whose footnote states a 1:1 ratio ("each ADS represents one ordinary share") must be left untouched (no correction, ratio 0), since Shares (ordinary) already equals Shares (ADS).