### PR TITLE
feat(sec): capture 8-K item numbers and announce saved documents

### DIFF
--- a/src/Equibles.Integrations.Sec/Models/FillingData.cs
+++ b/src/Equibles.Integrations.Sec/Models/FillingData.cs
@@ -17,4 +17,11 @@ public class FilingData
     public string PrimaryDocument { get; set; }
     public string Description { get; set; }
     public string DocumentUrl { get; set; }
+
+    /// <summary>
+    /// Comma-joined SEC item numbers reported by this filing, e.g. <c>"2.02,9.01"</c> on
+    /// an 8-K earnings release. Null/empty for forms that don't carry items. Sourced from
+    /// the submissions feed's parallel <c>items</c> array, so it costs no extra request.
+    /// </summary>
+    public string Items { get; set; }
 }

--- a/src/Equibles.Integrations.Sec/Models/Responses/RecentFilings.cs
+++ b/src/Equibles.Integrations.Sec/Models/Responses/RecentFilings.cs
@@ -21,4 +21,9 @@ internal class RecentFilings
 
     [JsonProperty("primaryDocDescription")]
     public List<string> PrimaryDocDescription { get; set; } = [];
+
+    // Comma-joined item numbers for the filing, e.g. "2.02,9.01" on an 8-K. Only
+    // 8-K / 8-K/A rows carry items; the array is empty (or short) for other forms.
+    [JsonProperty("items")]
+    public List<string> Items { get; set; } = [];
 }

--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -1039,6 +1039,12 @@ public class SecEdgarClient : ISecEdgarClient
             Description =
                 i < recent.PrimaryDocDescription.Count ? recent.PrimaryDocDescription[i] : null,
             DocumentUrl = GetDocumentUrl(cik, accessionNumber),
+            // Items is a parallel optional array — SEC populates it only for 8-Ks and omits
+            // trailing empties — so index defensively and normalise blanks to null.
+            Items =
+                i < recent.Items.Count && !string.IsNullOrWhiteSpace(recent.Items[i])
+                    ? recent.Items[i]
+                    : null,
         };
         return true;
     }

--- a/src/Equibles.Messaging/Contracts/Sec/DocumentSaved.cs
+++ b/src/Equibles.Messaging/Contracts/Sec/DocumentSaved.cs
@@ -1,0 +1,18 @@
+namespace Equibles.Messaging.Contracts.Sec;
+
+// Raised after a Document is persisted (any form — 10-K, 10-Q, 8-K, the commercial
+// earnings-call transcript, etc.), carrying enough metadata for a consumer to act
+// without re-querying the financial database. The earnings-call linker uses it to
+// resolve and attach artefacts to an EarningsCallEvent as filings and transcripts
+// arrive. Published after the insert commits (OSS ships no transactional outbox), so
+// consumers must be idempotent and the backfill closes any gap left by a missed event.
+public record DocumentSaved(
+    Guid DocumentId,
+    Guid CommonStockId,
+    string Ticker,
+    string DocumentType,
+    DateOnly ReportingDate,
+    DateOnly ReportingForDate,
+    string AccessionNumber,
+    string Items
+);

--- a/src/Equibles.Migrations/Migrations/20260609111658_AddDocumentItems.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260609111658_AddDocumentItems.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609111658_AddDocumentItems")]
+    partial class AddDocumentItems
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260609111658_AddDocumentItems.cs
+++ b/src/Equibles.Migrations/Migrations/20260609111658_AddDocumentItems.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDocumentItems : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Items",
+                table: "Document",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Items",
+                table: "Document");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -49,6 +49,15 @@ public class Document
     public string AccessionNumber { get; set; }
 
     /// <summary>
+    /// Comma-joined SEC item numbers reported by this filing, e.g. <c>"2.02,9.01"</c> on an
+    /// 8-K. Lets a consumer pick out earnings-release 8-Ks (Item 2.02 "Results of Operations
+    /// and Financial Condition") without re-parsing. Null for forms that carry no items and
+    /// for legacy rows ingested before capture.
+    /// </summary>
+    [MaxLength(256)]
+    public string Items { get; set; }
+
+    /// <summary>
     /// Tracks whether the filing's raw XBRL envelope has been captured. Defaults to
     /// <see cref="XbrlCaptureStatus.NotChecked"/> so existing rows and freshly-ingested
     /// documents are picked up by the backfill until examined.

