### PR TITLE
test(web): pin OwnershipPercent returns null on zero shares outstanding

### DIFF
--- a/tests/Equibles.UnitTests/Web/HolderPositionChangeOwnershipPercentZeroDivisorTests.cs
+++ b/tests/Equibles.UnitTests/Web/HolderPositionChangeOwnershipPercentZeroDivisorTests.cs
@@ -1,0 +1,20 @@
+using Equibles.Web.ViewModels.Stocks;
+
+namespace Equibles.UnitTests.Web;
+
+public class HolderPositionChangeOwnershipPercentZeroDivisorTests
+{
+    // Contract: OwnershipPercent returns the holder's current shares as a percentage
+    // of shares outstanding. When shares outstanding is not positive there is no
+    // meaningful percentage, so it must return null — never divide by zero into
+    // Infinity/NaN, which would render as a garbage ownership figure in the table.
+    [Fact]
+    public void OwnershipPercent_ZeroSharesOutstanding_ReturnsNull()
+    {
+        var change = new HolderPositionChange { CurrentShares = 1_000_000 };
+
+        var result = change.OwnershipPercent(0);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Lane A (adversarial → behavior confirmed) `/add-test`: pins `HolderPositionChange.OwnershipPercent`.
- With `sharesOutstanding == 0` the method must return `null`, never divide into Infinity/NaN — which would render a garbage ownership figure in the holdings table. Test passes (guard confirmed).

## Code changes

- `tests/Equibles.UnitTests/Web/HolderPositionChangeOwnershipPercentZeroDivisorTests.cs` — new unit test asserting `OwnershipPercent(0)` is null when current shares are positive.