### PR TITLE
test(insider-trading): pin InsiderFilingParser holding row as snapshot transaction

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseHoldingTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseHoldingTests.cs
@@ -1,0 +1,54 @@
+using System.Xml.Linq;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserParseHoldingTests
+{
+    [Fact]
+    public void ParseTransactions_NonDerivativeHolding_ProducesHoldingSnapshotRow()
+    {
+        // Contract: a Form 3/4/5 *holding* (a position reported with no transaction) parses into an
+        // InsiderTransaction snapshot — TransactionCode.Other, no price, Acquired, and
+        // Shares == SharesOwnedAfter == the post-transaction holding amount. Only transaction rows
+        // are covered today; the holding path (nonDerivativeHolding) was entirely untested.
+        var root = XElement.Parse(
+            """
+            <ownershipDocument>
+              <nonDerivativeTable>
+                <nonDerivativeHolding>
+                  <securityTitle><value>Common Stock</value></securityTitle>
+                  <postTransactionAmounts>
+                    <sharesOwnedFollowingTransaction><value>5000</value></sharesOwnedFollowingTransaction>
+                  </postTransactionAmounts>
+                </nonDerivativeHolding>
+              </nonDerivativeTable>
+            </ownershipDocument>
+            """
+        );
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000000000-24-000001",
+            FilingDate = new DateOnly(2024, 2, 1),
+            ReportDate = new DateOnly(2024, 1, 31),
+        };
+
+        var result = InsiderFilingParser.ParseTransactions(
+            root,
+            new InsiderOwner { Id = Guid.NewGuid() },
+            Guid.NewGuid(),
+            filing,
+            isAmendment: false
+        );
+
+        var holding = result.Should().ContainSingle().Subject;
+        holding.TransactionCode.Should().Be(TransactionCode.Other);
+        holding.PricePerShare.Should().Be(0);
+        holding.AcquiredDisposed.Should().Be(AcquiredDisposed.Acquired);
+        holding.Shares.Should().Be(5000);
+        holding.SharesOwnedAfter.Should().Be(5000);
+        holding.SecurityKind.Should().Be(InsiderSecurityKind.NonDerivative);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `InsiderFilingParser`'s holding path: a Form 3/4/5 `nonDerivativeHolding` (a position reported with no transaction) parses into an InsiderTransaction snapshot — `TransactionCode.Other`, price 0, `Acquired`, and `Shares == SharesOwnedAfter ==` the post-transaction holding amount.
- Existing parser tests only cover transaction rows; the holding branch was entirely unit-uncovered.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseHoldingTests.cs` — new unit test feeding a holding-only ownership document through `ParseTransactions` and asserting the snapshot semantics.