### PR TITLE
fix(holdings): repair 13F filings that duplicate value into the share-count column

### DIFF
--- a/src/Equibles.Holdings.HostedService/Models/BufferedHoldingRow.cs
+++ b/src/Equibles.Holdings.HostedService/Models/BufferedHoldingRow.cs
@@ -1,0 +1,22 @@
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.Holdings.HostedService.Models;
+
+/// <summary>
+/// One INFOTABLE row parsed for the current filing, buffered until the
+/// accession boundary so per-filing sanity checks (the duplicated share-count
+/// column repair) can see the whole filing before rows merge into upsert
+/// batches.
+/// </summary>
+public class BufferedHoldingRow
+{
+    public InstitutionalHolding Holding { get; set; }
+    public HoldingManagerEntry ManagerEntry { get; set; }
+
+    /// <summary>
+    /// The position's market value exactly as filed (SEC <c>VALUE</c> column);
+    /// 0 when the column is absent. Used only to cross-check the share count —
+    /// persisted values are always derived from shares × closing price.
+    /// </summary>
+    public long ReportedValue { get; set; }
+}

--- a/src/Equibles.Holdings.HostedService/Models/Corrupt13FRepairOutcome.cs
+++ b/src/Equibles.Holdings.HostedService/Models/Corrupt13FRepairOutcome.cs
@@ -1,0 +1,8 @@
+namespace Equibles.Holdings.HostedService.Models;
+
+/// <summary>
+/// Counters from repairing a filing whose share-count column duplicated its
+/// value column: rows whose share count was recovered, and rows dropped
+/// because no repair anchor (closing price or voting-authority total) existed.
+/// </summary>
+public record Corrupt13FRepairOutcome(int RepairedRows, int DroppedRows);

--- a/src/Equibles.Holdings.HostedService/Models/Parsed13FHolding.cs
+++ b/src/Equibles.Holdings.HostedService/Models/Parsed13FHolding.cs
@@ -15,6 +15,13 @@ public class Parsed13FHolding
     public string ShareType { get; set; }
     public long Shares { get; set; }
 
+    /// <summary>
+    /// SEC <c>value</c>: the position's market value exactly as filed (whole
+    /// dollars for filings on/after 2023-01-03, thousands before). Carried so
+    /// the import pipeline can cross-check it against the share count.
+    /// </summary>
+    public long Value { get; set; }
+
     /// <summary>SEC <c>putCall</c>: <c>Put</c>, <c>Call</c>, or null/empty.</summary>
     public string PutCall { get; set; }
 

