### PR TITLE
test(sec): pin EdgarXmlSubmissionParser.Val treats whitespace-only element as null

### DIFF
--- a/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserValWhitespaceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserValWhitespaceTests.cs
@@ -1,0 +1,19 @@
+using System.Xml.Linq;
+using Equibles.Sec.HostedService.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class EdgarXmlSubmissionParserValWhitespaceTests
+{
+    [Fact]
+    public void Val_PresentButWhitespaceOnlyElement_ReturnsNull()
+    {
+        // Contract (doc): "Trimmed text of the named child element, or null when missing or empty."
+        // A present element holding only whitespace must read as absent (null) so downstream form
+        // processors treat blank optional fields uniformly. Val is otherwise unit-untested; a
+        // regression dropping the Trim/IsNullOrEmpty would return "   " and break null-checks.
+        var parent = XElement.Parse("<root><field>   \n  </field></root>");
+
+        EdgarXmlSubmissionParser.Val(parent, "field").Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first direct test for `EdgarXmlSubmissionParser.Val`, pinning its documented contract that a present-but-whitespace-only child element reads as absent (null) — so SEC form processors handle blank optional fields uniformly.
- A regression dropping the `Trim()`/`IsNullOrEmpty` check would return whitespace instead of null and break downstream null-checks.

## Code changes

- `tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserValWhitespaceTests.cs` — new unit test: `Val(parent, "field")` on `<field>   </field>` returns null.