### PR TITLE
refactor(finra-mcp): collapse duplicated short-interest row rendering into RenderShortInterestRow

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -134,13 +134,7 @@ public class ShortDataTools
                     $"Short interest for {stock.Ticker} ({stock.Name}):",
                     "| Settlement Date | Short Position | Change | Avg Daily Volume | Days to Cover |",
                     "|----------------|---------------|--------|-----------------|---------------|",
-                    r =>
-                    {
-                        var changeStr = FormatSignedChange(r.ChangeInShortPosition);
-                        var advStr = McpFormat.OrDash(r.AverageDailyVolume, "N0");
-                        var dtcStr = McpFormat.OrDash(r.DaysToCover, "F1");
-                        return $"| {r.SettlementDate:yyyy-MM-dd} | {McpFormat.WholeNumber(r.CurrentShortPosition)} | {changeStr} | {advStr} | {dtcStr} |";
-                    }
+                    r => RenderShortInterestRow($"{r.SettlementDate:yyyy-MM-dd}", r)
                 );
             },
             "GetShortInterest",
@@ -188,16 +182,7 @@ public class ShortDataTools
                     $"Short interest snapshot — settlement date {latestDate:yyyy-MM-dd}:",
                     "| Ticker | Short Position | Change | Avg Daily Volume | Days to Cover |",
                     "|--------|---------------|--------|-----------------|---------------|",
-                    r =>
-                    {
-                        var changeStr = FormatSignedChange(r.ChangeInShortPosition);
-                        var advStr = McpFormat.OrDash(r.AverageDailyVolume, "N0");
-                        // Render with InvariantCulture so the MCP markdown does not fork the
-                        // separators by host locale (e.g. de-DE would render 1.234.567 / 12,3).
-                        var shortPositionStr = McpFormat.WholeNumber(r.CurrentShortPosition);
-                        var dtcStr = McpFormat.OrDash(r.DaysToCover, "F1");
-                        return $"| {r.CommonStock.Ticker} | {shortPositionStr} | {changeStr} | {advStr} | {dtcStr} |";
-                    }
+                    r => RenderShortInterestRow(r.CommonStock.Ticker, r)
                 );
             },
             "GetShortInterestSnapshot",
@@ -260,6 +245,16 @@ public class ShortDataTools
     {
         var shortPct = r.TotalVolume > 0 ? (double)r.ShortVolume / r.TotalVolume * 100 : 0;
         return $"| {leadCell} | {McpFormat.WholeNumber(r.ShortVolume)} | {McpFormat.WholeNumber(r.ShortExemptVolume)} | {McpFormat.WholeNumber(r.TotalVolume)} | {McpFormat.Invariant(shortPct, "F1")}% |";
+    }
+
+    // Render with InvariantCulture so the MCP markdown does not fork the separators by host
+    // locale (e.g. de-DE would render 1.234.567 / 12,3).
+    private static string RenderShortInterestRow(string leadCell, ShortInterest r)
+    {
+        var changeStr = FormatSignedChange(r.ChangeInShortPosition);
+        var advStr = McpFormat.OrDash(r.AverageDailyVolume, "N0");
+        var dtcStr = McpFormat.OrDash(r.DaysToCover, "F1");
+        return $"| {leadCell} | {McpFormat.WholeNumber(r.CurrentShortPosition)} | {changeStr} | {advStr} | {dtcStr} |";
     }
 
     private static string FormatSignedChange(long change) =>


### PR DESCRIPTION
## Summary

- The `GetShortInterest` and `GetShortInterestSnapshot` MCP tools built their short-interest markdown rows with two identical lambdas (same change/avg-daily-volume/days-to-cover formatting), differing only in the leading cell.
- Collapsed both into a single shared row builder so the formatting and the InvariantCulture rule live in one place. Mirrors the recent `RenderShortVolumeRow` extraction in the same file.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — extracted the duplicated row-rendering logic into a private static `RenderShortInterestRow(string leadCell, ShortInterest r)` helper; both tools now call it, passing the settlement date or ticker as the leading cell. Behavior is unchanged — the helper emits the same row string.