### PR TITLE
test(web): pin AdvisersController.Show returns 404 for an unknown CRD

### DIFF
--- a/tests/Equibles.IntegrationTests/Web/AdvisersControllerShowTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/AdvisersControllerShowTests.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+[Collection(WebHostCollection.Name)]
+public class AdvisersControllerShowTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public AdvisersControllerShowTests(WebHostFixture fixture) => _fixture = fixture;
+
+    // Contract: GET /advisers/{crd} returns 404 when no adviser has that CRD — the
+    // Show action's GetByCrd.FirstOrDefaultAsync() == null branch. AdvisersController
+    // has no test coverage; this pins the not-found path end-to-end (route → controller
+    // → repository) so a regression that 500s or renders an empty view is caught.
+    [Fact]
+    public async Task Show_UnknownCrd_Returns404()
+    {
+        await _fixture.ResetAndSeedAsync();
+
+        var response = await _fixture.Client.GetAsync("/advisers/999999");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the not-found path of `AdvisersController.Show` end-to-end (route → controller → repository): `GET /advisers/{crd}` returns 404 when no adviser has that CRD.
- `AdvisersController` had no test coverage; this catches a regression that would 500 or render an empty view instead of 404. Reuses the existing `WebHostFixture` controller-integration pattern.

## Code changes

- `tests/Equibles.IntegrationTests/Web/AdvisersControllerShowTests.cs` — new passing integration test asserting `GET /advisers/999999` against a reset database returns `404 Not Found`.