### PR TITLE
test(sec): add skipped repro for GH-3514 — Item-digit prose promoted to h2

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepItemDigitProseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepItemDigitProseTests.cs
@@ -1,0 +1,26 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class HeadingConversionStepItemDigitProseTests
+{
+    private readonly HeadingConversionStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    // Contract: the Item→h2 path classifies SEC "ITEM N" SECTION HEADINGS only; prose must
+    // never be promoted. A cross-reference sentence "Item 1 of this Annual Report …" is body
+    // text even though "1" is a valid item identifier (digit sibling of GH-3512's roman case).
+    // The span is mixed-case and unstyled, so only the IsItemHeading branch can fire.
+    [Fact(Skip = "GH-3514 — prose sentence beginning \"Item 1 of …\" is promoted to an h2 heading")]
+    public void Execute_ProseSentenceBeginningItemDigit_IsNotPromotedToHeading()
+    {
+        var doc = _parser.ParseDocument(
+            "<html><body><p><span>Item 1 of this Annual Report contains information about our business and operations that should be read carefully</span></p></body></html>"
+        );
+
+        _step.Execute(doc);
+
+        doc.Body!.InnerHtml.Should().NotContain("<h2");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a unit regression test showing `HeadingConversionStep` promotes a prose cross-reference sentence "Item 1 of this Annual Report contains information about our business…" to `<h2>` — the Item→h2 heuristic accepts any text whose first token after "Item" is a valid identifier, so long prose is classified as a section heading and the document outline is corrupted (skipped — see GH-3514).
- Digit/Item sibling of GH-3512 (Part→h1, roman prose) and GH-3510 (page-break deletion of the same shape); the family shares one root cause in the header-shape heuristics.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepItemDigitProseTests.cs` — new test parsing an unstyled mixed-case `<span>` with the prose sentence, running `Execute`, and asserting no `<h2>` appears; observed the full sentence wrapped in `<h2>`. Skipped pending the GH-3514 fix.