### PR TITLE
test(worker): pin SyncDateResolver.Resolve MaxValue saturates to MaxValue

### DIFF
--- a/tests/Equibles.UnitTests/Core/SyncDateResolverMaxValueClampTests.cs
+++ b/tests/Equibles.UnitTests/Core/SyncDateResolverMaxValueClampTests.cs
@@ -1,0 +1,19 @@
+using Equibles.Core.Configuration;
+using Equibles.Worker;
+
+namespace Equibles.UnitTests.Core;
+
+public class SyncDateResolverMaxValueClampTests
+{
+    [Fact]
+    public void Resolve_LatestDateIsMaxValue_ReturnsMaxValueNotAdvanced()
+    {
+        // Contract: a non-default latest date advances by one day, EXCEPT DateOnly.MaxValue
+        // which saturates to itself (AddDays(1) would overflow). The sibling overflow test only
+        // asserts DoesNotThrow — a regression that returned default/fallback would still pass it.
+        // Pin the clamp VALUE: MaxValue in must yield MaxValue out.
+        var result = SyncDateResolver.Resolve(DateOnly.MaxValue, new WorkerOptions());
+
+        result.Should().Be(DateOnly.MaxValue);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the saturating clamp on `SyncDateResolver.Resolve`: a latest date of `DateOnly.MaxValue` must return `MaxValue` (it can't advance by a day without overflowing).
- The existing overflow test only asserts the call doesn't throw — a regression returning `default` or the configured fallback would still pass it. This pins the actual returned value.

## Code changes

- `tests/Equibles.UnitTests/Core/SyncDateResolverMaxValueClampTests.cs` — new unit test asserting `Resolve(DateOnly.MaxValue, …) == DateOnly.MaxValue`.