### PR TITLE
refactor(views): extract repeated scrollable-table shell into ScrollTableTagHelper

### DIFF
--- a/src/Equibles.Web/TagHelpers/ScrollTableTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/ScrollTableTagHelper.cs
@@ -1,0 +1,26 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.Web.TagHelpers;
+
+// Wraps tabular content in the standard vertical-scroll (max-h) + zebra-table shell
+// used by the market and economic-data history tables, so the shared markup lives in
+// one place. Differs from <table-card> (no card wrapper, scrollable height, aria-label).
+[HtmlTargetElement("scroll-table")]
+public class ScrollTableTagHelper : TagHelper
+{
+    [HtmlAttributeName("aria-label")]
+    public string AriaLabel { get; set; }
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        output.TagName = "div";
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.Attributes.SetAttribute("class", "overflow-x-auto max-h-[400px] overflow-y-auto");
+        var label = HtmlEncoder.Default.Encode(AriaLabel ?? string.Empty);
+        output.PreContent.SetHtmlContent(
+            $"<table class=\"table table-zebra table-sm\" aria-label=\"{label}\">"
+        );
+        output.PostContent.SetHtmlContent("</table>");
+    }
+}

--- a/src/Equibles.Web/Views/Cftc/Show.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Show.cshtml
@@ -90,44 +90,42 @@
             @if (Model.Reports.Count == 0) {
                 <partial name="_EmptyStateInline" model='"No reports yet"' />
             } else {
-                <div class="overflow-x-auto max-h-[400px] overflow-y-auto">
-                    <table class="table table-zebra table-sm" aria-label="Position history">
-                        <thead class="sticky top-0 bg-base-100 z-10">
+                <scroll-table aria-label="Position history">
+                    <thead class="sticky top-0 bg-base-100 z-10">
+                        <tr>
+                            <th scope="col">Date</th>
+                            <th scope="col" class="text-right">Open Interest</th>
+                            <th scope="col" class="text-right hidden sm:table-cell">Comm Long</th>
+                            <th scope="col" class="text-right hidden sm:table-cell">Comm Short</th>
+                            <th scope="col" class="text-right hidden md:table-cell">Non-Comm Long</th>
+                            <th scope="col" class="text-right hidden md:table-cell">Non-Comm Short</th>
+                            <th scope="col" class="text-right hidden lg:table-cell">Spreads</th>
+                            <th scope="col" class="text-right hidden lg:table-cell">Change OI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var report in Model.Reports) {
                             <tr>
-                                <th scope="col">Date</th>
-                                <th scope="col" class="text-right">Open Interest</th>
-                                <th scope="col" class="text-right hidden sm:table-cell">Comm Long</th>
-                                <th scope="col" class="text-right hidden sm:table-cell">Comm Short</th>
-                                <th scope="col" class="text-right hidden md:table-cell">Non-Comm Long</th>
-                                <th scope="col" class="text-right hidden md:table-cell">Non-Comm Short</th>
-                                <th scope="col" class="text-right hidden lg:table-cell">Spreads</th>
-                                <th scope="col" class="text-right hidden lg:table-cell">Change OI</th>
+                                <td class="font-mono text-sm">@report.ReportDate.ToString("yyyy-MM-dd")</td>
+                                <td class="text-right font-semibold tabular-nums">@report.OpenInterest.ToString("N0")</td>
+                                <td class="text-right tabular-nums hidden sm:table-cell">@report.CommLong.ToString("N0")</td>
+                                <td class="text-right tabular-nums hidden sm:table-cell">@report.CommShort.ToString("N0")</td>
+                                <td class="text-right tabular-nums hidden md:table-cell">@report.NonCommLong.ToString("N0")</td>
+                                <td class="text-right tabular-nums hidden md:table-cell">@report.NonCommShort.ToString("N0")</td>
+                                <td class="text-right tabular-nums hidden lg:table-cell">@report.NonCommSpreads.ToString("N0")</td>
+                                <td class="text-right tabular-nums hidden lg:table-cell">
+                                    @if (report.ChangeOpenInterest.HasValue) {
+                                        <span class="@(report.ChangeOpenInterest.Value.SignCss("text-base-content/50"))">
+                                            @report.ChangeOpenInterest.Value.ToStringWithSign("N0")
+                                        </span>
+                                    } else {
+                                        <span class="text-base-content/30">&mdash;</span>
+                                    }
+                                </td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var report in Model.Reports) {
-                                <tr>
-                                    <td class="font-mono text-sm">@report.ReportDate.ToString("yyyy-MM-dd")</td>
-                                    <td class="text-right font-semibold tabular-nums">@report.OpenInterest.ToString("N0")</td>
-                                    <td class="text-right tabular-nums hidden sm:table-cell">@report.CommLong.ToString("N0")</td>
-                                    <td class="text-right tabular-nums hidden sm:table-cell">@report.CommShort.ToString("N0")</td>
-                                    <td class="text-right tabular-nums hidden md:table-cell">@report.NonCommLong.ToString("N0")</td>
-                                    <td class="text-right tabular-nums hidden md:table-cell">@report.NonCommShort.ToString("N0")</td>
-                                    <td class="text-right tabular-nums hidden lg:table-cell">@report.NonCommSpreads.ToString("N0")</td>
-                                    <td class="text-right tabular-nums hidden lg:table-cell">
-                                        @if (report.ChangeOpenInterest.HasValue) {
-                                            <span class="@(report.ChangeOpenInterest.Value.SignCss("text-base-content/50"))">
-                                                @report.ChangeOpenInterest.Value.ToStringWithSign("N0")
-                                            </span>
-                                        } else {
-                                            <span class="text-base-content/30">&mdash;</span>
-                                        }
-                                    </td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                </div>
+                        }
+                    </tbody>
+                </scroll-table>
             }
         </div>
     </div>

