### PR TITLE
refactor(insider-trading): collapse repeated GetByStock+Include(InsiderOwner) into GetByStockWithOwner

### DIFF
--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -60,8 +60,7 @@ public class InsiderTradingTools
                 maxResults = McpLimit.Clamp(maxResults);
 
                 var transactions = await _transactionRepository
-                    .GetByStock(stock)
-                    .Include(t => t.InsiderOwner)
+                    .GetByStockWithOwner(stock)
                     .OrderByDescending(t => t.TransactionDate)
                     .Take(maxResults)
                     .ToListAsync();
@@ -111,7 +110,8 @@ public class InsiderTradingTools
 
                 var byStock = _transactionRepository.GetByStock(stock);
 
-                var latestTransactions = await byStock
+                var latestTransactions = await _transactionRepository
+                    .GetByStockWithOwner(stock)
                     .Where(t =>
                         t.Id
                         == byStock
@@ -121,7 +121,6 @@ public class InsiderTradingTools
                             .Select(t2 => t2.Id)
                             .First()
                     )
-                    .Include(t => t.InsiderOwner)
                     .OrderByDescending(t => t.SharesOwnedAfter)
                     .Take(30)
                     .ToListAsync();

--- a/src/Equibles.InsiderTrading.Repositories/InsiderTransactionRepository.cs
+++ b/src/Equibles.InsiderTrading.Repositories/InsiderTransactionRepository.cs
@@ -15,6 +15,13 @@ public class InsiderTransactionRepository : BaseRepository<InsiderTransaction>
         return GetAll().Where(t => t.CommonStockId == stock.Id);
     }
 
+    // Same stock filter as GetByStock, with the InsiderOwner navigation eagerly loaded for
+    // callers that read insider fields (name/role) while ordering or rendering rows.
+    public IQueryable<InsiderTransaction> GetByStockWithOwner(CommonStock stock)
+    {
+        return GetByStock(stock).Include(t => t.InsiderOwner);
+    }
+
     public IQueryable<InsiderTransaction> GetByStock(CommonStock stock, DateOnly from, DateOnly to)
     {
         return GetAll()

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -299,7 +299,7 @@ public class StockTabService
     public async Task<InsiderTradingTabViewModel> LoadInsiderTradingTab(CommonStock stock)
     {
         var transactions = await TakeMostRecent(
-            _insiderTransactionRepository.GetByStock(stock).Include(t => t.InsiderOwner),
+            _insiderTransactionRepository.GetByStockWithOwner(stock),
             t => t.TransactionDate
         );
         return new InsiderTradingTabViewModel


### PR DESCRIPTION
## Summary

- The same `GetByStock(stock).Include(t => t.InsiderOwner)` chain was repeated across three call sites (Web stock tab + two MCP insider tools). Collapse it into a single `GetByStockWithOwner` repository method, mirroring the existing `GetByHolderWithStock` / `GetByStockWithHolder` convention.
- Behavior-preserving: the method returns the identical deferred `IQueryable`; `Include` position relative to `Where` does not change the EF-generated SQL, and callers keep their own ordering/materialization.

## Code changes

- `src/Equibles.InsiderTrading.Repositories/InsiderTransactionRepository.cs` — add `GetByStockWithOwner` returning `GetByStock(stock).Include(t => t.InsiderOwner)`.
- `src/Equibles.Web/Services/StockTabService.cs` — use `GetByStockWithOwner` in the insider trading tab load.
- `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs` — use `GetByStockWithOwner` in `GetInsiderTransactions` and `GetInsiderOwnership` (the latter keeps the plain `GetByStock` query for its correlated subquery).