### PR TITLE
test(sec): pin FormAdvCsvParser duplicate header binds to first occurrence

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FormAdvCsvParserDuplicateHeaderTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormAdvCsvParserDuplicateHeaderTests.cs
@@ -1,0 +1,21 @@
+using Equibles.Integrations.Sec.FormAdv;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FormAdvCsvParserDuplicateHeaderTests
+{
+    [Fact]
+    public void Parse_DuplicateColumnHeader_BindsFieldToFirstOccurrence()
+    {
+        // Contract (BuildColumnMap doc): "Keep the first occurrence." The SEC export is
+        // untrusted and 260+ columns wide; if a header name repeats, a field must bind to the
+        // FIRST matching column, not the last. No existing test exercises the duplicate path.
+        var csv = "Organization CRD#,Legal Name,Legal Name\n" + "1001,First Wins,Second Ignored\n";
+
+        using var reader = new StringReader(csv);
+        var advisers = FormAdvCsvParser.Parse(reader).ToList();
+
+        advisers.Should().ContainSingle();
+        advisers[0].LegalName.Should().Be("First Wins");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `FormAdvCsvParser` column-mapping invariant — documented as "Keep the first occurrence" — for the case where the untrusted, 260+-column SEC Form ADV export repeats a header name: a field must bind to the first matching column, not the last.
- No existing test exercised the duplicate-header path.

## Code changes

- `tests/Equibles.UnitTests/Sec/FormAdvCsvParserDuplicateHeaderTests.cs` — new unit test: a CSV with two `Legal Name` columns binds `LegalName` to the first column's value.