### PR TITLE
test(holdings): pin HoldingsBacktestCalculator.RebalanceDateOf overflow clamp to MaxValue

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorRebalanceDateOfOverflowClampTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorRebalanceDateOfOverflowClampTests.cs
@@ -1,0 +1,19 @@
+using Equibles.Holdings.Repositories;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsBacktestCalculatorRebalanceDateOfOverflowClampTests
+{
+    [Fact]
+    public void RebalanceDateOf_ReportDateOverflowsCalendar_ClampsToMaxValue()
+    {
+        // Contract (doc-comment): a ReportDate within RebalanceDelayDays of DateOnly.MaxValue
+        // would push +45 days past the calendar, so the shift is capped at MaxValue instead of
+        // throwing. The two existing overflow tests only assert Calculate "does not throw"; none
+        // pins the clamp VALUE on the public member. A ReportDate of MaxValue itself overflows
+        // unconditionally, so the oracle is exactly DateOnly.MaxValue.
+        var result = HoldingsBacktestCalculator.RebalanceDateOf(DateOnly.MaxValue);
+
+        result.Should().Be(DateOnly.MaxValue);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the calendar-overflow contract of `HoldingsBacktestCalculator.RebalanceDateOf` directly on the public method: a ReportDate within the 45-day rebalance delay of `DateOnly.MaxValue` must clamp to `MaxValue` rather than overflow.
- The two existing overflow tests only assert the higher-level `Calculate` "does not throw" — neither pins the clamp value on the member itself, so a regression that returned a wrong (but valid) date would slip through.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorRebalanceDateOfOverflowClampTests.cs` — new unit test asserting `RebalanceDateOf(DateOnly.MaxValue) == DateOnly.MaxValue`.