### PR TITLE
test(web): add skipped repro for GH-3429 — ComputeStats empty-sample median

### DIFF
--- a/tests/Equibles.UnitTests/Web/StatisticsExtensionsComputeStatsEmptyTests.cs
+++ b/tests/Equibles.UnitTests/Web/StatisticsExtensionsComputeStatsEmptyTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Web.Extensions;
+
+namespace Equibles.UnitTests.Web;
+
+public class StatisticsExtensionsComputeStatsEmptyTests
+{
+    // An empty sample has no defined mean/median/min/max/stddev. The SafeRound guard
+    // exists to null out the non-finite results MathNet emits for degenerate samples,
+    // so ComputeStats over no data must yield an all-null summary — never throw on the
+    // decimal cast and never surface a NaN. The single-value edge is pinned elsewhere;
+    // the zero-element edge (where Min/Max/Median can also be undefined) is not.
+    [Fact(Skip = "GH-3429 — ComputeStats returns Median=0 for an empty sample instead of null")]
+    public void ComputeStats_EmptySample_AllStatisticsNullWithoutThrowing()
+    {
+        var summary = Array.Empty<double>().ComputeStats(decimals: 2);
+
+        summary.Mean.Should().BeNull();
+        summary.Median.Should().BeNull();
+        summary.Min.Should().BeNull();
+        summary.Max.Should().BeNull();
+        summary.StdDev.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test pinning that `StatisticsExtensions.ComputeStats` over an empty sample returns an all-null `StatsSummary`.
- The test currently fails — `Median` comes back `0` while `Mean`/`Min`/`Max`/`StdDev` are `null` — so it ships as `[Skip]` (skipped — see GH-3429). Un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Web/StatisticsExtensionsComputeStatsEmptyTests.cs` — new `[Skip]` unit test asserting empty-input statistics are all null; documents the observed `Median = 0` defect tracked in GH-3429.