### PR TITLE
refactor(common-stocks): collapse duplicated live-stock batch filtering into FilterByExistingStocks

### DIFF
--- a/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
+++ b/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
@@ -27,4 +27,22 @@ public static class CommonStockRepositoryExtensions
     {
         return repository.GetByIds(ids).Select(s => s.Id).ToHashSetAsync(cancellationToken);
     }
+
+    // Returns the subset of items whose CommonStockId still exists, preserving order.
+    // Importers filter each batch through this before insert because a parallel CompanySync
+    // can hard-delete a stock after a ticker map is built, and a single dangling FK rolls
+    // back the whole batch.
+    public static async Task<List<T>> FilterByExistingStocks<T>(
+        this CommonStockRepository repository,
+        List<T> items,
+        Func<T, Guid> stockIdSelector,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var liveStockIds = await repository.GetExistingIds(
+            items.Select(stockIdSelector).Distinct(),
+            cancellationToken
+        );
+        return items.Where(i => liveStockIds.Contains(stockIdSelector(i))).ToList();
+    }
 }

--- a/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
@@ -268,10 +268,11 @@ public class ShortInterestImportService
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
         var repo = scope.ServiceProvider.GetRequiredService<ShortInterestRepository>();
 
-        var batchStockIds = batch.Select(b => b.CommonStockId).Distinct().ToList();
-        var liveStockIds = await stockRepo.GetExistingIds(batchStockIds, cancellationToken);
-
-        var validBatch = batch.Where(b => liveStockIds.Contains(b.CommonStockId)).ToList();
+        var validBatch = await stockRepo.FilterByExistingStocks(
+            batch,
+            b => b.CommonStockId,
+            cancellationToken
+        );
         var dropped = batch.Count - validBatch.Count;
         if (dropped > 0)
         {

--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -116,18 +116,11 @@ public class ShortVolumeImportService
                     var repo =
                         scope.ServiceProvider.GetRequiredService<DailyShortVolumeRepository>();
 
-                    // tickerMap was built at the start of Import and can go stale if CompanySyncService
-                    // hard-deletes/replaces a stock in parallel. Re-validate each batch against the
-                    // current CommonStock table so dangling-FK inserts don't poison the whole batch.
-                    var batchStockIds = batch.Select(b => b.CommonStockId).Distinct().ToList();
-                    var liveStockIds = await stockRepo.GetExistingIds(
-                        batchStockIds,
+                    var validBatch = await stockRepo.FilterByExistingStocks(
+                        batch,
+                        b => b.CommonStockId,
                         cancellationToken
                     );
-
-                    var validBatch = batch
-                        .Where(b => liveStockIds.Contains(b.CommonStockId))
-                        .ToList();
                     var dropped = batch.Count - validBatch.Count;
                     if (dropped > 0)
                     {

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -218,15 +218,11 @@ public class FtdImportService
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
 
-        // Guards GH-1591: CompanySync can delete a CommonStock between
-        // BuildTickerMap and this flush. Without filtering, one stale
-        // CommonStockId trips FK_FailToDeliver_CommonStock_CommonStockId and
-        // rolls back the entire UpsertRange — dropping rows for surviving
-        // stocks alongside the orphan.
-        var stockIds = items.Select(i => i.CommonStockId).Distinct().ToHashSet();
-        var existingIds = await stockRepo.GetExistingIds(stockIds);
-
-        var safeItems = items.Where(i => existingIds.Contains(i.CommonStockId)).ToList();
+        // Guards GH-1591: CompanySync can delete a CommonStock between BuildTickerMap and
+        // this flush. Without filtering, one stale CommonStockId trips
+        // FK_FailToDeliver_CommonStock_CommonStockId and rolls back the entire UpsertRange —
+        // dropping rows for surviving stocks alongside the orphan.
+        var safeItems = await stockRepo.FilterByExistingStocks(items, i => i.CommonStockId);
         var skipped = items.Count - safeItems.Count;
         if (skipped > 0)
         {


### PR DESCRIPTION
## Summary

- Three importers (`ShortInterestImportService`, `ShortVolumeImportService`, `FtdImportService`) each re-validate every batch against the live `CommonStock` table before insert — the same `Select → Distinct → GetExistingIds → Where(Contains)` block copied in all three.
- Extracted that block into a single `CommonStockRepository.FilterByExistingStocks<T>` extension, sitting beside the `GetExistingIds` helper it builds on. Behavior is unchanged: the returned subset preserves batch order, and each site keeps its own dropped-count log message.

## Code changes

- `src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs` — added `FilterByExistingStocks<T>(items, stockIdSelector, ct)` returning the order-preserving subset whose `CommonStockId` still exists.
- `src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs` — replaced the inline filter triple with the helper call.
- `src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs` — same, inside the batch-persist lambda.
- `src/Equibles.Sec.HostedService/Services/FtdImportService.cs` — same in `FlushBatch`, preserving the GH-1591 guard comment.