### PR TITLE
test(sec): pin PaginationRemovalStep preserves bare 'Part' paragraph after hr

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepBarePartTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepBarePartTests.cs
@@ -1,0 +1,33 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class PaginationRemovalStepBarePartTests
+{
+    // Contract (from the IsPartHeader doc): a Part header is "Part" followed by a
+    // whitespace boundary ("Part I"). The bare word "Part" with nothing after it
+    // has no following character — no boundary — so it is ordinary content and
+    // must be preserved. This pins the `Length > 4` guard, which both rejects the
+    // false header AND prevents an out-of-range read of upperText[4] on "PART".
+    [Fact]
+    public void Execute_HrFollowedByParagraphWithBareWordPart_PreservesParagraph()
+    {
+        var parser = new HtmlParser();
+        var step = new PaginationRemovalStep();
+        var doc = parser.ParseDocument(
+            """
+            <html><body>
+              <p>Content before</p>
+              <hr>
+              <p>Part</p>
+              <p>Content after</p>
+            </body></html>
+            """
+        );
+
+        step.Execute(doc);
+
+        doc.Body!.InnerHtml.Should().Contain("<p>Part</p>");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `IsPartHeader` length-boundary branch of `PaginationRemovalStep`: a paragraph after a page-break `<hr>` whose text is the bare word "Part" (exactly 4 chars, no following whitespace) is ordinary content, not a "Part I"-style section header, and must be preserved.
- The existing word-boundary test covers a Part-prefixed word ("Partnership", non-whitespace char at index 4); this isolates the `Length > 4` guard, which also prevents an out-of-range read of `upperText[4]` on "PART".

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepBarePartTests.cs` — new passing unit test asserting `Execute` leaves a bare `<p>Part</p>` intact after removing the adjacent `<hr>`.