### PR TITLE
test(web): pin heat-map retention is zero (not -Infinity) when prior filer count is zero

### DIFF
--- a/tests/Equibles.UnitTests/Web/HoldingsActivityControllerBuildHeatMapPointZeroPreviousFilersTests.cs
+++ b/tests/Equibles.UnitTests/Web/HoldingsActivityControllerBuildHeatMapPointZeroPreviousFilersTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using Equibles.Holdings.Data.Models;
+using Equibles.Web.Controllers;
+using Equibles.Web.ViewModels.Holdings;
+
+namespace Equibles.UnitTests.Web;
+
+public class HoldingsActivityControllerBuildHeatMapPointZeroPreviousFilersTests
+{
+    // Retention = share of PRIOR-quarter filers not sold out, dividing by
+    // PreviousFilerCount. For a stock with no prior filers there is no base to
+    // retain, so the documented guard yields 0 — never a divide-by-zero. The
+    // existing score pin only exercises PreviousFilerCount > 0; this pins the
+    // == 0 guard, which a dropped check would turn into -Infinity (soldOut/0).
+    [Fact]
+    public void BuildHeatMapPoint_ZeroPreviousFilersWithSoldOuts_RetentionIsZeroNotNegativeInfinity()
+    {
+        var controllerType = typeof(HoldingsActivityController);
+        var stockLabelType = controllerType.GetNestedType("StockLabel", BindingFlags.NonPublic);
+        var iDictType = typeof(IDictionary<,>).MakeGenericType(typeof(Guid), stockLabelType!);
+        var dictType = typeof(Dictionary<,>).MakeGenericType(typeof(Guid), stockLabelType!);
+        var stocks = Activator.CreateInstance(dictType);
+
+        var method = controllerType.GetMethod(
+            "BuildHeatMapPoint",
+            BindingFlags.NonPublic | BindingFlags.Static,
+            binder: null,
+            types: [typeof(StockQuarterlyActivity), typeof(int), iDictType],
+            modifiers: null
+        );
+
+        var activity = new StockQuarterlyActivity
+        {
+            CommonStockId = Guid.NewGuid(),
+            CurrentFilerCount = 10,
+            PreviousFilerCount = 0,
+            NewFilerCount = 10,
+            SoldOutFilerCount = 5,
+            CurrentValue = 1_000_000,
+        };
+
+        var point = (HeatMapPoint)method!.Invoke(null, [activity, 1000, stocks]);
+
+        point.RetentionPct.Should().Be(0.0);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the divide-by-zero guard in `HoldingsActivityController.BuildHeatMapPoint`: retention divides by `PreviousFilerCount`, so a stock with zero prior filers must yield retention 0 (no base to retain), never a divide-by-zero.
- The existing score pin only exercises `PreviousFilerCount > 0` (retention 87.5). This adds the `== 0` guard case, which a dropped check would turn into `-Infinity` (`1.0 - soldOut/0`) and corrupt the conviction score.

## Code changes

- `tests/Equibles.UnitTests/Web/HoldingsActivityControllerBuildHeatMapPointZeroPreviousFilersTests.cs` — new passing unit test (reflection on the private static overload, mirroring the score pin) asserting `RetentionPct == 0.0` for an activity with `PreviousFilerCount = 0` and sold-outs present.