### PR TITLE
refactor(views): route hand-rolled chart cards through the _ChartCard partial

### DIFF
--- a/src/Equibles.Web/Views/Cftc/Show.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Show.cshtml
@@ -48,15 +48,7 @@
     }
 
     @if (chronological.Count > 0) {
-        <!-- Chart -->
-        <div class="card bg-base-100 shadow-sm mb-6">
-            <div class="card-body p-4 lg:p-6">
-                <h2 class="font-semibold text-sm mb-3">Net Positioning</h2>
-                <div class="h-[320px]">
-                    <canvas id="cftc-chart" role="img" aria-label="CFTC net positioning over time"></canvas>
-                </div>
-            </div>
-        </div>
+        <partial name="_ChartCard" model='("Net Positioning", "cftc-chart", "CFTC net positioning over time", "h-[320px]", "mb-6")' />
     }
 
     <!-- Data Table -->

--- a/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
+++ b/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
@@ -53,15 +53,7 @@
     </div>
 
     @if (chronological.Count > 0) {
-        <!-- Chart -->
-        <div class="card bg-base-100 shadow-sm mb-6">
-            <div class="card-body p-4 lg:p-6">
-                <h2 class="font-semibold text-sm mb-3">@Model.DisplayName P/C Ratio</h2>
-                <div class="h-[320px]">
-                    <canvas id="pcr-chart" role="img" aria-label="Put / call ratio history"></canvas>
-                </div>
-            </div>
-        </div>
+        <partial name="_ChartCard" model='($"{Model.DisplayName} P/C Ratio", "pcr-chart", "Put / call ratio history", "h-[320px]", "mb-6")' />
     }
 
     <!-- Data Table -->

--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -70,15 +70,7 @@
     </div>
 
     @if (chronological.Count > 0) {
-        <!-- Chart -->
-        <div class="card bg-base-100 shadow-sm mb-6">
-            <div class="card-body p-4 lg:p-6">
-                <h2 class="font-semibold text-sm mb-3">VIX Close</h2>
-                <div class="h-[320px]">
-                    <canvas id="vix-chart" role="img" aria-label="VIX daily close history"></canvas>
-                </div>
-            </div>
-        </div>
+        <partial name="_ChartCard" model='("VIX Close", "vix-chart", "VIX daily close history", "h-[320px]", "mb-6")' />
     }
 
     <!-- Data Table -->


### PR DESCRIPTION
## Summary

- `Market/Vix`, `Market/PutCallRatio`, and `Cftc/Show` each hand-rolled a chart card whose markup is byte-identical to the existing `_ChartCard` partial (`card > card-body > h2 + height div > canvas`), differing only by title, canvas id, and aria-label.
- Routed them through `_ChartCard`, matching how `EconomicData/Show`, `HoldingsActivity/*`, and the stock tabs already render their charts.

## Code changes

- `src/Equibles.Web/Views/Market/Vix.cshtml`, `Market/PutCallRatio.cshtml`, `Cftc/Show.cshtml` — replaced the inline chart-card block with `<partial name="_ChartCard" model='(Title, ChartId, AriaLabel, "h-[320px]", "mb-6")' />`. Rendered HTML is unchanged; the surrounding `@if (… > 0)` guard and the chart JS (which looks the canvas up by id) are untouched.