### PR TITLE
refactor(views): extract repeated stats wrapper markup into StatsRowTagHelper

### DIFF
--- a/src/Equibles.Web/TagHelpers/StatsRowTagHelper.cs
+++ b/src/Equibles.Web/TagHelpers/StatsRowTagHelper.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Equibles.Web.TagHelpers;
+
+[HtmlTargetElement("stats-row")]
+public class StatsRowTagHelper : TagHelper
+{
+    // DaisyUI responsive breakpoint at which the stat tiles switch from a
+    // vertical stack to a horizontal row. Only "sm" and "lg" are used today.
+    [HtmlAttributeName("breakpoint")]
+    public string Breakpoint { get; set; } = "lg";
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        output.TagName = "div";
+        output.TagMode = TagMode.StartTagAndEndTag;
+
+        // Full literal class strings (no interpolation) so Tailwind's content
+        // scanner detects both responsive variants in this file.
+        var css =
+            Breakpoint == "sm"
+                ? "stats stats-vertical sm:stats-horizontal shadow-sm bg-base-200 w-full"
+                : "stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200 w-full";
+        output.Attributes.SetAttribute("class", css);
+    }
+}

--- a/src/Equibles.Web/Views/Institutions/SmartMoneyIndex.cshtml
+++ b/src/Equibles.Web/Views/Institutions/SmartMoneyIndex.cshtml
@@ -60,12 +60,12 @@
                     <div class="card bg-base-100 shadow-sm" data-testid="@row.TestId">
                         <div class="card-body p-4">
                             <h2 class="text-base font-medium mb-2">@row.Label</h2>
-                            <div class="stats stats-vertical sm:stats-horizontal shadow-sm bg-base-200 w-full">
+                            <stats-row breakpoint="sm">
                                 <stat-tile title="Total return">@row.Summary.TotalReturnPercent.ToString("F2")%</stat-tile>
                                 @* CAGR is null when the window is too short to annualize meaningfully. *@
                                 <stat-tile title="CAGR">@(row.Summary.CagrPercent is decimal cagr ? cagr.ToString("F2") + "%" : "—")</stat-tile>
                                 <stat-tile title="Max drawdown">@row.Summary.MaxDrawdownPercent.ToString("F2")%</stat-tile>
-                            </div>
+                            </stats-row>
                         </div>
                     </div>
                 }

--- a/src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml
@@ -62,12 +62,12 @@
                 <div class="card bg-base-100 shadow-sm" data-testid="@row.TestId">
                     <div class="card-body p-4">
                         <h2 class="text-base font-medium mb-2">@row.Label</h2>
-                        <div class="stats stats-vertical sm:stats-horizontal shadow-sm bg-base-200 w-full">
+                        <stats-row breakpoint="sm">
                             <stat-tile title="Total return">@row.Summary.TotalReturnPercent.ToString("F2")%</stat-tile>
                             @* CAGR is null when the window is too short to annualize meaningfully. *@
                             <stat-tile title="CAGR">@(row.Summary.CagrPercent is decimal cagr ? cagr.ToString("F2") + "%" : "—")</stat-tile>
                             <stat-tile title="Max drawdown">@row.Summary.MaxDrawdownPercent.ToString("F2")%</stat-tile>
-                        </div>
+                        </stats-row>
                     </div>
                 </div>
             }

--- a/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
+++ b/src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml
@@ -41,12 +41,12 @@
                         <span class="badge badge-ghost">@Model.CommonReportDates.Count common quarters</span>
                     }
                 </badge-strip>
-                <div class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200 w-full">
+                <stats-row>
                     <stat-tile title="Union positions">@overlap.UnionPositionCount.ToString("N0")</stat-tile>
                     <stat-tile title="Shared positions">@overlap.IntersectionPositionCount.ToString("N0")</stat-tile>
                     <stat-tile title="Jaccard similarity" tooltip="|A ∩ B| / |A ∪ B|">@overlap.JaccardSimilarityPercent.ToString("F1")%</stat-tile>
                     <stat-tile title="$-weighted overlap" tooltip="Σ min(value)/Σ max(value) across shared stocks">@overlap.DollarWeightedOverlapPercent.ToString("F1")%</stat-tile>
