### PR TITLE
test(sec): pin HeadingConversionStep promotes titled Part headings to h1

### DIFF
--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartHeadingWithTitleTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartHeadingWithTitleTests.cs
@@ -1,0 +1,29 @@
+using AngleSharp.Html.Parser;
+using Equibles.Sec.BusinessLogic.Normalizers;
+
+namespace Equibles.UnitTests.Sec.Normalizers;
+
+public class HeadingConversionStepPartHeadingWithTitleTests
+{
+    private readonly HeadingConversionStep _step = new();
+    private readonly HtmlParser _parser = new();
+
+    // Contract: a real SEC "Part" heading is promoted to h1 even when the bare "PART <roman>"
+    // carries a short standardized title ("PART II — OTHER INFORMATION"). The length guard that
+    // rejects long prose cross-references (GH-3512) must not demote these titled headers — only
+    // full sentences are excluded, never a brief Part title.
+    [Fact]
+    public void Execute_PartHeadingFollowedByShortTitle_PromotesItToH1()
+    {
+        var doc = _parser.ParseDocument(
+            "<html><body><div><span>Part II — Other Information</span></div></body></html>"
+        );
+
+        _step.Execute(doc);
+
+        var body = doc.Body!.InnerHtml;
+        body.Should().Contain("<h1>");
+        body.Should().Contain("Part II — Other Information");
+        body.Should().NotContain("<span");
+    }
+}


### PR DESCRIPTION
## Summary

- Pins that a real SEC "Part" heading with a short standardized title ("PART II — OTHER INFORMATION") is still promoted to `<h1>`.
- Guards the lower boundary of the word-count cap added in #3512: existing tests only covered bare "Part I"/"Part IV", so nothing prevented a future tightening of the cap from silently demoting titled Part headers and corrupting the document outline.

## Code changes

- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepPartHeadingWithTitleTests.cs` — new unit test running `Execute` on a `Part II — Other Information` span and asserting it becomes an `<h1>`.