### PR TITLE
test(holdings): pin OrderedInfoTableCandidates empty when only cover and non-xml

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Realtime13FIngestionServiceOrderedInfoTableCandidatesEmptyTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13FIngestionServiceOrderedInfoTableCandidatesEmptyTests.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Realtime13FIngestionServiceOrderedInfoTableCandidatesEmptyTests
+{
+    // The information table is one of the filing's NON-cover .xml artifacts. A filing carrying only
+    // its cover doc (primary_doc.xml) plus a non-.xml file has no info-table candidate, so the
+    // result must be empty. The existing tests check exclusion WITH a real table present; this pins
+    // the all-excluded boundary so a regression admitting primary_doc or non-xml is caught.
+    [Fact]
+    public void OrderedInfoTableCandidates_OnlyCoverDocAndNonXml_ReturnsEmpty()
+    {
+        List<string> artifacts = ["primary_doc.xml", "primary_doc.html"];
+
+        var method = typeof(Realtime13FIngestionService).GetMethod(
+            "OrderedInfoTableCandidates",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var result = (IEnumerable<string>)method.Invoke(null, [artifacts]);
+
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the all-excluded boundary of `Realtime13FIngestionService.OrderedInfoTableCandidates`: a filing carrying only its cover doc (`primary_doc.xml`) plus a non-`.xml` file has no info-table candidate, so the result is empty.
- The existing tests check exclusion with a real table present; this covers the empty boundary, catching a regression that would admit the cover doc or a non-xml artifact.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Realtime13FIngestionServiceOrderedInfoTableCandidatesEmptyTests.cs` — new unit test: `OrderedInfoTableCandidates(["primary_doc.xml", "primary_doc.html"])` is empty (reflection-invokes the private static method).