### PR TITLE
test(sec): add skipped repro for GH-3518 — XBRL file-name cap orphans surrogate pairs

### DIFF
--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests.cs
@@ -1,0 +1,61 @@
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// The MaxFileNameLength cap exists so the File insert can never overflow — i.e. the capped
+/// name must be DB-safe. An orphan surrogate corrupts the PostgreSQL UTF-8 round-trip (the
+/// GH-3408 failure mode, guarded in EdgarXmlSubmissionParser.Truncate and the Congress
+/// sibling), so a cut landing inside a surrogate pair must not keep the lone high surrogate.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests : ParadeDbMcpTestBase
+{
+    public DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact(
+        Skip = "GH-3518 — XBRL file-name cap slices mid-surrogate-pair, leaving an orphan high surrogate"
+    )]
+    public async Task UpdateXbrl_FileNameCapSplitsSurrogatePair_PassesNoOrphanSurrogateToFileManager()
+    {
+        // 255 ASCII chars + "🏛" (U+1F3DB, two UTF-16 units) = 257 units: the 256-unit cap
+        // lands exactly between the high and low surrogate.
+        var fileName = new string('a', 255) + "🏛";
+        string capturedName = null;
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager
+            .SaveInternalFile(
+                Arg.Any<byte[]>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>()
+            )
+            .Returns(ci =>
+            {
+                capturedName = ci.ArgAt<string>(1);
+                return (Equibles.Media.Data.Models.File)null;
+            });
+
+        await using var ctx = Fixture.CreateDbContext();
+        var service = new DocumentPersistenceService(new DocumentRepository(ctx), fileManager);
+
+        await service.UpdateXbrl(
+            new Document(),
+            XbrlCaptureResult.Captured(XbrlType.InlineIxbrl, fileName, [1, 2, 3])
+        );
+
+        capturedName.Should().NotBeNull();
+        capturedName.Length.Should().BeLessThanOrEqualTo(256);
+        char.IsHighSurrogate(capturedName[^1])
+            .Should()
+            .BeFalse("a capped file name must not end in an orphan high surrogate");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an integration regression test showing `DocumentPersistenceService` caps `XbrlCaptureResult.SourceFileName` with a raw `[..256]` slice: when the cut lands inside a surrogate pair, the name handed to the file manager ends in an orphan high surrogate, corrupting the PostgreSQL UTF-8 round-trip the cap exists to prevent (skipped — see GH-3518).
- Third instance of the GH-3408 bug class; `EdgarXmlSubmissionParser.Truncate` (#3481) and the Congress sibling already carry the back-off guard this call site is missing.

## Code changes

- `tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests.cs` — new test calling `UpdateXbrl` with a 255-char + "🏛" source file name and a substituted `IFileManager`; asserts the captured name never ends in a lone high surrogate. Skipped pending the GH-3518 fix.