### PR TITLE
refactor(holdings): extract shared heat-map point construction and reuse Percentage.Of

### DIFF
--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -481,21 +481,15 @@ public class HoldingsActivityController : BaseController
                 : 0;
         var universePct = Percentage.Of(activity.CurrentFilerCount, totalFilers);
 
-        var score = netConviction + retention + universePct;
-
-        var (ticker, name) = ResolveStockCells(stocks, activity.CommonStockId);
-        return new HeatMapPoint
-        {
-            CommonStockId = activity.CommonStockId,
-            Ticker = ticker,
-            Name = name,
-            CurrentFilerCount = activity.CurrentFilerCount,
-            CurrentValue = activity.CurrentValue,
-            ConvictionScore = Math.Round(score, 1),
-            NetConvictionPct = Math.Round(netConviction, 1),
-            RetentionPct = Math.Round(retention, 1),
-            UniversePct = Math.Round(universePct, 2),
-        };
+        return BuildHeatMapPoint(
+            activity.CommonStockId,
+            activity.CurrentFilerCount,
+            activity.CurrentValue,
+            netConviction,
+            retention,
+            universePct,
+            stocks
+        );
     }
 
     // Materialised single-quarter source: filer counts and new/sold-out churn are
@@ -507,29 +501,49 @@ public class HoldingsActivityController : BaseController
         IDictionary<Guid, StockLabel> stocks
     )
     {
-        var netConviction =
-            activity.CurrentFilerCount > 0
-                ? (double)(activity.NewFilerCount - activity.SoldOutFilerCount)
-                    / activity.CurrentFilerCount
-                    * 100.0
-                : 0;
+        var netConviction = Percentage.Of(
+            activity.NewFilerCount - activity.SoldOutFilerCount,
+            activity.CurrentFilerCount
+        );
         var retention =
             activity.PreviousFilerCount > 0
                 ? (1.0 - (double)activity.SoldOutFilerCount / activity.PreviousFilerCount) * 100.0
                 : 0;
-        var universePct =
-            totalFilers > 0 ? (double)activity.CurrentFilerCount / totalFilers * 100.0 : 0;
+        var universePct = Percentage.Of(activity.CurrentFilerCount, totalFilers);
 
+        return BuildHeatMapPoint(
+            activity.CommonStockId,
+            activity.CurrentFilerCount,
+            activity.CurrentValue,
+            netConviction,
+            retention,
+            universePct,
+            stocks
+        );
+    }
+
+    // Shared scoring + projection for both heat-map sources: conviction score is the
+    // sum of the three component percentages, rounded for display.
+    private static HeatMapPoint BuildHeatMapPoint(
+        Guid commonStockId,
+        int currentFilerCount,
+        long currentValue,
+        double netConviction,
+        double retention,
+        double universePct,
+        IDictionary<Guid, StockLabel> stocks
+    )
+    {
         var score = netConviction + retention + universePct;
 
-        var (ticker, name) = ResolveStockCells(stocks, activity.CommonStockId);
+        var (ticker, name) = ResolveStockCells(stocks, commonStockId);
         return new HeatMapPoint
         {
-            CommonStockId = activity.CommonStockId,
+            CommonStockId = commonStockId,
             Ticker = ticker,
             Name = name,
-            CurrentFilerCount = activity.CurrentFilerCount,
-            CurrentValue = activity.CurrentValue,
+            CurrentFilerCount = currentFilerCount,
+            CurrentValue = currentValue,
             ConvictionScore = Math.Round(score, 1),
             NetConvictionPct = Math.Round(netConviction, 1),
             RetentionPct = Math.Round(retention, 1),


### PR DESCRIPTION
## Summary

- The two `BuildHeatMapPoint` overloads in `HoldingsActivityController` duplicated the conviction-score sum and `HeatMapPoint` projection, and the single-quarter overload re-implemented percentage math that the `Percentage.Of` helper already provides.
- Collapse that duplication so both heat-map sources share one scoring/projection path, with no change to the rendered values.

## Code changes

- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — replaced the single-quarter overload's hand-rolled net-conviction and universe-percentage math with `Percentage.Of` (already used by the live overload), and extracted the shared scoring + `HeatMapPoint` construction tail into one private helper that both overloads call. The retention formula and all rounding precisions are unchanged.