### PR TITLE
refactor(holdings): collapse repeated GetByStock+Include(InstitutionalHolder) into GetByStockWithHolder

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -351,13 +351,11 @@ public class InstitutionalHoldingsTools
                 var previousDate = GetPriorReportDate(reportDates, targetDate);
 
                 var currentHoldings = await _holdingRepository
-                    .GetByStock(stock, targetDate)
-                    .Include(h => h.InstitutionalHolder)
+                    .GetByStockWithHolder(stock, targetDate)
                     .ToListAsync();
                 var previousHoldings = previousDate.HasValue
                     ? await _holdingRepository
-                        .GetByStock(stock, previousDate.Value)
-                        .Include(h => h.InstitutionalHolder)
+                        .GetByStockWithHolder(stock, previousDate.Value)
                         .ToListAsync()
                     : [];
 

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -19,6 +19,16 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         return GetAll().Where(h => h.CommonStockId == stock.Id && h.ReportDate == reportDate);
     }
 
+    // Same stock/date filter as GetByStock, with the InstitutionalHolder navigation eagerly
+    // loaded for callers that read holder fields (name) while aggregating or rendering rows.
+    public IQueryable<InstitutionalHolding> GetByStockWithHolder(
+        CommonStock stock,
+        DateOnly reportDate
+    )
+    {
+        return GetByStock(stock, reportDate).Include(h => h.InstitutionalHolder);
+    }
+
     public IQueryable<InstitutionalHolding> GetByHolder(
         InstitutionalHolder holder,
         DateOnly reportDate

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -683,11 +683,7 @@ public class StockTabService
     private Task<List<InstitutionalHolding>> LoadHoldingsByStockWithHolder(
         CommonStock stock,
         DateOnly reportDate
-    ) =>
-        _institutionalHoldingRepository
-            .GetByStock(stock, reportDate)
-            .Include(h => h.InstitutionalHolder)
-            .ToListAsync();
+    ) => _institutionalHoldingRepository.GetByStockWithHolder(stock, reportDate).ToListAsync();
 
     // Narrow the Sold-Out filter to only holders who were in the previous
     // quarter but are absent from the current quarter for this stock. The


### PR DESCRIPTION
## Summary

- Three call sites across two projects repeated `GetByStock(stock, date).Include(h => h.InstitutionalHolder)`. Moved the eager-include shaping into a single repository method `InstitutionalHoldingRepository.GetByStockWithHolder`, mirroring the existing `GetByHolderWithStock`.
- Behavior is unchanged — the new method returns the same deferred `IQueryable` (same stock/date filter, same `InstitutionalHolder` eager include), so each caller's downstream materialization composes identically.

## Code changes

- `Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — add `GetByStockWithHolder` returning `GetByStock(...).Include(h => h.InstitutionalHolder)`.
- `Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — GetTopBuyersSellers current/previous quarter loads now call the repository method.
- `Equibles.Web/Services/StockTabService.cs` — `LoadHoldingsByStockWithHolder` now calls the repository method.