### PR TITLE
test(sec): add skipped repro for GH-3510 — Part-roman prose deleted after page breaks

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartRomanProseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartRomanProseTests.cs
@@ -1,0 +1,28 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class PaginationRemovalStepPartRomanProseTests
+{
+    private readonly PaginationRemovalStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    // Contract: only a SEC "Part" SECTION HEADER after a page-break <hr> is pagination cruft;
+    // body prose must never be deleted (content loss — the GH-3489 rationale). A cross-reference
+    // sentence "Part II of this Annual Report …" is prose even though "II" is a roman numeral.
+    [Fact(
+        Skip = "GH-3510 — prose paragraph beginning \"Part II of …\" after an <hr> is deleted as a Part header"
+    )]
+    public void Execute_HrFollowedByProseSentenceBeginningPartRoman_PreservesParagraph()
+    {
+        var doc = _parser.ParseDocument(
+            "<html><body><hr><p>Part II of this Annual Report on Form 10-K contains forward-looking statements that involve risks and uncertainties</p></body></html>"
+        );
+
+        _step.Execute(doc);
+
+        doc.Body!.InnerHtml.Should()
+            .Contain("Part II of this Annual Report on Form 10-K contains forward-looking");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit regression test showing `PaginationRemovalStep` deletes a prose paragraph beginning "Part II of this Annual Report …" when it follows a page-break `<hr>` — the roman-numeral guard from #3491 spares "Part of …" prose but still classifies roman-numeral cross-reference sentences as Part headers, wiping body content (skipped — see GH-3510).
- Same content-loss failure mode #3489/#3491 addressed; such cross-references commonly open a paragraph right after a page break in 10-K/10-Q filings.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartRomanProseTests.cs` — new test parsing `<hr><p>Part II of this Annual Report …</p>`, running `Execute`, and asserting the paragraph survives; observed `Body.InnerHtml` is empty. Skipped pending the GH-3510 fix.