### PR TITLE
fix(sec): widen Form 144 class title and cap issuer-feed free-text fields

### DIFF
--- a/src/Equibles.InsiderTrading.Data/Models/Form144Filing.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/Form144Filing.cs
@@ -41,7 +41,10 @@ public class Form144Filing
     [MaxLength(256)]
     public string RelationshipToIssuer { get; set; }
 
-    [MaxLength(128)]
+    // ADR/foreign-issuer class titles are long legal descriptions (e.g. "American Depositary
+    // Shares, each representing the right to receive one Share of Capital Stock of ..."), so this
+    // is sized well beyond a plain ticker class to store them in full.
+    [MaxLength(512)]
     public string SecurityClassTitle { get; set; }
 
     [MaxLength(256)]

--- a/src/Equibles.InsiderTrading.Data/Models/Form144PriorSale.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/Form144PriorSale.cs
@@ -19,7 +19,8 @@ public class Form144PriorSale
     [MaxLength(512)]
     public string SellerName { get; set; }
 
-    [MaxLength(128)]
+    // Matches Form144Filing.SecurityClassTitle — long ADR/foreign-issuer class descriptions.
+    [MaxLength(512)]
     public string SecurityClassTitle { get; set; }
 
     public DateOnly? SaleDate { get; set; }

--- a/src/Equibles.Migrations/Migrations/20260603153426_WidenForm144SecurityClassTitle.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260603153426_WidenForm144SecurityClassTitle.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603153426_WidenForm144SecurityClassTitle")]
+    partial class WidenForm144SecurityClassTitle
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260603153426_WidenForm144SecurityClassTitle.cs
+++ b/src/Equibles.Migrations/Migrations/20260603153426_WidenForm144SecurityClassTitle.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class WidenForm144SecurityClassTitle : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "SecurityClassTitle",
+                table: "Form144PriorSale",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SecurityClassTitle",
+                table: "Form144Filing",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "SecurityClassTitle",
+                table: "Form144PriorSale",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SecurityClassTitle",
+                table: "Form144Filing",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
+++ b/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
@@ -130,6 +130,19 @@ internal static class EdgarXmlSubmissionParser
     }
 
     /// <summary>
+    /// Caps a parsed value at its destination column's length so an oversized free-text field
+    /// (e.g. a foreign issuer's long ADR class-title description) can't fail the whole filing's
+    /// INSERT with a length-overflow. Pass the column's <c>[MaxLength]</c> as
+    /// <paramref name="maxLength"/>; <c>null</c> and shorter values pass through unchanged.
+    /// </summary>
+    internal static string Truncate(string value, int maxLength)
+    {
+        if (value == null || value.Length <= maxLength)
+            return value;
+        return value[..maxLength];
+    }
+
+    /// <summary>
     /// Trimmed text with the "N/A" placeholder and blanks normalized to <c>null</c>.
     /// </summary>
     internal static string Clean(string value)

--- a/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/Form144FilingProcessor.cs
@@ -78,16 +78,22 @@ public class Form144FilingProcessor
             CommonStockId = companyId,
             AccessionNumber = filing.AccessionNumber,
             FilingDate = filing.FilingDate,
-            SellerName = Val(issuerInfo, "nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold"),
-            RelationshipToIssuer = string.IsNullOrEmpty(relationship) ? null : relationship,
-            SecurityClassTitle = Val(securities, "securitiesClassTitle"),
-            BrokerName = Val(El(securities, "brokerOrMarketmakerDetails"), "name"),
+            SellerName = Truncate(
+                Val(issuerInfo, "nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold"),
+                512
+            ),
+            RelationshipToIssuer = Truncate(
+                string.IsNullOrEmpty(relationship) ? null : relationship,
+                256
+            ),
+            SecurityClassTitle = Truncate(Val(securities, "securitiesClassTitle"), 512),
+            BrokerName = Truncate(Val(El(securities, "brokerOrMarketmakerDetails"), "name"), 256),
             SharesToBeSold = ParseLong(Val(securities, "noOfUnitsSold")),
             AggregateMarketValue = ParseDecimal(Val(securities, "aggregateMarketValue")),
             SharesOutstanding = ParseLong(Val(securities, "noOfUnitsOutstanding")),
             ApproxSaleDate = ParseDate(Val(securities, "approxSaleDate")),
-            SecuritiesExchangeName = Val(securities, "securitiesExchangeName"),
-            Remarks = Val(formData, "remarks"),
+            SecuritiesExchangeName = Truncate(Val(securities, "securitiesExchangeName"), 64),
+            Remarks = Truncate(Val(formData, "remarks"), 2048),
         };
 
         foreach (var saleElement in Els(formData, "securitiesSoldInPast3Months"))
