### PR TITLE
test(sec): pin FormDFilingProcessor.ParseNullableInt preserves zero vs null

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FormDFilingProcessorParseNullableIntTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormDFilingProcessorParseNullableIntTests.cs
@@ -1,0 +1,17 @@
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FormDFilingProcessorParseNullableIntTests
+{
+    // ParseNullableInt returns null only when the field is missing/invalid — a real
+    // reported "0" must round-trip to 0, not null. Asserting "0" → 0 alongside "" →
+    // null pins that discriminator; a guard that treated falsy/empty as null would
+    // wrongly collapse a genuine zero count.
+    [Fact]
+    public void ParseNullableInt_ZeroIsPreservedAndEmptyIsNull()
+    {
+        FormDFilingProcessor.ParseNullableInt("0").Should().Be(0);
+        FormDFilingProcessor.ParseNullableInt("").Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `FormDFilingProcessor.ParseNullableInt`, previously untested: a reported `0` must round-trip to `0` (not `null`), while a missing/empty value is `null`.
- Locks the discriminator against a regression that treats a legitimate zero count as "no value".

## Code changes

- `tests/Equibles.UnitTests/Sec/FormDFilingProcessorParseNullableIntTests.cs` — new unit test for the internal static `ParseNullableInt` (visible via the existing `InternalsVisibleTo`).