### PR TITLE
test(data): pin LikePattern.Escape backslash-before-metachar ordering

### DIFF
--- a/tests/Equibles.UnitTests/Data/LikePatternEscapeTests.cs
+++ b/tests/Equibles.UnitTests/Data/LikePatternEscapeTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Data;
+
+namespace Equibles.UnitTests.Data;
+
+public class LikePatternEscapeTests
+{
+    // Adversarial Lane A. Contract: Escape makes '\' '%' '_' match literally under ILIKE.
+    // The order is load-bearing — '\' MUST be escaped before '%'/'_', or the backslash that
+    // escaping '_' introduces ("\_") gets doubled into "\\_" (a literal backslash + a live
+    // '_' wildcard), leaking matches. The existing Contains pin only feeds '%', so neither
+    // the backslash rule nor its ordering is covered. Input mixes both: a\b_c must come back
+    // with the backslash doubled and the underscore escaped exactly once.
+    [Fact]
+    public void Escape_BackslashAndUnderscore_DoublesBackslashAndEscapesUnderscoreInOrder()
+    {
+        var result = LikePattern.Escape(@"a\b_c");
+
+        result.Should().Be(@"a\\b\_c");
+    }
+}


### PR DESCRIPTION
## Summary

- `LikePattern.Escape` is the LIKE-injection guard behind every typeahead search, but only `Contains` had coverage — and only with a `%`, so neither the backslash rule nor its ordering was pinned. The order is load-bearing: `\` must be escaped before `%`/`_`, or the backslash that escaping `_` introduces (`\_`) gets doubled into `\\_` (a literal backslash plus a live `_` wildcard), leaking matches.
- Adds one adversarial unit test mixing a backslash and an underscore to pin the order.

## Code changes

- `tests/Equibles.UnitTests/Data/LikePatternEscapeTests.cs` — new test: `Escape(@"a\b_c")` must return `@"a\\b\_c"` (backslash doubled, underscore escaped exactly once), failing loudly if the replace order is swapped.