--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -106,41 +106,39 @@
             @if (Model.Observations.Count == 0) {
                 <partial name="_EmptyStateInline" model='"No observations yet"' />
             } else {
-                <div class="overflow-x-auto max-h-[400px] overflow-y-auto">
-                    <table class="table table-zebra table-sm" aria-label="Series observations">
-                        <thead class="sticky top-0 bg-base-100 z-10">
+                <scroll-table aria-label="Series observations">
+                    <thead class="sticky top-0 bg-base-100 z-10">
+                        <tr>
+                            <th scope="col">Date</th>
+                            <th scope="col" class="text-right">Value</th>
+                            <th scope="col" class="text-right hidden sm:table-cell">Change %</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @for (var i = 0; i < Model.Observations.Count; i++) {
+                            var obs = Model.Observations[i];
+                            var prev = i + 1 < Model.Observations.Count ? Model.Observations[i + 1] : null;
+                            var pctChange = obs.Value.HasValue && prev?.Value != null && prev.Value.Value != 0
+                                ? (obs.Value.Value - prev.Value.Value) / prev.Value.Value * 100
+                                : (decimal?)null;
                             <tr>
-                                <th scope="col">Date</th>
-                                <th scope="col" class="text-right">Value</th>
-                                <th scope="col" class="text-right hidden sm:table-cell">Change %</th>
+                                <td class="font-mono text-sm">@obs.Date.ToString("yyyy-MM-dd")</td>
+                                <td class="text-right font-semibold tabular-nums">
+                                    @if (obs.Value.HasValue) {
+                                        @obs.Value.Value.ToString("N2")
+                                    } else {
+                                        <span class="text-base-content/30">&mdash;</span>
+                                    }
+                                </td>
+                                <td class="text-right text-sm tabular-nums hidden sm:table-cell @(pctChange.SignCss("text-base-content/50"))">
+                                    @if (pctChange.HasValue) {
+                                        @pctChange.Value.ToStringWithSign("N2")<text>%</text>
+                                    }
+                                </td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            @for (var i = 0; i < Model.Observations.Count; i++) {
-                                var obs = Model.Observations[i];
-                                var prev = i + 1 < Model.Observations.Count ? Model.Observations[i + 1] : null;
-                                var pctChange = obs.Value.HasValue && prev?.Value != null && prev.Value.Value != 0
-                                    ? (obs.Value.Value - prev.Value.Value) / prev.Value.Value * 100
-                                    : (decimal?)null;
-                                <tr>
-                                    <td class="font-mono text-sm">@obs.Date.ToString("yyyy-MM-dd")</td>
-                                    <td class="text-right font-semibold tabular-nums">
-                                        @if (obs.Value.HasValue) {
-                                            @obs.Value.Value.ToString("N2")
-                                        } else {
-                                            <span class="text-base-content/30">&mdash;</span>
-                                        }
-                                    </td>
-                                    <td class="text-right text-sm tabular-nums hidden sm:table-cell @(pctChange.SignCss("text-base-content/50"))">
-                                        @if (pctChange.HasValue) {
-                                            @pctChange.Value.ToStringWithSign("N2")<text>%</text>
-                                        }
-                                    </td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                </div>
+                        }
+                    </tbody>
+                </scroll-table>
             }
         </div>
     </div>

--- a/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
+++ b/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
@@ -75,42 +75,40 @@
             @if (Model.Records.Count == 0) {
                 <partial name="_EmptyStateInline" model='"No data yet"' />
             } else {
-                <div class="overflow-x-auto max-h-[400px] overflow-y-auto">
-                    <table class="table table-zebra table-sm" aria-label="Put / call ratio history">
-                        <thead class="sticky top-0 bg-base-100 z-10">
+                <scroll-table aria-label="Put / call ratio history">
+                    <thead class="sticky top-0 bg-base-100 z-10">
+                        <tr>
+                            <th scope="col">Date</th>
+                            <th scope="col" class="text-right">Call Vol</th>
+                            <th scope="col" class="text-right">Put Vol</th>
+                            <th scope="col" class="text-right hidden sm:table-cell">Total Vol</th>
+                            <th scope="col" class="text-right">P/C Ratio</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var record in tableRecords) {
                             <tr>
-                                <th scope="col">Date</th>
-                                <th scope="col" class="text-right">Call Vol</th>
-                                <th scope="col" class="text-right">Put Vol</th>
-                                <th scope="col" class="text-right hidden sm:table-cell">Total Vol</th>
-                                <th scope="col" class="text-right">P/C Ratio</th>
+                                <td class="font-mono text-sm">@record.Date.ToString("yyyy-MM-dd")</td>
+                                <td class="text-right tabular-nums">
+                                    @if (record.CallVolume != null) {
+                                        <compactable-number value="@((decimal)record.CallVolume)" />
+                                    }
+                                </td>
+                                <td class="text-right tabular-nums">
+                                    @if (record.PutVolume != null) {
+                                        <compactable-number value="@((decimal)record.PutVolume)" />
+                                    }
+                                </td>
+                                <td class="text-right tabular-nums hidden sm:table-cell">
+                                    @if (record.TotalVolume != null) {
+                                        <compactable-number value="@((decimal)record.TotalVolume)" />
+                                    }
+                                </td>
+                                <td class="text-right font-semibold tabular-nums">@record.PutCallRatio?.ToString("N2")</td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var record in tableRecords) {
-                                <tr>
-                                    <td class="font-mono text-sm">@record.Date.ToString("yyyy-MM-dd")</td>
-                                    <td class="text-right tabular-nums">
-                                        @if (record.CallVolume != null) {
-                                            <compactable-number value="@((decimal)record.CallVolume)" />
-                                        }
-                                    </td>
-                                    <td class="text-right tabular-nums">
-                                        @if (record.PutVolume != null) {
-                                            <compactable-number value="@((decimal)record.PutVolume)" />
-                                        }
-                                    </td>
-                                    <td class="text-right tabular-nums hidden sm:table-cell">
-                                        @if (record.TotalVolume != null) {
-                                            <compactable-number value="@((decimal)record.TotalVolume)" />
-                                        }
-                                    </td>
-                                    <td class="text-right font-semibold tabular-nums">@record.PutCallRatio?.ToString("N2")</td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                </div>
+                        }
+                    </tbody>
+                </scroll-table>
             }
         </div>
     </div>

