### PR TITLE
test(sec): pin CsvRecordReader preserves CRLF inside a quoted field without splitting

### DIFF
--- a/tests/Equibles.UnitTests/Sec/CsvRecordReaderCrlfInsideQuotedFieldTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CsvRecordReaderCrlfInsideQuotedFieldTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Integrations.Sec.FormAdv;
+
+namespace Equibles.UnitTests.Sec;
+
+public class CsvRecordReaderCrlfInsideQuotedFieldTests
+{
+    // Contract: a line break inside a quoted field is preserved and does not end
+    // the record. The existing newline-inside pin uses a bare \n; a CRLF inside
+    // quotes must be kept verbatim (\r\n) — the CR/LF swallowing that collapses
+    // CRLF between records only applies OUTSIDE quotes, so a quoted CRLF must not
+    // be normalized or split the record.
+    [Fact]
+    public void Read_CrlfInsideQuotedField_PreservesCrlfAndKeepsOneRecord()
+    {
+        var records = CsvRecordReader
+            .Read(new StringReader("\"line1\r\nline2\",second\n"))
+            .ToList();
+
+        records.Should().HaveCount(1);
+        records[0].Should().Equal("line1\r\nline2", "second");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the documented "line breaks preserved" behaviour of `CsvRecordReader.Read` for the CRLF case: a `\r\n` inside a quoted field is kept verbatim and does not terminate the record.
- The existing newline-inside pin uses a bare `\n`. The CR/LF swallowing that collapses CRLF between records applies only outside quotes, so a quoted CRLF exercises a distinct branch that was untested.

## Code changes

- `tests/Equibles.UnitTests/Sec/CsvRecordReaderCrlfInsideQuotedFieldTests.cs` — new passing unit test asserting `"line1\r\nline2",second\n` yields one record `["line1\r\nline2", "second"]`.