### PR TITLE
feat(finra): add off-exchange volume MCP tool

### DIFF
--- a/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
@@ -1,0 +1,100 @@
+using System.ComponentModel;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Repositories;
+using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Equibles.Finra.Mcp.Tools;
+
+[McpServerToolType]
+public class OffExchangeVolumeTools
+{
+    private readonly OffExchangeVolumeRepository _offExchangeVolumeRepository;
+    private readonly CommonStockRepository _commonStockRepository;
+    private readonly McpToolRunner _runner;
+
+    public OffExchangeVolumeTools(
+        OffExchangeVolumeRepository offExchangeVolumeRepository,
+        CommonStockRepository commonStockRepository,
+        ErrorManager errorManager,
+        ILogger<OffExchangeVolumeTools> logger
+    )
+    {
+        _offExchangeVolumeRepository = offExchangeVolumeRepository;
+        _commonStockRepository = commonStockRepository;
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
+    }
+
+    [McpServerTool(Name = "GetOffExchangeVolume")]
+    [Description(
+        "Get weekly off-exchange (dark pool / OTC) trading volume for a stock from the FINRA OTC/ATS Transparency data. "
+            + "Each week shows ATS (alternating trading system / dark pool) volume and trade count, non-ATS OTC volume and trade count, "
+            + "and the total off-exchange volume (ATS + non-ATS OTC). The FINRA file does not include consolidated tape volume, so the "
+            + "off-exchange share of total market volume is not reported here; compute that share elsewhere against a consolidated-volume source."
+    )]
+    public Task<string> GetOffExchangeVolume(
+        [Description("Stock ticker symbol (e.g., AAPL, GME, TSLA)")] string ticker,
+        [Description("Start date in YYYY-MM-DD format (defaults to 6 months ago)")]
+            string startDate = null,
+        [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
+            string endDate = null,
+        [Description("Maximum number of weeks to return (default: 26, newest first)")]
+            int maxResults = 26
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
+
+                var (start, end) = McpToolExecutor.ParseDateRange(
+                    startDate,
+                    endDate,
+                    McpToolExecutor.UtcMonthsAgo(6)
+                );
+
+                var startWeek = DateOnly.FromDateTime(start.ToDateTime(TimeOnly.MinValue));
+                var endWeek = DateOnly.FromDateTime(end.ToDateTime(TimeOnly.MinValue));
+
+                maxResults = McpLimit.Clamp(maxResults);
+
+                var records = await _offExchangeVolumeRepository
+                    .GetHistoryByStock(stock)
+                    .Where(d => d.WeekStartDate >= startWeek && d.WeekStartDate <= endWeek)
+                    .OrderByDescending(d => d.WeekStartDate)
+                    .Take(maxResults)
+                    .ToListAsync();
+
+                return MarkdownTable.Render(
+                    records.OrderBy(r => r.WeekStartDate).ToList(),
+                    $"No off-exchange volume data found for {stock.Ticker} in the specified date range.",
+                    $"Weekly off-exchange (dark pool / OTC) volume for {stock.Ticker} ({stock.Name}):",
+                    "| Week Start | ATS Volume | ATS Trades | Non-ATS OTC Volume | Non-ATS OTC Trades | Total Off-Exchange Volume |",
+                    "|------------|-----------|-----------|-------------------|-------------------|--------------------------|",
+                    r => RenderOffExchangeRow($"{r.WeekStartDate:yyyy-MM-dd}", r)
+                );
+            },
+            "GetOffExchangeVolume",
+            $"ticker: {ticker}"
+        );
+    }
+
+    // Render with InvariantCulture so the MCP markdown does not fork the separators by host
+    // locale (e.g. de-DE would render 5.000.000 instead of 5,000,000). Total off-exchange
+    // volume is the sum of ATS and non-ATS OTC volume; the share of consolidated tape volume
+    // is intentionally omitted because the FINRA file carries no consolidated total.
+    private static string RenderOffExchangeRow(string leadCell, OffExchangeVolume r)
+    {
+        var totalOffExchangeVolume = r.AtsVolume + r.NonAtsOtcVolume;
+        return $"| {leadCell} | {McpFormat.WholeNumber(r.AtsVolume)} | {McpFormat.WholeNumber(r.AtsTradeCount)} | {McpFormat.WholeNumber(r.NonAtsOtcVolume)} | {McpFormat.WholeNumber(r.NonAtsOtcTradeCount)} | {McpFormat.WholeNumber(totalOffExchangeVolume)} |";
+    }
+}

