### PR TITLE
test(sec): pin NPORT issuer-category fallback to the conditional attribute

### DIFF
--- a/tests/Equibles.UnitTests/Sec/NportFilingProcessorParseIssuerCategoryConditionalTests.cs
+++ b/tests/Equibles.UnitTests/Sec/NportFilingProcessorParseIssuerCategoryConditionalTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using System.Xml.Linq;
+using Equibles.Sec.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class NportFilingProcessorParseIssuerCategoryConditionalTests
+{
+    // Contract: NPORT issuer category comes from the <issuerCat> child element; EDGAR also
+    // emits it as an issuerCat ATTRIBUTE on <issuerConditional> when the direct element is
+    // absent, so the parser must fall back to that attribute rather than returning null.
+    [Fact]
+    public void ParseIssuerCategory_DirectElementAbsentConditionalAttributePresent_ReturnsAttribute()
+    {
+        var element = XElement.Parse(
+            "<invstOrSec><issuerConditional issuerCat=\"CORP\" desc=\"Corporate\" /></invstOrSec>"
+        );
+
+        var method = typeof(NportFilingProcessor).GetMethod(
+            "ParseIssuerCategory",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var result = (string)method.Invoke(null, [element]);
+
+        result.Should().Be("CORP");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins the untested fallback branch of `NportFilingProcessor.ParseIssuerCategory`: when the direct `<issuerCat>` child element is absent, EDGAR emits the category as an `issuerCat` attribute on `<issuerConditional>`, and the parser must read it from there rather than returning null.
- The recent NPORT churn (#3496, #3498) exercised the holdings loop but left this issuer-category fallback unpinned; a regression dropping the attribute path would silently null out the category for every conditional-issuer holding.

## Code changes

- `tests/Equibles.UnitTests/Sec/NportFilingProcessorParseIssuerCategoryConditionalTests.cs` — new unit test reflection-invoking the private static `ParseIssuerCategory` with an `<invstOrSec>` that carries only `<issuerConditional issuerCat="CORP" />`, asserting it returns "CORP".