### PR TITLE
test(sec): pin FormDFilingProcessor.ParseBool returns parsed boolean not presence

### DIFF
--- a/tests/Equibles.UnitTests/Sec/FormDFilingProcessorParseBoolTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FormDFilingProcessorParseBoolTests.cs
@@ -1,0 +1,17 @@
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FormDFilingProcessorParseBoolTests
+{
+    // Form D boolean fields carry XSD "true"/"false"; ParseBool must return the parsed
+    // value, not just "non-empty → true". Asserting "false" → false (alongside "true" →
+    // true) pins the discriminator — a regression to a presence check would read the
+    // explicit "false" as true.
+    [Fact]
+    public void ParseBool_TrueIsTrueAndFalseIsFalse()
+    {
+        FormDFilingProcessor.ParseBool("true").Should().BeTrue();
+        FormDFilingProcessor.ParseBool("false").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins `FormDFilingProcessor.ParseBool`, previously untested: Form D XSD booleans are "true"/"false", and the helper must return the parsed value — "false" → false, not "non-empty → true".
- Locks the discriminator against a regression to a presence check that would read an explicit "false" as true.

## Code changes

- `tests/Equibles.UnitTests/Sec/FormDFilingProcessorParseBoolTests.cs` — new unit test for the internal static `ParseBool` (visible via the existing `InternalsVisibleTo`).