### PR TITLE
test(holdings): pin Realtime13FIngestionService.SelectCoverPage returns null when absent

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Realtime13FIngestionServiceSelectCoverPageMissingTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13FIngestionServiceSelectCoverPageMissingTests.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Realtime13FIngestionServiceSelectCoverPageMissingTests
+{
+    // SelectCoverPage locates the filing's primary_doc.xml among its artifacts. When none is
+    // present it must return null so the caller skips the filing ("no primary_doc.xml, skipping")
+    // rather than mis-picking a non-cover artifact. The existing test only covers the match case;
+    // this pins the no-match → null branch. A fallback-to-first regression would break it.
+    [Fact]
+    public void SelectCoverPage_NoPrimaryDocArtifact_ReturnsNull()
+    {
+        List<string> artifacts = ["form13fInfoTable.xml", "primary_doc.xsd"];
+
+        var method = typeof(Realtime13FIngestionService).GetMethod(
+            "SelectCoverPage",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var result = (string)method.Invoke(null, [artifacts]);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the no-match branch of `Realtime13FIngestionService.SelectCoverPage`: when the filing's artifacts contain no `primary_doc.xml`, it returns null so the caller skips the filing rather than mis-picking a non-cover artifact.
- The existing test only covers the case-insensitive match; this covers the absent-cover-page → null branch (a near-miss `primary_doc.xsd` must not match). A fallback-to-first regression would break it.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Realtime13FIngestionServiceSelectCoverPageMissingTests.cs` — new unit test: `SelectCoverPage(["form13fInfoTable.xml", "primary_doc.xsd"])` returns null (reflection-invokes the private static method).