### PR TITLE
fix(web): give startup migrations time before the healthcheck fails

### DIFF
--- a/src/Equibles.Web/Dockerfile
+++ b/src/Equibles.Web/Dockerfile
@@ -25,6 +25,11 @@ FROM base AS final
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build /app/publish .
-HEALTHCHECK --interval=5s --timeout=3s --retries=10 --start-period=15s \
+# start-period must outlast the longest startup migration: web runs pending EF
+# migrations before Kestrel binds, and a heavy backfill on a populated DB can
+# take several minutes. Probe failures during start-period don't count against
+# the container, so a long window can't slow a fast start — it only prevents a
+# still-migrating upgrade from being marked unhealthy (which aborts worker/mcp).
+HEALTHCHECK --interval=5s --timeout=3s --retries=10 --start-period=10m \
     CMD curl --fail http://localhost:8080/healthz || exit 1
 ENTRYPOINT ["dotnet", "Equibles.Web.dll"]

--- a/tests/Equibles.UnitTests/Deployment/WebHealthcheckStartPeriodTests.cs
+++ b/tests/Equibles.UnitTests/Deployment/WebHealthcheckStartPeriodTests.cs
@@ -1,0 +1,100 @@
+using System.Text.RegularExpressions;
+
+namespace Equibles.UnitTests.Deployment;
+
+public class WebHealthcheckStartPeriodTests
+{
+    // The web container runs pending EF migrations before Kestrel binds and
+    // /healthz answers. On a populated production database a single heavy
+    // backfill migration (e.g. a full-table UPDATE on the multi-million-row
+    // InsiderTransaction table) takes minutes. Docker only starts counting
+    // failed health probes against the container AFTER --start-period elapses,
+    // so the start period is the real budget the migration phase gets before
+    // the container is marked unhealthy and dependents (worker, mcp) abort
+    // with "dependency failed to start ... is unhealthy".
+    //
+    // A 15s start period (the original value) gives a ~65s budget
+    // (start-period + retries x interval) that a real upgrade outlives, making
+    // a successful upgrade look like a broken release. This test pins a floor
+    // well above observed migration times so the budget can't silently shrink
+    // back below it.
+    private static readonly TimeSpan MinimumStartPeriod = TimeSpan.FromMinutes(5);
+
+    [Fact]
+    public void WebDockerfile_HealthcheckStartPeriod_CoversLongStartupMigrations()
+    {
+        var dockerfile = File.ReadAllText(FindWebDockerfile());
+
+        var startPeriod = ParseHealthcheckStartPeriod(dockerfile);
+
+        startPeriod
+            .Should()
+            .BeGreaterThanOrEqualTo(
+                MinimumStartPeriod,
+                "the web healthcheck start period is the budget startup migrations run in "
+                    + "before the container is marked unhealthy and worker/mcp abort"
+            );
+    }
+
+    private static TimeSpan ParseHealthcheckStartPeriod(string dockerfile)
+    {
+        var match = Regex.Match(
+            dockerfile,
+            @"HEALTHCHECK\b[^\n]*?--start-period=(?<value>\S+)",
+            RegexOptions.IgnoreCase
+        );
+
+        match
+            .Success.Should()
+            .BeTrue("the web Dockerfile must declare a HEALTHCHECK with --start-period");
+
+        return ParseDockerDuration(match.Groups["value"].Value);
+    }
+
+    // Docker durations are a concatenation of decimal-number + unit pairs
+    // (e.g. "10m", "1h30m", "90s"). Supports the units a healthcheck realistically uses.
+    private static TimeSpan ParseDockerDuration(string value)
+    {
+        var matches = Regex.Matches(value, @"(?<amount>\d+)(?<unit>ms|h|m|s)");
+
+        matches.Count.Should().BeGreaterThan(0, $"'{value}' is not a recognizable Docker duration");
+
+        var total = TimeSpan.Zero;
+        foreach (Match part in matches)
+        {
+            var amount = int.Parse(part.Groups["amount"].Value);
+            total += part.Groups["unit"].Value switch
+            {
+                "h" => TimeSpan.FromHours(amount),
+                "m" => TimeSpan.FromMinutes(amount),
+                "s" => TimeSpan.FromSeconds(amount),
+                "ms" => TimeSpan.FromMilliseconds(amount),
+                _ => TimeSpan.Zero,
+            };
+        }
+
+        return total;
+    }
+
+    private static string FindWebDockerfile()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            var candidate = Path.Combine(directory.FullName, "src", "Equibles.Web", "Dockerfile");
+            if (
+                File.Exists(candidate)
+                && File.Exists(Path.Combine(directory.FullName, "docker-compose.yml"))
+            )
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException(
+            "Could not locate src/Equibles.Web/Dockerfile by walking up from the test output directory."
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- On a populated database, the web container's startup EF migrations (e.g. a full-table backfill on the multi-million-row `InsiderTransaction` table) can run for minutes before Kestrel binds and `/healthz` answers. The Docker healthcheck only allowed a ~65s budget (`start-period` 15s + retries × interval), so a still-migrating upgrade was marked `unhealthy` and `worker`/`mcp` aborted with `dependency failed to start ... is unhealthy` — making a successful upgrade look broken.
- Raise the web `HEALTHCHECK --start-period` to `10m`. Failed probes during `start-period` don't count against the container, so a fast start is unaffected; the longer window only stops a migrating container from being declared unhealthy prematurely.

## Code changes

- `src/Equibles.Web/Dockerfile` — bump `HEALTHCHECK --start-period` from `15s` to `10m`, with a comment explaining the budget must outlast the longest startup migration.
- `tests/Equibles.UnitTests/Deployment/WebHealthcheckStartPeriodTests.cs` — new regression test: parses the Dockerfile HEALTHCHECK and asserts the start period clears a 5-minute floor, so the budget can't silently shrink back below observed migration times.

closes #3361