### PR TITLE
test(congress): pin ParseAmountRange uses first two amounts as bounds when a third is present

### DIFF
--- a/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseAmountRangeThreeAmountsTests.cs
+++ b/tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseAmountRangeThreeAmountsTests.cs
@@ -1,0 +1,23 @@
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+public class DisclosureParsingHelperParseAmountRangeThreeAmountsTests
+{
+    // Contract: a disclosed amount bracket has two bounds — from and to. When the
+    // cell carries a third dollar figure (e.g. a trailing parenthetical fee note),
+    // the bounds are still the first two amounts; the extra figure is not a bound.
+    // Existing pins only exercise exactly-two amounts, leaving the `>= 2` (not
+    // `== 2`) branch untested — a regression reading the last two would silently
+    // shift the reported range.
+    [Fact]
+    public void ParseAmountRange_ThreeDollarAmounts_UsesFirstTwoAsBounds()
+    {
+        var (from, to) = DisclosureParsingHelper.ParseAmountRange(
+            "$1,001 - $15,000 (incl. $50 fee)"
+        );
+
+        from.Should().Be(1_001);
+        to.Should().Be(15_000);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `matches.Count >= 2` branch of `DisclosureParsingHelper.ParseAmountRange` for a cell carrying three dollar figures (e.g. a trailing parenthetical fee). The from/to bounds must come from the first two amounts; the extra figure is not a bound.
- Existing pins only cover exactly-two-amount brackets, leaving the `>= 2` (vs `== 2`) path untested — a regression reading the last two figures would silently shift the reported range.

## Code changes

- `tests/Equibles.UnitTests/Congress/DisclosureParsingHelperParseAmountRangeThreeAmountsTests.cs` — new passing unit test asserting `"$1,001 - $15,000 (incl. $50 fee)"` parses to `(1001, 15000)`.