### PR TITLE
test(insider): pin AdsRatioExtractor skips correction when price already per-ordinary

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/AdsRatioExtractorAlreadyConvertedTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/AdsRatioExtractorAlreadyConvertedTests.cs
@@ -1,0 +1,32 @@
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class AdsRatioExtractorAlreadyConvertedTests
+{
+    [Fact]
+    public void TryGetOrdinarySharesPerAds_PriceAlreadyConvertedToPerOrdinary_LeavesRowUntouched()
+    {
+        // Contract: a per-ADS price + ordinary title + a valid ratio still must NOT
+        // be corrected when a footnote says the price was ALREADY restated to a
+        // per-ordinary figure — correcting again would double-divide and under-value
+        // the row. Existing cases cover the title/ratio/multiple guards but not this
+        // "already converted" guard. Oracle derived from the doc-comment + the
+        // AlreadyConvertedMarkers contract, before reading the gating logic.
+        var notes = new[]
+        {
+            "The price reported is per ADS. Each ADS represents 12 ordinary shares; "
+                + "the per-share amount shown was converted from the price per ADS divided by the ratio.",
+        };
+
+        var corrected = AdsRatioExtractor.TryGetOrdinarySharesPerAds(
+            "Ordinary Shares",
+            notes,
+            1_200L, // exact multiple of 12, so only the already-converted guard can refuse
+            out var ratio
+        );
+
+        corrected.Should().BeFalse();
+        ratio.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `AdsRatioExtractor.TryGetOrdinarySharesPerAds` refuses to correct a row when a footnote states the price was already restated to a per-ordinary figure — even with a valid per-ADS price, ratio, and exact share-count multiple.
- Guards against a double-conversion that would under-value the row; existing cases cover the title / ratio / exact-multiple guards but not this "already converted" guard.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/AdsRatioExtractorAlreadyConvertedTests.cs` — new unit test. Inputs satisfy every other gate (ratio 12 parses, per-ADS marker present, 1,200 is an exact multiple of 12), so the already-converted marker is the only thing that can refuse the correction.