### PR TITLE
test(insider): pin InsiderFilingParser.ParseDecimal is culture-invariant

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseDecimalCultureTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseDecimalCultureTests.cs
@@ -1,0 +1,27 @@
+using System.Globalization;
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserParseDecimalCultureTests
+{
+    // SEC Form 4 amounts (price per share, value) carry an ASCII '.' decimal point. ParseDecimal
+    // must read them culture-independently: under de-DE — where '.' is the THOUSANDS separator — a
+    // culture-sensitive parse of "12.50" yields 1250, off by 100x. The invariant parse must recover
+    // 12.50m. Pins the InvariantCulture guard against a locale fork. Oracle from the contract.
+    [Fact]
+    public void ParseDecimal_DecimalPointUnderGermanCulture_ParsesAsInvariantNotThousands()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            InsiderFilingParser.ParseDecimal("12.50").Should().Be(12.50m);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the first direct test for `InsiderFilingParser.ParseDecimal`, pinning its culture-invariance: under de-DE (where `.` is the thousands separator) `"12.50"` parses to `12.50`, not `1250`.
- The existing ar-SA ParseLong test only exercises the negative-sign fork via fallback; this covers the decimal-separator fork. A regression dropping `InvariantCulture` would misparse every Form 4 amount by 100x on comma-decimal hosts.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserParseDecimalCultureTests.cs` — new unit test: under `de-DE`, `ParseDecimal("12.50") == 12.50m`.