### PR TITLE
test(media): pin FileManager.SaveInternalFile allowlist bypass

### DIFF
--- a/tests/Equibles.UnitTests/Media/FileManagerSaveInternalFileTests.cs
+++ b/tests/Equibles.UnitTests/Media/FileManagerSaveInternalFileTests.cs
@@ -1,0 +1,32 @@
+using Equibles.Data;
+using Equibles.Media.BusinessLogic;
+using Equibles.Media.Repositories;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Media;
+
+// Lane B (coverage): SaveInternalFile was entirely zero-hit. Its documented job
+// is to persist a trusted, system-generated blob with an explicit extension and
+// content type, BYPASSING the SaveFile upload allowlist. Pins that an extension
+// absent from AcceptedExtensions ("gz") is accepted verbatim (no exception) and
+// the File entity is assembled from the explicit arguments — a regression that
+// re-applied the allowlist here would break SEC XBRL envelope ingest.
+public class FileManagerSaveInternalFileTests
+{
+    [Fact]
+    public async Task SaveInternalFile_NonAllowlistedExtension_PersistsBlobVerbatim()
+    {
+        var repository = Substitute.For<FileRepository>((EquiblesFinancialDbContext)null);
+        var sut = new FileManager(repository);
+        var content = "gzip-xbrl-bytes"u8.ToArray();
+
+        var file = await sut.SaveInternalFile(content, "xbrl-envelope", "gz", "application/gzip");
+
+        file.Extension.Should().Be("gz");
+        file.Name.Should().Be("xbrl-envelope");
+        file.ContentType.Should().Be("application/gzip");
+        file.Size.Should().Be(content.Length);
+        file.FileContent.Bytes.Should().BeEquivalentTo(content);
+        repository.Received(1).Add(file);
+    }
+}


### PR DESCRIPTION
## Summary

- `FileManager.SaveInternalFile` was entirely uncovered. It persists trusted, system-generated blobs with an explicit extension and content type, deliberately bypassing the `SaveFile` upload allowlist (used for content the app produces itself, e.g. gzip-compressed XBRL envelopes during SEC ingest).
- Adds one unit test pinning that behavior: an extension absent from the allowlist (`gz`) is accepted verbatim with no exception, and the `File` entity is assembled from the explicit arguments.

## Code changes

- `tests/Equibles.UnitTests/Media/FileManagerSaveInternalFileTests.cs` — new unit test asserting `SaveInternalFile` persists a `gz`/`application/gzip` blob with the given name, size, and content, and calls `FileRepository.Add`. Guards against a regression that re-applies the upload allowlist here and breaks XBRL envelope ingest.