### PR TITLE
fix(insider): stop derivative-price and chain-duplicate inflation on the dashboard

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderTransactionPriceValidator.cs
@@ -28,15 +28,6 @@ public class InsiderTransactionPriceValidator
     /// </summary>
     public const decimal MaxPriceToCloseMultiplier = 10m;
 
-    private static readonly string[] DerivativeTitleKeywords =
-    {
-        "option",
-        "warrant",
-        "right to buy",
-        "right to sell",
-        "convertible",
-    };
-
     public bool IsPlausible(decimal pricePerShare, string securityTitle, decimal? unadjustedClose)
     {
         // Holdings (Form 3 sentinels) and post-transaction-only rows report
@@ -53,7 +44,7 @@ public class InsiderTransactionPriceValidator
         // strike or a deeply OTM warrant). The dashboard sort weighs them
         // equally so they can produce surprising values, but the validation
         // rule (10× close) doesn't apply.
-        if (IsDerivativeSecurity(securityTitle))
+        if (InsiderSecurityClassification.IsDerivativeTitle(securityTitle))
             return true;
 
         // No close on file (delisted, brand-new IPO, foreign listing not in
@@ -183,16 +174,7 @@ public class InsiderTransactionPriceValidator
         {
             InsiderSecurityKind.Derivative => true,
             InsiderSecurityKind.NonDerivative => false,
-            _ => IsDerivativeSecurity(securityTitle),
+            _ => InsiderSecurityClassification.IsDerivativeTitle(securityTitle),
         };
-    }
-
-    private static bool IsDerivativeSecurity(string securityTitle)
-    {
-        if (string.IsNullOrWhiteSpace(securityTitle))
-            return false;
-        return DerivativeTitleKeywords.Any(keyword =>
-            securityTitle.Contains(keyword, StringComparison.OrdinalIgnoreCase)
-        );
     }
 }

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderSecurityClassification.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderSecurityClassification.cs
@@ -1,0 +1,69 @@
+using System.Linq.Expressions;
+
+namespace Equibles.InsiderTrading.Data.Models;
+
+/// <summary>
+/// Classifies an insider transaction as an actual share transaction versus a
+/// derivative (option, warrant, convertible note, etc.). The authoritative signal
+/// is <see cref="InsiderSecurityKind"/>, parsed from the Form 4 table; rows not yet
+/// reclassified (<see cref="InsiderSecurityKind.Unknown"/>) fall back to the
+/// security-title keywords.
+///
+/// A derivative row's <c>PricePerShare</c> is the instrument's own price, so
+/// Shares × PricePerShare is not a transaction dollar value and explodes any
+/// value-based ranking. The dashboard value boards use <see cref="IsShareTransaction"/>
+/// to exclude derivatives; the price validator reuses <see cref="IsDerivativeTitle"/>
+/// for the same Unknown fallback so both share one definition.
+/// </summary>
+public static class InsiderSecurityClassification
+{
+    /// <summary>
+    /// Substrings that identify a derivative security by its title (matched
+    /// case-insensitively). Kept in sync with the literals spelled out in
+    /// <see cref="IsShareTransaction"/> — EF Core can't translate an
+    /// <c>Any</c>-over-array <c>Contains</c>, so the query form lists them inline.
+    /// </summary>
+    public static readonly string[] DerivativeTitleKeywords =
+    {
+        "option",
+        "warrant",
+        "right to buy",
+        "right to sell",
+        "convertible",
+    };
+
+    /// <summary>
+    /// In-memory derivative test by title, used as the fallback for rows whose
+    /// authoritative <see cref="InsiderSecurityKind"/> is still Unknown.
+    /// </summary>
+    public static bool IsDerivativeTitle(string securityTitle)
+    {
+        if (string.IsNullOrWhiteSpace(securityTitle))
+            return false;
+        return DerivativeTitleKeywords.Any(keyword =>
+            securityTitle.Contains(keyword, StringComparison.OrdinalIgnoreCase)
+        );
+    }
+
+    /// <summary>
+    /// EF-translatable predicate selecting share (non-derivative) transactions:
+    /// an authoritative NonDerivative kind, or an unclassified row whose title
+    /// doesn't name a derivative. Derivative-kind rows are always excluded. The
+    /// keyword literals mirror <see cref="DerivativeTitleKeywords"/>.
+    /// </summary>
+    public static readonly Expression<Func<InsiderTransaction, bool>> IsShareTransaction = t =>
+        t.SecurityKind == InsiderSecurityKind.NonDerivative
+        || (
+            t.SecurityKind == InsiderSecurityKind.Unknown
+            && (
+                t.SecurityTitle == null
+                || (
+                    !t.SecurityTitle.ToLower().Contains("option")
+                    && !t.SecurityTitle.ToLower().Contains("warrant")
+                    && !t.SecurityTitle.ToLower().Contains("right to buy")
+                    && !t.SecurityTitle.ToLower().Contains("right to sell")
+                    && !t.SecurityTitle.ToLower().Contains("convertible")
+                )
+            )
+        );
+}

