### PR TITLE
test(sec): pin EdgarXmlSubmissionParser.ParseDate rejects calendar-invalid date

### DIFF
--- a/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserParseDateInvalidTests.cs
+++ b/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserParseDateInvalidTests.cs
@@ -1,0 +1,17 @@
+using Equibles.Sec.HostedService.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class EdgarXmlSubmissionParserParseDateInvalidTests
+{
+    // Contract: ParseDate returns null when the value is "unparseable". A value that fits the
+    // format SHAPE but names an impossible calendar day (Feb 30) is unparseable — TryParseExact
+    // must reject it, never roll over to Mar 1 or throw. Oracle: the doc-comment, not the body.
+    [Fact]
+    public void ParseDate_CalendarInvalidDayMatchingFormatShape_ReturnsNull()
+    {
+        var result = EdgarXmlSubmissionParser.ParseDate("02/30/2024", ["MM/dd/yyyy"]);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- `ParseDate` parses a filing date against caller-supplied exact formats in invariant culture, returning null when blank or unparseable. The existing pin covers the happy slash-format parse under a non-invariant culture.
- This pins the validation failure path: a value matching the format shape but naming an impossible calendar day (Feb 30) must be rejected to null — never rolled over to Mar 1 or thrown.

## Code changes

- `tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserParseDateInvalidTests.cs` — new unit test calling `ParseDate("02/30/2024", ["MM/dd/yyyy"])` and asserting the result is null, pinning the `TryParseExact`-fails branch on a calendar-invalid input.