### PR TITLE
test(holdings): pin ParseOptionType accepts SEC mixed-case Put/Call

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperParseOptionTypeMixedCaseTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperParseOptionTypeMixedCaseTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsParsingHelperParseOptionTypeMixedCaseTests
+{
+    [Fact]
+    public void ParseOptionType_SecSchemaMixedCaseCall_ReturnsCallEnum()
+    {
+        // The existing PUT/CALL pins use all-caps, but the SEC 13F information-table
+        // <putCall> element actually emits mixed-case "Put"/"Call" on the wire. The
+        // ToUpperInvariant normalization exists precisely to accept that real casing;
+        // a refactor that dropped it (assuming uppercase input) would pass every
+        // all-caps test yet misclassify every live option holding as null.
+        var result = HoldingsParsingHelper.ParseOptionType("Call");
+
+        result.Should().Be(OptionType.Call);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `HoldingsParsingHelper.ParseOptionType` maps the real SEC 13F wire value `"Call"` (mixed case, as the information-table `<putCall>` element emits it) to `OptionType.Call`.
- Existing PUT/CALL tests only use all-caps, so the `ToUpperInvariant` normalization that handles live filings was unpinned — a refactor assuming uppercase input would pass every test yet misclassify every real option holding as null.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsParsingHelperParseOptionTypeMixedCaseTests.cs` — new unit test asserting `ParseOptionType("Call")` returns `OptionType.Call`.