### PR TITLE
feat(web): filter institutional holders by SEC filing type

### DIFF
--- a/src/Equibles.Web/Controllers/InstitutionsController.cs
+++ b/src/Equibles.Web/Controllers/InstitutionsController.cs
@@ -43,6 +43,7 @@ public class InstitutionsController : BaseController
         long? maxValue,
         int? minPositions,
         int? maxPositions,
+        FilingType? filingType = null,
         InstitutionSort sort = InstitutionSort.Name,
         int page = 1
     )
@@ -53,10 +54,17 @@ public class InstitutionsController : BaseController
 
         const int pageSize = 50;
 
-        var latestReportDate = await _dbContext
-            .Set<InstitutionalHolding>()
-            .Select(h => (DateOnly?)h.ReportDate)
-            .MaxAsync();
+        // When a filing type is selected, every per-filer aggregate (latest
+        // report date, position count, book value) is computed from only that
+        // type's holdings, so the table reflects e.g. a filer's 13D book rather
+        // than its 13F book.
+        var holdingsBase = _dbContext.Set<InstitutionalHolding>().AsQueryable();
+        if (filingType.HasValue)
+        {
+            holdingsBase = holdingsBase.Where(h => h.FilingType == filingType.Value);
+        }
+
+        var latestReportDate = await holdingsBase.Select(h => (DateOnly?)h.ReportDate).MaxAsync();
 
         // Per-filer aggregate at each filer's OWN most-recent 13F report. The
         // universe-latest approach drops historical filers (e.g. Scion's 2022
@@ -64,13 +72,11 @@ public class InstitutionsController : BaseController
         // would mis-report active book sizes as zero. The two-stage shape (max
         // date per holder + join + group) translates to a single Postgres
         // query with a self-join.
-        var perFilerLatest = _dbContext
-            .Set<InstitutionalHolding>()
+        var perFilerLatest = holdingsBase
             .GroupBy(h => h.InstitutionalHolderId)
             .Select(g => new { HolderId = g.Key, LatestDate = g.Max(h => h.ReportDate) });
 
-        var aggByHolder = _dbContext
-            .Set<InstitutionalHolding>()
+        var aggByHolder = holdingsBase
             .Join(
                 perFilerLatest,
                 h => new { Holder = h.InstitutionalHolderId, Date = h.ReportDate },
@@ -110,6 +116,13 @@ public class InstitutionsController : BaseController
             a => a.HolderId,
             (h, aggs) => new { h, agg = aggs.FirstOrDefault() }
         );
+
+        // With a filing-type filter active, list only filers that actually filed
+        // that type — drop holders whose aggregate is null (no such holdings).
+        if (filingType.HasValue)
+        {
+            joined = joined.Where(x => x.agg != null);
+        }
 
         // AUM ($ value) and position-count range filters apply to each filer's
         // most-recent 13F aggregate. A filer with no holdings is treated as zero
@@ -201,6 +214,7 @@ public class InstitutionsController : BaseController
             MaxValue = maxValue,
             MinPositions = minPositions,
             MaxPositions = maxPositions,
+            FilingType = filingType,
             Sort = sort,
             LatestReportDate = latestReportDate,
             Page = page,

--- a/src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs
+++ b/src/Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs
@@ -1,3 +1,4 @@
+using Equibles.Holdings.Data.Models;
 using Equibles.Web.Extensions;
 
 namespace Equibles.Web.ViewModels.Institutions;
@@ -24,6 +25,10 @@ public class InstitutionBrowserViewModel
     public long? MaxValue { get; set; }
     public int? MinPositions { get; set; }
     public int? MaxPositions { get; set; }
+
+    // Active SEC filing-type filter (13F vs Schedule 13D/13G). Null means all
+    // types; when set, the listed filers and their aggregates are scoped to it.
+    public FilingType? FilingType { get; set; }
 
     // Latest universe-wide 13F report date — drives the per-filer aggregates
     // and the page subtitle. Null when no holdings have been ingested yet.

--- a/src/Equibles.Web/Views/Institutions/Index.cshtml
+++ b/src/Equibles.Web/Views/Institutions/Index.cshtml
@@ -1,3 +1,4 @@
+@using Equibles.Holdings.Data.Models
 @using Equibles.Web.ViewModels.Institutions
 @model InstitutionBrowserViewModel
 
