### PR TITLE
test(finra): pin AggregateVolumesByStock coalesces null volumes to zero

### DIFF
--- a/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockNullVolumeTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockNullVolumeTests.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.HostedService.Services;
+using Equibles.Integrations.Finra.Models;
+
+namespace Equibles.UnitTests.Finra;
+
+public class ShortVolumeImportServiceAggregateVolumesByStockNullVolumeTests
+{
+    // The volume fields on a FINRA record are nullable; AggregateVolumesByStock coalesces each with
+    // `?? 0`. A record with a TRACKED symbol but null volumes must still aggregate (as 0), never NRE
+    // and never be skipped. The existing triad pins the foreach GUARD branches (sum / unknown-symbol
+    // / null-symbol), not this volume-null coalesce. Oracle from the contract, not the body.
+    [Fact]
+    public void AggregateVolumesByStock_MappedRecordWithNullVolumes_AggregatesAsZeroWithoutThrowing()
+    {
+        var method = typeof(ShortVolumeImportService).GetMethod(
+            "AggregateVolumesByStock",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var stockId = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = stockId };
+        var records = new List<ShortVolumeRecord>
+        {
+            new()
+            {
+                Symbol = "AAPL",
+                ShortVolume = null,
+                ShortExemptVolume = null,
+                TotalVolume = null,
+            },
+        };
+
+        var result =
+            (Dictionary<Guid, DailyShortVolume>)
+                method.Invoke(null, [records, tickerMap, new DateOnly(2024, 9, 30)]);
+
+        result.Should().ContainKey(stockId);
+        result[stockId].ShortVolume.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the volume-field `?? 0` coalesce in `ShortVolumeImportService.AggregateVolumesByStock`: a record with a tracked symbol but null volume fields still aggregates (as 0) rather than throwing or being skipped.
- The existing triad pins the foreach guard branches (sum / unknown-symbol / null-symbol); this covers the distinct volume-null arm. A regression dropping the coalesce (e.g. `.Value`) would NRE on a partial FINRA row.

## Code changes

- `tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockNullVolumeTests.cs` — new unit test: a mapped record with null `ShortVolume`/`ShortExemptVolume`/`TotalVolume` yields an aggregated entry with `ShortVolume == 0` (reflection-invokes the private static method).