### PR TITLE
test(congress): pin IsValidDisclosureUrl rejects userinfo host-spoof SSRF bypass

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlUserInfoTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlUserInfoTests.cs
@@ -1,0 +1,36 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperIsValidUrlUserInfoTests
+{
+    // Contract: "scheme, host and port must match exactly." Existing tests pin the
+    // host-prefix, scheme-downgrade, port-mismatch and null vectors. The classic
+    // origin-check bypass still unpinned is the userinfo trick: an attacker URL that
+    // embeds the legitimate host in the credentials segment
+    // ("https://legit-host@evil.example/") — the real origin host is evil.example,
+    // so the guard must reject it. A naive string match on the base would be fooled.
+    [Fact]
+    public void IsValidDisclosureUrl_LegitimateHostInUserInfoButAttackerHost_ReturnsFalse()
+    {
+        const string baseUrl = "https://disclosures-clerk.house.gov";
+
+        var bypass = DisclosureParsingHelper.IsValidDisclosureUrl(
+            "https://disclosures-clerk.house.gov@evil.example/public_disc/2025FD.zip",
+            baseUrl
+        );
+        var legitimate = DisclosureParsingHelper.IsValidDisclosureUrl(
+            "https://disclosures-clerk.house.gov/public_disc/financial-pdfs/2025FD.zip",
+            baseUrl
+        );
+
+        bypass
+            .Should()
+            .BeFalse(
+                "the real origin host is evil.example; the base host in userinfo is not the host"
+            );
+        legitimate
+            .Should()
+            .BeTrue("the exact https origin is still accepted (predicate is not vacuous)");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `IsValidDisclosureUrl` rejects the userinfo host-spoof SSRF vector — a URL embedding the legitimate host in the credentials segment (`https://disclosures-clerk.house.gov@evil.example/`) whose real origin host is the attacker domain.
- Existing tests cover the host-prefix, scheme-downgrade, port-mismatch and null vectors; this closes the remaining classic origin-check bypass.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperIsValidUrlUserInfoTests.cs` — new unit test asserting the userinfo-embedded-host URL is rejected while the exact https origin is still accepted (predicate not vacuous). Oracle derived from the documented "scheme, host and port must match exactly" contract.