### PR TITLE
test(holdings): pin Filing13FXmlParser falls back to index CIK when XML omits it

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserCikFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserCikFallbackTests.cs
@@ -1,0 +1,35 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Filing13FXmlParserCikFallbackTests
+{
+    private readonly Filing13FXmlParser _sut = new();
+
+    // Contract (doc-comment): accessionNumber and cik come from the daily index and are used as
+    // fallbacks when the XML omits them. When headerData carries no <cik>, the zero-padded index
+    // cik must be adopted with its leading zeros trimmed to the canonical form. Both existing
+    // cover-page tests embed an XML <cik>, so only the XML-cik path is pinned; this pins fallback.
+    [Fact]
+    public void ParseCoverPage_XmlOmitsCik_FallsBackToIndexCikWithLeadingZerosTrimmed()
+    {
+        var xml =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<edgarSubmission xmlns=\"http://www.sec.gov/edgar/thirteenffiler\">"
+            + "  <headerData></headerData>"
+            + "  <coverPage>"
+            + "    <reportCalendarOrQuarter>12-31-2024</reportCalendarOrQuarter>"
+            + "    <filingManager><name>Test Manager LLC</name></filingManager>"
+            + "  </coverPage>"
+            + "</edgarSubmission>";
+
+        var filing = _sut.ParseCoverPage(
+            xml,
+            accessionNumber: "0001234567-24-000001",
+            cik: "0001234567",
+            filingDate: new DateOnly(2025, 2, 14)
+        );
+
+        filing.Cik.Should().Be("1234567");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the documented CIK fallback in `Filing13FXmlParser.ParseCoverPage`: when the cover-page XML carries no `<cik>`, the zero-padded index-supplied CIK is adopted with leading zeros trimmed to canonical form.
- Both existing cover-page tests embed an XML `<cik>`, so only the XML-cik path was pinned; this covers the fallback branch a regression could silently break.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Filing13FXmlParserCikFallbackTests.cs` — new unit test: a cover page with empty `headerData` and `cik: "0001234567"` yields `Cik == "1234567"`.