### PR TITLE
fix(sec): require a roman-numeral identifier before deleting a Part header

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs
@@ -5,6 +5,9 @@ namespace Equibles.Sec.BusinessLogic.Normalizers;
 
 internal class PaginationRemovalStep : IHtmlNormalizationStep
 {
+    // Uppercase Roman-numeral letters; the text is upper-cased before the check.
+    private const string RomanNumeralLetters = "IVXLCDM";
+
     public void Execute(IHtmlDocument doc)
     {
         var hrElements = doc.Body?.QuerySelectorAll(":scope > hr")?.ToList();
@@ -36,19 +39,28 @@ internal class PaginationRemovalStep : IHtmlNormalizationStep
         }
     }
 
-    // Mirrors HeadingConversionStep.IsPartHeading: only treat the after-HR
-    // sibling as a Part header when "Part" is followed by a whitespace
-    // boundary, so ordinary words that merely start with "Part" (Partnership,
-    // Particular, …) are not deleted.
+    // Mirrors HeadingConversionStep.IsPartHeading: treat the after-HR sibling as a Part
+    // header only when "Part" is followed by a whitespace boundary AND a roman-numeral
+    // identifier — so ordinary words that merely start with "Part" (Partnership, …) and
+    // prose sentences beginning "Part of …" are not mistaken for a header and deleted.
     private static bool IsPartHeader(string text)
     {
         if (string.IsNullOrWhiteSpace(text))
             return false;
 
         var upperText = text.ToUpperInvariant().Trim();
-        return upperText.StartsWith("PART")
-            && upperText.Length > 4
-            && char.IsWhiteSpace(upperText[4]);
+        if (
+            !upperText.StartsWith("PART")
+            || upperText.Length <= 4
+            || !char.IsWhiteSpace(upperText[4])
+        )
+            return false;
+
+        var afterPart = upperText.Substring(5).Trim();
+        var tokens = afterPart.Split([' ', '.', '-', ':'], StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0)
+            return false;
+        return tokens[0].All(c => RomanNumeralLetters.Contains(c));
     }
 
     private static INode FindFirstMeaningfulSibling(INode node, bool forward)

--- a/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartOfProseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartOfProseTests.cs
@@ -13,7 +13,7 @@ public class PaginationRemovalStepPartOfProseTests
     // "Part" + a roman-numeral identifier). A prose paragraph that merely begins "Part of …"
     // is body content, so removing it after a page-break <hr> is real content loss and must
     // not happen. Oracle derived from the contract, not the body.
-    [Fact(Skip = "GH-3489 — prose paragraph beginning \"Part of …\" after an <hr> is deleted as a Part header")]
+    [Fact]
     public void Execute_HrFollowedByProseParagraphBeginningPartOf_PreservesParagraph()
     {
         var doc = _parser.ParseDocument(


### PR DESCRIPTION
## Summary

- `PaginationRemovalStep` deletes the meaningful sibling after a page-break `<hr>` when `IsPartHeader` classifies it as a "Part" section header, but `IsPartHeader` accepted any text starting with `Part` + whitespace with no check on what followed. A prose paragraph beginning "Part of …" was mistaken for a header and **removed** — real content loss in the normalized filing.
- Require a roman-numeral identifier after "Part " (e.g. `Part I`–`Part IV`), mirroring the guard already applied to `HeadingConversionStep.IsPartHeading`. Real Part headers are still removed; prose and prefixed words are preserved.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs` — `IsPartHeader` now requires the token after "Part " to be composed solely of roman-numeral letters; added the `RomanNumeralLetters` constant.
- `tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartOfProseTests.cs` — un-skipped the regression test pinning that a "Part of …" prose paragraph after an `<hr>` is preserved, not deleted.

closes #3489