### PR TITLE
feat(sec): publish bus events when SEC rate-limit block triggers and clears

### DIFF
--- a/src/Equibles.Integrations.Sec/Contracts/ISecRateLimitNotifier.cs
+++ b/src/Equibles.Integrations.Sec/Contracts/ISecRateLimitNotifier.cs
@@ -1,0 +1,17 @@
+namespace Equibles.Integrations.Sec.Contracts;
+
+/// <summary>
+/// Hook for surfacing SEC rate-limit state changes (e.g. publishing a bus
+/// event). <see cref="SecEdgarClient"/> calls <see cref="RateLimited"/> whenever
+/// SEC throttles us (a 429 or the "Request Rate Threshold Exceeded" page) and
+/// <see cref="Reachable"/> whenever a request succeeds; the implementation
+/// decides what to do with those edges. Integrations.Sec has no messaging
+/// dependency, so the default is a no-op (<see cref="NullSecRateLimitNotifier"/>)
+/// and a higher layer (the worker) supplies a publishing implementation.
+/// </summary>
+public interface ISecRateLimitNotifier
+{
+    Task RateLimited(TimeSpan pause, string url);
+
+    Task Reachable(string url);
+}

--- a/src/Equibles.Integrations.Sec/Contracts/NullSecRateLimitNotifier.cs
+++ b/src/Equibles.Integrations.Sec/Contracts/NullSecRateLimitNotifier.cs
@@ -1,0 +1,15 @@
+namespace Equibles.Integrations.Sec.Contracts;
+
+/// <summary>
+/// No-op <see cref="ISecRateLimitNotifier"/> used when no publishing
+/// implementation is registered (the MCP server, the web app, and tests). Keeps
+/// <see cref="SecEdgarClient"/> free of any hard messaging dependency.
+/// </summary>
+public sealed class NullSecRateLimitNotifier : ISecRateLimitNotifier
+{
+    public static readonly NullSecRateLimitNotifier Instance = new();
+
+    public Task RateLimited(TimeSpan pause, string url) => Task.CompletedTask;
+
+    public Task Reachable(string url) => Task.CompletedTask;
+}

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -38,18 +38,23 @@ public class SecEdgarClient : ISecEdgarClient
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<SecEdgarClient> _logger;
+    private readonly ISecRateLimitNotifier _rateLimitNotifier;
     private CachedResponse _cachedContent; // Used to cache the latest fetched list of documents
     private const string BaseUrl = "https://data.sec.gov";
     private const string FilesBaseUrl = "https://www.sec.gov";
 
+    // Optional: the worker supplies a publishing implementation so rate-limit
+    // blocks surface on the bus; everywhere else (and in tests) it stays no-op.
     public SecEdgarClient(
         HttpClient httpClient,
         ILogger<SecEdgarClient> logger,
-        IConfiguration configuration
+        IConfiguration configuration,
+        ISecRateLimitNotifier rateLimitNotifier = null
     )
     {
         _httpClient = httpClient;
         _logger = logger;
+        _rateLimitNotifier = rateLimitNotifier ?? NullSecRateLimitNotifier.Instance;
 
         var contactEmail = configuration["Sec:ContactEmail"];
         if (!string.IsNullOrWhiteSpace(contactEmail))
@@ -642,6 +647,13 @@ public class SecEdgarClient : ISecEdgarClient
                 url
             );
 
+            // A successful reach proves SEC is not blocking our IP; let the
+            // notifier clear a prior block (it fires the recovery edge once).
+            if (response.IsSuccessStatusCode)
+            {
+                await _rateLimitNotifier.Reachable(url);
+            }
+
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {
                 var delay = GetRateLimitPause(response);
@@ -654,6 +666,7 @@ public class SecEdgarClient : ISecEdgarClient
                     MaxRetries
                 );
 
+                await _rateLimitNotifier.RateLimited(delay, url);
                 RateLimiter.PauseFor(delay);
 
                 if (attempt < MaxRetries)