--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -92,30 +92,28 @@
             @if (Model.Records.Count == 0) {
                 <partial name="_EmptyStateInline" model='"No data yet"' />
             } else {
-                <div class="overflow-x-auto max-h-[400px] overflow-y-auto">
-                    <table class="table table-zebra table-sm" aria-label="VIX daily values">
-                        <thead class="sticky top-0 bg-base-100 z-10">
+                <scroll-table aria-label="VIX daily values">
+                    <thead class="sticky top-0 bg-base-100 z-10">
+                        <tr>
+                            <th scope="col">Date</th>
+                            <th scope="col" class="text-right hidden sm:table-cell">Open</th>
+                            <th scope="col" class="text-right hidden sm:table-cell">High</th>
+                            <th scope="col" class="text-right hidden sm:table-cell">Low</th>
+                            <th scope="col" class="text-right">Close</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var record in tableRecords) {
                             <tr>
-                                <th scope="col">Date</th>
-                                <th scope="col" class="text-right hidden sm:table-cell">Open</th>
-                                <th scope="col" class="text-right hidden sm:table-cell">High</th>
-                                <th scope="col" class="text-right hidden sm:table-cell">Low</th>
-                                <th scope="col" class="text-right">Close</th>
+                                <td class="font-mono text-sm">@record.Date.ToString("yyyy-MM-dd")</td>
+                                <td class="text-right tabular-nums hidden sm:table-cell">@record.Open.ToString("N2")</td>
+                                <td class="text-right tabular-nums hidden sm:table-cell">@record.High.ToString("N2")</td>
+                                <td class="text-right tabular-nums hidden sm:table-cell">@record.Low.ToString("N2")</td>
+                                <td class="text-right font-semibold tabular-nums">@record.Close.ToString("N2")</td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var record in tableRecords) {
-                                <tr>
-                                    <td class="font-mono text-sm">@record.Date.ToString("yyyy-MM-dd")</td>
-                                    <td class="text-right tabular-nums hidden sm:table-cell">@record.Open.ToString("N2")</td>
-                                    <td class="text-right tabular-nums hidden sm:table-cell">@record.High.ToString("N2")</td>
-                                    <td class="text-right tabular-nums hidden sm:table-cell">@record.Low.ToString("N2")</td>
-                                    <td class="text-right font-semibold tabular-nums">@record.Close.ToString("N2")</td>
-                                </tr>
-                            }
-                        </tbody>
-                    </table>
-                </div>
+                        }
+                    </tbody>
+                </scroll-table>
             }
         </div>
     </div>


