### PR TITLE
fix(web): add baseline security response headers and HSTS

### DIFF
--- a/src/Equibles.Web/Extensions/SecurityHeadersExtensions.cs
+++ b/src/Equibles.Web/Extensions/SecurityHeadersExtensions.cs
@@ -1,0 +1,35 @@
+namespace Equibles.Web.Extensions;
+
+public static class SecurityHeadersExtensions
+{
+    // Content-Security-Policy for the portal. Scripts/styles allow 'unsafe-inline' because the
+    // views ship inline <script> blocks and inline styles; the remaining directives still add
+    // defense-in-depth (no plugins, no framing, locked-down base/form targets). External
+    // subresources are limited to the Google Fonts origins the layout loads (_Head.cshtml).
+    private const string ContentSecurityPolicy =
+        "default-src 'self'; "
+        + "script-src 'self' 'unsafe-inline'; "
+        + "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        + "font-src 'self' https://fonts.gstatic.com; "
+        + "img-src 'self' data: https:; "
+        + "connect-src 'self'; "
+        + "object-src 'none'; "
+        + "base-uri 'self'; "
+        + "form-action 'self'; "
+        + "frame-ancestors 'none'";
+
+    // Adds baseline security response headers to every response. Placed early in the pipeline so
+    // error responses and static files are covered too.
+    public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app) =>
+        app.Use(
+            async (context, next) =>
+            {
+                var headers = context.Response.Headers;
+                headers["Content-Security-Policy"] = ContentSecurityPolicy;
+                headers["X-Content-Type-Options"] = "nosniff";
+                headers["X-Frame-Options"] = "DENY";
+                headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+                await next();
+            }
+        );
+}

--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -6,6 +6,7 @@ using Equibles.Data.Extensions;
 using Equibles.Messaging.Extensions;
 using Equibles.Search.Extensions;
 using Equibles.Web.Authentication;
+using Equibles.Web.Extensions;
 using Equibles.Web.FlashMessage;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -208,8 +209,10 @@ public partial class Program
         if (!app.Environment.IsDevelopment())
         {
             app.UseExceptionHandler("/Home/Error");
+            app.UseHsts();
         }
 
+        app.UseSecurityHeaders();
         app.UseResponseCompression();
 
         app.UseStaticFiles(

--- a/tests/Equibles.IntegrationTests/Web/SecurityHeadersTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/SecurityHeadersTests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the baseline security response headers emitted by UseSecurityHeaders. The home
+/// route needs no seed data and no auth, so it exercises the middleware end-to-end while
+/// confirming the page still renders successfully with the headers in place.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class SecurityHeadersTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public SecurityHeadersTests(WebHostFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task GetIndex_EmitsBaselineSecurityHeaders()
+    {
+        var response = await _fixture.Client.GetAsync("/");
+
+        response
+            .StatusCode.Should()
+            .Be(HttpStatusCode.OK, "headers must not break normal rendering");
+        response
+            .Headers.GetValues("X-Content-Type-Options")
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("nosniff");
+        response
+            .Headers.GetValues("X-Frame-Options")
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("DENY");
+        response
+            .Headers.GetValues("Referrer-Policy")
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be("strict-origin-when-cross-origin");
+        response
+            .Headers.GetValues("Content-Security-Policy")
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("frame-ancestors 'none'")
+            .And.Contain("default-src 'self'");
+    }
+}


### PR DESCRIPTION
## Summary

The public portal set no HTTP security response headers, leaving it open to clickjacking (framing), MIME-sniffing, and with no defense-in-depth against any XSS that slips past the Razor/Markdig sanitizers. This adds a small middleware emitting baseline headers plus HSTS in production.

Found during a security review of the web portal.

## Code changes

- `src/Equibles.Web/Extensions/SecurityHeadersExtensions.cs` — new `UseSecurityHeaders` middleware setting `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `Referrer-Policy: strict-origin-when-cross-origin`. The CSP allows `'unsafe-inline'` for scripts/styles (the views ship inline blocks) and the Google Fonts origins the layout loads, while locking down `frame-ancestors`, `object-src`, `base-uri`, and `form-action`.
- `src/Equibles.Web/Program.cs` — wire `UseSecurityHeaders()` early in the pipeline (covers error responses and static files); add `UseHsts()` to the existing non-Development block.
- `tests/Equibles.IntegrationTests/Web/SecurityHeadersTests.cs` — verifies the headers are present on the home route and the page still renders 200.