### PR TITLE
refactor(fred-mcp): use MarkdownTable.Render in GetEconomicIndicator

### DIFF
--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -70,27 +70,23 @@ public class FredTools
                     .Take(maxResults)
                     .ToListAsync();
 
-                if (observations.Count == 0)
-                    return $"No observations found for {series.SeriesId} ({series.Title}) in the specified date range.";
-
-                var result = MarkdownTable.Start(
+                return MarkdownTable.Render(
+                    observations.OrderBy(o => o.Date).ToList(),
+                    $"No observations found for {series.SeriesId} ({series.Title}) in the specified date range.",
                     $"{series.Title} ({series.SeriesId})",
                     $"Units: {series.Units} | Frequency: {series.Frequency} | Seasonal Adj: {series.SeasonalAdjustment}",
                     "| Date | Value |",
-                    "|------|-------|"
+                    "|------|-------|",
+                    obs =>
+                    {
+                        // Format with InvariantCulture so the MCP markdown does not fork the
+                        // decimal separator by host locale (e.g. de-DE would render 5,25).
+                        var valueStr = obs.Value.HasValue
+                            ? McpFormat.Invariant(obs.Value.Value, "G")
+                            : "N/A";
+                        return $"| {obs.Date:yyyy-MM-dd} | {valueStr} |";
+                    }
                 );
-
-                foreach (var obs in observations.OrderBy(o => o.Date))
-                {
-                    // Format with InvariantCulture so the MCP markdown does not fork the
-                    // decimal separator by host locale (e.g. de-DE would render 5,25).
-                    var valueStr = obs.Value.HasValue
-                        ? McpFormat.Invariant(obs.Value.Value, "G")
-                        : "N/A";
-                    result.AppendLine($"| {obs.Date:yyyy-MM-dd} | {valueStr} |");
-                }
-
-                return result.ToString();
             },
             "GetEconomicIndicator",
             $"seriesId: {seriesId}"


### PR DESCRIPTION
## Summary

- Collapse the hand-rolled empty-check + `MarkdownTable.Start` (subtitle overload) + ascending `foreach`/`AppendLine` loop in `GetEconomicIndicator` into the existing subtitle-carrying `MarkdownTable.Render` overload, matching `SearchEconomicIndicators` in the same file.
- Behavior-preserving: `Render` returns the empty message when the list is empty and otherwise emits the same title/subtitle/header/separator start with one rendered row per observation; rows are the same `observations.OrderBy(o => o.Date).ToList()`. The InvariantCulture WHY-comment moves intact into the row lambda.

## Code changes

- `src/Equibles.Fred.Mcp/Tools/FredTools.cs` — `GetEconomicIndicator` now delegates table construction to `MarkdownTable.Render` instead of building the `StringBuilder` by hand (13 insertions, 17 deletions).