### PR TITLE
feat(holdings): ingest Schedule 13D/13G filings from the EDGAR daily index

### DIFF
--- a/src/Equibles.Holdings.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Holdings.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class ServiceCollectionExtensions
 
         services.AddHostedService<HoldingsScraperWorker>();
         services.AddHostedService<Holdings13FRealtimeWorker>();
+        services.AddHostedService<Holdings13DGRealtimeWorker>();
         services.AddHostedService<AumSnapshotDrainWorker>();
         services.AddHostedService<AumSnapshotRebuildWorker>();
         services.AddHostedService<FundScoringWorker>();

--- a/src/Equibles.Holdings.HostedService/Holdings13DGRealtimeWorker.cs
+++ b/src/Equibles.Holdings.HostedService/Holdings13DGRealtimeWorker.cs
@@ -1,0 +1,152 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+namespace Equibles.Holdings.HostedService;
+
+/// <summary>
+/// Near-real-time Schedule 13D/13G ingestion worker. Sweeps EDGAR's daily index
+/// for newly accepted beneficial-ownership filings and feeds them through the
+/// shared holdings import pipeline. Unlike 13F there is no quarterly bulk data
+/// set to reconcile against, so this worker is the sole source — and coverage
+/// only goes back to 2024-12-18, when 13D/13G became machine-readable XML.
+/// </summary>
+public class Holdings13DGRealtimeWorker : BaseScraperWorker
+{
+    // Schedule 13D/13G became machine-readable XML on this date; earlier filings
+    // are unstructured HTML and out of scope, so the sweep never goes before it.
+    private static readonly DateOnly ScheduleXmlInception = new(2024, 12, 18);
+
+    // Once a watermark exists, still re-sweep this many recent days so late and
+    // amended filings (which carry a fresh accession) are always re-checked.
+    private const int TrailingReSweepDays = 14;
+
+    private const string WorkerStateName = "Holdings13DGRealtime";
+
+    private readonly IConfiguration _configuration;
+
+    protected override string WorkerName => "13D/13G real-time ingestion";
+    protected override TimeSpan SleepInterval => TimeSpan.FromHours(6);
+    protected override ErrorSource ErrorSource => ErrorSource.HoldingsScraper;
+
+    // Stagger behind the 13F real-time worker so the two don't hit SEC's rate
+    // limiter at the same instant on startup.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(2);
+
+    public Holdings13DGRealtimeWorker(
+        ILogger<Holdings13DGRealtimeWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IConfiguration configuration
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        _configuration = configuration;
+    }
+
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(
+            _configuration,
+            "13D/13G real-time ingestion",
+            treatWhitespaceAsAbsent: true
+        );
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var stateRepo = scope.ServiceProvider.GetRequiredService<RealtimeSweepStateRepository>();
+        var ingestionService =
+            scope.ServiceProvider.GetRequiredService<Realtime13DGIngestionService>();
+
+        var state = await stateRepo.GetByWorker(WorkerStateName).FirstOrDefaultAsync(stoppingToken);
+
+        var windowStart = ComputeWindowStart(today, state?.SweptThrough);
+        var lookbackDays = today.DayNumber - windowStart.DayNumber + 1;
+
+        Logger.LogInformation(
+            "13D/13G real-time ingestion sweeping {LookbackDays} days of EDGAR daily index (from {Start:yyyy-MM-dd})",
+            lookbackDays,
+            windowStart
+        );
+
+        var result = await ingestionService.IngestRecentFilings(
+            today,
+            lookbackDays,
+            ScheduleXmlInception,
+            stoppingToken
+        );
+
+        var newWatermark = ComputeNextWatermark(today, result.EarliestFailedDate);
+        await SaveWatermark(stateRepo, state, newWatermark);
+
+        Logger.LogInformation(
+            "13D/13G real-time ingestion cycle complete: {Count} filings processed, swept through {Watermark:yyyy-MM-dd}",
+            result.FilingsImported,
+            newWatermark
+        );
+
+        if (result.FilingsImported > 0)
+        {
+            var maintenance =
+                scope.ServiceProvider.GetRequiredService<HoldingsTableMaintenanceService>();
+            await maintenance.VacuumInstitutionalHoldings(stoppingToken);
+        }
+    }
+
+    /// <summary>
+    /// The first daily-index date to sweep. With no watermark (cold start) it
+    /// goes back to the XML-inception date — the full available 13D/13G history.
+    /// With a watermark it resumes from it, but never covers fewer than the
+    /// trailing re-sweep window, and never crosses below inception.
+    /// </summary>
+    internal static DateOnly ComputeWindowStart(DateOnly today, DateOnly? watermark)
+    {
+        if (!watermark.HasValue)
+            return ScheduleXmlInception;
+
+        var trailingStart = today.AddDays(-TrailingReSweepDays);
+        var start = watermark.Value < trailingStart ? watermark.Value : trailingStart;
+        return start < ScheduleXmlInception ? ScheduleXmlInception : start;
+    }
+
+    /// <summary>
+    /// The watermark to persist after a cycle: today when every day swept
+    /// cleanly, otherwise the day before the earliest failed day so it (and
+    /// everything skipped behind it) is re-swept next cycle.
+    /// </summary>
+    internal static DateOnly ComputeNextWatermark(DateOnly today, DateOnly? earliestFailedDate) =>
+        earliestFailedDate.HasValue ? earliestFailedDate.Value.AddDays(-1) : today;
+
+    private static async Task SaveWatermark(
+        RealtimeSweepStateRepository repo,
+        RealtimeSweepState existing,
+        DateOnly sweptThrough
+    )
+    {
+        if (existing == null)
+        {
+            repo.Add(
+                new RealtimeSweepState
+                {
+                    WorkerName = WorkerStateName,
+                    SweptThrough = sweptThrough,
+                    UpdatedAt = DateTime.UtcNow,
+                }
+            );
+        }
+        else
+        {
+            existing.SweptThrough = sweptThrough;
+            existing.UpdatedAt = DateTime.UtcNow;
+        }
+
+        await repo.SaveChanges();
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -8,6 +8,7 @@ using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Extensions;
 using Equibles.Holdings.HostedService.Models;
 using Equibles.Holdings.Repositories;
 using Equibles.Messaging.Contracts.Holdings;
@@ -154,11 +155,11 @@ public class HoldingsImportService
 
         if (submissions.Count == 0)
         {
-            _logger.LogInformation("No 13F-HR submissions found in data set");
+            _logger.LogInformation("No supported submissions found in data set");
             return false;
         }
 
-        _logger.LogInformation("Found {Count} 13F-HR submissions", submissions.Count);
+        _logger.LogInformation("Found {Count} submissions", submissions.Count);
         context.Submissions = submissions;
         return true;
     }
