### PR TITLE
test(integrations): pin RetryBackoff.Exponential 2^(n+1) backoff schedule

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/RetryBackoffExponentialTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/RetryBackoffExponentialTests.cs
@@ -1,0 +1,18 @@
+using Equibles.Integrations.Common.Retry;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class RetryBackoffExponentialTests
+{
+    // Contract (doc): exponential backoff f(n) = 2^(n+1) seconds — f(0)=2s, f(1)=4s. The +1
+    // shift is load-bearing: dropping it halves every interval (f(0)=1s) and turns an upstream
+    // throttle into a hard ban. Two points lock the whole family: f(0)=2 alone passes for the
+    // plausible 2^n+1 typo (also 2), so f(1)=4 is needed to rule it out (2^1+1=3≠4). Existing
+    // coverage only counts Yahoo retries; the arithmetic itself was never pinned.
+    [Fact]
+    public void Exponential_FirstTwoAttempts_FollowDocumentedTwoToThePowerNPlusOne()
+    {
+        RetryBackoff.Exponential(0).Should().Be(TimeSpan.FromSeconds(2));
+        RetryBackoff.Exponential(1).Should().Be(TimeSpan.FromSeconds(4));
+    }
+}


### PR DESCRIPTION
## Summary

- `RetryBackoff.Exponential` computes the HTTP-retry backoff `f(n) = 2^(n+1)` seconds; the `+1` shift is load-bearing (dropping it halves every interval and turns an upstream throttle into a hard ban), but only the Yahoo client's retry *count* was tested — the arithmetic itself was never pinned.
- Adds one adversarial unit test asserting the documented schedule at two points, which together rule out the plausible regressions (drop the `+1` → 1s/2s, or a `2^n+1` typo → 3s).

## Code changes

- `tests/Equibles.UnitTests/Integrations/RetryBackoffExponentialTests.cs` — new test: `Exponential(0)` is 2s and `Exponential(1)` is 4s.