@@ -686,6 +699,7 @@ public class SecEdgarClient : ISecEdgarClient
                         MaxRetries
                     );
 
+                    await _rateLimitNotifier.RateLimited(delay, url);
                     RateLimiter.PauseFor(delay);
                     response.Dispose();
                     await Task.Delay(delay, cancellationToken);

--- a/src/Equibles.Messaging/Contracts/Activity/SecRateLimitBlocked.cs
+++ b/src/Equibles.Messaging/Contracts/Activity/SecRateLimitBlocked.cs
@@ -1,0 +1,8 @@
+namespace Equibles.Messaging.Contracts.Activity;
+
+// Published when SEC EDGAR rate-limit-blocks our IP (an HTTP 429 or the
+// "Request Rate Threshold Exceeded" page). All SEC requests are then paused for
+// ~Pause until the block lifts. Surfaced in the backoffice live-activity feed;
+// also available for any other subscriber (alerting, metrics). Not persisted —
+// dropped if no consumer is listening.
+public record SecRateLimitBlocked(DateTimeOffset Timestamp, TimeSpan Pause, string Url);

--- a/src/Equibles.Messaging/Contracts/Activity/SecRateLimitCleared.cs
+++ b/src/Equibles.Messaging/Contracts/Activity/SecRateLimitCleared.cs
@@ -1,0 +1,7 @@
+namespace Equibles.Messaging.Contracts.Activity;
+
+// Published when SEC EDGAR becomes reachable again after a rate-limit block —
+// the first successful request following a SecRateLimitBlocked. Surfaced in the
+// backoffice live-activity feed. Not persisted — dropped if no consumer is
+// listening.
+public record SecRateLimitCleared(DateTimeOffset Timestamp, string Url);

--- a/src/Equibles.Sec.HostedService/Equibles.Sec.HostedService.csproj
+++ b/src/Equibles.Sec.HostedService/Equibles.Sec.HostedService.csproj
@@ -24,5 +24,6 @@
     <ProjectReference Include="..\Equibles.Media.BusinessLogic\Equibles.Media.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Worker\Equibles.Worker.csproj" />
