### PR TITLE
fix(holdings): clamp maxResults in GetTopBuyersSellers MCP tool

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -334,6 +334,8 @@ public class InstitutionalHoldingsTools
         return _runner.Execute(
             async () =>
             {
+                maxResults = McpLimit.Clamp(maxResults);
+
                 var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTests.cs
@@ -1,0 +1,81 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTests
+    : ParadeDbMcpTestBase
+{
+    public InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTests(
+        ParadeDbFixture fixture
+    )
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetTopBuyersSellers_NegativeMaxResults_DoesNotSurfaceInternalError()
+    {
+        var prior = new DateOnly(2024, 9, 30);
+        var current = new DateOnly(2024, 12, 31);
+        var aapl = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "C1",
+        };
+        var holder = new InstitutionalHolder { Cik = "1", Name = "Big Fund" };
+        DbContext.AddRange(aapl, holder);
+        DbContext.Add(MakeHolding(aapl, holder, prior, shares: 1_000, value: 1_000_000));
+        DbContext.Add(MakeHolding(aapl, holder, current, shares: 1_500, value: 1_500_000));
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = NewSut(verify);
+
+        // Contract: maxResults is "Maximum number of buyers and sellers to return per section";
+        // a negative value is nonsensical input. Top buyers/sellers are taken via
+        // movers.Take(maxResults) on the in-memory list, so a negative cap throws
+        // ArgumentOutOfRangeException. The tool must clamp the value and degrade gracefully
+        // rather than leak the executor's internal-error sentinel to the caller.
+        var output = await sut.GetTopBuyersSellers(ticker: "AAPL", maxResults: -1);
+
+        output.Should().NotContain("An error occurred while executing");
+    }
+
+    private InstitutionalHoldingsTools NewSut(Equibles.Data.EquiblesFinancialDbContext ctx) =>
+        new(
+            new InstitutionalHoldingRepository(ctx),
+            new InstitutionalHolderRepository(ctx),
+            new CommonStockRepository(ctx),
+            ErrorManager,
+            Substitute.For<ILogger<InstitutionalHoldingsTools>>()
+        );
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares,
+        long value
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = shares,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{holder.Cik}-{reportDate:yyyyMMdd}",
+        };
+}


### PR DESCRIPTION
## Summary

The `GetTopBuyersSellers` MCP tool took `maxResults` straight from an untrusted client into `movers.Take(maxResults)` on an in-memory list without clamping. A negative value throws `ArgumentOutOfRangeException`, which the runner turns into a generic internal-error sentinel returned to the caller; a huge value is an unbounded render. Every sibling tool in this class already clamps via `McpLimit.Clamp`.

Found during a security review of the MCP surface.

## Code changes

- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — add `maxResults = McpLimit.Clamp(maxResults);` at the top of the `GetTopBuyersSellers` execution body, matching the other tools (the clamp now also enforces the shared upper bound).
- `tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersNegativeMaxResultsTests.cs` — regression test asserting a negative `maxResults` degrades gracefully instead of leaking the internal-error sentinel.