-                </div>
+                </stats-row>
             </div>
         </div>
 

--- a/src/Equibles.Web/Views/Profiles/Institution.cshtml
+++ b/src/Equibles.Web/Views/Profiles/Institution.cshtml
@@ -56,13 +56,13 @@
                     }
                     <span class="badge badge-ghost">Quarters reported: @Model.Summary.QuartersReported</span>
                 </badge-strip>
-                <div class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200 w-full">
+                <stats-row>
                     <stat-tile title="Reported AUM"><compactable-number value="@Model.Summary.ReportedAum" prefix="$" /></stat-tile>
                     <stat-tile title="# Positions"><compactable-number value="@Model.Summary.PositionCount" /></stat-tile>
                     <stat-tile title="Top 10 concentration">@Model.Summary.Top10ConcentrationPercent.ToString("F1")%</stat-tile>
                     <stat-tile title="Top 25 concentration">@Model.Summary.Top25ConcentrationPercent.ToString("F1")%</stat-tile>
                     <stat-tile title="QoQ turnover" tooltip="(Σ |Δ shares × current price proxy|) / (2 × AUM)">@Model.Summary.QoQTurnoverPercent.ToString("F1")%</stat-tile>
-                </div>
+                </stats-row>
             </div>
         </div>
     }
@@ -79,14 +79,14 @@
                         @Model.FundScore.WindowStart.ToString("MMM yyyy") – @Model.FundScore.WindowEnd.ToString("MMM yyyy")
                     </span>
                 </div>
-                <div class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200 w-full">
+                <stats-row>
                     <stat-tile title="Alpha vs @Model.FundScore.BenchmarkTicker">
                         <span class="@(Model.FundScore.AlphaPercent >= 0 ? "text-success" : "text-error")" data-testid="fund-score-alpha">@(Model.FundScore.AlphaPercent >= 0 ? "+" : "")@Model.FundScore.AlphaPercent.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)%</span>
                     </stat-tile>
                     <stat-tile title="Portfolio CAGR">@Model.FundScore.PortfolioCagrPercent.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)%</stat-tile>
                     <stat-tile title="@(Model.FundScore.BenchmarkTicker) CAGR">@Model.FundScore.BenchmarkCagrPercent.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)%</stat-tile>
                     <stat-tile title="Max drawdown">@Model.FundScore.MaxDrawdownPercent.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)%</stat-tile>
-                </div>
+                </stats-row>
                 <p class="text-xs text-base-content/50 mt-2">
                     Hypothetical buy-and-hold of the reported 13F portfolio, rebalanced 45 days after each
                     quarter-end. Past performance does not guarantee future results.


### PR DESCRIPTION
## Summary

- Five institution/fund views repeated the same `<div class="stats stats-vertical {sm|lg}:stats-horizontal shadow-sm bg-base-200 w-full">` wrapper around `<stat-tile>` children. Extracted it into a `<stats-row>` Tag Helper (mirrors the existing `StatTileTagHelper`), with a `breakpoint` attribute defaulting to `lg`.
- Behavior-preserving: the Tag Helper emits the identical literal class string per breakpoint. Both responsive variants stay as full literals inside the Tag Helper file, which Tailwind already scans (`@source "../../TagHelpers"`), so the generated CSS and rendered DOM are unchanged.

## Code changes

- `src/Equibles.Web/TagHelpers/StatsRowTagHelper.cs` — new `<stats-row>` container Tag Helper; selects the `sm:`/`lg:` stats wrapper class via a `breakpoint` attribute (full literal strings, no interpolation, to keep Tailwind detection working).
- `src/Equibles.Web/Views/Institutions/SmartMoneyIndex.cshtml`, `src/Equibles.Web/Views/Profiles/BacktestInstitution.cshtml` — use `<stats-row breakpoint="sm">`.
- `src/Equibles.Web/Views/Profiles/CompareInstitutions.cshtml`, `src/Equibles.Web/Views/Profiles/Institution.cshtml` (two blocks) — use `<stats-row>` (default `lg`).