### PR TITLE
fix(ci): format AddProcessedDataSetParserVersion migration with csharpier

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260604221458_AddProcessedDataSetParserVersion.cs
+++ b/src/Equibles.Migrations/Migrations/20260604221458_AddProcessedDataSetParserVersion.cs
@@ -15,15 +15,14 @@ namespace Equibles.Migrations.Migrations
                 table: "ProcessedDataSet",
                 type: "integer",
                 nullable: false,
-                defaultValue: 0);
+                defaultValue: 0
+            );
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropColumn(
-                name: "ParserVersion",
-                table: "ProcessedDataSet");
+            migrationBuilder.DropColumn(name: "ParserVersion", table: "ProcessedDataSet");
         }
     }
 }


### PR DESCRIPTION
## Summary

The lint job (`dotnet csharpier check .`) has been failing on every push to `main` since the 13F parser-version work landed. The generated migration `20260604221458_AddProcessedDataSetParserVersion.cs` was committed without being run through csharpier, so the formatting check flags it. The originating PR (#3501) was merged despite the same red lint, leaving the failure stuck on `main`.

This reformats the migration to the project style — closing-paren placement and a one-line call collapse only. No behavior change.

## Code changes

- `src/Equibles.Migrations/Migrations/20260604221458_AddProcessedDataSetParserVersion.cs` — csharpier formatting pass; `dotnet csharpier check .` is now clean (2541 files) and the project still builds.