### PR TITLE
refactor(sec): name iXBRL whitespace-stripping glyphs as constants

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -50,6 +50,12 @@ public class InlineXbrlParser
     private const string DenominatorLocalName = "xbrli:unitdenominator";
     private const string ExplicitMemberLocalName = "xbrldi:explicitmember";
 
+    // Whitespace glyphs filers insert around figures; named because they are
+    // visually indistinguishable from a regular space in source.
+    private const char NoBreakSpace = '\u00A0';
+    private const char NarrowNoBreakSpace = '\u202F';
+    private const char ThinSpace = '\u2009';
+
     private readonly HtmlParser _parser = new(
         new HtmlParserOptions { IsAcceptingCustomElementsEverywhere = true }
     );
@@ -339,9 +345,9 @@ public class InlineXbrlParser
             switch (ch)
             {
                 case ' ':
-                case ' ':
-                case ' ':
-                case ' ':
+                case NoBreakSpace:
+                case NarrowNoBreakSpace:
+                case ThinSpace:
                 case '$':
                 case '€':
                 case '£':


### PR DESCRIPTION
## Summary

- The `NormaliseDigits` digit-cleaning switch in `InlineXbrlParser` stripped four whitespace glyphs whose `case` labels were visually indistinguishable in source (regular space plus non-breaking, narrow non-breaking, and thin spaces).
- Named the three ambiguous space glyphs as `private const char` constants so the switch is self-documenting. Pure clarity change — byte-identical behavior.

## Code changes

- `src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs` — added `NoBreakSpace` (U+00A0), `NarrowNoBreakSpace` (U+202F), and `ThinSpace` (U+2009) constants alongside the existing local-name constants, and replaced the corresponding bare space `case` labels with them. The escape values match the original literal characters exactly, so the stripped character set is unchanged.