### PR TITLE
test(web): pin EnvAuthHandler.GenerateToken exact session-token format against drift

### DIFF
--- a/tests/Equibles.UnitTests/Web/EnvAuthHandlerGenerateTokenFormatTests.cs
+++ b/tests/Equibles.UnitTests/Web/EnvAuthHandlerGenerateTokenFormatTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Web.Authentication;
+
+namespace Equibles.UnitTests.Web;
+
+public class EnvAuthHandlerGenerateTokenFormatTests
+{
+    // The session token is base64(SHA-256("<username>:<secret>")) and is persisted
+    // in users' cookies — its exact format is a stability contract: any drift (order
+    // swap, dropped colon, different hash, hex vs base64) logs out every existing
+    // session. The existing diff-username / diff-secret pins still pass under such a
+    // change; only a fixed golden value catches it. Constant computed independently
+    // from "admin:s3cr3t" via `printf | openssl dgst -sha256 -binary | openssl base64`.
+    [Fact]
+    public void GenerateToken_KnownUsernameAndSecret_MatchesFrozenBase64Sha256()
+    {
+        var token = EnvAuthHandler.GenerateToken("admin", "s3cr3t");
+
+        token.Should().Be("hU8j8VHJWK7+rXnYOoB48UX5Bvnnad1vrOiYkECxYtU=");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the exact session-token format of `EnvAuthHandler.GenerateToken` with a frozen golden value: `base64(SHA-256("<username>:<secret>"))`.
- The token is persisted in users' cookies, so its format is a stability contract — any drift (field order swap, dropped colon separator, different hash algorithm, hex instead of base64) silently logs out every existing session. The existing `DifferentUsername` / `DifferentSecret` pins still pass under such a change; only a fixed golden value catches it.

## Code changes

- `tests/Equibles.UnitTests/Web/EnvAuthHandlerGenerateTokenFormatTests.cs` — new passing unit test asserting `GenerateToken("admin", "s3cr3t")` equals the base64 SHA-256 of `"admin:s3cr3t"` (computed independently).