### PR TITLE
test(media): pin FileManager.SaveFile case-insensitive extension handling

### DIFF
--- a/tests/Equibles.UnitTests/Media/FileManagerSaveFileUppercaseExtensionTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerSaveFileUppercaseExtensionTests.cs
@@ -1,0 +1,28 @@
+using Equibles.Data;
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.Repositories;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Media;
+
+// Lane A (adversarial): SaveFile documents its allowlist as case-insensitive,
+// and its summary says the content type is inferred from the extension. So an
+// accepted extension supplied in upper case (e.g. "report.PDF") must be both
+// accepted and resolved to the real MIME type — not rejected, and not silently
+// downgraded to "application/octet-stream". A case-sensitive allowlist or MIME
+// lookup would break that promise; only lower-case input is exercised elsewhere.
+public class FileManagerSaveFileUppercaseExtensionTests
+{
+    [Fact]
+    public async Task SaveFile_AcceptedExtensionInUpperCase_ResolvesRealContentType()
+    {
+        var repository = Substitute.For<FileRepository>((EquiblesFinancialDbContext)null);
+        var sut = new FileManager(repository);
+        var content = "fake-pdf-content"u8.ToArray();
+
+        var file = await sut.SaveFile(content, "quarterly-report.PDF");
+
+        file.Extension.Should().Be("PDF");
+        file.ContentType.Should().Be("application/pdf");
+    }
+}


### PR DESCRIPTION
## Summary

- `FileManager.SaveFile` documents its extension allowlist as case-insensitive and infers the content type from the extension, but only lower-case input was ever exercised in unit tests.
- Adds one adversarial test pinning the end-to-end case-insensitive contract: an accepted extension supplied in upper case (`report.PDF`) is accepted (not rejected) and resolves to the real MIME type, not `application/octet-stream`.

## Code changes

- `tests/Equibles.UnitTests/Media/FileManagerSaveFileUppercaseExtensionTests.cs` — new unit test asserting `SaveFile` accepts an upper-case `.PDF` and sets `ContentType` to `application/pdf`. Guards against a future regression that makes the allowlist or MIME lookup case-sensitive.