### PR TITLE
fix(insider): attribute Form 4 trades to the issuer, not the reporting owner's own ticker

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
@@ -124,6 +124,20 @@ public static class InsiderFilingParser
         }
     }
 
+    /// <summary>
+    /// The issuer CIK declared in the ownership document, with leading zeros stripped
+    /// so it compares against the un-padded CIK stored on the company. Returns null for
+    /// pre-XML-era filings that have no issuer block. A Form 4 surfaces in the EDGAR feed
+    /// of every CIK it references — issuer and each reporting owner — so this lets callers
+    /// confirm a filing actually belongs to the company being processed rather than to a
+    /// public-company insider that merely reported a trade in another issuer.
+    /// </summary>
+    public static string GetIssuerCik(XElement root)
+    {
+        var cik = root?.Element("issuer")?.Element("issuerCik")?.Value?.Trim();
+        return string.IsNullOrEmpty(cik) ? null : cik.TrimStart('0');
+    }
+
     internal static InsiderTransaction ParseTransaction(
         XElement txElement,
         InsiderOwner owner,

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -51,6 +51,8 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         // Capture IDs from the outer-scope entity to avoid leaking untracked entities into inner scope
         var companyId = companyOutContext.Id;
         var companyTicker = companyOutContext.Ticker;
+        var companyCiks = new List<string> { companyOutContext.Cik };
+        companyCiks.AddRange(companyOutContext.SecondaryCiks);
 
         await using var scope = _scopeFactory.CreateAsyncScope();
         var secEdgarClient = scope.ServiceProvider.GetRequiredService<ISecEdgarClient>();
@@ -84,6 +86,16 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
         var root = await TryParseOwnershipRoot(xmlContent, filing, companyTicker);
         if (root == null)
+            return false;
+
+        // A Form 4 appears in the EDGAR submissions feed of every CIK it references —
+        // the issuer and each reporting owner. When a tracked public company (e.g.
+        // Carlyle) is itself a reporting owner on another issuer's filing (e.g. its
+        // sale of Medline stock), that filing surfaces in the company's own feed.
+        // Attributing it here would stamp the other issuer's trade onto this ticker,
+        // so skip it: the filing is imported correctly when the real issuer's feed
+        // is scraped.
+        if (!IssuerMatchesCompany(root, companyCiks, filing, companyTicker))
             return false;
 
         var owner = await TryResolveOwner(root, ownerRepository, filing, companyTicker);
@@ -258,6 +270,38 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         }
 
         return root;
