### PR TITLE
refactor(congress-mcp): extract duplicated trade amount-range formatting into FormatAmountRange

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -87,8 +87,7 @@ public class CongressTools
                     {
                         var position = t.CongressMember.Position.NameForHumans();
                         var type = t.TransactionType.NameForHumans();
-                        var amount =
-                            $"${McpFormat.WholeNumber(t.AmountFrom)}–${McpFormat.WholeNumber(t.AmountTo)}";
+                        var amount = FormatAmountRange(t);
                         return $"| {t.TransactionDate:yyyy-MM-dd} | {t.CongressMember.Name} | {position} | {type} | {amount} | {t.OwnerType ?? "—"} |";
                     }
                 );
@@ -148,10 +147,7 @@ public class CongressTools
                     t =>
                     {
                         var type = t.TransactionType.NameForHumans();
-                        // Format with InvariantCulture so the MCP markdown does not fork the
-                        // separators by host locale (e.g. de-DE would render $1.000.000).
-                        var amount =
-                            $"${McpFormat.WholeNumber(t.AmountFrom)}–${McpFormat.WholeNumber(t.AmountTo)}";
+                        var amount = FormatAmountRange(t);
                         return $"| {t.TransactionDate:yyyy-MM-dd} | {t.CommonStock.Ticker} | {type} | {amount} | {t.AssetName} | {t.OwnerType ?? "—"} |";
                     }
                 );
@@ -195,6 +191,11 @@ public class CongressTools
             $"query: {query}"
         );
     }
+
+    // Format with InvariantCulture so the MCP markdown does not fork the separators by host
+    // locale (e.g. de-DE would render $1.000.000).
+    private static string FormatAmountRange(CongressionalTrade t) =>
+        $"${McpFormat.WholeNumber(t.AmountFrom)}–${McpFormat.WholeNumber(t.AmountTo)}";
 
     private static IQueryable<CongressionalTrade> ApplyTransactionTypeFilter(
         IQueryable<CongressionalTrade> query,


### PR DESCRIPTION
## Summary

- `GetCongressionalTrades` and `GetMemberTrades` formatted the trade amount range with the same inline expression, duplicating both the formatting and the InvariantCulture rule.
- Collapsed both into a single shared helper so the formatting lives in one place.

## Code changes

- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — extracted the duplicated `$"${WholeNumber(AmountFrom)}–${WholeNumber(AmountTo)}"` expression into a private static `FormatAmountRange(CongressionalTrade t)` helper carrying the InvariantCulture explanation; both tools now call it. Behavior is unchanged — the helper emits the same string.