### PR TITLE
test(holdings): pin BacktestPriceLoader.ForwardFill returns exact-date close not the prior

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/BacktestPriceLoaderForwardFillExactDateTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/BacktestPriceLoaderForwardFillExactDateTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using Equibles.Holdings.BusinessLogic;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class BacktestPriceLoaderForwardFillExactDateTests
+{
+    // ForwardFill's contract is "largest [close] on or before the requested date".
+    // On a date that EXACTLY equals an entry, that entry's own close is the answer
+    // — the boundary is inclusive (Date <= date). The sibling pin queries a date
+    // strictly between two entries, which a flipped `<=`→`<` regression survives
+    // (the prior entry still matches a strictly-greater query). An exact-date query
+    // is the only case that distinguishes the two: with `<` it would leak the
+    // PRIOR entry's close instead of the matching day's.
+    [Fact]
+    public void ForwardFill_DateExactlyEqualsAnEntry_ReturnsThatEntrysCloseNotThePrior()
+    {
+        var loaderType = typeof(FundScoringManager).Assembly.GetType(
+            "Equibles.Holdings.BusinessLogic.BacktestPriceLoader"
+        );
+        var priceRowType = loaderType.GetNestedType("PriceRow");
+        var priceRowCtor = priceRowType.GetConstructor([
+            typeof(Guid),
+            typeof(DateOnly),
+            typeof(decimal),
+        ]);
+
+        var stockId = Guid.NewGuid();
+        var series = Array.CreateInstance(priceRowType, 3);
+        series.SetValue(priceRowCtor.Invoke([stockId, new DateOnly(2025, 1, 1), 100m]), 0);
+        series.SetValue(priceRowCtor.Invoke([stockId, new DateOnly(2025, 1, 15), 200m]), 1);
+        series.SetValue(priceRowCtor.Invoke([stockId, new DateOnly(2025, 2, 1), 300m]), 2);
+
+        var forwardFill = loaderType
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m =>
+                m.Name == "ForwardFill"
+                && m.GetParameters().Length == 2
+                && m.GetParameters()[0].ParameterType == priceRowType.MakeArrayType()
+            );
+
+        var result = (decimal?)forwardFill.Invoke(null, [series, new DateOnly(2025, 1, 15)]);
+
+        result.Should().Be(200m);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the inclusive boundary of `BacktestPriceLoader.ForwardFill`: on a date that exactly equals a price entry, that entry's own close is returned ("largest close on or before the date").
- The existing sibling pin queries a date strictly between two entries, which a `<=`→`<` regression survives (the prior entry still matches a strictly-greater query). An exact-date query is the only case that distinguishes the two — with `<` it would leak the prior entry's close.

## Code changes

- `tests/Equibles.UnitTests/Holdings/BacktestPriceLoaderForwardFillExactDateTests.cs` — new passing unit test (reflection-based, mirroring the sibling since the type is internal) asserting a query exactly on an entry's date returns that entry's close, not the prior entry's.