--- a/src/Equibles.Holdings.HostedService/Services/Corrupt13FShareCountRepairer.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Corrupt13FShareCountRepairer.cs
@@ -1,0 +1,148 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Models;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Detects and repairs 13F filings whose share-count column duplicates the
+/// value column. Some filers' software writes the position's dollar value
+/// into <c>sshPrnamt</c> (every row reports <c>sshPrnamt == value</c>);
+/// ingesting those counts verbatim and deriving Value = shares × price
+/// inflates the portfolio by roughly the share price (~100–1000×), which
+/// then dominates the AUM-movers and top-by-AUM rankings.
+/// </summary>
+internal static class Corrupt13FShareCountRepairer
+{
+    /// <summary>
+    /// 13F values filed on/after this date are whole dollars (SEC's 2022 13F
+    /// modernization, effective 2023-01-03); earlier filings report thousands.
+    /// </summary>
+    internal static readonly DateOnly WholeDollarValueEffectiveDate = new(2023, 1, 3);
+
+    // A filing is only suspect when nearly every comparable row duplicates the
+    // value into the share count; scattered equalities (a stock trading at
+    // exactly $1.00) must never flag a filing.
+    private const double SuspectRowFraction = 0.8;
+
+    // Below this many comparable rows the fraction signal is meaningless — a
+    // tiny filing could trip it on price coincidence alone.
+    private const int MinimumComparableRows = 5;
+
+    /// <summary>
+    /// True when the filing's share-count column duplicates its value column:
+    /// at least 80% of comparable rows (share-type rows where both figures are
+    /// positive) report the exact same number in both. Principal-type rows are
+    /// excluded — a par bond legitimately reports principal ≈ value.
+    /// </summary>
+    internal static bool IsSuspect(IReadOnlyCollection<BufferedHoldingRow> rows)
+    {
+        var comparable = 0;
+        var duplicated = 0;
+
+        foreach (var row in rows)
+        {
+            if (row.Holding.ShareType != ShareType.Shares)
+                continue;
+            if (row.Holding.Shares <= 0 || row.ReportedValue <= 0)
+                continue;
+
+            comparable++;
+            if (row.Holding.Shares == row.ReportedValue)
+                duplicated++;
+        }
+
+        return comparable >= MinimumComparableRows && duplicated >= comparable * SuspectRowFraction;
+    }
+
+    /// <summary>
+    /// Repairs every duplicated row of a suspect filing in place. The value
+    /// column is internally consistent in these filings, so the true share
+    /// count is value ÷ closing price; without a price the voting-authority
+    /// total is used when populated (these filers report the real count
+    /// there), and a row with neither anchor is dropped from
+    /// <paramref name="rows"/> rather than allowed to poison the rankings.
+    /// </summary>
+    internal static Corrupt13FRepairOutcome Repair(
+        List<BufferedHoldingRow> rows,
+        IReadOnlyDictionary<(Guid StockId, DateOnly ReportDate), decimal> stockPrices
+    )
+    {
+        var repaired = 0;
+        var dropped = 0;
+        var kept = new List<BufferedHoldingRow>(rows.Count);
+
+        foreach (var row in rows)
+        {
+            if (!IsDuplicatedRow(row))
+            {
+                kept.Add(row);
+                continue;
+            }
+
+            var holding = row.Holding;
+            var reportedDollars = ToDollars(row.ReportedValue, holding.FilingDate);
+
+            if (
+                stockPrices.TryGetValue(
+                    (holding.CommonStockId, holding.ReportDate),
+                    out var closePrice
+                )
+                && closePrice > 0
+            )
+            {
+                var shares = (long)Math.Round(reportedDollars / closePrice);
+                // The truncating cast deliberately mirrors ParseHoldingRow's
+                // `(long)(shares * closePrice)` so a repaired row is identical
+                // to what the same filing would have produced if filed correctly.
+                ApplyRepair(row, shares, (long)(shares * closePrice), valuePending: false);
+                repaired++;
+                kept.Add(row);
+                continue;
+            }
+
+            // Assumes the three authority columns partition the position (the
+            // normal 13F shape, and what both reference filings exhibit); a
+            // filer reporting overlapping authority would overstate the count,
+            // but the row stays ValuePending and is repriced later anyway.
+            var votingTotal =
+                holding.VotingAuthSole + holding.VotingAuthShared + holding.VotingAuthNone;
+            if (votingTotal > 0)
+            {
+                // No price for this (stock, quarter) yet: keep the corrected
+                // count and let the pending-value retry path price it later.
+                ApplyRepair(row, votingTotal, 0L, valuePending: true);
+                repaired++;
+                kept.Add(row);
+                continue;
+            }
+
+            dropped++;
+        }
+
+        rows.Clear();
+        rows.AddRange(kept);
+        return new Corrupt13FRepairOutcome(repaired, dropped);
+    }
+
+    private static bool IsDuplicatedRow(BufferedHoldingRow row) =>
+        row.Holding.ShareType == ShareType.Shares
+        && row.Holding.Shares > 0
+        && row.Holding.Shares == row.ReportedValue;
+
+    private static decimal ToDollars(long reportedValue, DateOnly filingDate) =>
+        filingDate < WholeDollarValueEffectiveDate ? reportedValue * 1000m : reportedValue;
+
+    private static void ApplyRepair(
+        BufferedHoldingRow row,
+        long shares,
+        long value,
+        bool valuePending
+    )
+    {
+        row.Holding.Shares = shares;
+        row.Holding.Value = value;
+        row.Holding.ValuePending = valuePending;
+        row.ManagerEntry.Shares = shares;
+        row.ManagerEntry.Value = value;
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13FXmlParser.cs
@@ -110,6 +110,7 @@ public class Filing13FXmlParser
                     TitleOfClass = Value(Child(info, "titleOfClass")),
                     ShareType = Value(Child(amount, "sshPrnamtType")),
                     Shares = ParseLong(Value(Child(amount, "sshPrnamt"))),
+                    Value = ParseLong(Value(Child(info, "value"))),
                     PutCall = Value(Child(info, "putCall")),
                     InvestmentDiscretion = Value(Child(info, "investmentDiscretion")),
                     VotingAuthSole = ParseLong(Value(Child(voting, "Sole"))),

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -636,7 +636,7 @@ public class HoldingsImportService
     )
     {
         var infoTableEntry = FindEntry(context.Archive, "INFOTABLE.tsv");
-        var holdingsMap = new Dictionary<string, InstitutionalHolding>();
+        var bufferedRows = new List<BufferedHoldingRow>();
         var totalInserted = 0;
         var totalSkipped = 0;
         var totalDuplicates = 0;
@@ -658,12 +658,21 @@ public class HoldingsImportService
             // the last one's sum survives. SEC orders the bulk INFOTABLE by
             // INFOTABLE_SK and the realtime archive by XML element order, so
             // a single accession's rows are always contiguous; flushing only
-            // when the accession changes guarantees in-memory aggregation
-            // finishes before any UPSERT for that key runs.
-            if (currentAccession != null && accession != currentAccession && holdingsMap.Count > 0)
+            // when the accession changes guarantees both the per-filing
+            // share-count repair and the in-memory aggregation see the whole
+            // filing before any UPSERT for its keys runs.
+            if (currentAccession != null && accession != currentAccession && bufferedRows.Count > 0)
             {
-                totalInserted += await FlushBatch(holdingsMap.Values.ToList(), cancellationToken);
-                holdingsMap.Clear();
+                var flushed = await RepairMergeAndFlush(
+                    currentAccession,
+                    bufferedRows,
+                    context,
+                    cancellationToken
+                );
+                totalInserted += flushed.Inserted;
+                totalDuplicates += flushed.Duplicates;
+                totalPending += flushed.Pending;
+                bufferedRows.Clear();
             }
             currentAccession = accession;
 
@@ -683,7 +692,7 @@ public class HoldingsImportService
             TryParseDateOnly(submission.FilingDate, out var filingDate);
             TryParseDateOnly(submission.PeriodOfReport, out var reportDate);
 
-            var (holding, managerEntry, valuePending) = ParseHoldingRow(
+            var (holding, managerEntry, _, reportedValue) = ParseHoldingRow(
                 row,
                 accession,
                 cusip,
@@ -693,21 +702,28 @@ public class HoldingsImportService
                 reportDate,
                 context
             );
-            if (AddOrMergeHolding(holdingsMap, holding, managerEntry))
-            {
-                if (valuePending)
-                    totalPending++;
-            }
-            else
-            {
-                totalDuplicates++;
-            }
+            bufferedRows.Add(
+                new BufferedHoldingRow
+                {
+                    Holding = holding,
+                    ManagerEntry = managerEntry,
+                    ReportedValue = reportedValue,
+                }
+            );
         }
 
-        if (holdingsMap.Count > 0)
+        if (bufferedRows.Count > 0)
         {
-            totalInserted += await FlushBatch(holdingsMap.Values.ToList(), cancellationToken);
-            holdingsMap.Clear();
+            var flushed = await RepairMergeAndFlush(
+                currentAccession,
+                bufferedRows,
+                context,
+                cancellationToken
+            );
+            totalInserted += flushed.Inserted;
+            totalDuplicates += flushed.Duplicates;
+            totalPending += flushed.Pending;
+            bufferedRows.Clear();
         }
 
         _logger.LogInformation(
@@ -717,6 +733,54 @@ public class HoldingsImportService
             totalDuplicates,
             totalPending
         );
+    }
+
+    // Runs the per-filing share-count repair over one accession's buffered rows,
+    // merges them by upsert key, and flushes the batch. Repair must happen here —
+    // after the whole filing is buffered, before any row merges — because the
+    // duplicated-column signal is a property of the filing, not of a single row.
+    private async Task<(int Inserted, int Duplicates, int Pending)> RepairMergeAndFlush(
+        string accession,
+        List<BufferedHoldingRow> bufferedRows,
+        ImportContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        if (Corrupt13FShareCountRepairer.IsSuspect(bufferedRows))
+        {
+            var outcome = Corrupt13FShareCountRepairer.Repair(bufferedRows, context.StockPrices);
+            _logger.LogWarning(
+                "Filing {Accession} duplicates its value column into the share-count column; "
+                    + "recovered {Repaired} row(s) from the filed value, dropped {Dropped} unrepairable row(s)",
+                accession,
+                outcome.RepairedRows,
+                outcome.DroppedRows
+            );
+        }
+
+        var holdingsMap = new Dictionary<string, InstitutionalHolding>();
+        var duplicates = 0;
+        var pending = 0;
+
+        foreach (var row in bufferedRows)
+        {
+            if (AddOrMergeHolding(holdingsMap, row.Holding, row.ManagerEntry))
+            {
+                if (row.Holding.ValuePending)
+                    pending++;
+            }
+            else
+            {
+                duplicates++;
+            }
+        }
+
+        var inserted =
+            holdingsMap.Count > 0
+                ? await FlushBatch(holdingsMap.Values.ToList(), cancellationToken)
+                : 0;
+
+        return (inserted, duplicates, pending);
     }
 
     // Buffers a parsed row by its upsert key. A 13F holder can split one security
@@ -750,7 +814,8 @@ public class HoldingsImportService
     private static (
         InstitutionalHolding Holding,
         HoldingManagerEntry ManagerEntry,
-        bool ValuePending
+        bool ValuePending,
+        long ReportedValue
     ) ParseHoldingRow(
         Dictionary<string, string> row,
         string accession,
@@ -772,6 +837,10 @@ public class HoldingsImportService
         long ParseLongField(string field) => ParseLong(GetValue(row, field));
 
         var shares = ParseLongField("SSHPRNAMT");
+        // The filed market value is never persisted directly (Value is always
+        // derived from shares × closing price); it is carried out solely so the
+        // per-filing repair can cross-check it against the share count.
+        var reportedValue = ParseLongField("VALUE");
         var votingAuthSole = ParseLongField("VOTING_AUTH_SOLE");
         var votingAuthShared = ParseLongField("VOTING_AUTH_SHARED");
         var votingAuthNone = ParseLongField("VOTING_AUTH_NONE");
@@ -817,7 +886,7 @@ public class HoldingsImportService
             ValuePending = valuePending,
         };
 
-        return (holding, managerEntry, valuePending);
+        return (holding, managerEntry, valuePending, reportedValue);
     }
 
     private async Task<int> FlushBatch(

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FArchiveBuilder.cs
@@ -29,7 +29,7 @@ public class Realtime13FArchiveBuilder
                 + "CONFIDENTIALTREATMENT\n"
         );
         var infoTable = new StringBuilder(
-            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMTTYPE\tPUTCALL\tSSHPRNAMT\tVOTING_AUTH_SOLE\t"
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMTTYPE\tPUTCALL\tVALUE\tSSHPRNAMT\tVOTING_AUTH_SOLE\t"
                 + "VOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\tINVESTMENTDISCRETION\n"
         );
         var otherManager = new StringBuilder("ACCESSION_NUMBER\tSEQUENCENUMBER\tNAME\n");
