### PR TITLE
test(sec): pin SplitIntoChunks consecutive chunks overlap

### DIFF
--- a/tests/Equibles.UnitTests/Sec/ChunkingStrategySplitIntoChunksOverlapTests.cs
+++ b/tests/Equibles.UnitTests/Sec/ChunkingStrategySplitIntoChunksOverlapTests.cs
@@ -1,0 +1,29 @@
+using Equibles.Sec.BusinessLogic.Processing;
+using Equibles.Sec.BusinessLogic.Tokenization;
+
+namespace Equibles.UnitTests.Sec;
+
+public class ChunkingStrategySplitIntoChunksOverlapTests
+{
+    private readonly ChunkingStrategy _strategy = new(new TokenCounter());
+
+    [Fact]
+    public void SplitIntoChunks_ConsecutiveChunks_OverlapInCharacterRange()
+    {
+        // Contract (SplitIntoChunks: "Advance by chunk size minus overlap",
+        // OverlapTokenSize = 128): an overlapping chunker exists so adjacent
+        // chunks share context for RAG retrieval — so chunk N+1 must START before
+        // chunk N ENDS. Existing pins assert count>1, first StartPosition=0, and
+        // non-empty content, but never the overlap itself; a refactor advancing by
+        // the full window (no overlap) would pass all of them yet break retrieval.
+        var text = string.Join(
+            " ",
+            Enumerable.Repeat("The quick brown fox jumps over the lazy dog.", 300)
+        );
+
+        var result = _strategy.SplitIntoChunks(text);
+
+        result.Should().HaveCountGreaterThan(1);
+        result[1].StartPosition.Should().BeLessThan(result[0].EndPosition);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `ChunkingStrategy.SplitIntoChunks`'s overlap guarantee: an overlapping chunker (`OverlapTokenSize = 128`, "advance by chunk size minus overlap") exists so adjacent chunks share context for RAG retrieval — chunk N+1 must start before chunk N ends.
- Existing pins cover chunk count, first start position, content, and line numbers, but never the overlap itself. A refactor advancing by the full window (no overlap) would pass all of them yet silently break retrieval continuity.

## Code changes

- `tests/Equibles.UnitTests/Sec/ChunkingStrategySplitIntoChunksOverlapTests.cs` — new single-fact test asserting `result[1].StartPosition < result[0].EndPosition` for a multi-chunk input.