### PR TITLE
fix(sec): read NPORT-P holdings from formData, not fundInfo

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -86,7 +86,8 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
             IsFinalFiling = ParseYesNo(Val(genInfo, "isFinalFiling")),
         };
 
-        foreach (var investment in Els(El(fundInfo, "invstOrSecs"), "invstOrSec"))
+        // invstOrSecs is a child of formData, a sibling of fundInfo — not nested inside fundInfo.
+        foreach (var investment in Els(El(formData, "invstOrSecs"), "invstOrSec"))
         {
             var holding = ParseHolding(investment);
             if (holding != null)

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingProcessorTests.cs
@@ -279,7 +279,8 @@ public class NportFilingProcessorTests
               <totAssets>287467294.33</totAssets>
               <totLiabs>193875501.04</totLiabs>
               <netAssets>93591793.29</netAssets>
-              <invstOrSecs>
+            </fundInfo>
+            <invstOrSecs>
                 <invstOrSec>
                   <name>AT&amp;T Inc</name>
                   <lei>549300Z40J86GGSTL398</lei>
@@ -317,8 +318,7 @@ public class NportFilingProcessorTests
                   <issuerConditional desc="Total Return Swap" issuerCat="OTHER"/>
                   <invCountry>US</invCountry>
                 </invstOrSec>
-              </invstOrSecs>
-            </fundInfo>
+            </invstOrSecs>
           </formData>
         </edgarSubmission>
         </XML>
@@ -358,8 +358,8 @@ public class NportFilingProcessorTests
               <totAssets>287467294.33</totAssets>
               <totLiabs>193875501.04</totLiabs>
               <netAssets>93591793.29</netAssets>
-              <invstOrSecs/>
             </fundInfo>
+            <invstOrSecs/>
           </formData>
         </edgarSubmission>
         </XML>


### PR DESCRIPTION
## Summary

Form NPORT-P portfolio holdings were never being parsed: every NPORT-P filing imported with **zero** holdings. In production this shows as 9,835 `NportFiling` rows but 0 `NportHolding` rows, so the portal's fund-holdings tab is empty for every fund.

The holdings loop looked for `<invstOrSecs>` **inside** `<fundInfo>`:

```csharp
Els(El(fundInfo, "invstOrSecs"), "invstOrSec")
```

But in the real EDGAR NPORT-P schema, `<invstOrSecs>` is a **direct child of `<formData>`** — a sibling of `<genInfo>` and `<fundInfo>`, not nested inside `<fundInfo>`. So `El(fundInfo, "invstOrSecs")` always returned null and no holdings were added. The header fields (`genInfo`, `fundInfo` → net assets, etc.) parsed fine, which is why filings imported successfully and the bug went unnoticed.

Verified against a live filing (SPDR S&P 500 ETF Trust, CIK 884394): the document's 503 `<invstOrSec>` entries sit at `formData > invstOrSecs > invstOrSec`, and `fundInfo`'s children are `totAssets, totLiabs, netAssets, …` with no `invstOrSecs`.

The integration-test fixture nested `<invstOrSecs>` inside `<fundInfo>` — matching the buggy code — so the existing test passed and masked the defect.

## Code changes

- **`src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs`** — read `invstOrSecs` from `formData` instead of `fundInfo`.
- **`tests/Equibles.IntegrationTests/Sec/NportFilingProcessorTests.cs`** — move `<invstOrSecs>` out of `<fundInfo>` to a sibling under `<formData>` in both fixtures, so they reflect the real EDGAR layout and now actually guard this bug.

## Note on backfill

There's no reprocess path for NPORT filings and `Process()` skips already-imported accession numbers, so existing `NportFiling` rows won't gain holdings on a normal worker run — they need a one-off re-fetch/re-parse (or a clear-and-reimport of NPORT filings) after this ships.

All 20 NPORT processor tests pass.