--- a/src/Equibles.Sec.HostedService/DocumentScraper.cs
+++ b/src/Equibles.Sec.HostedService/DocumentScraper.cs
@@ -615,6 +615,7 @@ public class DocumentScraper : IDocumentScraper
                     filing.ReportDate,
                     filing.DocumentUrl,
                     filing.AccessionNumber,
+                    filing.Items,
                     xbrl,
                     cancellationToken
                 );

--- a/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/DocumentPersistenceService.cs
@@ -2,9 +2,11 @@ using System.Data;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Media.BusinessLogic;
+using Equibles.Messaging.Contracts.Sec;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Models;
 using Equibles.Sec.Repositories;
+using MassTransit;
 
 namespace Equibles.Sec.HostedService.Services;
 
@@ -14,14 +16,17 @@ public class DocumentPersistenceService : IDocumentPersistenceService
 
     private readonly DocumentRepository _documentRepository;
     private readonly IFileManager _fileManager;
+    private readonly IBus _bus;
 
     public DocumentPersistenceService(
         DocumentRepository documentRepository,
-        IFileManager fileManager
+        IFileManager fileManager,
+        IBus bus
     )
     {
         _documentRepository = documentRepository;
         _fileManager = fileManager;
+        _bus = bus;
     }
 
     public Task<bool> Exists(
@@ -43,6 +48,7 @@ public class DocumentPersistenceService : IDocumentPersistenceService
         DateOnly reportingForDate,
         string sourceUrl,
         string accessionNumber = null,
+        string items = null,
         XbrlCaptureResult xbrl = null,
         CancellationToken cancellationToken = default
     )
@@ -64,6 +70,7 @@ public class DocumentPersistenceService : IDocumentPersistenceService
             ReportingForDate = reportingForDate,
             SourceUrl = sourceUrl,
             AccessionNumber = accessionNumber,
+            Items = items,
             LineCount = lineCount,
         };
 
@@ -72,6 +79,23 @@ public class DocumentPersistenceService : IDocumentPersistenceService
         _documentRepository.Add(document);
         await _documentRepository.SaveChanges();
         await transaction.CommitAsync(cancellationToken);
+
+        // Announce the save after the insert commits — OSS has no transactional outbox, so a
+        // pre-commit publish could fire on a rolled-back insert. A consumer that misses this
+        // event (process crash between commit and publish) is reconciled by the backfill.
+        await _bus.Publish(
+            new DocumentSaved(
+                document.Id,
+                company.Id,
+                company.Ticker,
+                documentType.Value,
+                reportingDate,
+                reportingForDate,
+                accessionNumber,
+                items
+            ),
+            cancellationToken
+        );
     }
 
     public async Task UpdateXbrl(Document document, XbrlCaptureResult xbrl)

--- a/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
+++ b/src/Equibles.Sec.HostedService/Services/IDocumentPersistenceService.cs
@@ -22,6 +22,7 @@ public interface IDocumentPersistenceService
         DateOnly reportingForDate,
         string sourceUrl,
         string accessionNumber = null,
+        string items = null,
         XbrlCaptureResult xbrl = null,
         CancellationToken cancellationToken = default
     );

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceSaveTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceSaveTests.cs
@@ -4,9 +4,11 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.IntegrationTests.Helpers;
 using Equibles.Media.BusinessLogic;
 using Equibles.Media.Data.Models;
+using Equibles.Messaging.Contracts.Sec;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Sec.Repositories;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 using Xunit;
@@ -81,18 +83,24 @@ public class DocumentPersistenceServiceSaveTests : ParadeDbMcpTestBase
             .SaveFile(Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<bool>())
             .Returns(_ => Task.FromResult(savedFile));
 
