### PR TITLE
test(web): pin PageHeaderTagHelper HTML-encodes title into heading

### DIFF
--- a/tests/Equibles.UnitTests/Web/PageHeaderTagHelperTitleEncodingTests.cs
+++ b/tests/Equibles.UnitTests/Web/PageHeaderTagHelperTitleEncodingTests.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using Equibles.Web.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.UnitTests.Web;
+
+public class PageHeaderTagHelperTitleEncodingTests
+{
+    // Contract: the page-header `title` is plain data — company/profile names routinely
+    // carry an ampersand ("AT&T", "Procter & Gamble") — so it must be HTML-ENCODED into the
+    // <h1>, not written as raw markup. The implementation uses Content.Append(Title) (which
+    // encodes) rather than AppendHtml (which would not). The plausible regression: a refactor
+    // swapping Append -> AppendHtml "because it's all HTML anyway" would compile, render names
+    // with raw '&'/'<' (broken display / stored XSS for any data-driven title). Derive the
+    // oracle from the encoding contract: '&' -> &amp;, '<script>' -> &lt;script&gt;.
+    [Fact]
+    public async Task ProcessAsync_TitleWithHtmlSpecialCharacters_HtmlEncodesIntoHeading()
+    {
+        var sut = new PageHeaderTagHelper { Title = "AT&T <script>" };
+        var context = new TagHelperContext(
+            new TagHelperAttributeList(),
+            new Dictionary<object, object>(),
+            "test-id"
+        );
+        var output = new TagHelperOutput(
+            "page-header",
+            new TagHelperAttributeList(),
+            (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent())
+        );
+
+        await sut.ProcessAsync(context, output);
+
+        var rendered = Render(output.Content);
+        rendered
+            .Should()
+            .Contain("<h1 class=\"text-3xl font-bold mb-2\">AT&amp;T &lt;script&gt;</h1>");
+        rendered.Should().NotContain("<script>");
+    }
+
+    private static string Render(TagHelperContent content)
+    {
+        using var writer = new StringWriter();
+        content.WriteTo(writer, HtmlEncoder.Default);
+        return writer.ToString();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `PageHeaderTagHelper` HTML-encodes its `title` attribute when rendering the `<h1>`, rather than emitting it as raw markup.
- Titles come from data — profile and company names routinely contain an ampersand ("AT&T", "Procter & Gamble") — so encoding is both a correct-display and an injection-safety guarantee.

## Code changes

- `tests/Equibles.UnitTests/Web/PageHeaderTagHelperTitleEncodingTests.cs` — new unit test: a title containing `&` and `<script>` renders as `AT&amp;T &lt;script&gt;` inside the heading and never as raw `<script>`. Guards against a refactor swapping `Content.Append` (encodes) for `AppendHtml` (does not).