--- a/src/Equibles.Web/Controllers/InsiderActivityController.cs
+++ b/src/Equibles.Web/Controllers/InsiderActivityController.cs
@@ -26,6 +26,20 @@ public class InsiderActivityController : BaseController
     {
         var since = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-90));
 
+        // A single block sold by a private-equity sponsor is reported on a
+        // separate Form 4 by every entity in its beneficial-ownership chain, so
+        // the same economic transaction lands in the data many times with an
+        // identical ticker/date/share-count/price/code. Collapse those to one
+        // row so the boards aren't dominated by the same block repeated.
+        static object DedupKey(InsiderDashboardRow row) =>
+            (
+                row.Ticker,
+                row.TransactionDate,
+                row.Shares,
+                row.PricePerShare,
+                row.TransactionCodeLabel
+            );
+
         var topBuys = await LoadTopRows(
             _transactionRepository.GetRecentByType(TransactionCode.Purchase, since),
             t => new InsiderDashboardRow
@@ -39,7 +53,8 @@ public class InsiderActivityController : BaseController
                 SecurityTitle = t.SecurityTitle,
                 TransactionCodeLabel = "Buy",
                 IsAcquisition = true,
-            }
+            },
+            DedupKey
         );
 
         var topSells = await LoadTopRows(
@@ -55,7 +70,8 @@ public class InsiderActivityController : BaseController
                 SecurityTitle = t.SecurityTitle,
                 TransactionCodeLabel = "Sell",
                 IsAcquisition = false,
-            }
+            },
+            DedupKey
         );
 
         var biggest = await LoadTopRows(
@@ -71,7 +87,8 @@ public class InsiderActivityController : BaseController
                 SecurityTitle = t.SecurityTitle,
                 TransactionCodeLabel = t.TransactionCode.ToString(),
                 IsAcquisition = t.AcquiredDisposed == AcquiredDisposed.Acquired,
-            }
+            },
+            DedupKey
         );
 
         return View(
@@ -84,19 +101,45 @@ public class InsiderActivityController : BaseController
         );
     }
 
+    // Fetch this many times RowCap before de-duplicating, so collapsing a block
+    // reported across a long beneficial-ownership chain still leaves enough rows
+    // to fill the board.
+    private const int DedupFetchMultiplier = 8;
+
     // Top N priced transactions by dollar value (Shares * PricePerShare) from the given
     // source query, projected via the caller's expression. EF translates the projection
     // server-side, so the SELECT shape per call matches the previous inline chain.
