### PR TITLE
feat(sec): reprocess NPORT-P filings to backfill fund holdings

### DIFF
--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -21,6 +21,7 @@ public sealed class ErrorSource
     public static readonly ErrorSource CboeScraper = new("CboeScraper");
     public static readonly ErrorSource TranscriptScraper = new("TranscriptScraper");
     public static readonly ErrorSource InsiderTradingReprocess = new("InsiderTradingReprocess");
+    public static readonly ErrorSource NportReprocess = new("NportReprocess");
     public static readonly ErrorSource Other = new("Other");
 
     public static IEnumerable<ErrorSource> GetAll() =>
@@ -40,6 +41,7 @@ public sealed class ErrorSource
             CboeScraper,
             TranscriptScraper,
             InsiderTradingReprocess,
+            NportReprocess,
             Other,
         ];
 

--- a/src/Equibles.Migrations/Migrations/20260604160053_AddNportParserVersion.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260604160053_AddNportParserVersion.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604160053_AddNportParserVersion")]
+    partial class AddNportParserVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260604160053_AddNportParserVersion.cs
+++ b/src/Equibles.Migrations/Migrations/20260604160053_AddNportParserVersion.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNportParserVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ParserVersion",
+                table: "NportFiling",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NportFiling_ParserVersion",
+                table: "NportFiling",
+                column: "ParserVersion"
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(name: "IX_NportFiling_ParserVersion", table: "NportFiling");
+
+            migrationBuilder.DropColumn(name: "ParserVersion", table: "NportFiling");
+        }
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260604161130_AddNportReprocessTracking.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260604161130_AddNportReprocessTracking.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604161130_AddNportReprocessTracking")]
+    partial class AddNportReprocessTracking
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260604161130_AddNportReprocessTracking.cs
+++ b/src/Equibles.Migrations/Migrations/20260604161130_AddNportReprocessTracking.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNportReprocessTracking : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ReprocessAttempts",
+                table: "NportFiling",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "ReprocessAttempts", table: "NportFiling");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/NportFiling.cs
+++ b/src/Equibles.Sec.Data/Models/NportFiling.cs
@@ -18,8 +18,16 @@ namespace Equibles.Sec.Data.Models;
 [Index(nameof(CommonStockId), nameof(FilingDate))]
 [Index(nameof(AccessionNumber), IsUnique = true)]
 [Index(nameof(FilingDate))]
+[Index(nameof(ParserVersion))]
 public class NportFiling : IStockFiling
 {
+    /// <summary>
+    /// Current holdings-parsing algorithm version. Bump this whenever the NPORT-P parse changes so
+    /// the reprocess worker re-derives every filing's <see cref="Holdings"/> from EDGAR. Version 1
+    /// is the first that reads the portfolio schedule from the correct <c>formData</c> element.
+    /// </summary>
+    public const int CurrentParserVersion = 1;
+
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public Guid Id { get; set; } = Guid.NewGuid();
 
@@ -70,6 +78,13 @@ public class NportFiling : IStockFiling
 
     /// <summary>The series' schedule of portfolio investments reported on the filing.</summary>
     public virtual List<NportHolding> Holdings { get; set; } = [];
+
+    /// <summary>
+    /// Parsing-algorithm version that produced this filing's <see cref="Holdings"/>. See
+    /// <see cref="CurrentParserVersion"/>. Defaults to 0 for filings imported before versioning,
+    /// which marks them for reprocessing.
+    /// </summary>
+    public int ParserVersion { get; set; }
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Sec.Data/Models/NportFiling.cs
+++ b/src/Equibles.Sec.Data/Models/NportFiling.cs
@@ -86,5 +86,13 @@ public class NportFiling : IStockFiling
     /// </summary>
     public int ParserVersion { get; set; }
 
+    /// <summary>
+    /// Number of times the reprocess pass has failed to fetch or re-parse this filing. Once it
+    /// reaches the reprocess ceiling the filing is advanced to <see cref="CurrentParserVersion"/>
+    /// regardless, so a permanently-unfetchable filing (e.g. a delisted issuer's pulled submission)
+    /// can't keep the backlog from draining.
+    /// </summary>
+    public int ReprocessAttempts { get; set; }
+
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<FormAdvScraperWorker>();
         services.AddHostedService<XbrlBackfillWorker>();
         services.AddHostedService<InsiderFilingReprocessWorker>();
+        services.AddHostedService<NportFilingReprocessWorker>();
 
         return services;
     }

