### PR TITLE
fix(holdings): degrade out-of-range share counts to 0 in Filing13DGXmlParser

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/Filing13DGXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13DGXmlParser.cs
@@ -190,6 +190,11 @@ public class Filing13DGXmlParser
             CultureInfo.InvariantCulture,
             out var value
         )
+        // A value that parses but exceeds Int64 (corrupt/typo'd field) must degrade
+        // to 0 like every other field-parser here; the decimal->long cast is always
+        // range-checked and would otherwise throw, crashing the whole filing parse.
+        && value >= long.MinValue
+        && value <= long.MaxValue
             ? (long)value
             : 0;
 

--- a/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserShareOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserShareOverflowTests.cs
@@ -35,7 +35,7 @@ public class Filing13DGXmlParserShareOverflowTests
             </edgarSubmission>
             """;
 
-    [Fact(Skip = "GH-3578 — ParseShares throws OverflowException on share counts above long.MaxValue instead of degrading to 0")]
+    [Fact]
     public void ParseFiling_ShareCountAboveInt64Max_DegradesToZeroRatherThanThrowing()
     {
         var xml = MinimalFilingWithSoleVotingPower(OverflowingShareCount);


### PR DESCRIPTION
## Summary

- Fixes GH-3578: `Filing13DGXmlParser.ParseShares` cast a successfully-parsed `decimal` straight to `long`. A share/power value above `long.MaxValue` (corrupt or typo'd field) threw `OverflowException` at the always-range-checked cast, crashing the parse of the **entire** filing instead of degrading that one field to `0` like every other field-parser in the class.
- Range-check the value before the cast so out-of-range degrades to `0`, consistent with the existing unparseable→`0` path. Valid inputs are unaffected (all cassette-based parser tests still assert their exact values).

## Code changes

- `src/Equibles.Holdings.HostedService/Services/Filing13DGXmlParser.cs` — add `value >= long.MinValue && value <= long.MaxValue` guard to `ParseShares` before the `(long)` cast; degrade out-of-range to `0`.
- `tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserShareOverflowTests.cs` — un-skip the GH-3578 regression test (fails before, passes after).

closes #3578