### PR TITLE
test(sec): pin XbrlValueParser.ParseDecimals maps case-insensitive INF to MaxValue

### DIFF
--- a/tests/Equibles.UnitTests/Sec/XbrlValueParserParseDecimalsInfinityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlValueParserParseDecimalsInfinityTests.cs
@@ -1,0 +1,21 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+public class XbrlValueParserParseDecimalsInfinityTests
+{
+    // Per XBRL 2.1, @decimals="INF" means the fact is reported to infinite precision;
+    // ParseDecimals maps that to int.MaxValue as the "round nowhere" sentinel. The
+    // match is documented as case-insensitive, so a lowercase "inf" must resolve the
+    // same way — a case-sensitive regression (== "INF") would return null and silently
+    // demote an exact figure to "unknown precision".
+    [Fact]
+    public void ParseDecimals_LowercaseInf_ReturnsMaxValueSentinel()
+    {
+        var result = XbrlValueParser.ParseDecimals("inf");
+
+        result.Should().Be(int.MaxValue);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `XbrlValueParser.ParseDecimals` handling of the XBRL 2.1 `@decimals="INF"` sentinel — the only branch of the method that had no test.
- Uses a lowercase `"inf"` input to also lock in the documented case-insensitive match; a case-sensitive regression (`== "INF"`) would return null and silently demote an exact figure to unknown precision.

## Code changes

- `tests/Equibles.UnitTests/Sec/XbrlValueParserParseDecimalsInfinityTests.cs` — new unit test asserting `ParseDecimals("inf")` returns `int.MaxValue`.