### PR TITLE
refactor(web): route StockTabService most-recent helpers through TakeMostRecent extension

### DIFF
--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -276,7 +276,7 @@ public class StockTabService
         int take
     )
     {
-        var rows = await source.OrderByDescending(orderKey).Take(take).ToListAsync();
+        var rows = await source.TakeMostRecent(orderKey, take).ToListAsync();
         return rows.OrderBy(orderKey.Compile()).ToList();
     }
 
@@ -285,7 +285,7 @@ public class StockTabService
     private static Task<List<T>> TakeMostRecent<T, TKey>(
         IQueryable<T> source,
         Expression<Func<T, TKey>> orderKey
-    ) => source.OrderByDescending(orderKey).Take(RecentRowLimit).ToListAsync();
+    ) => source.TakeMostRecent(orderKey, RecentRowLimit).ToListAsync();
 
     public async Task<DocumentsTabViewModel> LoadDocumentsTab(CommonStock stock)
     {


### PR DESCRIPTION
## Summary

- `StockTabService` had two private helpers that re-implemented the "most recent N rows" query shape (`OrderByDescending(orderKey).Take(n)`) inline, even though the project already has a canonical `QueryableExtensions.TakeMostRecent` extension for exactly this — and that extension's own comment says it's the shape "shared by the profile read actions".
- Routes both helpers through the existing extension so the descending-take logic lives in one place. Behavior is identical; no public surface, method names, or signatures change.

## Code changes

- `src/Equibles.Web/Services/StockTabService.cs` — `FetchMostRecentAscending` and the private `TakeMostRecent` now call `source.TakeMostRecent(orderKey, count)` instead of inlining `OrderByDescending(orderKey).Take(count)`. The extension is defined as exactly that expression, so the generated EF query and materialization are unchanged.