### PR TITLE
test(holdings): pin FundClassifierService first-match-wins rule precedence

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/FundClassifierServicePrecedenceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundClassifierServicePrecedenceTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class FundClassifierServicePrecedenceTests
+{
+    [Fact]
+    public void Classify_NameMatchingTwoCategoryPatterns_ReturnsTheEarlierRuleInOrder()
+    {
+        // Contract: Classify returns the first matching pattern in Rules order. "PENSION"
+        // (PensionFund) is deliberately ordered before "INSURANCE" (InsuranceCompany), so a
+        // name carrying both must classify as PensionFund. Each existing test matches a single
+        // category; this pins the ordered first-match-wins precedence, which a refactor to an
+        // unordered dictionary or alphabetized rules would silently break.
+        var result = FundClassifierService.Classify("STATE PENSION INSURANCE FUND");
+
+        result.Should().Be(FundClassification.PensionFund);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `FundClassifierService.Classify` resolves a name matching two category patterns to the earlier rule in `Rules` order ("PENSION" before "INSURANCE" → PensionFund).
- Existing tests each match a single category; the ordered first-match-wins precedence — an emergent property of the rule array's order — was unpinned, so a refactor to an unordered dictionary or alphabetized rules would silently change the winner.

## Code changes

- `tests/Equibles.UnitTests/Holdings/FundClassifierServicePrecedenceTests.cs` — new unit test asserting `Classify("STATE PENSION INSURANCE FUND")` returns `FundClassification.PensionFund`.