### PR TITLE
refactor(holdings): collapse repeated GetByHolder+Include(CommonStock) into GetByHolderWithStock

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -1286,11 +1286,7 @@ public class InstitutionalHoldingsTools
     private Task<List<InstitutionalHolding>> LoadHoldingsByHolderWithStock(
         InstitutionalHolder holder,
         DateOnly reportDate
-    ) =>
-        _holdingRepository
-            .GetByHolder(holder, reportDate)
-            .Include(h => h.CommonStock)
-            .ToListAsync();
+    ) => _holdingRepository.GetByHolderWithStock(holder, reportDate).ToListAsync();
 
     private Task<Dictionary<Guid, CommonStock>> LoadStocksByIds(List<Guid> stockIds) =>
         _commonStockRepository.GetByIds(stockIds).ToDictionaryAsync(s => s.Id);

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -5,6 +5,7 @@ using Equibles.Data;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories.Extensions;
 using Equibles.Holdings.Repositories.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Holdings.Repositories;
 
@@ -25,6 +26,16 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     {
         return GetAll()
             .Where(h => h.InstitutionalHolderId == holder.Id && h.ReportDate == reportDate);
+    }
+
+    // Same holder/date filter as GetByHolder, with the CommonStock navigation eagerly loaded
+    // for callers that read stock fields (ticker/name) while projecting or rendering rows.
+    public IQueryable<InstitutionalHolding> GetByHolderWithStock(
+        InstitutionalHolder holder,
+        DateOnly reportDate
+    )
+    {
+        return GetByHolder(holder, reportDate).Include(h => h.CommonStock);
     }
 
     public IQueryable<InstitutionalHolding> GetLatestByStock(CommonStock stock)

--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -114,8 +114,7 @@ public class HoldingsExportController : BaseController
         var selectedDate = reportDates.ResolveSelectedDateOrFirst(date);
 
         var rowsRaw = await _holdingRepository
-            .GetByHolder(holder, selectedDate)
-            .Include(h => h.CommonStock)
+            .GetByHolderWithStock(holder, selectedDate)
             .OrderByDescending(h => h.Value)
             .Select(h => new
             {

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -492,11 +492,7 @@ public class ProfilesController : BaseController
     private Task<List<InstitutionalHolding>> LoadHoldingsByHolderWithStock(
         InstitutionalHolder holder,
         DateOnly reportDate
-    ) =>
-        _institutionalHoldingRepository
-            .GetByHolder(holder, reportDate)
-            .Include(h => h.CommonStock)
-            .ToListAsync();
+    ) => _institutionalHoldingRepository.GetByHolderWithStock(holder, reportDate).ToListAsync();
 
     private static DateOnly ResolveSelectedDate(DateOnly? requested, List<DateOnly> available) =>
         available.ResolveSelectedDateOrFirst(requested);


### PR DESCRIPTION
## Summary

- Three call sites across two projects repeated the same query: `GetByHolder(holder, date).Include(h => h.CommonStock)`. Moved the eager-include shaping into a single repository method `InstitutionalHoldingRepository.GetByHolderWithStock`, the idiomatic home for query shaping.
- Behavior is unchanged — the new method returns the same deferred `IQueryable` (same holder/date filter, same `CommonStock` eager include), so each caller's downstream LINQ and materialization compose identically.

## Code changes

- `Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — add `GetByHolderWithStock` returning `GetByHolder(...).Include(h => h.CommonStock)`.
- `Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — `LoadHoldingsByHolderWithStock` now calls the repository method.
- `Equibles.Web/Controllers/ProfilesController.cs` — `LoadHoldingsByHolderWithStock` now calls the repository method.
- `Equibles.Web/Controllers/HoldingsExportController.cs` — holder export query now calls the repository method.