### PR TITLE
fix(mcp): cap McpLimit.Clamp upper bound to prevent oversized result sets

### DIFF
--- a/src/Equibles.Mcp/Helpers/McpLimit.cs
+++ b/src/Equibles.Mcp/Helpers/McpLimit.cs
@@ -2,8 +2,15 @@ namespace Equibles.Mcp.Helpers;
 
 public static class McpLimit
 {
-    // A negative result cap would flow into .Take(...) as a negative SQL LIMIT, which
-    // PostgreSQL rejects and surfaces as the internal-error sentinel. Clamping to non-negative
-    // makes a non-positive cap yield zero rows and the existing no-results message instead.
-    public static int Clamp(int maxResults) => Math.Max(0, maxResults);
+    // Upper bound on the number of rows any MCP tool will return. An unbounded cap from the
+    // client (e.g. int.MaxValue) would flow into .Take(...) and pull/render an enormous result
+    // set, exhausting memory and database time.
+    public const int MaxResults = 500;
+
+    // Clamps the client-supplied result cap to [0, MaxResults]. A negative cap would flow into
+    // .Take(...) as a negative SQL LIMIT, which PostgreSQL rejects and surfaces as the
+    // internal-error sentinel; clamping to non-negative makes a non-positive cap yield zero rows
+    // and the existing no-results message instead. The upper bound guards against resource
+    // exhaustion from an oversized request.
+    public static int Clamp(int maxResults) => Math.Clamp(maxResults, 0, MaxResults);
 }

--- a/tests/Equibles.UnitTests/Mcp/McpLimitClampNegativeCapTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpLimitClampNegativeCapTests.cs
@@ -17,4 +17,27 @@ public class McpLimitClampNegativeCapTests
 
         result.Should().Be(0);
     }
+
+    // Contract: an oversized cap (e.g. int.MaxValue) must be bounded so it never flows
+    // into .Take(...) and pulls an enormous result set, exhausting memory and DB time.
+    // Clamp caps at McpLimit.MaxResults.
+    [Fact]
+    public void Clamp_IntMaxValue_ReturnsMaxResultsCap()
+    {
+        var result = McpLimit.Clamp(int.MaxValue);
+
+        result.Should().Be(McpLimit.MaxResults);
+    }
+
+    // Values within [0, MaxResults] must pass through unchanged.
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(10, 10)]
+    [InlineData(McpLimit.MaxResults, McpLimit.MaxResults)]
+    public void Clamp_WithinRange_ReturnsInput(int input, int expected)
+    {
+        var result = McpLimit.Clamp(input);
+
+        result.Should().Be(expected);
+    }
 }


### PR DESCRIPTION
## Summary

MCP tools take `maxResults`/`maxPeriods` straight from an untrusted client. `McpLimit.Clamp` only floored at 0, so a value like `int.MaxValue` flowed into `.Take(...)` and would pull/render an enormous result set, exhausting memory and database time. This adds an upper bound.

Found during a security review of the MCP surface.

## Code changes

- `src/Equibles.Mcp/Helpers/McpLimit.cs` — add `MaxResults = 500` constant; `Clamp` now uses `Math.Clamp(maxResults, 0, MaxResults)`. Negative-input behavior is unchanged (still yields 0). Every tool that already routes through `Clamp` (27 call sites) inherits the cap.
- `tests/Equibles.UnitTests/Mcp/McpLimitClampNegativeCapTests.cs` — add cases for `int.MaxValue` → cap and in-range pass-through; existing negative-input test unchanged.