### PR TITLE
feat(finra): scrape FINRA OTC/ATS Transparency weekly off-exchange volume

### DIFF
--- a/src/Equibles.Finra.HostedService/FinraScraperWorker.cs
+++ b/src/Equibles.Finra.HostedService/FinraScraperWorker.cs
@@ -54,5 +54,13 @@ public class FinraScraperWorker : BaseScraperWorker
                 scope.ServiceProvider.GetRequiredService<ShortInterestImportService>();
             await shortInterestService.Import(stoppingToken);
         }
+
+        Logger.LogInformation("Starting off-exchange volume import");
+        await using (var scope = ScopeFactory.CreateAsyncScope())
+        {
+            var offExchangeService =
+                scope.ServiceProvider.GetRequiredService<OffExchangeVolumeImportService>();
+            await offExchangeService.Import(stoppingToken);
+        }
     }
 }

--- a/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
@@ -1,0 +1,254 @@
+using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.Core.AutoWiring;
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Repositories;
+using Equibles.Integrations.Finra.Contracts;
+using Equibles.Integrations.Finra.Models;
+using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Finra.HostedService.Services;
+
+[Service]
+public class OffExchangeVolumeImportService
+{
+    // FINRA summaryTypeCode values for the per-symbol weekly aggregates.
+    private const string AtsSummaryTypeCode = "ATS_W_SMBL";
+    private const string NonAtsOtcSummaryTypeCode = "OTC_W_SMBL";
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<OffExchangeVolumeImportService> _logger;
+    private readonly IFinraClient _finraClient;
+    private readonly TickerMapService _tickerMapService;
+    private readonly ErrorReporter _errorReporter;
+    private readonly WorkerOptions _workerOptions;
+
+    public OffExchangeVolumeImportService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<OffExchangeVolumeImportService> logger,
+        IFinraClient finraClient,
+        TickerMapService tickerMapService,
+        ErrorReporter errorReporter,
+        IOptions<WorkerOptions> workerOptions
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _finraClient = finraClient;
+        _tickerMapService = tickerMapService;
+        _errorReporter = errorReporter;
+        _workerOptions = workerOptions.Value;
+    }
+
+    public async Task Import(CancellationToken cancellationToken)
+    {
+        var startDate = await SyncStartDate.Resolve<OffExchangeVolumeRepository>(
+            _scopeFactory,
+            _workerOptions,
+            repo => repo.GetLatestWeek(),
+            cancellationToken
+        );
+
+        // FINRA partitions the OTC/ATS Transparency feed by the Monday that starts
+        // each reporting week, so iterate Monday-by-Monday rather than day-by-day.
+        var startWeek = ToWeekStart(startDate);
+        var endWeek = ToWeekStart(DateOnly.FromDateTime(DateTime.UtcNow));
+
+        if (startWeek > endWeek)
+        {
+            _logger.LogInformation(
+                "Off-exchange volume data is up to date (latest week: {Week})",
+                startWeek.AddDays(-7)
+            );
+            return;
+        }
+
+        _logger.LogInformation(
+            "Importing off-exchange volume from week {Start} to week {End}",
+            startWeek,
+            endWeek
+        );
+
+        var tickerMap = await _tickerMapService.Build(
+            _workerOptions.TickersToSync,
+            cancellationToken
+        );
+
+        var currentWeek = startWeek;
+        while (currentWeek <= endWeek)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await ImportWeek(currentWeek, tickerMap, cancellationToken);
+            currentWeek = currentWeek.AddDays(7);
+        }
+    }
+
+    private async Task ImportWeek(
+        DateOnly weekStartDate,
+        IReadOnlyDictionary<string, Guid> tickerMap,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            var records = await _finraClient.GetWeeklyOffExchangeVolume(weekStartDate);
+
+            if (records.Count == 0)
+            {
+                _logger.LogDebug(
+                    "No off-exchange volume data for week {Week}, skipping",
+                    weekStartDate
+                );
+                return;
+            }
+
+            var merged = MergeRecordsByStock(records, tickerMap, weekStartDate);
+
+            await UpsertWeek(merged.Values, weekStartDate, cancellationToken);
+
+            _logger.LogInformation(
+                "Imported {Count} off-exchange volume records for week {Week}",
+                merged.Count,
+                weekStartDate
+            );
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to fetch off-exchange volume for week {Week}, skipping",
+                weekStartDate
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Error importing off-exchange volume for week {Week}",
+                weekStartDate
+            );
+            await _errorReporter.Report(
+                ErrorSource.FinraScraper,
+                "OffExchangeVolume.ImportWeek",
+                ex.Message,
+                ex.StackTrace,
+                $"week: {weekStartDate}"
+            );
+        }
+    }
+
+    // Idempotent upsert: update the existing row for each (CommonStockId, WeekStartDate),
+    // otherwise insert. Re-runs of the same week overwrite rather than duplicate, so a
+    // resumed or rescheduled scrape never produces two rows for the same stock and week.
+    private async Task UpsertWeek(
+        IEnumerable<OffExchangeVolume> volumes,
+        DateOnly weekStartDate,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var repo = scope.ServiceProvider.GetRequiredService<OffExchangeVolumeRepository>();
+
+        var batch = volumes.ToList();
+        var validBatch = await stockRepo.FilterByExistingStocks(
+            batch,
+            b => b.CommonStockId,
+            cancellationToken
+        );
+        var dropped = batch.Count - validBatch.Count;
+        if (dropped > 0)
+        {
+            _logger.LogWarning(
+                "Dropped {Dropped} off-exchange volume rows for week {Week} referencing CommonStockIds no longer in the database",
+                dropped,
+                weekStartDate
+            );
+        }
+
+        if (validBatch.Count == 0)
+            return;
+
+        var existing = await repo.GetByWeek(weekStartDate)
+            .ToDictionaryAsync(v => v.CommonStockId, cancellationToken);
+
+        foreach (var volume in validBatch)
+        {
+            if (existing.TryGetValue(volume.CommonStockId, out var current))
+            {
+                current.AtsVolume = volume.AtsVolume;
+                current.AtsTradeCount = volume.AtsTradeCount;
+                current.NonAtsOtcVolume = volume.NonAtsOtcVolume;
+                current.NonAtsOtcTradeCount = volume.NonAtsOtcTradeCount;
+            }
+            else
+            {
+                repo.Add(volume);
+            }
+        }
+
+        await repo.SaveChanges();
+    }
+
+    // Merge FINRA's two per-symbol weekly aggregate rows into one OffExchangeVolume per
+    // (CommonStockId, week): the ATS_W_SMBL row supplies Ats* and the OTC_W_SMBL row
+    // supplies NonAtsOtc*. A symbol with only one of the two rows keeps the other pair at
+    // zero. Symbols absent from the tickerMap (untracked) and blank symbols are skipped.
+    private static Dictionary<Guid, OffExchangeVolume> MergeRecordsByStock(
+        List<OffExchangeWeeklyRecord> records,
+        IReadOnlyDictionary<string, Guid> tickerMap,
+        DateOnly weekStartDate
+    )
+    {
+        var merged = new Dictionary<Guid, OffExchangeVolume>();
+
+        foreach (var record in records)
+        {
+            if (
+                string.IsNullOrEmpty(record.Symbol)
+                || !tickerMap.TryGetValue(record.Symbol, out var commonStockId)
+            )
+            {
+                continue;
+            }
+
+            if (!merged.TryGetValue(commonStockId, out var volume))
+            {
+                volume = new OffExchangeVolume
+                {
+                    CommonStockId = commonStockId,
+                    WeekStartDate = weekStartDate,
+                };
+                merged[commonStockId] = volume;
+            }
+
+            var shares = record.TotalWeeklyShareQuantity ?? 0;
+            var trades = record.TotalWeeklyTradeCount ?? 0;
+
+            if (record.SummaryTypeCode == AtsSummaryTypeCode)
+            {
+                volume.AtsVolume += shares;
+                volume.AtsTradeCount += trades;
+            }
+            else if (record.SummaryTypeCode == NonAtsOtcSummaryTypeCode)
+            {
+                volume.NonAtsOtcVolume += shares;
+                volume.NonAtsOtcTradeCount += trades;
+            }
+        }
+
+        return merged;
+    }
+
+    // Normalize any date to the Monday that starts its FINRA reporting week.
+    private static DateOnly ToWeekStart(DateOnly date)
+    {
+        var offset = ((int)date.DayOfWeek + 6) % 7;
+        return date.AddDays(-offset);
+    }
+}

