### PR TITLE
fix(sec): back off mid-surrogate XBRL file-name cap to keep UTF-16 well-formed

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -93,11 +93,18 @@ public class DocumentPersistenceService : IDocumentPersistenceService
 
         var compressed = GzipCompressor.Compress(xbrl.RawBytes);
         // File.Name is capped at 256 chars; EDGAR document names are bare short tokens, but
-        // guard against a pathological envelope value so the insert can never overflow.
-        var name =
-            xbrl.SourceFileName?.Length > MaxFileNameLength
-                ? xbrl.SourceFileName[..MaxFileNameLength]
-                : xbrl.SourceFileName;
+        // guard against a pathological envelope value so the insert can never overflow. A raw
+        // slice can split a surrogate pair, leaving an orphan high surrogate that corrupts the
+        // UTF-8 round-trip on insert — back off one unit when the cut lands mid-pair (mirrors
+        // EdgarXmlSubmissionParser.Truncate).
+        var name = xbrl.SourceFileName;
+        if (name?.Length > MaxFileNameLength)
+        {
+            var end = char.IsHighSurrogate(name[MaxFileNameLength - 1])
+                ? MaxFileNameLength - 1
+                : MaxFileNameLength;
+            name = name[..end];
+        }
         var xbrlFile = await _fileManager.SaveInternalFile(
             compressed,
             name,

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests.cs
@@ -21,9 +21,7 @@ public class DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests : Parade
     public DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests(ParadeDbFixture fixture)
         : base(fixture) { }
 
-    [Fact(
-        Skip = "GH-3518 — XBRL file-name cap slices mid-surrogate-pair, leaving an orphan high surrogate"
-    )]
+    [Fact]
     public async Task UpdateXbrl_FileNameCapSplitsSurrogatePair_PassesNoOrphanSurrogateToFileManager()
     {
         // 255 ASCII chars + "🏛" (U+1F3DB, two UTF-16 units) = 257 units: the 256-unit cap


### PR DESCRIPTION
## Summary

- `DocumentPersistenceService.ApplyXbrlCapture` capped `XbrlCaptureResult.SourceFileName` with a raw UTF-16 code-unit slice (`[..MaxFileNameLength]`). When the 256-unit cap landed between the two units of a supplementary-plane character, the kept name ended in an orphan high surrogate, corrupting the PostgreSQL UTF-8 round-trip on the `File` insert — the exact overflow the cap exists to prevent.
- Same bug class already fixed in `EdgarXmlSubmissionParser.Truncate` (#3481/GH-3408) and its Congress sibling; this applies the same back-off guard.

## Code changes

- `src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs` — when the cap lands on a high surrogate, back off one unit so the capped name is always well-formed UTF-16.
- `tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests.cs` — un-skipped the regression test (255 ASCII + "🏛"): asserts the captured file name never ends in an orphan high surrogate.

closes #3518