### PR TITLE
refactor(profiles): extract repeated most-recent-rows query into TakeMostRecent helper

### DIFF
--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -65,8 +65,7 @@ public class ProfilesController : BaseController
 
         var holdings = await _institutionalHoldingRepository
             .GetHistoryByHolder(holder)
-            .OrderByDescending(holding => holding.ReportDate)
-            .Take(RecentRowLimit)
+            .TakeMostRecent(holding => holding.ReportDate, RecentRowLimit)
             .Select(holding => new HoldingRowViewModel
             {
                 Ticker = holding.CommonStock.Ticker,
@@ -334,8 +333,7 @@ public class ProfilesController : BaseController
 
         var transactions = await _insiderTransactionRepository
             .GetByOwner(owner)
-            .OrderByDescending(transaction => transaction.TransactionDate)
-            .Take(RecentRowLimit)
+            .TakeMostRecent(transaction => transaction.TransactionDate, RecentRowLimit)
             .Select(transaction => new InsiderTradeRowViewModel
             {
                 Ticker = transaction.CommonStock.Ticker,
@@ -372,8 +370,7 @@ public class ProfilesController : BaseController
 
         var trades = await _congressionalTradeRepository
             .GetByMember(member)
-            .OrderByDescending(trade => trade.TransactionDate)
-            .Take(RecentRowLimit)
+            .TakeMostRecent(trade => trade.TransactionDate, RecentRowLimit)
             .Select(trade => new CongressTradeRowViewModel
             {
                 Ticker = trade.CommonStock.Ticker,

--- a/src/Equibles.Web/Extensions/QueryableExtensions.cs
+++ b/src/Equibles.Web/Extensions/QueryableExtensions.cs
@@ -1,0 +1,15 @@
+using System.Linq.Expressions;
+
+namespace Equibles.Web.Extensions;
+
+public static class QueryableExtensions
+{
+    // Order by the given key descending and cap at count — the "most recent N rows"
+    // shape shared by the profile read actions. Returns IQueryable so callers can
+    // still project before materializing.
+    public static IQueryable<T> TakeMostRecent<T, TKey>(
+        this IQueryable<T> source,
+        Expression<Func<T, TKey>> orderKey,
+        int count
+    ) => source.OrderByDescending(orderKey).Take(count);
+}


### PR DESCRIPTION
## Summary

- The three read actions in `ProfilesController` (institution, insider, congress member) each inlined the same `OrderByDescending(key).Take(RecentRowLimit)` query shape before projecting. Collapse that into one intent-revealing `IQueryable` extension so the "most recent N rows" convention lives in a single place.
- Behavior is unchanged: the extension builds the identical query; the row limit is passed as an argument, so each caller keeps its own constant and its own projection.

## Code changes

- `src/Equibles.Web/Extensions/QueryableExtensions.cs` — new `TakeMostRecent(orderKey, count)` extension returning `IQueryable<T>` (orders descending, caps at count), so callers can still project before materializing.
- `src/Equibles.Web/Controllers/ProfilesController.cs` — `Institution`, `Insider`, and `Member` now call `TakeMostRecent(...)` instead of the inline `OrderByDescending(...).Take(...)`, matching the project convention of keeping reusable query helpers in `Extensions/`.