### PR TITLE
fix(web): return all-null stats for an empty sample

### DIFF
--- a/src/Equibles.Web/Extensions/StatisticsExtensions.cs
+++ b/src/Equibles.Web/Extensions/StatisticsExtensions.cs
@@ -29,6 +29,13 @@ public static class StatisticsExtensions
 
     public static StatsSummary ComputeStats(this double[] values, int decimals)
     {
+        // An empty sample has no defined statistics. DescriptiveStatistics.Mean and
+        // Median() both return a finite 0.0 here, so SafeRound's non-finite guard never
+        // fires for them (unlike Min/Max/StdDev, which come back NaN) — without this guard
+        // a "no data" sample would surface a mean and median of 0. Return an all-null summary.
+        if (values.Length == 0)
+            return new StatsSummary(Mean: null, Median: null, Min: null, Max: null, StdDev: null);
+
         var stats = new DescriptiveStatistics(values);
         return new StatsSummary(
             Mean: stats.Mean.SafeRound(decimals),

--- a/tests/Equibles.UnitTests/Web/StatisticsExtensionsComputeStatsEmptyTests.cs
+++ b/tests/Equibles.UnitTests/Web/StatisticsExtensionsComputeStatsEmptyTests.cs
@@ -9,7 +9,7 @@ public class StatisticsExtensionsComputeStatsEmptyTests
     // so ComputeStats over no data must yield an all-null summary — never throw on the
     // decimal cast and never surface a NaN. The single-value edge is pinned elsewhere;
     // the zero-element edge (where Min/Max/Median can also be undefined) is not.
-    [Fact(Skip = "GH-3429 — ComputeStats returns Median=0 for an empty sample instead of null")]
+    [Fact]
     public void ComputeStats_EmptySample_AllStatisticsNullWithoutThrowing()
     {
         var summary = Array.Empty<double>().ComputeStats(decimals: 2);


### PR DESCRIPTION
## Summary

- `StatisticsExtensions.ComputeStats` over an empty sample surfaced `Mean = 0` and `Median = 0` while `Min`/`Max`/`StdDev` correctly came back `null`, presenting "no data" as "the mean and median are zero".
- `DescriptiveStatistics.Mean` and `Median()` both return a finite `0.0` for no data, so `SafeRound`'s non-finite (NaN) guard never nulled them. Return an all-null summary for an empty sample so every statistic is consistently `null`.

## Code changes

- `src/Equibles.Web/Extensions/StatisticsExtensions.cs` — early return of an all-null `StatsSummary` when `values` is empty, before constructing `DescriptiveStatistics`.
- `tests/Equibles.UnitTests/Web/StatisticsExtensionsComputeStatsEmptyTests.cs` — un-skipped the regression test pinning that an empty sample yields all-null statistics without throwing.

closes #3429