### PR TITLE
test(sec): pin ListConversionStep preserves anchor-only item without inline content div

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepAnchorOnlyItemTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepAnchorOnlyItemTests.cs
@@ -1,0 +1,37 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class ListConversionStepAnchorOnlyItemTests
+{
+    private readonly ListConversionStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    [Fact]
+    public void Execute_ItemWithoutInlineContentDiv_PreservesAnchorInsteadOfEmptyLi()
+    {
+        // Contract: when a list item has NO `<div style="display:inline">` content
+        // wrapper, the converter must fall back to the item's whole content so an
+        // anchor-only entry (SEC exhibit-index links) survives in the <li>. This is
+        // the exact regression the source comment documents: an earlier version that
+        // cloned only <span> children produced an empty <li> and dropped the reference.
+        // Oracle derived from the doc-comment, before reading the body.
+        var html =
+            "<html><body>"
+            + "<div class=\"item-list-element-wrapper\"><span>•</span>"
+            + "<a href=\"ex10-1.htm\">Exhibit 10.1</a></div>"
+            + "</body></html>";
+        var doc = _parser.ParseDocument(html);
+
+        _step.Execute(doc);
+
+        var result = doc.Body!.InnerHtml;
+        result.Should().Contain("<ul>");
+        result.Should().Contain("<li>");
+        result.Should().Contain("Exhibit 10.1");
+        result.Should().Contain("ex10-1.htm");
+        result.Should().NotContain("•");
+        result.Should().NotContain("item-list-element-wrapper");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `ListConversionStep` converts a list item lacking a `<div style="display:inline">` content wrapper by falling back to the item's whole content, so an anchor-only entry (SEC exhibit-index links) survives in the `<li>`.
- Locks in the documented fix for a past regression where cloning only `<span>` children produced an empty `<li>` and dropped the reference.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepAnchorOnlyItemTests.cs` — new unit test for the fallback branch (existing tests only cover items with an inline content div). Asserts the anchor's text and href survive the conversion.