### PR TITLE
test(sec): add skipped repro for GH-3431 — HeadingConversionStep Part-of prose

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartOfProseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartOfProseTests.cs
@@ -1,0 +1,28 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class HeadingConversionStepPartOfProseTests
+{
+    private readonly HeadingConversionStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    // Contract: the Part→h1 path classifies SEC "PART N" SECTION HEADINGS (per the
+    // IsPartHeading docs and existing pins). An ordinary prose sentence that merely
+    // begins "Part of …" is body text, not a section heading, so it must NOT be
+    // promoted to a heading — doing so corrupts the document outline used by chunking.
+    // The span is mixed-case and unstyled, so only the IsPartHeading branch can fire.
+    [Fact(Skip = "GH-3431 — prose beginning \"Part of …\" is promoted to an <h1> heading")]
+    public void Execute_ProseSentenceBeginningWithPartOf_IsNotPromotedToHeading()
+    {
+        var doc = _parser.ParseDocument(
+            "<html><body><p><span>Part of the proceeds will be reinvested in operations</span></p></body></html>"
+        );
+
+        _step.Execute(doc);
+
+        var body = doc.Body!.InnerHtml;
+        body.Should().NotContain("<h1");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test pinning that `HeadingConversionStep` leaves an ordinary prose sentence beginning "Part of …" as body text rather than promoting it to a heading.
- The test currently fails — the sentence is converted to `<h1>`, corrupting the document outline — so it ships as `[Skip]` (skipped — see GH-3431). Un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartOfProseTests.cs` — new `[Skip]` unit test feeding a mixed-case, unstyled `<p><span>Part of the proceeds will be reinvested in operations</span></p>` and asserting it is not promoted to an `<h1>`; documents the IsPartHeading false-positive tracked in GH-3431.