### PR TITLE
test(insider): pin InsiderFilingParser.GetWrappedValue returns null on missing path

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserGetWrappedValueMissingPathTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserGetWrappedValueMissingPathTests.cs
@@ -1,0 +1,25 @@
+using System.Xml.Linq;
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserGetWrappedValueMissingPathTests
+{
+    // GetWrappedValue walks a path of nested elements then reads the inner <value>. Every Form 4
+    // field read goes through it, so an absent intermediate element must yield null gracefully —
+    // never an NRE. Here the parent has "ownershipNature" but not the "directOrIndirectOwnership"
+    // leaf, so the mid-walk null-propagation must short-circuit to null. Oracle from the contract.
+    [Fact]
+    public void GetWrappedValue_IntermediatePathElementMissing_ReturnsNullWithoutThrowing()
+    {
+        var element = new XElement("transactionEntry", new XElement("ownershipNature"));
+
+        var result = InsiderFilingParser.GetWrappedValue(
+            element,
+            "ownershipNature",
+            "directOrIndirectOwnership"
+        );
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `InsiderFilingParser.GetWrappedValue`, the SEC-XML field-extraction helper every Form 4 field read flows through (the parser is production-wired via `InsiderTradingFilingProcessor` and `InsiderFilingReprocessManager`).
- Pins the mid-walk null-safety: when an intermediate path element is absent, the helper returns null gracefully rather than throwing an NRE.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserGetWrappedValueMissingPathTests.cs` — new unit test: a parent with `ownershipNature` but no `directOrIndirectOwnership` leaf yields null.