### PR TITLE
refactor(holdings): extract duplicated market-wide activity bucket queries into MarketWideActivityQueryExtensions

### DIFF
--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -10,6 +10,7 @@ using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Extensions;
 using Equibles.Holdings.Repositories.Models;
 using Equibles.Mcp;
 using Equibles.Mcp.Helpers;
@@ -593,16 +594,8 @@ public class InstitutionalHoldingsTools
         var movers = activity.Where(a => a.CurrentShares != a.PreviousShares);
         var rows =
             normalizedBucket == "top-buys"
-                ? await movers
-                    .Where(a => a.CurrentShares > a.PreviousShares)
-                    .OrderByDescending(a => a.CurrentValue - a.PreviousValue)
-                    .Take(maxResults)
-                    .ToListAsync()
-                : await movers
-                    .Where(a => a.CurrentShares < a.PreviousShares)
-                    .OrderBy(a => a.CurrentValue - a.PreviousValue)
-                    .Take(maxResults)
-                    .ToListAsync();
+                ? await movers.TopBuyers().Take(maxResults).ToListAsync()
+                : await movers.TopSellers().Take(maxResults).ToListAsync();
         if (rows.Count == 0)
             return result + "_No stocks moved in this direction this quarter._";
 
@@ -632,16 +625,8 @@ public class InstitutionalHoldingsTools
         var churn = _holdingRepository.GetQuarterlyNewSoldOutPositions(targetDate, previousDate);
         var rows =
             normalizedBucket == "new-positions"
-                ? await churn
-                    .Where(c => c.NewFilerCount > 0)
-                    .OrderByDescending(c => c.NewFilerCount)
-                    .Take(maxResults)
-                    .ToListAsync()
-                : await churn
-                    .Where(c => c.SoldOutFilerCount > 0)
-                    .OrderByDescending(c => c.SoldOutFilerCount)
-                    .Take(maxResults)
-                    .ToListAsync();
+                ? await churn.NewPositions().Take(maxResults).ToListAsync()
+                : await churn.SoldOutPositions().Take(maxResults).ToListAsync();
         if (rows.Count == 0)
             return result + "_No stocks in this bucket this quarter._";
 

--- a/src/Equibles.Holdings.Repositories/Extensions/MarketWideActivityQueryExtensions.cs
+++ b/src/Equibles.Holdings.Repositories/Extensions/MarketWideActivityQueryExtensions.cs
@@ -1,0 +1,56 @@
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.Holdings.Repositories.Extensions;
+
+// Market-wide 13F leaderboard buckets. The same four filter+order definitions are
+// consumed by the holdings activity views, the CSV export, and the MCP tools, so they
+// live here to keep a single source of truth for what each bucket means.
+// IQueryable overloads translate to SQL for callers that page straight from the database;
+// IEnumerable overloads serve callers (e.g. the CSV export) that fetch once and split the
+// movers/churn sets in memory.
+public static class MarketWideActivityQueryExtensions
+{
+    public static IQueryable<MarketWideStockActivity> TopBuyers(
+        this IQueryable<MarketWideStockActivity> source
+    ) =>
+        source
+            .Where(a => a.CurrentShares > a.PreviousShares)
+            .OrderByDescending(a => a.CurrentValue - a.PreviousValue);
+
+    public static IEnumerable<MarketWideStockActivity> TopBuyers(
+        this IEnumerable<MarketWideStockActivity> source
+    ) =>
+        source
+            .Where(a => a.CurrentShares > a.PreviousShares)
+            .OrderByDescending(a => a.CurrentValue - a.PreviousValue);
+
+    public static IQueryable<MarketWideStockActivity> TopSellers(
+        this IQueryable<MarketWideStockActivity> source
+    ) =>
+        source
+            .Where(a => a.CurrentShares < a.PreviousShares)
+            .OrderBy(a => a.CurrentValue - a.PreviousValue);
+
+    public static IEnumerable<MarketWideStockActivity> TopSellers(
+        this IEnumerable<MarketWideStockActivity> source
+    ) =>
+        source
+            .Where(a => a.CurrentShares < a.PreviousShares)
+            .OrderBy(a => a.CurrentValue - a.PreviousValue);
+
+    public static IQueryable<MarketWideStockChurn> NewPositions(
+        this IQueryable<MarketWideStockChurn> source
+    ) => source.Where(c => c.NewFilerCount > 0).OrderByDescending(c => c.NewFilerCount);
+
+    public static IEnumerable<MarketWideStockChurn> NewPositions(
+        this IEnumerable<MarketWideStockChurn> source
+    ) => source.Where(c => c.NewFilerCount > 0).OrderByDescending(c => c.NewFilerCount);
+
+    public static IQueryable<MarketWideStockChurn> SoldOutPositions(
+        this IQueryable<MarketWideStockChurn> source
+    ) => source.Where(c => c.SoldOutFilerCount > 0).OrderByDescending(c => c.SoldOutFilerCount);
+
+    public static IEnumerable<MarketWideStockChurn> SoldOutPositions(
+        this IEnumerable<MarketWideStockChurn> source
+    ) => source.Where(c => c.SoldOutFilerCount > 0).OrderByDescending(c => c.SoldOutFilerCount);
+}

