### PR TITLE
test(sec): pin TryParseMasterIndexLine rejects row with no accession

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientTryParseMasterIndexLineEmptyAccessionTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientTryParseMasterIndexLineEmptyAccessionTests.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Equibles.Integrations.Sec;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecEdgarClientTryParseMasterIndexLineEmptyAccessionTests
+{
+    [Fact]
+    public void TryParseMasterIndexLine_FilenameYieldsNoAccession_ReturnsFalse()
+    {
+        // Contract (SecEdgarClient.cs:529-532): the accession number is derived
+        // from the filename field; "if (string.IsNullOrEmpty(accession)) return
+        // false". A 13F-HR row that is otherwise valid (numeric CIK, five fields)
+        // but whose filename is empty produces no accession — it must be rejected,
+        // never emitted as an entry with a blank AccessionNumber (which would build
+        // a broken edgar/data URL downstream). Sibling pins cover short rows,
+        // non-numeric CIK, non-13F form, and bad dates — none the empty-filename arm.
+        var method = typeof(SecEdgarClient).GetMethod(
+            "TryParseMasterIndexLine",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var line = "0000320193|Apple Inc.|13F-HR|2024-11-01|";
+        object[] args = [line, new DateOnly(2024, 11, 1), null];
+
+        var success = (bool)method!.Invoke(null, args);
+
+        success.Should().BeFalse();
+        args[2].Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `SecEdgarClient.TryParseMasterIndexLine`'s accession guard: a 13F-HR master-index row that is otherwise valid (numeric CIK, five fields) but whose filename field is empty yields no accession number and must be rejected (`return false`), never emitted as an entry with a blank `AccessionNumber` that would build a broken `edgar/data` URL downstream.
- Sibling tests cover short rows, non-numeric CIK, non-13F form, lowercase form, and malformed dates — none exercised the empty-filename/accession arm.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecEdgarClientTryParseMasterIndexLineEmptyAccessionTests.cs` — new single-fact test (reflection-invoking the private static parser, matching the existing sibling tests) feeding a row with an empty trailing filename field and asserting it returns false with no entry.