### PR TITLE
test(cboe): pin ExtractOptionsDataJson unbalanced object returns null

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CboeClientExtractOptionsDataJsonUnbalancedTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CboeClientExtractOptionsDataJsonUnbalancedTests.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using Equibles.Integrations.Cboe;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CboeClientExtractOptionsDataJsonUnbalancedTests
+{
+    // ExtractOptionsDataJson returns the balanced `{...}` after the optionsData marker.
+    // Contract: when the object opens but its braces never balance — a CBOE page truncated
+    // mid-payload — there is no complete object to return, so it yields null rather than a
+    // garbled partial substring. Pins the depth-never-zero / end<0 guard.
+    [Fact]
+    public void ExtractOptionsDataJson_UnbalancedObjectNeverCloses_ReturnsNull()
+    {
+        var method = typeof(CboeClient).GetMethod(
+            "ExtractOptionsDataJson",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        // Marker + an object that opens '{' and ends mid-field with no closing '}'.
+        var html = "<script>x = {\"optionsData\\\":" + "{\\\"label\\\":\\\"a\\\"";
+
+        var result = (string)method!.Invoke(null, [html]);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- `ExtractOptionsDataJson` scans a scraped CBOE page for the `optionsData` marker and returns the balanced `{...}` that follows. The only existing pin covers the happy path (a stray `}` inside a string value).
- This pins the truncated-payload path: when the object opens but its braces never balance (a page cut off mid-payload), the scanner's depth never returns to zero, so the method yields null rather than a garbled partial substring.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CboeClientExtractOptionsDataJsonUnbalancedTests.cs` — new unit test feeding the marker plus an object that opens `{` and ends mid-field with no closing `}`, asserting the result is null. Reflection-invokes the private static helper, matching the sibling test's escaping and style.