### PR TITLE
test(holdings): pin IsSuspect at the joint 5-row 80% detection boundary

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerIsSuspectJointBoundaryTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerIsSuspectJointBoundaryTests.cs
@@ -1,0 +1,41 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class Corrupt13FShareCountRepairerIsSuspectJointBoundaryTests
+{
+    // Joint boundary of both detection thresholds: exactly MinimumComparableRows (5) and
+    // exactly the 80% fraction (4 of 5 duplicated) — the doc says "at least 80%", so this
+    // smallest qualifying filing must flag. Existing tests pin only strictly-inside points.
+    [Fact]
+    public void IsSuspect_FourOfFiveComparableRowsDuplicated_True()
+    {
+        var duplicated = Enumerable
+            .Range(1, 4)
+            .Select(i => Row(shares: i * 1_000, reportedValue: i * 1_000));
+        var healthy = new[] { Row(shares: 500, reportedValue: 125_000) };
+        var rows = duplicated.Concat(healthy).ToList();
+
+        Corrupt13FShareCountRepairer.IsSuspect(rows).Should().BeTrue();
+    }
+
+    private static BufferedHoldingRow Row(long shares, long reportedValue) =>
+        new()
+        {
+            Holding = new InstitutionalHolding
+            {
+                CommonStockId = Guid.NewGuid(),
+                InstitutionalHolderId = Guid.NewGuid(),
+                FilingDate = new DateOnly(2026, 4, 15),
+                ReportDate = new DateOnly(2026, 3, 31),
+                Shares = shares,
+                Value = 0,
+                ShareType = ShareType.Shares,
+                ValuePending = true,
+            },
+            ManagerEntry = new HoldingManagerEntry { Shares = shares, Value = 0 },
+            ReportedValue = reportedValue,
+        };
+}


### PR DESCRIPTION
## Summary

- Pins the smallest filing the duplicated-share-count detector must flag: exactly `MinimumComparableRows` (5) with exactly 80% duplication (4 of 5). The doc-comment promises "at least 80% of comparable rows", so this joint boundary is suspect — a regression to a strict `>` on either threshold would let the smallest corrupt filings (the #3499 DIAMANT shape) through unrepaired.
- Existing tests pin only strictly-inside points (6/6 duplicated, 4 rows below minimum, 7/10 below fraction); neither detection threshold was pinned at its exact edge.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Corrupt13FShareCountRepairerIsSuspectJointBoundaryTests.cs` — new unit test: 4 duplicated + 1 healthy share rows ⇒ `IsSuspect` is true.