### PR TITLE
fix(holdings): guard ParseShares decimal->long cast against overflow

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/Filing13DGXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13DGXmlParser.cs
@@ -183,15 +183,26 @@ public class Filing13DGXmlParser
     /// 13D as plain integers; both may carry thousands separators. Parsed as a
     /// decimal and truncated to whole shares.
     /// </summary>
-    private static long ParseShares(string raw) =>
-        decimal.TryParse(
-            raw?.Replace(",", string.Empty),
-            NumberStyles.Number,
-            CultureInfo.InvariantCulture,
-            out var value
+    private static long ParseShares(string raw)
+    {
+        if (
+            !decimal.TryParse(
+                raw?.Replace(",", string.Empty),
+                NumberStyles.Number,
+                CultureInfo.InvariantCulture,
+                out var value
+            )
         )
-            ? (long)value
-            : 0;
+            return 0;
+
+        // The decimal->long cast is range-checked and throws on values above
+        // long.MaxValue (a corrupted or concatenated share count); degrade to 0
+        // like every other field rather than crash the whole filing parse.
+        if (value < long.MinValue || value > long.MaxValue)
+            return 0;
+
+        return (long)value;
+    }
 
     private static decimal? ParsePercent(string raw) =>
         decimal.TryParse(

--- a/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserShareOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserShareOverflowTests.cs
@@ -35,7 +35,7 @@ public class Filing13DGXmlParserShareOverflowTests
             </edgarSubmission>
             """;
 
-    [Fact(Skip = "GH-3578 — ParseShares throws OverflowException on share counts above long.MaxValue instead of degrading to 0")]
+    [Fact]
     public void ParseFiling_ShareCountAboveInt64Max_DegradesToZeroRatherThanThrowing()
     {
         var xml = MinimalFilingWithSoleVotingPower(OverflowingShareCount);


### PR DESCRIPTION
## Summary

- `Filing13DGXmlParser.ParseShares` cast a parsed `decimal` to `long` with the always range-checked `(long)` cast. A share/power value above `long.MaxValue` (≈9.2e18) — a corrupted, concatenated, or typo'd `soleVotingPower`/`sharedVotingPower`/`aggregateAmountOwned` — threw `OverflowException`, which propagated up through `ParseReportingPerson`/`ParseFiling` and crashed the parse of the **entire** filing. The realtime 13D/13G ingestion's catch-all then silently dropped the whole filing.
- This broke the parser's documented never-drop-the-filing contract, under which every unparseable field degrades to a default (`ParseShares` → 0). An unparseable count (`"abc"`) degraded to 0, but a parseable-but-too-large one crashed.
- Fix range-checks the decimal before the cast so an out-of-range value degrades to 0 like every other field. Closes #3578.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/Filing13DGXmlParser.cs` — `ParseShares` now returns 0 when the parsed decimal falls outside `[long.MinValue, long.MaxValue]`, before the range-checked cast.
- `tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserShareOverflowTests.cs` — removed the `Skip` marker; the regression test (a 13D filing with a `soleVotingPower` of `99999999999999999999`) now runs and asserts the field degrades to 0.