### PR TITLE
test(sec): add skipped repro for GH-3485 — ListConversionStep sibling class-token match

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepSiblingClassTokenTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepSiblingClassTokenTests.cs
@@ -1,0 +1,38 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class ListConversionStepSiblingClassTokenTests
+{
+    private readonly ListConversionStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    // Contract: only "item-list-element-wrapper" divs form a list. The run starts from a
+    // CSS class-TOKEN match (div.item-list-element-wrapper), so a sibling whose class only
+    // contains that text as part of a larger token (e.g. "sub-item-list-element-wrapper")
+    // is a different element and must NOT be absorbed into the list. Oracle from the
+    // contract: exactly one <li> (the real item); the unrelated sibling stays outside.
+    [Fact(Skip = "GH-3485 — sibling div with class containing the wrapper substring is wrongly absorbed into the list")]
+    public void Execute_SiblingClassContainsWrapperAsSubstringOnly_IsNotMergedIntoList()
+    {
+        var doc = _parser.ParseDocument(
+            """
+            <html><body>
+            <div class="item-list-element-wrapper">
+              <span>•</span>
+              <div style="display:inline">Real item</div>
+            </div>
+            <div class="sub-item-list-element-wrapper">Unrelated sibling block</div>
+            </body></html>
+            """
+        );
+
+        _step.Execute(doc);
+
+        var liCount = doc.Body!.QuerySelectorAll("li").Length;
+        liCount.Should().Be(1);
+        // The unrelated sibling div must survive as itself, not be lifted into the list.
+        doc.Body!.QuerySelector("div.sub-item-list-element-wrapper").Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- While hardening `ListConversionStep`, an adversarial test surfaced a real defect (filed as GH-3485): the list run starts from a CSS class-**token** match but is extended with a class **substring** match, so a sibling div whose class only contains `item-list-element-wrapper` as part of a larger token (e.g. `sub-item-list-element-wrapper`) is wrongly absorbed into the list.
- This PR adds the regression test only — committed `[Skip]`-ped (see GH-3485). It does not change production code; the fix lands separately by un-skipping the test.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepSiblingClassTokenTests.cs` — new test asserting a sibling whose class merely contains the wrapper substring is not merged into the list (exactly one `<li>`; sibling survives outside). Skipped — see GH-3485.