### PR TITLE
test(sec): pin ListConversionStep strips a bullet nested inside the inline content div

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepNestedBulletTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepNestedBulletTests.cs
@@ -1,0 +1,38 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class ListConversionStepNestedBulletTests
+{
+    private readonly ListConversionStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    private string Execute(string bodyHtml)
+    {
+        var doc = _parser.ParseDocument($"<html><body>{bodyHtml}</body></html>");
+        _step.Execute(doc);
+        return doc.Body!.InnerHtml;
+    }
+
+    // Combination the existing bullet pins miss: the bullet span sits INSIDE the inline
+    // content div, not as a sibling before it. The bullet matcher is a descendant query,
+    // so the glyph must still be stripped — and because removal happens before the content
+    // div's InnerHtml is lifted into the <li>, the rendered item must keep its text and
+    // drop the decorative bullet rather than baking "•" into the persisted document.
+    [Fact]
+    public void Execute_BulletSpanNestedInsideInlineContentDiv_StripsBulletKeepsText()
+    {
+        var input = """
+            <div class="item-list-element-wrapper">
+              <div style="display:inline"><span>•</span>Item with nested bullet</div>
+            </div>
+            """;
+
+        var result = Execute(input);
+
+        result.Should().Contain("<li>");
+        result.Should().Contain("Item with nested bullet");
+        result.Should().NotContain("•");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins a list-item bullet combination the existing pins miss: the decorative bullet span sits INSIDE the `display:inline` content div rather than as a sibling before it. The bullet matcher is a descendant query and removal runs before the content div's InnerHtml is lifted into the `<li>`, so the rendered item must keep its text and drop the "•" glyph — a regression baking the bullet into persisted document text would surface in the public viewer and MCP keyword search.
- All existing bullet tests (#3487 family) place the bullet as a preceding sibling; the nested case was unpinned.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/ListConversionStepNestedBulletTests.cs` — new unit test: a wrapper whose inline content div contains `<span>•</span>Item with nested bullet` converts to a `<li>` retaining the text and containing no bullet glyph.