### PR TITLE
test(sec): pin EdgarXmlSubmissionParser.Truncate caps oversized value to maxLength

### DIFF
--- a/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserTruncateTests.cs
+++ b/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserTruncateTests.cs
@@ -1,0 +1,18 @@
+using Equibles.Sec.HostedService.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class EdgarXmlSubmissionParserTruncateTests
+{
+    // Contract (doc-comment): Truncate caps an oversized free-text value at its destination
+    // column's MaxLength so an over-long field can't fail the whole filing's INSERT. A value
+    // longer than the cap must be cut to EXACTLY maxLength characters, preserving the prefix —
+    // not maxLength-1, and never throwing. Oracle from the contract, not the body.
+    [Fact]
+    public void Truncate_ValueLongerThanMax_CapsToExactlyMaxLength()
+    {
+        var result = EdgarXmlSubmissionParser.Truncate("ABCDEF", 4);
+
+        result.Should().Be("ABCD");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `EdgarXmlSubmissionParser.Truncate`, which caps oversized free-text fields at their destination column's MaxLength so an over-long value can't fail the whole filing's INSERT.
- Pins that a value longer than the cap is cut to exactly `maxLength` characters (prefix preserved) — guarding against an off-by-one in the slice and against a regression that stops truncating.

## Code changes

- `tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserTruncateTests.cs` — new unit test: `Truncate("ABCDEF", 4)` returns `"ABCD"`.