### PR TITLE
test(sec): pin SanitizeXml preserves hexadecimal character references

### DIFF
--- a/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserSanitizeXmlHexCharRefTests.cs
+++ b/tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserSanitizeXmlHexCharRefTests.cs
@@ -1,0 +1,30 @@
+using System.Xml.Linq;
+using Equibles.Sec.HostedService.Helpers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class EdgarXmlSubmissionParserSanitizeXmlHexCharRefTests
+{
+    [Fact]
+    public void SanitizeXml_HexadecimalCharacterReference_IsPreservedAndDecodes()
+    {
+        // Contract: escape only STRAY ampersands — never the ampersand that opens a valid
+        // character reference. Oracle from the XML spec, not the body: a hex char ref
+        // &#xA9; denotes U+00A9 '©'. The escaping regex's "#x[\da-fA-F]+;" branch is the one
+        // the existing decimal (&#38;) and named-entity tests don't reach; double-escaping it
+        // would corrupt the ref into the literal text "&#xA9;" instead of decoding to '©'.
+        var submission =
+            "<XML>\n"
+            + "<edgarSubmission><issuerName>Acme &#xA9; 2024</issuerName></edgarSubmission>\n"
+            + "</XML>";
+
+        var sanitized = EdgarXmlSubmissionParser.SanitizeXml(submission);
+
+        var issuerName = XDocument
+            .Parse(sanitized)
+            .Root.Elements()
+            .First(e => e.Name.LocalName == "issuerName")
+            .Value;
+        issuerName.Should().Be("Acme © 2024");
+    }
+}


### PR DESCRIPTION
## Summary

- `EdgarXmlSubmissionParser.SanitizeXml` escapes stray ampersands without double-escaping valid character references. Existing tests cover the decimal (`&#38;`) and named-entity branches, but the regex's hexadecimal branch (`#x[\da-fA-F]+;`) was unexercised.
- Pins that a valid hex char reference (`&#xA9;` → `©`) survives sanitization and decodes correctly, rather than being corrupted into the literal text `&#xA9;`.

## Code changes

- `tests/Equibles.UnitTests/Sec/EdgarXmlSubmissionParserSanitizeXmlHexCharRefTests.cs` — new test asserting a hex character reference round-trips through `SanitizeXml` + `XDocument.Parse` to its decoded character.