### PR TITLE
refactor(finra): name repeated OTCMarket dataset group as constant

### DIFF
--- a/src/Equibles.Integrations.Finra/FinraClient.cs
+++ b/src/Equibles.Integrations.Finra/FinraClient.cs
@@ -27,6 +27,9 @@ public class FinraClient : IFinraClient
     // FINRA dataset field name; referenced as a sort/filter key and in the projected field list.
     private const string SettlementDateField = "settlementDate";
 
+    // FINRA API dataset group for OTC market data (short volume and short interest).
+    private const string OtcMarketGroup = "OTCMarket";
+
     private static readonly string[] ShortInterestFields =
     [
         SettlementDateField,
@@ -78,7 +81,7 @@ public class FinraClient : IFinraClient
 
         var results = new List<ShortVolumeRecord>();
         await PaginateQuery<ShortVolumeRecord>(
-            "OTCMarket",
+            OtcMarketGroup,
             "regShoDaily",
             offset => new
             {
@@ -137,7 +140,7 @@ public class FinraClient : IFinraClient
 
         var results = new List<ShortInterestRecord>();
         await PaginateQuery<ShortInterestRecord>(
-            "OTCMarket",
+            OtcMarketGroup,
             "consolidatedShortInterest",
             offset =>
             {
@@ -225,7 +228,7 @@ public class FinraClient : IFinraClient
     {
         var dates = new HashSet<DateOnly>();
         await PaginateQuery<ShortInterestRecord>(
-            "OTCMarket",
+            OtcMarketGroup,
             "consolidatedShortInterest",
             buildQuery,
             records =>


### PR DESCRIPTION
## Summary

- `FinraClient` passed the FINRA dataset group name `"OTCMarket"` as a bare string literal to `PaginateQuery` in three query methods (daily short volume and short interest). A typo in any copy would silently break the API call.
- Centralized it into an `OtcMarketGroup` constant, alongside the existing `SettlementDateField` constant. Pure deduplication — the value is unchanged, so the same dataset group is queried.

## Code changes

- `src/Equibles.Integrations.Finra/FinraClient.cs` — added `private const string OtcMarketGroup = "OTCMarket";` and replaced the three `PaginateQuery` group arguments with it.