### PR TITLE
fix(sec): pause all SEC requests for the full block window on a rate-limit 429

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -27,6 +27,15 @@ public class SecEdgarClient : ISecEdgarClient
     private const int MaxRetries = 10;
     private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(5);
 
+    // SEC blocks an IP that exceeds 10 req/s for 10 minutes, and — per its own
+    // throttle page — *continuing to request during the block extends it*. SEC sends
+    // no Retry-After, so a short exponential backoff would keep poking SEC inside the
+    // window and renew the block indefinitely. When we detect the throttle we instead
+    // idle the whole rate limiter for this full penalty so the block can auto-lift.
+    // Configurable via Sec:RateLimitPauseSeconds (default 600); tests set 0 to stay fast.
+    private static readonly TimeSpan DefaultRateLimitPause = TimeSpan.FromMinutes(10);
+    private readonly TimeSpan _rateLimitPause;
+
     private readonly HttpClient _httpClient;
     private readonly ILogger<SecEdgarClient> _logger;
     private CachedResponse _cachedContent; // Used to cache the latest fetched list of documents
@@ -59,6 +68,12 @@ public class SecEdgarClient : ISecEdgarClient
         }
 
         _httpClient.Timeout = TimeSpan.FromMinutes(2);
+
+        var pauseSeconds = configuration["Sec:RateLimitPauseSeconds"];
+        _rateLimitPause =
+            int.TryParse(pauseSeconds, out var seconds) && seconds >= 0
+                ? TimeSpan.FromSeconds(seconds)
+                : DefaultRateLimitPause;
     }
 
     public async Task<List<CompanyInfo>> GetActiveCompanies()
