### PR TITLE
test(sec): pin IsTransientNetworkError returns false for unrelated inner exception

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientIsTransientNetworkErrorNonTransientTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientIsTransientNetworkErrorNonTransientTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Equibles.Integrations.Sec;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecEdgarClientIsTransientNetworkErrorNonTransientTests
+{
+    // IsTransientNetworkError classifies an HttpRequestException as retryable only when its inner
+    // exception is Socket/IO/Authentication. An inner exception OUTSIDE that set must return false,
+    // so a genuinely non-transient failure surfaces instead of looping the retry forever. The three
+    // arm pins are all POSITIVE; only this catches a regression that broadens the `is` pattern.
+    [Fact]
+    public void IsTransientNetworkError_UnrelatedInnerException_ReturnsFalse()
+    {
+        var method = typeof(SecEdgarClient).GetMethod(
+            "IsTransientNetworkError",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var wrapped = new HttpRequestException(
+            "Permanent failure",
+            new InvalidOperationException("not a transport error")
+        );
+
+        var result = (bool)method!.Invoke(null, [wrapped]);
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the negative case of `SecEdgarClient.IsTransientNetworkError`: an `HttpRequestException` whose inner exception is outside the Socket/IO/Authentication set is NOT transient and returns false, so a genuinely permanent failure surfaces instead of looping the retry.
- The three existing arm tests are all positive; only this catches a regression that broadens the `is` pattern (e.g. `or Exception`), which would mark every error retryable.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecEdgarClientIsTransientNetworkErrorNonTransientTests.cs` — new unit test: an `HttpRequestException` wrapping an `InvalidOperationException` returns false (reflection-invokes the private static predicate).