### PR TITLE
test(holdings): pin FundClassifier ranks SECURITIES before BANK for broker-dealer subsidiaries

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/FundClassifierServiceSecuritiesBeforeBankTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundClassifierServiceSecuritiesBeforeBankTests.cs
@@ -1,0 +1,21 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class FundClassifierServiceSecuritiesBeforeBankTests
+{
+    // Contract: Classify returns the first matching pattern in Rules order.
+    // "SECURITIES" (BrokerDealer) is ordered before "BANK " (Bank), so a bank's
+    // broker-dealer subsidiary — a common 13F filer — must classify by its
+    // function (BrokerDealer), not by the trailing "BANK" token. The existing
+    // precedence pin covers PENSION-before-INSURANCE; this pins a different,
+    // real-world rule pair that an unordered/alphabetized refactor would break.
+    [Fact]
+    public void Classify_NameWithBothSecuritiesAndBank_ReturnsBrokerDealer()
+    {
+        var result = FundClassifierService.Classify("DEUTSCHE BANK SECURITIES INC");
+
+        result.Should().Be(FundClassification.BrokerDealer);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins a real-world first-match-wins precedence in `FundClassifierService.Classify`: "SECURITIES" (BrokerDealer) is ordered before "BANK " (Bank), so a bank's broker-dealer subsidiary classifies by function (BrokerDealer), not by the trailing "BANK" token.
- The existing precedence pin covers PENSION-before-INSURANCE; this covers a different, common rule pair (e.g. "DEUTSCHE BANK SECURITIES INC") that an unordered or alphabetized refactor of the rule list would silently break.

## Code changes

- `tests/Equibles.UnitTests/Holdings/FundClassifierServiceSecuritiesBeforeBankTests.cs` — new passing unit test asserting `"DEUTSCHE BANK SECURITIES INC"` classifies as `BrokerDealer`.