--- a/src/Equibles.Integrations.Finra/Contracts/IFinraClient.cs
+++ b/src/Equibles.Integrations.Finra/Contracts/IFinraClient.cs
@@ -13,4 +13,5 @@ public interface IFinraClient
     );
     Task<List<DateOnly>> GetShortInterestSettlementDates();
     Task<List<DateOnly>> GetShortInterestSettlementDatesAfter(DateOnly afterDate);
+    Task<List<OffExchangeWeeklyRecord>> GetWeeklyOffExchangeVolume(DateOnly weekStartDate);
 }

--- a/src/Equibles.Integrations.Finra/FinraClient.cs
+++ b/src/Equibles.Integrations.Finra/FinraClient.cs
@@ -30,6 +30,19 @@ public class FinraClient : IFinraClient
     // FINRA API dataset group for OTC market data (short volume and short interest).
     private const string OtcMarketGroup = "OTCMarket";
 
+    // FINRA API dataset group for the OTC/ATS Transparency weekly summary feed.
+    // Note this is distinct from OtcMarketGroup ("OTCMarket"): the weekly dataset
+    // lives under the lower-cased "otcMarket" group.
+    private const string OtcMarketWeeklyGroup = "otcMarket";
+
+    // FINRA weekly OTC/ATS Transparency dataset field name; the Monday partition key.
+    private const string WeekStartDateField = "weekStartDate";
+
+    // summaryTypeCode values for per-security weekly aggregates:
+    //   ATS_W_SMBL → ATS (dark-pool) volume aggregated by symbol
+    //   OTC_W_SMBL → non-ATS OTC volume aggregated by symbol
+    private static readonly string[] OffExchangeSummaryTypeCodes = ["ATS_W_SMBL", "OTC_W_SMBL"];
+
     private static readonly string[] ShortInterestFields =
     [
         SettlementDateField,
@@ -222,6 +235,55 @@ public class FinraClient : IFinraClient
             afterDate
         );
         return dates.OrderBy(d => d).ToList();
