### PR TITLE
fix(sec): clamp maxResults in RAG search MCP tools to prevent negative SQL LIMIT

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -50,6 +50,7 @@ public class RagSearchTools
         return _runner.Execute(
             async () =>
             {
+                maxResults = McpLimit.Clamp(maxResults);
                 var parsedType = ParseDocumentType(documentType);
                 var chunks = await _ragManager.SearchRelevantChunks(
                     query,
@@ -81,6 +82,7 @@ public class RagSearchTools
         return _runner.Execute(
             async () =>
             {
+                maxResults = McpLimit.Clamp(maxResults);
                 var parsedType = ParseDocumentType(documentType);
                 var chunks = await _ragManager.SearchRelevantChunksByCompany(
                     query,
@@ -110,6 +112,7 @@ public class RagSearchTools
         return _runner.Execute(
             async () =>
             {
+                maxResults = McpLimit.Clamp(maxResults);
                 var chunks = await _ragManager.SearchRelevantChunksByDocument(
                     query,
                     documentId,

--- a/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs
@@ -220,6 +220,27 @@ public class RagSearchToolsTests : ParadeDbMcpTestBase
         result.Should().NotContain("AAPL");
     }
 
+    [Fact]
+    public async Task SearchDocuments_NegativeMaxResults_DoesNotSurfaceInternalError()
+    {
+        await SeedDocumentWithChunks(
+            chunkContents: new[]
+            {
+                "Apple's services segment grew 15% year-over-year, driven by App Store revenue.",
+            }
+        );
+
+        // Contract: maxResults comes straight from an untrusted MCP client. Unclamped it flows
+        // into ChunkRepository.HybridSearch's .Take(maxResults), so a negative value reaches
+        // PostgreSQL as a negative LIMIT, which the engine rejects. The tool must clamp it and
+        // degrade gracefully rather than leak the executor's internal-error sentinel.
+        var result = await Sut().SearchDocuments("services segment revenue", maxResults: -1);
+
+        result.Should().NotContain("An error occurred while executing");
+        // Clamped to zero rows → the standard empty-result message.
+        result.Should().Be("No relevant financial documents found.");
+    }
+
     // ── SearchCompanyDocuments ──────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

`SearchDocuments`, `SearchCompanyDocuments`, and `SearchDocument` took `maxResults` straight from an untrusted MCP client and forwarded it unclamped through `RagManager` into `ChunkRepository.HybridSearch`'s `.Take(maxResults)`. A negative value reaches PostgreSQL as a negative `LIMIT`, which the engine rejects — the runner then returns its generic internal-error sentinel to the caller. An oversized value would pull an enormous result set. These were the only RAG-path tools still missing the clamp every other MCP tool applies.

Found during a security review of the MCP surface (the High-severity finding).

## Code changes

- `src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs` — add `maxResults = McpLimit.Clamp(maxResults);` at the top of the three search tools' execution bodies, matching the sibling tools (the clamp also enforces the shared upper bound).
- `tests/Equibles.IntegrationTests/Mcp/RagSearchToolsTests.cs` — regression test (full ParadeDB path) asserting a negative `maxResults` degrades to the empty-result message instead of leaking the internal-error sentinel.