### PR TITLE
docs(technical/scrapers): document investor relations discovery worker

### DIFF
--- a/docs/technical/scrapers.md
+++ b/docs/technical/scrapers.md
@@ -105,6 +105,15 @@ These sources publish a continuous time series rather than discrete filings. Eac
 
 The cursor pattern means re-running is cheap (a single query for `max(date)` per cycle); duplicate ingestion is prevented by the per-source unique index (`[Index(nameof(CommonStockId), nameof(Date), IsUnique = true)]` etc.).
 
+### Investor relations discovery — pending-column backlog
+
+[`InvestorRelationsDiscoveryWorker`](../../src/Equibles.CommonStocks.HostedService/InvestorRelationsDiscoveryWorker.cs) fills `CommonStock.InvestorRelationsUrl` without a feed, a ledger, or a date cursor — its work queue is the set of rows where the column is still null.
+
+- Idempotency comes from the candidate query itself: [`InvestorRelationsDiscoveryService.LoadCandidates`](../../src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs) selects `Website != null && InvestorRelationsUrl == null`, ordered by ticker, capped at `BatchSize` (default 100). A filled row drops out of the backlog automatically; re-runs never re-do solved stocks.
+- Discovery is a probe, not a fetch: [`InvestorRelationsProbeClient`](../../src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs) tries `CandidatePaths` against the company website (`/investor-relations`, `/investors`, …) then `CandidateSubdomains` (`ir.`, `investors.`), and [`InvestorRelationsPageValidator`](../../src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsPageValidator.cs) confirms the HTML is a real IR page — title/body keyword signals reject soft-404s and homepages a guessed path redirected to.
+- `Persist` re-loads the row and writes only when `InvestorRelationsUrl` is still null, so an overlapping run or manual edit is never clobbered.
+- A stock that has no discoverable IR page stays null and is re-probed every cycle — there is no last-attempted timestamp yet, so persistent misses are not yet suppressed.
+
 ## Cold-start patterns
 
 - Empty `CommonStock` table → most scrapers `RequestRetrySoon()` and wait `NotReadyRetryInterval` (2 min) instead of the full `SleepInterval` (24h).


### PR DESCRIPTION
## Summary

- Documents the new investor relations discovery worker (#3574) in the technical scrapers reference.
- Adds it as a third idempotency model alongside the dedup ledger and date cursor — a pending-column backlog driven by the candidate query rather than a separate ledger table.

## Code changes

- `docs/technical/scrapers.md` — new "Investor relations discovery — pending-column backlog" subsection under Bookkeeping: explains how `InvestorRelationsDiscoveryWorker` selects null-`InvestorRelationsUrl` stocks in bounded batches, probes candidate paths/subdomains, validates page content, persists only when still unset, and re-probes misses each cycle.