### PR TITLE
feat(finra): add OffExchangeVolume weekly entity, repository and migration

### DIFF
--- a/src/Equibles.Finra.Data/FinraModuleConfiguration.cs
+++ b/src/Equibles.Finra.Data/FinraModuleConfiguration.cs
@@ -8,6 +8,7 @@ public class FinraModuleConfiguration : Equibles.Data.IFinancialModule
     public void ConfigureEntities(ModelBuilder builder)
     {
         builder.Entity<DailyShortVolume>();
+        builder.Entity<OffExchangeVolume>();
         builder.Entity<ShortInterest>();
     }
 }

--- a/src/Equibles.Finra.Data/Models/OffExchangeVolume.cs
+++ b/src/Equibles.Finra.Data/Models/OffExchangeVolume.cs
@@ -1,0 +1,27 @@
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Finra.Data.Models;
+
+[Index(nameof(CommonStockId), nameof(WeekStartDate), IsUnique = true)]
+[Index(nameof(WeekStartDate))]
+public class OffExchangeVolume
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    public DateOnly WeekStartDate { get; set; }
+
+    public long AtsVolume { get; set; }
+    public long AtsTradeCount { get; set; }
+    public long NonAtsOtcVolume { get; set; }
+    public long NonAtsOtcTradeCount { get; set; }
+
+    // The off-exchange share of consolidated volume is computed at read time:
+    // the FINRA OTC/ATS Transparency file does not include consolidated tape
+    // volume, so that ratio is not stored on this record.
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Finra.Repositories/OffExchangeVolumeRepository.cs
+++ b/src/Equibles.Finra.Repositories/OffExchangeVolumeRepository.cs
@@ -1,0 +1,32 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Data.Extensions;
+using Equibles.Finra.Data.Models;
+
+namespace Equibles.Finra.Repositories;
+
+public class OffExchangeVolumeRepository : BaseRepository<OffExchangeVolume>
+{
+    public OffExchangeVolumeRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<OffExchangeVolume> GetByStock(CommonStock stock, DateOnly weekStartDate)
+    {
+        return GetAll().Where(d => d.CommonStockId == stock.Id && d.WeekStartDate == weekStartDate);
+    }
+
+    public IQueryable<OffExchangeVolume> GetHistoryByStock(CommonStock stock)
+    {
+        return GetAll().Where(d => d.CommonStockId == stock.Id);
+    }
+
+    public IQueryable<DateOnly> GetLatestWeek()
+    {
+        return GetAll().LatestValue(d => d.WeekStartDate, distinct: true);
+    }
+
+    public IQueryable<OffExchangeVolume> GetByWeek(DateOnly weekStartDate)
+    {
+        return GetAll().Where(d => d.WeekStartDate == weekStartDate);
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260609005652_AddOffExchangeVolume.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260609005652_AddOffExchangeVolume.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609005652_AddOffExchangeVolume")]
+    partial class AddOffExchangeVolume
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260609005652_AddOffExchangeVolume.cs
+++ b/src/Equibles.Migrations/Migrations/20260609005652_AddOffExchangeVolume.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOffExchangeVolume : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OffExchangeVolume",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    WeekStartDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    AtsVolume = table.Column<long>(type: "bigint", nullable: false),
+                    AtsTradeCount = table.Column<long>(type: "bigint", nullable: false),
+                    NonAtsOtcVolume = table.Column<long>(type: "bigint", nullable: false),
+                    NonAtsOtcTradeCount = table.Column<long>(type: "bigint", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OffExchangeVolume", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OffExchangeVolume_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OffExchangeVolume_CommonStockId_WeekStartDate",
+                table: "OffExchangeVolume",
+                columns: new[] { "CommonStockId", "WeekStartDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OffExchangeVolume_WeekStartDate",
+                table: "OffExchangeVolume",
+                column: "WeekStartDate");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OffExchangeVolume");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the data foundation for **off-exchange (dark-pool / ATS) volume per security**, sourced from FINRA's OTC/ATS Transparency weekly dataset. This is the data layer only — no scraper and no MCP tools (those land in later slices).

`OffExchangeVolume` records, per `CommonStock` and per reporting week, the shares and trade counts executed on:
- **ATS (dark-pool)** venues — `AtsVolume`, `AtsTradeCount`
- **non-ATS OTC** venues — `NonAtsOtcVolume`, `NonAtsOtcTradeCount`

The off-exchange share of consolidated volume is computed at read time, since the FINRA OTC file does not include consolidated tape volume — so that ratio is not stored on the record.

The layout mirrors the existing `DailyShortVolume` short-volume entity exactly: real FK navigation to `CommonStock`, a unique `(CommonStockId, WeekStartDate)` index plus a `WeekStartDate` index, and a thin query-only repository.

## Code changes

- **`OffExchangeVolume`** entity (`Equibles.Finra.Data/Models`): weekly FINRA OTC/ATS transparency record with the two `[Index]` attributes.
- **`FinraModuleConfiguration`**: register `OffExchangeVolume` in `ConfigureEntities`.
- **`OffExchangeVolumeRepository`** (`Equibles.Finra.Repositories`): `GetByStock`, `GetHistoryByStock`, `GetLatestWeek` (via `LatestValue(distinct: true)`), `GetByWeek`.
- **`AddOffExchangeVolume`** migration: creates the `OffExchangeVolume` table, the FK to `CommonStock`, and both indexes. No custom SQL.

Release build green; Finra unit tests green (23 passed).