### PR TITLE
fix(stocks): show Fund Operations/Holdings tabs only for funds

### DIFF
--- a/src/Equibles.Web/Controllers/StocksController.cs
+++ b/src/Equibles.Web/Controllers/StocksController.cs
@@ -237,6 +237,12 @@ public class StocksController : BaseController
         viewModel.FilingActivityDays = FilingActivityDays;
         viewModel.KeyMetrics = await _stockTabService.LoadKeyMetrics(stock);
 
+        var (hasFundHoldings, hasFundOperations) = await _stockTabService.LoadFundTabAvailability(
+            stock
+        );
+        viewModel.HasFundHoldings = hasFundHoldings;
+        viewModel.HasFundOperations = hasFundOperations;
+
         ViewData["TabViewModel"] = await loadTab(stock);
         return View("Show", viewModel);
     }

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -327,6 +327,18 @@ public class StockTabService
         return new ExemptOfferingsTabViewModel { Filings = filings, Ticker = stock.Ticker };
     }
 
+    // Whether the stock has any fund-only filings, used to decide if the
+    // Fund Operations (N-CEN) and Fund Holdings (NPORT) tabs are shown at all.
+    // Operating companies file neither, so both flags are false for them.
+    public async Task<(bool HasFundHoldings, bool HasFundOperations)> LoadFundTabAvailability(
+        CommonStock stock
+    )
+    {
+        var hasFundHoldings = await _nportFilingRepository.GetByStock(stock).AnyAsync();
+        var hasFundOperations = await _nCenFilingRepository.GetByStock(stock).AnyAsync();
+        return (hasFundHoldings, hasFundOperations);
+    }
+
     public async Task<FundOperationsTabViewModel> LoadFundOperationsTab(CommonStock stock)
     {
         var filings = await TakeMostRecent(

--- a/src/Equibles.Web/ViewModels/Stocks/StockDetailViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Stocks/StockDetailViewModel.cs
@@ -11,5 +11,11 @@ public class StockDetailViewModel
     public int RecentFilerCount { get; set; }
     public int FilingActivityDays { get; set; }
 
+    // Gate the fund-only tabs: true only when the stock is a registered fund that
+    // files NPORT (holdings) / N-CEN (operations). Operating companies file neither,
+    // so the tabs are hidden rather than shown empty.
+    public bool HasFundHoldings { get; set; }
+    public bool HasFundOperations { get; set; }
+
     public KeyMetricsViewModel KeyMetrics { get; set; }
 }

--- a/src/Equibles.Web/Views/Stocks/Show.cshtml
+++ b/src/Equibles.Web/Views/Stocks/Show.cshtml
@@ -119,6 +119,10 @@
     <!-- Section navbar -->
     <nav class="flex flex-wrap gap-2 mb-6" aria-label="@(stock.Ticker) sections">
         @foreach (var tab in sectionTabs) {
+            @* Fund-only tabs (NPORT/N-CEN) appear only for registered funds; hide them
+               for operating companies, which file neither and would show empty tabs. *@
+            if (tab.Key == "fund-operations" && !Model.HasFundOperations) { continue; }
+            if (tab.Key == "fund-holdings" && !Model.HasFundHoldings) { continue; }
             <a class="@TabBtnClass(tab.Key)" aria-current="@TabAriaCurrent(tab.Key)" asp-action="@tab.Action" asp-route-ticker="@stock.Ticker">@tab.Label</a>
         }
     </nav>

--- a/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadFundTabAvailabilityTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServiceLoadFundTabAvailabilityTests.cs
@@ -1,0 +1,155 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Congress.Data;
+using Equibles.Congress.Repositories;
+using Equibles.Data;
+using Equibles.Finra.Data;
+using Equibles.Finra.Repositories;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Repositories;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Equibles.Sec.Repositories;
+using Equibles.Web.Services;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Repositories;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the gating behind the Fund Operations (N-CEN) and Fund Holdings (NPORT)
+/// tabs: <see cref="StockTabService.LoadFundTabAvailability"/> reports each tab as
+/// available only when the stock actually has a filing of that type. Operating
+/// companies file neither, so both flags must be false — otherwise the page shows
+/// empty fund tabs for every non-fund stock.
+/// </summary>
+public class StockTabServiceLoadFundTabAvailabilityTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly StockTabService _service;
+
+    public StockTabServiceLoadFundTabAvailabilityTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new MediaModuleConfiguration(),
+            new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
+            new FinraModuleConfiguration(),
+            new HoldingsModuleConfiguration(),
+            new InsiderTradingModuleConfiguration(),
+            new CongressModuleConfiguration(),
+            new YahooModuleConfiguration()
+        );
+        _service = new StockTabService(
+            new InstitutionalHoldingRepository(_dbContext),
+            new InstitutionalHolderRepository(_dbContext),
+            new DailyShortVolumeRepository(_dbContext),
+            new ShortInterestRepository(_dbContext),
+            new FailToDeliverRepository(_dbContext),
+            new DocumentRepository(_dbContext),
+            new InsiderTransactionRepository(_dbContext),
+            new Form144FilingRepository(_dbContext),
+            new FormDFilingRepository(_dbContext),
+            new NCenFilingRepository(_dbContext),
+            new NportFilingRepository(_dbContext),
+            new CongressionalTradeRepository(_dbContext),
+            new DailyStockPriceRepository(_dbContext),
+            new FinancialFactRepository(_dbContext),
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task LoadFundTabAvailability_FundWithBothFilings_ReportsBothAvailable()
+    {
+        var fund = new CommonStock { Ticker = "PHD", Name = "Pioneer Floating Rate Fund" };
+        _dbContext.Add(fund);
+        _dbContext.Add(
+            new NportFiling
+            {
+                CommonStockId = fund.Id,
+                AccessionNumber = "0001-NPORT",
+                FilingDate = new DateOnly(2026, 3, 31),
+            }
+        );
+        _dbContext.Add(
+            new NCenFiling
+            {
+                CommonStockId = fund.Id,
+                AccessionNumber = "0001-NCEN",
+                FilingDate = new DateOnly(2026, 1, 31),
+            }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var (hasFundHoldings, hasFundOperations) = await _service.LoadFundTabAvailability(fund);
+
+        hasFundHoldings.Should().BeTrue();
+        hasFundOperations.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LoadFundTabAvailability_OperatingCompanyWithNoFundFilings_ReportsNeitherAvailable()
+    {
+        var stock = new CommonStock { Ticker = "ARE", Name = "Alexandria Real Estate Equities" };
+        _dbContext.Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var (hasFundHoldings, hasFundOperations) = await _service.LoadFundTabAvailability(stock);
+
+        hasFundHoldings.Should().BeFalse();
+        hasFundOperations.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task LoadFundTabAvailability_OnlyNportFiling_ReportsHoldingsAvailableButNotOperations()
+    {
+        var fund = new CommonStock { Ticker = "ABC", Name = "Holdings Only Fund" };
+        _dbContext.Add(fund);
+        _dbContext.Add(
+            new NportFiling
+            {
+                CommonStockId = fund.Id,
+                AccessionNumber = "0002-NPORT",
+                FilingDate = new DateOnly(2026, 3, 31),
+            }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var (hasFundHoldings, hasFundOperations) = await _service.LoadFundTabAvailability(fund);
+
+        hasFundHoldings.Should().BeTrue();
+        hasFundOperations.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task LoadFundTabAvailability_OnlyNCenFiling_ReportsOperationsAvailableButNotHoldings()
+    {
+        var fund = new CommonStock { Ticker = "XYZ", Name = "Operations Only Fund" };
+        _dbContext.Add(fund);
+        _dbContext.Add(
+            new NCenFiling
+            {
+                CommonStockId = fund.Id,
+                AccessionNumber = "0002-NCEN",
+                FilingDate = new DateOnly(2026, 1, 31),
+            }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var (hasFundHoldings, hasFundOperations) = await _service.LoadFundTabAvailability(fund);
+
+        hasFundHoldings.Should().BeFalse();
+        hasFundOperations.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

The stock detail page (`/stocks/{ticker}/...`) rendered the **Fund Operations** (N-CEN) and **Fund Holdings** (NPORT) tabs for *every* stock. Those filings only exist for registered investment companies (ETFs / closed-end / mutual funds); operating companies file neither, so the two tabs always showed up empty (e.g. `ARE`).

This gates each fund tab behind a per-stock availability flag — the tab renders only when the stock actually has a filing of that type. Direct navigation to the tab URL still resolves to the empty state.

## Code changes
- **`StockDetailViewModel`** — adds `HasFundHoldings` / `HasFundOperations` bool flags.
- **`StockTabService.LoadFundTabAvailability`** (new) — two `AnyAsync()` EXISTS probes (NPORT → holdings, N-CEN → operations), index-supported on `CommonStockId`.
- **`StocksController.ShowStockTab`** — sets the flags on every tab render.
- **`Views/Stocks/Show.cshtml`** — skips the two fund tabs in the nav loop when their flag is false.
- **Test** — `StockTabServiceLoadFundTabAvailabilityTests` covers both-filings, neither, NPORT-only, and N-CEN-only.

## Testing
- `dotnet build` green; new integration test added (in-memory fixture, mirrors existing `StockTabService` tests).