### PR TITLE
fix(sec): stop promoting "Part <roman> of …" prose sentences to h1 headings

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -5,6 +5,14 @@ namespace Equibles.Sec.BusinessLogic.Normalizers;
 
 internal class HeadingConversionStep : IHtmlNormalizationStep
 {
+    // A real SEC "Part" heading is short — "PART II", at most followed by a brief title
+    // ("PART II — INFORMATION NOT REQUIRED IN PROSPECTUS" is ~8 words). A prose
+    // cross-reference like "Part II of this Annual Report on Form 10-K contains …" opens with
+    // the same keyword + roman numeral but runs on much longer, so only a short candidate
+    // qualifies as a heading. The threshold clears every standard Part title with margin while
+    // rejecting full sentences.
+    private const int MaxPartHeadingWords = 12;
+
     public void Execute(IHtmlDocument doc)
     {
         // Select spans that are NOT descendants of table elements
@@ -111,9 +119,16 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
     }
 
     // A real Part identifier is a Roman numeral (Part I–IV); prose beginning "Part of …"
-    // or a word like "Partnership" must not be tagged as a heading.
+    // or a word like "Partnership" must not be tagged as a heading — and neither must a long
+    // prose sentence that merely opens "Part <roman> …", so the candidate must also be short.
     private bool IsPartHeading(string text) =>
-        SecHeadingKeyword.MatchesKeywordIdentifier(text, "PART", SecHeadingKeyword.IsRomanNumeral);
+        SecHeadingKeyword.MatchesKeywordIdentifier(text, "PART", SecHeadingKeyword.IsRomanNumeral)
+        && WordCount(text) <= MaxPartHeadingWords;
+
+    // Whitespace-delimited word count; SEC EDGAR's non-breaking space (U+00A0) counts as a
+    // separator like any other Unicode whitespace.
+    private static int WordCount(string text) =>
+        text.Split((char[])null, StringSplitOptions.RemoveEmptyEntries).Length;
 
     // A real Item identifier is number-led (Item 1, 1A, 7A); prose beginning "Item of …"
     // starts with a letter and must not be tagged as a heading.

--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartRomanProseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartRomanProseTests.cs
@@ -12,9 +12,7 @@ public class HeadingConversionStepPartRomanProseTests
     // never be promoted (the GH-3488 rationale). A cross-reference sentence "Part II of this
     // Annual Report …" is body text even though "II" is a roman numeral.
     // The span is mixed-case and unstyled, so only the IsPartHeading branch can fire.
-    [Fact(
-        Skip = "GH-3512 — prose sentence beginning \"Part II of …\" is promoted to an h1 heading"
-    )]
+    [Fact]
     public void Execute_ProseSentenceBeginningPartRoman_IsNotPromotedToHeading()
     {
         var doc = _parser.ParseDocument(


### PR DESCRIPTION
## Summary

- `HeadingConversionStep` classified any candidate starting with "Part" + a roman numeral as a Part section heading. A cross-reference prose sentence like "Part II of this Annual Report on Form 10-K contains forward-looking statements…" satisfies that ("II" is a roman numeral) and was promoted to `<h1>`, corrupting the document outline used by chunking and section navigation.
- Real SEC Part headings are short — even the longest standard title, "PART II — INFORMATION NOT REQUIRED IN PROSPECTUS", is ~8 words — so a generous word-count cap cleanly separates them from full prose sentences without demoting any legitimate heading.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs` — cap the Part→h1 candidate at a short word count (≤12 words) in `IsPartHeading`. Scoped to the Part path only — the Item→h2 path (GH-3514) is unchanged, because real Item titles are long enough to collide with prose and have no safe threshold.
- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartRomanProseTests.cs` — un-skipped the regression test asserting the prose sentence is not promoted to `<h1>`.

closes #3512