### PR TITLE
test(holdings): pin FormatSignedMillions renders a zero delta unsigned, not +0.0

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsFormatSignedMillionsZeroTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsFormatSignedMillionsZeroTests.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using Equibles.Holdings.Mcp.Tools;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class InstitutionalHoldingsToolsFormatSignedMillionsZeroTests
+{
+    // FormatSignedMillions uses the three-part format "+#,##0.0;-#,##0.0;0.0".
+    // The third (zero) section is distinct: an exactly-$0 delta must render "0.0"
+    // with NO sign. The existing pin only covers the positive arm ("+1,234.5"),
+    // so a regression to a two-part format ("+#,##0.0;-#,##0.0") — which applies
+    // the positive section to zero — would mislabel a flat delta as "+0.0".
+    [Fact]
+    public void FormatSignedMillions_ZeroDelta_RendersUnsignedZeroNotPlusZero()
+    {
+        var method = typeof(InstitutionalHoldingsTools).GetMethod(
+            "FormatSignedMillions",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (string)method!.Invoke(null, [0m]);
+
+        result.Should().Be("0.0");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the zero section of `InstitutionalHoldingsTools.FormatSignedMillions`'s three-part format `"+#,##0.0;-#,##0.0;0.0"`: an exactly-$0 delta renders `0.0` with no sign.
- The existing pin only covers the positive arm (`+1,234.5`). A regression to a two-part format (`+#,##0.0;-#,##0.0`) would apply the positive section to zero and mislabel a flat delta as `+0.0` across the Δ Value ($M) cells in the holdings MCP tools.

## Code changes

- `tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsFormatSignedMillionsZeroTests.cs` — new passing unit test (reflection on the private static helper, mirroring the existing culture pin) asserting `FormatSignedMillions(0m)` is `"0.0"`.