### PR TITLE
test(sec): pin FormDFilingProcessor.ParseAmount trims whitespace around Indefinite

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FormDFilingProcessorParseAmountWhitespaceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormDFilingProcessorParseAmountWhitespaceTests.cs
@@ -1,0 +1,18 @@
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FormDFilingProcessorParseAmountWhitespaceTests
+{
+    [Fact]
+    public void ParseAmount_WhitespacePaddedIndefinite_ReturnsNullFlagged()
+    {
+        // Contract: the literal "Indefinite" maps to (null, true). Form D XML element text
+        // routinely carries surrounding newlines/indentation, so the match trims first. Existing
+        // tests only pass unpadded "Indefinite"/"indefinite" — a regression dropping the Trim()
+        // would still pass them while silently misreading real padded filings as a $0 amount.
+        var result = FormDFilingProcessor.ParseAmount("  \n  Indefinite  \n");
+
+        result.Should().Be(((long?)null, true));
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `FormDFilingProcessor.ParseAmount` recognizes the literal "Indefinite" even when wrapped in surrounding whitespace/newlines — the shape Form D XML element text routinely carries.
- Existing tests only pass unpadded "Indefinite"/"indefinite", so a regression dropping the `Trim()` would silently misread real padded filings as a $0 amount while keeping those tests green.

## Code changes

- `tests/Equibles.UnitTests/Sec/FormDFilingProcessorParseAmountWhitespaceTests.cs` — new unit test: `ParseAmount("  \n  Indefinite  \n")` returns `(null, true)`.