### PR TITLE
test(sec): add skipped repro for GH-3435 — ListConversionStep spaced display:inline

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepSpacedInlineStyleTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepSpacedInlineStyleTests.cs
@@ -1,0 +1,37 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class ListConversionStepSpacedInlineStyleTests
+{
+    private readonly ListConversionStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    // SEC EDGAR emits inline CSS both as "display:inline" and "display: inline" (the
+    // sibling HeadingConversionStep documents this and matches both). The contract:
+    // the inline-display content div is unwrapped INTO the <li> (per the no-space pin
+    // ContentFromInlineDisplayDiv_IsPreservedInLi). A spaced "display: inline" must be
+    // treated identically — the wrapper div must not survive inside the list item.
+    [Fact(Skip = "GH-3435 — spaced \"display: inline\" content div is not unwrapped into the <li>")]
+    public void Execute_ContentDivWithSpacedDisplayInline_UnwrapsContentIntoLi()
+    {
+        var doc = _parser.ParseDocument(
+            """
+            <html><body>
+            <div class="item-list-element-wrapper">
+              <span>-</span>
+              <div style="display: inline">Preserved <strong>bold</strong> content</div>
+            </div>
+            </body></html>
+            """
+        );
+
+        _step.Execute(doc);
+
+        var body = doc.Body!.InnerHtml;
+        body.Should().Contain("Preserved <strong>bold</strong> content");
+        // The inline-display wrapper must be lifted out, exactly as the no-space form is.
+        body.Should().NotContain("display:");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a regression test pinning that `ListConversionStep` unwraps an inline-display content div into the `<li>` for the spaced `display: inline` form SEC EDGAR emits — identical to the already-pinned no-space form.
- The test currently fails — the `<li>` keeps the raw `<div style="display: inline">` wrapper — so it ships as `[Skip]` (skipped — see GH-3435). Un-skip it as part of the fix.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepSpacedInlineStyleTests.cs` — new `[Skip]` unit test feeding a wrapper whose content div uses `display: inline` (space after colon) and asserting the content is unwrapped into the `<li>` with no leftover `display:` style; documents the colon-spacing gap tracked in GH-3435.