@@ -172,7 +173,9 @@ public class HoldingsImportService
         submission = null;
 
         var formType = GetValue(row, "SUBMISSIONTYPE");
-        if (formType is not ("13F-HR" or "13F-HR/A"))
+        // Accept every form the holdings pipeline ingests (13F-HR, and the
+        // beneficial-ownership Schedules 13D/13G), keyed off the shared map.
+        if (formType.ToHoldingsFilingType() is null)
             return false;
 
         var accession = GetValue(row, AccessionNumberColumn);
@@ -855,6 +858,17 @@ public class HoldingsImportService
         var otherManagerNumber = ParseNullableInt(GetValue(row, "OTHERMANAGER"));
         var discretion = ParseInvestmentDiscretion(GetValue(row, "INVESTMENTDISCRETION"));
 
+        // The filing type follows the submission's form (13F-HR vs Schedule
+        // 13D/13G); fall back to 13F if the submission is somehow missing. The
+        // percent-of-class column is only present on the 13D/13G archive — it is
+        // absent (null) for 13F INFOTABLE rows.
+        var filingType =
+            context.Submissions != null
+            && context.Submissions.TryGetValue(accession, out var submission)
+                ? submission.FormType.ToHoldingsFilingType() ?? FilingType.Form13F
+                : FilingType.Form13F;
+        var percentOfClass = ParseNullableDecimal(GetValue(row, "PERCENTOFCLASS"));
+
         var managerEntry = new HoldingManagerEntry
         {
             ManagerNumber = otherManagerNumber,
@@ -875,7 +889,8 @@ public class HoldingsImportService
             ShareType = shareType,
             OptionType = optionType,
             InvestmentDiscretion = discretion,
-            FilingType = FilingType.Form13F,
+            FilingType = filingType,
+            PercentOfClass = percentOfClass,
             VotingAuthSole = votingAuthSole,
             VotingAuthShared = votingAuthShared,
             VotingAuthNone = votingAuthNone,
@@ -928,6 +943,7 @@ public class HoldingsImportService
                         VotingAuthSole = incoming.VotingAuthSole,
                         VotingAuthShared = incoming.VotingAuthShared,
                         VotingAuthNone = incoming.VotingAuthNone,
+                        PercentOfClass = incoming.PercentOfClass,
                         TitleOfClass = incoming.TitleOfClass,
                         Cusip = incoming.Cusip,
                         IsAmendment = incoming.IsAmendment,

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsParsingHelper.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsParsingHelper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO.Compression;
 using Equibles.Holdings.Data.Models;
 using Equibles.Holdings.HostedService.Models;
@@ -85,6 +86,18 @@ internal static class HoldingsParsingHelper
     internal static int? ParseNullableInt(string value)
     {
         return int.TryParse(value, out var result) ? result : null;
+    }
+
+    internal static decimal? ParseNullableDecimal(string value)
+    {
+        return decimal.TryParse(
+            value,
+            NumberStyles.Number,
+            CultureInfo.InvariantCulture,
+            out var result
+        )
+            ? result
+            : null;
     }
 
     internal static string ResolveManagerName(

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13DGArchiveBuilder.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13DGArchiveBuilder.cs
@@ -1,0 +1,156 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using Equibles.Core.AutoWiring;
+using Equibles.Holdings.HostedService.Models;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Projects parsed Schedule 13D/13G filings into the same TSV layout the
+/// quarterly 13F data set uses, so beneficial-ownership filings flow through the
+/// identical <see cref="HoldingsImportService"/> pipeline (CUSIP/price
+/// resolution, holder upsert, amendment handling, upsert key) without
+/// duplicating any persistence logic.
+///
+/// A 13D/13G lists every member of a reporting group — funds, their general
+/// partner, the parent — each reporting overlapping stakes in the SAME issuer,
+/// so the amounts are NOT additive. We attribute one position per filing to the
+/// lead filer: the reporting person whose CIK matches the filer, else the
+/// person reporting the largest aggregate (the top of the ownership chain, i.e.
+/// the group's total beneficial ownership). The per-share value is left 0 — 13D/
+/// 13G never report a dollar value, so the import pipeline derives it from the
+/// share count and the period's closing price, exactly as it does for 13F.
+/// </summary>
+[Service]
+public class Realtime13DGArchiveBuilder
+{
+    public ZipArchive Build(IReadOnlyCollection<Parsed13DGFiling> filings)
+    {
+        var submission = new StringBuilder(
+            "SUBMISSIONTYPE\tACCESSION_NUMBER\tFILING_DATE\tPERIODOFREPORT\tCIK\n"
+        );
+        var coverPage = new StringBuilder(
+            "ACCESSION_NUMBER\tISAMENDMENT\tAMENDMENTTYPE\tFILINGMANAGER_NAME\tFILINGMANAGER_CITY\t"
+                + "FILINGMANAGER_STATEORCOUNTRY\tFORM13FFILENUMBER\tCRDNUMBER\t"
+                + "CONFIDENTIALTREATMENT\n"
+        );
+        // PERCENTOFCLASS is appended after the 13F columns; the 13F INFOTABLE has
+        // no such column, so HoldingsImportService reads it as null there.
+        var infoTable = new StringBuilder(
+            "ACCESSION_NUMBER\tCUSIP\tSSHPRNAMTTYPE\tPUTCALL\tVALUE\tSSHPRNAMT\tVOTING_AUTH_SOLE\t"
+                + "VOTING_AUTH_SHARED\tVOTING_AUTH_NONE\tTITLEOFCLASS\tOTHERMANAGER\t"
+                + "INVESTMENTDISCRETION\tPERCENTOFCLASS\n"
+        );
+        // 13D/13G carry no other-manager table; the file is still written (empty)
+        // because the import pipeline expects the same archive shape as 13F.
+        var otherManager = new StringBuilder("ACCESSION_NUMBER\tSEQUENCENUMBER\tNAME\n");
+
+        foreach (var filing in filings)
+        {
+            var person = SelectLeadPerson(filing);
+            if (person == null)
+                continue;
+
+            AppendRow(
+                submission,
+                Clean(filing.SubmissionType),
+                Clean(filing.AccessionNumber),
+                filing.FilingDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                filing.DateOfEvent.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                Clean(filing.FilerCik)
+            );
+
+            AppendRow(
+                coverPage,
+                Clean(filing.AccessionNumber),
+                filing.IsAmendment ? "Y" : "N",
+                string.Empty,
+                Clean(person.Name),
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                "N"
+            );
+
+            AppendRow(
+                infoTable,
+                Clean(filing.AccessionNumber),
+                Clean(filing.IssuerCusip),
+                "SH",
+                string.Empty,
+                0,
+                person.AggregateAmountOwned,
+                person.SoleVotingPower,
+                person.SharedVotingPower,
+                0,
+                Clean(filing.SecuritiesClassTitle),
+                string.Empty,
+                string.Empty,
+                person.PercentOfClass?.ToString(CultureInfo.InvariantCulture) ?? string.Empty
+            );
+        }
+
+        byte[] zipBytes;
+        using (var buffer = new MemoryStream())
+        {
+            using (var writer = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                WriteEntry(writer, "SUBMISSION.tsv", submission);
+                WriteEntry(writer, "COVERPAGE.tsv", coverPage);
+                WriteEntry(writer, "INFOTABLE.tsv", infoTable);
+                WriteEntry(writer, "OTHERMANAGER2.tsv", otherManager);
+            }
+            zipBytes = buffer.ToArray();
+        }
+
+        return new ZipArchive(new MemoryStream(zipBytes), ZipArchiveMode.Read);
+    }
+
+    /// <summary>
+    /// The reporting person whose position represents the filing: the one whose
+    /// CIK matches the lead filer, else the one reporting the largest aggregate
+    /// (the controlling/parent entity that beneficially owns the whole group's
+    /// stake). Null when the filing lists no reporting persons.
+    /// </summary>
+    internal static Parsed13DGReportingPerson SelectLeadPerson(Parsed13DGFiling filing)
+    {
+        if (filing.ReportingPersons.Count == 0)
+            return null;
+
+        var byFilerCik = filing.ReportingPersons.FirstOrDefault(p =>
+            !string.IsNullOrEmpty(p.Cik)
+            && !string.IsNullOrEmpty(filing.FilerCik)
+            && p.Cik == filing.FilerCik
+        );
+
+        return byFilerCik
+            ?? filing.ReportingPersons.OrderByDescending(p => p.AggregateAmountOwned).First();
+    }
+
+    private static void AppendRow(StringBuilder sb, params object[] fields)
+    {
+        sb.AppendJoin('\t', fields).Append('\n');
+    }
+
+    private static void WriteEntry(ZipArchive archive, string name, StringBuilder content)
+    {
+        var entry = archive.CreateEntry(name);
+        using var stream = entry.Open();
+        var bytes = Encoding.UTF8.GetBytes(content.ToString());
+        stream.Write(bytes, 0, bytes.Length);
+    }
+
+    /// <summary>
+    /// The TSV reader splits on tabs and newlines; any embedded in a free-text
+    /// field (names, titles) would corrupt the row. Replace them with spaces —
+    /// the import pipeline trims values anyway.
+    /// </summary>
+    private static string Clean(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+        return value.Replace('\t', ' ').Replace('\r', ' ').Replace('\n', ' ');
+    }
+}

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13DGIngestionService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13DGIngestionService.cs
@@ -1,0 +1,305 @@
+using System.Text;
+using Equibles.Core.AutoWiring;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.HostedService.Services;
+
+/// <summary>
+/// Near-real-time Schedule 13D/13G ingestion. Discovers freshly accepted
+/// beneficial-ownership filings from EDGAR's daily index, parses their XML
+/// <c>primary_doc.xml</c>, and feeds them through the existing bulk-dataset
+/// import pipeline. Unlike 13F there is no quarterly authoritative data set, so
+/// this is the sole source — coverage begins 2024-12-18 when the forms became
+/// machine-readable XML.
+/// </summary>
+[Service]
+public class Realtime13DGIngestionService
+{
+    // Daily-index form types: "SCHEDULE 13D", "SCHEDULE 13D/A", "SCHEDULE 13G",
+    // "SCHEDULE 13G/A" — all matched by these StartsWith prefixes.
+    private static readonly string[] ScheduleFormPrefixes = ["SCHEDULE 13D", "SCHEDULE 13G"];
+
+    private readonly ISecEdgarClient _edgarClient;
+    private readonly Filing13DGXmlParser _parser;
+    private readonly Realtime13DGArchiveBuilder _archiveBuilder;
+    private readonly HoldingsImportService _importService;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<Realtime13DGIngestionService> _logger;
+
+    public Realtime13DGIngestionService(
+        ISecEdgarClient edgarClient,
+        Filing13DGXmlParser parser,
+        Realtime13DGArchiveBuilder archiveBuilder,
+        HoldingsImportService importService,
+        IServiceScopeFactory scopeFactory,
+        ILogger<Realtime13DGIngestionService> logger
+    )
+    {
+        _edgarClient = edgarClient;
+        _parser = parser;
+        _archiveBuilder = archiveBuilder;
+        _importService = importService;
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Sweeps the last <paramref name="lookbackDays"/> days of the daily index
+    /// (inclusive of <paramref name="today"/>), ingesting every new 13D/13G
+    /// whose event date is on/after <paramref name="minReportDate"/>.
+    /// </summary>
+    public async Task<RealtimeIngestionResult> IngestRecentFilings(
+        DateOnly today,
+        int lookbackDays,
+        DateOnly minReportDate,
+        CancellationToken cancellationToken
+    )
+    {
+        var (entries, earliestFailedDate) = await DiscoverEntries(
+            today,
+            lookbackDays,
+            cancellationToken
+        );
+        if (entries.Count == 0)
+        {
+            _logger.LogInformation("No 13D/13G submissions found in daily index window");
+            return new RealtimeIngestionResult(0, earliestFailedDate);
+        }
+
+        var alreadyProcessed = await LoadProcessedAccessions(
+            entries.Select(e => e.AccessionNumber),
+            cancellationToken
+        );
+
+        // Sort chronologically so originals import before their amendments.
+        var sorted = entries
+            .OrderBy(e => e.DateFiled)
+            .ThenBy(e => e.AccessionNumber, StringComparer.Ordinal)
+            .ToList();
+
+        var totalImported = 0;
+        foreach (var entry in sorted)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (alreadyProcessed.Contains(entry.AccessionNumber))
+                continue;
+
+            var filing = await TryParseAndValidateEntry(entry, minReportDate, cancellationToken);
+            if (filing == null)
+                continue;
+
+            _logger.LogInformation(
+                "Importing {Form} {Accession} (CIK {Cik}, event {Event})",
+                filing.SubmissionType,
+                entry.AccessionNumber,
+                entry.Cik,
+                filing.DateOfEvent
+            );
+
+            using (var archive = _archiveBuilder.Build([filing]))
+            {
+                await _importService.ImportDataSet(archive, minReportDate, cancellationToken);
+            }
+
+            await RecordProcessed([entry.AccessionNumber], cancellationToken);
+            totalImported++;
+        }
+
+        _logger.LogInformation(
+            "13D/13G real-time ingestion cycle complete: {Count} filings imported",
+            totalImported
+        );
+
+        return new RealtimeIngestionResult(totalImported, earliestFailedDate);
+    }
+
+    private async Task<Parsed13DGFiling> TryParseAndValidateEntry(
+        EdgarDailyIndexEntry entry,
+        DateOnly minReportDate,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            var filing = await ParseFiling(entry, cancellationToken);
+            if (filing == null)
+                return null;
+
+            if (filing.DateOfEvent == DateOnly.MinValue)
+            {
+                _logger.LogWarning(
+                    "Skipping filing {Accession}: unparseable event date",
+                    entry.AccessionNumber
+                );
+                return null;
+            }
+
+            if (filing.DateOfEvent < minReportDate)
+                return null;
+
+            if (filing.ReportingPersons.Count == 0)
+            {
+                _logger.LogWarning(
+                    "Skipping filing {Accession}: no reporting persons",
+                    entry.AccessionNumber
+                );
+                return null;
+            }
+
+            return filing;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // One malformed filing must not abort the whole sweep.
+            _logger.LogError(
+                ex,
+                "Failed to ingest 13D/13G filing {Accession} (CIK {Cik}), continuing",
+                entry.AccessionNumber,
+                entry.Cik
+            );
+            return null;
+        }
+    }
+
+    private async Task<(
+        List<EdgarDailyIndexEntry> Entries,
+        DateOnly? EarliestFailedDate
+    )> DiscoverEntries(DateOnly today, int lookbackDays, CancellationToken cancellationToken)
+    {
+        var byAccession = new Dictionary<string, EdgarDailyIndexEntry>(
+            StringComparer.OrdinalIgnoreCase
+        );
+
+        DateOnly? earliestFailed = null;
+
+        for (var offset = 0; offset < lookbackDays; offset++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var date = today.AddDays(-offset);
+
+            List<EdgarDailyIndexEntry> indexEntries;
+            try
+            {
+                indexEntries = await _edgarClient.GetDailyIndexForForms(
+                    date,
+                    ScheduleFormPrefixes,
+                    cancellationToken
+                );
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to fetch the {Date:yyyy-MM-dd} daily index; skipping this day",
+                    date
+                );
+                earliestFailed = date;
+                continue;
+            }
+
+            foreach (var entry in indexEntries)
+            {
+                if (!string.IsNullOrEmpty(entry.AccessionNumber))
+                    byAccession[entry.AccessionNumber] = entry;
+            }
+        }
+
+        return (byAccession.Values.ToList(), earliestFailed);
+    }
+
+    private async Task<Parsed13DGFiling> ParseFiling(
+        EdgarDailyIndexEntry entry,
+        CancellationToken cancellationToken
+    )
+    {
+        var artifacts = await _edgarClient.GetFilingArtifactNames(
+            entry.Cik,
+            entry.AccessionNumber,
+            cancellationToken
+        );
+
+        var primaryDocName = artifacts.FirstOrDefault(a =>
+            a.Equals("primary_doc.xml", StringComparison.OrdinalIgnoreCase)
+        );
+        if (primaryDocName == null)
+        {
+            _logger.LogWarning(
+                "Filing {Accession} has no primary_doc.xml, skipping",
+                entry.AccessionNumber
+            );
+            return null;
+        }
+
+        var bytes = await _edgarClient.GetDocumentFileBytes(
+            entry.Cik,
+            entry.AccessionNumber,
+            primaryDocName,
+            cancellationToken
+        );
+        if (bytes.Length == 0)
+            return null;
+
+        return _parser.ParseFiling(
+            Encoding.UTF8.GetString(bytes),
+            entry.AccessionNumber,
+            entry.Cik,
+            entry.DateFiled
+        );
+    }
+
+    private async Task<HashSet<string>> LoadProcessedAccessions(
+        IEnumerable<string> accessionNumbers,
+        CancellationToken cancellationToken
+    )
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ProcessedFilingRepository>();
+        return await LoadProcessedSet(repo, accessionNumbers, cancellationToken);
+    }
+
+    private async Task RecordProcessed(
+        IReadOnlyCollection<string> accessionNumbers,
+        CancellationToken cancellationToken
+    )
+    {
+        if (accessionNumbers.Count == 0)
+            return;
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ProcessedFilingRepository>();
+
+        var existingSet = await LoadProcessedSet(repo, accessionNumbers, cancellationToken);
+
+        foreach (var accession in accessionNumbers)
+        {
+            if (existingSet.Add(accession))
+                repo.Add(new ProcessedFiling { AccessionNumber = accession });
+        }
+
+        await repo.SaveChanges();
+    }
+
+    private static async Task<HashSet<string>> LoadProcessedSet(
+        ProcessedFilingRepository repo,
+        IEnumerable<string> accessionNumbers,
+        CancellationToken cancellationToken
+    )
+    {
+        var processed = await repo.GetByAccessionNumbers(accessionNumbers.ToList())
+            .Select(p => p.AccessionNumber)
+            .ToListAsync(cancellationToken);
+
+        return new HashSet<string>(processed, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/Contracts/ISecEdgarClient.cs
@@ -53,6 +53,18 @@ public interface ISecEdgarClient
     );
 
     /// <summary>
+    /// Like <see cref="GetDailyIndex"/> but keeps every submission whose form
+    /// type starts with any of <paramref name="formPrefixes"/> (e.g.
+    /// "SCHEDULE 13D", "SCHEDULE 13G"), letting non-13F sweeps reuse the same
+    /// fetch, throttle handling and parsing.
+    /// </summary>
+    Task<List<EdgarDailyIndexEntry>> GetDailyIndexForForms(
+        DateOnly date,
+        IReadOnlyCollection<string> formPrefixes,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// Lists the artifact file names inside a single filing via its
     /// <c>index.json</c>. Used to locate <c>primary_doc.xml</c> and the
     /// information-table XML of a 13F-HR submission.

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -423,9 +423,37 @@ public class SecEdgarClient : ISecEdgarClient
         return await response.Content.ReadAsStreamAsync();
     }
 
+    // 13F-HR and 13F-HR/A both start with this; the default form set for the
+    // back-compatible GetDailyIndex.
+    private static readonly string[] ThirteenFFormPrefixes = ["13F-HR"];
+
     public async Task<List<EdgarDailyIndexEntry>> GetDailyIndex(
         DateOnly date,
         CancellationToken cancellationToken = default
+    )
+    {
+        var content = await FetchMasterIndexContent(date, cancellationToken);
+        return content == null ? [] : ParseMasterIndex(content, date);
+    }
+
+    public async Task<List<EdgarDailyIndexEntry>> GetDailyIndexForForms(
+        DateOnly date,
+        IReadOnlyCollection<string> formPrefixes,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var content = await FetchMasterIndexContent(date, cancellationToken);
+        return content == null ? [] : ParseMasterIndexForForms(content, date, formPrefixes);
+    }
+
+    /// <summary>
+    /// Fetches the raw pipe-delimited <c>master.idx</c> body for a day, or null
+    /// when SEC published no index for that date (weekend/holiday). Throws when
+    /// SEC is still throttling after retries so the caller holds its watermark.
+    /// </summary>
+    private async Task<string> FetchMasterIndexContent(
+        DateOnly date,
+        CancellationToken cancellationToken
     )
     {
         var quarter = (date.Month - 1) / 3 + 1;
@@ -453,7 +481,7 @@ public class SecEdgarClient : ISecEdgarClient
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
             _logger.LogInformation("No daily index published for {Date:yyyy-MM-dd}", date);
-            return [];
+            return null;
         }
 
         if (response.StatusCode == HttpStatusCode.Forbidden)
@@ -480,7 +508,7 @@ public class SecEdgarClient : ISecEdgarClient
                     "No daily index published for {Date:yyyy-MM-dd} (non-trading day)",
                     date
                 );
