### PR TITLE
test(sec): pin ContainsInlineXbrl detects ix element without namespace decl

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserContainsInlineXbrlElementTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserContainsInlineXbrlElementTests.cs
@@ -1,0 +1,18 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentEnvelopeParserContainsInlineXbrlElementTests
+{
+    // Contract (doc-comment): true when the document carries inline XBRL — the ix namespace
+    // declaration OR any element in that namespace. This pins the second, independent trigger:
+    // content with an `<ix:` element but NO `xmlns:ix=` declaration must still be detected — a
+    // naive check of only the namespace-declaration form would miss element-only fragments.
+    [Fact]
+    public void ContainsInlineXbrl_IxElementWithoutNamespaceDeclaration_ReturnsTrue()
+    {
+        var content = "<ix:nonFraction contextRef=\"c1\">1234</ix:nonFraction>";
+
+        SecDocumentEnvelopeParser.ContainsInlineXbrl(content).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- `SecDocumentEnvelopeParser.ContainsInlineXbrl` had no direct test. Its contract has two independent triggers: the `xmlns:ix=` namespace declaration OR any `<ix:` element.
- This pins the second trigger in isolation: content carrying an `<ix:` element but no `xmlns:ix=` declaration must still be detected as inline XBRL — a naive check of only the namespace-declaration form would miss element-only fragments and silently drop the filing's XBRL facts.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecDocumentEnvelopeParserContainsInlineXbrlElementTests.cs` — new unit test calling `ContainsInlineXbrl` with an `<ix:nonFraction>` fragment (no `xmlns:ix=`) and asserting true.