### PR TITLE
test(sec): pin ChunkingStrategy.FindLastSentenceEnd returns -1 with no boundary

### DIFF
--- a/tests/Equibles.UnitTests/Sec/ChunkingStrategyFindLastSentenceEndNoBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ChunkingStrategyFindLastSentenceEndNoBoundaryTests.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using Equibles.Sec.BusinessLogic.Processing;
+using Equibles.Sec.BusinessLogic.Tokenization;
+
+namespace Equibles.UnitTests.Sec;
+
+public class ChunkingStrategyFindLastSentenceEndNoBoundaryTests
+{
+    // Contract (ChunkingStrategy.FindLastSentenceEnd, ChunkingStrategy.cs:120): return the position
+    // after the latest of ".", "!", "?", "\n\n" in [start,end), or the -1 sentinel when none exist.
+    // The sibling pins all hit the found arm; the no-boundary -1 arm is unexercised. When a chunk's
+    // overlap zone has no sentence ending, the caller must keep the full window — not truncate.
+    [Fact]
+    public void FindLastSentenceEnd_NoSentenceEndingInRange_ReturnsNegativeOne()
+    {
+        var strategy = new ChunkingStrategy(new TokenCounter());
+        var method = typeof(ChunkingStrategy).GetMethod(
+            "FindLastSentenceEnd",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+        const string text = "no sentence ending here";
+        var result = (int)method!.Invoke(strategy, [text, 0, text.Length]);
+
+        result.Should().Be(-1);
+    }
+}


### PR DESCRIPTION
## Summary

- `FindLastSentenceEnd` returns the position after the latest of `.`, `!`, `?`, `\n\n` in the search range, or the `-1` sentinel when none exist. The sibling pins all exercise the found arm (and the negative-start clamp); the no-boundary `-1` arm was unexercised.
- This pins it: a range with no sentence-ending token returns `-1`, so the chunker keeps the full window rather than truncating mid-word.

## Code changes

- `tests/Equibles.UnitTests/Sec/ChunkingStrategyFindLastSentenceEndNoBoundaryTests.cs` — new unit test reflection-invoking the private `FindLastSentenceEnd` with a boundary-free string, asserting `-1`. Mirrors the sibling reflection pins' construction and style.