### PR TITLE
fix(sec): avoid orphaning a surrogate pair when truncating filing fields

### DIFF
--- a/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
+++ b/src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs
@@ -139,7 +139,9 @@ internal static class EdgarXmlSubmissionParser
     {
         if (value == null || value.Length <= maxLength)
             return value;
-        return value[..maxLength];
+        var end =
+            maxLength > 0 && char.IsHighSurrogate(value[maxLength - 1]) ? maxLength - 1 : maxLength;
+        return value[..end];
     }
 
     /// <summary>

--- a/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserTruncateSurrogatePairTests.cs
+++ b/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserTruncateSurrogatePairTests.cs
@@ -15,7 +15,7 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class EdgarXmlSubmissionParserTruncateSurrogatePairTests
 {
-    [Fact(Skip = "GH-3408 — Truncate orphans a surrogate pair at the cut boundary")]
+    [Fact]
     public void Truncate_MaxLengthSplitsSurrogatePair_ResultContainsNoOrphanSurrogate()
     {
         // "🏛" (U+1F3DB) is a surrogate pair; placed so maxLength=10 falls between the


### PR DESCRIPTION
## Summary

- `EdgarXmlSubmissionParser.Truncate` capped free-text filing fields with `value[..maxLength]`, counting UTF-16 code units. When the cap landed between the two units of a supplementary-plane character (a surrogate pair — the foreign-issuer ADR class-title case the doc-comment names), it kept the high surrogate and dropped the low one, leaving an orphan surrogate that corrupts the PostgreSQL UTF-8 round-trip — the very INSERT failure `Truncate` exists to prevent.
- Back off to `maxLength - 1` when the cut lands on a high surrogate, mirroring the existing guard in the sibling `Congress.DisclosureParsingHelper.Truncate`.

## Code changes

- `src/Equibles.Sec.HostedService/Helpers/EdgarXmlSubmissionParser.cs` — `Truncate` now excludes the whole surrogate pair when the cut point lands inside one, so the result never contains an unpaired surrogate.
- `tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserTruncateSurrogatePairTests.cs` — un-skipped the regression test pinning the contract (no orphan surrogate when `maxLength` splits a pair).

closes #3408