-        var sut = new DocumentPersistenceService(new DocumentRepository(DbContext), fileManager);
+        var bus = Substitute.For<IBus>();
+        var sut = new DocumentPersistenceService(
+            new DocumentRepository(DbContext),
+            fileManager,
+            bus
+        );
 
         var body = "<html>line1\nline2\nline3</html>"u8.ToArray();
         await sut.Save(
             company: apple,
             content: body,
-            fileName: "AAPL-2024-10K.html",
-            documentType: DocumentType.TenK,
+            fileName: "AAPL-2024-8K.html",
+            documentType: DocumentType.EightK,
             reportingDate: new DateOnly(2024, 3, 15),
-            reportingForDate: new DateOnly(2023, 12, 31),
+            reportingForDate: new DateOnly(2024, 3, 15),
             sourceUrl: "https://example.test/filing",
-            accessionNumber: "0000320193-24-000123"
+            accessionNumber: "0000320193-24-000123",
+            items: "2.02,9.01"
         );
 
         await using var verify = Fixture.CreateDbContext();
@@ -105,10 +113,28 @@ public class DocumentPersistenceServiceSaveTests : ParadeDbMcpTestBase
         // SingleAsync throws; mishandle Content and ContentId stays Guid.Empty; mis-encode
         // and LineCount drifts.
         saved.ContentId.Should().Be(savedFile.Id);
-        saved.DocumentType.Should().Be(DocumentType.TenK);
+        saved.DocumentType.Should().Be(DocumentType.EightK);
         saved.ReportingDate.Should().Be(new DateOnly(2024, 3, 15));
         saved.LineCount.Should().Be(3, "the LF-split line count for 3 \\n-separated segments is 3");
         saved.SourceUrl.Should().Be("https://example.test/filing");
         saved.AccessionNumber.Should().Be("0000320193-24-000123");
+        // The item list must round-trip onto the row so a consumer can pick out Item 2.02.
+        saved.Items.Should().Be("2.02,9.01");
+
+        // Save announces the persisted document on the bus after the commit, carrying the
+        // assigned id and the metadata a consumer needs — the earnings-call linker keys off
+        // DocumentType + Items without re-querying the financial database.
+        await bus.Received(1)
+            .Publish(
+                Arg.Is<DocumentSaved>(e =>
+                    e.DocumentId == saved.Id
+                    && e.CommonStockId == apple.Id
+                    && e.Ticker == apple.Ticker
+                    && e.DocumentType == DocumentType.EightK.Value
+                    && e.AccessionNumber == "0000320193-24-000123"
+                    && e.Items == "2.02,9.01"
+                ),
+                Arg.Any<CancellationToken>()
+            );
     }
 }

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceTests.cs
@@ -9,6 +9,7 @@ using Equibles.Media.Data.Models;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Sec.Repositories;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using NSubstitute;
@@ -97,7 +98,7 @@ public class DocumentPersistenceServiceTests : IDisposable
             .Returns(savedFile);
 
         var documentRepo = new DocumentRepository(_dbContext);
-        var sut = new DocumentPersistenceService(documentRepo, fileManager);
+        var sut = new DocumentPersistenceService(documentRepo, fileManager, Substitute.For<IBus>());
 
         var content = Encoding.UTF8.GetBytes("First line\nSecond line\nThird line");
 

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests.cs
@@ -4,6 +4,7 @@ using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Models;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Sec.Repositories;
+using MassTransit;
 using NSubstitute;
 using Xunit;
 
@@ -43,7 +44,11 @@ public class DocumentPersistenceServiceUpdateXbrlSurrogateFileNameTests : Parade
             });
 
         await using var ctx = Fixture.CreateDbContext();
-        var service = new DocumentPersistenceService(new DocumentRepository(ctx), fileManager);
+        var service = new DocumentPersistenceService(
+            new DocumentRepository(ctx),
+            fileManager,
+            Substitute.For<IBus>()
+        );
 
         await service.UpdateXbrl(
             new Document(),

--- a/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceXbrlTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentPersistenceServiceXbrlTests.cs
@@ -8,7 +8,9 @@ using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Models;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Sec.Repositories;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
+using NSubstitute;
 using Xunit;
 using File = Equibles.Media.Data.Models.File;
 
@@ -49,7 +51,11 @@ public class DocumentPersistenceServiceXbrlTests : ParadeDbMcpTestBase
     }
 
     private DocumentPersistenceService BuildSut() =>