-    private static Task<List<TRow>> LoadTopRows<TRow>(
+    private static async Task<List<TRow>> LoadTopRows<TRow>(
         IQueryable<InsiderTransaction> source,
-        Expression<Func<InsiderTransaction, TRow>> projection
-    ) =>
-        source
+        Expression<Func<InsiderTransaction, TRow>> projection,
+        Func<TRow, object> dedupKey
+    )
+    {
+        var rows = await source
             // Show valid and not-yet-evaluated (null) rows; hide only rows
             // positively rejected as implausible.
             .Where(t => t.IsPriceValid != false)
+            // Exclude derivatives: their PricePerShare is the instrument's own
+            // price, so Shares * PricePerShare is not a dollar value and would
+            // otherwise dominate the value sort with nonsense (option/warrant/
+            // convertible "prices" in the millions).
+            .Where(InsiderSecurityClassification.IsShareTransaction)
             .OrderByDescending(t => t.Shares * t.PricePerShare)
-            .Take(InsiderDashboardViewModel.RowCap)
+            .Take(InsiderDashboardViewModel.RowCap * DedupFetchMultiplier)
             .Select(projection)
             .ToListAsync();
+
+        var seen = new HashSet<object>();
+        var deduped = new List<TRow>(InsiderDashboardViewModel.RowCap);
+        foreach (var row in rows)
+        {
+            if (!seen.Add(dedupKey(row)))
+                continue;
+            deduped.Add(row);
+            if (deduped.Count == InsiderDashboardViewModel.RowCap)
+                break;
+        }
+
+        return deduped;
+    }
 }

--- a/tests/Equibles.IntegrationTests/Web/InsiderActivityControllerDashboardTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/InsiderActivityControllerDashboardTests.cs
@@ -90,4 +90,187 @@ public class InsiderActivityControllerDashboardTests
         html.Should().Contain("Jane Doe");
         html.Should().Contain("AAPL");
     }
