### PR TITLE
test(holdings): pin ClassifyChange prefers Initiated over Exited when both quarters zero

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/HolderQuarterlyActivityCalculatorClassifyChangeBothZeroTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HolderQuarterlyActivityCalculatorClassifyChangeBothZeroTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HolderQuarterlyActivityCalculatorClassifyChangeBothZeroTests
+{
+    // The five per-arm pins cover each classification in isolation, but not the
+    // precedence at the intersection of the first two guards. Both the
+    // previous-is-0 (Initiated) and current-is-0 (Exited) arms match when a
+    // representable 0-share-both-quarters row arrives; the `previousShares == 0`
+    // guard is evaluated FIRST, so the contract a caller relies on is Initiated.
+    // Reordering the guards (checking current==0 first) would silently flip this
+    // degenerate row to Exited — this pins the ordering.
+    [Fact]
+    public void ClassifyChange_BothCurrentAndPriorZero_PrefersInitiatedOverExited()
+    {
+        var method = typeof(HolderQuarterlyActivityCalculator).GetMethod(
+            "ClassifyChange",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (StockPositionChangeType)method!.Invoke(null, [0L, 0L]);
+
+        result.Should().Be(StockPositionChangeType.Initiated);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the branch precedence in `ClassifyChange`: the `previousShares == 0` guard is evaluated before `currentShares == 0`, so a representable 0-share-in-both-quarters row classifies as Initiated, not Exited.
- The five per-arm pins cover each classification in isolation but not this guard-ordering intersection; a reorder would silently flip the degenerate row.

## Code changes

- `tests/Equibles.UnitTests/Holdings/HolderQuarterlyActivityCalculatorClassifyChangeBothZeroTests.cs` — new unit test: `ClassifyChange(0, 0)` returns `Initiated`. Oracle: the documented guard ordering a caller relies on.