### PR TITLE
test(insider-trading): pin AdsRatioExtractor adverb before ratio

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/AdsRatioExtractorAdverbBeforeRatioTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/AdsRatioExtractorAdverbBeforeRatioTests.cs
@@ -1,0 +1,30 @@
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class AdsRatioExtractorAdverbBeforeRatioTests
+{
+    // Contract (TryParseRatio, AdsRatioExtractor.cs:179): "The ratio is the first
+    // number within a token or two of 'represents'." Every other positive case in
+    // the suite places the number immediately after "represents"; here an adverb
+    // ("approximately") sits between them, so the ratio is the SECOND token after
+    // "represents". With an ordinary-share title, a per-ADS price, and a count that
+    // is an exact multiple of the ratio, the row must still be corrected with 12.
+    [Fact]
+    public void TryGetOrdinarySharesPerAds_AdverbBetweenRepresentsAndRatio_StillFindsRatio()
+    {
+        var corrected = AdsRatioExtractor.TryGetOrdinarySharesPerAds(
+            "Ordinary Shares",
+            new[]
+            {
+                "The reported price is per ADS.",
+                "Each ADS represents approximately 12 ordinary shares of the Issuer.",
+            },
+            240L,
+            out var ratio
+        );
+
+        corrected.Should().BeTrue();
+        ratio.Should().Be(12);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the documented "first number within a token or two of 'represents'" tolerance in `AdsRatioExtractor.TryGetOrdinarySharesPerAds` — every existing positive case places the ratio number immediately after "represents", leaving the intervening-word path unexercised.
- Confirms an adverb between "represents" and the ratio ("Each ADS represents approximately 12 ordinary shares") still resolves the ratio and corrects the row.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/AdsRatioExtractorAdverbBeforeRatioTests.cs` — new single-fact test asserting an ordinary-share row priced per ADS, with one adverb before the ratio token, is corrected with ratio 12.