### PR TITLE
refactor(sec): collapse duplicated WordCount into SecHeadingKeyword

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -123,12 +123,7 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
     // prose sentence that merely opens "Part <roman> …", so the candidate must also be short.
     private bool IsPartHeading(string text) =>
         SecHeadingKeyword.MatchesKeywordIdentifier(text, "PART", SecHeadingKeyword.IsRomanNumeral)
-        && WordCount(text) <= MaxPartHeadingWords;
-
-    // Whitespace-delimited word count; SEC EDGAR's non-breaking space (U+00A0) counts as a
-    // separator like any other Unicode whitespace.
-    private static int WordCount(string text) =>
-        text.Split((char[])null, StringSplitOptions.RemoveEmptyEntries).Length;
+        && SecHeadingKeyword.WordCount(text) <= MaxPartHeadingWords;
 
     // A real Item identifier is number-led (Item 1, 1A, 7A); prose beginning "Item of …"
     // starts with a letter and must not be tagged as a heading.

--- a/src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/PaginationRemovalStep.cs
@@ -50,12 +50,7 @@ internal class PaginationRemovalStep : IHtmlNormalizationStep
     // bare header rather than a prose sentence that happens to open "Part <roman> …".
     private static bool IsPartHeader(string text) =>
         SecHeadingKeyword.MatchesKeywordIdentifier(text, "PART", SecHeadingKeyword.IsRomanNumeral)
-        && WordCount(text) <= MaxPartHeaderWords;
-
-    // Whitespace-delimited word count; SEC EDGAR's non-breaking space (U+00A0) counts as a
-    // separator like any other Unicode whitespace.
-    private static int WordCount(string text) =>
-        text.Split((char[])null, StringSplitOptions.RemoveEmptyEntries).Length;
+        && SecHeadingKeyword.WordCount(text) <= MaxPartHeaderWords;
 
     private static INode FindFirstMeaningfulSibling(INode node, bool forward)
     {

--- a/src/Equibles.Sec.BusinessLogic/Normalizers/SecHeadingKeyword.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/SecHeadingKeyword.cs
@@ -41,4 +41,10 @@ internal static class SecHeadingKeyword
     // require every character to be a Roman-numeral letter.
     public static bool IsRomanNumeral(string token) =>
         token.All(c => RomanNumeralLetters.Contains(c));
+
+    // Whitespace-delimited word count, used to keep a short bare header apart from a prose
+    // sentence that merely opens with the same keyword + identifier. SEC EDGAR's non-breaking
+    // space (U+00A0) counts as a separator like any other Unicode whitespace.
+    public static int WordCount(string text) =>
+        text.Split((char[])null, StringSplitOptions.RemoveEmptyEntries).Length;
 }


### PR DESCRIPTION
## Summary

- `HeadingConversionStep` and `PaginationRemovalStep` each carried a byte-identical private `WordCount` helper (same body, same comment). Both already depend on the shared `SecHeadingKeyword` class, and the word-count guard is part of the same "real heading vs. prose" decision that class owns.
- Moved the single implementation into `SecHeadingKeyword.WordCount` and pointed both call sites at it. Behavior is unchanged — identical `Split` semantics, same call sites.

## Code changes

- `Normalizers/SecHeadingKeyword.cs` — add public `WordCount(string)` with the shared comment.
- `Normalizers/HeadingConversionStep.cs` — drop the private `WordCount`; call `SecHeadingKeyword.WordCount`.
- `Normalizers/PaginationRemovalStep.cs` — drop the private `WordCount`; call `SecHeadingKeyword.WordCount`.