### PR TITLE
fix(sec): stop promoting "Part of …"/"Item of …" prose to headings

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -5,6 +5,9 @@ namespace Equibles.Sec.BusinessLogic.Normalizers;
 
 internal class HeadingConversionStep : IHtmlNormalizationStep
 {
+    // Uppercase Roman-numeral letters; the text is upper-cased before the check.
+    private const string RomanNumeralLetters = "IVXLCDM";
+
     public void Execute(IHtmlDocument doc)
     {
         // Select spans that are NOT descendants of table elements
@@ -133,7 +136,11 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
                 if (tokens.Length == 0)
                     return false;
                 var firstWord = tokens[0];
-                return !string.IsNullOrEmpty(firstWord) && firstWord.All(char.IsLetter);
+                // A real Part identifier is a Roman numeral (Part I–IV). An ordinary word
+                // like "of"/"the" from a prose sentence beginning "Part of …" is all-letters
+                // too, so require the first token to be composed solely of Roman-numeral
+                // letters — that rejects the prose while still accepting "Part IV".
+                return firstWord.All(c => RomanNumeralLetters.Contains(c));
             }
         }
 
@@ -166,7 +173,11 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
                 if (tokens.Length == 0)
                     return false;
                 var firstWord = tokens[0];
-                return !string.IsNullOrEmpty(firstWord) && firstWord.Any(char.IsLetterOrDigit);
+                // A real Item identifier is number-led (Item 1, 1A, 7A). An ordinary word
+                // like "of"/"the" from a prose sentence beginning "Item of …" starts with a
+                // letter, so require the first token to start with a digit — that rejects the
+                // prose while still accepting "Item 1A".
+                return char.IsDigit(firstWord[0]);
             }
         }
 

--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepItemOfProseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepItemOfProseTests.cs
@@ -13,7 +13,7 @@ public class HeadingConversionStepItemOfProseTests
     // text and must not be promoted to a heading — IsItemHeading only checks for "ITEM"
     // + whitespace + an alphanumeric first token, so an ordinary following word passes.
     // The span is mixed-case and unstyled, so only the IsItemHeading branch can fire.
-    [Fact(Skip = "GH-3431 — prose beginning \"Item of …\" is promoted to an <h2> heading")]
+    [Fact]
     public void Execute_ProseSentenceBeginningWithItemOf_IsNotPromotedToHeading()
     {
         var doc = _parser.ParseDocument(

--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartOfProseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartOfProseTests.cs
@@ -13,7 +13,7 @@ public class HeadingConversionStepPartOfProseTests
     // begins "Part of …" is body text, not a section heading, so it must NOT be
     // promoted to a heading — doing so corrupts the document outline used by chunking.
     // The span is mixed-case and unstyled, so only the IsPartHeading branch can fire.
-    [Fact(Skip = "GH-3431 — prose beginning \"Part of …\" is promoted to an <h1> heading")]
+    [Fact]
     public void Execute_ProseSentenceBeginningWithPartOf_IsNotPromotedToHeading()
     {
         var doc = _parser.ParseDocument(


### PR DESCRIPTION
## Summary

- `HeadingConversionStep` promoted any sentence beginning `Part <word>` or `Item <word>` to a section heading, because the only check after the keyword was an all-letter (Part) / letter-or-digit (Item) first token. Prose like `Part of the proceeds will be reinvested …` or `Item of business …` became an `<h1>`/`<h2>`, injecting spurious top-level headings that corrupt the heading-based document outline used downstream for chunking.
- Require a real SEC section identifier after the keyword: a Roman numeral for Part (`Part I`–`Part IV`) and a number-led token for Item (`Item 1`, `Item 1A`). This matches the canonical forms the existing pins already accept and rejects ordinary prose words like `of`/`the`.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs` — `IsPartHeading` now requires the first token to be composed solely of Roman-numeral letters; `IsItemHeading` now requires it to start with a digit. Added the `RomanNumeralLetters` constant.
- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartOfProseTests.cs`, `HeadingConversionStepItemOfProseTests.cs` — un-skipped the two regression tests pinning that `Part of …`/`Item of …` prose stays body text.

closes #3431