### PR TITLE
refactor(sec): extract duplicated inline-CSS declaration check into SecInlineCss

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -100,8 +100,8 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
         var style = node.GetAttribute("style") ?? "";
         var parentStyle = node.ParentElement?.GetAttribute("style") ?? "";
 
-        return ContainsCssDeclaration(style, "text-align", "center")
-            || ContainsCssDeclaration(parentStyle, "text-align", "center");
+        return SecInlineCss.ContainsDeclaration(style, "text-align", "center")
+            || SecInlineCss.ContainsDeclaration(parentStyle, "text-align", "center");
     }
 
     private bool IsApart(IElement node)
@@ -156,14 +156,7 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
     private static bool HasInlineCss(IElement span, string property, string value)
     {
         var style = span.GetAttribute("style") ?? "";
-        return ContainsCssDeclaration(style, property, value)
-            || ContainsCssDeclaration(span.InnerHtml, property, value);
-    }
-
-    // SEC EDGAR emits inline CSS with and without a space after the colon
-    // (e.g. "font-weight:bold" and "font-weight: bold"); both forms must match.
-    private static bool ContainsCssDeclaration(string source, string property, string value)
-    {
-        return source.Contains($"{property}:{value}") || source.Contains($"{property}: {value}");
+        return SecInlineCss.ContainsDeclaration(style, property, value)
+            || SecInlineCss.ContainsDeclaration(span.InnerHtml, property, value);
     }
 }

--- a/src/Equibles.Sec.BusinessLogic/Normalizers/ListConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/ListConversionStep.cs
@@ -99,17 +99,14 @@ internal class ListConversionStep : IHtmlNormalizationStep
             .FirstOrDefault(s => s.TextContent.Trim() is "•" or "·" or "-");
         bulletSpan?.Remove();
 
-        // Get the content div or use the entire content. SEC EDGAR emits inline CSS with
-        // and without a space after the colon ("display:inline" and "display: inline"), as
-        // the sibling HeadingConversionStep documents; match both so the spaced form is
-        // unwrapped into the <li> instead of surviving as a raw wrapper div.
+        // Get the content div or use the entire content. The shared inline-CSS check matches
+        // both the spaced and unspaced "display: inline" forms SEC EDGAR emits, so the spaced
+        // form is unwrapped into the <li> instead of surviving as a raw wrapper div.
         var contentDiv = itemElement
             .QuerySelectorAll("div")
             .FirstOrDefault(d =>
-            {
-                var style = d.GetAttribute("style") ?? "";
-                return style.Contains("display:inline") || style.Contains("display: inline");
-            });
+                SecInlineCss.ContainsDeclaration(d.GetAttribute("style") ?? "", "display", "inline")
+            );
         if (contentDiv != null)
         {
             liElement.InnerHtml = contentDiv.InnerHtml;

--- a/src/Equibles.Sec.BusinessLogic/Normalizers/SecInlineCss.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/SecInlineCss.cs
@@ -1,0 +1,14 @@
+namespace Equibles.Sec.BusinessLogic.Normalizers;
+
+// Shared inline-CSS matching for SEC HTML normalization. Both HeadingConversionStep
+// and ListConversionStep need to detect a CSS declaration inside a raw style/markup
+// string, tolerating SEC EDGAR's two emitted forms.
+internal static class SecInlineCss
+{
+    // SEC EDGAR emits inline CSS with and without a space after the colon
+    // (e.g. "font-weight:bold" and "font-weight: bold"); both forms must match.
+    public static bool ContainsDeclaration(string source, string property, string value)
+    {
+        return source.Contains($"{property}:{value}") || source.Contains($"{property}: {value}");
+    }
+}


### PR DESCRIPTION
## Summary

- The colon-spacing-tolerant inline-CSS check (matching both `prop:val` and `prop: val` forms SEC EDGAR emits) lived in `HeadingConversionStep` as a private helper and was reimplemented inline in the sibling `ListConversionStep`. Collapsed both into one shared `SecInlineCss` helper, mirroring the existing `SecHeadingKeyword` extraction.
- Behavior-preserving: the shared method is the verbatim former `ContainsCssDeclaration` body; `ListConversionStep`'s `display:inline`/`display: inline` check is exactly `SecInlineCss.ContainsDeclaration(style, "display", "inline")`.

## Code changes

- `Normalizers/SecInlineCss.cs` — new shared internal static helper `ContainsDeclaration(source, property, value)`.
- `Normalizers/HeadingConversionStep.cs` — route `IsCenterAligned`/`HasInlineCss` through `SecInlineCss`; remove the now-shared private `ContainsCssDeclaration`.
- `Normalizers/ListConversionStep.cs` — replace the inline two-form `display:inline` check with the shared helper.