-        new(new DocumentRepository(DbContext), new FileManager(new FileRepository(DbContext)));
+        new(
+            new DocumentRepository(DbContext),
+            new FileManager(new FileRepository(DbContext)),
+            Substitute.For<IBus>()
+        );
 
     [Fact]
     public async Task Save_WithCapturedInlineXbrl_StoresGzipFileAndRecordsXbrlFields()

--- a/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceSkippedCeilingTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceSkippedCeilingTests.cs
@@ -7,6 +7,7 @@ using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Configuration;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Sec.Repositories;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -82,7 +83,8 @@ public class XbrlBackfillServiceSkippedCeilingTests : ParadeDbMcpTestBase
         var repo = new DocumentRepository(DbContext);
         var persistence = new DocumentPersistenceService(
             repo,
-            new FileManager(new FileRepository(DbContext))
+            new FileManager(new FileRepository(DbContext)),
+            Substitute.For<IBus>()
         );
         var capture = new XbrlEnvelopeCaptureService(
             Options.Create(new XbrlCaptureOptions { Enabled = false }),

--- a/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs
@@ -7,6 +7,7 @@ using Equibles.Sec.Data.Models;
 using Equibles.Sec.HostedService.Configuration;
 using Equibles.Sec.HostedService.Services;
 using Equibles.Sec.Repositories;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -83,7 +84,8 @@ public class XbrlBackfillServiceTests : ParadeDbMcpTestBase
         var repo = new DocumentRepository(DbContext);
         var persistence = new DocumentPersistenceService(
             repo,
-            new FileManager(new FileRepository(DbContext))
+            new FileManager(new FileRepository(DbContext)),
+            Substitute.For<IBus>()
         );
         var capture = new XbrlEnvelopeCaptureService(
             Options.Create(new XbrlCaptureOptions { Enabled = true }),
@@ -197,7 +199,8 @@ public class XbrlBackfillServiceTests : ParadeDbMcpTestBase
         var repo = new DocumentRepository(DbContext);
         var persistence = new DocumentPersistenceService(
             repo,
-            new FileManager(new FileRepository(DbContext))
+            new FileManager(new FileRepository(DbContext)),
+            Substitute.For<IBus>()
         );
         // Capture disabled => every fetched submission resolves to NotChecked (the Skipped branch).
         var capture = new XbrlEnvelopeCaptureService(

--- a/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentScraperTests.cs
@@ -80,6 +80,7 @@ public class DocumentScraperTests
                 default,
                 default,
                 default,
+                default,
                 default
             );
     }
@@ -151,6 +152,7 @@ public class DocumentScraperTests
                 ReportDateAlpha,
                 "https://sec.gov/acme-10k.htm",
                 "0000123456-25-000001",
+                Arg.Any<string>(),
                 Arg.Any<XbrlCaptureResult>(),
                 Arg.Any<CancellationToken>()
             );
@@ -205,6 +207,7 @@ public class DocumentScraperTests
         await harness
             .Persistence.DidNotReceiveWithAnyArgs()
             .Save(
+                default,
                 default,
                 default,
                 default,
@@ -280,6 +283,7 @@ public class DocumentScraperTests
                 Arg.Any<DateOnly>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
+                Arg.Any<string>(),
                 Arg.Any<XbrlCaptureResult>(),
                 Arg.Any<CancellationToken>()
             );
@@ -294,6 +298,7 @@ public class DocumentScraperTests
                 Arg.Any<DateOnly>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
+                Arg.Any<string>(),
                 Arg.Any<XbrlCaptureResult>(),
                 Arg.Any<CancellationToken>()
             );
@@ -306,6 +311,7 @@ public class DocumentScraperTests
                 Arg.Any<DocumentType>(),
                 Arg.Any<DateOnly>(),
                 Arg.Any<DateOnly>(),
