### PR TITLE
test(holdings): add skipped repro for GH-3578 — Filing13DGXmlParser ParseShares Int64 overflow

### DIFF
--- a/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserShareOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserShareOverflowTests.cs
@@ -1,0 +1,53 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+// Adversarial: the parser documents itself as resilient — every unparseable
+// field degrades to a default (ParseShares -> 0, ParsePercent -> null,
+// ParseSecDate -> MinValue) so "the filing is never silently dropped". A share
+// count that parses as a decimal but exceeds long.MaxValue must follow the same
+// contract and degrade to 0, not throw OverflowException and crash the whole
+// filing parse.
+public class Filing13DGXmlParserShareOverflowTests
+{
+    private readonly Filing13DGXmlParser _sut = new();
+
+    // 20 nines ~= 1e20, comfortably inside decimal's range but above
+    // long.MaxValue (~9.2e18). decimal.TryParse succeeds; the (long) cast in
+    // ParseShares is the only place this value goes.
+    private const string OverflowingShareCount = "99999999999999999999";
+
+    private static string MinimalFilingWithSoleVotingPower(string soleVotingPower) =>
+        $"""
+            <edgarSubmission>
+              <headerData>
+                <submissionType>SCHEDULE 13D</submissionType>
+              </headerData>
+              <coverPageHeader>
+                <issuerInfo>
+                  <issuerName>Test Issuer Inc.</issuerName>
+                </issuerInfo>
+                <reportingPersonInfo>
+                  <reportingPersonName>Overflow Holder LP</reportingPersonName>
+                  <soleVotingPower>{soleVotingPower}</soleVotingPower>
+                </reportingPersonInfo>
+              </coverPageHeader>
+            </edgarSubmission>
+            """;
+
+    [Fact(Skip = "GH-3578 — ParseShares throws OverflowException on share counts above long.MaxValue instead of degrading to 0")]
+    public void ParseFiling_ShareCountAboveInt64Max_DegradesToZeroRatherThanThrowing()
+    {
+        var xml = MinimalFilingWithSoleVotingPower(OverflowingShareCount);
+
+        var person = _sut.ParseFiling(
+                xml,
+                accessionNumber: "0001140361-25-000001",
+                cik: "0001234567",
+                filingDate: new DateOnly(2025, 1, 1)
+            )
+            .ReportingPersons.Single();
+
+        person.SoleVotingPower.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial `/add-test` found a real defect: `Filing13DGXmlParser.ParseShares` throws `OverflowException` on a share count that parses as `decimal` but exceeds `long.MaxValue`, crashing the parse of the entire filing instead of degrading that field to `0` like every other field-parser in the class. Filed as GH-3578.
- This PR ships the failing regression test as `[Skip]` (no production change). Un-skip it as part of the GH-3578 fix.

## Code changes

- `tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserShareOverflowTests.cs` — new test: a minimal 13D `primary_doc.xml` with `soleVotingPower = 99999999999999999999` should degrade `SoleVotingPower` to `0`; currently throws `OverflowException` (skipped — see GH-3578).