### PR TITLE
test(sec): add skipped repro for GH-3431 — HeadingConversionStep Item-of prose

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepItemOfProseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepItemOfProseTests.cs
@@ -1,0 +1,28 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class HeadingConversionStepItemOfProseTests
+{
+    private readonly HeadingConversionStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    // Sibling to the Part→h1 case (GH-3431): the Item→h2 path classifies SEC "ITEM N"
+    // SECTION HEADINGS, not arbitrary prose. A sentence beginning "Item of …" is body
+    // text and must not be promoted to a heading — IsItemHeading only checks for "ITEM"
+    // + whitespace + an alphanumeric first token, so an ordinary following word passes.
+    // The span is mixed-case and unstyled, so only the IsItemHeading branch can fire.
+    [Fact(Skip = "GH-3431 — prose beginning \"Item of …\" is promoted to an <h2> heading")]
+    public void Execute_ProseSentenceBeginningWithItemOf_IsNotPromotedToHeading()
+    {
+        var doc = _parser.ParseDocument(
+            "<html><body><p><span>Item of business before the committee was deferred</span></p></body></html>"
+        );
+
+        _step.Execute(doc);
+
+        var body = doc.Body!.InnerHtml;
+        body.Should().NotContain("<h2");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression guard for the sibling `IsItemHeading` path of GH-3431: an ordinary prose sentence beginning "Item of …" must stay body text, not be promoted to an `<h2>` heading.
- The test currently fails — the sentence becomes `<h2>` — so it ships as `[Skip]` (skipped — see GH-3431). No new issue filed; GH-3431 already enumerates the Item variant. Both the Part→h1 and Item→h2 skipped tests should be un-skipped together when fixed.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepItemOfProseTests.cs` — new `[Skip]` unit test feeding a mixed-case, unstyled `<p><span>Item of business before the committee was deferred</span></p>` and asserting it is not promoted to an `<h2>`.