### PR TITLE
test(sec): pin FormAdvCsvParser.Parse skips rows with unusable CRD

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FormAdvCsvParserUnkeyableRowTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormAdvCsvParserUnkeyableRowTests.cs
@@ -1,0 +1,27 @@
+using Equibles.Integrations.Sec.FormAdv;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FormAdvCsvParserUnkeyableRowTests
+{
+    [Fact]
+    public void Parse_RowsWithBlankOrNonNumericCrd_AreSkippedWhileKeyableRowsSurvive()
+    {
+        // Contract: "Rows without a usable Organization CRD number are skipped —
+        // without it an adviser cannot be keyed." A blank or non-numeric CRD in the
+        // untrusted SEC export must drop only that row, never abort the import or
+        // emit an unkeyable adviser.
+        var csv =
+            "Organization CRD#,Legal Name\n"
+            + "231,Valid Adviser\n"
+            + ",Blank Crd Adviser\n"
+            + "N/A,Non Numeric Crd Adviser\n";
+
+        using var reader = new StringReader(csv);
+        var advisers = FormAdvCsvParser.Parse(reader).ToList();
+
+        advisers.Should().ContainSingle();
+        advisers[0].Crd.Should().Be(231);
+        advisers[0].LegalName.Should().Be("Valid Adviser");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the Form ADV CSV parser's keying invariant: a row whose `Organization CRD#` cell is blank or non-numeric is dropped, while keyable rows still parse.
- The parser documents this ("Rows without a usable Organization CRD number are skipped") but no test exercised the malformed-row path — important because the SEC bulk export is untrusted and one bad cell must not abort the streaming import or emit an unkeyable adviser.

## Code changes

- `tests/Equibles.UnitTests/Sec/FormAdvCsvParserUnkeyableRowTests.cs` — new unit test: feeds a 3-row CSV (valid CRD, blank CRD, non-numeric CRD) through `FormAdvCsvParser.Parse` and asserts exactly one adviser is returned (CRD 231), confirming the two unkeyable rows are silently skipped.