### PR TITLE
docs(guide): add how-to — view proposed sales

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -43,6 +43,7 @@ Task-focused recipes for someone who has Equibles running.
 - [Check worker health and recent errors](how-to-view-status-and-errors.md)
 - [Search for stocks, filings, institutions, and more](how-to-search.md)
 - [View market-wide insider trading activity](how-to-view-insider-activity.md)
+- [View proposed insider sales (SEC Form 144)](how-to-view-proposed-sales.md)
 - [Browse market-wide short data (most shorted and largest short volume)](how-to-browse-short-data.md)
 - [Browse economic indicators](how-to-browse-economic-data.md)
 - [Browse market indicators (VIX and put/call ratios)](how-to-browse-market-indicators.md)

--- a/docs/guide/how-to-view-proposed-sales.md
+++ b/docs/guide/how-to-view-proposed-sales.md
@@ -1,0 +1,30 @@
+# View proposed insider sales (SEC Form 144)
+
+This guide shows you how to see notices of intent to sell restricted or control shares that insiders and affiliates file with the SEC on Form 144.
+
+A Form 144 signals a *planned* sale — it does not confirm the shares were actually sold. Treat it as a heads-up, not a completed transaction.
+
+## Open the Proposed Sales tab
+
+1. Search for a company by its ticker and open its profile page.
+
+2. Click the **Proposed Sales** tab (or go to `http://localhost:8080/stocks/{ticker}/proposed-sales`).
+
+3. If the company has Form 144 notices, you see a table of them, newest first. If not, the tab shows a "No Proposed Sales" message.
+
+## Read the proposed-sales table
+
+Each row is one Form 144 notice. The columns are:
+
+- **Filed** — when the notice was submitted to the SEC.
+- **Seller** — the person or entity proposing the sale.
+- **Relationship** — the seller's relationship to the company (for example, officer or director).
+- **Shares** — the number of shares the seller intends to sell.
+- **Market Value** — the aggregate market value of those shares, as reported on the notice.
+- **Approx. Sale** — the approximate date of the proposed sale.
+- **Broker** — the broker handling the sale.
+
+## Related
+
+- For completed insider transactions (Forms 3, 4, and 5), see the **Insider Trading** tab on the same profile.
+- To walk through every tab on a stock profile, see [Explore a company's data on the web portal](tutorial-explore-stock.md).


### PR DESCRIPTION
## Summary

- Expand lane: the Proposed Sales (SEC Form 144) tab on a stock profile had no how-to.
- Adds a guide page covering the notices table (seller, relationship, shares, market value, approx. sale date, broker) and clarifies a Form 144 signals a planned sale, not a confirmed one.

## Code changes

- `docs/guide/how-to-view-proposed-sales.md` — new how-to page.
- `docs/guide/README.md` — adds the TOC bullet under How-to guides.