### PR TITLE
test(sec): pin InvestmentAdviserTools.FormatFeeStructure subscription/commissions/other arms

### DIFF
--- a/tests/Equibles.UnitTests/Sec/InvestmentAdviserToolsFormatFeeStructureLateFlagsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InvestmentAdviserToolsFormatFeeStructureLateFlagsTests.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InvestmentAdviserToolsFormatFeeStructureLateFlagsTests
+{
+    // Complements the MixedFlags pin (hourly + fixed + performance-based). FormatFeeStructure
+    // emits one label per set Form ADV Item 5.E flag, comma-joined, in fixed 5.E(1)→(7) order.
+    // The three later flags — subscription 5.E(3), commissions 5.E(5), other 5.E(7) — have their
+    // set-arm unexercised; this pins their exact labels and that order survives between them.
+    [Fact]
+    public void FormatFeeStructure_SubscriptionCommissionsOther_JoinsInItem5EOrder()
+    {
+        var adviser = new FormAdvAdviser
+        {
+            ChargesSubscription = true,
+            ChargesCommissions = true,
+            ChargesOther = true,
+            // ChargesPercentageOfAum, ChargesHourly, ChargesFixed, ChargesPerformanceBased
+            // left false — must not appear in the rendered list.
+        };
+
+        var method = typeof(InvestmentAdviserTools).GetMethod(
+            "FormatFeeStructure",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (string)method!.Invoke(null, [adviser]);
+
+        result.Should().Be("subscription, commissions, other");
+    }
+}


### PR DESCRIPTION
## Summary

- `FormatFeeStructure` renders the "Fee structure" line of the investment-adviser MCP profile from the seven Form ADV Item 5.E compensation flags. The existing pins cover the all-false placeholder, the lone percentage-of-AUM case, and a hourly/fixed/performance-based mix — leaving the subscription 5.E(3), commissions 5.E(5), and other 5.E(7) set-arms unexercised.
- This pins that complementary subset: their exact labels and that the fixed 5.E ordering holds between them, with the other four flags excluded.

## Code changes

- `tests/Equibles.UnitTests/Sec/InvestmentAdviserToolsFormatFeeStructureLateFlagsTests.cs` — new unit test setting only `ChargesSubscription`, `ChargesCommissions`, `ChargesOther` and asserting the rendered list is `subscription, commissions, other`. Reflection-invokes the private static helper, matching the existing FormatFeeStructure pin's style.