### PR TITLE
refactor(cftc-mcp): use MarkdownTable.Render in GetCftcPositioning

### DIFF
--- a/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
+++ b/src/Equibles.Cftc.Mcp/Tools/CftcTools.cs
@@ -71,23 +71,15 @@ public class CftcTools
                     .Take(McpLimit.Clamp(maxResults))
                     .ToListAsync();
 
-                if (reports.Count == 0)
-                    return $"No COT reports found for {contract.MarketName} ({contract.MarketCode}) in the specified date range.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    reports.OrderBy(r => r.ReportDate).ToList(),
+                    $"No COT reports found for {contract.MarketName} ({contract.MarketCode}) in the specified date range.",
                     $"{contract.MarketName} ({contract.MarketCode}) — {contract.Category.NameForHumans()}",
                     "| Date | Open Interest | Comm Long | Comm Short | Non-Comm Long | Non-Comm Short | Non-Comm Spread |",
-                    "|------|--------------|-----------|------------|---------------|----------------|-----------------|"
-                );
-
-                foreach (var r in reports.OrderBy(r => r.ReportDate))
-                {
-                    result.AppendLine(
+                    "|------|--------------|-----------|------------|---------------|----------------|-----------------|",
+                    r =>
                         $"| {r.ReportDate:yyyy-MM-dd} | {McpFormat.WholeNumber(r.OpenInterest)} | {McpFormat.WholeNumber(r.CommLong)} | {McpFormat.WholeNumber(r.CommShort)} | {McpFormat.WholeNumber(r.NonCommLong)} | {McpFormat.WholeNumber(r.NonCommShort)} | {McpFormat.WholeNumber(r.NonCommSpreads)} |"
-                    );
-                }
-
-                return result.ToString();
+                );
             },
             "GetCftcPositioning",
             $"marketCode: {marketCode}"


### PR DESCRIPTION
## Summary

- Collapse the hand-rolled empty-check + `MarkdownTable.Start` + ascending `foreach`/`AppendLine` loop in `GetCftcPositioning` into the existing `MarkdownTable.Render` helper, matching the idiom already used by `SearchCftcMarkets` in the same file and the Cboe/Insider tools.
- Behavior-preserving: `Render` returns the empty message when the row list is empty and otherwise emits the same title/header/separator start with one rendered row per item; the rows passed are the same `reports.OrderBy(r => r.ReportDate).ToList()`.

## Code changes

- `src/Equibles.Cftc.Mcp/Tools/CftcTools.cs` — `GetCftcPositioning` now delegates table construction to `MarkdownTable.Render` instead of building the `StringBuilder` by hand (6 insertions, 14 deletions).