### PR TITLE
perf(holdings): vacuum InstitutionalHolding after a 13F sweep

### DIFF
--- a/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
+++ b/src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs
@@ -107,6 +107,16 @@ public class Holdings13FRealtimeWorker : BaseScraperWorker
             result.FilingsImported,
             newWatermark
         );
+
+        // A productive sweep bulk-inserted rows, leaving their heap pages out of the visibility
+        // map. Vacuum so the holdings dashboards' index-only scans don't fall back to a heap
+        // fetch per new row (a cold read was measured at ~66s before the visibility map was set).
+        if (result.FilingsImported > 0)
+        {
+            var maintenance =
+                scope.ServiceProvider.GetRequiredService<HoldingsTableMaintenanceService>();
+            await maintenance.VacuumInstitutionalHoldings(stoppingToken);
+        }
     }
 
     /// <summary>

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsTableMaintenanceService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsTableMaintenanceService.cs
@@ -1,0 +1,54 @@
+using Equibles.Core.AutoWiring;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Online maintenance for the InstitutionalHolding table after a 13F sweep.
+///
+/// Each sweep bulk-inserts rows, and Postgres leaves those new heap pages out of the visibility
+/// map until a VACUUM runs. Until then the index-only scans behind the holdings dashboards fall
+/// back to a heap fetch per row: a cold /holdings/activity read was measured at ~66s, dominated
+/// by that random heap I/O over millions of not-yet-all-visible rows. Running VACUUM (ANALYZE)
+/// right after a productive sweep restores true index-only scans and refreshes planner statistics
+/// before the snapshot rebuild and user reads touch the new rows.
+///
+/// VACUUM cannot run inside a transaction block, so this takes its own scope/connection with no
+/// ambient transaction. Plain VACUUM is online — it does not block concurrent reads or writes.
+/// </summary>
+[Service]
+public class HoldingsTableMaintenanceService
+{
+    // VACUUM only processes pages changed since the last run, so a post-sweep pass is cheap — but
+    // cap it generously so a one-off large pass can never hang the ingestion worker indefinitely.
+    private static readonly TimeSpan VacuumTimeout = TimeSpan.FromMinutes(30);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<HoldingsTableMaintenanceService> _logger;
+
+    public HoldingsTableMaintenanceService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<HoldingsTableMaintenanceService> logger
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public virtual async Task VacuumInstitutionalHoldings(CancellationToken cancellationToken)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        var connection = dbContext.Database.GetDbConnection();
+
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        // VACUUM forbids bind parameters and a surrounding transaction; the table name is a constant.
+        command.CommandText = "VACUUM (ANALYZE) \"InstitutionalHolding\"";
+        command.CommandTimeout = (int)VacuumTimeout.TotalSeconds;
+
+        _logger.LogInformation("Vacuuming InstitutionalHolding after 13F ingestion");
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        _logger.LogInformation("InstitutionalHolding vacuum complete");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsTableMaintenanceServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsTableMaintenanceServiceTests.cs
@@ -1,0 +1,117 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// VACUUM (ANALYZE) on InstitutionalHolding runs against a real Postgres connection with no
+/// ambient transaction (VACUUM is forbidden inside a transaction block) and leaves the table
+/// data intact. Pins that the maintenance command is well-formed and completes — the actual risk,
+/// since EF normally executes inside a transaction. Uses ParadeDB (not the in-memory factory):
+/// VACUUM is Postgres-specific.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsTableMaintenanceServiceTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public HoldingsTableMaintenanceServiceTests(ParadeDbFixture fixture) => _fixture = fixture;
+
+    public Task InitializeAsync() => _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task VacuumInstitutionalHoldings_CompletesAndLeavesDataIntact()
+    {
+        await SeedTwoHoldingsAsync();
+
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = _fixture.CreateDbContext();
+                _contexts.Add(ctx);
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+
+        var service = new HoldingsTableMaintenanceService(
+            scopeFactory,
+            Substitute.For<ILogger<HoldingsTableMaintenanceService>>()
+        );
+
+        // The command would throw if it ran inside a transaction (Postgres: "VACUUM cannot run
+        // inside a transaction block") or if the SQL were malformed.
+        await service.VacuumInstitutionalHoldings(CancellationToken.None);
+
+        await using var verify = _fixture.CreateDbContext();
+        var count = await verify.Set<InstitutionalHolding>().CountAsync(CancellationToken.None);
+        count.Should().Be(2);
+    }
+
+    private async Task SeedTwoHoldingsAsync()
+    {
+        await using var ctx = _fixture.CreateDbContext();
+
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "VACU",
+            Name = "Vacuum Test Co.",
+            Cik = "0009980001",
+            Cusip = "099800015",
+        };
+        var holder = new InstitutionalHolder
+        {
+            Id = Guid.NewGuid(),
+            Cik = "0001000020",
+            Name = "Vacuum Filer",
+        };
+        ctx.Set<CommonStock>().Add(stock);
+        ctx.Set<InstitutionalHolder>().Add(holder);
+        ctx.Set<InstitutionalHolding>()
+            .AddRange(
+                Holding(stock.Id, holder.Id, new DateOnly(2024, 9, 30), 100, "VAC-Q3"),
+                Holding(stock.Id, holder.Id, new DateOnly(2024, 12, 31), 150, "VAC-Q4")
+            );
+        await ctx.SaveChangesAsync(CancellationToken.None);
+    }
+
+    private static InstitutionalHolding Holding(
+        Guid stockId,
+        Guid holderId,
+        DateOnly reportDate,
+        long shares,
+        string accession
+    ) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = stockId,
+            InstitutionalHolderId = holderId,
+            ReportDate = reportDate,
+            FilingDate = reportDate,
+            Shares = shares,
+            Value = shares * 100,
+            AccessionNumber = accession,
+        };
+}


### PR DESCRIPTION
## Summary

- Each real-time 13F sweep bulk-inserts rows into `InstitutionalHolding`, leaving their heap pages out of Postgres's visibility map until a VACUUM runs. Until then the index-only scans behind the holdings dashboards fall back to a heap fetch per new row — a cold market-wide activity read was measured at ~66s, dominated by that random heap I/O (2.09M heap fetches on a 3.5M-row two-quarter scan).
- Run `VACUUM (ANALYZE)` right after a sweep that imported rows, restoring true index-only scans and refreshing planner statistics before the snapshot rebuild and user reads touch the new rows.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsTableMaintenanceService.cs` — new `[Service]` with `VacuumInstitutionalHoldings`. Runs `VACUUM (ANALYZE) "InstitutionalHolding"` on its own scope/connection with no ambient transaction (VACUUM cannot run inside a transaction block); 30-minute command-timeout cap. Plain VACUUM is online and does not block reads or writes.
- `src/Equibles.Holdings.HostedService/Holdings13FRealtimeWorker.cs` — after a sweep with `FilingsImported > 0`, resolve the service and vacuum.
- `tests/Equibles.IntegrationTests/Holdings/HoldingsTableMaintenanceServiceTests.cs` — ParadeDB integration test: seeds rows, runs the vacuum, asserts it completes (no transaction-block error) and the data is intact.