### PR TITLE
test(insider): pin InsiderFilingParser.TryParseTransactionDate is culture-invariant

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserTryParseTransactionDateHijriCultureTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserTryParseTransactionDateHijriCultureTests.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserTryParseTransactionDateHijriCultureTests
+{
+    // Contract (doc-comment): Form 4 transactionDate is ISO yyyy-MM-dd and must parse
+    // culture-independently. Under a non-Gregorian host culture (ar-SA Umm al-Qura) a
+    // culture-sensitive parse would fail and silently drop every insider transaction. So the
+    // invariant parse must still recover 2024-03-15 as a Gregorian date. Oracle from the contract.
+    [Fact]
+    public void TryParseTransactionDate_IsoDateUnderUmmAlQuraCulture_ParsesGregorianDate()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+
+            var parsed = InsiderFilingParser.TryParseTransactionDate("2024-03-15", out var date);
+
+            parsed.Should().BeTrue();
+            date.Should().Be(new DateOnly(2024, 3, 15));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `InsiderFilingParser.TryParseTransactionDate`, pinning its documented culture-invariance: an ISO `yyyy-MM-dd` Form 4 transaction date parses to the correct Gregorian date even under a non-Gregorian host culture (ar-SA Umm al-Qura).
- A regression to a culture-sensitive parse would fail under such a culture and silently drop every insider transaction — this guards that failure mode.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserTryParseTransactionDateHijriCultureTests.cs` — new unit test: under `ar-SA`, `TryParseTransactionDate("2024-03-15", out date)` returns true and `date == 2024-03-15`.