### PR TITLE
test(sec): add skipped repro for GH-3512 — Part-roman prose promoted to h1

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartRomanProseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartRomanProseTests.cs
@@ -1,0 +1,28 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class HeadingConversionStepPartRomanProseTests
+{
+    private readonly HeadingConversionStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    // Contract: the Part→h1 path classifies SEC "PART N" SECTION HEADINGS only; prose must
+    // never be promoted (the GH-3488 rationale). A cross-reference sentence "Part II of this
+    // Annual Report …" is body text even though "II" is a roman numeral.
+    // The span is mixed-case and unstyled, so only the IsPartHeading branch can fire.
+    [Fact(
+        Skip = "GH-3512 — prose sentence beginning \"Part II of …\" is promoted to an h1 heading"
+    )]
+    public void Execute_ProseSentenceBeginningPartRoman_IsNotPromotedToHeading()
+    {
+        var doc = _parser.ParseDocument(
+            "<html><body><p><span>Part II of this Annual Report on Form 10-K contains forward-looking statements that involve risks and uncertainties</span></p></body></html>"
+        );
+
+        _step.Execute(doc);
+
+        doc.Body!.InnerHtml.Should().NotContain("<h1");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit regression test showing `HeadingConversionStep` promotes a prose cross-reference sentence "Part II of this Annual Report on Form 10-K contains forward-looking statements…" to `<h1>` — the roman-numeral guard from #3488 spares "Part of …" prose but still classifies roman-numeral prose as a Part section heading, corrupting the document outline (skipped — see GH-3512).
- Promotion-side sibling of GH-3510 (the mirrored `PaginationRemovalStep` guard deletes the same prose after page breaks); a shared header-shape fix likely resolves both.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartRomanProseTests.cs` — new test parsing an unstyled mixed-case `<span>` with the prose sentence, running `Execute`, and asserting no `<h1>` appears; observed the full sentence wrapped in `<h1>`. Skipped pending the GH-3512 fix.