### PR TITLE
test(yahoo): pin HasOverflowPrice Low arm flags overflow

### DIFF
--- a/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceLowArmOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceLowArmOverflowTests.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using Equibles.Integrations.Yahoo.Models;
+using Equibles.Yahoo.HostedService.Services;
+
+namespace Equibles.UnitTests.Yahoo;
+
+public class YahooPriceImportServiceLowArmOverflowTests
+{
+    private static readonly MethodInfo HasOverflowPriceMethod =
+        typeof(YahooPriceImportService).GetMethod(
+            "HasOverflowPrice",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    // Completes the per-arm sweep of HasOverflowPrice's 5-arm OR chain
+    // (Open || High || Low || Close || AdjustedClose). Open/High/Close/AdjustedClose are pinned by
+    // siblings; Low is the last unpinned interior arm. Dropping the `Math.Abs(p.Low) > Max` clause
+    // would compile and pass every sibling, re-introducing a numeric-overflow crash for a corrupted
+    // Low value. Adversarial input: only Low exceeds the ceiling → must return true.
+    [Fact]
+    public void HasOverflowPrice_OnlyLowExceedsCeiling_ReturnsTrue()
+    {
+        var price = new HistoricalPrice
+        {
+            Open = 150.25m,
+            High = 151.45m,
+            Low = 200_000_000_000_000m,
+            Close = 150.90m,
+            AdjustedClose = 150.50m,
+        };
+
+        var result = (bool)HasOverflowPriceMethod.Invoke(null, [price]);
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Completes the per-arm sweep of `YahooPriceImportService.HasOverflowPrice`'s 5-arm OR chain: the `Low` arm was the last unpinned one (Open/High/Close/AdjustedClose already have sibling tests).
- A price where only `Low` exceeds the numeric ceiling must be flagged as overflow (true). Dropping the `Math.Abs(p.Low) > Max` clause would compile, pass every sibling, and re-introduce a numeric-overflow crash on a corrupted Low value.

## Code changes

- `tests/Equibles.UnitTests/Yahoo/YahooPriceImportServiceLowArmOverflowTests.cs` — new unit test: a price with only `Low` over the ceiling returns true (reflection-invokes the private static `HasOverflowPrice`).