### PR TITLE
test(holdings): pin Percentage.Of guards a zero total to 0 not Infinity

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/PercentageOfTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/PercentageOfTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Holdings.Repositories;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Pins Percentage.Of's divide-by-zero guard. The doc-comment promises a zero (or
+/// empty) total yields 0% rather than NaN/Infinity — an unguarded double divide would
+/// make 5/0*100 evaluate to +Infinity and poison every downstream allocation/overlap
+/// percentage that flows from an empty portfolio. Oracle derived from the contract.
+/// </summary>
+public class PercentageOfTests
+{
+    [Fact]
+    public void Of_ZeroTotalWithNonZeroValue_ReturnsZeroNotInfinity()
+    {
+        var result = Percentage.Of(5.0, 0.0);
+
+        result.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

- `Percentage.Of` guards its divide so an empty/zero total yields 0% rather than NaN/Infinity, but the guard had no test — every production caller passes a non-zero total.
- Without the guard a zero-total portfolio would make `5/0*100` evaluate to +Infinity and poison every downstream allocation/overlap percentage. This pins the zero-total branch.

## Code changes

- `tests/Equibles.UnitTests/Holdings/PercentageOfTests.cs` — new test asserting `Percentage.Of(5.0, 0.0)` returns `0` (not Infinity).