### PR TITLE
refactor(sec): extract duplicated submissions cache lookup into GetCachedSubmissions

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -188,6 +188,23 @@ public class SecEdgarClient : ISecEdgarClient
         }
     }
 
+    // Returns the submissions payload for a URL from the single-entry cache when it
+    // matches, otherwise fetches it and caches it. logCacheHit preserves the cache-hit
+    // log line that GetCompanyFilings emitted before this was extracted.
+    private async Task<string> GetCachedSubmissions(string url, bool logCacheHit = false)
+    {
+        if (_cachedContent != null && _cachedContent.Url == url)
+        {
+            if (logCacheHit)
+                _logger.LogInformation("Using cached content for URL: {Url}", url);
+            return _cachedContent.Content;
+        }
+
+        var content = await FetchStringAsync(url);
+        _cachedContent = new CachedResponse(url, content);
+        return content;
+    }
+
     public async Task<List<FilingData>> GetCompanyFilings(
         string cik,
         DocumentTypeFilter? documentType = null,
@@ -200,17 +217,7 @@ public class SecEdgarClient : ISecEdgarClient
             var formattedCik = FormatCik(cik);
             var url = BuildUrl($"/submissions/CIK{formattedCik}.json");
 
-            string content;
-            if (_cachedContent != null && _cachedContent.Url == url)
-            {
-                _logger.LogInformation("Using cached content for URL: {Url}", url);
-                content = _cachedContent.Content;
-            }
-            else
-            {
-                content = await FetchStringAsync(url);
-                _cachedContent = new CachedResponse(url, content);
-            }
+            var content = await GetCachedSubmissions(url, logCacheHit: true);
 
             var apiResponse = JsonConvert.DeserializeObject<SecApiResponse>(content);
 
@@ -251,16 +258,7 @@ public class SecEdgarClient : ISecEdgarClient
             var formattedCik = FormatCik(cik);
             var url = BuildUrl($"/submissions/CIK{formattedCik}.json");
 
-            string content;
-            if (_cachedContent != null && _cachedContent.Url == url)
-            {
-                content = _cachedContent.Content;
-            }
-            else
-            {
-                content = await FetchStringAsync(url);
-                _cachedContent = new CachedResponse(url, content);
-            }
+            var content = await GetCachedSubmissions(url);
 
             var apiResponse = JsonConvert.DeserializeObject<SecApiResponse>(content);
             var recentFilings = MapToFilingData(apiResponse?.Filings?.Recent, cik);


### PR DESCRIPTION
## Summary

- `GetCompanyFilings` and `GetMostRecentReportDate` each inlined the same "use the single-entry `_cachedContent` payload if the URL matches, otherwise fetch and cache it" block. Collapsed both into one private `GetCachedSubmissions(url, logCacheHit)` helper.
- Behavior is unchanged: the helper runs the same field-read / fetch / field-assign in the same order, and the `logCacheHit` flag reproduces each call site's original logging — `GetCompanyFilings` still logs a cache hit, `GetMostRecentReportDate` still doesn't.

## Code changes

- `src/Equibles.Integrations.Sec/SecEdgarClient.cs` — added the private `GetCachedSubmissions` helper and replaced the two duplicated cache-lookup blocks with calls to it (`logCacheHit: true` for `GetCompanyFilings`, default `false` for `GetMostRecentReportDate`).