### PR TITLE
refactor(mcp): collapse unnumbered table-row loops into MarkdownTable.AppendRows helper

### DIFF
--- a/src/Equibles.Mcp/Helpers/MarkdownTable.cs
+++ b/src/Equibles.Mcp/Helpers/MarkdownTable.cs
@@ -76,6 +76,20 @@ public static class MarkdownTable
         return sb.ToString();
     }
 
+    // Appends one markdown row per item in order. Unnumbered sibling of AppendNumberedRows,
+    // for tables whose rows carry no rank. Centralises the per-item AppendLine loop that
+    // follows MarkdownTable.Start across the MCP tools.
+    public static StringBuilder AppendRows<T>(
+        this StringBuilder sb,
+        IEnumerable<T> rows,
+        Func<T, string> renderRow
+    )
+    {
+        foreach (var row in rows)
+            sb.AppendLine(renderRow(row));
+        return sb;
+    }
+
     // Appends one markdown row per item in order, passing the 1-based rank and the item to
     // renderRow. Centralises the ranked-table loop so call sites don't repeat the `i + 1`
     // off-by-one and the `rows[i]` indexing.

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -252,18 +252,17 @@ public class FinancialFactsTools
             "| Period End | FY | Period | Value | Unit | Form | Filed | Accession |",
             "|-----------|---:|--------|------:|------|------|-------|-----------|"
         );
-        foreach (var f in perPeriod)
-        {
-            result.AppendLine(
+        result.AppendRows(
+            perPeriod,
+            f =>
                 $"| {f.PeriodEnd:yyyy-MM-dd} | {f.FiscalYear} | "
-                    + $"{f.FiscalPeriod.NameForHumans()} | "
-                    + $"{FactMarkdown.Value(f.Value, f.Unit)} | "
-                    + $"{FactMarkdown.Cell(f.Unit)} | "
-                    + $"{FactMarkdown.Cell(f.Form?.DisplayName)} | "
-                    + $"{f.FiledDate:yyyy-MM-dd} | "
-                    + $"{FactMarkdown.Cell(f.AccessionNumber)} |"
-            );
-        }
+                + $"{f.FiscalPeriod.NameForHumans()} | "
+                + $"{FactMarkdown.Value(f.Value, f.Unit)} | "
+                + $"{FactMarkdown.Cell(f.Unit)} | "
+                + $"{FactMarkdown.Cell(f.Form?.DisplayName)} | "
+                + $"{f.FiledDate:yyyy-MM-dd} | "
+                + $"{FactMarkdown.Cell(f.AccessionNumber)} |"
+        );
 
         return result.ToString();
     }
@@ -309,16 +308,15 @@ public class FinancialFactsTools
             "| Ticker | Company | Value | Unit | Form | Filed |",
             "|--------|---------|------:|------|------|-------|"
         );
-        foreach (var (ticker, name, fact) in rows)
-        {
-            result.AppendLine(
-                $"| {FactMarkdown.Cell(ticker)} | {FactMarkdown.Cell(name)} | "
-                    + $"{FactMarkdown.Value(fact.Value, fact.Unit)} | "
-                    + $"{FactMarkdown.Cell(fact.Unit)} | "
-                    + $"{FactMarkdown.Cell(fact.Form?.DisplayName)} | "
-                    + $"{fact.FiledDate:yyyy-MM-dd} |"
-            );
-        }
+        result.AppendRows(
+            rows,
+            r =>
+                $"| {FactMarkdown.Cell(r.Ticker)} | {FactMarkdown.Cell(r.Name)} | "
+                + $"{FactMarkdown.Value(r.Fact.Value, r.Fact.Unit)} | "
+                + $"{FactMarkdown.Cell(r.Fact.Unit)} | "
+                + $"{FactMarkdown.Cell(r.Fact.Form?.DisplayName)} | "
+                + $"{r.Fact.FiledDate:yyyy-MM-dd} |"
+        );
 
         if (rows.Count == 0)
             result.AppendLine(

--- a/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NCenTools.cs
@@ -66,12 +66,11 @@ public class NCenTools
                     "|-------|------------|------|-------------|-----------|--------------|-------------|"
                 );
 
