### PR TITLE
refactor(views): route hand-rolled Cftc stat cards through the _MetricCard partial

### DIFF
--- a/src/Equibles.Web/Views/Cftc/Show.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Show.cshtml
@@ -40,30 +40,10 @@
             <span class="text-xs text-base-content/50">@latest.ReportDate.ToString("yyyy-MM-dd")</span>
         </div>
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Open Interest</div>
-                    <div class="text-lg font-bold tabular-nums">@latest.OpenInterest.ToString("N0")</div>
-                </div>
-            </div>
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Commercial Net</div>
-                    <div class="text-lg font-bold tabular-nums">@((latest.CommLong - latest.CommShort).ToString("N0"))</div>
-                </div>
-            </div>
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Non-Commercial Net</div>
-                    <div class="text-lg font-bold tabular-nums">@((latest.NonCommLong - latest.NonCommShort).ToString("N0"))</div>
-                </div>
-            </div>
-            <div class="card bg-base-100 shadow-sm">
-                <div class="card-body p-3">
-                    <div class="text-xs text-base-content/50 uppercase tracking-wider">Spreads</div>
-                    <div class="text-lg font-bold tabular-nums">@latest.NonCommSpreads.ToString("N0")</div>
-                </div>
-            </div>
+            <partial name="_MetricCard" model='(Label: "Open Interest", Value: latest.OpenInterest.ToString("N0"))' />
+            <partial name="_MetricCard" model='(Label: "Commercial Net", Value: (latest.CommLong - latest.CommShort).ToString("N0"))' />
+            <partial name="_MetricCard" model='(Label: "Non-Commercial Net", Value: (latest.NonCommLong - latest.NonCommShort).ToString("N0"))' />
+            <partial name="_MetricCard" model='(Label: "Spreads", Value: latest.NonCommSpreads.ToString("N0"))' />
         </div>
     }
 


### PR DESCRIPTION
## Summary

- `Cftc/Show` hand-rolled four stat cards whose markup is byte-identical to the existing `_MetricCard` partial (`card > card-body p-3 > label + bold value`), differing only by label and value.
- Routed them through `_MetricCard`, matching how `Market/Vix` and `EconomicData/Show` already render their stat tiles.

## Code changes

- `src/Equibles.Web/Views/Cftc/Show.cshtml` — replaced the four inline stat-card blocks (Open Interest, Commercial Net, Non-Commercial Net, Spreads) with `<partial name="_MetricCard" model='(Label: …, Value: …)' />`. Rendered HTML is unchanged; the grid wrapper and the surrounding `@if (latest != null)` guard are untouched.