### PR TITLE
test(yahoo): pin DetectMaCross returns DeathCross when prior bar equal then short drops below

### DIFF
--- a/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceDeathCrossPriorEqualTests.cs
+++ b/tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceDeathCrossPriorEqualTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Yahoo.Repositories;
+
+namespace Equibles.UnitTests.Web;
+
+public class TechnicalIndicatorServiceDeathCrossPriorEqualTests
+{
+    // Mirror of DetectMaCross_PriorBarEqual_ThenAbove_ReturnsGoldenCross for the
+    // bearish side: a death cross is the short MA being at-or-above the long MA on
+    // the prior bar and strictly below on the current bar. Equality on the prior
+    // bar must still trigger — the boundary is inclusive (prevShort >= prevLong),
+    // symmetric to the golden cross's <=. The golden equality case is pinned; this
+    // pins the death-cross equality boundary.
+    [Fact]
+    public void DetectMaCross_PriorBarEqual_ThenBelow_ReturnsDeathCross()
+    {
+        List<decimal?> shortMa = [10m, 9m];
+        List<decimal?> longMa = [10m, 10m];
+
+        var result = TechnicalIndicatorService.DetectMaCross(shortMa, longMa);
+
+        result.Should().Be(MovingAverageCrossSignal.DeathCross);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the death-cross equality boundary of `TechnicalIndicatorService.DetectMaCross`: when the short MA equals the long MA on the prior bar and drops strictly below on the current bar, the inclusive `prevShort >= prevLong` guard must still register a death cross.
- The golden-cross equality case (`PriorBarEqual_ThenAbove`) is already pinned; this adds the symmetric bearish mirror, which had no dedicated test.

## Code changes

- `tests/Equibles.UnitTests/Web/TechnicalIndicatorServiceDeathCrossPriorEqualTests.cs` — new passing unit test asserting `DetectMaCross([10, 9], [10, 10])` returns `DeathCross`.