### PR DESCRIPTION
## Summary

- Four history tables (`Market/Vix`, `Market/PutCallRatio`, `Cftc/Show`, `EconomicData/Show`) repeated an identical scrollable-table shell — `<div class="overflow-x-auto max-h-[400px] overflow-y-auto"><table class="table table-zebra table-sm" aria-label="…">…</table></div>` — differing only by the aria-label and the inner `thead`/`tbody`.
- Extracted it into a new `<scroll-table aria-label="…">` Tag Helper, mirroring the existing `TableCardTagHelper` precedent (this variant has no card wrapper, a scrollable max-height, and an aria-label).

## Code changes

- `src/Equibles.Web/TagHelpers/ScrollTableTagHelper.cs` — new Tag Helper rendering the `div` scroll wrapper + `table` shell, with the aria-label as an attribute (HTML-encoded). Lives under `TagHelpers/`, which Tailwind already scans (`@source`), so the arbitrary `max-h-[400px]` class is still generated.
- `Market/Vix.cshtml`, `Market/PutCallRatio.cshtml`, `Cftc/Show.cshtml`, `EconomicData/Show.cshtml` — replaced the inline shell with `<scroll-table>`; inner `thead`/`tbody` are unchanged (re-indented one level since nesting decreased). Rendered HTML is identical.