### PR TITLE
feat(common-stocks): add IrPlatformType to CommonStock

### DIFF
--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -36,6 +36,14 @@ public class CommonStock
     [MaxLength(256)]
     public string InvestorRelationsUrl { get; set; }
 
+    /// <summary>
+    /// Platform/CMS the company's investor-relations website runs on, detected from
+    /// the <see cref="InvestorRelationsUrl"/> page HTML. <see cref="IrPlatformType.Unknown"/>
+    /// until an IR page is discovered and classified. Determines which IR scraper
+    /// handles the company.
+    /// </summary>
+    public IrPlatformType IrPlatformType { get; set; }
+
     public double MarketCapitalization { get; set; }
     public long SharesOutStanding { get; set; }
 

--- a/src/Equibles.CommonStocks.Data/Models/IrPlatformType.cs
+++ b/src/Equibles.CommonStocks.Data/Models/IrPlatformType.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.CommonStocks.Data.Models;
+
+/// <summary>
+/// The platform or CMS a company's investor-relations website runs on, detected
+/// from the IR page HTML. Determines which scraper implementation handles each
+/// company's IR content.
+/// </summary>
+public enum IrPlatformType
+{
+    /// <summary>Not yet classified, or the company has no discovered IR page.</summary>
+    [Display(Name = "Unknown")]
+    Unknown = 0,
+
+    /// <summary>Q4 Inc investor-relations platform (assets served from q4cdn.com).</summary>
+    [Display(Name = "Q4 Inc")]
+    Q4Inc = 1,
+
+    /// <summary>Nasdaq IR Insight investor-relations platform.</summary>
+    [Display(Name = "Nasdaq IR Insight")]
+    NasdaqIrInsight = 2,
+
+    /// <summary>Business Wire investor-relations / newsroom platform.</summary>
+    [Display(Name = "Business Wire")]
+    BusinessWire = 3,
+
+    /// <summary>Notified (GlobeNewswire) investor-relations platform.</summary>
+    [Display(Name = "Notified")]
+    Notified = 4,
+
+    /// <summary>An IR page that matched no known vendor signature — a bespoke site.</summary>
+    [Display(Name = "Custom")]
+    Custom = 5,
+}

--- a/src/Equibles.Migrations/Migrations/20260609120859_AddIrPlatformTypeToCommonStock.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260609120859_AddIrPlatformTypeToCommonStock.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609120859_AddIrPlatformTypeToCommonStock")]
+    partial class AddIrPlatformTypeToCommonStock
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260609120859_AddIrPlatformTypeToCommonStock.cs
+++ b/src/Equibles.Migrations/Migrations/20260609120859_AddIrPlatformTypeToCommonStock.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIrPlatformTypeToCommonStock : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "IrPlatformType",
+                table: "CommonStock",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IrPlatformType",
+                table: "CommonStock");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds an `IrPlatformType` enum and an `IrPlatformType` column on `CommonStock` (defaults to `Unknown`). It records which platform/CMS a company's investor-relations website runs on — the foundation for routing each company to the right IR scraper. A follow-up PR adds the classifier that fills it in during IR-page discovery.

## Code changes

- `IrPlatformType` enum — `Unknown`, `Q4Inc`, `NasdaqIrInsight`, `BusinessWire`, `Notified`, `Custom`, each with a `[Display]` name.
- `CommonStock.IrPlatformType` property.
- Additive migration (`integer NOT NULL DEFAULT 0`).