### PR TITLE
feat(holdings): version-stamp 13F data set processing for parser self-heal

### DIFF
--- a/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
+++ b/src/Equibles.Holdings.Data/Models/ProcessedDataSet.cs
@@ -13,6 +13,16 @@ public class ProcessedDataSet
     // the real rows for a backfill.
     public const string BackfillGuardFileName = "__backfill-guard__";
 
+    /// <summary>
+    /// The 13F import pipeline's current parser version. Bump this when a
+    /// parser fix must re-apply to already-imported data: the scraper treats
+    /// any data set processed at a lower version as unprocessed and re-imports
+    /// it on the next cycle (oldest first, so amendments re-apply after their
+    /// originals). Mirrors <c>NportFiling.CurrentParserVersion</c>.
+    /// Version 1: duplicated share-count column repair (#3499).
+    /// </summary>
+    public const int CurrentParserVersion = 1;
+
     public Guid Id { get; set; } = Guid.NewGuid();
 
     [Required]
@@ -20,6 +30,13 @@ public class ProcessedDataSet
     public string FileName { get; set; }
 
     public int SubmissionCount { get; set; }
+
+    /// <summary>
+    /// Parser version the pipeline was at when this data set was imported.
+    /// Defaults to 0 for rows written before versioning so the first deploy
+    /// re-enrolls all history through the current parser.
+    /// </summary>
+    public int ParserVersion { get; set; }
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
+++ b/src/Equibles.Holdings.HostedService/HoldingsScraperWorker.cs
@@ -182,11 +182,19 @@ public class HoldingsScraperWorker : BaseScraperWorker
         if (fileNames.Count <= 1)
             return;
 
-        // Seed all except the last file name (most recent period)
+        // Seed all except the last file name (most recent period). Seeds are
+        // deliberate skips, so stamp the current parser version — a fresh
+        // install must not immediately re-import the history it just declined.
         var toSeed = fileNames.Take(fileNames.Count - 1);
         foreach (var fileName in toSeed)
         {
-            repo.Add(new Holdings.Data.Models.ProcessedDataSet { FileName = fileName });
+            repo.Add(
+                new Holdings.Data.Models.ProcessedDataSet
+                {
+                    FileName = fileName,
+                    ParserVersion = Holdings.Data.Models.ProcessedDataSet.CurrentParserVersion,
+                }
+            );
         }
 
         await repo.SaveChanges();
@@ -196,24 +204,46 @@ public class HoldingsScraperWorker : BaseScraperWorker
         );
     }
 
+    // A data set only counts as processed when it was imported at (or above)
+    // the current parser version. Bumping CurrentParserVersion therefore
+    // re-enrolls every older data set on the next cycle — the self-heal path
+    // for parser fixes that must re-apply to already-imported filings.
     private async Task<bool> IsAlreadyProcessed(string fileName)
     {
         await using var scope = ScopeFactory.CreateAsyncScope();
         var repo = scope.ServiceProvider.GetRequiredService<ProcessedDataSetRepository>();
-        return await repo.Exists(fileName);
+        return await repo.GetByFileName(fileName)
+            .AnyAsync(p =>
+                p.ParserVersion >= Holdings.Data.Models.ProcessedDataSet.CurrentParserVersion
+            );
     }
 
+    // Upsert rather than insert: after a parser-version bump the row already
+    // exists at the old version (FileName is unique), so a blind Add would
+    // collide on the unique index and the data set would re-import every cycle.
     private async Task MarkAsProcessed(string fileName, int submissionCount)
     {
         await using var scope = ScopeFactory.CreateAsyncScope();
         var repo = scope.ServiceProvider.GetRequiredService<ProcessedDataSetRepository>();
-        repo.Add(
-            new Holdings.Data.Models.ProcessedDataSet
-            {
-                FileName = fileName,
-                SubmissionCount = submissionCount,
-            }
-        );
+
+        var existing = await repo.GetByFileName(fileName).FirstOrDefaultAsync();
+        if (existing == null)
+        {
+            repo.Add(
+                new Holdings.Data.Models.ProcessedDataSet
+                {
+                    FileName = fileName,
+                    SubmissionCount = submissionCount,
+                    ParserVersion = Holdings.Data.Models.ProcessedDataSet.CurrentParserVersion,
+                }
+            );
+        }
+        else
+        {
+            existing.SubmissionCount = submissionCount;
+            existing.ParserVersion = Holdings.Data.Models.ProcessedDataSet.CurrentParserVersion;
+        }
+
         await repo.SaveChanges();
     }
 

