### PR TITLE
fix: do not annualize backtest CAGR for windows under 90 days

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
@@ -148,12 +148,12 @@ public class FundScoringManager
 
         score.WindowStart = result.StartDate;
         score.WindowEnd = result.EndDate;
+        // IsStorable gated both CAGRs as non-null before Upsert is reached.
         score.PortfolioTotalReturnPercent = result.PortfolioSummary.TotalReturnPercent;
-        score.PortfolioCagrPercent = result.PortfolioSummary.CagrPercent;
+        score.PortfolioCagrPercent = result.PortfolioSummary.CagrPercent.Value;
         score.BenchmarkTotalReturnPercent = result.BenchmarkSummary.TotalReturnPercent;
-        score.BenchmarkCagrPercent = result.BenchmarkSummary.CagrPercent;
-        score.AlphaPercent =
-            result.PortfolioSummary.CagrPercent - result.BenchmarkSummary.CagrPercent;
+        score.BenchmarkCagrPercent = result.BenchmarkSummary.CagrPercent.Value;
+        score.AlphaPercent = score.PortfolioCagrPercent - score.BenchmarkCagrPercent;
         score.MaxDrawdownPercent = result.PortfolioSummary.MaxDrawdownPercent;
         score.CreationTime = DateTime.UtcNow;
 
@@ -204,12 +204,16 @@ public class FundScoringManager
             })
             .ToList();
 
+    // A null CAGR means the simulated window was too short to annualize
+    // (HoldingsBacktestCalculator.MinAnnualizationDays) — such a score is not meaningful.
     private static bool IsStorable(BacktestResult result) =>
-        InRange(result.PortfolioSummary.TotalReturnPercent)
-        && InRange(result.PortfolioSummary.CagrPercent)
+        result.PortfolioSummary.CagrPercent is decimal portfolioCagr
+        && result.BenchmarkSummary.CagrPercent is decimal benchmarkCagr
+        && InRange(result.PortfolioSummary.TotalReturnPercent)
+        && InRange(portfolioCagr)
         && InRange(result.PortfolioSummary.MaxDrawdownPercent)
         && InRange(result.BenchmarkSummary.TotalReturnPercent)
-        && InRange(result.BenchmarkSummary.CagrPercent);
+        && InRange(benchmarkCagr);
 
     private static bool InRange(decimal value) => Math.Abs(value) < MaxStorableMagnitude;
 

--- a/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HoldingsBacktestCalculator.cs
@@ -13,6 +13,10 @@ public static class HoldingsBacktestCalculator
 
     public const decimal InitialValue = 100m;
 
+    // Annualizing a sub-quarter window extrapolates noise into an absurd rate (19 days of
+    // +8.75% reads as a "448% CAGR"); below this window length no CAGR is reported at all.
+    public const int MinAnnualizationDays = 90;
+
     // Shift a 13F ReportDate forward to its rebalance date (+RebalanceDelayDays). A ReportDate
     // within RebalanceDelayDays of DateOnly.MaxValue would overflow the calendar, so cap the
     // shift at MaxValue instead of throwing — a far-future date then reads as out-of-window.
@@ -196,14 +200,16 @@ public static class HoldingsBacktestCalculator
         return new BacktestStrategySummary
         {
             TotalReturnPercent = Math.Round(totalReturn, 2),
-            CagrPercent = Math.Round(cagr, 2),
+            CagrPercent = cagr is null ? null : Math.Round(cagr.Value, 2),
             MaxDrawdownPercent = Math.Round(maxDrawdown, 2),
         };
     }
 
