### PR TITLE
test(sec): pin FormDFilingProcessor.ParseLong handles grouped figures invariantly

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FormDFilingProcessorParseLongGroupedTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormDFilingProcessorParseLongGroupedTests.cs
@@ -1,0 +1,16 @@
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FormDFilingProcessorParseLongGroupedTests
+{
+    // Form D dollar figures can arrive with thousands separators; ParseLong uses
+    // NumberStyles.Any under InvariantCulture, so "5,000,000" must read as 5000000
+    // (comma = grouping) regardless of host locale. A German-culture parse without
+    // the invariant pin would treat "," as a decimal point and misread the figure.
+    [Fact]
+    public void ParseLong_ThousandsGroupedFigure_ParsesGroupingInvariantly()
+    {
+        FormDFilingProcessor.ParseLong("5,000,000").Should().Be(5_000_000L);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `FormDFilingProcessor.ParseLong` for a thousands-grouped Form D dollar figure: `"5,000,000"` must read as `5000000` under InvariantCulture (`NumberStyles.Any`), regardless of host locale.
- Existing `ParseAmount` coverage only uses plain digit strings; the grouping + invariant-culture branch was unexercised. A German-culture parse without the invariant pin would misread the comma as a decimal point.

## Code changes

- `tests/Equibles.UnitTests/Sec/FormDFilingProcessorParseLongGroupedTests.cs` — new unit test for the internal static `ParseLong` (visible via the existing `InternalsVisibleTo`).