### PR TITLE
test(sec): pin FormAdvCsvParser maps reported zero AUM to 0 not null

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumReportedZeroTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumReportedZeroTests.cs
@@ -1,0 +1,21 @@
+using Equibles.Integrations.Sec.FormAdv;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FormAdvCsvParserParseAumReportedZeroTests
+{
+    // ParseAum documents that a blank cell returns null so "not reported" stays
+    // distinguishable from a reported zero. This pins the other side of that
+    // contract: an adviser reporting exactly "0.00" AUM must map to 0L, not null.
+    // A regression coalescing 0 into null would erase the reported-zero signal.
+    [Fact]
+    public void Parse_ReportedZeroAum_MapsToZeroNotNull()
+    {
+        var csv = "Organization CRD#,5F(2)(c)\n777,0.00\n";
+        using var reader = new StringReader(csv);
+
+        var adviser = FormAdvCsvParser.Parse(reader).Single();
+
+        adviser.TotalRegulatoryAum.Should().Be(0L);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the documented `ParseAum` invariant in `FormAdvCsvParser`: a reported zero AUM (`0.00`) maps to `0L`, not null, keeping a reported zero distinguishable from a blank "not reported" cell.
- Existing AUM tests cover rounding, overflow, underflow, and culture; none asserted the reported-zero side of the contract. A regression coalescing `0` into null would silently erase the reported-zero signal.

## Code changes

- `tests/Equibles.UnitTests/Sec/FormAdvCsvParserParseAumReportedZeroTests.cs` — new unit test: an adviser row with `5F(2)(c) = 0.00` yields `TotalRegulatoryAum == 0L`.