### PR TITLE
chore(ci): exclude generated EF migrations from the csharpier check

### DIFF
--- a/.csharpierignore
+++ b/.csharpierignore
@@ -5,9 +5,9 @@ obj/
 ## Worktrees (transient git worktrees from the harness)
 worktrees/
 
-## Generated migrations — keep EF's exact output untouched
-**/Migrations/*.Designer.cs
-**/Migrations/*ModelSnapshot.cs
+## Generated migrations — EF's output is never hand-edited, so don't let csharpier
+## gate it. Covers the migration class, its .Designer.cs, and the model snapshot.
+**/Migrations/
 
 ## Node / front-end assets (if any sneak in)
 node_modules/


### PR DESCRIPTION
## Summary

The `CI` lint job (`dotnet csharpier check .`) keeps breaking on freshly generated migrations. EF emits migration classes that don't match csharpier's style, and the project never hand-edits migrations, but the format check was still gating them — `.csharpierignore` only excluded the `*.Designer.cs` and `*ModelSnapshot.cs` siblings, not the main migration `.cs`. That's how PR #3501's migration landed red and stuck the failure on `main` (fixed after the fact in #3504). Every `migrations add` was a fresh chance to repeat it.

This excludes the whole generated `Migrations/` folder from the check so EF's output can't fail formatting. The hand-written `DesignTimeDbContextFactory.cs` lives at the migrations project root (not in the `Migrations/` subfolder), so it stays formatted-checked.

## Code changes

- `.csharpierignore` — replace the two narrow `**/Migrations/*.Designer.cs` / `*ModelSnapshot.cs` patterns with `**/Migrations/`, covering the migration class, its designer, and the snapshot. Verified: `dotnet csharpier check .` now inspects the non-generated tree (2503 files) and a deliberately mis-formatted migration no longer fails the check.