### PR TITLE
test(sec): pin NPORT ParseIssuerCategory falls back to issuerConditional attribute

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/NportFilingProcessorParseIssuerCategoryConditionalTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingProcessorParseIssuerCategoryConditionalTests.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using System.Xml.Linq;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class NportFilingProcessorParseIssuerCategoryConditionalTests
+{
+    // Contract (ParseIssuerCategory doc): NPORT reports the issuer category either as
+    // an <issuerCat> element OR, for conditional categories (e.g. swaps), as the
+    // issuerCat attribute on <issuerConditional>. When the direct element is absent,
+    // the attribute fallback must supply the value. The Process test only exercises
+    // the direct-element path; this pins the conditional-attribute fallback branch.
+    [Fact]
+    public void ParseFiling_IssuerCategoryOnlyOnConditionalAttribute_UsesAttributeFallback()
+    {
+        var processor = new NportFilingProcessor(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<NportFilingProcessor>>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+
+        var root = XElement.Parse(
+            "<edgarSubmission><formData>"
+                + "<genInfo><regName>Test Fund</regName></genInfo>"
+                + "<fundInfo><invstOrSecs><invstOrSec>"
+                + "<name>Acme Total Return Swap</name>"
+                + "<issuerConditional issuerCat=\"CORP\" />"
+                + "</invstOrSec></invstOrSecs></fundInfo>"
+                + "</formData></edgarSubmission>"
+        );
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000000000-24-000001",
+            FilingDate = new DateOnly(2025, 1, 31),
+            ReportDate = new DateOnly(2024, 12, 31),
+            Form = "NPORT-P",
+        };
+
+        var method = typeof(NportFilingProcessor).GetMethod(
+            "ParseFiling",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        var entity = (NportFiling)method.Invoke(processor, [root, Guid.NewGuid(), filing]);
+
+        entity.Holdings.Should().ContainSingle();
+        entity.Holdings[0].IssuerCategory.Should().Be("CORP");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the documented fallback in `NportFilingProcessor.ParseIssuerCategory`: when a holding has no direct `<issuerCat>` element but carries the `issuerCat` attribute on `<issuerConditional>` (the NPORT shape for conditional categories like swaps), that attribute supplies the issuer category.
- The Process test only exercises the direct-element path; the conditional-attribute branch was untested. Reflection-based via `ParseFiling`, mirroring the project's other NPORT pins (no DB needed).

## Code changes

- `tests/Equibles.IntegrationTests/Sec/NportFilingProcessorParseIssuerCategoryConditionalTests.cs` — new passing test asserting a holding whose category lives only on `<issuerConditional issuerCat="CORP">` parses to `IssuerCategory == "CORP"`.