### PR TITLE
test(holdings): pin Percentage.Of negative value over positive total is not clamped

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/PercentageOfNegativeValueTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/PercentageOfNegativeValueTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Holdings.Repositories;
+
+namespace Equibles.UnitTests.Holdings;
+
+/// <summary>
+/// Contract: Percentage.Of's guard only protects the divide against a non-positive
+/// TOTAL — it does not (and must not) clamp the numerator. A negative value over a
+/// positive total is a legitimate negative percentage (e.g. a reduced position or a
+/// quarter-over-quarter decline) and must flow through as a negative number, not be
+/// flattened to 0. The existing test pins the zero-total guard; this pins the
+/// negative-numerator path. Oracle derived from the "percentage of" contract.
+/// </summary>
+public class PercentageOfNegativeValueTests
+{
+    [Fact]
+    public void Of_NegativeValueWithPositiveTotal_ReturnsNegativePercentageNotClampedToZero()
+    {
+        var result = Percentage.Of(-5.0, 20.0);
+
+        result.Should().Be(-25.0);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that `Percentage.Of` returns a true negative percentage for a negative value over a positive total — its guard only protects the divide against a non-positive total and must not clamp the numerator.
- Realistic scenario: reduced positions / quarter-over-quarter declines feed negative numerators into allocation and activity calculators. The existing test covers only the zero-total guard.

## Code changes

- `tests/Equibles.UnitTests/Holdings/PercentageOfNegativeValueTests.cs` — new unit test: `Of(-5, 20) == -25.0`. Oracle derived from the "percentage of" contract (numerator passes through; only the denominator is guarded).