### PR TITLE
feat(holdings): parse Schedule 13D/13G beneficial-ownership XML

### DIFF
--- a/src/Equibles.Holdings.HostedService/Extensions/HoldingsFilingTypeExtensions.cs
+++ b/src/Equibles.Holdings.HostedService/Extensions/HoldingsFilingTypeExtensions.cs
@@ -1,0 +1,40 @@
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.Holdings.HostedService.Extensions;
+
+/// <summary>
+/// Maps raw SEC submission/form-type strings (as they appear in the EDGAR daily
+/// index and in a filing's <c>submissionType</c> element) to the
+/// <see cref="FilingType"/> the holdings model records.
+/// </summary>
+public static class HoldingsFilingTypeExtensions
+{
+    /// <summary>
+    /// Returns the <see cref="FilingType"/> for a SEC form type, or null when the
+    /// form is not one the holdings pipeline ingests. The amendment marker
+    /// (<c>/A</c>) is ignored — an amendment maps to the same type as its base
+    /// form.
+    /// </summary>
+    public static FilingType? ToHoldingsFilingType(this string formType)
+    {
+        if (string.IsNullOrWhiteSpace(formType))
+            return null;
+
+        var normalized = formType
+            .Replace("/A", string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Trim()
+            .ToUpperInvariant();
+
+        return normalized switch
+        {
+            "13F-HR" => FilingType.Form13F,
+            "SCHEDULE 13D" or "SC 13D" => FilingType.Schedule13D,
+            "SCHEDULE 13G" or "SC 13G" => FilingType.Schedule13G,
+            _ => null,
+        };
+    }
+
+    /// <summary>True when the form type is an amendment (its type carries "/A").</summary>
+    public static bool IsAmendmentFormType(this string formType) =>
+        formType?.Contains("/A", StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/src/Equibles.Holdings.HostedService/Models/Parsed13DGFiling.cs
+++ b/src/Equibles.Holdings.HostedService/Models/Parsed13DGFiling.cs
@@ -1,0 +1,38 @@
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.Holdings.HostedService.Models;
+
+/// <summary>
+/// A single Schedule 13D/13G (or 13D/A / 13G/A) submission parsed from its raw
+/// EDGAR <c>primary_doc.xml</c>. Schedule 13D and 13G became machine-readable
+/// XML on 2024-12-18, so only filings from that date forward can be parsed; the
+/// two forms share a namespace family but use different element names, which the
+/// parser reconciles. This is the beneficial-ownership equivalent of one 13F
+/// filing and is projected into the same import pipeline by the realtime path.
+/// </summary>
+public class Parsed13DGFiling
+{
+    public string AccessionNumber { get; set; }
+    public DateOnly FilingDate { get; set; }
+
+    /// <summary>Raw SEC submission type, e.g. <c>SCHEDULE 13D</c> or <c>SCHEDULE 13G/A</c>.</summary>
+    public string SubmissionType { get; set; }
+
+    /// <summary><see cref="Data.Models.FilingType.Schedule13D"/> or <see cref="Data.Models.FilingType.Schedule13G"/>.</summary>
+    public FilingType FilingType { get; set; }
+
+    public bool IsAmendment { get; set; }
+
+    /// <summary>CIK of the lead filer (the entity that submitted the schedule).</summary>
+    public string FilerCik { get; set; }
+
+    /// <summary>Date of the event that required the filing (the cover-page event date).</summary>
+    public DateOnly DateOfEvent { get; set; }
+
+    public string IssuerCik { get; set; }
+    public string IssuerCusip { get; set; }
+    public string IssuerName { get; set; }
+    public string SecuritiesClassTitle { get; set; }
+
+    public List<Parsed13DGReportingPerson> ReportingPersons { get; set; } = [];
+}

--- a/src/Equibles.Holdings.HostedService/Models/Parsed13DGReportingPerson.cs
+++ b/src/Equibles.Holdings.HostedService/Models/Parsed13DGReportingPerson.cs
@@ -1,0 +1,37 @@
+namespace Equibles.Holdings.HostedService.Models;
+
+/// <summary>
+/// One reporting person (beneficial owner) parsed from a Schedule 13D/13G
+/// submission. A single filing lists every member of the reporting group —
+/// individual funds, their general partner, the parent, and so on — each with
+/// its own beneficially-owned amount and percent of the class. Several members
+/// frequently report the SAME underlying shares at different levels of the
+/// ownership chain, so these are NOT additive.
+/// </summary>
+public class Parsed13DGReportingPerson
+{
+    /// <summary>
+    /// The reporting person's CIK, or null when the filing marks the person as
+    /// having no CIK (<c>reportingPersonNoCIK = Y</c>).
+    /// </summary>
+    public string Cik { get; set; }
+
+    public string Name { get; set; }
+
+    public long SoleVotingPower { get; set; }
+    public long SharedVotingPower { get; set; }
+    public long SoleDispositivePower { get; set; }
+    public long SharedDispositivePower { get; set; }
+
+    /// <summary>Aggregate amount beneficially owned by this reporting person.</summary>
+    public long AggregateAmountOwned { get; set; }
+
+    /// <summary>Percent of the class beneficially owned, or null when omitted.</summary>
+    public decimal? PercentOfClass { get; set; }
+
+    /// <summary>SEC <c>typeOfReportingPerson</c> code (e.g. <c>PN</c>, <c>IA</c>, <c>OO</c>).</summary>
+    public string TypeOfReportingPerson { get; set; }
+
+    /// <summary>SEC <c>citizenshipOrOrganization</c> code (e.g. <c>DE</c>, <c>E9</c>).</summary>
+    public string CitizenshipOrOrganization { get; set; }
+}

--- a/src/Equibles.Holdings.HostedService/Services/Filing13DGXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13DGXmlParser.cs
@@ -1,0 +1,205 @@
+using System.Globalization;
+using System.Xml.Linq;
+using Equibles.Core.AutoWiring;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Extensions;
+using Equibles.Holdings.HostedService.Models;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Parses the raw <c>primary_doc.xml</c> of a single Schedule 13D or 13G filing
+/// (beneficial-ownership reports, machine-readable XML since 2024-12-18).
+///
+/// The two forms share a namespace family but differ in element names — 13D uses
+/// <c>dateOfEvent</c>, <c>issuerCUSIP</c>, repeated <c>reportingPersonInfo</c>
+/// blocks with flat <c>soleVotingPower</c>… children and <c>percentOfClass</c>;
+/// 13G uses <c>eventDateRequiresFilingThisStatement</c>, <c>issuerCusip</c>,
+/// repeated <c>coverPageHeaderReportingPersonDetails</c> blocks with the voting
+/// powers nested under <c>reportingPersonBeneficiallyOwnedNumberOfShares</c> and
+/// <c>classPercent</c>. Every lookup is by <see cref="XName.LocalName"/> (so
+/// namespace versions don't matter) and accepts the candidate names from both
+/// forms, which lets one parser handle 13D and 13G alike.
+/// </summary>
+[Service]
+public class Filing13DGXmlParser
+{
+    /// <summary>
+    /// Parses a 13D/13G <c>primary_doc.xml</c>. <paramref name="accessionNumber"/>,
+    /// <paramref name="cik"/> and <paramref name="filingDate"/> come from the daily
+    /// index; the CIK is a fallback when the XML header omits the filer CIK.
+    /// </summary>
+    public Parsed13DGFiling ParseFiling(
+        string primaryDocXml,
+        string accessionNumber,
+        string cik,
+        DateOnly filingDate
+    )
+    {
+        var root = XDocument.Parse(primaryDocXml).Root;
+        if (root == null)
+            throw new FormatException("primary_doc.xml has no root element");
+
+        var headerData = Descendant(root, "headerData");
+        var submissionType = Value(Descendant(headerData, "submissionType"));
+        var xmlFilerCik = Value(Descendant(headerData, "cik"));
+
+        var coverPage = Descendant(root, "coverPageHeader");
+        var issuerInfo = Descendant(coverPage, "issuerInfo");
+
+        var filing = new Parsed13DGFiling
+        {
+            AccessionNumber = accessionNumber,
+            FilingDate = filingDate,
+            SubmissionType = submissionType,
+            // A 13D/13G XML can only describe a 13D or 13G; default to 13D if the
+            // header is somehow unmapped so the filing is never silently dropped.
+            FilingType = submissionType.ToHoldingsFilingType() ?? FilingType.Schedule13D,
+            IsAmendment = submissionType.IsAmendmentFormType(),
+            FilerCik = string.IsNullOrEmpty(xmlFilerCik)
+                ? cik?.TrimStart('0')
+                : xmlFilerCik.TrimStart('0'),
+            DateOfEvent = ParseSecDate(
+                FirstValue(coverPage, "dateOfEvent", "eventDateRequiresFilingThisStatement")
+            ),
+            IssuerCik = FirstValue(issuerInfo, "issuerCIK", "issuerCik")?.TrimStart('0'),
+            IssuerCusip = FirstValue(issuerInfo, "issuerCUSIP", "issuerCusip"),
+            IssuerName = Value(Descendant(issuerInfo, "issuerName")),
+            SecuritiesClassTitle = Value(Descendant(coverPage, "securitiesClassTitle")),
+        };
+
+        // 13D groups reporting persons under <reportingPersonInfo>; 13G under
+        // <coverPageHeaderReportingPersonDetails>. Collect either.
+        var personElements = Descendants(root, "reportingPersonInfo")
+            .Concat(Descendants(root, "coverPageHeaderReportingPersonDetails"));
+
+        foreach (var person in personElements)
+            filing.ReportingPersons.Add(ParseReportingPerson(person));
+
+        return filing;
+    }
+
+    private static Parsed13DGReportingPerson ParseReportingPerson(XElement person)
+    {
+        var cik = Value(Child(person, "reportingPersonCIK"));
+
+        return new Parsed13DGReportingPerson
+        {
+            Cik = string.IsNullOrEmpty(cik) ? null : cik.TrimStart('0'),
+            Name = Value(Descendant(person, "reportingPersonName")),
+            // In 13D these powers are flat children; in 13G they nest under
+            // <reportingPersonBeneficiallyOwnedNumberOfShares>. A descendant scan
+            // scoped to this person's element finds both without cross-row bleed.
+            SoleVotingPower = ParseShares(Value(Descendant(person, "soleVotingPower"))),
+            SharedVotingPower = ParseShares(Value(Descendant(person, "sharedVotingPower"))),
+            SoleDispositivePower = ParseShares(Value(Descendant(person, "soleDispositivePower"))),
+            SharedDispositivePower = ParseShares(
+                Value(Descendant(person, "sharedDispositivePower"))
+            ),
+            AggregateAmountOwned = ParseShares(
+                FirstValue(
+                    person,
+                    "aggregateAmountOwned",
+                    "reportingPersonBeneficiallyOwnedAggregateNumberOfShares"
+                )
+            ),
+            PercentOfClass = ParsePercent(FirstValue(person, "percentOfClass", "classPercent")),
+            TypeOfReportingPerson = Value(Descendant(person, "typeOfReportingPerson")),
+            CitizenshipOrOrganization = Value(Descendant(person, "citizenshipOrOrganization")),
+        };
+    }
+
+    private static IEnumerable<XElement> WithLocalName(
+        IEnumerable<XElement> source,
+        string localName
+    ) =>
+        source.Where(e =>
+            string.Equals(e.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)
+        );
+
+    private static IEnumerable<XElement> Children(XElement parent, string localName) =>
+        WithLocalName(parent.Elements(), localName);
+
+    private static IEnumerable<XElement> Descendants(XElement parent, string localName) =>
+        WithLocalName(parent.Descendants(), localName);
+
+    private static XElement Descendant(XElement parent, string localName) =>
+        parent == null ? null : Descendants(parent, localName).FirstOrDefault();
+
+    private static XElement Child(XElement parent, string localName) =>
+        parent == null ? null : Children(parent, localName).FirstOrDefault();
+
+    private static string Value(XElement element) => element?.Value.Trim();
+
+    /// <summary>First non-empty descendant value among the candidate local names.</summary>
+    private static string FirstValue(XElement parent, params string[] localNames)
+    {
+        if (parent == null)
+            return null;
+
+        foreach (var name in localNames)
+        {
+            var value = Value(Descendant(parent, name));
+            if (!string.IsNullOrEmpty(value))
+                return value;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Cover-page event dates are <c>MM/DD/YYYY</c>. Returns
+    /// <see cref="DateOnly.MinValue"/> when unparseable so the import pipeline
+    /// filters the filing out rather than crashing.
+    /// </summary>
+    private static DateOnly ParseSecDate(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return DateOnly.MinValue;
+
+        if (
+            DateOnly.TryParseExact(
+                raw.Trim(),
+                ["MM/dd/yyyy", "MM-dd-yyyy"],
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var exact
+            )
+        )
+            return exact;
+
+        return DateOnly.TryParse(
+            raw.Trim(),
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var general
+        )
+            ? general
+            : DateOnly.MinValue;
+    }
+
+    /// <summary>
+    /// Share/power amounts. 13G files them as decimals (<c>1624818.00</c>),
+    /// 13D as plain integers; both may carry thousands separators. Parsed as a
+    /// decimal and truncated to whole shares.
+    /// </summary>
+    private static long ParseShares(string raw) =>
+        decimal.TryParse(
+            raw?.Replace(",", string.Empty),
+            NumberStyles.Number,
+            CultureInfo.InvariantCulture,
+            out var value
+        )
+            ? (long)value
+            : 0;
+
+    private static decimal? ParsePercent(string raw) =>
+        decimal.TryParse(
+            raw?.Replace(",", string.Empty),
+            NumberStyles.Number,
+            CultureInfo.InvariantCulture,
+            out var value
+        )
+            ? value
+            : null;
+}

--- a/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserParse13DAmendmentTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserParse13DAmendmentTests.cs
@@ -1,0 +1,60 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+// Record-replay against a real Schedule 13D/A amendment (Abu Dhabi Investment
+// Authority's 2025-05-06 13D/A). Confirms the amendment marker is detected, an
+// amendment still maps to its base FilingType, decimal share amounts truncate,
+// and a placeholder issuer CUSIP is carried through verbatim (the import stage,
+// not the parser, decides whether an unknown CUSIP maps to a tracked stock).
+public class Filing13DGXmlParserParse13DAmendmentTests
+{
+    private readonly Filing13DGXmlParser _sut = new();
+
+    private static string LoadCassette() =>
+        File.ReadAllText(
+            Path.Combine(AppContext.BaseDirectory, "TestAssets", "Holdings13DG", "sc13da-adia.xml")
+        );
+
+    [Fact]
+    public void ParseFiling_Real13DAmendment_FlagsAmendmentAndMapsToBaseType()
+    {
+        var result = _sut.ParseFiling(
+            LoadCassette(),
+            accessionNumber: "0001011438-25-000254",
+            cik: "0001362558",
+            filingDate: new DateOnly(2025, 5, 6)
+        );
+
+        result.SubmissionType.Should().Be("SCHEDULE 13D/A");
+        result.IsAmendment.Should().BeTrue();
+        result.FilingType.Should().Be(FilingType.Schedule13D);
+        result.DateOfEvent.Should().Be(new DateOnly(2025, 5, 2));
+        result.IssuerCusip.Should().Be("000000000");
+        result.ReportingPersons.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void ParseFiling_Real13DAmendment_TruncatesDecimalShareAmounts()
+    {
+        var person = _sut.ParseFiling(
+            LoadCassette(),
+            "0001011438-25-000254",
+            "0001362558",
+            default
+        ).ReportingPersons[0];
+
+        person.Name.Should().Be("Abu Dhabi Investment Authority");
+        person.Cik.Should().Be("1362558");
+        // soleVotingPower is filed as 942779.94 — truncated to whole shares.
+        person.SoleVotingPower.Should().Be(942779);
+        person.SharedVotingPower.Should().Be(0);
+        // soleDispositivePower / aggregate filed as 11615772.8.
+        person.SoleDispositivePower.Should().Be(11615772);
+        person.AggregateAmountOwned.Should().Be(11615772);
+        person.PercentOfClass.Should().Be(60.4m);
+        person.TypeOfReportingPerson.Should().Be("OO");
+        person.CitizenshipOrOrganization.Should().Be("C0");
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserParse13DTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserParse13DTests.cs
@@ -1,0 +1,78 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+// Record-replay: drives the parser through a real captured Schedule 13D
+// primary_doc.xml (Affinity Partners' 2025-05-06 13D on QXO, Inc.). Frozen
+// input, so exact values are asserted — any drift means the parser regressed.
+public class Filing13DGXmlParserParse13DTests
+{
+    private readonly Filing13DGXmlParser _sut = new();
+
+    private static string LoadCassette() =>
+        File.ReadAllText(
+            Path.Combine(AppContext.BaseDirectory, "TestAssets", "Holdings13DG", "sc13d-qxo.xml")
+        );
+
+    [Fact]
+    public void ParseFiling_Real13D_ExtractsCoverPageAndAllReportingPersons()
+    {
+        var result = _sut.ParseFiling(
+            LoadCassette(),
+            accessionNumber: "0001140361-25-017533",
+            cik: "0002059583",
+            filingDate: new DateOnly(2025, 5, 6)
+        );
+
+        result.SubmissionType.Should().Be("SCHEDULE 13D");
+        result.FilingType.Should().Be(FilingType.Schedule13D);
+        result.IsAmendment.Should().BeFalse();
+        result.FilerCik.Should().Be("2059583");
+        result.DateOfEvent.Should().Be(new DateOnly(2025, 4, 29));
+        result.IssuerCik.Should().Be("1236275");
+        result.IssuerCusip.Should().Be("82846H405");
+        result.IssuerName.Should().Be("QXO, Inc.");
+        result.SecuritiesClassTitle.Should().Be("Common Stock, par value $0.00001 per share");
+        result.ReportingPersons.Should().HaveCount(6);
+    }
+
+    [Fact]
+    public void ParseFiling_Real13D_ExtractsFirstReportingPersonWithNoCik()
+    {
+        var person = _sut.ParseFiling(
+            LoadCassette(),
+            "0001140361-25-017533",
+            "0002059583",
+            default
+        ).ReportingPersons[0];
+
+        person.Name.Should().Be("Affinity Partners Fund I LP");
+        person.Cik.Should().BeNull();
+        person.SoleVotingPower.Should().Be(0);
+        person.SharedVotingPower.Should().Be(164310);
+        person.SoleDispositivePower.Should().Be(0);
+        person.SharedDispositivePower.Should().Be(164310);
+        person.AggregateAmountOwned.Should().Be(164310);
+        person.PercentOfClass.Should().Be(0.03m);
+        person.TypeOfReportingPerson.Should().Be("PN");
+        person.CitizenshipOrOrganization.Should().Be("DE");
+    }
+
+    [Fact]
+    public void ParseFiling_Real13D_CapturesTheReportingPersonThatCarriesACik()
+    {
+        var generalPartner = _sut.ParseFiling(
+                LoadCassette(),
+                "0001140361-25-017533",
+                "0002059583",
+                default
+            )
+            .ReportingPersons.Single(p => p.Cik != null);
+
+        generalPartner.Cik.Should().Be("2059583");
+        generalPartner.Name.Should().Be("Affinity Partners GP LP");
+        generalPartner.AggregateAmountOwned.Should().Be(32671542);
+        generalPartner.PercentOfClass.Should().Be(6.3m);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserParse13GTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserParse13GTests.cs
@@ -1,0 +1,73 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+// Record-replay against a real Schedule 13G (Citadel Advisors' 2025-05-06 13G on
+// Spirit Aviation). 13G uses different element names than 13D — a separate
+// event-date element, lowercase issuer CIK/CUSIP, a different reporting-person
+// container with nested voting powers, and classPercent rather than
+// percentOfClass — so this proves the one parser reconciles both forms.
+public class Filing13DGXmlParserParse13GTests
+{
+    private readonly Filing13DGXmlParser _sut = new();
+
+    private static string LoadCassette() =>
+        File.ReadAllText(
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "TestAssets",
+                "Holdings13DG",
+                "sc13g-citadel-spirit.xml"
+            )
+        );
+
+    [Fact]
+    public void ParseFiling_Real13G_ExtractsCoverPageUsingTheGVariantElementNames()
+    {
+        var result = _sut.ParseFiling(
+            LoadCassette(),
+            accessionNumber: "0001104659-25-045128",
+            cik: "0001423053",
+            filingDate: new DateOnly(2025, 5, 6)
+        );
+
+        result.SubmissionType.Should().Be("SCHEDULE 13G");
+        result.FilingType.Should().Be(FilingType.Schedule13G);
+        result.IsAmendment.Should().BeFalse();
+        result.FilerCik.Should().Be("1423053");
+        // 13G files the event date under eventDateRequiresFilingThisStatement.
+        result.DateOfEvent.Should().Be(new DateOnly(2025, 4, 29));
+        // 13G lowercases issuerCik / issuerCusip.
+        result.IssuerCik.Should().Be("1498710");
+        result.IssuerCusip.Should().Be("84863V101");
+        result.IssuerName.Should().Be("Spirit Aviation Holdings, Inc.");
+        result.ReportingPersons.Should().HaveCount(7);
+    }
+
+    [Fact]
+    public void ParseFiling_Real13G_ReadsNestedVotingPowersAndClassPercent()
+    {
+        var person = _sut.ParseFiling(
+            LoadCassette(),
+            "0001104659-25-045128",
+            "0001423053",
+            default
+        ).ReportingPersons[0];
+
+        person.Name.Should().Be("Citadel Advisors LLC");
+        // 13G omits per-person CIK entirely.
+        person.Cik.Should().BeNull();
+        // Powers nest under reportingPersonBeneficiallyOwnedNumberOfShares and are
+        // filed as decimals (e.g. 1624818.00) — truncated to whole shares.
+        person.SoleVotingPower.Should().Be(0);
+        person.SharedVotingPower.Should().Be(1624818);
+        person.SoleDispositivePower.Should().Be(0);
+        person.SharedDispositivePower.Should().Be(1624818);
+        person.AggregateAmountOwned.Should().Be(1624818);
+        // Sourced from classPercent, not percentOfClass.
+        person.PercentOfClass.Should().Be(9.9m);
+        person.TypeOfReportingPerson.Should().Be("IA");
+        person.CitizenshipOrOrganization.Should().Be("DE");
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsFilingTypeExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsFilingTypeExtensionsTests.cs
@@ -1,0 +1,48 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Extensions;
+
+namespace Equibles.UnitTests.Holdings;
+
+// The form-type -> FilingType map is the single point that decides which SEC
+// submissions the holdings pipeline ingests, so every accepted spelling (daily
+// index vs full-text "SC" form, base vs amendment) and the reject path are pinned.
+public class HoldingsFilingTypeExtensionsTests
+{
+    [Theory]
+    [InlineData("13F-HR", FilingType.Form13F)]
+    [InlineData("13F-HR/A", FilingType.Form13F)]
+    [InlineData("SCHEDULE 13D", FilingType.Schedule13D)]
+    [InlineData("SCHEDULE 13D/A", FilingType.Schedule13D)]
+    [InlineData("SC 13D", FilingType.Schedule13D)]
+    [InlineData("SCHEDULE 13G", FilingType.Schedule13G)]
+    [InlineData("SCHEDULE 13G/A", FilingType.Schedule13G)]
+    [InlineData("SC 13G", FilingType.Schedule13G)]
+    [InlineData("schedule 13d", FilingType.Schedule13D)]
+    public void ToHoldingsFilingType_KnownForm_MapsToType(string formType, FilingType expected)
+    {
+        formType.ToHoldingsFilingType().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("8-K")]
+    [InlineData("SCHEDULE 13F")]
+    [InlineData("13D")]
+    public void ToHoldingsFilingType_UnsupportedOrEmpty_ReturnsNull(string formType)
+    {
+        formType.ToHoldingsFilingType().Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("SCHEDULE 13D/A", true)]
+    [InlineData("13F-HR/A", true)]
+    [InlineData("SCHEDULE 13D", false)]
+    [InlineData("13F-HR", false)]
+    [InlineData(null, false)]
+    public void IsAmendmentFormType_DetectsAmendmentMarker(string formType, bool expected)
+    {
+        formType.IsAmendmentFormType().Should().Be(expected);
+    }
+}

--- a/tests/Equibles.UnitTests/TestAssets/Holdings13DG/sc13d-qxo.xml
+++ b/tests/Equibles.UnitTests/TestAssets/Holdings13DG/sc13d-qxo.xml
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="UTF-8"?><edgarSubmission xmlns="http://www.sec.gov/edgar/schedule13D" xmlns:com="http://www.sec.gov/edgar/common">
+<headerData>
+<submissionType>SCHEDULE 13D</submissionType>
+<filerInfo>
+<filer>
+<filerCredentials>
+<cik>0002059583</cik>
+<ccc>XXXXXXXX</ccc>
+</filerCredentials>
+</filer>
+<liveTestFlag>LIVE</liveTestFlag>
+
+
+
+</filerInfo>
+</headerData>
+<formData>
+<coverPageHeader>
+<securitiesClassTitle>Common Stock, par value $0.00001 per share</securitiesClassTitle>
+<dateOfEvent>04/29/2025</dateOfEvent>
+<previouslyFiledFlag>false</previouslyFiledFlag>
+<issuerInfo>
+<issuerCIK>0001236275</issuerCIK>
+<issuerCUSIP>82846H405</issuerCUSIP>
+<issuerName>QXO, Inc.</issuerName>
+<address>
+<com:street1>Five American Lane</com:street1>
+<com:city>Greenwich</com:city>
+<com:stateOrCountry>CT</com:stateOrCountry>
+<com:zipCode>06831</com:zipCode>
+</address>
+</issuerInfo>
+<authorizedPersons>
+<notificationInfo>
+<personName>Ian Brekke</personName>
+<personPhoneNum>786-815-9041</personPhoneNum>
+<personAddress>
+<com:street1>Affinity Partners GP LP</com:street1>
+<com:street2>16690 Collins Avenue</com:street2>
+<com:city>Sunny Isles Beach</com:city>
+<com:stateOrCountry>FL</com:stateOrCountry>
+<com:zipCode>33160</com:zipCode>
+</personAddress>
+</notificationInfo>
+</authorizedPersons>
+</coverPageHeader>
+<reportingPersons>
+<reportingPersonInfo>
+<reportingPersonNoCIK>Y</reportingPersonNoCIK>
+<reportingPersonName>Affinity Partners Fund I LP</reportingPersonName>
+<fundType>AF</fundType>
+<citizenshipOrOrganization>DE</citizenshipOrOrganization>
+<soleVotingPower>0</soleVotingPower>
+<sharedVotingPower>164310</sharedVotingPower>
+<soleDispositivePower>0</soleDispositivePower>
+<sharedDispositivePower>164310</sharedDispositivePower>
+<aggregateAmountOwned>164310</aggregateAmountOwned>
+<isAggregateExcludeShares>N</isAggregateExcludeShares>
+<percentOfClass>0.03</percentOfClass>
+<typeOfReportingPerson>PN</typeOfReportingPerson>
+<commentContent>* Based on 514,694,504 shares outstanding of QXO, Inc. as of April 29, 2025.</commentContent>
+</reportingPersonInfo>
+<reportingPersonInfo>
+<reportingPersonNoCIK>Y</reportingPersonNoCIK>
+<reportingPersonName>Affinity Partners Parallel Fund I LP</reportingPersonName>
+<fundType>AF</fundType>
+<citizenshipOrOrganization>E9</citizenshipOrOrganization>
+<soleVotingPower>0</soleVotingPower>
+<sharedVotingPower>16247069</sharedVotingPower>
+<soleDispositivePower>0</soleDispositivePower>
+<sharedDispositivePower>16247069</sharedDispositivePower>
+<aggregateAmountOwned>16247069</aggregateAmountOwned>
+<isAggregateExcludeShares>N</isAggregateExcludeShares>
+<percentOfClass>3.2</percentOfClass>
+<typeOfReportingPerson>PN</typeOfReportingPerson>
+<commentContent>* Based on 514,694,504 shares outstanding of QXO, Inc. as of April 29, 2025.</commentContent>
+</reportingPersonInfo>
+<reportingPersonInfo>
+<reportingPersonCIK>0002059583</reportingPersonCIK>
+<reportingPersonName>Affinity Partners GP LP</reportingPersonName>
+<fundType>AF</fundType>
+<citizenshipOrOrganization>DE</citizenshipOrOrganization>
+<soleVotingPower>0</soleVotingPower>
+<sharedVotingPower>32671542</sharedVotingPower>
+<soleDispositivePower>0</soleDispositivePower>
+<sharedDispositivePower>32671542</sharedDispositivePower>
+<aggregateAmountOwned>32671542</aggregateAmountOwned>
+<isAggregateExcludeShares>N</isAggregateExcludeShares>
+<percentOfClass>6.3</percentOfClass>
+<typeOfReportingPerson>PN</typeOfReportingPerson>
+<commentContent>* Based on 514,694,504 shares outstanding of QXO, Inc. as of April 29, 2025.</commentContent>
+</reportingPersonInfo>
+<reportingPersonInfo>
+<reportingPersonNoCIK>Y</reportingPersonNoCIK>
+<reportingPersonName>Affinity QXO 1 LLC</reportingPersonName>
+<fundType>AF</fundType>
+<citizenshipOrOrganization>DE</citizenshipOrOrganization>
+<soleVotingPower>0</soleVotingPower>
+<sharedVotingPower>16260163</sharedVotingPower>
+<soleDispositivePower>0</soleDispositivePower>
+<sharedDispositivePower>16260163</sharedDispositivePower>
+<aggregateAmountOwned>16260163</aggregateAmountOwned>
+<isAggregateExcludeShares>N</isAggregateExcludeShares>
+<percentOfClass>3.2</percentOfClass>
+<typeOfReportingPerson>OO</typeOfReportingPerson>
+<commentContent>* Based on 514,694,504 shares outstanding of QXO, Inc. as of April 29, 2025.</commentContent>
+</reportingPersonInfo>
+<reportingPersonInfo>
+<reportingPersonNoCIK>Y</reportingPersonNoCIK>
+<reportingPersonName>Affinity Partners???Fund I Co-Invest???GP LP</reportingPersonName>
+<fundType>AF</fundType>
+<citizenshipOrOrganization>DE</citizenshipOrOrganization>
+<soleVotingPower>0</soleVotingPower>
+<sharedVotingPower>16260163</sharedVotingPower>
+<soleDispositivePower>0</soleDispositivePower>
+<sharedDispositivePower>16260163</sharedDispositivePower>
+<aggregateAmountOwned>16260163</aggregateAmountOwned>
+<isAggregateExcludeShares>N</isAggregateExcludeShares>
+<percentOfClass>3.2</percentOfClass>
+<typeOfReportingPerson>PN</typeOfReportingPerson>
+<commentContent>* Based on 514,694,504 shares outstanding of QXO, Inc. as of April 29, 2025.</commentContent>
+</reportingPersonInfo>
+<reportingPersonInfo>
+<reportingPersonNoCIK>Y</reportingPersonNoCIK>
+<reportingPersonName>Jared Kushner</reportingPersonName>
+<fundType>AF</fundType>
+<citizenshipOrOrganization>X1</citizenshipOrOrganization>
+<soleVotingPower>0</soleVotingPower>
+<sharedVotingPower>32671542</sharedVotingPower>
+<soleDispositivePower>0</soleDispositivePower>
+<sharedDispositivePower>32671542</sharedDispositivePower>
+<aggregateAmountOwned>32671542</aggregateAmountOwned>
+<isAggregateExcludeShares>N</isAggregateExcludeShares>
+<percentOfClass>6.3</percentOfClass>
+<typeOfReportingPerson>IN</typeOfReportingPerson>
+<commentContent>* Based on 514,694,504 shares outstanding of QXO, Inc. as of April 29, 2025.</commentContent>
+</reportingPersonInfo>
+</reportingPersons>
+<items1To7>
+<item1>
+<securityTitle>Common Stock, par value $0.00001 per share</securityTitle>
+<issuerName>QXO, Inc.</issuerName>
+<issuerPrincipalAddress>
+<com:street1>Five American Lane</com:street1>
+<com:city>Greenwich</com:city>
+<com:stateOrCountry>CT</com:stateOrCountry>
+<com:zipCode>06831</com:zipCode>
+</issuerPrincipalAddress>
+<commentText>This Statement on Schedule 13D (this "Schedule 13D") relates to the shares of common stock, par value $0.00001 per share (the "Common Stock"), of QXO, Inc. (the "Issuer"). The Issuer's principal executive offices are located at Five American Lane, Greenwich, CT 06831. Shares of the Common Stock are listed on the New York Stock Exchange and trade under the symbol "QXO."</commentText>
+</item1>
+<item2>
+<filingPersonName>The persons filing this statement are Affinity Partners Fund I LP ("Affinity LP"), Affinity Partners Parallel Fund I LP ("Affinity Parallel LP"), Affinity QXO 1 LLC ("Affinity QXO"), Affinity Partners GP LP ("Affinity GP"), Affinity Partners Fund I Co-Invest GP LP ("Co-Invest GP") and Jared Kushner, a citizen of the United States of America (collectively, the "Reporting Persons"). The agreement among the Reporting Persons to file this Schedule 13D jointly in accordance with Rule 13d-1(k) of the Exchange Act is attached hereto as Exhibit 99.1.  Except as expressly otherwise set forth in this Schedule 13D, each Reporting Person disclaims beneficial ownership of the shares of Common Stock beneficially owned by each other Reporting Person or any other person.</filingPersonName>
+<principalBusinessAddress>The principal business address of each of the Reporting Persons is 16690 Collins Avenue, Sunny Isles Beach, Florida 33160.</principalBusinessAddress>
+<principalJob>Affinity GP is the general partner of Affinity LP and Affinity Parallel LP. Affinity GP and Co-Invest GP share voting and investment power with respect to Affinity QXO. Mr. Kushner controls a majority of the ownership of Affinity GP and Co-Invest GP and, as such, has shared voting power and dispositive power with respect to the Common Stock held by Affinity LP, Affinity Parallel LP and Affinity QXO. Mr. Kushner disclaims beneficial ownership of all shares of Common Stock beneficially held or deemed to be held by Affinity LP, Affinity Parallel LP, Affinity QXO, Affinity GP and Co-Invest GP, except to the extent of his pecuniary interest therein. Each of Affinity LP, Affinity Parallel LP and Affinity QXO is an investment vehicle formed to make equity investments in companies. Affinity GP is primarily engaged in the business of serving as the general partner of Affinity LP and Affinity Parallel LP. Co-Invest GP is primarily engaged in the business of serving as the general partner of certain investment vehicles that are members of Affinity QXO.</principalJob>
+<hasBeenConvicted>None of the Reporting Persons nor any manager or executive officer of the Reporting Persons, has, during the past five years, been convicted in a criminal proceeding (excluding traffic violations or similar misdemeanors).</hasBeenConvicted>
+<convictionDescription>None of the Reporting Persons nor any manager or executive officer of the Reporting Persons, has, during the past five years, been a party to a civil proceeding of a judicial or administrative body of competent jurisdiction and as a result of such proceeding was or is subject to a judgment, decree or final order enjoining future violations of, or prohibiting, or mandating activities subject to, Federal or State securities laws or a finding of any violation with respect to such laws.</convictionDescription>
+<citizenship>See row 6 of each cover page of this Schedule 13D.</citizenship>
+</item2>
+<item3>
+<fundsSource>On July 22, 2024, the Issuer entered into a Purchase Agreement with Affinity LP and Affinity Parallel LP, pursuant to which the Issuer agreed to issue and sell in a private placement ("Private Placement I") (i) 16,247,069 shares of Common Stock to Affinity Parallel LP at an offering price of $9.14 per share for an aggregate purchase price of $148,498,210.66, and (ii) 164,310 shares of Common Stock to Affinity LP at an offering price of $9.14 per share for an aggregate purchase price of $1,501,793.40. On July 25, 2024, Private Placement I closed. &#13;
+&#13;
+On March 17, 2025, the Issuer entered into a Purchase Agreement with Affinity QXO, pursuant to which, subject to certain closing conditions, the Issuer agreed to issue and sell in a private placement ("Private Placement II") 16,260,163 shares of Common Stock to Affinity QXO at an offering price of $12.30 per share for an aggregate purchase price of $200,000,004.90. On April 29, 2025, Private Placement II closed. &#13;
+&#13;
+Private Placement I and Private Placement II were funded with the respective capital of Affinity LP, Parallel LP and Affinity QXO.</fundsSource>
+</item3>
+<item4>
+<transactionPurpose>The responses set forth in Items 3 and 6 hereof are incorporated by reference in their entirety. &#13;
+&#13;
+The Reporting Persons acquired the Common Stock for investment purposes. The Reporting Persons review their investment in the Issuer on a continuing basis, and may determine to (i) acquire additional securities of the Issuer through open market purchases, private agreements or otherwise, (ii) dispose of all or a portion of the securities of the Issuer owned by them through public offerings (including pursuant to a resale registration statement filed by the Issuer), private transactions or otherwise, or (iii) take any other available course of action.&#13;
+&#13;
+From time to time, the Reporting Persons, including Mr. Kushner, as a director of the Issuer, intend to engage in discussions with the Board of Directors of the Issuer and/or members of the Issuer's management team concerning a broad range of operational and strategic matters, including, without limitation, the Issuer's business, operations, capital structure, governance, management, and strategy as well as potential financings, business combinations, strategic alternatives, and other matters concerning the Issuer, including transactions in which the Reporting Persons may seek to participate and potentially engage. The Reporting Persons may communicate with other stockholders or third parties regarding the foregoing.&#13;
+&#13;
+Notwithstanding anything contained herein, the Reporting Persons specifically reserve the right to change their intention with respect to any or all of such matters. In reaching any decision as to their course of action (as well as to the specific elements thereof), the Reporting Persons currently expect that they would take into consideration a variety of factors, including the following: the Issuer's business and prospects; other developments concerning the Issuer and its businesses generally; other business opportunities available to the Reporting Persons; developments with respect to the business of the Reporting Persons; changes in law and government regulations; general economic conditions; and money and stock market conditions, including the market price of the securities of the Issuer.&#13;
+&#13;
+Except as set forth in this Item 4 of this Schedule 13D, the Reporting Persons do not have any present plans or proposals that relate to or would result in any of the actions specified in clauses (a) through (j) of the instructions to Item 4 of this Schedule 13D.</transactionPurpose>
+</item4>
+<item5>
+<percentageOfClassSecurities>The information set forth in or incorporated by reference in Items 2, 3 and 4 and on the cover pages of this Schedule 13D is incorporated by reference in its entirety into this Item 5.&#13;
+&#13;
+As of the date hereof, (i) Affinity LP may be deemed to be the beneficial owner of 164,310 shares of Common Stock, representing less than 0.1% of the outstanding shares of Common Stock, (ii) Affinity Parallel LP may be deemed to be the beneficial owner of 16,247,069 shares of Common Stock, representing approximately 3.2% of the outstanding shares of Common Stock, (iii) Affinity QXO may be deemed to be the beneficial owner of 16,260,163 shares of Common Stock, representing approximately 3.2% of the outstanding shares of Common Stock, (iv) Affinity GP may be deemed to be the beneficial owner of 32,671,542 shares of Common Stock, representing approximately 6.3% of the outstanding shares of Common Stock, (v) Co-Invest GP may be deemed to be the beneficial owner of 16,260,163 shares of Common Stock, representing approximately 3.2% of the outstanding shares of Common Stock and (vi) Mr. Kushner may be deemed to be the beneficial owner of 32,671,542 shares of Common Stock, representing approximately 6.3% of the outstanding shares of Common Stock, in each case of this, based on 514,694,504 shares of Common Stock outstanding as of April 29, 2025.</percentageOfClassSecurities>
+<numberOfShares>See Item 5(a) above.</numberOfShares>
+<transactionDesc>Except as set forth in this Schedule 13D, no transactions in the shares of Common Stock were effected by the Reporting Persons, or, to the knowledge of the Reporting Persons, by any of the persons listed on Schedule A hereto in the 60 days preceding the date hereof.</transactionDesc>
+<listOfShareholders>Except as set forth herein, to the knowledge of the Reporting Persons, no other person has the right to receive or the power to direct the receipt of dividends from, or the proceeds from the sale of, any Common Stock beneficially owned by the Reporting Persons as described in this Item 5.</listOfShareholders>
+<date5PercentOwnership>Not applicable.</date5PercentOwnership>
+</item5>
+<item6>
+<contractDescription>The information set forth in Item 3 and Item 4 of this Schedule 13D is incorporated by reference in its entirety into this Item 6. While no contractual right exists on the part of any of the Reporting Persons to appoint a director to the board of directors of the Issuer, on July 25, 2024, Mr. Kushner was appointed to the board of directors of the Issuer.</contractDescription>
+</item6>
+<item7>
+<filedExhibits>99.1        Joint Filing Agreement&#13;
+&#13;
+99.2        Purchase Agreement, dated July 22, 2024, by and among QXO, Inc., Affinity Partners Fund I LP and Affinity Partners Parallel Fund I LP. &#13;
+&#13;
+99.3        Purchase Agreement, dated March 17, 2025, by and between QXO, Inc. and Affinity QXO 1 LLC.</filedExhibits>
+</item7>
+</items1To7>
+<signatureInfo>
+<signaturePerson>
+<signatureReportingPerson>Affinity Partners Fund I LP</signatureReportingPerson>
+<signatureDetails>
+<signature>/s/ Ian Brekke</signature>
+<title>Ian Brekke / Authorized Signatory, Affinity Partners GP LP, its general partner</title>
+<date>05/06/2025</date>
+</signatureDetails>
+</signaturePerson>
+<signaturePerson>
+<signatureReportingPerson>Affinity Partners Parallel Fund I LP</signatureReportingPerson>
+<signatureDetails>
+<signature>/s/ Ian Brekke</signature>
+<title>Ian Brekke / Authorized Signatory, Affinity Partners GP LP, its general partner</title>
+<date>05/06/2025</date>
+</signatureDetails>
+</signaturePerson>
+<signaturePerson>
+<signatureReportingPerson>Affinity Partners GP LP</signatureReportingPerson>
+<signatureDetails>
+<signature>/s/ Ian Brekke</signature>
+<title>Ian Brekke / Authorized Signatory</title>
+<date>05/06/2025</date>
+</signatureDetails>
+</signaturePerson>
+<signaturePerson>
+<signatureReportingPerson>Affinity QXO 1 LLC</signatureReportingPerson>
+<signatureDetails>
+<signature>/s/ Ian Brekke</signature>
+<title>Ian Brekke / Secretary</title>
+<date>05/06/2025</date>
+</signatureDetails>
+</signaturePerson>
+<signaturePerson>
+<signatureReportingPerson>Affinity Partners???Fund I Co-Invest???GP LP</signatureReportingPerson>
+<signatureDetails>
+<signature>/s/ Ian Brekke</signature>
+<title>Ian Brekke / Authorized Signatory</title>
+<date>05/06/2025</date>
+</signatureDetails>
+</signaturePerson>
+<signaturePerson>
+<signatureReportingPerson>Jared Kushner</signatureReportingPerson>
+<signatureDetails>
+<signature>/s/ Jared Kushner</signature>
+<title>Jared Kushner</title>
+<date>05/06/2025</date>
+</signatureDetails>
+</signaturePerson>
+</signatureInfo>
+</formData>
+
+</edgarSubmission>

--- a/tests/Equibles.UnitTests/TestAssets/Holdings13DG/sc13da-adia.xml
+++ b/tests/Equibles.UnitTests/TestAssets/Holdings13DG/sc13da-adia.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?><edgarSubmission xmlns="http://www.sec.gov/edgar/schedule13D" xmlns:com="http://www.sec.gov/edgar/common">
+<headerData>
+<submissionType>SCHEDULE 13D/A</submissionType>
+<previousAccessionNumber>0001011438-24-000307</previousAccessionNumber>
+<filerInfo>
+<filer>
+<filerCredentials>
+<cik>0001362558</cik>
+<ccc>XXXXXXXX</ccc>
+</filerCredentials>
+</filer>
+<liveTestFlag>LIVE</liveTestFlag>
+
+
+
+</filerInfo>
+</headerData>
+<formData>
+<coverPageHeader>
+<amendmentNo>3</amendmentNo>
+<securitiesClassTitle>Common Shares of Beneficial Interest, par value $0.001 per share</securitiesClassTitle>
+<dateOfEvent>05/02/2025</dateOfEvent>
+<previouslyFiledFlag>false</previouslyFiledFlag>
+<issuerInfo>
+<issuerCIK>0001965934</issuerCIK>
+<issuerCUSIP>000000000</issuerCUSIP>
+<issuerName>Overland Advantage</issuerName>
+<address>
+<com:street1>375 Park Avenue, 11th Floor</com:street1>
+<com:city>New York</com:city>
+<com:stateOrCountry>NY</com:stateOrCountry>
+<com:zipCode>10152</com:zipCode>
+</address>
+</issuerInfo>
+<authorizedPersons>
+<notificationInfo>
+<personName>Turner Herbert</personName>
+<personPhoneNum>971 2 4150000</personPhoneNum>
+<personAddress>
+<com:street1>211 Corniche, PO Box 3600</com:street1>
+<com:city>Abu Dhabi</com:city>
+<com:stateOrCountry>C0</com:stateOrCountry>
+<com:zipCode>00000</com:zipCode>
+</personAddress>
+</notificationInfo>
+</authorizedPersons>
+</coverPageHeader>
+<reportingPersons>
+<reportingPersonInfo>
+<reportingPersonCIK>0001362558</reportingPersonCIK>
+<reportingPersonName>Abu Dhabi Investment Authority</reportingPersonName>
+<fundType>OO</fundType>
+<citizenshipOrOrganization>C0</citizenshipOrOrganization>
+<soleVotingPower>942779.94</soleVotingPower>
+<sharedVotingPower>0</sharedVotingPower>
+<soleDispositivePower>11615772.8</soleDispositivePower>
+<sharedDispositivePower>0</sharedDispositivePower>
+<aggregateAmountOwned>11615772.8</aggregateAmountOwned>
+<isAggregateExcludeShares>N</isAggregateExcludeShares>
+<percentOfClass>60.4</percentOfClass>
+<typeOfReportingPerson>OO</typeOfReportingPerson>
+<commentContent>Abu Dhabi Investment Authority (ADIA) is a public institution established in 1976 by the Government of the Emirate of Abu Dhabi (the Government) as an independent investment institution. ADIA is wholly owned and subject to constitutional supervision by the Government. ADIA has an independent legal identity with full capacity to act in fulfilling its statutory mandate and objectives.</commentContent>
+</reportingPersonInfo>
+<reportingPersonInfo>
+<reportingPersonCIK>0001790748</reportingPersonCIK>
+<reportingPersonName>Platinum International Investment Holdings RSC Limited</reportingPersonName>
+<fundType>OO</fundType>
+<citizenshipOrOrganization>C0</citizenshipOrOrganization>
+<soleVotingPower>942779.94</soleVotingPower>
+<sharedVotingPower>0</sharedVotingPower>
+<soleDispositivePower>11615772.8</soleDispositivePower>
+<sharedDispositivePower>0</sharedDispositivePower>
+<aggregateAmountOwned>11615772.8</aggregateAmountOwned>
+<isAggregateExcludeShares>N</isAggregateExcludeShares>
+<percentOfClass>60.4</percentOfClass>
+<typeOfReportingPerson>CO</typeOfReportingPerson>
+</reportingPersonInfo>
+<reportingPersonInfo>
+<reportingPersonCIK>0001790749</reportingPersonCIK>
+<reportingPersonName>Platinum Falcon B 2018 RSC Limited</reportingPersonName>
+<fundType>WC</fundType>
+<citizenshipOrOrganization>C0</citizenshipOrOrganization>
+<soleVotingPower>942779.94</soleVotingPower>
+<sharedVotingPower>0</sharedVotingPower>
+<soleDispositivePower>11615772.8</soleDispositivePower>
+<sharedDispositivePower>0</sharedDispositivePower>
+<aggregateAmountOwned>11615772.8</aggregateAmountOwned>
+<isAggregateExcludeShares>N</isAggregateExcludeShares>
+<percentOfClass>60.4</percentOfClass>
+<typeOfReportingPerson>CO</typeOfReportingPerson>
+</reportingPersonInfo>
+</reportingPersons>
+<items1To7>
+<item1>
+<securityTitle>Common Shares of Beneficial Interest, par value $0.001 per share</securityTitle>
+<issuerName>Overland Advantage</issuerName>
+<issuerPrincipalAddress>
+<com:street1>375 Park Avenue, 11th Floor</com:street1>
+<com:city>New York</com:city>
+<com:stateOrCountry>NY</com:stateOrCountry>
+<com:zipCode>10152</com:zipCode>
+</issuerPrincipalAddress>
+<commentText>The following constitutes Amendment No. 3 ("Amendment No. 3") to the Schedule 13D filed with the Securities and Exchange Commission ("SEC") by Abu Dhabi Investment Authority ("ADIA"), Platinum Investment Holdings RSC Limited ("Platinum Holdings") and Platinum Falcon B 2018 RSC Limited ("Platinum Falcon", and together with Platinum Holdings and ADIA, the "Reporting Persons") on April 30, 2024, as amended by Amendment No. 1 filed on October 31, 2024, and Amendment No. 2 filed on February 11, 2025. This Amendment No. 3 amends and supplements the Schedule 13D as specifically set forth herein.&#13;
+&#13;
+All capitalized terms contained herein but not otherwise defined shall have the meanings ascribed to such terms in the Schedule 13D, as amended. Information given in response to each item shall be deemed incorporated by reference in all other items, as applicable.</commentText>
+</item1>
+<item3>
+<fundsSource>Item 3 of this Schedule 13D is supplemented and superseded, as the case may be, as follows:&#13;
+&#13;
+The information in Item 4 is incorporated herein by reference. The Common Shares of the Issuer were purchased by Platinum Falcon with the working capital of Platinum Falcon.</fundsSource>
+</item3>
+<item4>
+<transactionPurpose>Item 4 of this Schedule 13D is supplemented and superseded, as the case may be, as follows:&#13;
+&#13;
+On March 17, 2025, the Issuer delivered a Drawdown Notice to Platinum Falcon to purchase Common Shares in an aggregate amount equal to $30,339,807 (the "Fourth Purchase Amount").  Platinum Falcon paid the Fourth Purchase Amount to the Issuer to purchase 1,226,521.435 Common Shares at a per share purchase price of $24.736467, with such number of shares and purchase price being determined by the Issuer on May 2, 2025.</transactionPurpose>
+</item4>
+<item5>
+<percentageOfClassSecurities>Each of ADIA, Platinum Holdings and Platinum Falcon may be deemed to beneficially own 11,615,772.799 Common Shares of the Issuer, which represents approximately 60.4% of the Common Shares outstanding, based on 19,240,406.894 Common Shares outstanding as of May 2, 2025, based on information received from the Issuer.  The Common Shares reported herein are directly held and beneficially owned by Platinum Falcon. Platinum Holdings, the sole owner of Platinum Falcon, may be deemed to beneficially own the Common Shares directly held by Platinum Falcon.  ADIA, the sole owner of Platinum Holdings, may be deemed the beneficial owner of the Common Shares directly held by Platinum Falcon.</percentageOfClassSecurities>
+<numberOfShares>Items 7 through 10 of each of the cover pages of this Schedule 13D are incorporated herein by reference.  Each of the Reporting Persons may be deemed to have sole voting power over 942,779.937806 Common Shares and sole dispositive power over 11,615,772.799 Common Shares.  The information in Item 4 regarding voting power over the Common Shares reported herein under the Voting Trust Agreement and the termination provisions of the Voting Trust Agreement are incorporated herein by reference.</numberOfShares>
+<transactionDesc>The information in Items 3 and 4 are incorporated herein by reference. Except as disclosed in this Schedule 13D, as amended, there have been no transactions by the Reporting Persons or the Scheduled Persons in the securities of the Issuer during the past sixty days.</transactionDesc>
+<listOfShareholders>The disclosure regarding the relationship between the Reporting Persons in Item 2(c) of this Schedule 13D is incorporated by reference herein.</listOfShareholders>
+<date5PercentOwnership>Not applicable.</date5PercentOwnership>
+</item5>
+<item6>
+<contractDescription>Item 6 of this Schedule 13D is supplemented and superseded, as the case may be, as follows:&#13;
+&#13;
+The information in Item 4 is incorporated herein by reference.</contractDescription>
+</item6>
+</items1To7>
+<signatureInfo>
+<signaturePerson>
+<signatureReportingPerson>Abu Dhabi Investment Authority</signatureReportingPerson>
+<signatureDetails>
+<signature>/s/ Hamad Shahwan AlDhaheri</signature>
+<title>Hamad Shahwan AlDhaheri/ Authorized Signatory</title>
+<date>05/06/2025</date>
+</signatureDetails>
+<signatureDetails>
+<signature>/s/ Saif Surour AlMashghouni</signature>
+<title>Saif Surour AlMashghouni/Authorized Signatory</title>
+<date>05/06/2025</date>
+</signatureDetails>
+</signaturePerson>
+<signaturePerson>
+<signatureReportingPerson>Platinum International Investment Holdings RSC Limited</signatureReportingPerson>
+<signatureDetails>
+<signature>/s/ Ahmed Salem Abdulla AlNeyadi</signature>
+<title>Ahmed Salem Abdulla AlNeyadi/Authorized Signatory</title>
+<date>05/06/2025</date>
+</signatureDetails>
+<signatureDetails>
+<signature>/s/ Mubarak Awad Qanazel AlAmeri</signature>
+<title>Mubarak Awad Qanazel AlAmeri/Authorized Signatory</title>
+<date>05/06/2025</date>
+</signatureDetails>
+</signaturePerson>
+<signaturePerson>
+<signatureReportingPerson>Platinum Falcon B 2018 RSC Limited</signatureReportingPerson>
+<signatureDetails>
+<signature>/s/ Ahmed Salem Abdulla AlNeyadi</signature>
+<title>Ahmed Salem Abdulla AlNeyadi/Authorized Signatory</title>
+<date>05/06/2025</date>
+</signatureDetails>
+<signatureDetails>
+<signature>/s/ Mubarak Awad Qanazel AlAmeri</signature>
+<title>Mubarak Awad Qanazel AlAmeri/Authorized Signatory</title>
+<date>05/06/2025</date>
+</signatureDetails>
+</signaturePerson>
+</signatureInfo>
+</formData>
+</edgarSubmission>

--- a/tests/Equibles.UnitTests/TestAssets/Holdings13DG/sc13g-citadel-spirit.xml
+++ b/tests/Equibles.UnitTests/TestAssets/Holdings13DG/sc13g-citadel-spirit.xml
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8"?><edgarSubmission xmlns="http://www.sec.gov/edgar/schedule13g" xmlns:com="http://www.sec.gov/edgar/common">
+  <headerData>
+    <submissionType>SCHEDULE 13G</submissionType>
+    <filerInfo>
+      <filer>
+        <filerCredentials>
+          <!-- Field: Pseudo-Tag; ID: Name; Data: CITADEL ADVISORS LLC -->
+          <cik>0001423053</cik>
+          <ccc>XXXXXXXX</ccc>
+        </filerCredentials>
+      </filer>
+      <liveTestFlag>LIVE</liveTestFlag>
+
+
+
+    </filerInfo>
+  </headerData>
+  <formData>
+    <coverPageHeader>
+      <securitiesClassTitle>Common Stock, par value $0.0001 per share (the "Shares")</securitiesClassTitle>
+      <eventDateRequiresFilingThisStatement>04/29/2025</eventDateRequiresFilingThisStatement>
+      <issuerInfo>
+        <issuerCik>0001498710</issuerCik>
+        <issuerName>Spirit Aviation Holdings, Inc.</issuerName>
+        <issuerCusip>84863V101</issuerCusip>
+        <issuerPrincipalExecutiveOfficeAddress>
+          <com:street1>1731 Radiant Drive</com:street1>
+          <com:city>Dania Beach</com:city>
+          <com:stateOrCountry>FL</com:stateOrCountry>
+          <com:zipCode>33004</com:zipCode>
+        </issuerPrincipalExecutiveOfficeAddress>
+      </issuerInfo>
+      <designateRulesPursuantThisScheduleFiled>
+        <designateRulePursuantThisScheduleFiled>Rule 13d-1(c)</designateRulePursuantThisScheduleFiled>
+      </designateRulesPursuantThisScheduleFiled>
+    </coverPageHeader>
+    <coverPageHeaderReportingPersonDetails>
+
+
+      <reportingPersonName>Citadel Advisors LLC</reportingPersonName>
+      <citizenshipOrOrganization>DE</citizenshipOrOrganization>
+      <reportingPersonBeneficiallyOwnedNumberOfShares>
+        <soleVotingPower>0.00</soleVotingPower>
+        <sharedVotingPower>1624818.00</sharedVotingPower>
+        <soleDispositivePower>0.00</soleDispositivePower>
+        <sharedDispositivePower>1624818.00</sharedDispositivePower>
+      </reportingPersonBeneficiallyOwnedNumberOfShares>
+      <reportingPersonBeneficiallyOwnedAggregateNumberOfShares>1624818.00</reportingPersonBeneficiallyOwnedAggregateNumberOfShares>
+      <aggregateAmountExcludesCertainSharesFlag>N</aggregateAmountExcludesCertainSharesFlag>
+      <classPercent>9.9</classPercent>
+      <typeOfReportingPerson>IA</typeOfReportingPerson>
+      <typeOfReportingPerson>HC</typeOfReportingPerson>
+      <typeOfReportingPerson>OO</typeOfReportingPerson>
+      <comments>The percentages reported in this Schedule 13G are based upon 16,412,900 Shares outstanding comprised of (i) 16,067,305 Shares outstanding as of April 29, 2025 (according to the issuer's Form 10-K/A as filed with the Securities and Exchange Commission on April 30, 2025), and (ii) 345,595 Shares issuable upon conversion of certain warrants held by affiliates of the reporting persons. The applicable warrants are subject to terms that limit exercise, if, after such exercise, the holder and its affiliates and any member of a Section 13(d) group with such holder and its affiliates would beneficially own more than 9.9% of the number of shares of common stock outstanding immediately after exercise. Except as described in the preceding sentence, all Shares for the holdings of the reporting persons reported in this Schedule 13G are as of the opening of the market on May 6, 2025.</comments>
+    </coverPageHeaderReportingPersonDetails>
+    <coverPageHeaderReportingPersonDetails>
+
+
+      <reportingPersonName>Citadel Advisors Holdings LP</reportingPersonName>
+      <citizenshipOrOrganization>DE</citizenshipOrOrganization>
+      <reportingPersonBeneficiallyOwnedNumberOfShares>
+        <soleVotingPower>0.00</soleVotingPower>
+        <sharedVotingPower>1624818.00</sharedVotingPower>
+        <soleDispositivePower>0.00</soleDispositivePower>
+        <sharedDispositivePower>1624818.00</sharedDispositivePower>
+      </reportingPersonBeneficiallyOwnedNumberOfShares>
+      <reportingPersonBeneficiallyOwnedAggregateNumberOfShares>1624818.00</reportingPersonBeneficiallyOwnedAggregateNumberOfShares>
+      <aggregateAmountExcludesCertainSharesFlag>N</aggregateAmountExcludesCertainSharesFlag>
+      <classPercent>9.9</classPercent>
+      <typeOfReportingPerson>HC</typeOfReportingPerson>
+      <typeOfReportingPerson>PN</typeOfReportingPerson>
+    </coverPageHeaderReportingPersonDetails>
+    <coverPageHeaderReportingPersonDetails>
+
+
+      <reportingPersonName>Citadel GP LLC</reportingPersonName>
+      <citizenshipOrOrganization>DE</citizenshipOrOrganization>
+      <reportingPersonBeneficiallyOwnedNumberOfShares>
+        <soleVotingPower>0.00</soleVotingPower>
+        <sharedVotingPower>1624818.00</sharedVotingPower>
+        <soleDispositivePower>0.00</soleDispositivePower>
+        <sharedDispositivePower>1624818.00</sharedDispositivePower>
+      </reportingPersonBeneficiallyOwnedNumberOfShares>
+      <reportingPersonBeneficiallyOwnedAggregateNumberOfShares>1624818.00</reportingPersonBeneficiallyOwnedAggregateNumberOfShares>
+      <aggregateAmountExcludesCertainSharesFlag>N</aggregateAmountExcludesCertainSharesFlag>
+      <classPercent>9.9</classPercent>
+      <typeOfReportingPerson>HC</typeOfReportingPerson>
+      <typeOfReportingPerson>OO</typeOfReportingPerson>
+    </coverPageHeaderReportingPersonDetails>
+    <coverPageHeaderReportingPersonDetails>
+
+
+      <reportingPersonName>Citadel Securities LLC</reportingPersonName>
+      <citizenshipOrOrganization>DE</citizenshipOrOrganization>
+      <reportingPersonBeneficiallyOwnedNumberOfShares>
+        <soleVotingPower>0.00</soleVotingPower>
+        <sharedVotingPower>59.00</sharedVotingPower>
+        <soleDispositivePower>0.00</soleDispositivePower>
+        <sharedDispositivePower>59.00</sharedDispositivePower>
+      </reportingPersonBeneficiallyOwnedNumberOfShares>
+      <reportingPersonBeneficiallyOwnedAggregateNumberOfShares>59.00</reportingPersonBeneficiallyOwnedAggregateNumberOfShares>
+      <aggregateAmountExcludesCertainSharesFlag>N</aggregateAmountExcludesCertainSharesFlag>
+      <classPercent>0.0</classPercent>
+      <typeOfReportingPerson>BD</typeOfReportingPerson>
+      <typeOfReportingPerson>OO</typeOfReportingPerson>
+    </coverPageHeaderReportingPersonDetails>
+    <coverPageHeaderReportingPersonDetails>
+
+
+      <reportingPersonName>Citadel Securities Group LP</reportingPersonName>
+      <citizenshipOrOrganization>DE</citizenshipOrOrganization>
+      <reportingPersonBeneficiallyOwnedNumberOfShares>
+        <soleVotingPower>0.00</soleVotingPower>
+        <sharedVotingPower>59.00</sharedVotingPower>
+        <soleDispositivePower>0.00</soleDispositivePower>
+        <sharedDispositivePower>59.00</sharedDispositivePower>
+      </reportingPersonBeneficiallyOwnedNumberOfShares>
+      <reportingPersonBeneficiallyOwnedAggregateNumberOfShares>59.00</reportingPersonBeneficiallyOwnedAggregateNumberOfShares>
+      <aggregateAmountExcludesCertainSharesFlag>N</aggregateAmountExcludesCertainSharesFlag>
+      <classPercent>0.0</classPercent>
+      <typeOfReportingPerson>HC</typeOfReportingPerson>
+      <typeOfReportingPerson>PN</typeOfReportingPerson>
+    </coverPageHeaderReportingPersonDetails>
+    <coverPageHeaderReportingPersonDetails>
+
+
+      <reportingPersonName>Citadel Securities GP LLC</reportingPersonName>
+      <citizenshipOrOrganization>DE</citizenshipOrOrganization>
+      <reportingPersonBeneficiallyOwnedNumberOfShares>
+        <soleVotingPower>0.00</soleVotingPower>
+        <sharedVotingPower>59.00</sharedVotingPower>
+        <soleDispositivePower>0.00</soleDispositivePower>
+        <sharedDispositivePower>59.00</sharedDispositivePower>
+      </reportingPersonBeneficiallyOwnedNumberOfShares>
+      <reportingPersonBeneficiallyOwnedAggregateNumberOfShares>59.00</reportingPersonBeneficiallyOwnedAggregateNumberOfShares>
+      <aggregateAmountExcludesCertainSharesFlag>N</aggregateAmountExcludesCertainSharesFlag>
+      <classPercent>0.0</classPercent>
+      <typeOfReportingPerson>HC</typeOfReportingPerson>
+      <typeOfReportingPerson>OO</typeOfReportingPerson>
+    </coverPageHeaderReportingPersonDetails>
+    <coverPageHeaderReportingPersonDetails>
+
+
+      <reportingPersonName>Kenneth Griffin</reportingPersonName>
+      <citizenshipOrOrganization>X1</citizenshipOrOrganization>
+      <reportingPersonBeneficiallyOwnedNumberOfShares>
+        <soleVotingPower>0.00</soleVotingPower>
+        <sharedVotingPower>1624877.00</sharedVotingPower>
+        <soleDispositivePower>0.00</soleDispositivePower>
+        <sharedDispositivePower>1624877.00</sharedDispositivePower>
+      </reportingPersonBeneficiallyOwnedNumberOfShares>
+      <reportingPersonBeneficiallyOwnedAggregateNumberOfShares>1624877.00</reportingPersonBeneficiallyOwnedAggregateNumberOfShares>
+      <aggregateAmountExcludesCertainSharesFlag>N</aggregateAmountExcludesCertainSharesFlag>
+      <classPercent>9.9</classPercent>
+      <typeOfReportingPerson>HC</typeOfReportingPerson>
+      <typeOfReportingPerson>IN</typeOfReportingPerson>
+    </coverPageHeaderReportingPersonDetails>
+    <items>
+      <item1>
+        <issuerName>Spirit Aviation Holdings, Inc.</issuerName>
+        <issuerPrincipalExecutiveOfficeAddress>1731 Radiant Drive, Dania Beach, FL 33004</issuerPrincipalExecutiveOfficeAddress>
+      </item1>
+      <item2>
+        <filingPersonName>This Schedule 13G is being jointly filed by Citadel Advisors LLC ("Citadel Advisors"), Citadel Advisors Holdings LP ("CAH"), Citadel GP LLC ("CGP"), Citadel Securities LLC ("Citadel Securities"), Citadel Securities Group LP ("CALC4"), Citadel Securities GP LLC ("CSGP") and Mr. Kenneth Griffin (collectively with Citadel Advisors, CAH, CGP, Citadel Securities, CALC4 and CSGP, the "Reporting Persons") with respect to the Shares of the above-named issuer owned by Citadel Multi-Asset Master Fund Ltd., a Cayman Islands company ("CMAM"), and Citadel Securities.  Such owned Shares may include other instruments exercisable for or convertible into Shares.
+
+Citadel Advisors is the portfolio manager for CMAM.  CAH is the sole member of Citadel Advisors.  CGP is the general partner of CAH.  CALC4 is the non-member manager of Citadel Securities.  CSGP is the general partner of CALC4.  Mr. Griffin is the President and Chief Executive Officer of CGP, and owns a controlling interest in CGP and CSGP.
+
+The filing of this statement shall not be construed as an admission that any of the Reporting Persons is the beneficial owner of any securities covered by the statement other than the securities actually owned by such person (if any).</filingPersonName>
+        <principalBusinessOfficeOrResidenceAddress>The address of each of CSGP, Citadel Securities and CALC4 is 830 Brickell Plaza, Miami, Florida 33131. The address of the other Reporting Persons is Southeast Financial Center, 200 S. Biscayne Blvd., Suite 3300, Miami, Florida 33131.</principalBusinessOfficeOrResidenceAddress>
+        <citizenship>Each of Citadel Advisors, CGP, Citadel Securities and CSGP is organized as a limited liability company under the laws of the State of Delaware. Each of CALC4 and CAH is organized as a limited partnership under the laws of the State of Delaware. Mr. Griffin is a U.S. citizen.</citizenship>
+      </item2>
+      <item3>
+        <notApplicableFlag>Y</notApplicableFlag>
+      </item3>
+      <item4>
+        <amountBeneficiallyOwned>1. Each of Citadel Advisors LLC, Citadel Advisors Holdings LP and Citadel GP LLC may be deemed to beneficially own 1,624,818 Shares.
+
+2. Citadel Securities LLC may be deemed to beneficially own 59 Shares.
+
+3. Each of Citadel Securities Group LP and Citadel Securities GP LLC may be deemed to beneficially own 59 Shares.
+
+4. Mr. Griffin may be deemed to beneficially own 1,624,877 Shares.</amountBeneficiallyOwned>
+        <classPercent>1. The number of Shares that each of Citadel Advisors LLC, Citadel Advisors Holdings LP and Citadel GP LLC may be deemed to beneficially own constitutes 9.9% of the Shares outstanding.
+
+2. The number of Shares that Citadel Securities LLC may be deemed to beneficially own constitutes 0.0% of the Shares outstanding.
+
+3. The number of Shares that each of Citadel Securities Group LP and Citadel Securities GP LLC may be deemed to beneficially own constitutes 0.0% of the Shares outstanding.
+
+4. The number of Shares that Mr. Griffin may be deemed to beneficially own constitutes 9.9% of the Shares outstanding.</classPercent>
+        <numberOfSharesPersonHas>
+          <solePowerOrDirectToVote>1. Each of Citadel Advisors LLC, Citadel Advisors Holdings LP and Citadel GP LLC: 0
+
+2. Citadel Securities LLC: 0
+
+3. Each of Citadel Securities Group LP and Citadel Securities GP LLC: 0
+
+4. Mr. Griffin: 0</solePowerOrDirectToVote>
+          <sharedPowerOrDirectToVote>1. Each of Citadel Advisors LLC, Citadel Advisors Holdings LP and Citadel GP LLC: 1,624,818
+
+2. Citadel Securities LLC: 59
+
+3. Each of Citadel Securities Group LP and Citadel Securities GP LLC: 59
+
+4. Mr. Griffin: 1,624,877</sharedPowerOrDirectToVote>
+          <solePowerOrDirectToDispose>1. Each of Citadel Advisors LLC, Citadel Advisors Holdings LP and Citadel GP LLC: 0
+
+2. Citadel Securities LLC: 0
+
+3. Each of Citadel Securities Group LP and Citadel Securities GP LLC: 0
+
+4. Mr. Griffin: 0</solePowerOrDirectToDispose>
+          <sharedPowerOrDirectToDispose>1. Each of Citadel Advisors LLC, Citadel Advisors Holdings LP and Citadel GP LLC: 1,624,818
+
+2. Citadel Securities LLC: 59
+
+3. Each of Citadel Securities Group LP and Citadel Securities GP LLC: 59
+
+4. Mr. Griffin: 1,624,877</sharedPowerOrDirectToDispose>
+        </numberOfSharesPersonHas>
+      </item4>
+      <item5>
+        <notApplicableFlag>Y</notApplicableFlag>
+      </item5>
+      <item6>
+        <notApplicableFlag>Y</notApplicableFlag>
+      </item6>
+      <item7>
+        <notApplicableFlag>Y</notApplicableFlag>
+      </item7>
+      <item8>
+        <notApplicableFlag>Y</notApplicableFlag>
+      </item8>
+      <item9>
+        <notApplicableFlag>Y</notApplicableFlag>
+      </item9>
+      <item10>
+        <notApplicableFlag>N</notApplicableFlag>
+        <certifications>By signing below I certify that, to the best of my knowledge and belief, the securities referred to above were not acquired and are not held for the purpose of or with the effect of changing or influencing the control of the issuer of the securities and were not acquired and are not held in connection with or as a participant in any transaction having that purpose or effect, other than activities solely in connection with a nomination under ?? 240.14a-11.</certifications>
+      </item10>
+    </items>
+    <exhibitInfo>Exhibit 99.1 - Joint Filing Agreement</exhibitInfo>
+    <signatureInformation>
+      <reportingPersonName>Citadel Advisors LLC</reportingPersonName>
+      <signatureDetails>
+        <signature>/s/ Seth Levy</signature>
+        <title>Seth Levy, Authorized Signatory</title>
+        <date>05/06/2025</date>
+      </signatureDetails>
+    </signatureInformation>
+    <signatureInformation>
+      <reportingPersonName>Citadel Advisors Holdings LP</reportingPersonName>
+      <signatureDetails>
+        <signature>/s/ Seth Levy</signature>
+        <title>Seth Levy, Authorized Signatory</title>
+        <date>05/06/2025</date>
+      </signatureDetails>
+    </signatureInformation>
+    <signatureInformation>
+      <reportingPersonName>Citadel GP LLC</reportingPersonName>
+      <signatureDetails>
+        <signature>/s/ Seth Levy</signature>
+        <title>Seth Levy, Authorized Signatory</title>
+        <date>05/06/2025</date>
+      </signatureDetails>
+    </signatureInformation>
+    <signatureInformation>
+      <reportingPersonName>Citadel Securities LLC</reportingPersonName>
+      <signatureDetails>
+        <signature>/s/ Guy Miller</signature>
+        <title>Guy Miller, Authorized Signatory</title>
+        <date>05/06/2025</date>
+      </signatureDetails>
+    </signatureInformation>
+    <signatureInformation>
+      <reportingPersonName>Citadel Securities Group LP</reportingPersonName>
+      <signatureDetails>
+        <signature>/s/ Guy Miller</signature>
+        <title>Guy Miller, Authorized Signatory</title>
+        <date>05/06/2025</date>
+      </signatureDetails>
+    </signatureInformation>
+    <signatureInformation>
+      <reportingPersonName>Citadel Securities GP LLC</reportingPersonName>
+      <signatureDetails>
+        <signature>/s/ Guy Miller</signature>
+        <title>Guy Miller, Authorized Signatory</title>
+        <date>05/06/2025</date>
+      </signatureDetails>
+    </signatureInformation>
+    <signatureInformation>
+      <reportingPersonName>Kenneth Griffin</reportingPersonName>
+      <signatureDetails>
+        <signature>/s/ Seth Levy</signature>
+        <title>Seth Levy, attorney-in-fact*</title>
+        <date>05/06/2025</date>
+      </signatureDetails>
+    </signatureInformation>
+    <signatureComments>* Seth Levy is signing on behalf of Kenneth Griffin as attorney-in-fact pursuant to a power of attorney previously filed with the Securities and Exchange Commission, and hereby incorporated by reference herein.  The power of attorney was filed as an attachment to a filing by Citadel Advisors LLC on Schedule 13G for Allakos Inc. on October 13, 2023.</signatureComments>
+  </formData>
+
+</edgarSubmission>


### PR DESCRIPTION
## Summary

- Second slice toward Schedule 13D/13G ingestion (#3564): a parser for the machine-readable XML that 13D/13G filings have used since 2024-12-18.
- 13D and 13G share a namespace family but use different element names. One parser reconciles both by looking up by local name and accepting the candidates from each form.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/Filing13DGXmlParser.cs` — parses `primary_doc.xml`: cover page (issuer CUSIP/name, event date, class title) and every reporting person (aggregate amount, percent of class, sole/shared voting and dispositive power). Tolerates 13D vs 13G element-name and structure differences (flat vs nested voting powers; decimal share amounts; `percentOfClass` vs `classPercent`).
- `src/Equibles.Holdings.HostedService/Models/Parsed13DGFiling.cs`, `Parsed13DGReportingPerson.cs` — parsed result models.
- `src/Equibles.Holdings.HostedService/Extensions/HoldingsFilingTypeExtensions.cs` — maps SEC form-type strings to `FilingType` (shared with the upcoming ingestion path) and detects amendments.
- `tests/Equibles.UnitTests/Holdings/*` + `TestAssets/Holdings13DG/*` — record-replay tests over real captured 13D (QXO), 13G (Citadel/Spirit) and 13D/A (ADIA) filings, asserting exact extracted values; plus the form-type map.

Refs #3564