### PR TITLE
test(mcp): pin MarkdownTable.Render subtitle keeps blank line before header

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/MarkdownTableRenderSubtitleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/MarkdownTableRenderSubtitleTests.cs
@@ -1,0 +1,28 @@
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class MarkdownTableRenderSubtitleTests
+{
+    [Fact]
+    public void Render_WithSubtitleAndRows_KeepsLoadBearingBlankLineBeforeHeader()
+    {
+        // Contract (doc): the subtitle Render emits title, subtitle, then a load-bearing BLANK
+        // line before the header — strict CommonMark renderers need it to recognise the following
+        // rows as a table. The subtitle overload is unit-untested; a regression dropping the blank
+        // line would render the table as plain text in MCP clients.
+        var nl = Environment.NewLine;
+        var result = MarkdownTable.Render(
+            rows: new[] { 1 },
+            emptyMessage: "No results.",
+            title: "## Results",
+            subtitle: "Showing 1 of 1",
+            headerRow: "| Value |",
+            separatorRow: "|---|",
+            renderRow: x => $"| {x} |"
+        );
+
+        result.Should().Contain($"Showing 1 of 1{nl}{nl}| Value |");
+        result.Should().Contain($"| 1 |");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds unit coverage for `MarkdownTable.Render`'s subtitle overload, pinning the documented "load-bearing blank line" between the subtitle and the header row that strict CommonMark renderers require to recognise the table.
- Previously only the non-subtitle empty case was unit-tested; a regression dropping the blank line would silently render tables as plain text in MCP clients.

## Code changes

- `tests/Equibles.UnitTests/Mcp/MarkdownTableRenderSubtitleTests.cs` — new unit test: subtitle Render with rows emits `subtitle` + blank line + header, and renders the row.