@@ -73,6 +73,7 @@ public class Realtime13FArchiveBuilder
                     Clean(holding.Cusip),
                     Clean(holding.ShareType),
                     Clean(holding.PutCall),
+                    holding.Value,
                     holding.Shares,
                     holding.VotingAuthSole,
                     holding.VotingAuthShared,

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceFullPipelineTests.cs
@@ -213,6 +213,88 @@ public class HoldingsImportServiceFullPipelineTests : IAsyncLifetime
         holder.City.Should().Be("Omaha");
     }
 
+    // ── Duplicated share-count column repair ───────────────────────────
+
+    [Fact]
+    public async Task ImportDataSet_FilingDuplicatesValueIntoShareCount_PersistsRepairedSharesFromValueDividedByPrice()
+    {
+        // Some filers' software writes each position's dollar value into
+        // SSHPRNAMT (e.g. DIAMANT ASSET MANAGEMENT 0001731124-26-000002):
+        // every row reports SSHPRNAMT == VALUE. Ingesting those counts
+        // verbatim and deriving Value = shares × price inflated portfolios
+        // ~1000×. Pin the full-pipeline repair: with ≥5 such rows the filing
+        // is flagged and each persisted holding carries shares = VALUE ÷
+        // closing price instead of the corrupt count.
+        var reportDate = new DateOnly(2026, 3, 31);
+        var stocks = new List<CommonStock>();
+        var prices = new Dictionary<(Guid, DateOnly), decimal>();
+        var infoTable = new StringBuilder(
+            "ACCESSION_NUMBER\tCUSIP\tVALUE\tSSHPRNAMT\tSSHPRNAMTTYPE\tPUTCALL\tINVESTMENTDISCRETION\tVOTING_AUTH_SOLE\tVOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\n"
+        );
+
+        for (var i = 1; i <= 5; i++)
+        {
+            var stock = new CommonStock
+            {
+                Id = Guid.NewGuid(),
+                Ticker = $"TK{i}",
+                Name = $"Tracked Co {i}",
+                Cik = $"000000010{i}",
+                Cusip = $"11111111{i}",
+            };
+            stocks.Add(stock);
+            prices[(stock.Id, reportDate)] = 250m;
+
+            // SSHPRNAMT duplicates VALUE — the defect under test.
+            var dollarValue = i * 2_500_000L;
+            infoTable.Append(
+                $"ACC-13F\t{stock.Cusip}\t{dollarValue}\t{dollarValue}\tSH\t\tSOLE\t{i * 10_000}\t0\t0\tCOM\t\n"
+            );
+        }
+
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>().AddRange(stocks);
+            await seed.SaveChangesAsync();
+        }
+
+        var submission =
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+            + "13F-HR\tACC-13F\t2026-05-15\t2026-03-31\t0001731124\n";
+        var coverPage =
+            "ACCESSION_NUMBER\tISAMENDMENT\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\tFILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\n"
+            + "ACC-13F\tN\tDiamant Asset Management\tRidgefield\tCT\t028-99999\t54321\n";
+
+        using var archive = BuildArchive(
+            ("SUBMISSION.tsv", submission),
+            ("COVERPAGE.tsv", coverPage),
+            ("INFOTABLE.tsv", infoTable.ToString())
+        );
+
+        var sut = CreateImporter(PriceProviderReturning(prices));
+
+        var result = await sut.ImportDataSet(
+            archive,
+            new DateOnly(2026, 1, 1),
+            CancellationToken.None
+        );
+
+        result.IsComplete.Should().BeTrue();
+
+        using var verify = FreshContext();
+        var holdings = await verify.Set<InstitutionalHolding>().ToListAsync();
+        holdings.Should().HaveCount(5);
+
+        for (var i = 1; i <= 5; i++)
+        {
+            var holding = holdings.Single(h => h.Cusip == $"11111111{i}");
+            // value ÷ price: (i × 2,500,000) ÷ 250 = i × 10,000 shares.
+            holding.Shares.Should().Be(i * 10_000L);
+            holding.Value.Should().Be(i * 2_500_000L);
+            holding.ValuePending.Should().BeFalse();
+        }
+    }
+
     // ── Cold-start CUSIP race (GH-817) ─────────────────────────────────
 
     [Fact]

