### PR TITLE
docs(technical/mcp-tools): add GetMostHeldStocks to the AddHoldings catalog

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -32,6 +32,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetInstitutionQuarterlyActivity` — one filer's position changes vs. the prior quarter, bucketed into Initiated / Increased / Reduced / Exited; optional `bucket` filter to a single bucket.
 - `GetFundOverlap` — 13F portfolio overlap between two filers at their latest common `ReportDate`: Jaccard similarity, dollar-weighted overlap, and a side-by-side stock table with per-fund shares + percent of portfolio.
 - `GetConsensusHoldings` — combined portfolio of 2-25 filers at their latest common `ReportDate`; stocks ranked by holder count then combined value, with optional `minFunds` floor.
+- `GetMostHeldStocks` — cross-sectional ranking of stocks by institutional 13F breadth for a quarter, ordered by filer count (default), quarter-over-quarter change in filer count (warming / cooling), or total reported value; includes Δ filers, total value, Δ value, and the stock's share of the 13F universe.
 
 ### `mcp.AddInsiderTrading()` — Form 3 / 4
 


### PR DESCRIPTION
## Summary

- Maintain lane: the MCP tool catalog claims to list every tool in `tools/list`, but `mcp.AddHoldings()` omitted the live `GetMostHeldStocks` tool.
- Adds the missing bullet so the catalog matches `src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs`.

## Code changes

- `docs/technical/mcp-tools.md` — add `GetMostHeldStocks` under `InstitutionalHoldingsTools` with a one-line description matching the tool's `[Description]`.