### PR TITLE
test(sec): pin DocumentTypeConverter.ConvertTo non-string destination throws

### DIFF
--- a/tests/Equibles.UnitTests/Sec/DocumentTypeConverterConvertToNonStringTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeConverterConvertToNonStringTests.cs
@@ -1,0 +1,27 @@
+using System.Globalization;
+using Equibles.Sec.Data.Models;
+
+namespace Equibles.UnitTests.Sec;
+
+public class DocumentTypeConverterConvertToNonStringTests
+{
+    private readonly DocumentTypeConverter _sut = new();
+
+    [Fact]
+    public void ConvertTo_NonStringDestination_ThrowsNotSupportedException()
+    {
+        // Contract: ConvertTo only knows how to emit the stable Value string from a
+        // DocumentType — its `if` guards on `destinationType == typeof(string)`. Any other
+        // destination must fall through to `base.ConvertTo`, which per the TypeConverter
+        // convention rejects an unsupported target with NotSupportedException. This pins the
+        // RIGHT arm of that guard (the existing ConvertTo pin only exercises the string arm).
+        // A refactor that dropped the base delegation (e.g. returning Value unconditionally,
+        // or `documentType.Value` regardless of destinationType) would silently hand back a
+        // string where the caller asked for an int — caught here because typeof(int) must
+        // throw rather than coerce.
+        var act = () =>
+            _sut.ConvertTo(null, CultureInfo.InvariantCulture, DocumentType.TenK, typeof(int));
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the error path for `DocumentTypeConverter.ConvertTo` when asked to convert a `DocumentType` to a non-string destination type — it must delegate to the base `TypeConverter` and surface `NotSupportedException`, not silently coerce.
- Closes the only uncovered branch in the converter (the right arm of the `destinationType == typeof(string)` guard), symmetric to the existing `ConvertFrom` non-string test.

## Code changes

- `tests/Equibles.UnitTests/Sec/DocumentTypeConverterConvertToNonStringTests.cs` — new unit test asserting `ConvertTo(..., DocumentType.TenK, typeof(int))` throws `NotSupportedException`.