### PR TITLE
style(migrations): format WidenForm144SecurityClassTitle to satisfy csharpier

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260603153426_WidenForm144SecurityClassTitle.cs
+++ b/src/Equibles.Migrations/Migrations/20260603153426_WidenForm144SecurityClassTitle.cs
@@ -19,7 +19,8 @@ namespace Equibles.Migrations.Migrations
                 oldClrType: typeof(string),
                 oldType: "character varying(128)",
                 oldMaxLength: 128,
-                oldNullable: true);
+                oldNullable: true
+            );
 
             migrationBuilder.AlterColumn<string>(
                 name: "SecurityClassTitle",
@@ -30,7 +31,8 @@ namespace Equibles.Migrations.Migrations
                 oldClrType: typeof(string),
                 oldType: "character varying(128)",
                 oldMaxLength: 128,
-                oldNullable: true);
+                oldNullable: true
+            );
         }
 
         /// <inheritdoc />
@@ -45,7 +47,8 @@ namespace Equibles.Migrations.Migrations
                 oldClrType: typeof(string),
                 oldType: "character varying(512)",
                 oldMaxLength: 512,
-                oldNullable: true);
+                oldNullable: true
+            );
 
             migrationBuilder.AlterColumn<string>(
                 name: "SecurityClassTitle",
@@ -56,7 +59,8 @@ namespace Equibles.Migrations.Migrations
                 oldClrType: typeof(string),
                 oldType: "character varying(512)",
                 oldMaxLength: 512,
-                oldNullable: true);
+                oldNullable: true
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

The lint job on `main` was failing because the EF-generated migration `20260603153426_WidenForm144SecurityClassTitle.cs` was committed without running CSharpier. `dotnet csharpier check .` flagged the `AlterColumn` calls where the closing `)` sat on the same line as the last argument.

## Code changes

- `src/Equibles.Migrations/Migrations/20260603153426_WidenForm144SecurityClassTitle.cs` — ran `dotnet csharpier format`; the four `AlterColumn` calls now close `)` on their own line. No behavioral change.

Verified `dotnet csharpier check .` passes clean across all 2524 files.