+    <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Sec.HostedService/Services/SecRateLimitEventPublisher.cs
+++ b/src/Equibles.Sec.HostedService/Services/SecRateLimitEventPublisher.cs
@@ -1,0 +1,53 @@
+using Equibles.Core.AutoWiring;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Messaging.Contracts.Activity;
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Publishes <see cref="SecRateLimitBlocked"/> / <see cref="SecRateLimitCleared"/>
+/// on the bus when SEC's rate-limit state changes, so the backoffice
+/// live-activity feed (and any other subscriber) can show when scraping is
+/// blocked and when it recovers.
+///
+/// Registered as a singleton so the edge detection is process-global: a 429 seen
+/// by any of the worker's concurrent SEC processors publishes exactly one
+/// "blocked" event, and the next successful request publishes exactly one
+/// "cleared" event — no duplicates from the retry loop or parallel fetches.
+/// </summary>
+[Service(ServiceLifetime.Singleton, typeof(ISecRateLimitNotifier))]
+public class SecRateLimitEventPublisher : ISecRateLimitNotifier
+{
+    private readonly IBus _bus;
+
+    // 0 = reachable, 1 = blocked. Flipped with Interlocked so only the thread
+    // that observes the edge publishes.
+    private int _blocked;
+
+    public SecRateLimitEventPublisher(IBus bus)
+    {
+        _bus = bus;
+    }
+
+    public Task RateLimited(TimeSpan pause, string url)
+    {
+        if (Interlocked.Exchange(ref _blocked, 1) == 0)
+        {
+            return _bus.Publish(new SecRateLimitBlocked(DateTimeOffset.UtcNow, pause, url));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task Reachable(string url)
+    {
+        if (Interlocked.Exchange(ref _blocked, 0) == 1)
+        {
+            return _bus.Publish(new SecRateLimitCleared(DateTimeOffset.UtcNow, url));
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientRateLimitNotifierTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientRateLimitNotifierTests.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using Equibles.Integrations.Sec;
+using Equibles.Integrations.Sec.Contracts;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins that SecEdgarClient signals its rate-limit notifier: a throttled
+/// response calls RateLimited and a successful one calls Reachable. The edge
+/// de-duplication lives in the notifier (see
+/// <see cref="SecRateLimitEventPublisherTests"/>); the client only forwards, so
+/// these assertions are count-based and order-free. Sec:RateLimitPauseSeconds=0
+/// keeps the retry pause instant.
+/// </summary>
+public class SecEdgarClientRateLimitNotifierTests
+{
+    private const string DocumentBody = "<SEC-DOCUMENT>ok</SEC-DOCUMENT>";
+
+    private static SecEdgarClient BuildClient(
+        HttpMessageHandler handler,
+        ISecRateLimitNotifier notifier
+    )
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string>
+                {
+                    ["Sec:ContactEmail"] = "test@example.com",
+                    ["Sec:RateLimitPauseSeconds"] = "0",
+                }
+            )
+            .Build();
+        return new SecEdgarClient(
+            new HttpClient(handler),
+            NullLogger<SecEdgarClient>.Instance,
+            config,
+            notifier
+        );
+    }
+
+    [Fact]
+    public async Task Send_429ThenSuccess_SignalsRateLimitedThenReachable()
+    {
+        var notifier = new RecordingNotifier();
+        var handler = new SequencedHandler(
+            () => new HttpResponseMessage(HttpStatusCode.TooManyRequests),
+            () => Ok(DocumentBody)
+        );
+        var sut = BuildClient(handler, notifier);
+
+        var content = await sut.GetDocumentContent("0000899243-22-038492", "1932393");
+
+        content.Should().Be(DocumentBody);
+        notifier.RateLimitedCount.Should().BeGreaterThan(0);
+        notifier.ReachableCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Send_Success_SignalsReachableNotRateLimited()
+    {
+        var notifier = new RecordingNotifier();
+        var handler = new SequencedHandler(() => Ok(DocumentBody));
+        var sut = BuildClient(handler, notifier);
+
+        await sut.GetDocumentContent("0000899243-22-038492", "1932393");
+
+        notifier.ReachableCount.Should().Be(1);
+        notifier.RateLimitedCount.Should().Be(0);
+    }
+
+    private static HttpResponseMessage Ok(string body) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(body) };
+
+    private sealed class RecordingNotifier : ISecRateLimitNotifier
+    {
+        public int RateLimitedCount { get; private set; }
+        public int ReachableCount { get; private set; }
+
+        public Task RateLimited(TimeSpan pause, string url)
+        {
+            RateLimitedCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task Reachable(string url)
+        {
+            ReachableCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SequencedHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpResponseMessage>[] _responses;
+        public int CallCount { get; private set; }
+
+        public SequencedHandler(params Func<HttpResponseMessage>[] responses) =>
+            _responses = responses;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var factory = _responses[Math.Min(CallCount, _responses.Length - 1)];
+            CallCount++;
+            return Task.FromResult(factory());
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/SecRateLimitEventPublisherTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecRateLimitEventPublisherTests.cs
@@ -1,0 +1,69 @@
+using Equibles.Messaging.Contracts.Activity;
+using Equibles.Sec.HostedService.Services;
+using MassTransit;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins SecRateLimitEventPublisher's edge detection. SecEdgarClient calls
+/// RateLimited on every throttled response and Reachable on every success; the
+/// publisher must emit exactly one SecRateLimitBlocked on the
+/// reachable→blocked edge and one SecRateLimitCleared on the blocked→reachable
+/// edge, so a retry storm or parallel fetches don't spam the feed.
+/// </summary>
+public class SecRateLimitEventPublisherTests
+{
+    private const string Url = "https://www.sec.gov/Archives/edgar/data/1/0-0.txt";
+
+    [Fact]
+    public async Task RateLimited_RepeatedWhileBlocked_PublishesBlockedOnce()
+    {
+        var bus = Substitute.For<IBus>();
+        var sut = new SecRateLimitEventPublisher(bus);
+
+        await sut.RateLimited(TimeSpan.FromMinutes(10), Url);
+        await sut.RateLimited(TimeSpan.FromMinutes(10), Url);
+        await sut.RateLimited(TimeSpan.FromMinutes(10), Url);
+
+        await bus.Received(1).Publish(Arg.Any<SecRateLimitBlocked>());
+    }
+
+    [Fact]
+    public async Task Reachable_AfterBlocked_PublishesClearedOnce()
+    {
+        var bus = Substitute.For<IBus>();
+        var sut = new SecRateLimitEventPublisher(bus);
+        await sut.RateLimited(TimeSpan.FromMinutes(10), Url);
+
+        await sut.Reachable(Url);
+        await sut.Reachable(Url);
+
+        await bus.Received(1).Publish(Arg.Any<SecRateLimitCleared>());
+    }
+
+    [Fact]
+    public async Task Reachable_WithoutPriorBlock_PublishesNothing()
+    {
+        var bus = Substitute.For<IBus>();
+        var sut = new SecRateLimitEventPublisher(bus);
+
+        await sut.Reachable(Url);
+
+        await bus.DidNotReceive().Publish(Arg.Any<SecRateLimitCleared>());
+    }
+
+    [Fact]
+    public async Task BlockedThenClearedThenBlocked_PublishesBothEdgesAgain()
+    {
+        var bus = Substitute.For<IBus>();
+        var sut = new SecRateLimitEventPublisher(bus);
+
+        await sut.RateLimited(TimeSpan.FromMinutes(10), Url);
+        await sut.Reachable(Url);
+        await sut.RateLimited(TimeSpan.FromMinutes(10), Url);
+
+        await bus.Received(2).Publish(Arg.Any<SecRateLimitBlocked>());
+        await bus.Received(1).Publish(Arg.Any<SecRateLimitCleared>());
+    }
+}


### PR DESCRIPTION
## Summary
Surfaces SEC EDGAR rate-limit blocks as bus events so the backoffice live-activity feed (and any other subscriber) can show when scraping is blocked and when it recovers.

When SEC blocks our IP it serves a 429 / "Request Rate Threshold Exceeded" page and we pause all SEC requests for the block window. This adds a signal for that transition:
- **`SecRateLimitBlocked`** — published on the first throttle (carries the pause duration).
- **`SecRateLimitCleared`** — published on the first successful request afterwards.

## Code changes
- **`Equibles.Messaging`**: two new contracts in `Contracts/Activity/` (`SecRateLimitBlocked`, `SecRateLimitCleared`).
- **`Equibles.Integrations.Sec`**: new `ISecRateLimitNotifier` (+ `NullSecRateLimitNotifier` no-op default). `SecEdgarClient` calls `RateLimited` on a 429 / 403-threshold and `Reachable` on a success. The notifier ctor arg is **optional** (defaults to no-op), so the integration layer keeps no messaging dependency and existing construction is unaffected.
- **`Equibles.Sec.HostedService`**: `SecRateLimitEventPublisher` (singleton `ISecRateLimitNotifier`) publishes the events on the reachable↔blocked edges, with `Interlocked` de-dup so the retry loop and the worker's parallel SEC processors emit exactly one event per transition. Adds an `Equibles.Messaging` project reference.

## Tests
- `SecRateLimitEventPublisherTests`: edge de-dup (repeated throttles → one blocked; recovery → one cleared; no-block recovery → nothing; re-block → both edges again).
- `SecEdgarClientRateLimitNotifierTests`: client signals `RateLimited` on 429 and `Reachable` on success.
- Full SEC unit suite (814) green.