### PR TITLE
docs(technical/mcp-tools): document GetOffExchangeVolume tool

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -104,6 +104,10 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetShortInterest` — bi-monthly short-interest reports for a ticker.
 - `GetShortInterestSnapshot` — latest short-interest snapshot across tickers.
 
+`OffExchangeVolumeTools`:
+
+- `GetOffExchangeVolume` — weekly off-exchange (dark-pool / OTC) volume per ticker from FINRA OTC/ATS Transparency data: ATS volume and trade count, non-ATS OTC volume and trade count, and the ATS + non-ATS OTC total.
+
 ### `mcp.AddCftc()` — CFTC Commitments of Traders
 
 `CftcTools`:


### PR DESCRIPTION
## Summary

- Maintain lane: missing doc for a new feature.
- The Finra MCP module registers its tools assembly-wide (`WithToolsFromAssembly`), so `OffExchangeVolumeTools` (added in #3569) is exposed under `mcp.AddShortData()` but was absent from the tool catalog. This adds its `GetOffExchangeVolume` entry.

## Code changes

- `docs/technical/mcp-tools.md` — adds an `OffExchangeVolumeTools` block under the `mcp.AddShortData()` section listing `GetOffExchangeVolume`.