--- a/tests/Equibles.UnitTests/Finra/FinraClientGetDailyShortVolumeCultureTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraClientGetDailyShortVolumeCultureTests.cs
@@ -15,7 +15,7 @@ namespace Equibles.UnitTests.Finra;
 public class FinraClientGetDailyShortVolumeCultureTests
 {
     [Fact]
-    public async Task GetDailyShortVolume_HijriCultureThread_SendsGregorianDateInRequest()
+    public void GetDailyShortVolume_HijriCultureThread_SendsGregorianDateInRequest()
     {
         string capturedBody = null;
         var handler = new CaptureBodyHandler(body =>
@@ -30,16 +30,20 @@ public class FinraClientGetDailyShortVolumeCultureTests
             options
         );
 
-        var prev = CultureInfo.CurrentCulture;
-        try
+        // Run the culture-sensitive call on a dedicated thread that owns and
+        // restores its own culture. The original form set CurrentCulture on the
+        // xUnit thread-pool thread, then awaited: the await continuation could
+        // resume on a different thread, so the finally restored the culture on the
+        // continuation thread while the original pooled thread stayed ar-SA. A
+        // sibling Finra test reusing that pooled thread then inherited Hijri
+        // formatting and failed intermittently. A dedicated thread removes the race.
+        var worker = new Thread(() =>
         {
             CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
-            await sut.GetDailyShortVolume(new DateOnly(2024, 3, 15));
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = prev;
-        }
+            sut.GetDailyShortVolume(new DateOnly(2024, 3, 15)).GetAwaiter().GetResult();
+        });
+        worker.Start();
+        worker.Join();
 
         capturedBody.Should().Contain("2024-03-15", "date filter must be Gregorian, not Hijri");
     }
