### PR TITLE
docs(technical/mcp-tools): add GetProposedSales to the AddInsiderTrading catalog

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -41,6 +41,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetInsiderTransactions` — recent transactions for a ticker, filterable by transaction code.
 - `GetInsiderOwnership` — current insider ownership summary for a ticker.
 - `SearchInsiders` — search insiders by name / company / role.
+- `GetProposedSales` — recent proposed insider sales for a ticker from SEC Form 144 notices: seller, relationship to the company, shares and aggregate market value to be sold, approximate sale date, and broker.
 
 ### `mcp.AddSec()` — SEC filings
 


### PR DESCRIPTION
## Summary

- Maintain lane: the MCP tool catalog claims to list every tool in `tools/list`, but `mcp.AddInsiderTrading()` omitted the live `GetProposedSales` (Form 144) tool.
- Adds the missing bullet so the catalog matches `src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs`. This completes the catalog — all module sections now list every registered tool.

## Code changes

- `docs/technical/mcp-tools.md` — add `GetProposedSales` under `InsiderTradingTools` with a one-line description matching the tool's `[Description]`.