### PR TITLE
fix(sec): avoid a false rate-limit 'cleared' signal from in-flight successes

### DIFF
--- a/src/Equibles.Integrations.Common/RateLimiter/IRateLimiter.cs
+++ b/src/Equibles.Integrations.Common/RateLimiter/IRateLimiter.cs
@@ -4,4 +4,8 @@ public interface IRateLimiter
 {
     Task WaitAsync();
     void PauseFor(TimeSpan duration);
+
+    // True while a PauseFor window is still in effect. The single source of truth
+    // for "are we currently throttled" — callers should not keep a separate flag.
+    bool IsThrottled { get; }
 }

--- a/src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs
+++ b/src/Equibles.Integrations.Common/RateLimiter/RateLimiter.cs
@@ -48,6 +48,17 @@ public class RateLimiter : IRateLimiter
         }
     }
 
+    public bool IsThrottled
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return DateTime.UtcNow < _pauseUntil;
+            }
+        }
+    }
+
     public void PauseFor(TimeSpan duration)
     {
         lock (_lock)

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -649,7 +649,10 @@ public class SecEdgarClient : ISecEdgarClient
 
             // A successful reach proves SEC is not blocking our IP; let the
             // notifier clear a prior block (it fires the recovery edge once).
-            if (response.IsSuccessStatusCode)
+            // Skip while the limiter is still throttled: a request that was
+            // already in flight when a sibling tripped a block can return 200
+            // here, and announcing "cleared" then would be a false signal.
+            if (response.IsSuccessStatusCode && !RateLimiter.IsThrottled)
             {
                 await _rateLimitNotifier.Reachable(url);
             }
@@ -666,8 +669,11 @@ public class SecEdgarClient : ISecEdgarClient
                     MaxRetries
                 );
 
-                await _rateLimitNotifier.RateLimited(delay, url);
+                // Pause first so the limiter (the source of truth) reflects the
+                // block before we announce it — a concurrent success then sees
+                // IsThrottled and won't publish a premature "cleared".
                 RateLimiter.PauseFor(delay);
+                await _rateLimitNotifier.RateLimited(delay, url);
 
                 if (attempt < MaxRetries)
                 {
@@ -699,8 +705,8 @@ public class SecEdgarClient : ISecEdgarClient
                         MaxRetries
                     );
 
-                    await _rateLimitNotifier.RateLimited(delay, url);
                     RateLimiter.PauseFor(delay);
+                    await _rateLimitNotifier.RateLimited(delay, url);
                     response.Dispose();
                     await Task.Delay(delay, cancellationToken);
                     continue;

--- a/tests/Equibles.UnitTests/Integrations/RateLimiterIsThrottledTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/RateLimiterIsThrottledTests.cs
@@ -1,0 +1,40 @@
+using Equibles.Integrations.Common.RateLimiter;
+
+namespace Equibles.UnitTests.Integrations;
+
+/// <summary>
+/// Pins RateLimiter.IsThrottled — the single source of truth callers use instead
+/// of mirroring the pause in a separate flag. False before any pause, true while
+/// a PauseFor window is in effect, false again once it elapses.
+/// </summary>
+public class RateLimiterIsThrottledTests
+{
+    [Fact]
+    public void IsThrottled_NoPause_False()
+    {
+        var limiter = new RateLimiter(maxRequests: 5, timeWindow: TimeSpan.FromMilliseconds(100));
+
+        limiter.IsThrottled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsThrottled_DuringPause_True()
+    {
+        var limiter = new RateLimiter(maxRequests: 5, timeWindow: TimeSpan.FromMilliseconds(100));
+
+        limiter.PauseFor(TimeSpan.FromMinutes(10));
+
+        limiter.IsThrottled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsThrottled_AfterPauseElapses_False()
+    {
+        var limiter = new RateLimiter(maxRequests: 5, timeWindow: TimeSpan.FromMilliseconds(100));
+
+        limiter.PauseFor(TimeSpan.FromMilliseconds(20));
+        await Task.Delay(60);
+
+        limiter.IsThrottled.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #3359. The SEC rate-limit publisher tracked a `_blocked` flag independent of the rate limiter's actual pause, giving two sources of truth. A request already in flight when a sibling processor tripped a block could return 200 and publish `SecRateLimitCleared` even though all SEC traffic had just been paused for the block window — a misleading "resuming SEC requests" row in the live-activity feed.

## Code changes
- `IRateLimiter` / `RateLimiter`: add `IsThrottled` — the single source of truth for "are we paused right now".
- `SecEdgarClient`: pause the limiter *before* announcing the block (so a concurrent success sees `IsThrottled`), and skip the `Reachable` (clear) signal while `IsThrottled` is true.

## Tests
- `RateLimiterIsThrottledTests`: false before any pause, true during, false after it elapses.
- Full SEC + RateLimiter unit suite (829) green.