### PR TITLE
refactor(sec): name Form ADV charge-field CSV headers as constants

### DIFF
--- a/src/Equibles.Integrations.Sec/FormAdv/FormAdvCsvParser.cs
+++ b/src/Equibles.Integrations.Sec/FormAdv/FormAdvCsvParser.cs
@@ -25,6 +25,13 @@ public static class FormAdvCsvParser
     private const string DiscretionaryAumHeader = "5F(2)(a)";
     private const string NonDiscretionaryAumHeader = "5F(2)(b)";
     private const string TotalAumHeader = "5F(2)(c)";
+    private const string ChargesPercentageOfAumHeader = "5E(1)";
+    private const string ChargesHourlyHeader = "5E(2)";
+    private const string ChargesSubscriptionHeader = "5E(3)";
+    private const string ChargesFixedHeader = "5E(4)";
+    private const string ChargesCommissionsHeader = "5E(5)";
+    private const string ChargesPerformanceBasedHeader = "5E(6)";
+    private const string ChargesOtherHeader = "5E(7)";
 
     public static IEnumerable<FormAdvAdviserData> Parse(TextReader reader)
     {
@@ -83,13 +90,15 @@ public static class FormAdvCsvParser
             DiscretionaryAum = ParseAum(Field(row, columns, DiscretionaryAumHeader)),
             NonDiscretionaryAum = ParseAum(Field(row, columns, NonDiscretionaryAumHeader)),
             TotalRegulatoryAum = ParseAum(Field(row, columns, TotalAumHeader)),
-            ChargesPercentageOfAum = ParseYesNo(Field(row, columns, "5E(1)")),
-            ChargesHourly = ParseYesNo(Field(row, columns, "5E(2)")),
-            ChargesSubscription = ParseYesNo(Field(row, columns, "5E(3)")),
-            ChargesFixed = ParseYesNo(Field(row, columns, "5E(4)")),
-            ChargesCommissions = ParseYesNo(Field(row, columns, "5E(5)")),
-            ChargesPerformanceBased = ParseYesNo(Field(row, columns, "5E(6)")),
-            ChargesOther = ParseYesNo(Field(row, columns, "5E(7)")),
+            ChargesPercentageOfAum = ParseYesNo(Field(row, columns, ChargesPercentageOfAumHeader)),
+            ChargesHourly = ParseYesNo(Field(row, columns, ChargesHourlyHeader)),
+            ChargesSubscription = ParseYesNo(Field(row, columns, ChargesSubscriptionHeader)),
+            ChargesFixed = ParseYesNo(Field(row, columns, ChargesFixedHeader)),
+            ChargesCommissions = ParseYesNo(Field(row, columns, ChargesCommissionsHeader)),
+            ChargesPerformanceBased = ParseYesNo(
+                Field(row, columns, ChargesPerformanceBasedHeader)
+            ),
+            ChargesOther = ParseYesNo(Field(row, columns, ChargesOtherHeader)),
         };
     }
 


### PR DESCRIPTION
## Summary

- The Form ADV CSV parser already names every persisted column header as a `const string` near the top of the class, but the seven `5E(x)` charge-fee fields were still mapped with inline string literals — completing that convention.
- Behavior is unchanged: each new constant holds the byte-identical header string and is referenced once, so the compiled column lookups are the same.

## Code changes

- `src/Equibles.Integrations.Sec/FormAdv/FormAdvCsvParser.cs` — added `ChargesPercentageOfAumHeader` … `ChargesOtherHeader` constants for `5E(1)`–`5E(7)` and referenced them in `MapRow` instead of the inline literals.