### PR TITLE
test(mcp): pin MarkdownTable.Render returns emptyMessage verbatim for no rows

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/MarkdownTableRenderEmptyTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/MarkdownTableRenderEmptyTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class MarkdownTableRenderEmptyTests
+{
+    [Fact]
+    public void Render_NoRows_ReturnsEmptyMessageVerbatimWithoutTableScaffolding()
+    {
+        // Contract (doc): Render "returns emptyMessage verbatim when there are none". An empty
+        // result set must surface the caller's message exactly — not an empty table (title +
+        // header + separator with zero rows), which would read as a malformed/blank table to MCP
+        // consumers. Only integration tests exercise Render; the empty short-circuit is unit-unpinned.
+        var result = MarkdownTable.Render(
+            rows: new List<int>(),
+            emptyMessage: "No results found.",
+            title: "## Results",
+            headerRow: "| Value |",
+            separatorRow: "|---|",
+            renderRow: x => $"| {x} |"
+        );
+
+        result.Should().Be("No results found.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds unit coverage for `MarkdownTable.Render`'s empty short-circuit: with no rows it returns the caller's `emptyMessage` verbatim, not an empty (header + separator, zero rows) table that would read as malformed to MCP consumers.
- `Render` was previously exercised only by integration tests; this pins the documented empty-case contract at the unit level.

## Code changes

- `tests/Equibles.UnitTests/Mcp/MarkdownTableRenderEmptyTests.cs` — new unit test: `Render` on an empty list returns exactly `"No results found."`.