+
+    // A derivative's PricePerShare is the instrument's own price, so Shares × Price
+    // is not a dollar value — option/warrant/convertible rows with multi-million
+    // "prices" would otherwise dominate the value sort. They must be excluded both
+    // by authoritative kind and by the title fallback for not-yet-reclassified rows.
+    [Fact]
+    public async Task Dashboard_ExcludesDerivativesFromValueBoards()
+    {
+        var shareStockId = Guid.NewGuid();
+        var derivKindStockId = Guid.NewGuid();
+        var derivTitleStockId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = shareStockId,
+                    Ticker = "SHRE",
+                    Name = "Share Co",
+                    Cik = "0000000101",
+                }
+            );
+            db.Add(
+                new CommonStock
+                {
+                    Id = derivKindStockId,
+                    Ticker = "DRVK",
+                    Name = "Deriv Kind Co",
+                    Cik = "0000000102",
+                }
+            );
+            db.Add(
+                new CommonStock
+                {
+                    Id = derivTitleStockId,
+                    Ticker = "DRVT",
+                    Name = "Deriv Title Co",
+                    Cik = "0000000103",
+                }
+            );
+            db.Add(
+                new InsiderOwner
+                {
+                    Id = ownerId,
+                    OwnerCik = "0005000010",
+                    Name = "Derivative Holder",
+                    IsTenPercentOwner = true,
+                }
+            );
+
+            // A small genuine share transaction — the only one that should rank.
+            db.Add(
+                new InsiderTransaction
+                {
+                    CommonStockId = shareStockId,
+                    InsiderOwnerId = ownerId,
+                    TransactionDate = today.AddDays(-5),
+                    FilingDate = today.AddDays(-3),
+                    TransactionCode = TransactionCode.Sale,
+                    AcquiredDisposed = AcquiredDisposed.Disposed,
+                    Shares = 1_000,
+                    PricePerShare = 100m,
+                    SharesOwnedAfter = 0,
+                    SecurityKind = InsiderSecurityKind.NonDerivative,
+                    SecurityTitle = "Common Stock",
+                    AccessionNumber = "0005000010-25-000001",
+                }
+            );
+            // Huge value via authoritative derivative kind — must be excluded.
+            db.Add(
+                new InsiderTransaction
+                {
+                    CommonStockId = derivKindStockId,
+                    InsiderOwnerId = ownerId,
+                    TransactionDate = today.AddDays(-5),
+                    FilingDate = today.AddDays(-3),
+                    TransactionCode = TransactionCode.Sale,
+                    AcquiredDisposed = AcquiredDisposed.Disposed,
+                    Shares = 1_000_000,
+                    PricePerShare = 15_000_000m,
+                    SharesOwnedAfter = 0,
+                    SecurityKind = InsiderSecurityKind.Derivative,
+                    SecurityTitle = "Common Stock",
+                    AccessionNumber = "0005000010-25-000002",
+                }
+            );
+            // Huge value via title fallback (kind still Unknown) — must be excluded.
+            db.Add(
+                new InsiderTransaction
+                {
+                    CommonStockId = derivTitleStockId,
+                    InsiderOwnerId = ownerId,
+                    TransactionDate = today.AddDays(-5),
+                    FilingDate = today.AddDays(-3),
+                    TransactionCode = TransactionCode.Sale,
+                    AcquiredDisposed = AcquiredDisposed.Disposed,
+                    Shares = 1_000_000,
+                    PricePerShare = 8_000_000m,
+                    SharesOwnedAfter = 0,
+                    SecurityKind = InsiderSecurityKind.Unknown,
+                    SecurityTitle = "Pre-Funded Warrant (right to buy)",
+                    AccessionNumber = "0005000010-25-000003",
+                }
+            );
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/insider-trading/dashboard");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("SHRE");
+        html.Should().NotContain("DRVK");
+        html.Should().NotContain("DRVT");
+    }
+
+    // The same block sold by a PE sponsor is filed by every entity in its
+    // beneficial-ownership chain — identical ticker/date/shares/price/code on
+    // separate Form 4s. The boards must collapse those to a single row.
+    [Fact]
+    public async Task Dashboard_CollapsesDuplicateChainFilings()
+    {
+        var stockId = Guid.NewGuid();
+        var chainOwners = new[] { "Chain Alpha LP", "Chain Bravo LP", "Chain Charlie LP" };
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "DUPE",
+                    Name = "Dupe Co",
+                    Cik = "0000000201",
+                }
+            );
+            for (var i = 0; i < chainOwners.Length; i++)
+            {
+                var ownerId = Guid.NewGuid();
+                db.Add(
+                    new InsiderOwner
+                    {
+                        Id = ownerId,
+                        OwnerCik = $"000600000{i}",
+                        Name = chainOwners[i],
+                        IsTenPercentOwner = true,
+                    }
+                );
+                // Identical block on each filing — same date/shares/price/code.
+                db.Add(
+                    new InsiderTransaction
+                    {
+                        CommonStockId = stockId,
+                        InsiderOwnerId = ownerId,
+                        TransactionDate = today.AddDays(-7),
+                        FilingDate = today.AddDays(-5),
+                        TransactionCode = TransactionCode.Sale,
+                        AcquiredDisposed = AcquiredDisposed.Disposed,
+                        Shares = 26_105_840,
+                        PricePerShare = 41m,
+                        SharesOwnedAfter = 0,
+                        SecurityKind = InsiderSecurityKind.NonDerivative,
+                        SecurityTitle = "Common Stock",
+                        AccessionNumber = $"0006000000-25-00000{i}",
+                    }
+                );
+            }
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/insider-trading/dashboard");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        // The block survives as exactly one row, so only one of the three chain
+        // entities is shown — regardless of which wins the value-sort tie.
+        var ownersShown = chainOwners.Count(name => html.Contains(name));
+        ownersShown.Should().Be(1);
+    }
 }

