### PR TITLE
feat(holdings): add PercentOfClass to InstitutionalHolding

### DIFF
--- a/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
@@ -42,6 +42,11 @@ public class InstitutionalHolding
     public long VotingAuthShared { get; set; }
     public long VotingAuthNone { get; set; }
 
+    // Percent of the class beneficially owned. Reported on Schedule 13D/13G cover
+    // pages; null for Form 13F (which has no percent-of-class concept).
+    [Column(TypeName = "numeric(7,4)")]
+    public decimal? PercentOfClass { get; set; }
+
     [MaxLength(128)]
     public string TitleOfClass { get; set; }
 

--- a/src/Equibles.Migrations/Migrations/20260608170846_AddPercentOfClassToInstitutionalHolding.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260608170846_AddPercentOfClassToInstitutionalHolding.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608170846_AddPercentOfClassToInstitutionalHolding")]
+    partial class AddPercentOfClassToInstitutionalHolding
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260608170846_AddPercentOfClassToInstitutionalHolding.cs
+++ b/src/Equibles.Migrations/Migrations/20260608170846_AddPercentOfClassToInstitutionalHolding.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPercentOfClassToInstitutionalHolding : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "PercentOfClass",
+                table: "InstitutionalHolding",
+                type: "numeric(7,4)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PercentOfClass",
+                table: "InstitutionalHolding");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- First slice toward Schedule 13D/13G beneficial-ownership ingestion (#3564).
- 13D/13G cover pages report the percent of the class beneficially owned — a field Form 13F has no concept of. This adds the column so later slices can populate it.

## Code changes

- `src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs` — add nullable `decimal? PercentOfClass` mapped to `numeric(7,4)`; null for 13F holdings.
- `src/Equibles.Migrations/Migrations/*_AddPercentOfClassToInstitutionalHolding.*` — additive migration adding the nullable column (no rename/drop, no custom SQL).

Refs #3564