### PR TITLE
test(mcp): pin MarkdownTable.Render basic non-empty emits title/blank/header/rows

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/MarkdownTableRenderBasicRowsTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/MarkdownTableRenderBasicRowsTests.cs
@@ -1,0 +1,28 @@
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+public class MarkdownTableRenderBasicRowsTests
+{
+    [Fact]
+    public void Render_NoSubtitleWithRows_EmitsTitleBlankHeaderThenRows()
+    {
+        // Contract: the no-subtitle Render builds title + load-bearing blank line + header +
+        // separator, then one line per row. The empty short-circuit and the subtitle overload are
+        // covered; this basic non-empty path (3-arg Start + row loop) is the remaining uncovered
+        // branch — a regression skipping rows or the blank line would break the rendered table.
+        var nl = Environment.NewLine;
+        var result = MarkdownTable.Render(
+            rows: new[] { "10-K" },
+            emptyMessage: "No filings.",
+            title: "## Filings",
+            headerRow: "| Form |",
+            separatorRow: "|---|",
+            renderRow: f => $"| {f} |"
+        );
+
+        result.Should().Contain($"## Filings{nl}{nl}| Form |");
+        result.Should().Contain("| 10-K |");
+        result.Should().NotBe("No filings.");
+    }
+}


### PR DESCRIPTION
## Summary

- Covers the remaining uncovered branch of `MarkdownTable.Render` (no-subtitle overload) — the non-empty path that builds title + load-bearing blank line + header + separator, then one line per row.
- The empty short-circuit and the subtitle overload were already pinned; this completes coverage of the helper's render paths.

## Code changes

- `tests/Equibles.UnitTests/Mcp/MarkdownTableRenderBasicRowsTests.cs` — new unit test asserting the populated basic table structure and that a rendered row is present.