### PR TITLE
test(web): pin StockTabService chronological rank sorts FullYear after Q4

### DIFF
--- a/tests/Equibles.UnitTests/Web/StockTabServiceChronologicalRankTests.cs
+++ b/tests/Equibles.UnitTests/Web/StockTabServiceChronologicalRankTests.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Web.Services;
+
+namespace Equibles.UnitTests.Web;
+
+public class StockTabServiceChronologicalRankTests
+{
+    // ChronologicalRank remaps SecFiscalPeriod so the 10-K (FullYear), filed after
+    // Q4 and the canonical annual number, sorts AFTER Q4 within a year — the enum
+    // ordinal (FullYear=0) would float it to the wrong end. The existing ordering
+    // pin mixes FullYear with Q1 (ranks 5 vs 1), which survives a regression that
+    // breaks the tight FullYear-vs-Q4 boundary; this pins that adjacent pair.
+    [Fact]
+    public void ChronologicalRank_FullYear_RanksAboveQ4()
+    {
+        var method = typeof(StockTabService).GetMethod(
+            "ChronologicalRank",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var fullYear = (int)method.Invoke(null, [SecFiscalPeriod.FullYear]);
+        var q4 = (int)method.Invoke(null, [SecFiscalPeriod.Q4]);
+
+        fullYear.Should().BeGreaterThan(q4);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the tight boundary of `StockTabService.ChronologicalRank`: the 10-K (FullYear) — filed after Q4 and the canonical annual number — must rank above Q4 within a fiscal year, overriding the misleading enum ordinal (FullYear=0).
- The existing Financials-tab ordering test mixes FullYear with Q1 (ranks 5 vs 1), which still passes if a regression collapses the FullYear-vs-Q4 boundary (5 vs 4). This adjacent-pair pin closes that gap.

## Code changes

- `tests/Equibles.UnitTests/Web/StockTabServiceChronologicalRankTests.cs` — new passing unit test (reflection on the private static helper, the repo's established pattern) asserting `ChronologicalRank(FullYear) > ChronologicalRank(Q4)`.