--- a/src/Equibles.Holdings.Repositories/ProcessedDataSetRepository.cs
+++ b/src/Equibles.Holdings.Repositories/ProcessedDataSetRepository.cs
@@ -1,6 +1,5 @@
 using Equibles.Data;
 using Equibles.Holdings.Data.Models;
-using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Holdings.Repositories;
 
@@ -9,8 +8,8 @@ public class ProcessedDataSetRepository : BaseRepository<ProcessedDataSet>
     public ProcessedDataSetRepository(EquiblesFinancialDbContext dbContext)
         : base(dbContext) { }
 
-    public async Task<bool> Exists(string fileName)
+    public IQueryable<ProcessedDataSet> GetByFileName(string fileName)
     {
-        return await GetAll().AnyAsync(p => p.FileName == fileName);
+        return GetAll().Where(p => p.FileName == fileName);
     }
 }

--- a/src/Equibles.Migrations/Migrations/20260604221458_AddProcessedDataSetParserVersion.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260604221458_AddProcessedDataSetParserVersion.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604221458_AddProcessedDataSetParserVersion")]
+    partial class AddProcessedDataSetParserVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260604221458_AddProcessedDataSetParserVersion.cs
+++ b/src/Equibles.Migrations/Migrations/20260604221458_AddProcessedDataSetParserVersion.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProcessedDataSetParserVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ParserVersion",
+                table: "ProcessedDataSet",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ParserVersion",
+                table: "ProcessedDataSet");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerIsAlreadyProcessedTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerIsAlreadyProcessedTests.cs
@@ -33,32 +33,29 @@ public class HoldingsScraperWorkerIsAlreadyProcessedTests : ParadeDbMcpTestBase
     [Fact]
     public async Task IsAlreadyProcessed_ExactNamePresentSubstringAbsent_ReturnsTrueForExactFalseForSubstring()
     {
-        // Seed two real ProcessedDataSet rows. The substring case probes the
-        // exact-match guarantee — "2024q1" is a proper substring of the seeded
-        // "2024q1_form13f.zip", so a buggy `Contains`/`StartsWith` regression
-        // would also report true on the substring.
-        DbContext.Add(new ProcessedDataSet { FileName = "2024q1_form13f.zip" });
-        DbContext.Add(new ProcessedDataSet { FileName = "2024q2_form13f.zip" });
+        // Seed two real ProcessedDataSet rows at the current parser version.
+        // The substring case probes the exact-match guarantee — "2024q1" is a
+        // proper substring of the seeded "2024q1_form13f.zip", so a buggy
+        // `Contains`/`StartsWith` regression would also report true on the
+        // substring.
+        DbContext.Add(
+            new ProcessedDataSet
+            {
+                FileName = "2024q1_form13f.zip",
+                ParserVersion = ProcessedDataSet.CurrentParserVersion,
+            }
+        );
+        DbContext.Add(
+            new ProcessedDataSet
+            {
+                FileName = "2024q2_form13f.zip",
+                ParserVersion = ProcessedDataSet.CurrentParserVersion,
+            }
+        );
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
-        var scopeFactory = ServiceScopeSubstitute.Create(
-            (typeof(ProcessedDataSetRepository), new ProcessedDataSetRepository(DbContext))
-        );
-        var configuration = Substitute.For<IConfiguration>();
-        configuration["Sec:ContactEmail"].Returns("test@example.com");
-
-        var worker = new HoldingsScraperWorker(
-            Substitute.For<ILogger<HoldingsScraperWorker>>(),
-            scopeFactory,
-            new ErrorReporter(
-                Substitute.For<IServiceScopeFactory>(),
-                Substitute.For<ILogger<ErrorReporter>>()
-            ),
-            Options.Create(new WorkerOptions()),
-            configuration,
-            new HoldingsRescanSignal()
-        );
+        var worker = CreateWorker();
         var method = typeof(HoldingsScraperWorker).GetMethod(
             "IsAlreadyProcessed",
             BindingFlags.NonPublic | BindingFlags.Instance
@@ -71,5 +68,55 @@ public class HoldingsScraperWorkerIsAlreadyProcessedTests : ParadeDbMcpTestBase
         exactHit.Should().BeTrue();
         substringMiss.Should().BeFalse();
         unrelated.Should().BeFalse();
+    }
+
+    // The self-heal contract behind a parser-version bump: a data set imported
+    // by an older parser (including pre-versioning rows, which default to 0)
+    // must read as NOT processed so the next cycle re-imports it through the
+    // current pipeline. A regression back to a bare existence check would
+    // permanently strand stale parses (the #1535 corruption class).
+    [Fact]
+    public async Task IsAlreadyProcessed_RowStampedBelowCurrentParserVersion_ReturnsFalse()
+    {
+        DbContext.Add(
+            new ProcessedDataSet
+            {
+                FileName = "2023q4_form13f.zip",
+                ParserVersion = ProcessedDataSet.CurrentParserVersion - 1,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var worker = CreateWorker();
+        var method = typeof(HoldingsScraperWorker).GetMethod(
+            "IsAlreadyProcessed",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+        var staleVersionHit = await (Task<bool>)method.Invoke(worker, ["2023q4_form13f.zip"]);
+
+        staleVersionHit.Should().BeFalse();
+    }
+
+    private HoldingsScraperWorker CreateWorker()
+    {
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(ProcessedDataSetRepository), new ProcessedDataSetRepository(DbContext))
+        );
+        var configuration = Substitute.For<IConfiguration>();
+        configuration["Sec:ContactEmail"].Returns("test@example.com");
+
+        return new HoldingsScraperWorker(
+            Substitute.For<ILogger<HoldingsScraperWorker>>(),
+            scopeFactory,
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions()),
+            configuration,
+            new HoldingsRescanSignal()
+        );
     }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerMarkAsProcessedTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsScraperWorkerMarkAsProcessedTests.cs
@@ -30,25 +30,9 @@ public class HoldingsScraperWorkerMarkAsProcessedTests : ParadeDbMcpTestBase
         : base(fixture) { }
 
     [Fact]
-    public async Task MarkAsProcessed_NewFileName_PersistsRowWithSubmissionCount()
+    public async Task MarkAsProcessed_NewFileName_PersistsRowWithSubmissionCountAndCurrentParserVersion()
     {
-        var scopeFactory = ServiceScopeSubstitute.Create(
-            (typeof(ProcessedDataSetRepository), new ProcessedDataSetRepository(DbContext))
-        );
-        var configuration = Substitute.For<IConfiguration>();
-        configuration["Sec:ContactEmail"].Returns("test@example.com");
-
-        var worker = new HoldingsScraperWorker(
-            Substitute.For<ILogger<HoldingsScraperWorker>>(),
-            scopeFactory,
-            new ErrorReporter(
-                Substitute.For<IServiceScopeFactory>(),
-                Substitute.For<ILogger<ErrorReporter>>()
-            ),
-            Options.Create(new WorkerOptions()),
-            configuration,
-            new HoldingsRescanSignal()
-        );
+        var worker = CreateWorker();
 
         var method = typeof(HoldingsScraperWorker).GetMethod(
             "MarkAsProcessed",
@@ -63,5 +47,62 @@ public class HoldingsScraperWorkerMarkAsProcessedTests : ParadeDbMcpTestBase
             .AsNoTracking()
             .SingleAsync(p => p.FileName == "2024q4_form13f.zip");
         row.SubmissionCount.Should().Be(7842);
+        row.ParserVersion.Should().Be(ProcessedDataSet.CurrentParserVersion);
+    }
+
+    // After a parser-version bump the row already exists at the old version
+    // (FileName is unique). MarkAsProcessed must update it in place — a blind
+    // insert would violate the unique index, the marker would never advance,
+    // and the data set would re-import on every single cycle.
+    [Fact]
+    public async Task MarkAsProcessed_RowExistsAtOlderParserVersion_UpdatesInPlaceWithoutDuplicating()
+    {
+        DbContext.Add(
+            new ProcessedDataSet
+            {
+                FileName = "2023q2_form13f.zip",
+                SubmissionCount = 6500,
+                ParserVersion = ProcessedDataSet.CurrentParserVersion - 1,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var worker = CreateWorker();
+
+        var method = typeof(HoldingsScraperWorker).GetMethod(
+            "MarkAsProcessed",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        await (Task)method.Invoke(worker, ["2023q2_form13f.zip", 6612]);
+
+        await using var verify = Fixture.CreateDbContext();
+        var row = await verify
+            .Set<ProcessedDataSet>()
+            .AsNoTracking()
+            .SingleAsync(p => p.FileName == "2023q2_form13f.zip");
+        row.SubmissionCount.Should().Be(6612);
+        row.ParserVersion.Should().Be(ProcessedDataSet.CurrentParserVersion);
+    }
+
+    private HoldingsScraperWorker CreateWorker()
+    {
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(ProcessedDataSetRepository), new ProcessedDataSetRepository(DbContext))
+        );
+        var configuration = Substitute.For<IConfiguration>();
+        configuration["Sec:ContactEmail"].Returns("test@example.com");
+
+        return new HoldingsScraperWorker(
+            Substitute.For<ILogger<HoldingsScraperWorker>>(),
+            scopeFactory,
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions()),
+            configuration,
+            new HoldingsRescanSignal()
+        );
     }
 }

--- a/tests/Equibles.IntegrationTests/Holdings/ProcessedDataSetRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/ProcessedDataSetRepositoryTests.cs
@@ -23,15 +23,28 @@ public class ProcessedDataSetRepositoryTests : IDisposable
     }
 
     [Fact]
