### PR TITLE
refactor(views): extract repeated inline empty-state markup into _EmptyStateInline partial

### DIFF
--- a/src/Equibles.Web/Views/Cftc/Show.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Show.cshtml
@@ -88,9 +88,7 @@
             </h2>
 
             @if (Model.Reports.Count == 0) {
-                <div class="text-center py-8 text-base-content/50">
-                    <p class="text-sm">No reports yet</p>
-                </div>
+                <partial name="_EmptyStateInline" model='"No reports yet"' />
             } else {
                 <div class="overflow-x-auto max-h-[400px] overflow-y-auto">
                     <table class="table table-zebra table-sm" aria-label="Position history">

--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -104,9 +104,7 @@
             </h2>
 
             @if (Model.Observations.Count == 0) {
-                <div class="text-center py-8 text-base-content/50">
-                    <p class="text-sm">No observations yet</p>
-                </div>
+                <partial name="_EmptyStateInline" model='"No observations yet"' />
             } else {
                 <div class="overflow-x-auto max-h-[400px] overflow-y-auto">
                     <table class="table table-zebra table-sm" aria-label="Series observations">

--- a/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
+++ b/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
@@ -73,9 +73,7 @@
             </h2>
 
             @if (Model.Records.Count == 0) {
-                <div class="text-center py-8 text-base-content/50">
-                    <p class="text-sm">No data yet</p>
-                </div>
+                <partial name="_EmptyStateInline" model='"No data yet"' />
             } else {
                 <div class="overflow-x-auto max-h-[400px] overflow-y-auto">
                     <table class="table table-zebra table-sm" aria-label="Put / call ratio history">

--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -90,9 +90,7 @@
             </h2>
 
             @if (Model.Records.Count == 0) {
-                <div class="text-center py-8 text-base-content/50">
-                    <p class="text-sm">No data yet</p>
-                </div>
+                <partial name="_EmptyStateInline" model='"No data yet"' />
             } else {
                 <div class="overflow-x-auto max-h-[400px] overflow-y-auto">
                     <table class="table table-zebra table-sm" aria-label="VIX daily values">

--- a/src/Equibles.Web/Views/Shared/_EmptyStateInline.cshtml
+++ b/src/Equibles.Web/Views/Shared/_EmptyStateInline.cshtml
@@ -1,0 +1,4 @@
+@model string
+<div class="text-center py-8 text-base-content/50">
+    <p class="text-sm">@Model</p>
+</div>


### PR DESCRIPTION
## Summary

- Four views (`Market/Vix`, `Market/PutCallRatio`, `Cftc/Show`, `EconomicData/Show`) each repeated an identical inline empty-state block — `<div class="text-center py-8 text-base-content/50"><p class="text-sm">…</p></div>` — differing only by the message text.
- Extracted it into a new `_EmptyStateInline.cshtml` partial (`@model string`). This is the compact in-panel empty state and is distinct from the existing `_EmptyStateCard` (a full card), so no existing component covered it.

## Code changes

- `src/Equibles.Web/Views/Shared/_EmptyStateInline.cshtml` — new partial rendering the inline empty-state markup, with the message passed as the model.
- `src/Equibles.Web/Views/Market/Vix.cshtml`, `Market/PutCallRatio.cshtml`, `Cftc/Show.cshtml`, `EconomicData/Show.cshtml` — replaced the inline block with `<partial name="_EmptyStateInline" model='"…"' />`. Rendered HTML is unchanged; only the message varies per view.