### PR TITLE
fix(insider-trading): count only attempted filings as Processed on cancellation

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -116,10 +116,12 @@ public class InsiderFilingReprocessManager
             if (accessions.Count == 0)
                 break;
 
+            var attempted = 0;
             foreach (var accession in accessions)
             {
                 if (cancellationToken.IsCancellationRequested)
                     break;
+                attempted++;
                 try
                 {
                     await ReprocessFiling(accession, result);
@@ -141,7 +143,10 @@ public class InsiderFilingReprocessManager
             try
             {
                 await _transactionRepository.SaveChanges();
-                result.Processed += accessions.Count - accessions.Count(failedThisRun.Contains);
+                // Count only filings actually attempted this batch (successes + failures).
+                // Cancellation can break the loop early, so the remaining accessions were
+                // never tried and must not be credited as processed.
+                result.Processed += attempted;
             }
             catch (DbUpdateException ex)
             {

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerCancellationTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerCancellationTests.cs
@@ -25,9 +25,7 @@ public class InsiderFilingReprocessManagerCancellationTests : ParadeDbMcpTestBas
     public InsiderFilingReprocessManagerCancellationTests(ParadeDbFixture fixture)
         : base(fixture) { }
 
-    [Fact(
-        Skip = "GH-3507 — Run credits the whole batch to Processed when cancellation skips filings mid-batch"
-    )]
+    [Fact]
     public async Task Run_CancelledMidBatch_CountsOnlyAttemptedFilingsAsProcessed()
     {
         var date = new DateOnly(2024, 6, 14);


### PR DESCRIPTION
## Summary

- `InsiderFilingReprocessManager.Run` credited the entire batch to `Processed` even when a cancellation broke the per-filing loop early, so filings that were never attempted were reported as processed. The run summary and any `onProgress` consumer over-reported progress after a shutdown (default batch of 32 would report 32 processed after a cancellation following the first filing).
- On-disk state was already correct (skipped rows keep their old parser version and are re-selected next run); only the result accounting was wrong.

## Code changes

- `src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs` — track the number of filings actually entered in the batch loop and add that to `Processed`, so the count reflects successes plus failures actually attempted, matching the documented contract.
- `tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerCancellationTests.cs` — un-skip the regression test that cancels the token mid-batch and asserts only the attempted filing is counted.

closes #3507