### PR TITLE
refactor(common-stocks): collapse stale-FK batch validation into GetExistingIds extension

### DIFF
--- a/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
+++ b/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.CommonStocks.Repositories.Extensions;
 
@@ -12,5 +13,18 @@ public static class CommonStockRepositoryExtensions
     {
         var stock = await repository.GetByTicker(TickerNormalizer.Normalize(ticker));
         return stock == null ? (null, $"Stock '{ticker}' not found.") : (stock, null);
+    }
+
+    // Returns the subset of the given ids whose CommonStock still exists. Importers
+    // re-validate batches against this before insert because a parallel CompanySync can
+    // hard-delete a stock after a ticker map is built, and a dangling FK rolls back the
+    // whole batch.
+    public static Task<HashSet<Guid>> GetExistingIds(
+        this CommonStockRepository repository,
+        IEnumerable<Guid> ids,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return repository.GetByIds(ids).Select(s => s.Id).ToHashSetAsync(cancellationToken);
     }
 }

--- a/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
@@ -1,4 +1,5 @@
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
@@ -268,11 +269,7 @@ public class ShortInterestImportService
         var repo = scope.ServiceProvider.GetRequiredService<ShortInterestRepository>();
 
         var batchStockIds = batch.Select(b => b.CommonStockId).Distinct().ToList();
-        var liveStockIds = await stockRepo
-            .GetAll()
-            .Where(s => batchStockIds.Contains(s.Id))
-            .Select(s => s.Id)
-            .ToHashSetAsync(cancellationToken);
+        var liveStockIds = await stockRepo.GetExistingIds(batchStockIds, cancellationToken);
 
         var validBatch = batch.Where(b => liveStockIds.Contains(b.CommonStockId)).ToList();
         var dropped = batch.Count - validBatch.Count;

--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -1,4 +1,5 @@
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
@@ -119,11 +120,10 @@ public class ShortVolumeImportService
                     // hard-deletes/replaces a stock in parallel. Re-validate each batch against the
                     // current CommonStock table so dangling-FK inserts don't poison the whole batch.
                     var batchStockIds = batch.Select(b => b.CommonStockId).Distinct().ToList();
-                    var liveStockIds = await stockRepo
-                        .GetAll()
-                        .Where(s => batchStockIds.Contains(s.Id))
-                        .Select(s => s.Id)
-                        .ToHashSetAsync(cancellationToken);
+                    var liveStockIds = await stockRepo.GetExistingIds(
+                        batchStockIds,
+                        cancellationToken
+                    );
 
                     var validBatch = batch
                         .Where(b => liveStockIds.Contains(b.CommonStockId))

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.IO.Compression;
 using Equibles.CommonStocks.BusinessLogic;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
 using Equibles.Errors.BusinessLogic;
@@ -223,9 +224,7 @@ public class FtdImportService
         // rolls back the entire UpsertRange — dropping rows for surviving
         // stocks alongside the orphan.
         var stockIds = items.Select(i => i.CommonStockId).Distinct().ToHashSet();
-        var existingIds = (
-            await stockRepo.GetByIds(stockIds).Select(s => s.Id).ToListAsync()
-        ).ToHashSet();
+        var existingIds = await stockRepo.GetExistingIds(stockIds);
 
         var safeItems = items.Where(i => existingIds.Contains(i.CommonStockId)).ToList();
         var skipped = items.Count - safeItems.Count;


### PR DESCRIPTION
## Summary

- The same stale-FK guard — fetch the subset of CommonStock IDs that still exist in the database before inserting a batch — was hand-rolled in three import services. Collapse it into one reusable `CommonStockRepository.GetExistingIds` extension.
- Behavior-preserving: `GetByIds(ids)` is defined as `GetAll().Where(cs => ids.Contains(cs.Id))`, so the new query is identical to the inline Finra queries; each call site keeps its own filtering and log message.

## Code changes

- `Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs` — add `GetExistingIds(ids, ct)` returning the `HashSet<Guid>` of ids whose CommonStock still exists.
- `Equibles.Finra.HostedService/Services/ShortInterestImportService.cs` — replace inline `GetAll().Where(...).Select(...).ToHashSetAsync` with the extension.
- `Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs` — same replacement.
- `Equibles.Sec.HostedService/Services/FtdImportService.cs` — replace `GetByIds(...).ToListAsync().ToHashSet()` with the extension.