### PR TITLE
refactor(sec): centralize amendment-form "/A" check into IsAmendmentFormType extension

### DIFF
--- a/src/Equibles.Sec.HostedService/Extensions/FilingFormExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/FilingFormExtensions.cs
@@ -5,6 +5,8 @@ namespace Equibles.Sec.HostedService.Extensions;
 public static class FilingFormExtensions
 {
     // SEC amendment submissions carry "/A" in their form type (e.g. "D/A", "N-PORT/A", "N-CEN/A").
-    public static bool IsAmendmentForm(this FilingData filing) =>
-        filing.Form?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
+    public static bool IsAmendmentForm(this FilingData filing) => filing.Form.IsAmendmentFormType();
+
+    public static bool IsAmendmentFormType(this string formType) =>
+        formType?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
 }

--- a/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs
@@ -247,7 +247,7 @@ public class NCenFilingProcessor : IssuerFeedFilingProcessor<NCenFiling, NCenFil
     {
         var submissionType = Val(headerData, "submissionType");
         if (submissionType != null)
-            return submissionType.Contains("/A", StringComparison.OrdinalIgnoreCase);
+            return submissionType.IsAmendmentFormType();
 
         return filing.IsAmendmentForm();
     }

--- a/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs
@@ -153,7 +153,7 @@ public class NportFilingProcessor : IssuerFeedFilingProcessor<NportFiling, Nport
     {
         var submissionType = Val(headerData, "submissionType");
         if (submissionType != null)
-            return submissionType.Contains("/A", StringComparison.OrdinalIgnoreCase);
+            return submissionType.IsAmendmentFormType();
 
         return filing.IsAmendmentForm();
     }


### PR DESCRIPTION
## Summary

- The `"/A"` amendment-suffix check on SEC form types was duplicated as a magic string in three places. Centralized it behind a single `string.IsAmendmentFormType()` extension so the amendment-detection rule lives in one spot.
- Behavior-preserving: the existing `FilingData.IsAmendmentForm()` keeps its null-safe semantics by delegating to the new helper; the two `ParseIsAmendment` call sites only invoke the helper on values already guarded non-null.

## Code changes

- `src/Equibles.Sec.HostedService/Extensions/FilingFormExtensions.cs` — add `IsAmendmentFormType(this string)`; `IsAmendmentForm(FilingData)` now delegates to it.
- `src/Equibles.Sec.HostedService/Services/NportFilingProcessor.cs` — use `submissionType.IsAmendmentFormType()` instead of inline `Contains("/A", ...)`.
- `src/Equibles.Sec.HostedService/Services/NCenFilingProcessor.cs` — same substitution.