### PR TITLE
test(sec): pin NCenFilingProcessor returns null when registrantInfo section missing

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/NCenFilingProcessorParseFilingMissingRegistrantInfoTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NCenFilingProcessorParseFilingMissingRegistrantInfoTests.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+using System.Xml.Linq;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class NCenFilingProcessorParseFilingMissingRegistrantInfoTests
+{
+    // registrantInfo is N-CEN's required section. A submission that parses as valid XML but lacks
+    // it can't form a filing, so ParseFiling returns null (the base then logs and skips). The
+    // existing tests cover empty and non-XML content; this pins the well-formed-but-missing-section
+    // branch, a distinct guard from those. Oracle from the documented RequiredSection contract.
+    [Fact]
+    public void ParseFiling_WellFormedXmlMissingRegistrantInfo_ReturnsNull()
+    {
+        var processor = new NCenFilingProcessor(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<NCenFilingProcessor>>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+
+        var root = XElement.Parse(
+            "<edgarSubmission><formData><generalInfo></generalInfo></formData></edgarSubmission>"
+        );
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000000000-24-000001",
+            FilingDate = new DateOnly(2025, 1, 31),
+            ReportDate = new DateOnly(2024, 12, 31),
+            Form = "N-CEN",
+        };
+
+        var method = typeof(NCenFilingProcessor).GetMethod(
+            "ParseFiling",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var entity = (NCenFiling)method.Invoke(processor, [root, Guid.NewGuid(), filing]);
+
+        entity.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the required-section guard in `NCenFilingProcessor.ParseFiling`: a submission that parses as valid XML but lacks the `registrantInfo` section returns null (the base pipeline then logs and skips it), rather than producing a partial filing or throwing.
- Final processor in the required-section-guard set (NCen, NPORT, Form 144, Form D now all covered).

## Code changes

- `tests/Equibles.IntegrationTests/Sec/NCenFilingProcessorParseFilingMissingRegistrantInfoTests.cs` — new test: a `formData` with only `generalInfo` (no `registrantInfo`) yields a null entity (reflection-invokes the protected `ParseFiling`).