### PR TITLE
test(mcp): pin McpFormat.Invariant formats with invariant separators under de-DE

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/McpFormatInvariantCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpFormatInvariantCultureInvarianceTests.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class McpFormatInvariantCultureInvarianceTests
+{
+    // Contract (XML doc on McpFormat.Invariant): formats a value with the given format string in
+    // invariant culture so MCP markdown does not fork the separators by host locale. The OrDash and
+    // WholeNumber siblings carry de-DE pins; Invariant — the non-nullable companion — has none. Under
+    // de-DE the thread default swaps '.'/',' so a current-culture format would fork LLM-consumed output.
+    [Fact]
+    public void Invariant_UnderNonInvariantCulture_FormatsWithInvariantSeparators()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var result = McpFormat.Invariant(1_234_567.5m, "N1");
+
+            result.Should().Be("1,234,567.5");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `McpFormat.Invariant<T>` is the non-nullable companion to `OrDash`; its contract is to format with invariant culture so MCP markdown separators don't fork by host locale. The `OrDash` and `WholeNumber` siblings carry de-DE culture pins, but `Invariant` had none.
- This pins it under de-DE (where the thread default swaps `.`/`,`): `Invariant(1234567.5m, "N1")` must render `1,234,567.5` (invariant group/decimal separators), not the de-DE `1.234.567,5` — so LLM-consumed output is identical on every deploy locale.

## Code changes

- `tests/Equibles.UnitTests/Mcp/McpFormatInvariantCultureInvarianceTests.cs` — new unit test setting `CurrentCulture` to de-DE, calling `Invariant`, asserting invariant separators, and restoring the culture in a finally block. Mirrors the WholeNumber/OrDash culture-invariance pins.