--- a/src/Equibles.Sec.HostedService/Models/NportFilingReprocessResult.cs
+++ b/src/Equibles.Sec.HostedService/Models/NportFilingReprocessResult.cs
@@ -1,0 +1,27 @@
+namespace Equibles.Sec.HostedService.Models;
+
+/// <summary>
+/// Progress/outcome of a version-driven NPORT-P reprocess pass. Filings whose
+/// <see cref="Equibles.Sec.Data.Models.NportFiling.ParserVersion"/> sits below the current version
+/// are re-fetched from EDGAR and re-parsed, which re-derives the schedule of portfolio holdings and
+/// stamps the current version so the filing drops out of future passes.
+/// </summary>
+public class NportFilingReprocessResult
+{
+    /// <summary>Filings needing reprocess at the start of the run.</summary>
+    public int Total { get; set; }
+
+    /// <summary>Filings processed so far this run (excluding ones skipped after a failure).</summary>
+    public int Processed { get; set; }
+
+    /// <summary>Holdings inserted across all reprocessed filings this run.</summary>
+    public int HoldingsAdded { get; set; }
+
+    /// <summary>Filings that could not be fetched or parsed this run.</summary>
+    public int Failed { get; set; }
+
+    public string Summary =>
+        FormattableString.Invariant(
+            $"Reprocessed {Processed:N0}/{Total:N0} NPORT-P filings ({HoldingsAdded:N0} holdings added, {Failed:N0} failed)."
+        );
+}

--- a/src/Equibles.Sec.HostedService/NportFilingReprocessWorker.cs
+++ b/src/Equibles.Sec.HostedService/NportFilingReprocessWorker.cs
@@ -1,0 +1,52 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Sec.HostedService;
+
+/// <summary>
+/// Continuously brings NPORT-P filings up to the current holdings-parser version. Each cycle drains
+/// every filing whose <see cref="Equibles.Sec.Data.Models.NportFiling.ParserVersion"/> sits below
+/// <see cref="Equibles.Sec.Data.Models.NportFiling.CurrentParserVersion"/> — re-fetching the
+/// submission from EDGAR and re-deriving its schedule of holdings. The work is version-driven and
+/// resumable, so it survives restarts and automatically re-enrolls every filing after a
+/// parser-version bump — no manual trigger needed.
+///
+/// Runs in the worker process so it shares the single SEC rate-limiter with the other EDGAR
+/// scrapers, and starts after a stagger so its initial EDGAR burst doesn't collide with them at
+/// deploy time.
+/// </summary>
+public class NportFilingReprocessWorker : BaseScraperWorker
+{
+    protected override string WorkerName => "NPORT-P filing reprocess";
+    protected override ErrorSource ErrorSource => ErrorSource.NportReprocess;
+
+    // Once the backlog is drained each cycle finds nothing and idles; a periodic re-check is only
+    // meaningful to pick up filings left pending after a transient failure or a parser-version bump.
+    protected override TimeSpan SleepInterval => TimeSpan.FromHours(6);
+
+    // Stagger past deploy so the initial EDGAR burst doesn't collide with the other SEC scrapers
+    // starting at the same time.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(5);
+
+    public NportFilingReprocessWorker(
+        ILogger<NportFilingReprocessWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter
+    )
+        : base(logger, scopeFactory, errorReporter) { }
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var manager = scope.ServiceProvider.GetRequiredService<NportFilingReprocessManager>();
+
+        var result = await manager.Run(stoppingToken);
+
+        if (result.Processed > 0)
+            Logger.LogInformation("NPORT-P filing reprocess cycle: {Summary}", result.Summary);
+    }
+}

--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -58,7 +58,16 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
         );
     }
 
-    protected override NportFiling ParseFiling(XElement root, Guid companyId, FilingData filing)
+    protected override NportFiling ParseFiling(XElement root, Guid companyId, FilingData filing) =>
+        ParseEntity(root, companyId, filing);
+
+    /// <summary>
+    /// Parses an NPORT-P submission root into a <see cref="NportFiling"/> with its schedule of
+    /// holdings, stamped at <see cref="NportFiling.CurrentParserVersion"/>. Shared by the ingest
+    /// pipeline (<see cref="ParseFiling"/>) and the version-driven reprocess pass, so both derive
+    /// holdings identically. Returns null when the submission lacks the required genInfo section.
+    /// </summary>
+    internal static NportFiling ParseEntity(XElement root, Guid companyId, FilingData filing)
     {
         var headerData = El(root, "headerData");
         var formData = El(root, "formData");
@@ -84,6 +93,7 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
             TotalLiabilities = ParseDecimal(Val(fundInfo, "totLiabs")),
             NetAssets = ParseDecimal(Val(fundInfo, "netAssets")),
             IsFinalFiling = ParseYesNo(Val(genInfo, "isFinalFiling")),
+            ParserVersion = NportFiling.CurrentParserVersion,
         };
 
         // invstOrSecs is a child of formData, a sibling of fundInfo — not nested inside fundInfo.

