### PR TITLE
feat(common-stocks): discover investor relations page URLs

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -159,6 +159,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.InsiderTrading.Bus
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Holdings.BusinessLogic", "src\Equibles.Holdings.BusinessLogic\Equibles.Holdings.BusinessLogic.csproj", "{946B8E31-D1FC-4649-9E0E-DCF389C97979}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.CommonStocks.HostedService", "src\Equibles.CommonStocks.HostedService\Equibles.CommonStocks.HostedService.csproj", "{FFED11B2-5BED-4ABF-939E-D18589C1B07B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1081,6 +1083,18 @@ Global
 		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Release|x64.Build.0 = Release|Any CPU
 		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Release|x86.ActiveCfg = Release|Any CPU
 		{946B8E31-D1FC-4649-9E0E-DCF389C97979}.Release|x86.Build.0 = Release|Any CPU
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Debug|x64.Build.0 = Debug|Any CPU
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Debug|x86.Build.0 = Debug|Any CPU
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Release|x64.ActiveCfg = Release|Any CPU
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Release|x64.Build.0 = Release|Any CPU
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Release|x86.ActiveCfg = Release|Any CPU
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1162,6 +1176,7 @@ Global
 		{7CE67BE0-C4A0-4B5C-A4B5-CD3DAD58B796} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{77F0FC50-E234-49F3-9A43-46253DE68A0F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{946B8E31-D1FC-4649-9E0E-DCF389C97979} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{FFED11B2-5BED-4ABF-939E-D18589C1B07B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs
@@ -1,0 +1,27 @@
+using Equibles.Worker;
+
+namespace Equibles.CommonStocks.HostedService.Configuration;
+
+public class InvestorRelationsDiscoveryOptions : ScraperOptions
+{
+    /// <summary>
+    /// Maximum number of stocks probed per cycle. Discovery is network-bound and
+    /// politely rate-limited, so a cycle works through a bounded batch and the
+    /// remaining stocks are picked up on the next cycle.
+    /// </summary>
+    public int BatchSize { get; set; } = 100;
+
+    /// <summary>
+    /// Relative paths probed against the company website (e.g.
+    /// <c>https://acme.com/investor-relations</c>). Tried in order; the first that
+    /// resolves to a validated IR page wins.
+    /// </summary>
+    public List<string> CandidatePaths { get; set; } =
+    ["investor-relations", "investors", "investor", "ir", "shareholders", "shareholder"];
+
+    /// <summary>
+    /// Subdomain prefixes probed against the registrable domain (e.g.
+    /// <c>https://ir.acme.com</c>). Tried after the path candidates.
+    /// </summary>
+    public List<string> CandidateSubdomains { get; set; } = ["ir", "investors", "investor"];
+}

--- a/src/Equibles.CommonStocks.HostedService/Equibles.CommonStocks.HostedService.csproj
+++ b/src/Equibles.CommonStocks.HostedService/Equibles.CommonStocks.HostedService.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <InternalsVisibleTo Include="Equibles.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Equibles.Core.AutoWiring" />
+    <PackageReference Include="HtmlAgilityPack" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
+    <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
+    <ProjectReference Include="..\Equibles.Integrations.Common\Equibles.Integrations.Common.csproj" />
+    <ProjectReference Include="..\Equibles.Worker\Equibles.Worker.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.CommonStocks.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+using Equibles.CommonStocks.HostedService.Services;
+using Equibles.Core.AutoWiring;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.CommonStocks.HostedService.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddCommonStocksWorker(this IServiceCollection services)
+    {
+        services.AutoWireServicesFrom<InvestorRelationsDiscoveryService>();
+
+        // Typed client: short timeout and a contact User-Agent, following many
+        // redirects to land on the real IR page. Response size is capped so a
+        // misbehaving host can't stream an unbounded body into memory.
+        services.AddHttpClient<InvestorRelationsProbeClient>(client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(10);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(
+                "EquiblesBot/1.0 (+https://equibles.com)"
+            );
+            client.MaxResponseContentBufferSize = 2 * 1024 * 1024;
+        });
+
+        services.AddHostedService<InvestorRelationsDiscoveryWorker>();
+
+        return services;
+    }
+}

--- a/src/Equibles.CommonStocks.HostedService/InvestorRelationsDiscoveryWorker.cs
+++ b/src/Equibles.CommonStocks.HostedService/InvestorRelationsDiscoveryWorker.cs
@@ -1,0 +1,35 @@
+using Equibles.CommonStocks.HostedService.Configuration;
+using Equibles.CommonStocks.HostedService.Services;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.CommonStocks.HostedService;
+
+/// <summary>
+/// Periodically discovers each stock's investor-relations page URL, filling in
+/// <c>CommonStock.InvestorRelationsUrl</c> incrementally.
+/// </summary>
+public class InvestorRelationsDiscoveryWorker : BaseScraperWorker
+{
+    protected override string WorkerName => "Investor relations discovery";
+    protected override TimeSpan SleepInterval { get; }
+    protected override ErrorSource ErrorSource => ErrorSource.InvestorRelationsDiscovery;
+
+    public InvestorRelationsDiscoveryWorker(
+        ILogger<InvestorRelationsDiscoveryWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<InvestorRelationsDiscoveryOptions> options
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
+    }
+
+    protected override Task DoWork(CancellationToken stoppingToken) =>
+        RunImport<InvestorRelationsDiscoveryService>(stoppingToken);
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsCandidateBuilder.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsCandidateBuilder.cs
@@ -1,0 +1,65 @@
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Builds the ordered list of candidate investor-relations URLs to probe for a
+/// company, derived from its website. Pure logic (no I/O) so it is unit-testable
+/// in isolation from the network probe.
+/// </summary>
+public static class InvestorRelationsCandidateBuilder
+{
+    /// <summary>
+    /// Produces candidate URLs for <paramref name="website"/>: first the company
+    /// website with each <paramref name="paths"/> segment appended, then each
+    /// <paramref name="subdomains"/> prefix in front of the registrable domain.
+    /// Returns an empty list when the website is missing or unparseable. Results
+    /// are de-duplicated case-insensitively while preserving order.
+    /// </summary>
+    public static IReadOnlyList<string> Build(
+        string website,
+        IEnumerable<string> paths,
+        IEnumerable<string> subdomains
+    )
+    {
+        if (string.IsNullOrWhiteSpace(website))
+            return [];
+
+        // EDGAR-sourced websites occasionally omit the scheme ("acme.com"); assume
+        // https so Uri can parse them as absolute.
+        var normalized = website.Trim();
+        if (!normalized.Contains("://"))
+            normalized = "https://" + normalized;
+
+        if (
+            !Uri.TryCreate(normalized, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            || string.IsNullOrEmpty(uri.Host)
+        )
+            return [];
+
+        var scheme = uri.Scheme;
+        var host = uri.Host.ToLowerInvariant();
+
+        // Strip a leading "www." so subdomain candidates attach to the registrable
+        // domain (ir.acme.com, not ir.www.acme.com).
+        var registrableDomain = host.StartsWith("www.") ? host[4..] : host;
+
+        var candidates = new List<string>();
+
+        foreach (var path in paths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                continue;
+            candidates.Add($"{scheme}://{host}/{path.Trim('/')}");
+        }
+
+        foreach (var subdomain in subdomains)
+        {
+            if (string.IsNullOrWhiteSpace(subdomain))
+                continue;
+            candidates.Add($"{scheme}://{subdomain.Trim('.')}.{registrableDomain}");
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return candidates.Where(seen.Add).ToList();
+    }
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
@@ -1,0 +1,147 @@
+using Equibles.CommonStocks.HostedService.Configuration;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.AutoWiring;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Fills in <c>CommonStock.InvestorRelationsUrl</c> for stocks that have a known
+/// website but no discovered IR page yet, one bounded batch per cycle.
+/// </summary>
+[Service]
+public class InvestorRelationsDiscoveryService : IImporter
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly InvestorRelationsProbeClient _probeClient;
+    private readonly ErrorReporter _errorReporter;
+    private readonly ILogger<InvestorRelationsDiscoveryService> _logger;
+    private readonly InvestorRelationsDiscoveryOptions _options;
+
+    public InvestorRelationsDiscoveryService(
+        IServiceScopeFactory scopeFactory,
+        InvestorRelationsProbeClient probeClient,
+        ErrorReporter errorReporter,
+        ILogger<InvestorRelationsDiscoveryService> logger,
+        IOptions<InvestorRelationsDiscoveryOptions> options
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _probeClient = probeClient;
+        _errorReporter = errorReporter;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    public async Task Import(CancellationToken cancellationToken)
+    {
+        var batch = await LoadCandidates(cancellationToken);
+        if (batch.Count == 0)
+        {
+            _logger.LogInformation(
+                "Investor relations discovery: no stocks with a website pending discovery"
+            );
+            return;
+        }
+
+        _logger.LogInformation("Investor relations discovery: probing {Count} stocks", batch.Count);
+
+        var discovered = 0;
+        foreach (var candidate in batch)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var url = await _probeClient.Discover(
+                    candidate.Website,
+                    _options.CandidatePaths,
+                    _options.CandidateSubdomains,
+                    cancellationToken
+                );
+                // No IR page found this cycle. The stock stays null and is re-probed
+                // next cycle. TODO(#581 follow-up): record a last-attempted timestamp
+                // so persistent misses aren't re-probed every cycle.
+                if (url == null)
+                    continue;
+
+                if (await Persist(candidate.Id, url))
+                {
+                    discovered++;
+                    _logger.LogDebug(
+                        "Discovered investor relations page for {Ticker}: {Url}",
+                        candidate.Ticker,
+                        url
+                    );
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Error discovering investor relations page for {Ticker}",
+                    candidate.Ticker
+                );
+                await _errorReporter.Report(
+                    ErrorSource.InvestorRelationsDiscovery,
+                    $"Discover({candidate.Ticker})",
+                    ex.Message,
+                    ex.StackTrace
+                );
+            }
+        }
+
+        _logger.LogInformation(
+            "Investor relations discovery complete. Discovered {Count} new IR pages",
+            discovered
+        );
+    }
+
+    private async Task<List<CandidateStock>> LoadCandidates(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        var rows = await repo.GetAll()
+            .Where(s => s.Website != null && s.Website != "" && s.InvestorRelationsUrl == null)
+            .OrderBy(s => s.Ticker)
+            .Take(_options.BatchSize)
+            .Select(s => new
+            {
+                s.Id,
+                s.Ticker,
+                s.Website,
+            })
+            .ToListAsync(cancellationToken);
+
+        return rows.Select(r => new CandidateStock(r.Id, r.Ticker, r.Website)).ToList();
+    }
+
+    private async Task<bool> Persist(Guid commonStockId, string investorRelationsUrl)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        var stock = await repo.Get(commonStockId);
+        // The stock may have been deleted, or filled in by an overlapping run,
+        // between loading the batch and persisting — leave an existing value alone.
+        if (stock == null || stock.InvestorRelationsUrl != null)
+            return false;
+
+        stock.InvestorRelationsUrl = investorRelationsUrl;
+        await repo.SaveChanges();
+        return true;
+    }
+
+    private sealed record CandidateStock(Guid Id, string Ticker, string Website);
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsPageValidator.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsPageValidator.cs
@@ -1,0 +1,71 @@
+using HtmlAgilityPack;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Decides whether fetched HTML is actually an investor-relations page rather
+/// than a soft-404 or a homepage a guessed path redirected to. Pure logic (no
+/// I/O) so it is unit-testable against fixture HTML.
+/// </summary>
+public static class InvestorRelationsPageValidator
+{
+    // A page title carrying one of these is a strong signal on its own — IR pages
+    // almost always say so in the <title>.
+    private static readonly string[] TitlePhrases =
+    [
+        "investor relations",
+        "investor relation",
+        "investors",
+        "shareholder",
+        "ir home",
+    ];
+
+    // Content keywords. A homepage may mention "investor relations" once in a nav
+    // footer, so two distinct hits are required when the title alone isn't decisive.
+    private static readonly string[] BodyKeywords =
+    [
+        "investor relations",
+        "sec filings",
+        "quarterly results",
+        "quarterly earnings",
+        "annual report",
+        "press releases",
+        "shareholder",
+        "earnings release",
+        "financial results",
+        "stock information",
+        "annual meeting",
+        "dividend history",
+    ];
+
+    /// <summary>
+    /// True when <paramref name="html"/> looks like an investor-relations page:
+    /// the page title carries an IR phrase, or the visible text contains at least
+    /// two distinct IR content keywords.
+    /// </summary>
+    public static bool IsInvestorRelationsPage(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return false;
+
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+
+        // Drop script/style so their contents don't count as "visible" keywords.
+        var noise = document.DocumentNode.SelectNodes("//script|//style");
+        if (noise != null)
+        {
+            foreach (var node in noise)
+                node.Remove();
+        }
+
+        var title =
+            document.DocumentNode.SelectSingleNode("//title")?.InnerText?.ToLowerInvariant() ?? "";
+        if (TitlePhrases.Any(title.Contains))
+            return true;
+
+        var text = HtmlEntity.DeEntitize(document.DocumentNode.InnerText ?? "").ToLowerInvariant();
+        var distinctHits = BodyKeywords.Count(text.Contains);
+        return distinctHits >= 2;
+    }
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
@@ -1,0 +1,98 @@
+using Equibles.Integrations.Common.RateLimiter;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Probes a company's candidate investor-relations URLs over HTTP and returns the
+/// first one that resolves to a validated IR page. Registered as a typed
+/// <see cref="HttpClient"/> client (see <c>AddCommonStocksWorker</c>).
+/// </summary>
+public class InvestorRelationsProbeClient
+{
+    // Column ceiling for CommonStock.InvestorRelationsUrl.
+    private const int MaxUrlLength = 256;
+
+    // Polite shared throttle so a discovery cycle doesn't hammer many sites at once.
+    private static readonly IRateLimiter RateLimiter = new RateLimiter(
+        maxRequests: 5,
+        timeWindow: TimeSpan.FromSeconds(1)
+    );
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<InvestorRelationsProbeClient> _logger;
+
+    public InvestorRelationsProbeClient(
+        HttpClient httpClient,
+        ILogger<InvestorRelationsProbeClient> logger
+    )
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the validated investor-relations URL for <paramref name="website"/>,
+    /// or null when no candidate resolves to a recognisable IR page.
+    /// </summary>
+    public async Task<string> Discover(
+        string website,
+        IEnumerable<string> paths,
+        IEnumerable<string> subdomains,
+        CancellationToken cancellationToken
+    )
+    {
+        var candidates = InvestorRelationsCandidateBuilder.Build(website, paths, subdomains);
+
+        foreach (var candidate in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var resolved = await TryResolve(candidate, cancellationToken);
+            if (resolved != null)
+                return resolved;
+        }
+
+        return null;
+    }
+
+    private async Task<string> TryResolve(string url, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await RateLimiter.WaitAsync();
+
+            using var response = await _httpClient.GetAsync(url, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            // Only HTML is worth keyword-validating; skip PDFs, redirects to login
+            // walls that serve JSON, etc.
+            var mediaType = response.Content.Headers.ContentType?.MediaType;
+            if (!string.Equals(mediaType, "text/html", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            var html = await response.Content.ReadAsStringAsync(cancellationToken);
+            if (!InvestorRelationsPageValidator.IsInvestorRelationsPage(html))
+                return null;
+
+            // Prefer where the request actually landed after redirects, falling back
+            // to the probed URL. Stay within the column ceiling.
+            var finalUrl = response.RequestMessage?.RequestUri?.ToString() ?? url;
+            if (finalUrl.Length > MaxUrlLength)
+                finalUrl = url;
+            return finalUrl.Length > MaxUrlLength ? null : finalUrl;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A dead host, TLS error, or timeout on a guessed URL is expected and
+            // not worth reporting — most candidates won't exist.
+            _logger.LogDebug(ex, "Investor relations probe failed for {Url}", url);
+            return null;
+        }
+    }
+}

--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -22,6 +22,9 @@ public sealed class ErrorSource
     public static readonly ErrorSource TranscriptScraper = new("TranscriptScraper");
     public static readonly ErrorSource InsiderTradingReprocess = new("InsiderTradingReprocess");
     public static readonly ErrorSource NportReprocess = new("NportReprocess");
+    public static readonly ErrorSource InvestorRelationsDiscovery = new(
+        "InvestorRelationsDiscovery"
+    );
     public static readonly ErrorSource Other = new("Other");
 
     public static IEnumerable<ErrorSource> GetAll() =>
@@ -42,6 +45,7 @@ public sealed class ErrorSource
             TranscriptScraper,
             InsiderTradingReprocess,
             NportReprocess,
+            InvestorRelationsDiscovery,
             Other,
         ];
 

--- a/src/Equibles.Worker.Host/Equibles.Worker.Host.csproj
+++ b/src/Equibles.Worker.Host/Equibles.Worker.Host.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Sec.HostedService\Equibles.Sec.HostedService.csproj" />
+    <ProjectReference Include="..\Equibles.CommonStocks.HostedService\Equibles.CommonStocks.HostedService.csproj" />
     <ProjectReference Include="..\Equibles.Holdings.HostedService\Equibles.Holdings.HostedService.csproj" />
     <ProjectReference Include="..\Equibles.Congress.HostedService\Equibles.Congress.HostedService.csproj" />
     <ProjectReference Include="..\Equibles.Finra.HostedService\Equibles.Finra.HostedService.csproj" />

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -3,6 +3,8 @@ using Equibles.Cboe.HostedService.Extensions;
 using Equibles.Cftc.Data.Extensions;
 using Equibles.Cftc.HostedService.Extensions;
 using Equibles.CommonStocks.Data.Extensions;
+using Equibles.CommonStocks.HostedService.Configuration;
+using Equibles.CommonStocks.HostedService.Extensions;
 using Equibles.Congress.Data.Extensions;
 using Equibles.Congress.HostedService.Extensions;
 using Equibles.Core.AutoWiring;
@@ -95,6 +97,9 @@ builder.Services.Configure<Equibles.Cftc.HostedService.Configuration.CftcScraper
 builder.Services.Configure<Equibles.Cboe.HostedService.Configuration.CboeScraperOptions>(
     builder.Configuration.GetSection("CboeScraper")
 );
+builder.Services.Configure<InvestorRelationsDiscoveryOptions>(
+    builder.Configuration.GetSection("InvestorRelationsDiscovery")
+);
 
 // Without this bind, IOptions<EmbeddingConfig> is always default (Enabled=false),
 // so GenerateEmbeddingBatch short-circuits and no embeddings are ever produced —
@@ -123,6 +128,7 @@ builder.Services.AddCftcWorker();
 builder.Services.AddCboeWorker();
 builder.Services.AddCongressWorker();
 builder.Services.AddHoldingsWorker();
+builder.Services.AddCommonStocksWorker();
 
 var host = builder.Build();
 host.Run();

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsCandidateBuilderTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsCandidateBuilderTests.cs
@@ -1,0 +1,99 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class InvestorRelationsCandidateBuilderTests
+{
+    private static readonly string[] Paths = ["investor-relations", "ir"];
+    private static readonly string[] Subdomains = ["ir", "investors"];
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Build_MissingWebsite_ReturnsEmpty(string website)
+    {
+        // Contract: a stock with no website has nothing to probe against.
+        InvestorRelationsCandidateBuilder.Build(website, Paths, Subdomains).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Build_UnparseableWebsite_ReturnsEmpty()
+    {
+        // "not a url" prepends https:// but still contains a space, so Uri rejects it.
+        InvestorRelationsCandidateBuilder.Build("not a url", Paths, Subdomains).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Build_PathsPrecedeSubdomains_AndUseRegistrableDomainForSubdomains()
+    {
+        // Contract: probe the company website's own paths first (strongest match
+        // when present), then IR subdomains of the registrable domain. The "www."
+        // is kept for same-origin path probes but stripped for subdomain hosts.
+        var result = InvestorRelationsCandidateBuilder.Build(
+            "https://www.acme.com",
+            Paths,
+            Subdomains
+        );
+
+        result
+            .Should()
+            .Equal(
+                "https://www.acme.com/investor-relations",
+                "https://www.acme.com/ir",
+                "https://ir.acme.com",
+                "https://investors.acme.com"
+            );
+    }
+
+    [Fact]
+    public void Build_SchemeLessWebsite_AssumesHttps()
+    {
+        // EDGAR sometimes stores a bare host; it must still produce absolute URLs.
+        var result = InvestorRelationsCandidateBuilder.Build("acme.com", Paths, Subdomains);
+
+        result.Should().Contain("https://acme.com/investor-relations");
+        result.Should().Contain("https://ir.acme.com");
+    }
+
+    [Fact]
+    public void Build_PreservesHttpScheme()
+    {
+        var result = InvestorRelationsCandidateBuilder.Build("http://acme.com", ["ir"], ["ir"]);
+
+        result.Should().Equal("http://acme.com/ir", "http://ir.acme.com");
+    }
+
+    [Fact]
+    public void Build_DeduplicatesCandidatesPreservingOrder()
+    {
+        // Duplicate path entries must not yield duplicate probes.
+        var result = InvestorRelationsCandidateBuilder.Build("https://acme.com", ["ir", "ir"], []);
+
+        result.Should().Equal("https://acme.com/ir");
+    }
+
+    [Fact]
+    public void Build_IgnoresBlankPathAndSubdomainEntries()
+    {
+        var result = InvestorRelationsCandidateBuilder.Build(
+            "https://acme.com",
+            ["", "  ", "ir"],
+            [" "]
+        );
+
+        result.Should().Equal("https://acme.com/ir");
+    }
+
+    [Fact]
+    public void Build_TrimsSlashesAndDotsFromSegments()
+    {
+        var result = InvestorRelationsCandidateBuilder.Build(
+            "https://acme.com",
+            ["/investors/"],
+            [".ir."]
+        );
+
+        result.Should().Equal("https://acme.com/investors", "https://ir.acme.com");
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsPageValidatorTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsPageValidatorTests.cs
@@ -1,0 +1,65 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class InvestorRelationsPageValidatorTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsInvestorRelationsPage_EmptyHtml_ReturnsFalse(string html)
+    {
+        InvestorRelationsPageValidator.IsInvestorRelationsPage(html).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsInvestorRelationsPage_TitleCarriesIrPhrase_ReturnsTrue()
+    {
+        // Contract: an IR page almost always says so in its <title>; that alone is
+        // a strong enough signal.
+        const string html =
+            "<html><head><title>Investor Relations | Acme Corp</title></head>"
+            + "<body><p>Welcome.</p></body></html>";
+
+        InvestorRelationsPageValidator.IsInvestorRelationsPage(html).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsInvestorRelationsPage_TwoDistinctBodyKeywords_ReturnsTrue()
+    {
+        // No IR phrase in the title, but the content is unmistakably an IR page.
+        const string html =
+            "<html><head><title>Acme Corporation</title></head><body>"
+            + "<h1>Latest SEC filings and quarterly results</h1>"
+            + "</body></html>";
+
+        InvestorRelationsPageValidator.IsInvestorRelationsPage(html).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsInvestorRelationsPage_SingleFooterMention_ReturnsFalse()
+    {
+        // A homepage that merely links to "Investor Relations" in its nav is not an
+        // IR page: one keyword hit, no IR title phrase.
+        const string html =
+            "<html><head><title>Acme Corporation - Home</title></head><body>"
+            + "<nav><a href=\"/ir\">Investor Relations</a></nav>"
+            + "<p>We make great products.</p></body></html>";
+
+        InvestorRelationsPageValidator.IsInvestorRelationsPage(html).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsInvestorRelationsPage_KeywordsOnlyInScript_ReturnsFalse()
+    {
+        // Script/style content must not count as visible page text — guards against
+        // analytics blobs that happen to mention IR terms.
+        const string html =
+            "<html><head><title>Home</title></head><body>"
+            + "<script>var x = 'investor relations sec filings quarterly results';</script>"
+            + "<p>Welcome to Acme.</p></body></html>";
+
+        InvestorRelationsPageValidator.IsInvestorRelationsPage(html).Should().BeFalse();
+    }
+}

--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="..\..\src\Equibles.CommonStocks.Data\Equibles.CommonStocks.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.CommonStocks.BusinessLogic\Equibles.CommonStocks.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.CommonStocks.HostedService\Equibles.CommonStocks.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Holdings.Data\Equibles.Holdings.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Holdings.HostedService\Equibles.Holdings.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.InsiderTrading.Data\Equibles.InsiderTrading.Data.csproj" />


### PR DESCRIPTION
## Summary

Adds a background worker that discovers each stock's investor-relations page and fills the `CommonStock.InvestorRelationsUrl` column added in #3572. This is the backend foundation for downstream IR scraping (press releases, earnings calendars, event transcripts).

For each stock that has a known `Website` but no IR URL yet, it probes common IR paths (`/investor-relations`, `/investors`, `/ir`, `/shareholders`, …) and IR subdomains (`ir.`, `investors.`, `investor.`) of the company domain, keeping the first candidate that returns `200 text/html` **and** whose content validates as an IR page (an IR phrase in the `<title>`, or two distinct IR content keywords). The content check guards against soft-404s and guessed paths that redirect to the homepage, so only validated URLs are stored.

## Code changes

- **New `Equibles.CommonStocks.HostedService` project** — the module's first background worker:
  - `InvestorRelationsCandidateBuilder` — pure logic that turns a website into ordered candidate URLs (paths first, then subdomains of the registrable domain; de-duplicated).
  - `InvestorRelationsPageValidator` — pure logic that keyword-validates fetched HTML via HtmlAgilityPack (script/style stripped).
  - `InvestorRelationsProbeClient` — rate-limited typed `HttpClient` that probes candidates and returns the first validated URL.
  - `InvestorRelationsDiscoveryService` (`IImporter`) — loads a bounded batch of stocks pending discovery and persists results.
  - `InvestorRelationsDiscoveryWorker` — `BaseScraperWorker`-derived, wired into `Worker.Host`.
- `ErrorSource.InvestorRelationsDiscovery` added.
- Unit tests for candidate generation and page validation.

A follow-up (TODO noted in the discovery service) will add a last-attempted timestamp so stocks with no IR page aren't re-probed every cycle.