### PR TITLE
test(insider): pin InsiderFilingParser.ParseBool treats zero as false

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseBoolZeroTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseBoolZeroTests.cs
@@ -1,0 +1,16 @@
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserParseBoolZeroTests
+{
+    // SEC Form 4 boolean flags (isDirector, isOfficer, isTenPercentOwner, …) arrive as "1"/"0".
+    // ParseBool must treat only the affirmative tokens as true; a value of "0" — a flag explicitly
+    // disabled — must read as false. An over-permissive regression (e.g. !IsNullOrEmpty) would flip
+    // "0" to true and corrupt every insider-role flag. Oracle from the contract, not the body.
+    [Fact]
+    public void ParseBool_ZeroValue_ReturnsFalse()
+    {
+        InsiderFilingParser.ParseBool("0").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first test for `InsiderFilingParser.ParseBool` (distinct from the sibling `InsiderTradingFilingProcessor` method).
- Pins that a Form 4 boolean flag of `"0"` reads as false. SEC reporting flags (isDirector/isOfficer/isTenPercentOwner) arrive as `"1"`/`"0"`; an over-permissive regression flipping `"0"` to true would corrupt every insider-role flag. The `"0" → false` case isn't covered on either the parser or the sibling processor.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseBoolZeroTests.cs` — new unit test: `ParseBool("0")` returns false.