--- a/tests/Equibles.UnitTests/InsiderTrading/Models/InsiderSecurityClassificationTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/Models/InsiderSecurityClassificationTests.cs
@@ -1,0 +1,78 @@
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.Models;
+
+public class InsiderSecurityClassificationTests
+{
+    // IsShareTransaction keeps derivative rows out of the dashboard value boards:
+    // a derivative's PricePerShare is the instrument's own price, so Shares × Price
+    // is not a transaction dollar value. The authoritative signal is SecurityKind;
+    // only Unknown (not-yet-reclassified) rows fall back to the title keywords.
+    private static readonly Func<InsiderTransaction, bool> IsShareTransaction =
+        InsiderSecurityClassification.IsShareTransaction.Compile();
+
+    private static InsiderTransaction Row(InsiderSecurityKind kind, string title) =>
+        new() { SecurityKind = kind, SecurityTitle = title };
+
+    [Fact]
+    public void IsShareTransaction_NonDerivativeKind_IsTrue()
+    {
+        IsShareTransaction(Row(InsiderSecurityKind.NonDerivative, "Common Stock"))
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void IsShareTransaction_DerivativeKind_IsFalseEvenWithShareTitle()
+    {
+        // Authoritative kind wins over the title — a Derivative row is excluded
+        // regardless of what its title says.
+        IsShareTransaction(Row(InsiderSecurityKind.Derivative, "Common Stock"))
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void IsShareTransaction_UnknownWithPlainShareTitle_IsTrue()
+    {
+        IsShareTransaction(Row(InsiderSecurityKind.Unknown, "Common Stock")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsShareTransaction_UnknownWithNullTitle_IsTrue()
+    {
+        IsShareTransaction(Row(InsiderSecurityKind.Unknown, null)).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Pre-Funded Warrant (right to buy)")]
+    [InlineData("Convertible Note")]
+    [InlineData("Call option (obligation to sell)")]
+    [InlineData("Put Option")]
+    public void IsShareTransaction_UnknownWithDerivativeTitle_IsFalse(string title)
+    {
+        IsShareTransaction(Row(InsiderSecurityKind.Unknown, title)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDerivativeTitle_PlainShareTitle_IsFalse()
+    {
+        InsiderSecurityClassification.IsDerivativeTitle("Common Stock").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDerivativeTitle_OptionTitle_IsTrue()
+    {
+        InsiderSecurityClassification
+            .IsDerivativeTitle("Stock Option (Right to Buy)")
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void IsDerivativeTitle_NullOrBlank_IsFalse()
+    {
+        InsiderSecurityClassification.IsDerivativeTitle(null).Should().BeFalse();
+        InsiderSecurityClassification.IsDerivativeTitle("   ").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

The insider-trading dashboard's three value boards (Top Buys / Top Sells / Biggest) rank by `Shares × PricePerShare` across all rows, which surfaced two classes of inflated values:

1. **Derivatives** (options, warrants, convertible notes) carry the *instrument's own* price in `PricePerShare`, so `Shares × Price` is not a transaction dollar value. Multi-million 'prices' put trillion-dollar phantoms at the top — e.g. a WHWK pre-funded warrant ($16.8T), an XOS convertible note ($2.25T), CRWV options.
2. **Beneficial-ownership chain duplication** — a single block sold by a PE sponsor is filed on a separate Form 4 by every entity in its ownership chain, so the same economic transaction appears many times with an identical ticker/date/shares/price/code (e.g. a Medline block reported by 3–4 Carlyle entities).

## Code changes

- **`InsiderSecurityClassification`** (new, Data layer) — single definition of *share vs derivative*: authoritative `InsiderSecurityKind` with a security-title keyword fallback for rows not yet reclassified (the bulk of production is still `Unknown`). Exposes `IsDerivativeTitle` (in-memory) and `IsShareTransaction` (EF-translatable predicate).
- **`InsiderTransactionPriceValidator`** — reuses `InsiderSecurityClassification.IsDerivativeTitle` instead of a private keyword copy (single source of truth).
- **`InsiderActivityController.LoadTopRows`** — filters to `IsShareTransaction` (excludes derivatives) and collapses rows sharing (ticker, date, shares, price, code) to one, fetching a multiple of `RowCap` so the boards still fill after dedup.
- **Tests** — unit tests for the classification (kind authority + title fallback) and integration tests asserting derivatives are excluded (both kind and title paths) and duplicate chain filings collapse to one row.