### PR TITLE
test(sec): add skipped repro for GH-3489 — PaginationRemovalStep deletes "Part of …" prose

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartOfProseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartOfProseTests.cs
@@ -1,0 +1,28 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class PaginationRemovalStepPartOfProseTests
+{
+    private readonly PaginationRemovalStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    // Contract: the after-HR sibling is deleted only when it is a SEC "Part" section header
+    // (the doc-comment says IsPartHeader mirrors HeadingConversionStep.IsPartHeading — i.e.
+    // "Part" + a roman-numeral identifier). A prose paragraph that merely begins "Part of …"
+    // is body content, so removing it after a page-break <hr> is real content loss and must
+    // not happen. Oracle derived from the contract, not the body.
+    [Fact(Skip = "GH-3489 — prose paragraph beginning \"Part of …\" after an <hr> is deleted as a Part header")]
+    public void Execute_HrFollowedByProseParagraphBeginningPartOf_PreservesParagraph()
+    {
+        var doc = _parser.ParseDocument(
+            "<html><body><hr><p>Part of the proceeds will be reinvested in operations</p></body></html>"
+        );
+
+        _step.Execute(doc);
+
+        doc.Body!.InnerHtml.Should()
+            .Contain("Part of the proceeds will be reinvested in operations");
+    }
+}


### PR DESCRIPTION
## Summary

- While hardening the GH-3431 fix, an adversarial test surfaced a higher-severity sibling defect (filed as GH-3489): `PaginationRemovalStep.IsPartHeader` returns true for any `Part <anything>` after an `<hr>` and **deletes** that sibling. A prose paragraph beginning "Part of …" after a page-break `<hr>` is removed — real content loss. The classifier was documented to mirror `HeadingConversionStep.IsPartHeading` but was not tightened alongside it.
- This PR adds the regression test only — committed `[Skip]`-ped (see GH-3489). It does not change production code; the fix lands separately by un-skipping the test.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartOfProseTests.cs` — new test asserting a prose paragraph beginning "Part of …" after an `<hr>` is preserved, not deleted. Skipped — see GH-3489.