### PR TITLE
test(cftc): pin ParseLong returns null for non-numeric placeholder value

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CftcClientParseLongUnparseableTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientParseLongUnparseableTests.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using Equibles.Integrations.Cftc;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CftcClientParseLongUnparseableTests
+{
+    // Contract: ParseLong yields a numeric position value or null when unavailable. Existing pins
+    // cover the null-input guard and the thousands-strip success path; the non-null-but-unparseable
+    // arm is unexercised. A CFTC cell holding a non-numeric marker like "." (a missing-value glyph
+    // that survives GetField's empty→null check) must absorb to null — never throw or coerce to 0.
+    [Fact]
+    public void ParseLong_NonNumericPlaceholderValue_ReturnsNull()
+    {
+        var parseLong = typeof(CftcClient).GetMethod(
+            "ParseLong",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (long?)parseLong!.Invoke(null, ["."]);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- `CftcClient.ParseLong` extracts a numeric position value from a CFTC CSV cell, or null when unavailable. The existing pins cover the null-input guard and the thousands-separator strip path, but the non-null-but-unparseable arm was unexercised.
- This pins it: a cell holding a non-numeric missing-value marker like `"."` (which survives `GetField`'s empty→null check) must absorb to null — never throw or coerce to 0, so the rest of the row still imports.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CftcClientParseLongUnparseableTests.cs` — new unit test reflection-invoking the private static `ParseLong` with `"."` and asserting the result is null, pinning the `TryParse`-fails branch on a non-numeric value.