### PR TITLE
fix(sec): stop promoting "Item <n> of …" prose sentences to h2 headings

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
+++ b/src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs
@@ -13,6 +13,12 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
     // rejecting full sentences.
     private const int MaxPartHeadingWords = 12;
 
+    // A real SEC "Item" heading is short too — "Item 1. Business" through the longest standard
+    // title "Item 7A. Quantitative and Qualitative Disclosures About Market Risk" (~9 words). A
+    // prose cross-reference like "Item 1 of this Annual Report contains …" opens with the same
+    // keyword + digit but runs on much longer, so only a short candidate qualifies as a heading.
+    private const int MaxItemHeadingWords = 12;
+
     public void Execute(IHtmlDocument doc)
     {
         // Select spans that are NOT descendants of table elements
@@ -126,13 +132,15 @@ internal class HeadingConversionStep : IHtmlNormalizationStep
         && SecHeadingKeyword.WordCount(text) <= MaxPartHeadingWords;
 
     // A real Item identifier is number-led (Item 1, 1A, 7A); prose beginning "Item of …"
-    // starts with a letter and must not be tagged as a heading.
+    // starts with a letter and must not be tagged as a heading — and neither must a long prose
+    // sentence that merely opens "Item <n> …", so the candidate must also be short.
     private bool IsItemHeading(string text) =>
         SecHeadingKeyword.MatchesKeywordIdentifier(
             text,
             "ITEM",
             firstWord => char.IsDigit(firstWord[0])
-        );
+        )
+        && SecHeadingKeyword.WordCount(text) <= MaxItemHeadingWords;
 
     private bool IsItalicSpan(IElement span) => HasInlineCss(span, "font-style", "italic");
 

--- a/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepItemDigitProseTests.cs
+++ b/tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepItemDigitProseTests.cs
@@ -12,7 +12,7 @@ public class HeadingConversionStepItemDigitProseTests
     // never be promoted. A cross-reference sentence "Item 1 of this Annual Report …" is body
     // text even though "1" is a valid item identifier (digit sibling of GH-3512's roman case).
     // The span is mixed-case and unstyled, so only the IsItemHeading branch can fire.
-    [Fact(Skip = "GH-3514 — prose sentence beginning \"Item 1 of …\" is promoted to an h2 heading")]
+    [Fact]
     public void Execute_ProseSentenceBeginningItemDigit_IsNotPromotedToHeading()
     {
         var doc = _parser.ParseDocument(


### PR DESCRIPTION
## Summary

Fixes #3514.

`HeadingConversionStep`'s Item→h2 path classified any candidate starting with `ITEM` + a digit-led token as a section heading, so a prose cross-reference like *"Item 1 of this Annual Report contains information about our business…"* was promoted to `<h2>`, corrupting the document outline used by chunking and section navigation.

This is the digit/Item sibling of GH-3512 (Part→h1 prose). That fix added a word-count guard to `IsPartHeading` but left `IsItemHeading` unguarded — this PR applies the same guard to the Item path. The failing repro committed in #3515 as `[Skip]` is now un-skipped.

## Code changes

- `src/Equibles.Sec.BusinessLogic/Normalizers/HeadingConversionStep.cs` — add `MaxItemHeadingWords = 12` and require `SecHeadingKeyword.WordCount(text) <= MaxItemHeadingWords` in `IsItemHeading`, mirroring `IsPartHeading`. The threshold clears the longest standard Item title ("Item 7A. Quantitative and Qualitative Disclosures About Market Risk", ~9 words) with margin while rejecting full sentences.
- `tests/Equibles.UnitTests/Sec/Normalizers/HeadingConversionStepItemDigitProseTests.cs` — drop the `Skip`; the repro now passes. Full `HeadingConversionStep` suite green (43 tests, 0 skipped), confirming legitimate Item headings still promote.