@@ -27,6 +28,9 @@
     }
     if (Model.MaxPositions.HasValue) {
         filterRoute["maxPositions"] = Model.MaxPositions.Value.ToString();
+    }
+    if (Model.FilingType.HasValue) {
+        filterRoute["filingType"] = Model.FilingType.Value.ToString();
     }
     if (Model.Sort != InstitutionSort.Name) {
         filterRoute["sort"] = Model.Sort.ToString();
@@ -61,6 +65,15 @@
                     @foreach (var st in Model.States) {
                         <option value="@st" selected="@(st == Model.State)">@st</option>
                     }
+                </select>
+            </label>
+            <label class="form-control">
+                <span class="label-text text-sm mb-1">Filing type</span>
+                <select name="filingType" class="select select-bordered" aria-label="Filter institutions by SEC filing type">
+                    <option value="">All filing types</option>
+                    <option value="@FilingType.Form13F" selected="@(Model.FilingType == FilingType.Form13F)">Form 13F</option>
+                    <option value="@FilingType.Schedule13D" selected="@(Model.FilingType == FilingType.Schedule13D)">Schedule 13D</option>
+                    <option value="@FilingType.Schedule13G" selected="@(Model.FilingType == FilingType.Schedule13G)">Schedule 13G</option>
                 </select>
             </label>
             <label class="form-control">

--- a/tests/Equibles.IntegrationTests/Web/InstitutionsControllerFilingTypeFilterTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/InstitutionsControllerFilingTypeFilterTests.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the SEC filing-type filter on the /institutions index: selecting
+/// Schedule 13D narrows the listed filers to those that filed a 13D, and the
+/// filter control is rendered with all three types.
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class InstitutionsControllerFilingTypeFilterTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public InstitutionsControllerFilingTypeFilterTests(WebHostFixture fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    public async Task GetIndex_FilterBySchedule13D_ReturnsOnlyFilersThatFiledA13D()
+    {
+        var stockId = Guid.NewGuid();
+        var activistId = Guid.NewGuid();
+        var quantId = Guid.NewGuid();
+        var reportDate = new DateOnly(2025, 4, 29);
+
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "QXO",
+                    Name = "QXO, Inc.",
+                    Cik = "0001236275",
+                    Cusip = "82846H405",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = activistId,
+                    Cik = "0000001",
+                    Name = "Activist Capital",
+                }
+            );
+            db.Add(
+                new InstitutionalHolder
+                {
+                    Id = quantId,
+                    Cik = "0000002",
+                    Name = "Quant Fund",
+                }
+            );
+            db.Add(
+                new InstitutionalHolding
+                {
+                    InstitutionalHolderId = activistId,
+                    CommonStockId = stockId,
+                    FilingDate = reportDate,
+                    ReportDate = reportDate,
+                    Shares = 1_000_000,
+                    Value = 10_000_000,
+                    ShareType = ShareType.Shares,
+                    FilingType = FilingType.Schedule13D,
+                    PercentOfClass = 6.3m,
+                }
+            );
+            db.Add(
+                new InstitutionalHolding
+                {
+                    InstitutionalHolderId = quantId,
+                    CommonStockId = stockId,
+                    FilingDate = reportDate,
+                    ReportDate = reportDate,
+                    Shares = 500,
+                    Value = 5_000,
+                    ShareType = ShareType.Shares,
+                    FilingType = FilingType.Form13F,
+                }
+            );
+            await db.SaveChangesAsync();
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions?filingType=Schedule13D");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Activist Capital");
+        html.Should().NotContain("Quant Fund");
+    }
+
+    [Fact]
+    public async Task GetIndex_RendersFilingTypeFilterControl()
+    {
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(new InstitutionalHolder { Cik = "0000001", Name = "Some Fund" });
+            await db.SaveChangesAsync();
+        });
+
+        var response = await _fixture.Client.GetAsync("/institutions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("name=\"filingType\"");
+        html.Should().Contain(">Schedule 13D<");
+        html.Should().Contain(">Schedule 13G<");
+    }
+}


### PR DESCRIPTION
## Summary

- Final slice of #3564: a filing-type filter on the `/institutions` browse page (Form 13F / Schedule 13D / Schedule 13G).
- When a type is selected, each filer's aggregates (latest report date, position count, book value) are computed from only that type's holdings, and the list is narrowed to filers that actually filed it.

## Code changes

- `Equibles.Web/Controllers/InstitutionsController.cs` — bind an optional `FilingType? filingType`; scope the per-filer holdings base query to it and drop filers with no holdings of that type.
- `Equibles.Web/ViewModels/Institutions/InstitutionBrowserViewModel.cs` — carry the active filing type.
- `Equibles.Web/Views/Institutions/Index.cshtml` — filing-type `<select>` (plain query-param, matching the existing filters); carried in the pagination route.
- `tests/Equibles.IntegrationTests/Web/InstitutionsControllerFilingTypeFilterTests.cs` — the filter narrows to 13D filers; the control renders. Existing Institutions tests stay green.

Closes #3564