### PR TITLE
test(congress): pin ParseTransactionType spaced abbreviation qualifier

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseTransactionTypeSpacedAbbreviationTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseTransactionTypeSpacedAbbreviationTests.cs
@@ -1,0 +1,21 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperParseTransactionTypeSpacedAbbreviationTests
+{
+    // Contract (DisclosureParsingHelper.cs:255-257): "The House abbreviation may
+    // carry a qualifier suffix ('S (partial)'), so accept the bare letter or the
+    // letter followed by a space/'(' ...". Existing pins cover full words, the bare
+    // letter ("S"), and the paren-no-space form ("S(full)") — but not the
+    // space-separated qualifier, which is the doc's own example and reaches the
+    // distinct StartsWith("S ") arm (no "Sale"/"Sold" word, not equal to "S").
+    [Fact]
+    public void ParseTransactionType_AbbreviationWithSpacedQualifier_ReturnsSale()
+    {
+        var result = DisclosureParsingHelper.ParseTransactionType("S (partial)");
+
+        result.Should().Be(CongressTransactionType.Sale);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `DisclosureParsingHelper.ParseTransactionType`'s space-separated House-abbreviation arm: `"S (partial)"` → `Sale`. This is the doc comment's own example and reaches the distinct `StartsWith("S ")` branch (no `Sale`/`Sold` word present, not equal to bare `"S"`).
- Existing pins cover the full words, the bare letter, and the paren-no-space form (`"S(full)"`) — but not the spaced-qualifier arm.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseTransactionTypeSpacedAbbreviationTests.cs` — new single-fact test asserting `ParseTransactionType("S (partial)")` returns `CongressTransactionType.Sale`.