### PR TITLE
refactor(views): extract repeated holdings View link into _HoldingsLink partial

### DIFF
--- a/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml
@@ -71,10 +71,7 @@
                                                 <td class="text-right font-mono hidden md:table-cell @deltaValueCss"><compactable-number value="@row.DeltaValue" prefix="$" sign /></td>
                                                 <td class="text-right font-mono hidden lg:table-cell text-base-content/60"><compactable-number value="@row.PreviousFilerCount" /> → <compactable-number value="@row.CurrentFilerCount" /></td>
                                                 <td class="text-right">
-                                                    <a asp-controller="Stocks" asp-action="Holdings"
-                                                       asp-route-ticker="@row.Ticker"
-                                                       asp-route-date="@Model.SelectedDate.ToString("yyyy-MM-dd")"
-                                                       class="btn btn-ghost btn-sm">View</a>
+                                                    <partial name="_HoldingsLink" model='(Ticker: row.Ticker, Date: Model.SelectedDate)' />
                                                 </td>
                                             </tr>
                                         }
@@ -117,10 +114,7 @@
                                                 <td class="max-w-xs truncate">@row.Name</td>
                                                 <td class="text-right font-mono"><compactable-number value="@board.FilerSelector(row)" /></td>
                                                 <td class="text-right">
-                                                    <a asp-controller="Stocks" asp-action="Holdings"
-                                                       asp-route-ticker="@row.Ticker"
-                                                       asp-route-date="@Model.SelectedDate.ToString("yyyy-MM-dd")"
-                                                       class="btn btn-ghost btn-sm">View</a>
+                                                    <partial name="_HoldingsLink" model='(Ticker: row.Ticker, Date: Model.SelectedDate)' />
                                                 </td>
                                             </tr>
                                         }

--- a/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
+++ b/src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml
@@ -86,10 +86,7 @@
                                     </td>
                                     <td class="text-right font-mono hidden lg:table-cell">@row.PercentOfUniverse.ToString("F1")%</td>
                                     <td class="text-right">
-                                        <a asp-controller="Stocks" asp-action="Holdings"
-                                           asp-route-ticker="@row.Ticker"
-                                           asp-route-date="@Model.SelectedDate.ToString("yyyy-MM-dd")"
-                                           class="btn btn-ghost btn-sm">View</a>
+                                        <partial name="_HoldingsLink" model='(Ticker: row.Ticker, Date: Model.SelectedDate)' />
                                     </td>
                                 </tr>
                                 rowNumber++;

--- a/src/Equibles.Web/Views/Shared/_HoldingsLink.cshtml
+++ b/src/Equibles.Web/Views/Shared/_HoldingsLink.cshtml
@@ -1,0 +1,5 @@
+@model (string Ticker, DateOnly Date)
+<a asp-controller="Stocks" asp-action="Holdings"
+   asp-route-ticker="@Model.Ticker"
+   asp-route-date="@Model.Date.ToString("yyyy-MM-dd")"
+   class="btn btn-ghost btn-sm">View</a>


### PR DESCRIPTION
## Summary

- Three identical "View" holdings-link anchors were duplicated across the most-held and activity 13F pages.
- Collapsed them into a single shared `_HoldingsLink` partial, matching the existing single-purpose link-partial convention (`_StockLink`, `_InsiderLink`, `_InstitutionLink`).

## Code changes

- `src/Equibles.Web/Views/Shared/_HoldingsLink.cshtml` — new partial rendering the `Stocks/Holdings` anchor (`btn btn-ghost btn-sm` "View") from a `(string Ticker, DateOnly Date)` model.
- `src/Equibles.Web/Views/HoldingsActivity/MostHeld.cshtml` — replaced the inline anchor with the partial.
- `src/Equibles.Web/Views/HoldingsActivity/Activity.cshtml` — replaced both inline anchors (movers + churn boards) with the partial.

Behavior-preserving: the partial emits the identical anchor (same controller/action/route-ticker/route-date/class/text), so the generated href and DOM are unchanged. HoldingsActivity view-rendering integration tests pass (16/0), including the most-held and activity-movers renders that exercise the partial.