### PR TITLE
test(mcp): pin MarkdownTable.AppendNumberedRows 1-based rank in order

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/MarkdownTableAppendNumberedRowsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/MarkdownTableAppendNumberedRowsTests.cs
@@ -1,0 +1,23 @@
+using System.Text;
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class MarkdownTableAppendNumberedRowsTests
+{
+    // Contract: AppendNumberedRows passes a 1-BASED rank to renderRow, one row per item, in
+    // order. The helper exists precisely to centralise the `i + 1` so call sites can't drift
+    // to the 0-based `i`. A regression to 0-based would compile and silently renumber every
+    // ranked MCP table (top movers, search results) starting at 0. Derive the oracle from the
+    // doc: the first item is rank 1, not 0.
+    [Fact]
+    public void AppendNumberedRows_ThreeRows_PassesOneBasedRankInOrder()
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendNumberedRows(new[] { "a", "b", "c" }, (rank, item) => $"{rank}:{item}");
+
+        var lines = sb.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        lines.Should().Equal("1:a", "2:b", "3:c");
+    }
+}


### PR DESCRIPTION
## Summary

- `MarkdownTable.AppendNumberedRows` exists to centralise the `i + 1` rank so call sites can't drift to the 0-based `i`, but no test pinned the 1-based contract. A regression to 0-based would compile and silently renumber every ranked MCP table (top movers, search results) starting at 0.
- Adds one adversarial unit test asserting the first item is rank 1, in order.

## Code changes

- `tests/Equibles.UnitTests/Mcp/MarkdownTableAppendNumberedRowsTests.cs` — new test: appends three rows with a `(rank, item) => $"{rank}:{item}"` renderer and asserts the emitted lines are `1:a`, `2:b`, `3:c`.