+    }
+
+    // True when the filing's issuer is the company being processed (matched by primary
+    // or secondary CIK, leading zeros ignored). Pre-XML-era filings have no issuer block,
+    // so they fall back to trusting the feed that surfaced them rather than being dropped.
+    private bool IssuerMatchesCompany(
+        XElement root,
+        IReadOnlyCollection<string> companyCiks,
+        FilingData filing,
+        string companyTicker
+    )
+    {
+        var issuerCik = InsiderFilingParser.GetIssuerCik(root);
+        if (string.IsNullOrEmpty(issuerCik))
+            return true;
+
+        var matches = companyCiks.Any(c =>
+            !string.IsNullOrEmpty(c)
+            && string.Equals(c.TrimStart('0'), issuerCik, StringComparison.Ordinal)
+        );
+        if (matches)
+            return true;
+
+        _logger.LogDebug(
+            "Skipping Form {Form} {AccessionNumber} for {Ticker}: issuer CIK {IssuerCik} "
+                + "differs from the company (surfaced via a reporting-owner feed)",
+            filing.Form,
+            filing.AccessionNumber,
+            companyTicker,
+            issuerCik
+        );
+        return false;
     }
 
     private async Task<InsiderOwner> TryResolveOwner(

--- a/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/InsiderTradingFilingProcessorTests.cs
@@ -268,6 +268,78 @@ public class InsiderTradingFilingProcessorTests
         </ownershipDocument>
         """;
 
+    // A Form 4 where the processing company (Apple, CIK 320193) is a reporting owner,
+    // not the issuer — the issuer is Medline (CIK 2046386). EDGAR lists this filing in
+    // Apple's own CIK feed, so without an issuer check the Medline trade would be stamped
+    // onto AAPL. The CIK is zero-padded in the XML to match how EDGAR emits it.
+    private static readonly string Form4OtherIssuerXml = """
+        <ownershipDocument>
+            <issuer>
+                <issuerCik>0002046386</issuerCik>
+                <issuerTradingSymbol>MDLN</issuerTradingSymbol>
+            </issuer>
+            <reportingOwner>
+                <reportingOwnerId>
+                    <rptOwnerCik>0000320193</rptOwnerCik>
+                    <rptOwnerName>Apple Inc</rptOwnerName>
+                </reportingOwnerId>
+            </reportingOwner>
+            <nonDerivativeTable>
+                <nonDerivativeTransaction>
+                    <securityTitle><value>Common Stock</value></securityTitle>
+                    <transactionDate><value>2024-03-15</value></transactionDate>
+                    <transactionCoding><transactionCode>S</transactionCode></transactionCoding>
+                    <transactionAmounts>
+                        <transactionShares><value>1000</value></transactionShares>
+                        <transactionPricePerShare><value>41</value></transactionPricePerShare>
+                        <transactionAcquiredDisposedCode><value>D</value></transactionAcquiredDisposedCode>
+                    </transactionAmounts>
+                    <postTransactionAmounts>
+                        <sharesOwnedFollowingTransaction><value>5000</value></sharesOwnedFollowingTransaction>
+                    </postTransactionAmounts>
+                    <ownershipNature>
+                        <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+                    </ownershipNature>
+                </nonDerivativeTransaction>
+            </nonDerivativeTable>
+        </ownershipDocument>
+        """;
+
+    // Same shape but the issuer is the processing company itself, with the CIK zero-padded
+    // in the XML and un-padded on the company — the normalized comparison must still match.
+    private static readonly string Form4OwnIssuerPaddedCikXml = """
+        <ownershipDocument>
+            <issuer>
+                <issuerCik>0000320193</issuerCik>
+                <issuerTradingSymbol>AAPL</issuerTradingSymbol>
+            </issuer>
+            <reportingOwner>
+                <reportingOwnerId>
+                    <rptOwnerCik>0001234567</rptOwnerCik>
+                    <rptOwnerName>John Doe</rptOwnerName>
+                </reportingOwnerId>
+            </reportingOwner>
+            <nonDerivativeTable>
+                <nonDerivativeTransaction>
+                    <securityTitle><value>Common Stock</value></securityTitle>
+                    <transactionDate><value>2024-03-15</value></transactionDate>
+                    <transactionCoding><transactionCode>P</transactionCode></transactionCoding>
+                    <transactionAmounts>
+                        <transactionShares><value>1000</value></transactionShares>
+                        <transactionPricePerShare><value>150.50</value></transactionPricePerShare>
+                        <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+                    </transactionAmounts>
+                    <postTransactionAmounts>
+                        <sharesOwnedFollowingTransaction><value>5000</value></sharesOwnedFollowingTransaction>
+                    </postTransactionAmounts>
+                    <ownershipNature>
+                        <directOrIndirectOwnership><value>D</value></directOrIndirectOwnership>
+                    </ownershipNature>
+                </nonDerivativeTransaction>
+            </nonDerivativeTable>
+        </ownershipDocument>
+        """;
+
     private static readonly string Form3HoldingsXml = """
         <ownershipDocument>
             <reportingOwner>
@@ -389,6 +461,33 @@ public class InsiderTradingFilingProcessorTests
         owners[0].IsDirector.Should().BeTrue();
         owners[0].IsOfficer.Should().BeTrue();
         owners[0].OfficerTitle.Should().Be("CEO");
+    }
+
+    [Fact]
+    public async Task Process_IssuerCikDiffersFromCompany_SkipsAndInsertsNothing()
+    {
+        var (processor, ownerRepo, txRepo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(Form4OtherIssuerXml);
+
+        // MakeCompany is Apple; the filing's issuer is Medline, so Apple is only a
+        // reporting owner here and the filing must not be attributed to AAPL.
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeFalse();
+        txRepo.GetAll().Should().BeEmpty();
+        ownerRepo.GetAll().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Process_IssuerCikMatchesCompanyWithLeadingZeros_InsertsTransactions()
+    {
+        var (processor, _, txRepo, secClient) = CreateProcessorWithDeps();
+        secClient.GetDocumentContent(Arg.Any<FilingData>()).Returns(Form4OwnIssuerPaddedCikXml);
+
+        var result = await processor.Process(MakeFiling(), MakeCompany());
+
+        result.Should().BeTrue();
+        txRepo.GetAll().Should().HaveCount(1);
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserGetIssuerCikTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserGetIssuerCikTests.cs
@@ -1,0 +1,43 @@
+using Equibles.InsiderTrading.BusinessLogic;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserGetIssuerCikTests
+{
+    // GetIssuerCik lets the filing processor confirm a Form 4 surfaced by a CIK feed
+    // actually belongs to the company being processed. EDGAR lists a Form 4 under every
+    // CIK it references (issuer + each reporting owner), so a public-company insider that
+    // sold another issuer's stock would otherwise be attributed to itself. The issuer CIK
+    // is zero-padded in the XML but stored un-padded on the company, so the leading zeros
+    // must be stripped for the comparison to hold.
+
+    [Fact]
+    public void GetIssuerCik_PaddedIssuerCik_StripsLeadingZeros()
+    {
+        var root = InsiderFilingParser.TryGetOwnershipRoot(
+            "<ownershipDocument><issuer><issuerCik>0002046386</issuerCik></issuer></ownershipDocument>"
+        );
+
+        InsiderFilingParser.GetIssuerCik(root).Should().Be("2046386");
+    }
+
+    [Fact]
+    public void GetIssuerCik_NoIssuerBlock_ReturnsNull()
+    {
+        var root = InsiderFilingParser.TryGetOwnershipRoot(
+            "<ownershipDocument><reportingOwner /></ownershipDocument>"
+        );
+
+        InsiderFilingParser.GetIssuerCik(root).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetIssuerCik_EmptyIssuerCik_ReturnsNull()
+    {
+        var root = InsiderFilingParser.TryGetOwnershipRoot(
+            "<ownershipDocument><issuer><issuerCik></issuerCik></issuer></ownershipDocument>"
+        );
+
+        InsiderFilingParser.GetIssuerCik(root).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

A Form 4 appears in the EDGAR submissions feed of **every** CIK it references — the issuer and each reporting owner. When a tracked public company (e.g. Carlyle/CG, Berkshire/BRK-B, Goldman/GS) is itself a *reporting owner* on another issuer's filing (e.g. Carlyle selling Medline/MDLN stock), that filing surfaces in the tracked company's own CIK feed. The processor assigned every transaction to whichever company's feed surfaced the filing and never checked the issuer, so the other issuer's trade was stamped onto the company's own ticker — e.g. a $1.07B Medline sale appearing under CG, inflating the insider-trading dashboard.

A reporting owner is never an insider of itself, so these are unambiguous misattributions (≈7,400 transactions across ~330 tickers in production, concentrated in the largest dollar values).

## Code changes

- **`InsiderFilingParser.GetIssuerCik`** — new helper returning the issuer CIK from the ownership document with leading zeros stripped (to match the un-padded CIK stored on the company); null for pre-XML-era filings with no issuer block.
- **`InsiderTradingFilingProcessor.Process`** — after parsing the ownership root, skip the filing (return false) when the issuer CIK doesn't match the company's primary or secondary CIK. The real issuer's feed imports it correctly. Filings with no issuer block fall back to trusting the feed, so legacy ingestion is unchanged.
- **Tests** — unit tests for `GetIssuerCik` (zero-stripping, missing/empty issuer block) and integration tests for the processor (cross-issuer filing skipped and inserts nothing; own-issuer filing with a zero-padded CIK still inserts).