### PR TITLE
refactor(sec): extract duplicated Part/Item heading detection into SecHeadingKeyword

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -5,9 +5,6 @@ namespace Equibles.Sec.BusinessLogic.Normalizers;
 
 internal class HeadingConversionStep : IHtmlNormalizationStep
 {
-    // Uppercase Roman-numeral letters; the text is upper-cased before the check.
-    private const string RomanNumeralLetters = "IVXLCDM";
-
     public void Execute(IHtmlDocument doc)
     {
         // Select spans that are NOT descendants of table elements
@@ -113,76 +110,19 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
         return letters.Count > 0 && letters.All(char.IsUpper);
     }
 
-    private bool IsPartHeading(string text)
-    {
-        if (string.IsNullOrWhiteSpace(text))
-            return false;
+    // A real Part identifier is a Roman numeral (Part I–IV); prose beginning "Part of …"
+    // or a word like "Partnership" must not be tagged as a heading.
+    private bool IsPartHeading(string text) =>
+        SecHeadingKeyword.MatchesKeywordIdentifier(text, "PART", SecHeadingKeyword.IsRomanNumeral);
 
-        var upperText = text.ToUpperInvariant().Trim();
-
-        // SEC EDGAR renders "Part N" with a non-breaking space (U+00A0)
-        // between word and numeral, so accept any Unicode whitespace after
-        // "PART" — not just the literal U+0020 that StartsWith("PART ") demands.
-        // Mirrors the GH-975 fix applied to IsItemHeading.
-        if (upperText.StartsWith("PART") && upperText.Length > 4 && char.IsWhiteSpace(upperText[4]))
-        {
-            var afterPart = upperText.Substring(5).Trim();
-            if (!string.IsNullOrEmpty(afterPart))
-            {
-                var tokens = afterPart.Split(
-                    [' ', '.', '-', ':'],
-                    StringSplitOptions.RemoveEmptyEntries
-                );
-                if (tokens.Length == 0)
-                    return false;
-                var firstWord = tokens[0];
-                // A real Part identifier is a Roman numeral (Part I–IV). An ordinary word
-                // like "of"/"the" from a prose sentence beginning "Part of …" is all-letters
-                // too, so require the first token to be composed solely of Roman-numeral
-                // letters — that rejects the prose while still accepting "Part IV".
-                return firstWord.All(c => RomanNumeralLetters.Contains(c));
-            }
-        }
-
-        return false;
-    }
-
-    private bool IsItemHeading(string text)
-    {
-        if (string.IsNullOrWhiteSpace(text))
-            return false;
-
-        var upperText = text.ToUpperInvariant().Trim();
-
-        // SEC EDGAR renders "Item N" with a non-breaking space (U+00A0)
-        // between word and number, so accept any Unicode whitespace after
-        // "ITEM" — not just the literal U+0020 that StartsWith("ITEM ") demands.
-        if (upperText.StartsWith("ITEM") && upperText.Length > 5 && char.IsWhiteSpace(upperText[4]))
-        {
-            var afterItem = upperText.Substring(5).Trim();
-            if (!string.IsNullOrEmpty(afterItem))
-            {
-                // Require a real item identifier after the separator (e.g. "1",
-                // "1A"). A delimiter-only fragment like "Item -" is a visual
-                // divider, not a heading. Mirrors IsPartHeading's guard against
-                // "Part -"; items use alphanumeric identifiers rather than words.
-                var tokens = afterItem.Split(
-                    [' ', '.', '-', ':'],
-                    StringSplitOptions.RemoveEmptyEntries
-                );
-                if (tokens.Length == 0)
-                    return false;
-                var firstWord = tokens[0];
-                // A real Item identifier is number-led (Item 1, 1A, 7A). An ordinary word
-                // like "of"/"the" from a prose sentence beginning "Item of …" starts with a
-                // letter, so require the first token to start with a digit — that rejects the
-                // prose while still accepting "Item 1A".
-                return char.IsDigit(firstWord[0]);
-            }
-        }
-
-        return false;
-    }
+    // A real Item identifier is number-led (Item 1, 1A, 7A); prose beginning "Item of …"
+    // starts with a letter and must not be tagged as a heading.
+    private bool IsItemHeading(string text) =>
+        SecHeadingKeyword.MatchesKeywordIdentifier(
+            text,
+            "ITEM",
+            firstWord => char.IsDigit(firstWord[0])
+        );
 
     private bool IsItalicSpan(IElement span) => HasInlineCss(span, "font-style", "italic");
 

--- a/src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs
@@ -5,9 +5,6 @@ namespace Equibles.Sec.BusinessLogic.Normalizers;
 
 internal class PaginationRemovalStep : IHtmlNormalizationStep
 {
-    // Uppercase Roman-numeral letters; the text is upper-cased before the check.
-    private const string RomanNumeralLetters = "IVXLCDM";
-
     public void Execute(IHtmlDocument doc)
     {
         var hrElements = doc.Body?.QuerySelectorAll(":scope > hr")?.ToList();
@@ -39,29 +36,12 @@ internal class PaginationRemovalStep : IHtmlNormalizationStep
         }
     }
 
-    // Mirrors HeadingConversionStep.IsPartHeading: treat the after-HR sibling as a Part
-    // header only when "Part" is followed by a whitespace boundary AND a roman-numeral
-    // identifier — so ordinary words that merely start with "Part" (Partnership, …) and
-    // prose sentences beginning "Part of …" are not mistaken for a header and deleted.
-    private static bool IsPartHeader(string text)
-    {
-        if (string.IsNullOrWhiteSpace(text))
-            return false;
-
-        var upperText = text.ToUpperInvariant().Trim();
-        if (
-            !upperText.StartsWith("PART")
-            || upperText.Length <= 4
-            || !char.IsWhiteSpace(upperText[4])
-        )
-            return false;
-
-        var afterPart = upperText.Substring(5).Trim();
-        var tokens = afterPart.Split([' ', '.', '-', ':'], StringSplitOptions.RemoveEmptyEntries);
-        if (tokens.Length == 0)
-            return false;
-        return tokens[0].All(c => RomanNumeralLetters.Contains(c));
-    }
+    // Treat the after-HR sibling as a Part header only when "Part" is followed by a
+    // whitespace boundary AND a roman-numeral identifier — so ordinary words that merely
+    // start with "Part" (Partnership, …) and prose sentences beginning "Part of …" are not
+    // mistaken for a header and deleted.
+    private static bool IsPartHeader(string text) =>
+        SecHeadingKeyword.MatchesKeywordIdentifier(text, "PART", SecHeadingKeyword.IsRomanNumeral);
 
     private static INode FindFirstMeaningfulSibling(INode node, bool forward)
     {

--- a/src/Equibles.Sec.BusinessLogic/Normalizers/SecHeadingKeyword.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/SecHeadingKeyword.cs
@@ -1,0 +1,44 @@
+namespace Equibles.Sec.BusinessLogic.Normalizers;
+
+// Shared detection for SEC "Part"/"Item" section headers. Both HeadingConversionStep
+// and PaginationRemovalStep need to tell a real heading ("Part IV", "Item 1A") apart
+// from prose that merely starts with the keyword ("Partnership", "Part of …").
+internal static class SecHeadingKeyword
+{
+    // Uppercase Roman-numeral letters; the text is upper-cased before the check.
+    private const string RomanNumeralLetters = "IVXLCDM";
+
+    // True when `text` begins with `keyword` (case-insensitive) followed by a whitespace
+    // boundary and a first token satisfying `firstTokenMatches`. SEC EDGAR renders the
+    // separator with a non-breaking space (U+00A0), so any Unicode whitespace counts.
+    public static bool MatchesKeywordIdentifier(
+        string text,
+        string keyword,
+        Func<string, bool> firstTokenMatches
+    )
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        var upperText = text.ToUpperInvariant().Trim();
+        if (
+            !upperText.StartsWith(keyword)
+            || upperText.Length <= keyword.Length
+            || !char.IsWhiteSpace(upperText[keyword.Length])
+        )
+            return false;
+
+        var after = upperText.Substring(keyword.Length + 1).Trim();
+        var tokens = after.Split([' ', '.', '-', ':'], StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0)
+            return false;
+
+        return firstTokenMatches(tokens[0]);
+    }
+
+    // A real Part identifier is a Roman numeral (Part I–IV); an ordinary word like
+    // "of"/"the" from a prose sentence beginning "Part of …" is all-letters too, so
+    // require every character to be a Roman-numeral letter.
+    public static bool IsRomanNumeral(string token) =>
+        token.All(c => RomanNumeralLetters.Contains(c));
+}


### PR DESCRIPTION
## Summary

- Three places in the SEC HTML normalizer duplicated the same "keyword + whitespace boundary + first-token predicate" parse used to tell real `Part`/`Item` section headers apart from prose that merely starts with the word.
- Extracted that parse into a single `SecHeadingKeyword` helper, removing the repeated logic and the duplicated `RomanNumeralLetters` constant from two files.

## Code changes

- `Normalizers/SecHeadingKeyword.cs` — new internal helper: `MatchesKeywordIdentifier(text, keyword, firstTokenMatches)` and `IsRomanNumeral(token)`.
- `Normalizers/HeadingConversionStep.cs` — `IsPartHeading`/`IsItemHeading` now delegate to the helper (names/signatures unchanged so existing tests still bind); removed the duplicated constant.
- `Normalizers/PaginationRemovalStep.cs` — `IsPartHeader` now delegates to the helper; removed the duplicated constant.

Behavior preserved: the helper reproduces the identical parse (upper+trim, keyword+whitespace boundary, substring+trim, same delimiter split with `RemoveEmptyEntries`, same first-token predicate). The Item `Length > 5` vs generic `Length > keyword.Length` difference is unreachable because `Trim()` strips any trailing whitespace.