### PR TITLE
test(sec): pin IsMissingIndexError AccessDenied arm returns true

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/Sec/SecEdgarClientIsMissingIndexErrorAccessDeniedTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/Sec/SecEdgarClientIsMissingIndexErrorAccessDeniedTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Equibles.Integrations.Sec;
+
+namespace Equibles.UnitTests.Integrations.Sec;
+
+public class SecEdgarClientIsMissingIndexErrorAccessDeniedTests
+{
+    // IsMissingIndexError returns true when the S3 403 body carries AccessDenied or NoSuchKey —
+    // the non-trading-day signature that authorizes skipping the day. The existing test only pins
+    // the negative (throttle page) case; both positive arms are unpinned. This pins the
+    // AccessDenied arm so dropping it doesn't turn a quiet weekend skip into a paging error.
+    [Fact]
+    public void IsMissingIndexError_AccessDeniedBody_ReturnsTrue()
+    {
+        const string s3Body =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>";
+
+        var method = typeof(SecEdgarClient).GetMethod(
+            "IsMissingIndexError",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (bool)method!.Invoke(null, [s3Body]);
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the AccessDenied positive arm of `SecEdgarClient.IsMissingIndexError`: an S3 403 body carrying `AccessDenied` is classified as a missing index (non-trading-day signal) → true, so the scraper skips the day quietly.
- The existing test only pins the negative (throttle page) case; both positive arms (AccessDenied / NoSuchKey) were unpinned. Dropping the AccessDenied check would turn a weekend skip into a paging error.

## Code changes

- `tests/Equibles.UnitTests/Integrations/Sec/SecEdgarClientIsMissingIndexErrorAccessDeniedTests.cs` — new unit test: an S3 `<Error><Code>AccessDenied</Code>` body returns true (reflection-invokes the private static predicate).