### PR TITLE
fix(sec): stop deleting prose that opens "Part <roman> of …" after a page break

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs
@@ -5,6 +5,13 @@ namespace Equibles.Sec.BusinessLogic.Normalizers;
 
 internal class PaginationRemovalStep : IHtmlNormalizationStep
 {
+    // A page-break Part header is a short bare fragment — "PART II", at most followed by a
+    // brief standardized title ("PART II — OTHER INFORMATION"). A prose cross-reference like
+    // "Part II of this Annual Report …" merely starts with the same keyword + roman numeral
+    // but runs on much longer; deleting it as pagination cruft would lose body content, so
+    // only a short fragment qualifies for removal.
+    private const int MaxPartHeaderWords = 6;
+
     public void Execute(IHtmlDocument doc)
     {
         var hrElements = doc.Body?.QuerySelectorAll(":scope > hr")?.ToList();
@@ -39,9 +46,16 @@ internal class PaginationRemovalStep : IHtmlNormalizationStep
     // Treat the after-HR sibling as a Part header only when "Part" is followed by a
     // whitespace boundary AND a roman-numeral identifier — so ordinary words that merely
     // start with "Part" (Partnership, …) and prose sentences beginning "Part of …" are not
-    // mistaken for a header and deleted.
+    // mistaken for a header and deleted — and only when the fragment is short enough to be a
+    // bare header rather than a prose sentence that happens to open "Part <roman> …".
     private static bool IsPartHeader(string text) =>
-        SecHeadingKeyword.MatchesKeywordIdentifier(text, "PART", SecHeadingKeyword.IsRomanNumeral);
+        SecHeadingKeyword.MatchesKeywordIdentifier(text, "PART", SecHeadingKeyword.IsRomanNumeral)
+        && WordCount(text) <= MaxPartHeaderWords;
+
+    // Whitespace-delimited word count; SEC EDGAR's non-breaking space (U+00A0) counts as a
+    // separator like any other Unicode whitespace.
+    private static int WordCount(string text) =>
+        text.Split((char[])null, StringSplitOptions.RemoveEmptyEntries).Length;
 
     private static INode FindFirstMeaningfulSibling(INode node, bool forward)
     {

--- a/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartRomanProseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartRomanProseTests.cs
@@ -11,9 +11,7 @@ public class PaginationRemovalStepPartRomanProseTests
     // Contract: only a SEC "Part" SECTION HEADER after a page-break <hr> is pagination cruft;
     // body prose must never be deleted (content loss — the GH-3489 rationale). A cross-reference
     // sentence "Part II of this Annual Report …" is prose even though "II" is a roman numeral.
-    [Fact(
-        Skip = "GH-3510 — prose paragraph beginning \"Part II of …\" after an <hr> is deleted as a Part header"
-    )]
+    [Fact]
     public void Execute_HrFollowedByProseSentenceBeginningPartRoman_PreservesParagraph()
     {
         var doc = _parser.ParseDocument(


### PR DESCRIPTION
## Summary

- `PaginationRemovalStep` deleted any after-`<hr>` sibling whose text starts with "Part" + a roman numeral, treating it as a page-break header. A cross-reference prose sentence like "Part II of this Annual Report on Form 10-K contains forward-looking statements…" satisfies that ("II" is a roman numeral) and was deleted in full — body-content loss, exactly what the #3489/#3491 guards set out to prevent.
- Such cross-references commonly open a paragraph right after a page break in 10-K/10-Q filings.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs` — cap the after-`<hr>` candidate at a short word count before deleting it: a real page-break Part header is a bare "PART II" fragment (optionally with a brief standardized title), while a prose sentence runs on much longer. Scoped to this step's deletion decision only (not the shared `SecHeadingKeyword`), so heading promotion is untouched. Erring toward preservation is safe — at worst a stray bare header survives; it never loses body content.
- `tests/Equibles.UnitTests/Sec/Normalizers/PaginationRemovalStepPartRomanProseTests.cs` — un-skipped the regression test asserting the prose paragraph is preserved.

closes #3510