+    }
+
+    public async Task<List<OffExchangeWeeklyRecord>> GetWeeklyOffExchangeVolume(
+        DateOnly weekStartDate
+    )
+    {
+        var dateStr = FormatDate(weekStartDate);
+        _logger.LogDebug("Fetching weekly off-exchange volume for week starting {Date}", dateStr);
+
+        var results = new List<OffExchangeWeeklyRecord>();
+        await PaginateQuery<OffExchangeWeeklyRecord>(
+            OtcMarketWeeklyGroup,
+            "weeklySummary",
+            offset => new
+            {
+                fields = new[]
+                {
+                    "issueSymbolIdentifier",
+                    WeekStartDateField,
+                    "totalWeeklyShareQuantity",
+                    "totalWeeklyTradeCount",
+                    "tierIdentifier",
+                    "summaryTypeCode",
+                },
+                dateRangeFilters = new[]
+                {
+                    new
+                    {
+                        fieldName = WeekStartDateField,
+                        startDate = dateStr,
+                        endDate = dateStr,
+                    },
+                },
+                domainFilters = new[]
+                {
+                    new { fieldName = "summaryTypeCode", values = OffExchangeSummaryTypeCodes },
+                },
+                limit = MaxPageSize,
+                offset,
+            },
+            results.AddRange
+        );
+
+        _logger.LogDebug(
+            "Fetched {Count} weekly off-exchange volume records for week starting {Date}",
+            results.Count,
+            dateStr
+        );
+        return results;
     }
 
     private async Task<HashSet<DateOnly>> CollectSettlementDates(Func<int, object> buildQuery)