--- a/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerTests.cs
@@ -1,0 +1,202 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+// Pins the detection + repair of filings whose share-count column duplicates
+// the value column (issue: some filers' software writes the position's dollar
+// value into sshPrnamt — e.g. DIAMANT ASSET MANAGEMENT 0001731124-26-000002,
+// J. Stern & Co. 0002011335-26-000002). Ingesting those counts verbatim and
+// deriving Value = shares × price inflated portfolios ~1000×, corrupting the
+// AUM-movers and top-by-AUM rankings.
+public class Corrupt13FShareCountRepairerTests
+{
+    private static readonly DateOnly PostRuleFilingDate = new(2026, 4, 15);
+    private static readonly DateOnly ReportDate = new(2026, 3, 31);
+
+    [Fact]
+    public void IsSuspect_EveryShareRowDuplicatesValue_True()
+    {
+        var rows = Enumerable
+            .Range(1, 6)
+            .Select(i => Row(shares: i * 1000, reportedValue: i * 1000))
+            .ToList();
+
+        Corrupt13FShareCountRepairer.IsSuspect(rows).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSuspect_FewerThanFiveComparableRows_False()
+    {
+        // Four rows all duplicated: below the minimum sample, a small filing
+        // must never be flagged on coincidence (e.g. stocks at exactly $1.00).
+        var rows = Enumerable
+            .Range(1, 4)
+            .Select(i => Row(shares: i * 1000, reportedValue: i * 1000))
+            .ToList();
+
+        Corrupt13FShareCountRepairer.IsSuspect(rows).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSuspect_DuplicationBelowEightyPercent_False()
+    {
+        // 7 of 10 comparable rows duplicated (70%) — under the threshold.
+        var duplicated = Enumerable
+            .Range(1, 7)
+            .Select(i => Row(shares: i * 1000, reportedValue: i * 1000));
+        var healthy = Enumerable
+            .Range(1, 3)
+            .Select(i => Row(shares: i * 100, reportedValue: i * 25_000));
+        var rows = duplicated.Concat(healthy).ToList();
+
+        Corrupt13FShareCountRepairer.IsSuspect(rows).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSuspect_PrincipalRowsEqualValue_NotCounted()
+    {
+        // A par bond legitimately reports principal == value, so PRN rows must
+        // not contribute to the duplicated-column signal.
+        var rows = Enumerable
+            .Range(1, 6)
+            .Select(i =>
+                Row(
+                    shares: i * 1_000_000,
+                    reportedValue: i * 1_000_000,
+                    shareType: ShareType.Principal
+                )
+            )
+            .ToList();
+
+        Corrupt13FShareCountRepairer.IsSuspect(rows).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Repair_PricedDuplicatedRow_RecoversSharesFromValueDividedByPrice()
+    {
+        // DIAMANT-shaped row: sshPrnamt carries the dollar value. With the
+        // quarter's closing price the true count is value ÷ price.
+        var row = Row(shares: 2_500_000, reportedValue: 2_500_000);
+        var rows = new List<BufferedHoldingRow> { row };
+        var prices = Prices(row, 250.00m);
+
+        var outcome = Corrupt13FShareCountRepairer.Repair(rows, prices);
+
+        outcome.Should().Be(new Corrupt13FRepairOutcome(RepairedRows: 1, DroppedRows: 0));
+        row.Holding.Shares.Should().Be(10_000L);
+        row.Holding.Value.Should().Be(2_500_000L);
+        row.Holding.ValuePending.Should().BeFalse();
+        row.ManagerEntry.Shares.Should().Be(10_000L);
+        row.ManagerEntry.Value.Should().Be(2_500_000L);
+    }
+
+    [Fact]
+    public void Repair_NoPriceButVotingTotalPresent_UsesVotingTotalAndMarksValuePending()
+    {
+        // These filers report the true count in the voting-authority columns
+        // (verified against EDGAR for both reference filings). Without a price
+        // the count is recovered from there and the value left for the
+        // pending-price retry path.
+        var row = Row(shares: 6_702_883, reportedValue: 6_702_883, votingSole: 6_751);
+        var rows = new List<BufferedHoldingRow> { row };
+
+        var outcome = Corrupt13FShareCountRepairer.Repair(
+            rows,
+            new Dictionary<(Guid, DateOnly), decimal>()
+        );
+
+        outcome.Should().Be(new Corrupt13FRepairOutcome(RepairedRows: 1, DroppedRows: 0));
+        row.Holding.Shares.Should().Be(6_751L);
+        row.Holding.Value.Should().Be(0L);
+        row.Holding.ValuePending.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Repair_NoPriceAndNoVotingTotal_DropsRow()
+    {
+        var row = Row(shares: 1_000_000, reportedValue: 1_000_000);
+        var rows = new List<BufferedHoldingRow> { row };
+
+        var outcome = Corrupt13FShareCountRepairer.Repair(
+            rows,
+            new Dictionary<(Guid, DateOnly), decimal>()
+        );
+
+        outcome.Should().Be(new Corrupt13FRepairOutcome(RepairedRows: 0, DroppedRows: 1));
+        rows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Repair_FilingBefore2023_TreatsReportedValueAsThousands()
+    {
+        // Pre-modernization filings (before 2023-01-03) report value in
+        // thousands of dollars; the recovered count must scale accordingly.
+        var row = Row(
+            shares: 1_000,
+            reportedValue: 1_000,
+            filingDate: new DateOnly(2021, 8, 12),
+            reportDate: new DateOnly(2021, 6, 30)
+        );
+        var rows = new List<BufferedHoldingRow> { row };
+        var prices = Prices(row, 100.00m);
+
+        Corrupt13FShareCountRepairer.Repair(rows, prices);
+
+        // $1,000 thousands = $1,000,000 ÷ $100 = 10,000 shares.
+        row.Holding.Shares.Should().Be(10_000L);
+        row.Holding.Value.Should().Be(1_000_000L);
+    }
+
+    [Fact]
+    public void Repair_HealthyRowInSuspectFiling_LeftUntouched()
+    {
+        // A suspect filing can still contain rows where the share count is
+        // genuine (e.g. 19 of Align Financial's 233 rows); only duplicated
+        // rows may be rewritten.
+        var healthy = Row(shares: 500, reportedValue: 125_000);
+        var rows = new List<BufferedHoldingRow> { healthy };
+        var prices = Prices(healthy, 250.00m);
+
+        var outcome = Corrupt13FShareCountRepairer.Repair(rows, prices);
+
+        outcome.Should().Be(new Corrupt13FRepairOutcome(RepairedRows: 0, DroppedRows: 0));
+        healthy.Holding.Shares.Should().Be(500L);
+    }
+
+    private static BufferedHoldingRow Row(
+        long shares,
+        long reportedValue,
+        ShareType shareType = ShareType.Shares,
+        long votingSole = 0,
+        DateOnly? filingDate = null,
+        DateOnly? reportDate = null
+    )
+    {
+        var holding = new InstitutionalHolding
+        {
+            CommonStockId = Guid.NewGuid(),
+            InstitutionalHolderId = Guid.NewGuid(),
+            FilingDate = filingDate ?? PostRuleFilingDate,
+            ReportDate = reportDate ?? ReportDate,
+            Shares = shares,
+            Value = 0,
+            ShareType = shareType,
+            VotingAuthSole = votingSole,
+            ValuePending = true,
+        };
+
+        return new BufferedHoldingRow
+        {
+            Holding = holding,
+            ManagerEntry = new HoldingManagerEntry { Shares = shares, Value = 0 },
+            ReportedValue = reportedValue,
+        };
+    }
+
+    private static Dictionary<(Guid, DateOnly), decimal> Prices(
+        BufferedHoldingRow row,
+        decimal closePrice
+    ) => new() { [(row.Holding.CommonStockId, row.Holding.ReportDate)] = closePrice };
+}

--- a/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseInformationTableTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13FXmlParserParseInformationTableTests.cs
@@ -73,4 +73,31 @@ public class Filing13FXmlParserParseInformationTableTests
         second.VotingAuthNone.Should().Be(1234567);
         second.OtherManagerNumber.Should().BeNull();
     }
+
+    // The filed <value> element is the anchor the import pipeline uses to
+    // detect filings whose share-count column duplicates the value column;
+    // a parser that silently drops it would disable that repair entirely.
+    [Fact]
+    public void ParseInformationTable_RowWithValue_ParsesFiledValue()
+    {
+        var xml =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<informationTable xmlns=\"http://www.sec.gov/edgar/document/thirteenf/informationtable\">"
+            + "  <infoTable>"
+            + "    <cusip>037833100</cusip>"
+            + "    <value>26614323</value>"
+            + "    <shrsOrPrnAmt>"
+            + "      <sshPrnamt>26614323</sshPrnamt>"
+            + "      <sshPrnamtType>SH</sshPrnamtType>"
+            + "    </shrsOrPrnAmt>"
+            + "    <investmentDiscretion>SOLE</investmentDiscretion>"
+            + "  </infoTable>"
+            + "</informationTable>";
+
+        var result = _sut.ParseInformationTable(xml);
+
+        result.Should().HaveCount(1);
+        result[0].Value.Should().Be(26614323);
+        result[0].Shares.Should().Be(26614323);
+    }
 }

--- a/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13FArchiveBuilderTests.cs
@@ -128,6 +128,38 @@ public class Realtime13FArchiveBuilderTests
         lines[1].Should().Contain("915560");
     }
 
+    // The VALUE column carries the filed market value through to the import
+    // pipeline's duplicated share-count repair; dropping it from the synthetic
+    // archive would silently disable that repair on the real-time path.
+    [Fact]
+    public void Build_WithHoldings_InfoTableWritesFiledValueColumn()
+    {
+        var filing = CreateFiling();
+        filing.Holdings.Add(
+            new Parsed13FHolding
+            {
+                Cusip = "037833100",
+                TitleOfClass = "COM",
+                ShareType = "SH",
+                Shares = 915560,
+                Value = 26614323,
+                InvestmentDiscretion = "SOLE",
+            }
+        );
+
+        using var archive = _sut.Build([filing]);
+        var content = ReadEntry(archive, "INFOTABLE.tsv");
+        var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        var headers = lines[0].Split('\t');
+        var fields = lines[1].Split('\t');
+        var valueIndex = Array.IndexOf(headers, "VALUE");
+
+        valueIndex.Should().BeGreaterThan(-1, "INFOTABLE must carry the filed VALUE column");
+        fields[valueIndex].Should().Be("26614323");
+        fields[Array.IndexOf(headers, "SSHPRNAMT")].Should().Be("915560");
+    }
+
     [Fact]
     public void Build_HoldingWithOtherManager_OtherManagerNumberWritten()
     {
@@ -149,8 +181,8 @@ public class Realtime13FArchiveBuilderTests
         var dataLine = content.Split('\n')[1];
         var fields = dataLine.Split('\t');
 
-        // OTHERMANAGER is field index 9 (0-based)
-        fields[9].Should().Be("3");
+        // OTHERMANAGER is field index 10 (0-based, after the VALUE column)
+        fields[10].Should().Be("3");
     }
 
     [Fact]
@@ -174,7 +206,7 @@ public class Realtime13FArchiveBuilderTests
         var dataLine = content.Split('\n')[1];
         var fields = dataLine.Split('\t');
 
-        fields[9].Should().BeEmpty();
+        fields[10].Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Some filers' software writes each position's dollar value into the `sshPrnamt` share-count field — every info-table row reports `sshPrnamt == value` (confirmed against EDGAR for `0001731124-26-000002` DIAMANT ASSET MANAGEMENT and `0002011335-26-000002` J. Stern & Co., including its amendment). The pipeline ingested those counts verbatim and derived `Value = shares × closing price`, inflating the affected portfolios by roughly the share price (~100–1000×). Those filings then dominated the AUM movers / top-by-AUM / smart-money rankings (daniel3303/EquiblesCommercial#1535).

The filed `value` column is internally consistent in these filings, so the true share count is deterministically recoverable as `value ÷ closing price` — this PR detects the defect per filing and repairs it at ingestion, on both the bulk-dataset and real-time paths.

## Code changes

- `Filing13FXmlParser` / `Parsed13FHolding` — parse and carry the per-row filed `value`, previously discarded.
- `Realtime13FArchiveBuilder` — write a `VALUE` column into the synthetic INFOTABLE so the real-time path reconciles with the bulk path.
- `HoldingsImportService` — buffer each filing's rows at the existing accession-boundary flush, run the per-filing check, then merge + flush as before (`RepairMergeAndFlush`). Counter semantics unchanged.
- `Corrupt13FShareCountRepairer` (new) — flags a filing when ≥80% of ≥5 comparable share-type rows have `shares == value` (principal rows excluded: par bonds legitimately report principal ≈ value). Repairs flagged rows: `shares = value ÷ close` (pre-2023 filings report thousands per the SEC's 13F modernization), falls back to the voting-authority total with `ValuePending` when the quarter has no price yet, and drops rows with no anchor.
- Tests — unit pins for detection thresholds, repair arithmetic, pre-2023 scaling, voting fallback, drop path, and healthy-row passthrough; XML-parser and archive-builder pins for the new value plumbing; a full-pipeline integration test driving a corrupt filing through `ImportDataSet` against real Postgres.

Detection operates on tracked rows only, so a corrupt filing with fewer than 5 tracked positions still slips through — a deliberate trade-off against false positives.

Unit suite: 2596 passed. Holdings integration suite: 332 passed.