### PR TITLE
test(insider): pin Stock Option titles excluded from share classification

### DIFF
--- a/tests/Equibles.UnitTests/InsiderTrading/Models/InsiderSecurityClassificationStockOptionTitleTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/Models/InsiderSecurityClassificationStockOptionTitleTests.cs
@@ -1,0 +1,24 @@
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.Models;
+
+public class InsiderSecurityClassificationStockOptionTitleTests
+{
+    private static readonly Func<InsiderTransaction, bool> IsShareTransaction =
+        InsiderSecurityClassification.IsShareTransaction.Compile();
+
+    // Contract (#3502): the title fallback keeps derivatives off the value boards. A
+    // "Stock Option" is a derivative even though its title contains the share word "Stock" —
+    // the most common Form 4 derivative title must not slip through on that keyword.
+    [Fact]
+    public void IsShareTransaction_UnknownWithStockOptionTitle_IsFalse()
+    {
+        var row = new InsiderTransaction
+        {
+            SecurityKind = InsiderSecurityKind.Unknown,
+            SecurityTitle = "Stock Option (Right to Buy)",
+        };
+
+        IsShareTransaction(row).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the most consequential input to the #3502 title fallback: "Stock Option (Right to Buy)" — the most common Form 4 derivative title — contains the share keyword "Stock", and a keyword-precedence regression would let it back onto the dashboard value boards as a share row, re-creating the trillion-dollar phantom inflation #3502 fixed.
- Existing tests pin derivative titles without share keywords (Warrant, Convertible Note, Call/Put Option) and share titles without derivative keywords; the both-keywords combination was unpinned.

## Code changes

- `tests/Equibles.UnitTests/InsiderTrading/Models/InsiderSecurityClassificationStockOptionTitleTests.cs` — new unit test asserting `IsShareTransaction` is false for an Unknown-kind row titled "Stock Option (Right to Buy)".