### PR TITLE
feat(common-stocks): add InvestorRelationsUrl to CommonStock

### DIFF
--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -27,6 +27,15 @@ public class CommonStock
     [MaxLength(256)]
     public string Website { get; set; }
 
+    /// <summary>
+    /// Absolute URL of the company's investor-relations page, discovered by
+    /// probing common IR paths and subdomains of <see cref="Website"/>. Null
+    /// until discovered (or when no IR page could be validated). Foundation for
+    /// downstream IR scraping (press releases, earnings calendars, transcripts).
+    /// </summary>
+    [MaxLength(256)]
+    public string InvestorRelationsUrl { get; set; }
+
     public double MarketCapitalization { get; set; }
     public long SharesOutStanding { get; set; }
 

--- a/src/Equibles.Migrations/Migrations/20260609110902_AddInvestorRelationsUrlToCommonStock.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260609110902_AddInvestorRelationsUrlToCommonStock.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609110902_AddInvestorRelationsUrlToCommonStock")]
+    partial class AddInvestorRelationsUrlToCommonStock
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260609110902_AddInvestorRelationsUrlToCommonStock.cs
+++ b/src/Equibles.Migrations/Migrations/20260609110902_AddInvestorRelationsUrlToCommonStock.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvestorRelationsUrlToCommonStock : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "InvestorRelationsUrl",
+                table: "CommonStock",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InvestorRelationsUrl",
+                table: "CommonStock");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a nullable `InvestorRelationsUrl` column to `CommonStock` to hold each company's investor-relations page URL. This is the foundation for an IR-page discovery worker and downstream IR scraping (press releases, earnings calendars, event transcripts).

## Code changes

- `Equibles.CommonStocks.Data/Models/CommonStock.cs` — new `[MaxLength(256)] InvestorRelationsUrl` property, documented, placed next to the existing `Website` column it is derived from.
- `Equibles.Migrations` — additive nullable-column migration `AddInvestorRelationsUrlToCommonStock` (financial context).