### PR TITLE
test(data): pin QueryableLatestExtensions.LatestValue distinct path returns max

### DIFF
--- a/tests/Equibles.UnitTests/Data/QueryableLatestExtensionsLatestValueDistinctTests.cs
+++ b/tests/Equibles.UnitTests/Data/QueryableLatestExtensionsLatestValueDistinctTests.cs
@@ -1,0 +1,28 @@
+using Equibles.Data.Extensions;
+
+namespace Equibles.UnitTests.Data;
+
+public class QueryableLatestExtensionsLatestValueDistinctTests
+{
+    private sealed record Row(int Year);
+
+    [Fact]
+    public void LatestValue_DistinctOverRepeatedProjection_ReturnsSingleHighestValue()
+    {
+        // Lane B: the existing pin uses the default distinct=false; the distinct=true branch
+        // (projected.Distinct() before ORDER BY ... LIMIT 1) was zero-hit. With a projection that
+        // repeats values, distinct collapses duplicates and the latest value must still be the max.
+        var source = new[]
+        {
+            new Row(2020),
+            new Row(2022),
+            new Row(2020),
+            new Row(2021),
+            new Row(2022),
+        }.AsQueryable();
+
+        var result = source.LatestValue(r => r.Year, distinct: true).ToList();
+
+        result.Should().ContainSingle().Which.Should().Be(2022);
+    }
+}


### PR DESCRIPTION
## Summary

- Covers the previously-unexercised `distinct: true` branch of `QueryableLatestExtensions.LatestValue` (the existing test uses the default `distinct: false`).
- With a projection that repeats values, `Distinct()` collapses duplicates and the latest value must still be the maximum — pinned here.

## Code changes

- `tests/Equibles.UnitTests/Data/QueryableLatestExtensionsLatestValueDistinctTests.cs` — new unit test: `LatestValue(r => r.Year, distinct: true)` over duplicated years returns the single highest (2022).