### PR TITLE
docs(technical/mcp-tools): add missing SEC funds, Form D and adviser tools

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -59,6 +59,23 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 
 - `GetFailsToDeliver` — FTD records for a ticker over a date range.
 
+`FormDTools`:
+
+- `GetExemptOfferings` — recent exempt offerings (Regulation D private placements) for a company from SEC Form D notices: offering amount, amount sold (dollar figure or `Indefinite`), minimum investment, investor count, claimed exemptions, and amendment flag.
+
+`NportTools`:
+
+- `GetFundHoldings` — portfolio holdings of a fund or ETF from its latest SEC Form NPORT-P monthly report: series, reporting period, net assets, and largest positions (issuer, CUSIP, position size, USD value, share of net assets, asset category). Only registered funds file NPORT-P.
+
+`NCenTools`:
+
+- `GetFundOperations` — operational data for a fund, ETF or closed-end fund from SEC Form N-CEN annual reports: registrant classification, Investment Company Act file number, reporting period, first/last-filing flags, and named service providers (advisers, sub-advisers, custodians, transfer agents, administrators, auditors, underwriters). Only registered funds file N-CEN.
+
+`InvestmentAdviserTools`:
+
+- `SearchInvestmentAdvisers` — search SEC-registered investment advisers (Form ADV) by firm name; returns CRD number, main office, regulatory assets under management and employee count, largest by assets first.
+- `GetInvestmentAdviser` — full Form ADV profile for one adviser by Organization CRD number: legal and business names, SEC file number, main office, website, regulatory AUM (discretionary, non-discretionary, total), employee count, and fee structure.
+
 ### `mcp.AddFinancialFacts()` — XBRL facts
 
 `FinancialFactsTools`:


### PR DESCRIPTION
## Summary

- Maintain lane: the MCP tool catalog claims to list every tool an AI assistant sees in `tools/list`, but the `mcp.AddSec()` section had drifted — five live tools were undocumented.
- Adds the missing SEC tool-classes so the catalog matches `src/Equibles.Sec.Mcp/Tools/` and `src/Equibles.InsiderTrading.Mcp/...` is unaffected here (only SEC tools were added).

## Code changes

- `docs/technical/mcp-tools.md` — under `### mcp.AddSec()`, add `FormDTools` (`GetExemptOfferings`), `NportTools` (`GetFundHoldings`), `NCenTools` (`GetFundOperations`), and `InvestmentAdviserTools` (`SearchInvestmentAdvisers`, `GetInvestmentAdviser`), each with a one-line description matching the tool's `[Description]`.