@@ -113,8 +119,8 @@ public class Form144FilingProcessor
 
         return new Form144PriorSale
         {
-            SellerName = Val(El(element, "sellerDetails"), "name"),
-            SecurityClassTitle = Val(element, "securitiesClassTitle"),
+            SellerName = Truncate(Val(El(element, "sellerDetails"), "name"), 512),
+            SecurityClassTitle = Truncate(Val(element, "securitiesClassTitle"), 512),
             SaleDate = saleDate,
             AmountSold = amount,
             GrossProceeds = grossProceeds,

--- a/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
@@ -88,12 +88,15 @@ public class FormDFilingProcessor : IssuerFeedFilingProcessor<FormDFiling, FormD
             AccessionNumber = filing.AccessionNumber,
             FilingDate = filing.FilingDate,
             IsAmendment = ParseIsAmendment(typeOfFiling, filing),
-            EntityName = Val(issuer, "entityName"),
-            EntityType = Val(issuer, "entityType"),
-            JurisdictionOfInc = Val(issuer, "jurisdictionOfInc"),
+            EntityName = Truncate(Val(issuer, "entityName"), 512),
+            EntityType = Truncate(Val(issuer, "entityType"), 128),
+            JurisdictionOfInc = Truncate(Val(issuer, "jurisdictionOfInc"), 128),
             YearOfIncorporation = ParseNullableInt(Val(El(issuer, "yearOfInc"), "value")),
-            IndustryGroup = Val(El(offeringData, "industryGroup"), "industryGroupType"),
-            FederalExemptions = string.IsNullOrEmpty(exemptions) ? null : exemptions,
+            IndustryGroup = Truncate(
+                Val(El(offeringData, "industryGroup"), "industryGroupType"),
+                128
+            ),
+            FederalExemptions = Truncate(string.IsNullOrEmpty(exemptions) ? null : exemptions, 256),
             DateOfFirstSale = ParseDate(Val(El(typeOfFiling, "dateOfFirstSale"), "value")),
             TotalOfferingAmount = offeringAmount,
             IsOfferingAmountIndefinite = offeringIndefinite,
@@ -139,8 +142,11 @@ public class FormDFilingProcessor : IssuerFeedFilingProcessor<FormDFiling, FormD
 
         return new FormDRelatedPerson
         {
-            Name = string.IsNullOrEmpty(fullName) ? null : fullName,
-            Relationships = string.IsNullOrEmpty(relationships) ? null : relationships,
+            Name = Truncate(string.IsNullOrEmpty(fullName) ? null : fullName, 512),
+            Relationships = Truncate(
+                string.IsNullOrEmpty(relationships) ? null : relationships,
+                256
+            ),
         };
     }
 

--- a/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
@@ -74,7 +74,7 @@ public class NCenFilingProcessor : IssuerFeedFilingProcessor<NCenFiling, NCenFil
             AccessionNumber = filing.AccessionNumber,
             FilingDate = filing.FilingDate,
             IsAmendment = ParseIsAmendment(headerData, filing),
-            RegistrantName = Clean(Val(registrant, "registrantFullName")),
+            RegistrantName = Truncate(Clean(Val(registrant, "registrantFullName")), 512),
             InvestmentCompanyType = Clean(Val(filerInfo, "investmentCompanyType")),
             InvestmentCompanyFileNumber = Clean(Val(registrant, "investmentCompFileNo")),
             RegistrantLei = Clean(Val(registrant, "registrantLei")),
@@ -236,7 +236,7 @@ public class NCenFilingProcessor : IssuerFeedFilingProcessor<NCenFiling, NCenFil
         return new NCenServiceProvider
         {
             ProviderType = type,
-            Name = cleanName,
+            Name = Truncate(cleanName, 512),
             Country = Clean(country),
             IsAffiliated = affiliated,
         };

--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -74,8 +74,8 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
             AccessionNumber = filing.AccessionNumber,
             FilingDate = filing.FilingDate,
             IsAmendment = ParseIsAmendment(headerData, filing),
-            RegistrantName = Clean(Val(genInfo, "regName")),
-            SeriesName = Clean(Val(genInfo, "seriesName")),
+            RegistrantName = Truncate(Clean(Val(genInfo, "regName")), 512),
+            SeriesName = Truncate(Clean(Val(genInfo, "seriesName")), 512),
             SeriesId = Clean(Val(genInfo, "seriesId")),
             SeriesLei = Clean(Val(genInfo, "seriesLei")),
             ReportPeriodDate = ParseDate(Val(genInfo, "repPdDate")) ?? filing.ReportDate,
@@ -109,8 +109,8 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
 
         return new NportHolding
         {
-            Name = name,
-            Title = Clean(Val(element, "title")),
+            Name = Truncate(name, 512),
+            Title = Truncate(Clean(Val(element, "title")), 512),
             Cusip = Clean(Val(element, "cusip")),
             Isin = Clean(Attr(El(identifiers, "isin"), "value")),
             Lei = Clean(Val(element, "lei")),

--- a/tests/Equibles.IntegrationTests/Sec/Form144FilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/Form144FilingProcessorTests.cs
@@ -114,6 +114,41 @@ public class Form144FilingProcessorTests
     }
 
     [Fact]
