### PR TITLE
fix(sec): keep filings whose primaryDocDescription is missing

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -825,14 +825,16 @@ public class SecEdgarClient : ISecEdgarClient
         filing = null;
 
         // SEC can emit a ragged payload where a secondary array is shorter
-        // than AccessionNumber. Skip rows that cannot be fully mapped rather
-        // than throw, mirroring ParseCompaniesFromResponse's short-row guard.
+        // than AccessionNumber. Skip rows missing a genuinely required field
+        // rather than throw, mirroring ParseCompaniesFromResponse's short-row
+        // guard. PrimaryDocDescription is an optional human-readable label —
+        // SEC routinely omits its trailing empties — so it must not gate
+        // ingest; it is indexed defensively below and left null when absent.
         if (
             recent.FilingDate.Count <= i
             || recent.ReportDate.Count <= i
             || recent.Form.Count <= i
             || recent.PrimaryDocument.Count <= i
-            || recent.PrimaryDocDescription.Count <= i
         )
             return false;
 
@@ -845,7 +847,8 @@ public class SecEdgarClient : ISecEdgarClient
             ReportDate = ParseInvariantDateOr(recent.ReportDate[i], DateOnly.MinValue),
             Form = recent.Form[i],
             PrimaryDocument = recent.PrimaryDocument[i],
-            Description = recent.PrimaryDocDescription[i],
+            Description =
+                i < recent.PrimaryDocDescription.Count ? recent.PrimaryDocDescription[i] : null,
             DocumentUrl = GetDocumentUrl(cik, accessionNumber),
         };
         return true;

--- a/tests/Equibles.UnitTests/Integrations/Sec/SecEdgarClientTryBuildFilingDataAtRaggedPayloadTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/Sec/SecEdgarClientTryBuildFilingDataAtRaggedPayloadTests.cs
@@ -1,21 +1,21 @@
 using System.Reflection;
 using Equibles.Integrations.Sec;
