### PR TITLE
docs(technical/mcp-tools): add GetLargestShortVolume to the AddShortData catalog

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -122,6 +122,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetShortVolume` — daily short-volume time series (FINRA).
 - `GetShortInterest` — bi-monthly short-interest reports for a ticker.
 - `GetShortInterestSnapshot` — latest short-interest snapshot across tickers.
+- `GetLargestShortVolume` — stocks with the largest daily short volume for a single trading day (defaults to the latest available), sorted by short volume descending.
 
 `OffExchangeVolumeTools`:
 


### PR DESCRIPTION
## Summary

- Maintain lane: the MCP tool catalog claims to list every tool in `tools/list`, but `mcp.AddShortData()` omitted the live `GetLargestShortVolume` tool.
- Adds the missing bullet so the catalog matches `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs`.

## Code changes

- `docs/technical/mcp-tools.md` — add `GetLargestShortVolume` under `ShortDataTools` with a one-line description matching the tool's `[Description]`.