### PR TITLE
test(cboe): pin MapProduct routes each known product to its same-named ratio type

### DIFF
--- a/tests/Equibles.UnitTests/Cboe/CboeImportServiceMapProductKnownMappingsTests.cs
+++ b/tests/Equibles.UnitTests/Cboe/CboeImportServiceMapProductKnownMappingsTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Equibles.Cboe.Data.Models;
+using Equibles.Cboe.HostedService.Services;
+using Equibles.Integrations.Cboe.Models;
+
+namespace Equibles.UnitTests.Cboe;
+
+public class CboeImportServiceMapProductKnownMappingsTests
+{
+    // MapProduct must route each known CBOE product to its SAME-named persisted ratio
+    // type (Total→Total, Equity→Equity, Index→Index, Vix→Vix, Etp→Etp). The existing
+    // pin only exercises the catch-all throw, so a swapped arm (e.g. Equity→Index) — the
+    // exact "silent mis-map" that pin's comment warns about — would slip through. This
+    // pins all five mappings; the multiple asserts verify one concept (the correspondence).
+    [Fact]
+    public void MapProduct_EachKnownProduct_MapsToSameNamedRatioType()
+    {
+        var method = typeof(CboeImportService).GetMethod(
+            "MapProduct",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        CboePutCallRatioType Map(CboePutCallProductType p) =>
+            (CboePutCallRatioType)method!.Invoke(null, [p])!;
+
+        Map(CboePutCallProductType.Total).Should().Be(CboePutCallRatioType.Total);
+        Map(CboePutCallProductType.Equity).Should().Be(CboePutCallRatioType.Equity);
+        Map(CboePutCallProductType.Index).Should().Be(CboePutCallRatioType.Index);
+        Map(CboePutCallProductType.Vix).Should().Be(CboePutCallRatioType.Vix);
+        Map(CboePutCallProductType.Etp).Should().Be(CboePutCallRatioType.Etp);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins all five known mappings of `CboeImportService.MapProduct` (Total→Total, Equity→Equity, Index→Index, Vix→Vix, Etp→Etp). The existing pin only exercises the catch-all `_ => throw`, so a swapped arm — the "silent mis-map" that comment explicitly warns about — would slip through.
- The multiple asserts verify a single concept (the product→ratio correspondence).

## Code changes

- `tests/Equibles.UnitTests/Cboe/CboeImportServiceMapProductKnownMappingsTests.cs` — new passing unit test (reflection on the private static helper, mirroring the existing throw pin) asserting each `CboePutCallProductType` maps to its same-named `CboePutCallRatioType`.