### PR TITLE
test(web): pin SignCssExtensions.SignCss null nullable returns neutral class

### DIFF
--- a/tests/Equibles.UnitTests/Web/SignCssExtensionsNullableNullTests.cs
+++ b/tests/Equibles.UnitTests/Web/SignCssExtensionsNullableNullTests.cs
@@ -1,0 +1,19 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class SignCssExtensionsNullableNullTests
+{
+    // Contract: the nullable SignCss overload treats a null as "no sign" → returns the
+    // caller's neutralClass, never a sign colour and never an NRE. Every existing SignCss
+    // test feeds a concrete value, so the HasValue==false branch (the one a null financial
+    // figure — e.g. a missing change % — actually hits in a view) is unexercised. Custom
+    // neutralClass proves it's threaded through, not coincidentally the empty default.
+    [Fact]
+    public void SignCss_NullNullableValue_ReturnsNeutralClass()
+    {
+        decimal? value = null;
+
+        value.SignCss("text-base-content").Should().Be("text-base-content");
+    }
+}


### PR DESCRIPTION
## Summary

- `SignCssExtensions`' nullable `SignCss`/`InverseSignCss` overloads had no coverage of the `HasValue == false` path — every existing test feeds a concrete value. A null financial figure (e.g. a missing change %) is exactly what a view passes, and it must colour neutral, never a sign colour and never NRE.
- Adds one unit test pinning the null → neutralClass branch.

## Code changes

- `tests/Equibles.UnitTests/Web/SignCssExtensionsNullableNullTests.cs` — new test: a `null` `decimal?` returns the caller-supplied `neutralClass` (`"text-base-content"`), proving the value is threaded through rather than coincidentally the empty default.