### PR TITLE
test(sec): pin DocumentTypeConverter.ConvertFrom rejects non-string sources

### DIFF
--- a/tests/Equibles.UnitTests/Sec/DocumentTypeConverterConvertFromNonStringTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeConverterConvertFromNonStringTests.cs
@@ -1,0 +1,25 @@
+using System.Globalization;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.UnitTests.Sec;
+
+public class DocumentTypeConverterConvertFromNonStringTests
+{
+    private readonly DocumentTypeConverter _sut = new();
+
+    [Fact]
+    public void ConvertFrom_NonStringValue_ThrowsNotSupportedException()
+    {
+        // Contract: ConvertFrom only handles the explicit `value is string` arm; any other
+        // source must fall through to `base.ConvertFrom`, which per the TypeConverter
+        // convention rejects an unsupported source with NotSupportedException. The sibling
+        // `CanConvertFrom(typeof(int)) == false` pins the GATE; this pins the actual
+        // rejection. A refactor that dropped the base call (e.g. returning null, or coercing
+        // the value via ToString before FromValue) would silently admit numeric route values
+        // that DocumentType.FromValue never recognizes — caught here because int now throws
+        // NotSupportedException rather than returning a bogus or null DocumentType.
+        var act = () => _sut.ConvertFrom(null, CultureInfo.InvariantCulture, 123);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}


### PR DESCRIPTION
## Summary

- `DocumentTypeConverter.ConvertFrom` only handles the explicit `value is string` arm; every other source falls through to `base.ConvertFrom`, which per the TypeConverter convention rejects an unsupported source with `NotSupportedException`. That fall-through branch had no test.
- The sibling `CanConvertFrom(typeof(int)) == false` already pins the gate; this adds the matching pin for the actual rejection in `ConvertFrom`, completing the contract symmetry.

## Code changes

- `tests/Equibles.UnitTests/Sec/DocumentTypeConverterConvertFromNonStringTests.cs` — new unit test asserting `ConvertFrom(null, InvariantCulture, 123)` throws `NotSupportedException`, guarding against a refactor that drops the base delegation and silently admits non-string (e.g. numeric) route values that `DocumentType.FromValue` never recognizes.