### PR TITLE
test(sec): pin SecRateLimitEventPublisher block event carries pause and url

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecRateLimitEventPublisherBlockedPayloadTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecRateLimitEventPublisherBlockedPayloadTests.cs
@@ -1,0 +1,32 @@
+using Equibles.Messaging.Contracts.Activity;
+using Equibles.Sec.HostedService.Services;
+using MassTransit;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Adversarial sibling to <see cref="SecRateLimitEventPublisherTests"/>, which
+/// only counts published events with <c>Arg.Any</c>. The block event drives the
+/// backoffice live-activity feed, so a refactor that swaps or drops
+/// <c>RateLimited</c>'s (pause, url) arguments would still emit exactly one event
+/// and leave every count-only test green. This pins that the payload actually
+/// carries the pause and url it was called with.
+/// </summary>
+public class SecRateLimitEventPublisherBlockedPayloadTests
+{
+    private const string Url = "https://www.sec.gov/Archives/edgar/data/1/0-0.txt";
+
+    [Fact]
+    public async Task RateLimited_OnBlockEdge_PublishesEventCarryingPauseAndUrl()
+    {
+        var bus = Substitute.For<IBus>();
+        var sut = new SecRateLimitEventPublisher(bus);
+        var pause = TimeSpan.FromMinutes(7);
+
+        await sut.RateLimited(pause, Url);
+
+        await bus.Received(1)
+            .Publish(Arg.Is<SecRateLimitBlocked>(e => e.Pause == pause && e.Url == Url));
+    }
+}


### PR DESCRIPTION
## Summary

- The rate-limit block event drives the backoffice live-activity feed, but the existing tests only count published events with `Arg.Any`, so they never check that the pause and url actually reach the payload.
- This pins the payload, closing a gap where a refactor that swaps or drops `RateLimited`'s arguments would still emit one event and leave every count-only test green.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecRateLimitEventPublisherBlockedPayloadTests.cs` — new test asserting `RateLimited(pause, url)` publishes a `SecRateLimitBlocked` whose `Pause` and `Url` equal the arguments passed.