### PR TITLE
test(sec): pin HeadingConversionStep.Execute promotes part-heading block to h1

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepExecutePartHeadingTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepExecutePartHeadingTests.cs
@@ -1,0 +1,26 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class HeadingConversionStepExecutePartHeadingTests
+{
+    private readonly HeadingConversionStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    [Fact]
+    public void Execute_BlockWhoseSpanIsAPartHeading_PromotesItToH1()
+    {
+        // Contract: the pipeline classifies an SEC "Part N" heading at the TOP tier (h1) — above
+        // the Item (h2) tier covered separately. This is the distinct Part→h1 classification branch
+        // of Execute; a regression mis-tiering Part as h2/h3 would break the document outline.
+        var doc = _parser.ParseDocument("<html><body><div><span>Part I</span></div></body></html>");
+
+        _step.Execute(doc);
+
+        var body = doc.Body!.InnerHtml;
+        body.Should().Contain("<h1>");
+        body.Should().Contain("Part I");
+        body.Should().NotContain("<span");
+    }
+}


### PR DESCRIPTION
## Summary

- Covers the distinct Part→h1 classification branch of `HeadingConversionStep.Execute` (the Item→h2 branch was pinned separately). An SEC "Part N" heading must be promoted to the top tier (h1).
- A regression mis-tiering Part as h2/h3 would corrupt the document outline.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepExecutePartHeadingTests.cs` — new unit test: `<div><span>Part I</span></div>` becomes an `<h1>` after Execute.