--- a/src/Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs
@@ -32,6 +32,11 @@ public class NportFilingReprocessManager
     // interrupted run persists what it managed to fetch rather than losing a large in-flight batch.
     private const int BatchSize = 32;
 
+    // After this many failed fetch/parse attempts a filing is advanced to the current version even
+    // though it has no holdings, so a permanently-unfetchable filing (pulled submission, missing
+    // CIK) can't keep re-selecting itself every cycle.
+    internal const int MaxReprocessAttempts = 3;
+
     private readonly NportFilingRepository _filingRepository;
     private readonly ISecEdgarClient _secEdgarClient;
     private readonly EquiblesFinancialDbContext _dbContext;
@@ -92,24 +97,41 @@ public class NportFilingReprocessManager
                 break;
 
             var processedInBatch = 0;
+            var holdingsInBatch = 0;
             foreach (var filing in batch)
             {
                 if (cancellationToken.IsCancellationRequested)
                     break;
                 try
                 {
-                    await ReprocessFiling(filing, result);
+                    holdingsInBatch += await ReprocessFiling(filing);
                     processedInBatch++;
                 }
                 catch (Exception ex)
                 {
                     // One bad filing (e.g. a transient EDGAR 429/timeout) must not abort the whole
-                    // batch. Skip it this run; it's retried on the next.
-                    _logger.LogWarning(
-                        ex,
-                        "NPORT-P reprocess failed for {AccessionNumber}; skipping this run",
-                        filing.AccessionNumber
-                    );
+                    // batch. Skip it this run; it's retried on the next, up to the attempt ceiling
+                    // after which it's stamped current so it stops re-selecting itself forever.
+                    filing.ReprocessAttempts++;
+                    if (filing.ReprocessAttempts >= MaxReprocessAttempts)
+                    {
+                        filing.ParserVersion = NportFiling.CurrentParserVersion;
+                        _logger.LogWarning(
+                            ex,
+                            "NPORT-P reprocess gave up on {AccessionNumber} after {Attempts} attempts; advancing it to the current version with no holdings",
+                            filing.AccessionNumber,
+                            filing.ReprocessAttempts
+                        );
+                    }
+                    else
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "NPORT-P reprocess failed for {AccessionNumber} (attempt {Attempts}); retrying next run",
+                            filing.AccessionNumber,
+                            filing.ReprocessAttempts
+                        );
+                    }
                     failedThisRun.Add(filing.Id);
                     result.Failed++;
                 }
@@ -119,6 +141,9 @@ public class NportFilingReprocessManager
             {
                 await _filingRepository.SaveChanges();
                 result.Processed += processedInBatch;
+                // Fold the holdings counter only after the save commits, so a rolled-back batch
+                // doesn't inflate the headline backfill metric.
+                result.HoldingsAdded += holdingsInBatch;
             }
             catch (DbUpdateException ex)
             {
@@ -145,7 +170,9 @@ public class NportFilingReprocessManager
         return result;
     }
 
