### PR TITLE
test(web): pin TakeMostRecent returns highest keys in descending order

### DIFF
--- a/tests/Equibles.UnitTests/Web/QueryableExtensionsTakeMostRecentTests.cs
+++ b/tests/Equibles.UnitTests/Web/QueryableExtensionsTakeMostRecentTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+// Lane A (adversarial): TakeMostRecent promises the "most recent N rows" — it must
+// order by the key DESCENDING and cap at count, returning the highest keys newest-first.
+// A shuffled source proves it actually reorders: dropping the OrderByDescending (or
+// flipping it to ascending) would return the wrong rows. Oracle derived from the contract.
+public class QueryableExtensionsTakeMostRecentTests
+{
+    [Fact]
+    public void TakeMostRecent_ShuffledSource_ReturnsHighestKeysInDescendingOrder()
+    {
+        var source = new[] { 3, 1, 5, 2, 4 }.AsQueryable();
+
+        var result = source.TakeMostRecent(x => x, 2).ToList();
+
+        result.Should().Equal(5, 4);
+    }
+}


### PR DESCRIPTION
## Summary

- `TakeMostRecent` (added in #3364) backs the "most recent N rows" profile reads but had no test of its own.
- Pins its directional contract: ordering by key descending and capping at count, so a refactor that drops or flips the ordering can't silently return the oldest rows instead of the newest.

## Code changes

- `tests/Equibles.UnitTests/Web/QueryableExtensionsTakeMostRecentTests.cs` — new test feeding a shuffled source `{3,1,5,2,4}`, taking 2, and asserting the result is `[5, 4]` (highest keys, descending) — which also fails if the ordering were dropped entirely.