### PR TITLE
test(holdings): pin SmartMoneyIndexManager.Build no-holdings-on-file reason

### DIFF
--- a/tests/Equibles.IntegrationTests/Holdings/SmartMoneyIndexManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/SmartMoneyIndexManagerTests.cs
@@ -121,6 +121,22 @@ public class SmartMoneyIndexManagerTests : IDisposable
         result.Reason.Should().Contain("No stock");
     }
 
+    [Fact]
+    public async Task Build_TopFundsHaveNoHoldingsOnFile_ReturnsReasonAndZeroFundCount()
+    {
+        // A scored fund exists and resolves, but has zero 13F holdings on file,
+        // so LoadLatestPortfolio yields nothing and fundPortfolios stays empty.
+        // This is distinct from "no scores": the fund ranked, it just has no portfolio.
+        SeedBenchmark();
+        SeedFund("0000000001", alpha: 30m);
+
+        var result = await _manager.Build(AsOf, benchmarkTicker: "SPY");
+
+        result.FundCount.Should().Be(0);
+        result.Constituents.Should().BeEmpty();
+        result.Reason.Should().Contain("no holdings on file");
+    }
+
     private void SeedBenchmark()
     {
         AddStock("SPY", "S&P 500 ETF", start: 100m, end: 100m);


### PR DESCRIPTION
## Summary

- The Smart Money Index falls back to a "no holdings on file" message when its top-scoring funds have been ranked but have no 13F portfolios recorded yet. That early-return branch had no test.
- Pins that branch so it can't silently regress into a crash or a misleading empty index.

## Code changes

- `tests/Equibles.IntegrationTests/Holdings/SmartMoneyIndexManagerTests.cs` — add `Build_TopFundsHaveNoHoldingsOnFile_ReturnsReasonAndZeroFundCount`: seeds a benchmark and a scored fund with zero holdings, asserts `FundCount == 0`, no constituents, and the "no holdings on file" reason. Distinct from the existing no-scores and no-consensus cases.