### PR TITLE
fix: read the NPORT-P schedule of investments from formData

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -86,7 +86,12 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
             IsFinalFiling = ParseYesNo(Val(genInfo, "isFinalFiling")),
         };
 
-        foreach (var investment in Els(El(fundInfo, "invstOrSecs"), "invstOrSec"))
+        // The schedule of investments is a sibling of <fundInfo> directly under
+        // <formData> in the NPORT-P schema; the former <fundInfo>-child lookup matched
+        // no real filing, so every report imported with zero holdings. The <fundInfo>
+        // fallback is kept defensively for any non-conforming submission.
+        var investments = El(formData, "invstOrSecs") ?? El(fundInfo, "invstOrSecs");
+        foreach (var investment in Els(investments, "invstOrSec"))
         {
             var holding = ParseHolding(investment);
             if (holding != null)

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingProcessorTests.cs
@@ -279,7 +279,8 @@ public class NportFilingProcessorTests
               <totAssets>287467294.33</totAssets>
               <totLiabs>193875501.04</totLiabs>
               <netAssets>93591793.29</netAssets>
-              <invstOrSecs>
+            </fundInfo>
+            <invstOrSecs>
                 <invstOrSec>
                   <name>AT&amp;T Inc</name>
                   <lei>549300Z40J86GGSTL398</lei>
@@ -317,8 +318,7 @@ public class NportFilingProcessorTests
                   <issuerConditional desc="Total Return Swap" issuerCat="OTHER"/>
                   <invCountry>US</invCountry>
                 </invstOrSec>
-              </invstOrSecs>
-            </fundInfo>
+            </invstOrSecs>
           </formData>
         </edgarSubmission>
         </XML>
@@ -358,8 +358,8 @@ public class NportFilingProcessorTests
               <totAssets>287467294.33</totAssets>
               <totLiabs>193875501.04</totLiabs>
               <netAssets>93591793.29</netAssets>
-              <invstOrSecs/>
             </fundInfo>
+            <invstOrSecs/>
           </formData>
         </edgarSubmission>
         </XML>


### PR DESCRIPTION
## Summary

Every NPORT-P report imported its summary (net assets, series, dates) correctly but zero portfolio holdings — SPY showed $651.6B net assets with 0 positions. The parser looked for `<invstOrSecs>` inside `<fundInfo>`, but the NPORT-P schema places it as a **sibling** of `<fundInfo>` directly under `<formData>` (verified against SPY's live filing 0001410368-26-055357, which carries 503 `<invstOrSec>` entries there). The test fixtures encoded the same wrong nesting, which is why the suite stayed green while production extracted nothing.

## Code changes

- `NportFilingProcessor` — the schedule lookup reads `formData/invstOrSecs` with a defensive `fundInfo` fallback for non-conforming submissions.
- `NportFilingProcessorTests` — fixtures corrected to the real schema (schedule as a sibling of `fundInfo`); with that correction `Process_ValidNport_InsertsFilingWithHoldings` failed on the old parser (0 of 2 holdings) and passes now.

## Note for deployment

Already-imported NPORT filings are skipped by accession number, so existing zero-holdings rows won't self-heal — delete the affected `NportFiling` rows (any with net assets but no holdings) so the next sync re-imports them.