### PR TITLE
test(insider): pin InsiderFilingParser.ParseOwnershipNature maps I to Indirect

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseOwnershipNatureIndirectTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseOwnershipNatureIndirectTests.cs
@@ -1,0 +1,28 @@
+using System.Xml.Linq;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserParseOwnershipNatureIndirectTests
+{
+    // SEC Form 4 ownershipNature/directOrIndirectOwnership uses "D" for direct and "I" for
+    // indirect holdings. A holding flagged "I" must classify as Indirect — mislabelling it
+    // Direct would corrupt insider-ownership analysis. Pins the non-default arm and the wrapped
+    // <field><value> extraction. Oracle from the SEC convention, not the body.
+    [Fact]
+    public void ParseOwnershipNature_DirectOrIndirectValueI_ReturnsIndirect()
+    {
+        var element = new XElement(
+            "transactionEntry",
+            new XElement(
+                "ownershipNature",
+                new XElement("directOrIndirectOwnership", new XElement("value", "I"))
+            )
+        );
+
+        var result = InsiderFilingParser.ParseOwnershipNature(element);
+
+        result.Should().Be(OwnershipNature.Indirect);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `InsiderFilingParser.ParseOwnershipNature` (distinct from the sibling `InsiderTradingFilingProcessor` method).
- Pins the SEC convention: a Form 4 holding whose `directOrIndirectOwnership` value is `I` classifies as `OwnershipNature.Indirect`. Also exercises the wrapped `<field><value>` extraction path. Mislabelling an indirect holding as Direct would corrupt insider-ownership analysis.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseOwnershipNatureIndirectTests.cs` — new unit test: an `ownershipNature/directOrIndirectOwnership/value = I` element yields `Indirect`.