-    private async Task ReprocessFiling(NportFiling filing, NportFilingReprocessResult result)
+    // Returns the number of holdings parsed onto the filing. Throws on any fetch/parse failure so
+    // the caller can record the attempt and retry the filing on a later run.
+    private async Task<int> ReprocessFiling(NportFiling filing)
     {
         var cik = filing.CommonStock?.Cik;
         if (string.IsNullOrEmpty(cik))
@@ -205,7 +232,8 @@ public class NportFilingReprocessManager
         filing.NetAssets = parsed.NetAssets;
         filing.IsFinalFiling = parsed.IsFinalFiling;
         filing.ParserVersion = NportFiling.CurrentParserVersion;
+        filing.ReprocessAttempts = 0;
 
-        result.HoldingsAdded += parsed.Holdings.Count;
+        return parsed.Holdings.Count;
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs
@@ -1,0 +1,211 @@
+using Equibles.Core.AutoWiring;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Helpers;
+using Equibles.Sec.HostedService.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Re-derives the schedule of holdings for NPORT-P filings whose
+/// <see cref="NportFiling.ParserVersion"/> sits below
+/// <see cref="NportFiling.CurrentParserVersion"/>. For each such filing it re-fetches the
+/// submission from EDGAR, re-parses it through <see cref="NportFilingProcessor.ParseEntity"/>,
+/// replaces the stored holdings and header facts, and stamps the current version.
+///
+/// The parser version is the single selector: once a filing is stamped at the current version it
+/// drops out, so the run terminates and is resumable — an interrupted run continues where it left
+/// off next invocation, and bumping <see cref="NportFiling.CurrentParserVersion"/> after a parser
+/// change re-enrolls every filing automatically. Filings that imported before holdings were parsed
+/// correctly default to version 0 and are backfilled on the first pass.
+/// </summary>
+[Service]
+public class NportFilingReprocessManager
+{
+    // Small batches so progress commits often: SaveChanges runs once per batch, so a throttled or
+    // interrupted run persists what it managed to fetch rather than losing a large in-flight batch.
+    private const int BatchSize = 32;
+
+    private readonly NportFilingRepository _filingRepository;
+    private readonly ISecEdgarClient _secEdgarClient;
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly ErrorReporter _errorReporter;
+    private readonly ILogger<NportFilingReprocessManager> _logger;
+
+    public NportFilingReprocessManager(
+        NportFilingRepository filingRepository,
+        ISecEdgarClient secEdgarClient,
+        EquiblesFinancialDbContext dbContext,
+        ErrorReporter errorReporter,
+        ILogger<NportFilingReprocessManager> logger
+    )
+    {
+        _filingRepository = filingRepository;
+        _secEdgarClient = secEdgarClient;
+        _dbContext = dbContext;
+        _errorReporter = errorReporter;
+        _logger = logger;
+    }
+
+    public async Task<NportFilingReprocessResult> Run(CancellationToken cancellationToken = default)
+    {
+        var result = new NportFilingReprocessResult
+        {
+            Total = await _filingRepository
+                .GetAll()
+                .Where(f => f.ParserVersion < NportFiling.CurrentParserVersion)
+                .CountAsync(cancellationToken),
+        };
+
+        if (result.Total == 0)
+            return result;
+
+        // The re-fetch + re-parse of a full backlog can run long; lift the per-command timeout so a
+        // large batch's SaveChanges doesn't trip the default. Guarded because the timeout is a
+        // relational-only facility (the in-memory provider used in tests rejects it).
+        if (_dbContext.Database.IsRelational())
+            _dbContext.Database.SetCommandTimeout(TimeSpan.FromMinutes(10));
+
+        // No DB cursor: a reprocessed filing advances to the current version and drops out of the
+        // filter, so each pass takes the next batch. Filings that fail this run are held in-memory
+        // and excluded so the run still terminates; they're retried on the next run.
+        var failedThisRun = new HashSet<Guid>();
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var batch = await _filingRepository
+                .GetAll()
+                .Where(f => f.ParserVersion < NportFiling.CurrentParserVersion)
+                .Where(f => !failedThisRun.Contains(f.Id))
+                .OrderBy(f => f.FilingDate)
+                .Include(f => f.CommonStock)
+                .Include(f => f.Holdings)
+                .Take(BatchSize)
+                .ToListAsync(cancellationToken);
+
+            if (batch.Count == 0)
+                break;
+
+            var processedInBatch = 0;
+            foreach (var filing in batch)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+                try
+                {
+                    await ReprocessFiling(filing, result);
+                    processedInBatch++;
+                }
+                catch (Exception ex)
+                {
+                    // One bad filing (e.g. a transient EDGAR 429/timeout) must not abort the whole
+                    // batch. Skip it this run; it's retried on the next.
+                    _logger.LogWarning(
+                        ex,
+                        "NPORT-P reprocess failed for {AccessionNumber}; skipping this run",
+                        filing.AccessionNumber
+                    );
+                    failedThisRun.Add(filing.Id);
+                    result.Failed++;
+                }
+            }
+
+            try
+            {
+                await _filingRepository.SaveChanges();
+                result.Processed += processedInBatch;
+            }
+            catch (DbUpdateException ex)
+            {
+                // A concurrent ingest insert of the same filing or a similar conflict — drop the
+                // batch's changes and retry these next run.
+                _logger.LogWarning(ex, "NPORT-P reprocess batch save failed; retrying next run");
+                foreach (var filing in batch)
+                    failedThisRun.Add(filing.Id);
+            }
+            finally
+            {
+                _dbContext.ChangeTracker.Clear();
+            }
+
+            _logger.LogInformation(
+                "NPORT-P reprocess: {Processed}/{Total} filings, holdings added={HoldingsAdded}, failed={Failed}",
+                result.Processed,
+                result.Total,
+                result.HoldingsAdded,
+                result.Failed
+            );
+        }
+
+        return result;
+    }
+
+    private async Task ReprocessFiling(NportFiling filing, NportFilingReprocessResult result)
+    {
+        var cik = filing.CommonStock?.Cik;
+        if (string.IsNullOrEmpty(cik))
+            throw new InvalidOperationException(
+                $"NPORT-P filing {filing.AccessionNumber} has no issuer CIK to re-fetch from EDGAR."
+            );
+
+        var content = await _secEdgarClient.GetDocumentContent(filing.AccessionNumber, cik);
+        if (string.IsNullOrWhiteSpace(content))
+            throw new InvalidOperationException(
+                $"EDGAR returned empty content for NPORT-P {filing.AccessionNumber}."
+            );
+
+        var filingData = new FilingData
+        {
+            Cik = cik,
+            AccessionNumber = filing.AccessionNumber,
+            FilingDate = filing.FilingDate,
+            ReportDate = filing.ReportPeriodDate,
+        };
+
+        var root = await EdgarXmlSubmissionParser.TryParseSubmission(
+            content,
+            filingData,
+            filing.CommonStock?.Ticker,
+            "NPORT-P",
+            "Nport.Reprocess",
+            _logger,
+            _errorReporter
+        );
+        if (root == null)
+            throw new InvalidOperationException(
+                $"NPORT-P {filing.AccessionNumber} content was not parseable XML."
+            );
+
+        var parsed = NportFilingProcessor.ParseEntity(root, filing.CommonStockId, filingData);
+        if (parsed == null)
+            throw new InvalidOperationException(
+                $"NPORT-P {filing.AccessionNumber} is missing its genInfo section."
+            );
+
+        // Replace the schedule of holdings and refresh the header facts, then stamp the version so
+        // the filing drops out of the work-set.
+        _dbContext.Set<NportHolding>().RemoveRange(filing.Holdings);
+        foreach (var holding in parsed.Holdings)
+            holding.NportFilingId = filing.Id;
+        _dbContext.Set<NportHolding>().AddRange(parsed.Holdings);
+
+        filing.RegistrantName = parsed.RegistrantName;
+        filing.SeriesName = parsed.SeriesName;
+        filing.SeriesId = parsed.SeriesId;
+        filing.SeriesLei = parsed.SeriesLei;
+        filing.ReportPeriodDate = parsed.ReportPeriodDate;
+        filing.ReportPeriodEnd = parsed.ReportPeriodEnd;
+        filing.TotalAssets = parsed.TotalAssets;
+        filing.TotalLiabilities = parsed.TotalLiabilities;
+        filing.NetAssets = parsed.NetAssets;
+        filing.IsFinalFiling = parsed.IsFinalFiling;
+        filing.ParserVersion = NportFiling.CurrentParserVersion;
+
+        result.HoldingsAdded += parsed.Holdings.Count;
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingProcessorParseIssuerCategoryConditionalTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingProcessorParseIssuerCategoryConditionalTests.cs
@@ -29,13 +29,14 @@ public class NportFilingProcessorParseIssuerCategoryConditionalTests
             )
         );
 
