### PR TITLE
refactor(sec): extract repeated amendment-form check into IsAmendmentForm

### DIFF
--- a/src/Equibles.Sec.HostedService/Extensions/FilingFormExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/FilingFormExtensions.cs
@@ -1,0 +1,10 @@
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.Sec.HostedService.Extensions;
+
+public static class FilingFormExtensions
+{
+    // SEC amendment submissions carry "/A" in their form type (e.g. "D/A", "N-PORT/A", "N-CEN/A").
+    public static bool IsAmendmentForm(this FilingData filing) =>
+        filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs
@@ -3,6 +3,7 @@ using System.Xml.Linq;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Extensions;
 using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.Repositories;
 using static Equibles.Sec.HostedService.Helpers.EdgarXmlSubmissionParser;
@@ -157,7 +158,7 @@ public class FormDFilingProcessor : IssuerFeedFilingProcessor<FormDFiling, FormD
             return ParseBool(flag);
 
         // Fall back to the submission form string ("D/A") when the flag is absent.
-        return filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
+        return filing.IsAmendmentForm();
     }
 
     // Pinned by processor-scoped tests; the implementation lives in the shared parser.

--- a/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
@@ -2,6 +2,7 @@ using System.Xml.Linq;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Extensions;
 using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.Repositories;
 using static Equibles.Sec.HostedService.Helpers.EdgarXmlSubmissionParser;
@@ -248,7 +249,7 @@ public class NCenFilingProcessor : IssuerFeedFilingProcessor<NCenFiling, NCenFil
         if (submissionType != null)
             return submissionType.Contains("/A", StringComparison.OrdinalIgnoreCase);
 
-        return filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
+        return filing.IsAmendmentForm();
     }
 
     // Pinned by processor-scoped tests; the implementation lives in the shared parser.

--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -3,6 +3,7 @@ using System.Xml.Linq;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Extensions;
 using Equibles.Sec.HostedService.Helpers;
 using Equibles.Sec.Repositories;
 using static Equibles.Sec.HostedService.Helpers.EdgarXmlSubmissionParser;
@@ -154,7 +155,7 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
         if (submissionType != null)
             return submissionType.Contains("/A", StringComparison.OrdinalIgnoreCase);
 
-        return filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
+        return filing.IsAmendmentForm();
     }
 
     // Pinned by processor-scoped tests; the implementation lives in the shared parser.


### PR DESCRIPTION
## Summary

- The same SEC amendment-form fallback check — `filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true` — was duplicated verbatim across three filing processors (Form D, N-CEN, N-PORT).
- Collapsed the three identical expressions into one documented extension method so amendment detection lives in a single place.

## Code changes

- `src/Equibles.Sec.HostedService/Extensions/FilingFormExtensions.cs` — new `IsAmendmentForm` extension on `FilingData`; body is identical to the replaced expression (same null handling and case-insensitive comparison).
- `src/Equibles.Sec.HostedService/Services/FormDFilingProcessor.cs` — use the helper in the amendment fallback.
- `src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs` — same.
- `src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs` — same.

Behavior-preserving: literal substitution. Build green; SEC unit suite passes (955 passed, 3 pre-existing skips).