+    public async Task Process_LongAdrSecurityClassTitle_StoresFullTitle()
+    {
+        // Foreign issuers (e.g. Banco Santander) report a long ADR legal description as the
+        // securities class title — 144 chars here. The column was widened to 512 so it persists
+        // in full instead of overflowing the old 128-char limit and failing the whole INSERT.
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(LongAdrTitleSubmission);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().SingleAsync();
+        filing.SecurityClassTitle.Should().Be(LongAdrClassTitle);
+        filing.SecurityClassTitle.Length.Should().Be(144);
+    }
+
+    [Fact]
+    public async Task Process_OversizedSecurityClassTitle_TruncatesToColumnLength()
+    {
+        // Safety net: a class title longer than the 512-char column is capped on the way in so a
+        // single oversized free-text field can never fail the filing's INSERT again.
+        var oversizedTitle = new string('X', 600);
+        var (processor, repo, secClient) = CreateProcessorWithDeps();
+        secClient
+            .GetDocumentContent(Arg.Any<FilingData>())
+            .Returns(BuildSubmissionWithClassTitle(oversizedTitle));
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        var filing = await repo.GetAll().SingleAsync();
+        filing.SecurityClassTitle.Should().Be(new string('X', 512));
+    }
+
+    [Fact]
     public async Task Process_MultipleRelationships_JoinsWithComma()
     {
         var (processor, repo, secClient) = CreateProcessorWithDeps();
@@ -290,6 +325,39 @@ public class Form144FilingProcessorTests
         </DOCUMENT>
         </SEC-DOCUMENT>
         """;
+
+    // The exact ADR class title from Banco Santander's Form 144 (accession 0000950103-24-016159)
+    // that overflowed the original 128-char SecurityClassTitle column.
+    private const string LongAdrClassTitle =
+        "American Depositary Shares, each representing the right to receive one Share of Capital Stock of Banco Santander, S.A., par value euro 0.50 each";
+
+    private static readonly string LongAdrTitleSubmission = BuildSubmissionWithClassTitle(
+        LongAdrClassTitle
+    );
+
+    // Minimal valid Form 144 ownership submission with a caller-supplied securities class title.
+    private static string BuildSubmissionWithClassTitle(string classTitle) =>
+        $"""
+            <XML>
+            <edgarSubmission xmlns="http://www.sec.gov/edgar/ownership">
+              <formData>
+                <issuerInfo>
+                  <nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>Mahesh Chatta Aditya</nameOfPersonForWhoseAccountTheSecuritiesAreToBeSold>
+                  <relationshipsToIssuer>
+                    <relationshipToIssuer>Chief Risk Officer</relationshipToIssuer>
+                  </relationshipsToIssuer>
+                </issuerInfo>
+                <securitiesInformation>
+                  <securitiesClassTitle>{classTitle}</securitiesClassTitle>
+                  <noOfUnitsSold>10665</noOfUnitsSold>
+                  <aggregateMarketValue>50658.75</aggregateMarketValue>
+                  <approxSaleDate>11/08/2024</approxSaleDate>
+                  <securitiesExchangeName>NYSE</securitiesExchangeName>
+                </securitiesInformation>
+              </formData>
+            </edgarSubmission>
+            </XML>
+            """;
 
     private const string MultiRelationshipSubmission = """
         <XML>


### PR DESCRIPTION
## Summary

A Form 144 for a foreign issuer (Banco Santander, accession `0000950103-24-016159`) failed to import. Its security class title is the full ADR legal description — *"American Depositary Shares, each representing the right to receive one Share of Capital Stock of Banco Santander, S.A., par value euro 0.50 each"* (144 chars) — which overflowed the 128-char `SecurityClassTitle` column. `SaveChanges` threw a `DbUpdateException` in `IssuerFeedFilingProcessor.Process`, so the whole filing was dropped.

## Code changes

- **`Form144Filing` / `Form144PriorSale`** — widen `SecurityClassTitle` from 128 to 512 so realistic ADR titles store in full, plus the matching migration (`WidenForm144SecurityClassTitle`).
- **`EdgarXmlSubmissionParser.Truncate`** — new helper that caps a parsed value at its destination column length.
- **Issuer-feed processors** (Form 144, Form D, NPORT-P, N-CEN) — apply `Truncate` to the free-text fields (names, titles, descriptions, relationships, exemptions, remarks) so a single oversized field can never fail a filing's INSERT again. Fixed-format identifier columns (CUSIP/ISIN/LEI/ISO codes) are left untouched — they can't overflow by spec.
- **Tests** — `Process_LongAdrSecurityClassTitle_StoresFullTitle` (the exact Santander title round-trips in full) and `Process_OversizedSecurityClassTitle_TruncatesToColumnLength` (a >512-char title is capped).