-                foreach (var f in filings)
-                {
-                    result.AppendLine(
+                result.AppendRows(
+                    filings,
+                    f =>
                         $"| {f.FilingDate:yyyy-MM-dd} | {f.ReportEndingPeriod:yyyy-MM-dd} | {f.InvestmentCompanyType ?? "-"} | {f.InvestmentCompanyFileNumber ?? "-"} | {(f.IsAmendment ? "Yes" : "No")} | {(f.IsFirstFiling ? "Yes" : "No")} | {(f.IsLastFiling ? "Yes" : "No")} |"
-                    );
-                }
+                );
 
                 AppendServiceProviders(result, filings[0]);
 
@@ -95,13 +94,10 @@ public class NCenTools
         result.AppendLine("| Role | Firm | Country | Affiliated |");
         result.AppendLine("|------|------|---------|------------|");
 
-        foreach (
-            var provider in latest.ServiceProviders.OrderBy(p => p.ProviderType).ThenBy(p => p.Name)
-        )
-        {
-            result.AppendLine(
+        result.AppendRows(
+            latest.ServiceProviders.OrderBy(p => p.ProviderType).ThenBy(p => p.Name),
+            provider =>
                 $"| {provider.ProviderType.NameForHumans()} | {provider.Name} | {provider.Country ?? "-"} | {(provider.IsAffiliated ? "Yes" : "No")} |"
-            );
-        }
+        );
     }
 }

--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -71,12 +71,11 @@ public class NportTools
                     "|---------|-------|---------|-------|-------------|--------------|----------|---------|"
                 );
 
-                foreach (var h in holdings)
-                {
-                    result.AppendLine(
+                result.AppendRows(
+                    holdings,
+                    h =>
                         $"| {h.Name ?? "-"} | {h.Cusip ?? "-"} | {FormatAmount(h.Balance)} | {h.Units ?? "-"} | ${FormatAmount(h.ValueUsd)} | {FormatPercent(h.PercentValue)} | {h.AssetCategory ?? "-"} | {h.InvestmentCountry ?? "-"} |"
-                    );
-                }
+                );
 
                 return result.ToString();
             },

--- a/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs
@@ -171,12 +171,11 @@ public class RagSearchTools
                     "---|------|-------|---------------|------"
                 );
 
-                foreach (var doc in documents)
-                {
-                    result.AppendLine(
+                result.AppendRows(
+                    documents,
+                    doc =>
                         $"{doc.Id} | {doc.DocumentType} | {doc.ReportingDate:yyyy-MM-dd} | {doc.ReportingForDate:yyyy-MM-dd} | {McpFormat.WholeNumber(doc.LineCount)}"
-                    );
-                }
+                );
 
                 return result.ToString();
             },

--- a/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
+++ b/src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs
@@ -79,12 +79,11 @@ public class StockPriceTools
                     "|------|------|------|-----|-------|--------|"
                 );
 
-                foreach (var p in records.OrderBy(p => p.Date))
-                {
-                    result.AppendLine(
+                result.AppendRows(
+                    records.OrderBy(p => p.Date),
+                    p =>
                         $"| {p.Date:yyyy-MM-dd} | {McpFormat.Invariant(p.Open, "F2")} | {McpFormat.Invariant(p.High, "F2")} | {McpFormat.Invariant(p.Low, "F2")} | {McpFormat.Invariant(p.Close, "F2")} | {McpFormat.WholeNumber(p.Volume)} |"
-                    );
-                }
+                );
 
                 return result.ToString();
             },


### PR DESCRIPTION
## Summary

- Adds `MarkdownTable.AppendRows<T>` — the unnumbered sibling of the existing `AppendNumberedRows<T>` — to centralise the per-item `AppendLine` loop that follows `MarkdownTable.Start` across the MCP tools.
- Collapses seven hand-rolled `foreach (item) sb.AppendLine(rowFn(item))` loops in five tools into single `AppendRows` calls. Output is byte-identical (same sequence, same order, same rendered string per row).

## Code changes

- `src/Equibles.Mcp/Helpers/MarkdownTable.cs` — new `AppendRows<T>(this StringBuilder, IEnumerable<T>, Func<T,string>)` extension.
- `src/Equibles.Sec.Mcp/Tools/NCenTools.cs` — main filings table and the service-providers sub-table use `AppendRows`.
- `src/Equibles.Sec.Mcp/Tools/NportTools.cs` — holdings table uses `AppendRows`.
- `src/Equibles.Sec.Mcp/Tools/RagSearchTools.cs` — documents table uses `AppendRows`.
- `src/Equibles.Yahoo.Mcp/Tools/StockPriceTools.cs` — daily-prices table uses `AppendRows`.
- `src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs` — fact-history and peer-comparison tables use `AppendRows`.