@@ -47,7 +51,6 @@ public class FinraClientGetDailyShortVolumeCultureTests
     private class CaptureBodyHandler : HttpMessageHandler
     {
         private readonly Func<string, HttpResponseMessage> _onData;
-        private bool _tokenReturned;
 
         public CaptureBodyHandler(Func<string, HttpResponseMessage> onData) => _onData = onData;
 
@@ -56,9 +59,15 @@ public class FinraClientGetDailyShortVolumeCultureTests
             CancellationToken cancellationToken
         )
         {
-            if (!_tokenReturned || request.RequestUri!.AbsoluteUri.Contains("oauth2/access_token"))
+            // Route purely by URL, not by call order. FinraClient caches the OAuth
+            // token in static fields shared across the whole test process, so a
+            // parallel test can warm the cache and make this client skip the token
+            // request entirely — the data POST then arrives first. An order-based
+            // ("first request is the token") handler would answer that data POST
+            // with the token object, which fails to deserialize into a record list
+            // and crashes the test host. URL-based routing is order-independent.
+            if (request.RequestUri!.AbsoluteUri.Contains("oauth2/access_token"))
             {
-                _tokenReturned = true;
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent("{\"access_token\":\"test\",\"expires_in\":3600}"),

--- a/tests/Equibles.UnitTests/Finra/FinraMcpBuilderExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraMcpBuilderExtensionsTests.cs
@@ -1,7 +1,9 @@
+using System.ComponentModel;
 using Equibles.Finra.Mcp.Extensions;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Mcp;
 using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
 using NSubstitute;
 
 namespace Equibles.UnitTests.Finra;
@@ -28,5 +30,58 @@ public class FinraMcpBuilderExtensionsTests
             .ContainSingle()
             .Which.Should()
             .BeOfType<AssemblyMcpModule<ShortDataTools>>();
+    }
+
+    [Fact]
+    public void OffExchangeVolumeTools_LivesInTheAssemblyScannedByAddShortData()
+    {
+        // AddShortData wires AssemblyMcpModule<ShortDataTools>, which calls
+        // WithToolsFromAssembly(typeof(ShortDataTools).Assembly) — it scans the
+        // WHOLE Equibles.Finra.Mcp assembly, not just ShortDataTools. The
+        // off-exchange-volume MCP tool is a separate [McpServerToolType] class
+        // in that same assembly, so it is auto-discovered with no extra
+        // registration. A regression that moved OffExchangeVolumeTools into a
+        // different assembly (e.g. a misplaced refactor) would compile, pass the
+        // ShortDataTools registration pin, yet silently drop the off-exchange
+        // tool from the MCP server's tool list. Pin that the type ships in the
+        // scanned assembly so the regression surfaces here.
+        typeof(OffExchangeVolumeTools)
+            .Assembly.Should()
+            .BeSameAs(typeof(ShortDataTools).Assembly);
+    }
+
+    [Fact]
+    public void OffExchangeVolumeTools_IsAnMcpServerToolType()
+    {
+        // WithToolsFromAssembly only discovers classes marked [McpServerToolType];
+        // the off-exchange-volume tool will not be exposed without it. A regression
+        // that dropped the attribute would compile and pass the assembly-membership
+        // pin yet silently leave the tool unregistered. Pin the attribute.
+        typeof(OffExchangeVolumeTools)
+            .GetCustomAttributes(typeof(McpServerToolTypeAttribute), inherit: false)
+            .Should()
+            .ContainSingle();
+    }
+
+    [Fact]
+    public void GetOffExchangeVolume_IsAnMcpServerToolWithADescription()
+    {
+        // The tool method must carry [McpServerTool] (so it is enumerated) and a
+        // [Description] (so the LLM knows what it does). A regression that dropped
+        // either attribute would leave the tool invisible or undescribed. Pin both
+        // on the GetOffExchangeVolume method.
+        var method = typeof(OffExchangeVolumeTools).GetMethod(
+            nameof(OffExchangeVolumeTools.GetOffExchangeVolume)
+        );
+
+        method.Should().NotBeNull();
+        method!
+            .GetCustomAttributes(typeof(McpServerToolAttribute), inherit: false)
+            .Should()
+            .ContainSingle();
+        method
+            .GetCustomAttributes(typeof(DescriptionAttribute), inherit: false)
+            .Should()
+            .ContainSingle();
     }
 }

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -417,6 +417,10 @@ public class McpModuleToolDiscoveryTests
                 new[] { "GetCongressionalTrades", "GetMemberTrades", "SearchCongressMembers" }
             },
             {
+                // ShortDataTools is the marker for the whole Equibles.Finra.Mcp
+                // assembly scan, so this set must list every [McpServerTool] in
+                // that assembly — including GetOffExchangeVolume on the sibling
+                // OffExchangeVolumeTools class.
                 typeof(ShortDataTools),
                 new[]
                 {
@@ -424,6 +428,7 @@ public class McpModuleToolDiscoveryTests
                     "GetShortInterest",
                     "GetShortInterestSnapshot",
                     "GetLargestShortVolume",
+                    "GetOffExchangeVolume",
                 }
             },
             {


### PR DESCRIPTION
## Summary

Slice 3 of the off-exchange / dark-pool volume feature: exposes the weekly off-exchange volume data (added in slices 1–2) over MCP.

New `GetOffExchangeVolume` MCP tool in `Equibles.Finra.Mcp`, mirroring `ShortDataTools`:

- Accepts `ticker` plus optional `startDate` / `endDate` (YYYY-MM-DD) and `maxResults` (default 26 weeks, newest first), same shape as the short-volume tool.
- Resolves the ticker via `CommonStockRepository.ResolveByTicker` (authoritative symbol lookup, no ticker heuristics); returns the standard `Stock '<ticker>' not found.` message when unknown.
- Queries `OffExchangeVolumeRepository.GetHistoryByStock` over the date range and renders a markdown table of, per week: week start, ATS volume, ATS trades, non-ATS OTC volume, non-ATS OTC trades, and **total off-exchange volume** (ATS + non-ATS OTC).
- **No off-exchange share of consolidated volume** is reported: the FINRA OTC/ATS Transparency feed has no consolidated tape total and the Finra module has no consolidated-volume source, so a share would have to be fabricated. The tool `[Description]` notes the share is computed elsewhere. (This matches the `OffExchangeVolume` entity comment from slice 1.)

`OffExchangeVolumeTools` is in the same assembly as `ShortDataTools`, so `AssemblyMcpModule<ShortDataTools>`'s `WithToolsFromAssembly` scan auto-discovers it — no registration change.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs` — new `[McpServerToolType]` with `GetOffExchangeVolume`.
- `tests/Equibles.UnitTests/Finra/FinraMcpBuilderExtensionsTests.cs` — 3 new pins: assembly membership, `[McpServerToolType]`, and `[McpServerTool]`+`[Description]` on the method.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — add `GetOffExchangeVolume` to the `ShortDataTools` expected-tool set (that test pins the whole Finra assembly's tool surface).
- `tests/Equibles.UnitTests/Finra/FinraClientGetDailyShortVolumeCultureTests.cs` — fix a pre-existing intermittent flake surfaced by the new test count perturbing parallel scheduling: run the `ar-SA` culture mutation on a dedicated thread (culture no longer leaks onto a pooled thread across an `await`) and route the test HTTP handler by URL instead of call order (FinraClient's static OAuth token cache can be warmed by a parallel test, making the data POST arrive first; the order-based handler returned the token object and crashed deserialization).

## Verification

- `dotnet build Equibles.sln -c Release` → 0 errors.
- Finra-filtered unit tests: 31 passing (28 existing + 3 new), stable across 12 consecutive runs.
- Full unit suite: 2663 passing, twice.
- csharpier-formatted.