@@ -629,10 +644,10 @@ public class SecEdgarClient : ISecEdgarClient
 
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {
-                var delay = GetRetryDelay(response, attempt);
+                var delay = GetRateLimitPause(response);
 
                 _logger.LogWarning(
-                    "SEC EDGAR rate limited (429) for {Url}, pausing for {Delay}s (attempt {Attempt}/{Max})",
+                    "SEC EDGAR rate limited (429) for {Url}, pausing all SEC requests for {Delay}s (attempt {Attempt}/{Max})",
                     url,
                     delay.TotalSeconds,
                     attempt + 1,
@@ -661,10 +676,10 @@ public class SecEdgarClient : ISecEdgarClient
                 var body = await ReadDecodedBody(response, cancellationToken);
                 if (IsRateLimitThresholdPage(body))
                 {
-                    var delay = GetRetryDelay(response, attempt);
+                    var delay = GetRateLimitPause(response);
 
                     _logger.LogWarning(
-                        "SEC EDGAR throttled (403 threshold page) for {Url}, pausing for {Delay}s (attempt {Attempt}/{Max})",
+                        "SEC EDGAR throttled (403 threshold page) for {Url}, pausing all SEC requests for {Delay}s (attempt {Attempt}/{Max})",
                         url,
                         delay.TotalSeconds,
                         attempt + 1,
@@ -702,6 +717,37 @@ public class SecEdgarClient : ISecEdgarClient
         throw new HttpRequestException(
             $"Max retries ({MaxRetries}) exceeded for SEC EDGAR request: {url}"
         );
+    }
+
+    // The pause applied when SEC reports its rate-limit threshold (a 429, or the 403
+    // throttle page). SEC sends no Retry-After on these, so we idle for the full
+    // configured penalty (default 10 min) — long enough for the IP block to auto-lift
+    // rather than be renewed by our own retries. This penalty deliberately exceeds
+    // MaxRetryDelay (which bounds the transient/5xx backoff): it models SEC's fixed
+    // block window, not a backoff. An explicit Retry-After is still honored when
+    // present (a future SEC change, and 0 in tests to stay fast), clamped so a
+    // pathological value can't stall a processor indefinitely.
+    private TimeSpan GetRateLimitPause(HttpResponseMessage response)
+    {
+        var ceiling = _rateLimitPause > MaxRetryDelay ? _rateLimitPause : MaxRetryDelay;
+
+        if (response.Headers.RetryAfter?.Delta is { } delta)
+        {
+            return delta > ceiling ? ceiling : delta;
+        }
+
+        if (response.Headers.RetryAfter?.Date is { } date)
+        {
+            var wait = date - DateTimeOffset.UtcNow;
+            if (wait <= TimeSpan.Zero)
+            {
+                return TimeSpan.Zero;
+            }
+
+            return wait > ceiling ? ceiling : wait;
+        }
+
+        return _rateLimitPause;
     }
 
     private TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt)

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientRateLimitPauseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientRateLimitPauseTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using Equibles.Integrations.Sec;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins SendWithRetryAsync's handling of SEC's rate-limit response. SEC answers an
+/// over-limit IP with a 429 (or its 403 "Request Rate Threshold Exceeded" page) and
+/// sends NO Retry-After. That 429 must be treated as a throttle — the whole rate
+/// limiter is paused for the configured penalty window and the request retried — so
+/// the IP block can auto-lift, rather than surfaced or hammered with a short backoff
+/// that only renews the block. Sec:RateLimitPauseSeconds is set to 0 here so the pause
+/// is instant and the suite stays fast; the production default is 10 minutes.
+/// </summary>
+public class SecEdgarClientRateLimitPauseTests
+{
+    private const string DocumentBody = "<SEC-DOCUMENT>full submission text</SEC-DOCUMENT>";
+
+    private static SecEdgarClient BuildClient(HttpMessageHandler handler)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string>
+                {
+                    ["Sec:ContactEmail"] = "test@example.com",
+                    ["Sec:RateLimitPauseSeconds"] = "0",
+                }
+            )
+            .Build();
+        return new SecEdgarClient(
+            new HttpClient(handler),
+            NullLogger<SecEdgarClient>.Instance,
+            config
+        );
+    }
+
+    [Fact]
+    public async Task GetDocumentContent_429NoRetryAfterThenSuccess_RetriesAndReturnsContent()
+    {
+        // SEC's 429 carries no Retry-After; it is a throttle, not a hard failure, so
+        // the next attempt after the pause must succeed and return the document.
+        var handler = new SequencedHandler(
+            () => new HttpResponseMessage(HttpStatusCode.TooManyRequests),
+            () => Ok(DocumentBody)
+        );
+        var sut = BuildClient(handler);
+
+        var content = await sut.GetDocumentContent("0000899243-22-038492", "1932393");
+
+        content.Should().Be(DocumentBody);
+        handler.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetDocumentContent_429Persists_RetriesThenThrows()
+    {
+        // A persistent 429 is a real failure: it must be retried (never given up on
+        // the first response) and then surfaced once retries are exhausted.
+        var handler = new SequencedHandler(() =>
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+        );
+        var sut = BuildClient(handler);
+
+        var act = async () => await sut.GetDocumentContent("0000899243-22-038492", "1932393");
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        handler.CallCount.Should().BeGreaterThan(1);
+    }
+
+    [Fact]
+    public async Task GetDocumentContent_429WithRetryAfterThenSuccess_HonorsHeaderAndRetries()
+    {
+        // When SEC does send a Retry-After it is honored (here 0, to stay fast)
+        // instead of the default penalty window, then the retry succeeds.
+        var handler = new SequencedHandler(
+            () => TooManyRequests(TimeSpan.Zero),
+            () => Ok(DocumentBody)
+        );
+        var sut = BuildClient(handler);
+
+        var content = await sut.GetDocumentContent("0000899243-22-038492", "1932393");
+
+        content.Should().Be(DocumentBody);
+        handler.CallCount.Should().Be(2);
+    }
+
+    private static HttpResponseMessage Ok(string body) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(body) };
+
+    private static HttpResponseMessage TooManyRequests(TimeSpan retryAfter)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(
+            retryAfter
+        );
+        return response;
+    }
+
+    private sealed class SequencedHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpResponseMessage>[] _responses;
+        public int CallCount { get; private set; }
+
+        public SequencedHandler(params Func<HttpResponseMessage>[] responses) =>
+            _responses = responses;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            // Repeat the last configured response once the sequence is exhausted.
+            var factory = _responses[Math.Min(CallCount, _responses.Length - 1)];
+            CallCount++;
+            return Task.FromResult(factory());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
SEC EDGAR blocks an IP that exceeds 10 req/s for 10 minutes, and — per its own throttle page — **continuing to request during the block extends it**. SEC's 429 (and its 403 "Request Rate Threshold Exceeded" page) carry **no `Retry-After`**, so the previous handling fell back to a 2s exponential backoff (`GetRetryDelay` → `TransientBackoff`) and retried *inside* the block window — which renewed the ban indefinitely. Verified live: a single cold request to `www.sec.gov/Archives/...` returns 429 with that page and no `Retry-After`, while `data.sec.gov` stays 200.

On a 429 or the 403 threshold page, pause the **process-wide** `RateLimiter` for the full block window instead of a short backoff, so every scraper in the worker goes quiet and SEC's block auto-lifts.

## Code changes
- `SecEdgarClient`: new `GetRateLimitPause` used by both the 429 and 403-threshold branches. With no `Retry-After` it returns the configured penalty (`Sec:RateLimitPauseSeconds`, default **600s / 10 min**); an explicit `Retry-After` is honored, clamped to a safe ceiling so a pathological value can't stall a processor. The penalty intentionally exceeds `MaxRetryDelay` (which still bounds the transient/5xx backoff) because it models SEC's fixed block window, not a backoff.
- Log messages now say "pausing all SEC requests" to reflect the process-wide pause.
- `GetRetryDelay` is unchanged and still used by the 5xx/transient path.

## Tests
- New `SecEdgarClientRateLimitPauseTests`: 429-without-`Retry-After` recovers on retry, persistent 429 throws after retries, and a present `Retry-After` is honored. `Sec:RateLimitPauseSeconds=0` keeps the suite fast (the existing 403-threshold tests already cover that branch). All existing retry/throttle tests pass.