### PR TITLE
test(holdings): pin pre-2023 voting fallback in Corrupt13FShareCountRepairer

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerPre2023VotingFallbackTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerPre2023VotingFallbackTests.cs
@@ -1,0 +1,45 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Corrupt13FShareCountRepairerPre2023VotingFallbackTests
+{
+    // Combination pin: pre-2023 thousands scaling applies to the dollar VALUE only — the
+    // voting-authority total is a share count, so the no-price fallback must use it verbatim
+    // (existing tests pin thousands×priced and voting×post-2023 separately, never together).
+    [Fact]
+    public void Repair_FilingBefore2023NoPriceVotingTotalPresent_UsesVotingTotalUnscaled()
+    {
+        var holding = new InstitutionalHolding
+        {
+            CommonStockId = Guid.NewGuid(),
+            InstitutionalHolderId = Guid.NewGuid(),
+            FilingDate = new DateOnly(2021, 8, 12),
+            ReportDate = new DateOnly(2021, 6, 30),
+            Shares = 6_702_883,
+            Value = 0,
+            ShareType = ShareType.Shares,
+            VotingAuthSole = 6_751,
+            ValuePending = true,
+        };
+        var row = new BufferedHoldingRow
+        {
+            Holding = holding,
+            ManagerEntry = new HoldingManagerEntry { Shares = 6_702_883, Value = 0 },
+            ReportedValue = 6_702_883,
+        };
+        var rows = new List<BufferedHoldingRow> { row };
+
+        var outcome = Corrupt13FShareCountRepairer.Repair(
+            rows,
+            new Dictionary<(Guid, DateOnly), decimal>()
+        );
+
+        outcome.Should().Be(new Corrupt13FRepairOutcome(RepairedRows: 1, DroppedRows: 0));
+        row.Holding.Shares.Should().Be(6_751L);
+        row.Holding.Value.Should().Be(0L);
+        row.Holding.ValuePending.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the untested combination of two repair features from #3499: pre-2023 thousands scaling × the no-price voting-authority fallback. The thousands multiplier applies to the dollar value only — the voting-authority total is a share count and must be used verbatim.
- Existing tests pin each feature alone (thousands with a price; voting fallback post-2023); a regression that scales the voting count by 1000 (or divides it) would slip past both.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerPre2023VotingFallbackTests.cs` — new unit test: a 2021 suspect duplicated row with no closing price and `VotingAuthSole = 6,751` must repair to exactly 6,751 shares with `Value = 0` and `ValuePending = true`.