### PR TITLE
test(cftc): pin SplitCsvLine preserves quoted whitespace-only field verbatim

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineQuotedWhitespaceTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineQuotedWhitespaceTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Equibles.Integrations.Cftc;
+
+namespace Equibles.UnitTests.Integrations;
+
+public class CftcClientSplitCsvLineQuotedWhitespaceTests
+{
+    private static readonly MethodInfo SplitCsvLineMethod = typeof(CftcClient).GetMethod(
+        "SplitCsvLine",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    // Contract: "Quoted content is taken verbatim; unquoted fields are
+    // whitespace-trimmed." Existing pins exercise quoted values that contain no
+    // distinguishing whitespace, so none prove the verbatim half against the trim
+    // half. A quoted field that is ONLY spaces must survive intact ("   "), not
+    // collapse to "" — a refactor that trimmed every field uniformly would pass all
+    // current tests but silently destroy quoted whitespace.
+    [Fact]
+    public void SplitCsvLine_QuotedWhitespaceOnlyField_IsPreservedVerbatimNotTrimmed()
+    {
+        var line = "a,\"   \",b";
+
+        var fields = (string[])SplitCsvLineMethod.Invoke(null, [line]);
+
+        fields.Should().Equal("a", "   ", "b");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the verbatim half of `SplitCsvLine`'s contract ("quoted content is taken verbatim; unquoted fields are whitespace-trimmed"): a quoted whitespace-only field must survive as `"   "`, not collapse to `""`.
- Existing pins use quoted values with no distinguishing whitespace, so a refactor that trimmed every field uniformly would pass them all while silently destroying quoted whitespace.

## Code changes

- `tests/Equibles.UnitTests/Integrations/CftcClientSplitCsvLineQuotedWhitespaceTests.cs` — new unit test: `SplitCsvLine("a,\"   \",b")` returns `["a","   ","b"]`. Oracle derived from the documented verbatim-vs-trim contract.