-    public async Task Exists_DifferentFileName_ReturnsFalse()
+    public async Task GetByFileName_DifferentFileName_ReturnsEmpty()
     {
         _repository.Add(
             new ProcessedDataSet { FileName = "2025q3_form13f.zip", SubmissionCount = 1234 }
         );
         await _repository.SaveChanges();
 
-        var result = await _repository.Exists("2025q4_form13f.zip");
+        var result = _repository.GetByFileName("2025q4_form13f.zip").ToList();
 
-        result.Should().BeFalse();
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetByFileName_ExactFileName_ReturnsRow()
+    {
+        _repository.Add(
+            new ProcessedDataSet { FileName = "2025q3_form13f.zip", SubmissionCount = 1234 }
+        );
+        await _repository.SaveChanges();
+
+        var result = _repository.GetByFileName("2025q3_form13f.zip").ToList();
+
+        result.Should().ContainSingle().Which.SubmissionCount.Should().Be(1234);
     }
 }


### PR DESCRIPTION
## Summary

`ProcessedDataSet` rows are bare done-flags, so parser fixes never re-apply to data imported before them — the scraper skips processed data sets, the realtime sweep skips processed accessions and only looks back 15 days. Fixing the stored side of the duplicated share-count corruption (#3499) required manual SQL plus a hand-deleted ledger row, and a deploy-timing race re-corrupted a repaired filing minutes before the fixed code went live (daniel3303/EquiblesCommercial#1695).

This mirrors the NPORT `ParserVersion` design (#3498) on the 13F bulk-dataset ledger so future parser fixes self-heal: bump one constant and every data set re-imports through the current pipeline on the next daily cycle.

## Code changes

- `ProcessedDataSet` — `ParserVersion` column (migration defaults existing rows to 0) + `CurrentParserVersion` constant (1 = the share-count repair).
- `HoldingsScraperWorker` — `IsAlreadyProcessed` requires the stored version to be at or above current; `MarkAsProcessed` updates the existing row in place (FileName is unique — a blind insert would collide after a bump and re-import every cycle); first-run backfill seeds at the current version.
- `ProcessedDataSetRepository` — `Exists` replaced with a `GetByFileName` queryable; the worker composes the version check and the upsert from it.
- `Holdings13FRealtimeWorker.ComputeLookbackDays` deliberately stays version-agnostic: an old-version data set still bounds the realtime gap.
- Scope: only the data-set ledger is versioned. Re-processing individual realtime accessions could resurrect rows an amendment deleted (`ProcessedFiling`'s documented dedup hazard); every realtime filing is covered by its rolling data set instead. Data sets re-import oldest-first, so amendments re-apply after their originals.
- Deploy note: existing rows default to version 0 → the first deploy performs a one-time full re-import of all ~26 data sets through the #3499 repairer, organically healing any stored corruption.
- Tests — version-aware skip, stale-version re-enroll, upsert-in-place mark (no unique-index collision), repository query pins.

Unit suite: 2599 passed. Holdings integration suite: 335 passed.

Closes daniel3303/EquiblesCommercial#1695 (schema change also needs the paired commercial migration — shipped with the pin bump).