-    private static decimal ComputeCagr(decimal initial, decimal final, int dayCount)
+    private static decimal? ComputeCagr(decimal initial, decimal final, int dayCount)
     {
-        if (dayCount <= 0 || final <= 0)
+        if (dayCount < MinAnnualizationDays)
+            return null;
+        if (final <= 0)
             return 0m;
 
         var years = dayCount / 365.25;

--- a/src/Equibles.Holdings.Repositories/Models/BacktestStrategySummary.cs
+++ b/src/Equibles.Holdings.Repositories/Models/BacktestStrategySummary.cs
@@ -4,7 +4,9 @@ public class BacktestStrategySummary
 {
     public decimal TotalReturnPercent { get; set; }
 
-    public decimal CagrPercent { get; set; }
+    // Null when the simulated window is shorter than
+    // HoldingsBacktestCalculator.MinAnnualizationDays — too short to annualize meaningfully.
+    public decimal? CagrPercent { get; set; }
 
     public decimal MaxDrawdownPercent { get; set; }
 }

--- a/src/Equibles.Web/Views/Institutions/SmartMoneyIndex.cshtml
+++ b/src/Equibles.Web/Views/Institutions/SmartMoneyIndex.cshtml
@@ -62,7 +62,8 @@
                             <h2 class="text-base font-medium mb-2">@row.Label</h2>
                             <div class="stats stats-vertical sm:stats-horizontal shadow-sm bg-base-200 w-full">
                                 <stat-tile title="Total return">@row.Summary.TotalReturnPercent.ToString("F2")%</stat-tile>
-                                <stat-tile title="CAGR">@row.Summary.CagrPercent.ToString("F2")%</stat-tile>
+                                @* CAGR is null when the window is too short to annualize meaningfully. *@
+                                <stat-tile title="CAGR">@(row.Summary.CagrPercent is decimal cagr ? cagr.ToString("F2") + "%" : "—")</stat-tile>
                                 <stat-tile title="Max drawdown">@row.Summary.MaxDrawdownPercent.ToString("F2")%</stat-tile>
                             </div>
                         </div>

--- a/src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml
@@ -64,7 +64,8 @@
                         <h2 class="text-base font-medium mb-2">@row.Label</h2>
                         <div class="stats stats-vertical sm:stats-horizontal shadow-sm bg-base-200 w-full">
                             <stat-tile title="Total return">@row.Summary.TotalReturnPercent.ToString("F2")%</stat-tile>
-                            <stat-tile title="CAGR">@row.Summary.CagrPercent.ToString("F2")%</stat-tile>
+                            @* CAGR is null when the window is too short to annualize meaningfully. *@
+                            <stat-tile title="CAGR">@(row.Summary.CagrPercent is decimal cagr ? cagr.ToString("F2") + "%" : "—")</stat-tile>
                             <stat-tile title="Max drawdown">@row.Summary.MaxDrawdownPercent.ToString("F2")%</stat-tile>
                         </div>
                     </div>

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorCagrSaturationTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorCagrSaturationTests.cs
@@ -6,16 +6,20 @@ namespace Equibles.UnitTests.Holdings;
 public class HoldingsBacktestCalculatorCagrSaturationTests
 {
     [Fact]
-    public void Calculate_OneDayWindowWithDoublingPortfolio_CagrSaturatesToDecimalMaxValue()
+    public void Calculate_ExtremeMoveOverMinAnnualizableWindow_CagrSaturatesToDecimalMaxValue()
     {
         // Contract from the GH-1199 fix: "The CAGR cell may be saturated / clamped /
         // decimal.MaxValue, but the call must not throw." The existing regression
         // test (CagrShortWindowTests) only asserts non-throw and a populated summary;
         // pin the actual saturation VALUE so a future tweak to the catch block
-        // (e.g. swapping to a different sentinel) is caught.
+        // (e.g. swapping to a different sentinel) is caught. Windows below
+        // MinAnnualizationDays no longer annualize at all, so the overflow needs an
+        // extreme price ratio (1e8 over the minimum annualizable window —
+        // (1e8)^(365.25/90) far exceeds decimal.MaxValue ≈ 7.92e28).
         var stockId = Guid.Parse("33333333-3333-3333-3333-333333333333");
         var rebalanceDate = new DateOnly(2025, 1, 1);
         var reportDate = rebalanceDate.AddDays(-HoldingsBacktestCalculator.RebalanceDelayDays);
+        var endDate = rebalanceDate.AddDays(HoldingsBacktestCalculator.MinAnnualizationDays);
 
         var snapshot = new BacktestQuarterSnapshot
         {
@@ -35,9 +39,9 @@ public class HoldingsBacktestCalculatorCagrSaturationTests
         var result = HoldingsBacktestCalculator.Calculate(
             [snapshot],
             from: rebalanceDate,
-            to: rebalanceDate.AddDays(1),
-            priceOf: (_, day) => day == rebalanceDate ? 100m : 200m,
-            benchmarkPriceOf: day => day == rebalanceDate ? 100m : 200m
+            to: endDate,
+            priceOf: (_, day) => day == endDate ? 10_000m : 0.0001m,
+            benchmarkPriceOf: _ => 100m
         );
 
         result.PortfolioSummary.CagrPercent.Should().Be(decimal.MaxValue);

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorCagrShortWindowNotAnnualizedTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorCagrShortWindowNotAnnualizedTests.cs
@@ -1,0 +1,53 @@
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsBacktestCalculatorCagrShortWindowNotAnnualizedTests
+{
+    [Fact]
+    public void Calculate_NineteenDayWindow_DoesNotReportAnAnnualizedCagr()
+    {
+        // GH (commercial) #1540: the Smart Money Index page annualized a 19-day
+        // +8.75% return into a "CAGR" of (1.0875)^(365.25/19) - 1 ~= 448% — a
+        // statistically meaningless extrapolation presented as a compounding
+        // rate. Windows shorter than MinAnnualizationDays must report no CAGR
+        // at all (null); total return and max drawdown stay populated, since
+        // they are meaningful over any window.
+        var stockId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+        var rebalanceDate = new DateOnly(2026, 5, 15);
+        var reportDate = rebalanceDate.AddDays(-HoldingsBacktestCalculator.RebalanceDelayDays);
+        var endDate = rebalanceDate.AddDays(19);
+
+        var snapshot = new BacktestQuarterSnapshot
+        {
+            ReportDate = reportDate,
+            Positions =
+            {
+                new BacktestPosition
+                {
+                    CommonStockId = stockId,
+                    Shares = 10_000,
+                    Value = 1_000_000,
+                    IsOption = false,
+                },
+            },
+        };
+
+        var result = HoldingsBacktestCalculator.Calculate(
+            [snapshot],
+            from: rebalanceDate,
+            to: endDate,
+            priceOf: (_, day) => day == endDate ? 108.75m : 100m,
+            benchmarkPriceOf: _ => 100m
+        );
+
+        result.PortfolioSummary.TotalReturnPercent.Should().BeApproximately(8.75m, 0.01m);
+        result
+            .PortfolioSummary.CagrPercent.Should()
+            .BeNull("a 19-day window is too short to annualize into a meaningful CAGR");
+        result
+            .BenchmarkSummary.CagrPercent.Should()
+            .BeNull("the benchmark spans the same 19-day window");
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorComputeCagrOverflowSaturatesTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorComputeCagrOverflowSaturatesTests.cs
@@ -6,26 +6,28 @@ namespace Equibles.UnitTests.Holdings;
 public class HoldingsBacktestCalculatorComputeCagrOverflowSaturatesTests
 {
     [Fact]
-    public void ComputeCagr_DoublingOverOneDayWindow_ReturnsDecimalMaxValue()
+    public void ComputeCagr_ExtremeRatioOverMinAnnualizableWindow_ReturnsDecimalMaxValue()
     {
-        // Source contract (HoldingsBacktestCalculator.cs:205-208): "Extreme
-        // single-window moves (e.g. an intraday double on a one-day window)
-        // drive the annualised compounding past decimal.MaxValue; saturate
-        // the CAGR cell rather than aborting the calculation — TotalReturn%
-        // / MaxDrawdown% are still meaningful." A refactor that drops the
-        // try/catch on (decimal)compounded — perhaps reasoning that "no one
-        // throws here" — would crash on any single-day window where the
-        // portfolio at least doubles, because 2^365.25 overflows decimal.
-        // ratio = final/initial = 2; years = 1/365.25 ≈ 0.00274;
-        // compounded = 2^(1/years) - 1 ≈ 2^365.25 - 1 ≈ 7.5e109 — well
-        // past decimal.MaxValue (~7.9e28), so the cast throws and the
-        // catch must saturate to decimal.MaxValue.
+        // Source contract (HoldingsBacktestCalculator.ComputeCagr): extreme moves
+        // drive the annualised compounding past decimal.MaxValue; saturate the
+        // CAGR cell rather than aborting the calculation — TotalReturn% /
+        // MaxDrawdown% are still meaningful. A refactor that drops the try/catch
+        // on (decimal)compounded — perhaps reasoning that "no one throws here" —
+        // would crash on any extreme ratio. Sub-MinAnnualizationDays windows now
+        // return null instead of annualizing, so the overflow needs a huge ratio
+        // over the minimum annualizable window: ratio = 1e8 over 90 days gives
+        // (1e8)^(365.25/90) ≈ 1e32.5 — well past decimal.MaxValue (~7.9e28), so
+        // the cast throws and the catch must saturate to decimal.MaxValue.
         var method = typeof(HoldingsBacktestCalculator).GetMethod(
             "ComputeCagr",
             BindingFlags.NonPublic | BindingFlags.Static
         );
 
-        var result = (decimal)method.Invoke(null, [100m, 200m, 1]);
+        var result = (decimal?)
+            method.Invoke(
+                null,
+                [100m, 10_000_000_000m, HoldingsBacktestCalculator.MinAnnualizationDays]
+            );
 
         result.Should().Be(decimal.MaxValue);
     }

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorComputeCagrZeroDayTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorComputeCagrZeroDayTests.cs
@@ -6,25 +6,23 @@ namespace Equibles.UnitTests.Holdings;
 public class HoldingsBacktestCalculatorComputeCagrZeroDayTests
 {
     [Fact]
-    public void ComputeCagr_ZeroDayWindow_ReturnsZero()
+    public void ComputeCagr_ZeroDayWindow_ReturnsNull()
     {
-        // Contract (HoldingsBacktestCalculator.cs:204-205): `dayCount <= 0`
-        // short-circuits to 0m. The boundary dayCount == 0 is the failure mode
-        // a regression most easily reintroduces — flipping the guard to
-        // `dayCount < 0` lets a same-day window through. Then years = 0 / 365.25
-        // = 0, and Math.Pow(ratio, 1.0 / 0) yields PositiveInfinity (ratio > 1)
-        // or NaN (ratio == 1 → Pow(1, inf) == 1; PositiveInfinity - 1.0 still
-        // overflows the decimal cast). Either way the CAGR cell saturates to
-        // decimal.MaxValue (or throws if the catch is also dropped) instead of
-        // reporting an honest "no time elapsed → no annualised rate". Pinning
-        // the exact boundary protects this guard from a one-character drift.
+        // Contract (HoldingsBacktestCalculator.ComputeCagr): windows shorter than
+        // MinAnnualizationDays — including the degenerate dayCount == 0 — report
+        // no CAGR at all (null). The boundary matters: letting a same-day window
+        // through means years = 0 / 365.25 = 0, and Math.Pow(ratio, 1.0 / 0)
+        // yields PositiveInfinity (ratio > 1), overflowing the decimal cast and
+        // saturating the cell to decimal.MaxValue instead of reporting an honest
+        // "no time elapsed → no annualised rate". Pinning the boundary protects
+        // the guard from drifting.
         var method = typeof(HoldingsBacktestCalculator).GetMethod(
             "ComputeCagr",
             BindingFlags.NonPublic | BindingFlags.Static
         );
 
-        var result = (decimal)method!.Invoke(null, [100m, 200m, 0]);
+        var result = (decimal?)method!.Invoke(null, [100m, 200m, 0]);
 
-        result.Should().Be(0m);
+        result.Should().BeNull();
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorComputeSummaryEmptySeriesTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorComputeSummaryEmptySeriesTests.cs
@@ -32,7 +32,7 @@ public class HoldingsBacktestCalculatorComputeSummaryEmptySeriesTests
 
         act.Should().NotThrow();
         result.TotalReturnPercent.Should().Be(0m);
-        result.CagrPercent.Should().Be(0m);
+        result.CagrPercent.Should().BeNull("no series means there is nothing to annualize");
         result.MaxDrawdownPercent.Should().Be(0m);
     }
 }

--- a/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorComputeSummaryZeroInitialTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsBacktestCalculatorComputeSummaryZeroInitialTests.cs
@@ -33,7 +33,7 @@ public class HoldingsBacktestCalculatorComputeSummaryZeroInitialTests
 
         act.Should().NotThrow();
         result.TotalReturnPercent.Should().Be(0m);
-        result.CagrPercent.Should().Be(0m);
+        result.CagrPercent.Should().BeNull("a degenerate series yields no annualizable CAGR");
         result.MaxDrawdownPercent.Should().Be(0m);
     }
 }


### PR DESCRIPTION
## Summary

The backtest summary annualized any window length into a "CAGR", so a 19-day live history on the Smart Money Index page showed a 448% CAGR — `(1.0875)^(365.25/19) − 1` — a statistically meaningless extrapolation presented as a compounding rate. Windows shorter than 90 days now report no CAGR at all; total return and max drawdown stay populated since they are meaningful over any window.

## Code changes

- `HoldingsBacktestCalculator` — new `MinAnnualizationDays = 90` constant; `ComputeCagr` returns null below the threshold instead of annualizing.
- `BacktestStrategySummary.CagrPercent` — now `decimal?`; null means the window was too short to annualize.
- `FundScoringManager` — a null CAGR makes the result non-storable, so meaningless short-window fund scores are no longer persisted; `Upsert` reads the values after the gate.
- `Views/Institutions/SmartMoneyIndex.cshtml`, `Views/Profiles/BacktestInstitution.cshtml` — CAGR tile renders "—" when null.
- Tests: new regression test pinning the 19-day window contract; saturation and zero-day pins reworked to the new contract (overflow now needs an extreme ratio over an annualizable window); empty-series/zero-initial pins assert null CAGR.