+        // invstOrSecs is a child of formData (a sibling of fundInfo), as in real EDGAR filings.
         var root = XElement.Parse(
             "<edgarSubmission><formData>"
                 + "<genInfo><regName>Test Fund</regName></genInfo>"
-                + "<fundInfo><invstOrSecs><invstOrSec>"
+                + "<invstOrSecs><invstOrSec>"
                 + "<name>Acme Total Return Swap</name>"
                 + "<issuerConditional issuerCat=\"CORP\" />"
-                + "</invstOrSec></invstOrSecs></fundInfo>"
+                + "</invstOrSec></invstOrSecs>"
                 + "</formData></edgarSubmission>"
         );
         var filing = new FilingData

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingProcessorTests.cs
@@ -100,6 +100,7 @@ public class NportFilingProcessorTests
         filing.NetAssets.Should().Be(93591793.29m);
         filing.IsFinalFiling.Should().BeFalse();
         filing.IsAmendment.Should().BeFalse();
+        filing.ParserVersion.Should().Be(NportFiling.CurrentParserVersion);
 
         filing.Holdings.Should().HaveCount(2);
 

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerTests.cs
@@ -57,6 +57,56 @@ public class NportFilingReprocessManagerTests
         await secClient.DidNotReceive().GetDocumentContent(Arg.Any<string>(), Arg.Any<string>());
     }
 