+using Equibles.Integrations.Sec.Models;
 
 namespace Equibles.UnitTests.Integrations.Sec;
 
 public class SecEdgarClientTryBuildFilingDataAtRaggedPayloadTests
 {
     // TryBuildFilingDataAt (extracted in #1464) guards SEC's "ragged payload"
-    // case where a secondary array (FilingDate, ReportDate, Form,
-    // PrimaryDocument, PrimaryDocDescription) is shorter than
-    // AccessionNumber. The contract: "skip rows that cannot be fully mapped
-    // rather than throw". A refactor that consolidated the per-array Count
-    // guards into a single AccessionNumber-only check would compile, pass
-    // every existing test (no input today actually exercises this branch),
-    // and crash the worker on any ragged response from SEC EDGAR with an
-    // IndexOutOfRangeException at the unguarded array access.
+    // case where a REQUIRED secondary array (FilingDate, ReportDate, Form,
+    // PrimaryDocument) is shorter than AccessionNumber: skip rows that cannot
+    // be fully mapped rather than throw. PrimaryDocDescription is the one
+    // exception — an optional human-readable label SEC routinely emits short.
+    // It must NOT gate ingest: when it is short the row is still built with a
+    // null Description, indexed defensively so the worker never throws an
+    // IndexOutOfRangeException on a ragged response.
     [Fact]
-    public void TryBuildFilingDataAt_PrimaryDocDescriptionShorterThanAccessionNumber_ReturnsFalseNoThrow()
+    public void TryBuildFilingDataAt_PrimaryDocDescriptionShorterThanAccessionNumber_BuildsRowWithNullDescription()
     {
         var assembly = typeof(SecEdgarClient).Assembly;
         var recentFilingsType = assembly.GetType(
@@ -27,7 +27,7 @@ public class SecEdgarClientTryBuildFilingDataAtRaggedPayloadTests
         SetList(recent, "ReportDate", ["2024-01-01", "2024-01-02"]);
         SetList(recent, "Form", ["10-K", "10-K"]);
         SetList(recent, "PrimaryDocument", ["doc1.htm", "doc2.htm"]);
-        // PrimaryDocDescription one short — index 1 read would throw without the guard.
+        // PrimaryDocDescription one short — the optional label is absent for index 1.
         SetList(recent, "PrimaryDocDescription", ["desc1"]);
 
         var method = typeof(SecEdgarClient).GetMethod(
@@ -38,8 +38,11 @@ public class SecEdgarClientTryBuildFilingDataAtRaggedPayloadTests
         var args = new object[] { recent, "0000001", 1, null };
         var returned = (bool)method.Invoke(null, args);
 
-        returned.Should().BeFalse();
-        args[3].Should().BeNull();
+        returned.Should().BeTrue();
+        var filing = (FilingData)args[3];
+        filing.Should().NotBeNull();
+        filing.AccessionNumber.Should().Be("A2");
+        filing.Description.Should().BeNull();
     }
 
     private static void SetList(object target, string propertyName, List<string> value)

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientMapToFilingDataRaggedKeepsAllRowsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientMapToFilingDataRaggedKeepsAllRowsTests.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+using Equibles.Integrations.Sec;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Regression for the dropped-filing defect: SEC routinely emits the optional
+/// PrimaryDocDescription array shorter than AccessionNumber (trailing empties
+/// omitted). The description is a human-readable label, not a required field —
+/// a fully-announced filing (accession number, filing date, report date, form,
+/// primary document all present) must still be ingested when only its
+/// description is missing, with a null Description rather than a dropped row.
+/// </summary>
+public class SecEdgarClientMapToFilingDataRaggedKeepsAllRowsTests
+{
+    [Fact]
+    public void MapToFilingData_PrimaryDocDescriptionShorterThanAccessionNumbers_KeepsEveryFilingWithNullDescription()
+    {
+        var asm = typeof(SecEdgarClient).Assembly;
+        var recentType = asm.GetType("Equibles.Integrations.Sec.Models.Responses.RecentFilings")!;
+        var recent = Activator.CreateInstance(recentType)!;
+
+        void Set(string prop, List<string> values) =>
+            recentType.GetProperty(prop)!.SetValue(recent, values);
+
+        // Two announced filings; only the required arrays are full-length.
+        // PrimaryDocDescription carries a single entry — the optional label is
+        // present for row 0 and absent for row 1.
+        Set("AccessionNumber", ["0000320193-24-000010", "0000320193-24-000020"]);
+        Set("FilingDate", ["2024-02-01", "2024-03-15"]);
+        Set("ReportDate", ["2023-12-30", "2024-01-31"]);
+        Set("Form", ["10-K", "8-K"]);
+        Set("PrimaryDocument", ["aapl-20231230.htm", "ex991.htm"]);
+        Set("PrimaryDocDescription", ["Annual report"]);
+
+        var map = typeof(SecEdgarClient).GetMethod(
+            "MapToFilingData",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+        var result = (List<FilingData>)map.Invoke(null, [recent, "320193"])!;
+
+        // Both filings must survive — the missing description must not gate ingest.
+        result.Should().HaveCount(2);
+        result
+            .Should()
+            .Contain(f =>
+                f.AccessionNumber == "0000320193-24-000010" && f.Description == "Annual report"
+            );
+        result
+            .Should()
+            .Contain(f => f.AccessionNumber == "0000320193-24-000020" && f.Description == null);
+    }
+}


### PR DESCRIPTION
## Summary

- A valid SEC filing was silently dropped from ingest whenever its `primaryDocDescription` was missing — an optional human-readable label SEC routinely emits shorter than the other arrays (trailing empties omitted).
- The required fields (accession number, filing date, report date, form, primary document) were all present, so the filing should have been ingested with a null `Description` rather than dropped.

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — removed `primaryDocDescription` from `TryBuildFilingDataAt`'s required-field ragged-payload guard and index it defensively, leaving `Description` null when absent. The genuinely required arrays still gate ingest.
- `tests/Equibles.UnitTests/Sec/SecEdgarClientMapToFilingDataRaggedKeepsAllRowsTests.cs` — new regression test: two announced filings with a one-short `primaryDocDescription` are both ingested, the second with a null description.
- `tests/Equibles.UnitTests/Integrations/Sec/SecEdgarClientTryBuildFilingDataAtRaggedPayloadTests.cs` — updated the description-arm test to assert the corrected contract (row built with null description, not dropped).

closes #3323