### PR TITLE
test(cboe): pin CboeImportService.MapProduct throws on undefined product

### DIFF
--- a/tests/Equibles.UnitTests/Cboe/CboeImportServiceMapProductTests.cs
+++ b/tests/Equibles.UnitTests/Cboe/CboeImportServiceMapProductTests.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using Equibles.Cboe.HostedService.Services;
+using Equibles.Integrations.Cboe.Models;
+
+namespace Equibles.UnitTests.Cboe;
+
+public class CboeImportServiceMapProductTests
+{
+    // MapProduct maps each known CBOE put/call product to its persisted ratio type. An undefined
+    // product value must fail fast with ArgumentOutOfRangeException, never silently mis-map (e.g. a
+    // new product added to the source enum but not here). The Import tests only exercise the known
+    // products; this pins the catch-all throw. Oracle from the out-of-range-enum contract.
+    [Fact]
+    public void MapProduct_UndefinedProduct_ThrowsArgumentOutOfRange()
+    {
+        var method = typeof(CboeImportService).GetMethod(
+            "MapProduct",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var act = () => method.Invoke(null, [(CboePutCallProductType)999]);
+
+        act.Should()
+            .Throw<TargetInvocationException>()
+            .WithInnerException<ArgumentOutOfRangeException>();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the catch-all of `CboeImportService.MapProduct`: an undefined `CboePutCallProductType` throws `ArgumentOutOfRangeException` (fail-fast), never silently mis-mapping.
- The Import tests exercise only the known products; this covers the `_ => throw` branch, catching a regression where a new source product is added but not mapped here.

## Code changes

- `tests/Equibles.UnitTests/Cboe/CboeImportServiceMapProductTests.cs` — new unit test: `MapProduct((CboePutCallProductType)999)` throws `ArgumentOutOfRangeException` (reflection-invokes the private static method; assertion unwraps the `TargetInvocationException`).