### PR TITLE
refactor(views): extract repeated card-title count heading into _CountHeading partial

### DIFF
--- a/src/Equibles.Web/Views/Cftc/Show.cshtml
+++ b/src/Equibles.Web/Views/Cftc/Show.cshtml
@@ -54,10 +54,7 @@
     <!-- Data Table -->
     <div class="card bg-base-100 shadow-sm">
         <div class="card-body p-4 lg:p-6">
-            <h2 class="card-title text-lg mb-3">
-                Reports
-                <span class="text-sm font-normal text-base-content/50">(@Model.Reports.Count total)</span>
-            </h2>
+            <partial name="_CountHeading" model='("Reports", Model.Reports.Count)' />
 
             @if (Model.Reports.Count == 0) {
                 <partial name="_EmptyStateInline" model='"No reports yet"' />

--- a/src/Equibles.Web/Views/EconomicData/Show.cshtml
+++ b/src/Equibles.Web/Views/EconomicData/Show.cshtml
@@ -98,10 +98,7 @@
     <!-- Observations Table -->
     <div class="card bg-base-100 shadow-sm">
         <div class="card-body p-4 lg:p-6">
-            <h2 class="card-title text-lg mb-3">
-                Observations
-                <span class="text-sm font-normal text-base-content/50">(@Model.Observations.Count total)</span>
-            </h2>
+            <partial name="_CountHeading" model='("Observations", Model.Observations.Count)' />
 
             @if (Model.Observations.Count == 0) {
                 <partial name="_EmptyStateInline" model='"No observations yet"' />

--- a/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
+++ b/src/Equibles.Web/Views/Market/PutCallRatio.cshtml
@@ -59,10 +59,7 @@
     <!-- Data Table -->
     <div class="card bg-base-100 shadow-sm">
         <div class="card-body p-4 lg:p-6">
-            <h2 class="card-title text-lg mb-3">
-                History
-                <span class="text-sm font-normal text-base-content/50">(@Model.Records.Count total)</span>
-            </h2>
+            <partial name="_CountHeading" model='("History", Model.Records.Count)' />
 
             @if (Model.Records.Count == 0) {
                 <partial name="_EmptyStateInline" model='"No data yet"' />

--- a/src/Equibles.Web/Views/Market/Vix.cshtml
+++ b/src/Equibles.Web/Views/Market/Vix.cshtml
@@ -76,10 +76,7 @@
     <!-- Data Table -->
     <div class="card bg-base-100 shadow-sm">
         <div class="card-body p-4 lg:p-6">
-            <h2 class="card-title text-lg mb-3">
-                History
-                <span class="text-sm font-normal text-base-content/50">(@Model.Records.Count total)</span>
-            </h2>
+            <partial name="_CountHeading" model='("History", Model.Records.Count)' />
 
             @if (Model.Records.Count == 0) {
                 <partial name="_EmptyStateInline" model='"No data yet"' />

--- a/src/Equibles.Web/Views/Shared/_CountHeading.cshtml
+++ b/src/Equibles.Web/Views/Shared/_CountHeading.cshtml
@@ -1,0 +1,5 @@
+@model (string Label, int Count)
+<h2 class="card-title text-lg mb-3">
+    @Model.Label
+    <span class="text-sm font-normal text-base-content/50">(@Model.Count total)</span>
+</h2>


### PR DESCRIPTION
## Summary

- `Market/Vix`, `Market/PutCallRatio`, `Cftc/Show`, and `EconomicData/Show` each hand-rolled a byte-identical data-table heading: `<h2 class="card-title text-lg mb-3">{Label}<span class="text-sm font-normal text-base-content/50">({Count} total)</span></h2>`, differing only by the label and the count expression.
- Extracted it into a new `_CountHeading.cshtml` partial. The existing `_SectionHeading` renders a different (flex + badge) structure, so it didn't cover this.

## Code changes

- `src/Equibles.Web/Views/Shared/_CountHeading.cshtml` — new partial (`@model (string Label, int Count)`) rendering the card-title heading with the parenthetical total.
- `Market/Vix.cshtml`, `Market/PutCallRatio.cshtml`, `Cftc/Show.cshtml`, `EconomicData/Show.cshtml` — replaced the inline heading with `<partial name="_CountHeading" model='(Label, Count)' />`. Rendered HTML is unchanged.