-                return [];
+                return null;
             }
 
             // Any other 403 is unrecognized: be conservative and treat it as a fetch
@@ -489,9 +517,7 @@ public class SecEdgarClient : ISecEdgarClient
         }
 
         response.EnsureSuccessStatusCode();
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
-
-        return ParseMasterIndex(content, date);
+        return await response.Content.ReadAsStringAsync(cancellationToken);
     }
 
     /// <summary>
@@ -515,9 +541,38 @@ public class SecEdgarClient : ISecEdgarClient
         return entries;
     }
 
+    /// <summary>
+    /// Like <see cref="ParseMasterIndex"/> but keeps rows whose form type starts
+    /// with any of <paramref name="formPrefixes"/> (e.g. "SCHEDULE 13D",
+    /// "SCHEDULE 13G"), so non-13F sweeps share the same parsing.
+    /// </summary>
+    private static List<EdgarDailyIndexEntry> ParseMasterIndexForForms(
+        string content,
+        DateOnly fallbackDate,
+        IReadOnlyCollection<string> formPrefixes
+    )
+    {
+        var entries = new List<EdgarDailyIndexEntry>();
+
+        foreach (var rawLine in content.Split('\n'))
+        {
+            if (TryParseMasterIndexLineForForms(rawLine, fallbackDate, formPrefixes, out var entry))
+                entries.Add(entry);
+        }
+
+        return entries;
+    }
+
     private static bool TryParseMasterIndexLine(
         string rawLine,
         DateOnly fallbackDate,
+        out EdgarDailyIndexEntry entry
+    ) => TryParseMasterIndexLineForForms(rawLine, fallbackDate, ThirteenFFormPrefixes, out entry);
+
+    private static bool TryParseMasterIndexLineForForms(
+        string rawLine,
+        DateOnly fallbackDate,
+        IReadOnlyCollection<string> formPrefixes,
         out EdgarDailyIndexEntry entry
     )
     {
@@ -537,7 +592,11 @@ public class SecEdgarClient : ISecEdgarClient
         var dateFiled = fields[3].Trim();
         var fileName = fields[4].Trim();
 
-        if (!formType.StartsWith("13F-HR", StringComparison.OrdinalIgnoreCase))
+        if (
+            !formPrefixes.Any(prefix =>
+                formType.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            )
+        )
             return false;
 
         // Header/preamble rows ("CIK", "Company Name", dashes) fail this.

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13DGIngestionTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13DGIngestionTests.cs
@@ -1,0 +1,244 @@
+using System.Globalization;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// End-to-end Schedule 13D ingestion: a daily-index entry is parsed from its XML
+/// primary_doc, projected into the shared import pipeline, and lands as an
+/// InstitutionalHolding attributed to the lead filer with the right FilingType,
+/// share count, voting power and percent of class.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class Realtime13DGIngestionTests : IAsyncLifetime
+{
+    private const string FilerCik = "2059583";
+    private const string IssuerCusip = "82846H405";
+
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+    private readonly CultureInfo _previousCulture;
+
+    public Realtime13DGIngestionTests(ParadeDbFixture fixture)
+    {
+        _fixture = fixture;
+        _previousCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        CultureInfo.CurrentCulture = _previousCulture;
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(EquiblesFinancialDbContext)).Returns(ctx);
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(InstitutionalHolderRepository))
+                    .Returns(new InstitutionalHolderRepository(ctx));
+                sp.GetService(typeof(InstitutionalHoldingRepository))
+                    .Returns(new InstitutionalHoldingRepository(ctx));
+                sp.GetService(typeof(ProcessedFilingRepository))
+                    .Returns(new ProcessedFilingRepository(ctx));
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+        return scopeFactory;
+    }
+
+    // A 13D where one reporting person (the GP) carries the filer's CIK, so it is
+    // the lead position; a second no-CIK person reports a smaller overlapping stake.
+    private static string PrimaryDoc() =>
+        """
+            <edgarSubmission xmlns="http://www.sec.gov/edgar/schedule13D" xmlns:com="http://www.sec.gov/edgar/common">
+              <headerData>
+                <submissionType>SCHEDULE 13D</submissionType>
+                <filerInfo><filer><filerCredentials><cik>0002059583</cik></filerCredentials></filer></filerInfo>
+              </headerData>
+              <formData>
+                <coverPageHeader>
+                  <securitiesClassTitle>Common Stock</securitiesClassTitle>
+                  <dateOfEvent>04/29/2025</dateOfEvent>
+                  <issuerInfo>
+                    <issuerCIK>0001236275</issuerCIK>
+                    <issuerCUSIP>82846H405</issuerCUSIP>
+                    <issuerName>QXO, Inc.</issuerName>
+                  </issuerInfo>
+                </coverPageHeader>
+                <reportingPersons>
+                  <reportingPersonInfo>
+                    <reportingPersonNoCIK>Y</reportingPersonNoCIK>
+                    <reportingPersonName>Affinity Partners Fund I LP</reportingPersonName>
+                    <soleVotingPower>0</soleVotingPower><sharedVotingPower>164310</sharedVotingPower>
+                    <soleDispositivePower>0</soleDispositivePower><sharedDispositivePower>164310</sharedDispositivePower>
+                    <aggregateAmountOwned>164310</aggregateAmountOwned>
+                    <percentOfClass>0.03</percentOfClass>
+                    <typeOfReportingPerson>PN</typeOfReportingPerson>
+                  </reportingPersonInfo>
+                  <reportingPersonInfo>
+                    <reportingPersonCIK>0002059583</reportingPersonCIK>
+                    <reportingPersonName>Affinity Partners GP LP</reportingPersonName>
+                    <soleVotingPower>0</soleVotingPower><sharedVotingPower>32671542</sharedVotingPower>
+                    <soleDispositivePower>0</soleDispositivePower><sharedDispositivePower>32671542</sharedDispositivePower>
+                    <aggregateAmountOwned>32671542</aggregateAmountOwned>
+                    <percentOfClass>6.3</percentOfClass>
+                    <typeOfReportingPerson>PN</typeOfReportingPerson>
+                  </reportingPersonInfo>
+                </reportingPersons>
+              </formData>
+            </edgarSubmission>
+            """;
+
+    private static EdgarDailyIndexEntry Entry() =>
+        new()
+        {
+            FormType = "SCHEDULE 13D",
+            CompanyName = "Affinity Partners GP LP",
+            Cik = FilerCik,
+            DateFiled = new DateOnly(2025, 5, 6),
+            AccessionNumber = "0001140361-25-017533",
+        };
+
+    [Fact]
+    public async Task IngestRecentFilings_Real13D_LandsLeadFilerPositionWithPercentOfClass()
+    {
+        using (var seed = FreshContext())
+        {
+            seed.Set<CommonStock>()
+                .Add(
+                    new CommonStock
+                    {
+                        Id = Guid.NewGuid(),
+                        Ticker = "QXO",
+                        Name = "QXO, Inc.",
+                        Cik = "0001236275",
+                        Cusip = IssuerCusip,
+                    }
+                );
+            await seed.SaveChangesAsync();
+        }
+
+        var edgar = Substitute.For<ISecEdgarClient>();
+        edgar
+            .GetDailyIndexForForms(
+                Arg.Any<DateOnly>(),
+                Arg.Any<IReadOnlyCollection<string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(ci => ci.ArgAt<DateOnly>(0) == new DateOnly(2025, 5, 6) ? [Entry()] : []);
+        edgar
+            .GetFilingArtifactNames(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(["primary_doc.xml"]);
+        edgar
+            .GetDocumentFileBytes(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Encoding.UTF8.GetBytes(PrimaryDoc()));
+
+        var scopeFactory = CreateScopeFactory();
+
+        var prices = Substitute.For<IStockPriceProvider>();
+        prices
+            .GetClosingPrices(
+                Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(ci =>
+            {
+                var dict = new Dictionary<(Guid, DateOnly), decimal>();
+                foreach (var (id, date) in ci.ArgAt<IEnumerable<(Guid, DateOnly)>>(0))
+                    dict[(id, date)] = 10m;
+                return Task.FromResult(dict);
+            });
+
+        var importService = new HoldingsImportService(
+            scopeFactory,
+            Substitute.For<ILogger<HoldingsImportService>>(),
+            Options.Create(new WorkerOptions()),
+            prices,
+            Substitute.For<MassTransit.IBus>()
+        );
+        var ingestion = new Realtime13DGIngestionService(
+            edgar,
+            new Filing13DGXmlParser(),
+            new Realtime13DGArchiveBuilder(),
+            importService,
+            scopeFactory,
+            Substitute.For<ILogger<Realtime13DGIngestionService>>()
+        );
+
+        var result = await ingestion.IngestRecentFilings(
+            today: new DateOnly(2025, 5, 6),
+            lookbackDays: 1,
+            minReportDate: new DateOnly(2024, 12, 18),
+            CancellationToken.None
+        );
+
+        result.FilingsImported.Should().Be(1);
+
+        using var verify = FreshContext();
+        var holdings = await verify
+            .Set<InstitutionalHolding>()
+            .Include(h => h.InstitutionalHolder)
+            .Where(h => h.Cusip == IssuerCusip)
+            .ToListAsync();
+
+        // One row, attributed to the lead filer (the GP that carries the filer CIK),
+        // not one row per overlapping reporting person.
+        holdings.Should().ContainSingle();
+        var holding = holdings[0];
+        holding.FilingType.Should().Be(FilingType.Schedule13D);
+        holding.Shares.Should().Be(32_671_542);
+        holding.PercentOfClass.Should().Be(6.3m);
+        holding.VotingAuthShared.Should().Be(32_671_542);
+        holding.IsAmendment.Should().BeFalse();
+        holding.ReportDate.Should().Be(new DateOnly(2025, 4, 29));
+        holding.InstitutionalHolder.Cik.Should().Be(FilerCik);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/Realtime13DGArchiveBuilderTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Realtime13DGArchiveBuilderTests.cs
@@ -1,0 +1,128 @@
+using System.IO.Compression;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+// Pins the 13D/13G -> TSV projection: a filing lists overlapping reporting
+// persons, and the builder must attribute ONE non-additive position to the
+// lead filer, carrying percent-of-class through the synthetic INFOTABLE column.
+public class Realtime13DGArchiveBuilderTests
+{
+    private static Parsed13DGReportingPerson Person(
+        string cik,
+        long aggregate,
+        decimal percent,
+        long soleVote = 0,
+        long sharedVote = 0
+    ) =>
+        new()
+        {
+            Cik = cik,
+            Name = cik == null ? "No-CIK Person" : $"Person {cik}",
+            AggregateAmountOwned = aggregate,
+            PercentOfClass = percent,
+            SoleVotingPower = soleVote,
+            SharedVotingPower = sharedVote,
+        };
+
+    [Fact]
+    public void SelectLeadPerson_FilerCikMatches_PrefersThatPersonOverLargerAggregate()
+    {
+        var filing = new Parsed13DGFiling
+        {
+            FilerCik = "2059583",
+            ReportingPersons = [Person(null, 99_999, 9.9m), Person("2059583", 32_671_542, 6.3m)],
+        };
+
+        var lead = Realtime13DGArchiveBuilder.SelectLeadPerson(filing);
+
+        lead.Cik.Should().Be("2059583");
+        lead.PercentOfClass.Should().Be(6.3m);
+    }
+
+    [Fact]
+    public void SelectLeadPerson_NoFilerCikMatch_FallsBackToLargestAggregate()
+    {
+        var filing = new Parsed13DGFiling
+        {
+            FilerCik = "1423053",
+            ReportingPersons =
+            [
+                Person(null, 1_000, 0.1m),
+                Person(null, 1_624_818, 9.9m),
+                Person(null, 59, 0.0m),
+            ],
+        };
+
+        var lead = Realtime13DGArchiveBuilder.SelectLeadPerson(filing);
+
+        lead.AggregateAmountOwned.Should().Be(1_624_818);
+        lead.PercentOfClass.Should().Be(9.9m);
+    }
+
+    [Fact]
+    public void SelectLeadPerson_NoReportingPersons_ReturnsNull()
+    {
+        var filing = new Parsed13DGFiling { FilerCik = "1", ReportingPersons = [] };
+
+        Realtime13DGArchiveBuilder.SelectLeadPerson(filing).Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_ProjectsLeadPositionIntoInfoTableWithPercentOfClass()
+    {
+        var filing = new Parsed13DGFiling
+        {
+            AccessionNumber = "0001140361-25-017533",
+            SubmissionType = "SCHEDULE 13D",
+            FilingType = FilingType.Schedule13D,
+            IsAmendment = false,
+            FilerCik = "2059583",
+            FilingDate = new DateOnly(2025, 5, 6),
+            DateOfEvent = new DateOnly(2025, 4, 29),
+            IssuerCusip = "82846H405",
+            SecuritiesClassTitle = "Common Stock",
+            ReportingPersons =
+            [
+                Person("2059583", 32_671_542, 6.3m, soleVote: 0, sharedVote: 32_671_542),
+            ],
+        };
+
+        using var archive = new Realtime13DGArchiveBuilder().Build([filing]);
+
+        var infoTable = ReadEntry(archive, "INFOTABLE.tsv");
+        var row = DataRow(infoTable);
+        var columns = SplitColumns(infoTable);
+
+        // CUSIP, shares (aggregate), shared voting, and percent-of-class land in
+        // their columns; value is 0 (price map derives it later).
+        row[Index(columns, "CUSIP")].Should().Be("82846H405");
+        row[Index(columns, "SSHPRNAMT")].Should().Be("32671542");
+        row[Index(columns, "VOTING_AUTH_SHARED")].Should().Be("32671542");
+        row[Index(columns, "VALUE")].Should().Be("0");
+        row[Index(columns, "PERCENTOFCLASS")].Should().Be("6.3");
+
+        var submission = ReadEntry(archive, "SUBMISSION.tsv");
+        var subColumns = SplitColumns(submission);
+        var subRow = DataRow(submission);
+        // The event date becomes the report period; the form type is preserved.
+        subRow[Index(subColumns, "PERIODOFREPORT")].Should().Be("2025-04-29");
+        subRow[Index(subColumns, "SUBMISSIONTYPE")].Should().Be("SCHEDULE 13D");
+    }
+
+    private static string ReadEntry(ZipArchive archive, string name)
+    {
+        using var reader = new StreamReader(archive.GetEntry(name)!.Open());
+        return reader.ReadToEnd();
+    }
+
+    private static string[] SplitColumns(string tsv) =>
+        tsv.Split('\n')[0].TrimEnd('\r').Split('\t');
+
+    private static string[] DataRow(string tsv) =>
+        tsv.Split('\n', StringSplitOptions.RemoveEmptyEntries)[1].TrimEnd('\r').Split('\t');
+
+    private static int Index(string[] columns, string name) => Array.IndexOf(columns, name);
+}


### PR DESCRIPTION
## Summary

- Third slice of #3564: a near-real-time worker that ingests Schedule 13D/13G beneficial-ownership filings from EDGAR's daily index and feeds them through the existing holdings import pipeline.
- No quarterly bulk data set exists for these forms and they only became machine-readable XML on 2024-12-18, so the worker's cold-start floor is that date.
- A 13D/13G lists overlapping reporting persons on one issuer; the position is attributed to the lead filer (CIK match, else the largest aggregate = the group total), one row per filing.

## Code changes

- `Equibles.Holdings.HostedService/Holdings13DGRealtimeWorker.cs` — sweeps the daily index (cold-start floor 2024-12-18, trailing re-sweep, watermark), staggered behind the 13F worker; registered in `AddHoldingsWorker`.
- `Equibles.Holdings.HostedService/Services/Realtime13DGIngestionService.cs` — discovers `SCHEDULE 13D`/`13G` entries, fetches + parses `primary_doc.xml`, imports; `ProcessedFiling` dedup.
- `Equibles.Holdings.HostedService/Services/Realtime13DGArchiveBuilder.cs` — projects a filing's lead position into the shared TSV layout with a new `PERCENTOFCLASS` column (absent/null for 13F).
- `Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — derive `FilingType` from the submission form (was hardcoded `Form13F`) and persist `PercentOfClass`; null-safe so the 13F path is unchanged.
- `Equibles.Integrations.Sec/SecEdgarClient.cs` + `ISecEdgarClient.cs` — add `GetDailyIndexForForms(date, formPrefixes)` sharing the existing fetch/throttle/parse; `GetDailyIndex` keeps its exact 13F-only behavior (routed through a shared parameterized core; the reflection-pinned `TryParseMasterIndexLine` signature is untouched).
- Tests — unit tests for lead-person selection + TSV projection; an end-to-end integration test (daily index → parse → import → `InstitutionalHolding` with `Schedule13D`, shares, percent-of-class, holder = filer CIK). The existing 13F import + realtime integration tests stay green.

Refs #3564