--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Extensions;
 using Equibles.Web.Controllers.Abstract;
 using Equibles.Web.Extensions;
 using Equibles.Web.ViewModels.Holdings;
@@ -56,13 +57,11 @@ public class HoldingsActivityController : BaseController
             .Where(a => a.CurrentShares != a.PreviousShares);
 
         var topBuysAgg = await movers
-            .Where(a => a.CurrentShares > a.PreviousShares)
-            .OrderByDescending(a => a.CurrentValue - a.PreviousValue)
+            .TopBuyers()
             .Take(HoldingsActivityViewModel.RowCap)
             .ToListAsync();
         var topSellsAgg = await movers
-            .Where(a => a.CurrentShares < a.PreviousShares)
-            .OrderBy(a => a.CurrentValue - a.PreviousValue)
+            .TopSellers()
             .Take(HoldingsActivityViewModel.RowCap)
             .ToListAsync();
 
@@ -72,13 +71,11 @@ public class HoldingsActivityController : BaseController
             viewModel.IsCombinedSelected
         );
         var newPositionsAgg = await churn
-            .Where(c => c.NewFilerCount > 0)
-            .OrderByDescending(c => c.NewFilerCount)
+            .NewPositions()
             .Take(HoldingsActivityViewModel.RowCap)
             .ToListAsync();
         var soldOutPositionsAgg = await churn
-            .Where(c => c.SoldOutFilerCount > 0)
-            .OrderByDescending(c => c.SoldOutFilerCount)
+            .SoldOutPositions()
             .Take(HoldingsActivityViewModel.RowCap)
             .ToListAsync();
 

--- a/src/Equibles.Web/Controllers/HoldingsExportController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsExportController.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Extensions;
 using Equibles.Web.Controllers.Abstract;
 using Equibles.Web.Extensions;
 using Equibles.Web.Services;
@@ -178,27 +179,15 @@ public class HoldingsExportController : BaseController
             .GetQuarterlyActivity(selectedDate, previousDate)
             .Where(a => a.CurrentShares != a.PreviousShares)
             .ToListAsync();
-        var topBuys = activity
-            .Where(a => a.CurrentShares > a.PreviousShares)
-            .OrderByDescending(a => a.CurrentValue - a.PreviousValue)
-            .ToList();
-        var topSells = activity
-            .Where(a => a.CurrentShares < a.PreviousShares)
-            .OrderBy(a => a.CurrentValue - a.PreviousValue)
-            .ToList();
+        var topBuys = activity.TopBuyers().ToList();
+        var topSells = activity.TopSellers().ToList();
 
         var churn = await _holdingRepository
             .GetQuarterlyNewSoldOutPositions(selectedDate, previousDate)
             .Where(c => c.NewFilerCount > 0 || c.SoldOutFilerCount > 0)
             .ToListAsync();
-        var newPositions = churn
-            .Where(c => c.NewFilerCount > 0)
-            .OrderByDescending(c => c.NewFilerCount)
-            .ToList();
-        var soldOut = churn
-            .Where(c => c.SoldOutFilerCount > 0)
-            .OrderByDescending(c => c.SoldOutFilerCount)
-            .ToList();
+        var newPositions = churn.NewPositions().ToList();
+        var soldOut = churn.SoldOutPositions().ToList();
 
         var stockIds = topBuys
             .Concat(topSells)


### PR DESCRIPTION
## Summary

- The four market-wide 13F leaderboard bucket definitions (top buyers, top sellers, new positions, sold-out positions) were duplicated inline across the holdings activity page, the CSV export, and the MCP tools. Extracted them into a single shared source of truth.
- Behavior-preserving: the extracted Where/OrderBy predicates are identical to the originals at every call site; caller-specific pre-filters and `Take` placement are unchanged.

## Code changes

- `src/Equibles.Holdings.Repositories/Extensions/MarketWideActivityQueryExtensions.cs` — new public static class with `TopBuyers`/`TopSellers`/`NewPositions`/`SoldOutPositions`. Provides both `IQueryable` overloads (translate to SQL for the database-paged callers) and `IEnumerable` overloads (for the CSV export, which fetches once and splits in memory).
- `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs` — `RenderMarketActivityMovers`/`RenderMarketActivityChurn` now call the shared bucket methods.
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — `Activity` action uses the shared bucket methods.
- `src/Equibles.Web/Controllers/HoldingsExportController.cs` — `Activity` export uses the shared bucket methods (in-memory overloads).