### PR TITLE
fix(sec): match list-item wrapper class as a token, not a substring

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/ListConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/ListConversionStep.cs
@@ -44,7 +44,11 @@ internal class ListConversionStep : IHtmlNormalizationStep
                 current.NodeType == NodeType.Element
                 && current is IElement el
                 && el.LocalName == "div"
-                && (el.GetAttribute("class") ?? "").Contains("item-list-element-wrapper")
+                // Match the class as a token (consistent with the div.item-list-element-wrapper
+                // start selector), not a substring — otherwise a sibling whose class merely
+                // contains the text inside a larger token (e.g. "sub-item-list-element-wrapper")
+                // would be wrongly absorbed into the list.
+                && el.ClassList.Contains("item-list-element-wrapper")
             )
             {
                 consecutiveItems.Add(el);

--- a/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepSiblingClassTokenTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepSiblingClassTokenTests.cs
@@ -13,7 +13,7 @@ public class ListConversionStepSiblingClassTokenTests
     // contains that text as part of a larger token (e.g. "sub-item-list-element-wrapper")
     // is a different element and must NOT be absorbed into the list. Oracle from the
     // contract: exactly one <li> (the real item); the unrelated sibling stays outside.
-    [Fact(Skip = "GH-3485 — sibling div with class containing the wrapper substring is wrongly absorbed into the list")]
+    [Fact]
     public void Execute_SiblingClassContainsWrapperAsSubstringOnly_IsNotMergedIntoList()
     {
         var doc = _parser.ParseDocument(


### PR DESCRIPTION
## Summary

- `ListConversionStep` starts a list run from the CSS class-token selector `div.item-list-element-wrapper` but extended that run with a class **substring** check, `Contains("item-list-element-wrapper")`. A sibling `<div>` whose class only contained that text inside a larger token (e.g. `sub-item-list-element-wrapper`) was absorbed into the list — its content lifted into an extra `<li>` and the element removed from its position, corrupting the normalized output fed to the downstream HTML→markdown conversion.
- Match the class as a token via `ClassList.Contains`, consistent with the start selector, so only genuine `item-list-element-wrapper` siblings join the list.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/ListConversionStep.cs` — `GetConsecutiveItemListElements` now matches the wrapper class with `el.ClassList.Contains(...)` (token) instead of `GetAttribute("class").Contains(...)` (substring).
- `tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepSiblingClassTokenTests.cs` — un-skipped the regression test pinning that a sibling whose class merely contains the substring is not merged into the list.

closes #3485