+    [Fact]
+    public async Task Run_FilingWithEmptyHoldings_StampsVersionWithNoHoldings()
+    {
+        var (manager, dbContext, secClient) = CreateManagerWithDeps();
+        var stock = SeedStock(dbContext);
+        SeedFiling(dbContext, stock, parserVersion: 0);
+        secClient
+            .GetDocumentContent(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(EmptyHoldingsSubmission);
+
+        var result = await manager.Run();
+
+        result.Processed.Should().Be(1);
+        result.HoldingsAdded.Should().Be(0);
+        result.Failed.Should().Be(0);
+
+        // A legitimately empty filing still advances, so it doesn't re-select itself forever.
+        var reprocessed = await dbContext.Set<NportFiling>().Include(f => f.Holdings).SingleAsync();
+        reprocessed.ParserVersion.Should().Be(NportFiling.CurrentParserVersion);
+        reprocessed.Holdings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Run_FetchKeepsFailing_GivesUpAfterCeilingAndStopsReselecting()
+    {
+        var (manager, dbContext, secClient) = CreateManagerWithDeps();
+        var stock = SeedStock(dbContext);
+        SeedFiling(dbContext, stock, parserVersion: 0);
+        // EDGAR returns empty content every time, so every reprocess attempt fails.
+        secClient.GetDocumentContent(Arg.Any<string>(), Arg.Any<string>()).Returns("");
+
+        // One failed attempt per run until the ceiling is reached.
+        for (var attempt = 0; attempt < NportFilingReprocessManager.MaxReprocessAttempts; attempt++)
+        {
+            var failing = await manager.Run();
+            failing.Failed.Should().Be(1);
+        }
+
+        var givenUp = await dbContext.Set<NportFiling>().Include(f => f.Holdings).SingleAsync();
+        givenUp.ReprocessAttempts.Should().Be(NportFilingReprocessManager.MaxReprocessAttempts);
+        givenUp.ParserVersion.Should().Be(NportFiling.CurrentParserVersion);
+        givenUp.Holdings.Should().BeEmpty();
+
+        // Once stamped it leaves the work-set and is never re-fetched again.
+        secClient.ClearReceivedCalls();
+        var afterGiveUp = await manager.Run();
+        afterGiveUp.Total.Should().Be(0);
+        await secClient.DidNotReceive().GetDocumentContent(Arg.Any<string>(), Arg.Any<string>());
+    }
+
     // ── Helpers ──
 
     private static (
@@ -184,6 +234,36 @@ public class NportFilingReprocessManagerTests
                 <invCountry>US</invCountry>
               </invstOrSec>
             </invstOrSecs>
+          </formData>
+        </edgarSubmission>
+        </XML>
+        </TEXT>
+        </DOCUMENT>
+        </SEC-DOCUMENT>
+        """;
+
+    // A valid NPORT-P submission that reports no portfolio investments (e.g. a final filing).
+    private const string EmptyHoldingsSubmission = """
+        <SEC-DOCUMENT>0001104659-26-000099.txt : 20260330
+        <DOCUMENT>
+        <TYPE>NPORT-P
+        <TEXT>
+        <XML>
+        <?xml version="1.0" encoding="UTF-8"?>
+        <edgarSubmission xmlns="http://www.sec.gov/edgar/nport">
+          <headerData>
+            <submissionType>NPORT-P</submissionType>
+          </headerData>
+          <formData>
+            <genInfo>
+              <regName>ETF Opportunities Trust</regName>
+              <repPdEnd>2026-08-31</repPdEnd>
+              <repPdDate>2026-02-28</repPdDate>
+            </genInfo>
+            <fundInfo>
+              <netAssets>0.00</netAssets>
+            </fundInfo>
+            <invstOrSecs/>
           </formData>
         </edgarSubmission>
         </XML>

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingReprocessManagerTests.cs
@@ -1,0 +1,194 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Sec;
+
+public class NportFilingReprocessManagerTests
+{
+    [Fact]
+    public async Task Run_StaleFilingWithNoHoldings_FetchesReparsesAndStampsVersion()
+    {
+        var (manager, dbContext, secClient) = CreateManagerWithDeps();
+        var stock = SeedStock(dbContext);
+        // A filing imported before holdings were parsed correctly: version 0, zero holdings.
+        var filing = SeedFiling(dbContext, stock, parserVersion: 0);
+        secClient
+            .GetDocumentContent(filing.AccessionNumber, Arg.Any<string>())
+            .Returns(ValidNportSubmission);
+
+        var result = await manager.Run();
+
+        result.Total.Should().Be(1);
+        result.Processed.Should().Be(1);
+        result.HoldingsAdded.Should().Be(2);
+        result.Failed.Should().Be(0);
+        await secClient.Received().GetDocumentContent(filing.AccessionNumber, Arg.Any<string>());
+
+        var reprocessed = await dbContext.Set<NportFiling>().Include(f => f.Holdings).SingleAsync();
+        reprocessed.ParserVersion.Should().Be(NportFiling.CurrentParserVersion);
+        reprocessed.Holdings.Should().HaveCount(2);
+        reprocessed.Holdings.Should().Contain(h => h.Name == "AT&T Inc" && h.Cusip == "00206R102");
+        reprocessed.NetAssets.Should().Be(93591793.29m);
+    }
+
+    [Fact]
+    public async Task Run_FilingAlreadyAtCurrentVersion_IsLeftUntouched()
+    {
+        var (manager, dbContext, secClient) = CreateManagerWithDeps();
+        var stock = SeedStock(dbContext);
+        SeedFiling(dbContext, stock, parserVersion: NportFiling.CurrentParserVersion);
+
+        var result = await manager.Run();
+
+        result.Total.Should().Be(0);
+        result.Processed.Should().Be(0);
+        // A current-version filing is never re-fetched.
+        await secClient.DidNotReceive().GetDocumentContent(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    // ── Helpers ──
+
+    private static (
+        NportFilingReprocessManager manager,
+        Equibles.Data.EquiblesFinancialDbContext dbContext,
+        ISecEdgarClient secClient
+    ) CreateManagerWithDeps()
+    {
+        var dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration(),
+            new ErrorsModuleConfiguration()
+        );
+
+        var repo = new NportFilingRepository(dbContext);
+        var secClient = Substitute.For<ISecEdgarClient>();
+
+        // The error reporter is only reached when a submission fails to parse; the valid-XML paths
+        // here never invoke it, so a scope factory carrying just the error manager is enough.
+        var errorManager = new ErrorManager(new ErrorRepository(dbContext));
+        var scopeFactory = ServiceScopeSubstitute.Create((typeof(ErrorManager), errorManager));
+        var errorReporter = new ErrorReporter(
+            scopeFactory,
+            Substitute.For<ILogger<ErrorReporter>>()
+        );
+
+        var manager = new NportFilingReprocessManager(
+            repo,
+            secClient,
+            dbContext,
+            errorReporter,
+            Substitute.For<ILogger<NportFilingReprocessManager>>()
+        );
+
+        return (manager, dbContext, secClient);
+    }
+
+    private static CommonStock SeedStock(Equibles.Data.EquiblesFinancialDbContext dbContext)
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BTEC",
+            Name = "Big Tech Index ETF",
+            Cik = "0001771146",
+        };
+        dbContext.Add(stock);
+        dbContext.SaveChanges();
+        dbContext.ChangeTracker.Clear();
+        return stock;
+    }
+
+    private static NportFiling SeedFiling(
+        Equibles.Data.EquiblesFinancialDbContext dbContext,
+        CommonStock stock,
+        int parserVersion
+    )
+    {
+        var filing = new NportFiling
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stock.Id,
+            AccessionNumber = "0001104659-26-000099",
+            FilingDate = new DateOnly(2026, 3, 30),
+            ReportPeriodDate = new DateOnly(2026, 2, 28),
+            ReportPeriodEnd = new DateOnly(2026, 2, 28),
+            ParserVersion = parserVersion,
+        };
+        dbContext.Add(filing);
+        dbContext.SaveChanges();
+        dbContext.ChangeTracker.Clear();
+        return filing;
+    }
+
+    // A trimmed NPORT-P submission with two holdings, laid out as real EDGAR filings are —
+    // <invstOrSecs> is a child of <formData>, a sibling of <fundInfo>.
+    private const string ValidNportSubmission = """
+        <SEC-DOCUMENT>0001104659-26-000099.txt : 20260330
+        <DOCUMENT>
+        <TYPE>NPORT-P
+        <TEXT>
+        <XML>
+        <?xml version="1.0" encoding="UTF-8"?>
+        <edgarSubmission xmlns="http://www.sec.gov/edgar/nport">
+          <headerData>
+            <submissionType>NPORT-P</submissionType>
+          </headerData>
+          <formData>
+            <genInfo>
+              <regName>ETF Opportunities Trust</regName>
+              <seriesName>Big Tech Index ETF</seriesName>
+              <seriesId>S000087771</seriesId>
+              <repPdEnd>2026-08-31</repPdEnd>
+              <repPdDate>2026-02-28</repPdDate>
+              <isFinalFiling>N</isFinalFiling>
+            </genInfo>
+            <fundInfo>
+              <totAssets>287467294.33</totAssets>
+              <totLiabs>193875501.04</totLiabs>
+              <netAssets>93591793.29</netAssets>
+            </fundInfo>
+            <invstOrSecs>
+              <invstOrSec>
+                <name>AT&amp;T Inc</name>
+                <cusip>00206R102</cusip>
+                <balance>112500.00000000</balance>
+                <units>NS</units>
+                <curCd>USD</curCd>
+                <valUSD>1794375.00000000</valUSD>
+                <pctVal>1.92000000</pctVal>
+                <assetCat>EC</assetCat>
+                <issuerCat>CORP</issuerCat>
+                <invCountry>US</invCountry>
+              </invstOrSec>
+              <invstOrSec>
+                <name>Microsoft Corp</name>
+                <cusip>594918104</cusip>
+                <balance>5000.00000000</balance>
+                <units>NS</units>
+                <curCd>USD</curCd>
+                <valUSD>2100000.00000000</valUSD>
+                <pctVal>2.24000000</pctVal>
+                <assetCat>EC</assetCat>
+                <issuerCat>CORP</issuerCat>
+                <invCountry>US</invCountry>
+              </invstOrSec>
+            </invstOrSecs>
+          </formData>
+        </edgarSubmission>
+        </XML>
+        </TEXT>
+        </DOCUMENT>
+        </SEC-DOCUMENT>
+        """;
+}


### PR DESCRIPTION
## Summary

The NPORT-P holdings parser fix (#3496) only fills holdings for filings imported *after* it. The ~9,835 filings already in the table keep zero holdings, because the issuer-feed scraper skips any accession already present (`if (existing) return false`). So fund-holdings pages stay empty for every fund until the existing filings are re-parsed.

This adds a version-driven reprocess pass, mirroring the existing insider-filing reprocess (`InsiderFilingReprocessWorker` / `InsiderFilingReprocessManager`):

- `NportFiling` gains a `ParserVersion` column (`CurrentParserVersion = 1`). The ingest pipeline stamps newly-imported filings at the current version, so they're never reprocessed.
- `NportFilingReprocessManager` selects filings below the current version, re-fetches each from EDGAR, re-parses through the shared `NportFilingProcessor.ParseEntity`, replaces the stored holdings and header facts, and stamps the version. Version-driven means the run is resumable (an interrupted run continues next pass) and a future parser-version bump automatically re-enrolls every filing.
- `NportFilingReprocessWorker` drains the backlog on a 6h cycle in the worker process, sharing the single SEC rate-limiter with the other EDGAR scrapers and staggering startup so its initial burst doesn't collide with them.

No raw-payload cache is added (unlike the insider feature) — NPORT submissions are re-fetched from EDGAR. The `ParserVersion` stamp makes this a one-time re-fetch per filing per version bump, spread across cycles and rate-limited.

## Code changes

- `Equibles.Sec.Data/Models/NportFiling.cs` — `ParserVersion` property + `CurrentParserVersion` constant + index.
- `Equibles.Sec.HostedService/Services/NportFilingProcessor.cs` — extract the parse into a reusable `internal static ParseEntity`, stamp `ParserVersion` on import.
- `Equibles.Sec.HostedService/Services/NportFilingReprocessManager.cs` — new; version-driven re-fetch/re-parse in batches, resumable.
- `Equibles.Sec.HostedService/NportFilingReprocessWorker.cs` — new; 6h background drain.
- `Equibles.Sec.HostedService/Models/NportFilingReprocessResult.cs` — new; progress/outcome.
- `Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs` — register the worker.
- `Equibles.Errors.Data/Models/ErrorSource.cs` — add `NportReprocess` source.
- `Equibles.Migrations` — `AddNportParserVersion` migration (column default 0 → existing filings are eligible; index).

## Tests

- `NportFilingReprocessManagerTests` (new) — a stale (version 0, no holdings) filing is re-fetched, re-parsed and stamped (2 holdings inserted); a current-version filing is left untouched and never re-fetched.
- `NportFilingProcessorTests` — pins that import stamps `ParserVersion`.
- Fixes `NportFilingProcessorParseIssuerCategoryConditionalTests`, whose fixture still nested `invstOrSecs` inside `fundInfo` and broke once #3496 read holdings from `formData`.
- All 43 NPORT integration tests pass; full solution builds; csharpier clean.