### PR TITLE
fix(sec): unwrap spaced "display: inline" content div in list items

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/ListConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/ListConversionStep.cs
@@ -95,10 +95,17 @@ internal class ListConversionStep : IHtmlNormalizationStep
             .FirstOrDefault(s => s.TextContent.Trim() is "•" or "·" or "-");
         bulletSpan?.Remove();
 
-        // Get the content div or use the entire content
+        // Get the content div or use the entire content. SEC EDGAR emits inline CSS with
+        // and without a space after the colon ("display:inline" and "display: inline"), as
+        // the sibling HeadingConversionStep documents; match both so the spaced form is
+        // unwrapped into the <li> instead of surviving as a raw wrapper div.
         var contentDiv = itemElement
             .QuerySelectorAll("div")
-            .FirstOrDefault(d => (d.GetAttribute("style") ?? "").Contains("display:inline"));
+            .FirstOrDefault(d =>
+            {
+                var style = d.GetAttribute("style") ?? "";
+                return style.Contains("display:inline") || style.Contains("display: inline");
+            });
         if (contentDiv != null)
         {
             liElement.InnerHtml = contentDiv.InnerHtml;

--- a/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepSpacedInlineStyleTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepSpacedInlineStyleTests.cs
@@ -13,7 +13,7 @@ public class ListConversionStepSpacedInlineStyleTests
     // the inline-display content div is unwrapped INTO the <li> (per the no-space pin
     // ContentFromInlineDisplayDiv_IsPreservedInLi). A spaced "display: inline" must be
     // treated identically — the wrapper div must not survive inside the list item.
-    [Fact(Skip = "GH-3435 — spaced \"display: inline\" content div is not unwrapped into the <li>")]
+    [Fact]
     public void Execute_ContentDivWithSpacedDisplayInline_UnwrapsContentIntoLi()
     {
         var doc = _parser.ParseDocument(


### PR DESCRIPTION
## Summary

- `ListConversionStep.ConvertItemToListItem` located the inline-display content div with `Contains("display:inline")` — the no-space form only. SEC EDGAR emits inline CSS both as `display:inline` and `display: inline`, so for the spaced form the content div went unrecognized and the resulting `<li>` kept the raw `<div style="display: inline">` wrapper instead of lifting its inner content out.
- Match both colon-spacing variants, as the sibling `HeadingConversionStep` already documents and does. The stray wrapper no longer flows into the downstream HTML→markdown conversion.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/ListConversionStep.cs` — the content-div selector now matches `display:inline` and `display: inline`.
- `tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepSpacedInlineStyleTests.cs` — un-skipped the regression test pinning that a spaced `display: inline` div is unwrapped into the `<li>` with no leftover wrapper.

closes #3435