### PR TITLE
test(insider): pin InsiderFilingParser.ParseTransactionCode maps unknown code to Other

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseTransactionCodeUnknownTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseTransactionCodeUnknownTests.cs
@@ -1,0 +1,19 @@
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserParseTransactionCodeUnknownTests
+{
+    // ParseTransactionCode maps the known Form 4 codes (P/S/A/M/X/F/E/G/I/W) and routes
+    // everything else through the catch-all. A code outside that set — here "J", a real SEC
+    // code the parser doesn't model — must degrade to Other, never throw, so ingestion of a
+    // filing carrying an unmodelled code keeps working. Oracle from the contract, not the body.
+    [Fact]
+    public void ParseTransactionCode_UnrecognizedCode_MapsToOther()
+    {
+        var result = InsiderFilingParser.ParseTransactionCode("J");
+
+        result.Should().Be(TransactionCode.Other);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `InsiderFilingParser.ParseTransactionCode` (distinct from the already-tested `InsiderTradingFilingProcessor` method of the same name).
- Pins the catch-all branch: an SEC Form 4 code outside the modelled set (P/S/A/M/X/F/E/G/I/W) — here `J`, a real-but-unmodelled code — degrades to `TransactionCode.Other` and never throws, so a filing carrying an unmodelled code still ingests.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseTransactionCodeUnknownTests.cs` — new unit test: `ParseTransactionCode("J")` returns `TransactionCode.Other`.