### PR TITLE
test(sec): pin SecEdgarClient.IsMissingIndexError recognizes a NoSuchKey body

### DIFF
--- a/tests/Equibles.UnitTests/Integrations/Sec/SecEdgarClientIsMissingIndexErrorNoSuchKeyTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/Sec/SecEdgarClientIsMissingIndexErrorNoSuchKeyTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Equibles.Integrations.Sec;
+
+namespace Equibles.UnitTests.Integrations.Sec;
+
+public class SecEdgarClientIsMissingIndexErrorNoSuchKeyTests
+{
+    // IsMissingIndexError returns true for the S3 "missing object" signatures
+    // AccessDenied OR NoSuchKey. The AccessDenied arm is pinned; this pins the
+    // NoSuchKey arm of the OR (a partial branch), so dropping it wouldn't turn a
+    // NoSuchKey non-trading-day response into a paging/retry error.
+    [Fact]
+    public void IsMissingIndexError_NoSuchKeyBody_ReturnsTrue()
+    {
+        const string s3Body =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>";
+
+        var method = typeof(SecEdgarClient).GetMethod(
+            "IsMissingIndexError",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (bool)method!.Invoke(null, [s3Body]);
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the `|| NoSuchKey` arm of `SecEdgarClient.IsMissingIndexError` (a partial branch found via the Codecov line map). The S3-backed Archives return AccessDenied or NoSuchKey in the body for a missing index object — the non-trading-day signature that authorizes skipping the day.
- The AccessDenied arm is already pinned; this covers the NoSuchKey arm so dropping it wouldn't turn a NoSuchKey response into a paging/retry error.

## Code changes

- `tests/Equibles.UnitTests/Integrations/Sec/SecEdgarClientIsMissingIndexErrorNoSuchKeyTests.cs` — new passing unit test (reflection on the private static helper, mirroring the AccessDenied sibling) asserting a NoSuchKey S3 error body returns true.