+                Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
                 Arg.Any<XbrlCaptureResult>(),
@@ -338,6 +344,7 @@ public class DocumentScraperTests
         await harness
             .Persistence.DidNotReceiveWithAnyArgs()
             .Save(
+                default,
                 default,
                 default,
                 default,

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientMapToFilingDataTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientMapToFilingDataTests.cs
@@ -53,4 +53,37 @@ public class SecEdgarClientMapToFilingDataTests
 
         result[1].Form.Should().Be("8-K");
     }
+
+    // Items is the parallel column the earnings-call linker reads to spot Item 2.02
+    // earnings-release 8-Ks. SEC populates it only for 8-Ks and routinely drops the
+    // trailing empties, so the mapper must index defensively and normalise a blank
+    // (the 10-K row) to null while preserving the 8-K's comma-joined item list.
+    [Fact]
+    public void MapToFilingData_ItemsColumn_MapsEightKItemsAndNullsBlanks()
+    {
+        var asm = typeof(SecEdgarClient).Assembly;
+        var recentType = asm.GetType("Equibles.Integrations.Sec.Models.Responses.RecentFilings")!;
+        var recent = Activator.CreateInstance(recentType)!;
+
+        void Set(string prop, List<string> values) =>
+            recentType.GetProperty(prop)!.SetValue(recent, values);
+
+        Set("AccessionNumber", ["0000320193-24-000010", "0000320193-24-000020"]);
+        Set("FilingDate", ["2024-02-01", "2024-03-15"]);
+        Set("ReportDate", ["2023-12-30", "2024-01-31"]);
+        Set("Form", ["10-K", "8-K"]);
+        Set("PrimaryDocument", ["aapl-20231230.htm", "ex991.htm"]);
+        Set("PrimaryDocDescription", ["Annual report", "Press release"]);
+        Set("Items", ["", "2.02,9.01"]);
+
+        var map = typeof(SecEdgarClient).GetMethod(
+            "MapToFilingData",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+        var result = (List<FilingData>)map.Invoke(null, [recent, "320193"])!;
+
+        result[0].Items.Should().BeNull("a blank items cell maps to null");
+        result[1].Items.Should().Be("2.02,9.01");
+    }
 }


### PR DESCRIPTION
## Summary

Two related additions to the SEC document pipeline, both needed by the commercial earnings-call event work (EquiblesCommercial #671): identify earnings-release 8-Ks, and let a consumer react to new filings as they land.

- **8-K item numbers** — the company submissions feed already returns a parallel `items` array per filing (e.g. `"2.02,9.01"` on an 8-K), but it was dropped during deserialization. Carry it through `FilingData` and persist it on a new nullable `Document.Items` column. This lets a consumer pick out earnings-release 8-Ks (Item 2.02 — Results of Operations and Financial Condition) authoritatively, without re-parsing the filing. No extra HTTP request — the array rides the response we already fetch and cache.
- **DocumentSaved event** — published from `DocumentPersistenceService.Save` after the insert commits, carrying the document id plus the metadata a consumer needs (stock, ticker, type, items, reporting dates, accession). It fires for every persisted document, including the commercial earnings-call transcript that flows through the same `Save`, so a single seam covers all artefacts. There is no transactional outbox here, so the publish runs post-commit and consumers must be idempotent.

## Code changes

- `RecentFilings` / `FilingData` / `SecEdgarClient.TryBuildFilingDataAt` — deserialize and map the `items` column defensively (blank → null).
- `Document` — new `[MaxLength(256)]` nullable `Items` column + migration `AddDocumentItems`.
- `IDocumentPersistenceService` / `DocumentPersistenceService` — thread `items` through `Save`, inject `IBus`, publish `DocumentSaved` after commit.
- `DocumentScraper` — pass `filing.Items` to `Save`.
- New `Equibles.Messaging.Contracts.Sec.DocumentSaved` record.
- Tests — pin the `items` column mapping; assert `Save` round-trips `Items` and publishes `DocumentSaved`; thread the bus mock through the existing persistence-service test constructions.