### PR TITLE
test(sec): pin NportFilingProcessor.ParseYesNo discriminates Y from N

### DIFF
--- a/tests/Equibles.UnitTests/Sec/NportFilingProcessorParseYesNoTests.cs
+++ b/tests/Equibles.UnitTests/Sec/NportFilingProcessorParseYesNoTests.cs
@@ -1,0 +1,17 @@
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class NportFilingProcessorParseYesNoTests
+{
+    // N-PORT boolean fields carry "Y"/"N"; ParseYesNo must map only the affirmative
+    // to true. Asserting "N" → false (alongside "Y" → true) pins the discriminator —
+    // a regression to a non-empty/truthy check would wrongly read "N" as true. Nport's
+    // own ParseYesNo was unexercised (NCen has its own separate copy).
+    [Fact]
+    public void ParseYesNo_AffirmativeIsTrueAndNegativeIsFalse()
+    {
+        NportFilingProcessor.ParseYesNo("Y").Should().BeTrue();
+        NportFilingProcessor.ParseYesNo("N").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `NportFilingProcessor.ParseYesNo` — N-PORT boolean fields carry "Y"/"N", and this copy of the helper was unexercised (NCen has its own separately-tested copy).
- Asserts "Y" → true and "N" → false in one test, locking the discriminator so a regression to a non-empty/truthy check (which would read "N" as true) is caught.

## Code changes

- `tests/Equibles.UnitTests/Sec/NportFilingProcessorParseYesNoTests.cs` — new unit test for the internal static `ParseYesNo` (visible via the existing `InternalsVisibleTo`).