### PR TITLE
test(insider-trading): pin InsiderTransactionPriceValidator.Evaluate exact 10x-close boundary

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorEvaluateBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorEvaluateBoundaryTests.cs
@@ -1,0 +1,29 @@
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderTransactionPriceValidatorEvaluateBoundaryTests
+{
+    private readonly InsiderTransactionPriceValidator _validator = new();
+
+    [Fact]
+    public void Evaluate_PriceAtExactlyTenTimesClose_IsValidAndUnrepaired()
+    {
+        // Contract: reject only when the price exceeds the close by MORE THAN 10x, so a price
+        // sitting EXACTLY at 10x is the inclusive ceiling — valid and kept as-filed, never
+        // repaired. Evaluate carries its own copy of the 10x rule; only IsPlausible's boundary
+        // is pinned today, so a drift to a strict `<` here would silently repair 500 -> 0.5.
+        var result = _validator.Evaluate(
+            reportedPrice: 500m,
+            shares: 1000,
+            kind: InsiderSecurityKind.NonDerivative,
+            securityTitle: "Common Stock",
+            unadjustedClose: 50m
+        );
+
+        result.IsPriceValid.Should().Be(true);
+        result.WasRepaired.Should().BeFalse();
+        result.EffectivePrice.Should().Be(500m);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the inclusive 10x ceiling on `InsiderTransactionPriceValidator.Evaluate`: a per-share price sitting exactly at 10x the close is valid and kept as-filed, never repaired (the rule rejects only prices strictly above 10x).
- `Evaluate` carries its own copy of the 10x comparison; today only `IsPlausible`'s boundary is pinned, so a drift to a strict `<` in `Evaluate` would silently "repair" a legitimate at-boundary price. This guards against that divergence.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderTransactionPriceValidatorEvaluateBoundaryTests.cs` — new unit test: price 500 against close 50 (exactly 10x) returns valid, unrepaired, effective price unchanged at 500.