--- a/src/Equibles.Integrations.Finra/Models/OffExchangeWeeklyRecord.cs
+++ b/src/Equibles.Integrations.Finra/Models/OffExchangeWeeklyRecord.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+
+namespace Equibles.Integrations.Finra.Models;
+
+public class OffExchangeWeeklyRecord
+{
+    [JsonProperty("issueSymbolIdentifier")]
+    public string Symbol { get; set; }
+
+    [JsonProperty("weekStartDate")]
+    public string WeekStartDate { get; set; }
+
+    [JsonProperty("summaryTypeCode")]
+    public string SummaryTypeCode { get; set; }
+
+    [JsonProperty("totalWeeklyShareQuantity")]
+    public long? TotalWeeklyShareQuantity { get; set; }
+
+    [JsonProperty("totalWeeklyTradeCount")]
+    public long? TotalWeeklyTradeCount { get; set; }
+
+    [JsonProperty("tierIdentifier")]
+    public string TierIdentifier { get; set; }
+}

--- a/tests/Equibles.UnitTests/Finra/FinraClientGetWeeklyOffExchangeVolumeTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraClientGetWeeklyOffExchangeVolumeTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Reflection;
+using Equibles.Integrations.Finra;
+using Equibles.Integrations.Finra.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.UnitTests.Finra;
+
+/// <summary>
+/// Record-replay (cassette) pin for GetWeeklyOffExchangeVolume. A captured FINRA
+/// weeklySummary payload with one ATS_W_SMBL row and one OTC_W_SMBL row for a single
+/// symbol is replayed through the real client and HTTP stack offline. The client must
+/// deserialize every field exactly as FINRA's camelCase wire keys map to the DTO —
+/// issueSymbolIdentifier → Symbol, weekStartDate, summaryTypeCode, the two Number
+/// quantities, and tierIdentifier. A wrong JsonProperty name silently nulls/zeros the
+/// field, so every value is asserted exactly against the frozen cassette.
+/// </summary>
+public class FinraClientGetWeeklyOffExchangeVolumeTests
+{
+    private const string WeeklySummaryPayload = """
+        [
+            {
+                "issueSymbolIdentifier": "AAPL",
+                "weekStartDate": "2024-03-04",
+                "summaryTypeCode": "ATS_W_SMBL",
+                "totalWeeklyShareQuantity": 1234567,
+                "totalWeeklyTradeCount": 8901,
+                "tierIdentifier": "T1"
+            },
+            {
+                "issueSymbolIdentifier": "AAPL",
+                "weekStartDate": "2024-03-04",
+                "summaryTypeCode": "OTC_W_SMBL",
+                "totalWeeklyShareQuantity": 7654321,
+                "totalWeeklyTradeCount": 2109,
+                "tierIdentifier": "T1"
+            }
+        ]
+        """;
+
+    [Fact]
+    public async Task GetWeeklyOffExchangeVolume_ParsesAtsAndNonAtsRows_WithExactFieldValues()
+    {
+        // FinraClient caches the OAuth token in a private static field shared by every
+        // instance. Sibling tests (e.g. the Hijri-culture pin) assume a cold cache so their
+        // capture handler's first call is the token request. Clear the static cache before
+        // and after so this test neither inherits a stale token nor leaks one to others.
+        ResetTokenCache();
+
+        var handler = new ReplayHandler(WeeklySummaryPayload);
+        var options = Options.Create(new FinraOptions { ClientId = "test", ClientSecret = "test" });
+        var sut = new FinraClient(
+            new HttpClient(handler),
+            NullLogger<FinraClient>.Instance,
+            options
+        );
+
+        var records = await sut.GetWeeklyOffExchangeVolume(new DateOnly(2024, 3, 4));
+
+        ResetTokenCache();
+
+        records.Should().HaveCount(2);
+
+        var ats = records.Single(r => r.SummaryTypeCode == "ATS_W_SMBL");
+        ats.Symbol.Should().Be("AAPL");
+        ats.WeekStartDate.Should().Be("2024-03-04");
+        ats.TotalWeeklyShareQuantity.Should().Be(1_234_567);
+        ats.TotalWeeklyTradeCount.Should().Be(8_901);
+        ats.TierIdentifier.Should().Be("T1");
+
+        var nonAts = records.Single(r => r.SummaryTypeCode == "OTC_W_SMBL");
+        nonAts.Symbol.Should().Be("AAPL");
+        nonAts.TotalWeeklyShareQuantity.Should().Be(7_654_321);
+        nonAts.TotalWeeklyTradeCount.Should().Be(2_109);
+    }
+
+    private static void ResetTokenCache()
+    {
+        typeof(FinraClient)
+            .GetField("_cachedToken", BindingFlags.NonPublic | BindingFlags.Static)!
+            .SetValue(null, null);
+    }
+
+    // Returns the OAuth token for the token endpoint and replays the frozen weeklySummary
+    // payload for every data request. The token is cached statically across the client's
+    // lifetime, so a prior test may have already obtained one — dispatch on the request URL
+    // rather than a call counter so this handler works whether or not the token call fires.
+    private sealed class ReplayHandler : HttpMessageHandler
+    {
+        private readonly string _payload;
+
+        public ReplayHandler(string payload) => _payload = payload;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            if (request.RequestUri!.AbsoluteUri.Contains("oauth2/access_token"))
+            {
+                return Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(
+                            "{\"access_token\":\"test\",\"expires_in\":3600}"
+                        ),
+                    }
+                );
+            }
+
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_payload) }
+            );
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.HostedService.Services;
+using Equibles.Integrations.Finra.Models;
+
+namespace Equibles.UnitTests.Finra;
+
+public class OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests
+{
+    // Sibling to the ATS+OTC merge pin. FINRA does not guarantee both summary rows exist for
+    // every symbol in a given week: a security may trade on ATS venues only (no non-ATS OTC
+    // activity), so the feed ships an ATS_W_SMBL row with no matching OTC_W_SMBL row. The
+    // merge must still produce an entity, leaving the missing pair at its zero default rather
+    // than dropping the stock or carrying stale numbers.
+    //
+    // The risk this uniquely catches: a refactor that only persists a stock once BOTH rows
+    // are seen (e.g. requiring the OTC branch to have fired before adding to the dictionary)
+    // would silently omit every ATS-only symbol. Pin: a single ATS_W_SMBL row, asserting the
+    // entity exists with Ats* populated and NonAtsOtc* left at zero.
+    [Fact]
+    public void MergeRecordsByStock_AtsRowWithNoOtcRow_YieldsEntityWithNonAtsOtcZero()
+    {
+        var method = typeof(OffExchangeVolumeImportService).GetMethod(
+            "MergeRecordsByStock",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var stockId = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = stockId };
+        var records = new List<OffExchangeWeeklyRecord>
+        {
+            new()
+            {
+                Symbol = "AAPL",
+                SummaryTypeCode = "ATS_W_SMBL",
+                TotalWeeklyShareQuantity = 5_000,
+                TotalWeeklyTradeCount = 50,
+            },
+        };
+
+        var result =
+            (Dictionary<Guid, OffExchangeVolume>)
+                method!.Invoke(null, [records, tickerMap, new DateOnly(2024, 3, 4)]);
+
+        result.Should().ContainSingle();
+        var merged = result[stockId];
+        merged.AtsVolume.Should().Be(5_000);
+        merged.AtsTradeCount.Should().Be(50);
+        merged.NonAtsOtcVolume.Should().Be(0);
+        merged.NonAtsOtcTradeCount.Should().Be(0);
+    }
+}

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTests.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.HostedService.Services;
+using Equibles.Integrations.Finra.Models;
+
+namespace Equibles.UnitTests.Finra;
+
+public class OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTests
+{
+    // OffExchangeVolumeImportService.MergeRecordsByStock is the only path between FINRA's
+    // weeklySummary feed and the OffExchangeVolume table. FINRA emits the per-symbol weekly
+    // aggregate as TWO distinct rows for the same symbol+week: one tagged ATS_W_SMBL
+    // (dark-pool) and one tagged OTC_W_SMBL (non-ATS OTC). The merge must fold both into a
+    // single OffExchangeVolume, routing ATS_W_SMBL's share/trade quantities into Ats* and
+    // OTC_W_SMBL's into NonAtsOtc*.
+    //
+    // The risk this pins: a refactor that mis-routes the two summary codes (swaps the
+    // branches, drops the else-if, or overwrites instead of merging) would compile and pass
+    // any single-row test, then silently report ATS volume as OTC volume (or zero) on every
+    // actively-traded symbol. Pin: one ATS row + one OTC row for the same symbol, asserting
+    // a single merged entity with all four numbers placed in the correct field.
+    [Fact]
+    public void MergeRecordsByStock_AtsAndOtcRowsForSameSymbol_MergeIntoOneEntityWithBothPairs()
+    {
+        var method = typeof(OffExchangeVolumeImportService).GetMethod(
+            "MergeRecordsByStock",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var stockId = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = stockId };
+        var records = new List<OffExchangeWeeklyRecord>
+        {
+            new()
+            {
+                Symbol = "AAPL",
+                SummaryTypeCode = "ATS_W_SMBL",
+                TotalWeeklyShareQuantity = 1_000,
+                TotalWeeklyTradeCount = 10,
+            },
+            new()
+            {
+                Symbol = "AAPL",
+                SummaryTypeCode = "OTC_W_SMBL",
+                TotalWeeklyShareQuantity = 2_000,
+                TotalWeeklyTradeCount = 20,
+            },
+        };
+
+        var result =
+            (Dictionary<Guid, OffExchangeVolume>)
+                method!.Invoke(null, [records, tickerMap, new DateOnly(2024, 3, 4)]);
+
+        result.Should().HaveCount(1);
+        var merged = result[stockId];
+        merged.AtsVolume.Should().Be(1_000);
+        merged.AtsTradeCount.Should().Be(10);
+        merged.NonAtsOtcVolume.Should().Be(2_000);
+        merged.NonAtsOtcTradeCount.Should().Be(20);
+        merged.WeekStartDate.Should().Be(new DateOnly(2024, 3, 4));
+    }
+}

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests.cs
@@ -1,0 +1,47 @@
+using System.Reflection;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.HostedService.Services;
+using Equibles.Integrations.Finra.Models;
+
+namespace Equibles.UnitTests.Finra;
+
+public class OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests
+{
+    // The share/trade quantities on a FINRA weeklySummary record are nullable Numbers;
+    // MergeRecordsByStock coalesces each with `?? 0`. A row for a TRACKED symbol with null
+    // quantities must still produce an entity (with the affected pair at 0), never NRE and
+    // never be dropped. The existing merge/skip pins don't exercise the null-coalesce — a
+    // refactor that reads record.TotalWeeklyShareQuantity.Value directly (dropping the ?? 0)
+    // would throw on FINRA's occasional null cells and abort the whole week's ingest. Oracle
+    // from the contract, not the body.
+    [Fact]
+    public void MergeRecordsByStock_TrackedSymbolWithNullQuantities_MergesAsZeroWithoutThrowing()
+    {
+        var method = typeof(OffExchangeVolumeImportService).GetMethod(
+            "MergeRecordsByStock",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var stockId = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = stockId };
+        var records = new List<OffExchangeWeeklyRecord>
+        {
+            new()
+            {
+                Symbol = "AAPL",
+                SummaryTypeCode = "ATS_W_SMBL",
+                TotalWeeklyShareQuantity = null,
+                TotalWeeklyTradeCount = null,
+            },
+        };
+
+        var act = () =>
+            (Dictionary<Guid, OffExchangeVolume>)
+                method!.Invoke(null, [records, tickerMap, new DateOnly(2024, 3, 4)]);
+
+        var result = act.Should().NotThrow().Subject;
+        result.Should().ContainKey(stockId);
+        result[stockId].AtsVolume.Should().Be(0);
+        result[stockId].AtsTradeCount.Should().Be(0);
+    }
+}

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.HostedService.Services;
+using Equibles.Integrations.Finra.Models;
+
+namespace Equibles.UnitTests.Finra;
+
+public class OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests
+{
+    // Sibling to the merge pins, covering the tickerMap skip guard:
+    //   if (string.IsNullOrEmpty(record.Symbol)
+    //       || !tickerMap.TryGetValue(record.Symbol, out var commonStockId))
+    //       continue;
+    //
+    // FINRA's weeklySummary feed reports every OTC/ATS-active symbol — a universe far larger
+    // than the platform's tracked-stock master list. The tickerMap filter is the load-bearing
+    // guard that keeps only tracked stocks; without it, untracked symbols would map to
+    // Guid.Empty and either fail the FK constraint or poison the batch. The risk this uniquely
+    // catches: dropping the !TryGetValue skip (or inverting it) would either persist garbage
+    // keyed on Guid.Empty or empty the table by skipping every tracked symbol. Pin: a tracked
+    // symbol plus an untracked one, asserting only the tracked entity survives with its own
+    // numbers intact.
+    [Fact]
+    public void MergeRecordsByStock_SymbolNotInTickerMap_IsSkippedNotPersisted()
+    {
+        var method = typeof(OffExchangeVolumeImportService).GetMethod(
+            "MergeRecordsByStock",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var trackedStockId = Guid.NewGuid();
+        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = trackedStockId };
+        var records = new List<OffExchangeWeeklyRecord>
+        {
+            new()
+            {
+                Symbol = "AAPL",
+                SummaryTypeCode = "ATS_W_SMBL",
+                TotalWeeklyShareQuantity = 1_000,
+                TotalWeeklyTradeCount = 10,
+            },
+            new()
+            {
+                Symbol = "UNTRACKED",
+                SummaryTypeCode = "ATS_W_SMBL",
+                TotalWeeklyShareQuantity = 9_999,
+                TotalWeeklyTradeCount = 99,
+            },
+        };
+
+        var result =
+            (Dictionary<Guid, OffExchangeVolume>)
+                method!.Invoke(null, [records, tickerMap, new DateOnly(2024, 3, 4)]);
+
+        result.Should().ContainSingle();
+        result[trackedStockId].AtsVolume.Should().Be(1_000);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the ingestion side of the off-exchange / dark-pool volume feature. It fetches FINRA's authoritative weekly OTC/ATS Transparency summary feed and persists `OffExchangeVolume` rows (the entity + repository landed in #3569).

FINRA publishes its OTC/ATS Transparency data under the `otcMarket` group's `weeklySummary` dataset, partitioned by the Monday that starts each reporting week. For each per-security aggregate it ships two rows:

- `ATS_W_SMBL` — ATS (dark-pool) volume aggregated by symbol → `AtsVolume` + `AtsTradeCount`
- `OTC_W_SMBL` — non-ATS OTC volume aggregated by symbol → `NonAtsOtcVolume` + `NonAtsOtcTradeCount`

The importer merges those two rows into a single `OffExchangeVolume` per (stock, week). Symbols are resolved to common stocks with the same authoritative ticker lookup the short-volume importer already uses — no heuristics or ticker pattern matching. Untracked and blank symbols are skipped. Writes are idempotent: re-running a week updates each stock's existing row rather than inserting a duplicate.

The new feed runs as a third step inside the existing FINRA scraper worker, after short volume and short interest. It resolves the latest stored week and walks forward week-by-week to the current week, reusing the existing sync-start, ticker-map, and stock-validation plumbing.

## Code changes

- `Equibles.Integrations.Finra/Models/OffExchangeWeeklyRecord.cs` — new DTO mapping FINRA's `weeklySummary` fields (`issueSymbolIdentifier`, `weekStartDate`, `summaryTypeCode`, `totalWeeklyShareQuantity`, `totalWeeklyTradeCount`, `tierIdentifier`).
- `Equibles.Integrations.Finra/Contracts/IFinraClient.cs` + `FinraClient.cs` — new `GetWeeklyOffExchangeVolume(DateOnly weekStartDate)` that POSTs to `otcMarket/weeklySummary`, filtered by `weekStartDate` and a `summaryTypeCode` domain filter of `["ATS_W_SMBL","OTC_W_SMBL"]`, paging with the existing limit/offset plumbing.
- `Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs` — new import service. Pure `MergeRecordsByStock` step folds the two summary rows per symbol into one entity; `UpsertWeek` validates against existing stocks and upserts by (CommonStockId, WeekStartDate).
- `Equibles.Finra.HostedService/FinraScraperWorker.cs` — invokes the new importer as a third feed. (Auto-wired via the existing assembly scan; no DI change needed.)
- `tests/Equibles.UnitTests/Finra/` — a record-replay client test that parses a frozen `weeklySummary` payload (one ATS + one OTC row) and asserts every field, plus four merge-step tests (ATS+OTC merge, ATS-only → non-ATS zero, untracked symbol skipped, null quantities coalesced to zero).

Local Release build is clean and the Finra unit tests are green (23 existing + 5 new = 28).