### PR TITLE
test(sec): pin FormAdvAdviserRepository.GetLargestByAum null-AUM ranks last

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/FormAdvAdviserRepositoryGetLargestByAumTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FormAdvAdviserRepositoryGetLargestByAumTests.cs
@@ -1,0 +1,56 @@
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+// Lane A (adversarial): GetLargestByAum promises "largest AUM first". An adviser
+// whose TotalRegulatoryAum is null (unreported) must rank LAST — treated as the
+// smallest, not surfaced at the top. If the null AUM weren't coalesced to a floor,
+// a DESC ordering could surface unknown-AUM advisers ahead of real megafunds.
+[Collection(ParadeDbCollection.Name)]
+public class FormAdvAdviserRepositoryGetLargestByAumTests : ParadeDbMcpTestBase
+{
+    public FormAdvAdviserRepositoryGetLargestByAumTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetLargestByAum_NullAumAdviser_RanksLastBehindReportedAum()
+    {
+        DbContext
+            .Set<FormAdvAdviser>()
+            .AddRange(
+                new FormAdvAdviser
+                {
+                    Crd = 1,
+                    LegalName = "MEGA FUND",
+                    TotalRegulatoryAum = 8_000_000_000_000L,
+                    ReportDate = new DateOnly(2022, 4, 1),
+                },
+                new FormAdvAdviser
+                {
+                    Crd = 2,
+                    LegalName = "UNKNOWN AUM ADVISER",
+                    TotalRegulatoryAum = null,
+                    ReportDate = new DateOnly(2022, 4, 1),
+                },
+                new FormAdvAdviser
+                {
+                    Crd = 3,
+                    LegalName = "SMALL SHOP",
+                    TotalRegulatoryAum = 50_000_000L,
+                    ReportDate = new DateOnly(2022, 4, 1),
+                }
+            );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var sut = new FormAdvAdviserRepository(DbContext);
+
+        var ordered = await sut.GetLargestByAum().Select(a => a.LegalName).ToListAsync();
+
+        ordered.Should().Equal("MEGA FUND", "SMALL SHOP", "UNKNOWN AUM ADVISER");
+    }
+}


### PR DESCRIPTION
## Summary

- `FormAdvAdviserRepository.GetLargestByAum` had no direct test. It orders advisers by `TotalRegulatoryAum` descending with a `?? 0L` floor, so an adviser whose AUM is unreported (null) must rank **last**, not surface ahead of real megafunds.
- Adds one integration test pinning that contract: with large, small, and null-AUM advisers seeded, the method returns them large → small → null.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/FormAdvAdviserRepositoryGetLargestByAumTests.cs` — new ParadeDb-backed test asserting the null-AUM adviser sorts behind both reported-AUM advisers. Guards against a regression that drops the null-coalesce and lets unknown-AUM advisers float to the top.