### PR TITLE
feat(common-stocks): classify investor relations platform during discovery

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
@@ -59,7 +59,7 @@ public class InvestorRelationsDiscoveryService : IImporter
 
             try
             {
-                var url = await _probeClient.Discover(
+                var result = await _probeClient.Discover(
                     candidate.Website,
                     _options.CandidatePaths,
                     _options.CandidateSubdomains,
@@ -68,16 +68,17 @@ public class InvestorRelationsDiscoveryService : IImporter
                 // No IR page found this cycle. The stock stays null and is re-probed
                 // next cycle. TODO(#581 follow-up): record a last-attempted timestamp
                 // so persistent misses aren't re-probed every cycle.
-                if (url == null)
+                if (result == null)
                     continue;
 
-                if (await Persist(candidate.Id, url))
+                if (await Persist(candidate.Id, result))
                 {
                     discovered++;
                     _logger.LogDebug(
-                        "Discovered investor relations page for {Ticker}: {Url}",
+                        "Discovered investor relations page for {Ticker}: {Url} ({Platform})",
                         candidate.Ticker,
-                        url
+                        result.Url,
+                        result.Platform
                     );
                 }
             }
@@ -127,7 +128,7 @@ public class InvestorRelationsDiscoveryService : IImporter
         return rows.Select(r => new CandidateStock(r.Id, r.Ticker, r.Website)).ToList();
     }
 
-    private async Task<bool> Persist(Guid commonStockId, string investorRelationsUrl)
+    private async Task<bool> Persist(Guid commonStockId, IrDiscoveryResult result)
     {
         using var scope = _scopeFactory.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
@@ -138,7 +139,8 @@ public class InvestorRelationsDiscoveryService : IImporter
         if (stock == null || stock.InvestorRelationsUrl != null)
             return false;
 
-        stock.InvestorRelationsUrl = investorRelationsUrl;
+        stock.InvestorRelationsUrl = result.Url;
+        stock.IrPlatformType = result.Platform;
         await repo.SaveChanges();
         return true;
     }

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
@@ -32,10 +32,11 @@ public class InvestorRelationsProbeClient
     }
 
     /// <summary>
-    /// Returns the validated investor-relations URL for <paramref name="website"/>,
-    /// or null when no candidate resolves to a recognisable IR page.
+    /// Returns the validated investor-relations URL for <paramref name="website"/>
+    /// together with the platform classified from its page, or null when no
+    /// candidate resolves to a recognisable IR page.
     /// </summary>
-    public async Task<string> Discover(
+    public async Task<IrDiscoveryResult> Discover(
         string website,
         IEnumerable<string> paths,
         IEnumerable<string> subdomains,
@@ -56,7 +57,10 @@ public class InvestorRelationsProbeClient
         return null;
     }
 
-    private async Task<string> TryResolve(string url, CancellationToken cancellationToken)
+    private async Task<IrDiscoveryResult> TryResolve(
+        string url,
+        CancellationToken cancellationToken
+    )
     {
         try
         {
@@ -81,7 +85,12 @@ public class InvestorRelationsProbeClient
             var finalUrl = response.RequestMessage?.RequestUri?.ToString() ?? url;
             if (finalUrl.Length > MaxUrlLength)
                 finalUrl = url;
-            return finalUrl.Length > MaxUrlLength ? null : finalUrl;
+            if (finalUrl.Length > MaxUrlLength)
+                return null;
+
+            // Classify the platform from the page we already fetched — no second request.
+            var platform = IrPlatformClassifier.Classify(html);
+            return new IrDiscoveryResult(finalUrl, platform);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/Equibles.CommonStocks.HostedService/Services/IrDiscoveryResult.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/IrDiscoveryResult.cs
@@ -1,0 +1,9 @@
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Outcome of a successful investor-relations probe: the validated IR page URL and
+/// the platform classified from that page's HTML.
+/// </summary>
+public sealed record IrDiscoveryResult(string Url, IrPlatformType Platform);

--- a/src/Equibles.CommonStocks.HostedService/Services/IrPlatformClassifier.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/IrPlatformClassifier.cs
@@ -1,0 +1,46 @@
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Classifies which platform a company's investor-relations website runs on by
+/// looking for deterministic vendor markers (CDN / asset domains) in the page
+/// HTML. Pure logic (no I/O) so it is unit-testable against fixture HTML.
+/// </summary>
+public static class IrPlatformClassifier
+{
+    // Ordered vendor signatures: the first platform whose any marker appears in the
+    // page HTML wins. Markers are vendor-owned domains a hosted IR site loads assets
+    // from, so they don't collide with ordinary page content. Extend as more
+    // platforms are confirmed.
+    private static readonly (IrPlatformType Platform, string[] Markers)[] Signatures =
+    [
+        (IrPlatformType.Q4Inc, ["q4cdn.com", "q4inc.com", "q4web.com"]),
+        (IrPlatformType.BusinessWire, ["businesswire.com"]),
+        (IrPlatformType.Notified, ["notified.com", "globenewswire.com", "globenewswire"]),
+        (IrPlatformType.NasdaqIrInsight, ["ir.nasdaq.com", "nasdaqomx", "irinsight"]),
+    ];
+
+    /// <summary>
+    /// Returns the platform detected from <paramref name="html"/>:
+    /// <see cref="IrPlatformType.Unknown"/> when there is no HTML to inspect, a
+    /// specific vendor when one of its markers is present, or
+    /// <see cref="IrPlatformType.Custom"/> for a real IR page matching no known
+    /// vendor (a bespoke site).
+    /// </summary>
+    public static IrPlatformType Classify(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return IrPlatformType.Unknown;
+
+        var haystack = html.ToLowerInvariant();
+
+        foreach (var (platform, markers) in Signatures)
+        {
+            if (markers.Any(haystack.Contains))
+                return platform;
+        }
+
+        return IrPlatformType.Custom;
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
@@ -48,7 +48,7 @@ public class InvestorRelationsProbeClientTests
 
         var result = await client.Discover("https://acme.com", ["ir"], [], CancellationToken.None);
 
-        result.Should().Be("https://acme.com/ir");
-        result!.Length.Should().BeLessThanOrEqualTo(256);
+        result!.Url.Should().Be("https://acme.com/ir");
+        result.Url.Length.Should().BeLessThanOrEqualTo(256);
     }
 }

--- a/tests/Equibles.UnitTests/CommonStocks/IrPlatformClassifierTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/IrPlatformClassifierTests.cs
@@ -1,0 +1,66 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class IrPlatformClassifierTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Classify_NoHtml_ReturnsUnknown(string html)
+    {
+        // Contract: nothing to inspect → not classified (distinct from a real page
+        // that simply matches no vendor).
+        IrPlatformClassifier.Classify(html).Should().Be(IrPlatformType.Unknown);
+    }
+
+    [Theory]
+    [InlineData(
+        "<script src=\"https://s1.q4cdn.com/123/files/app.js\"></script>",
+        IrPlatformType.Q4Inc
+    )]
+    [InlineData("<link href=\"https://www.q4inc.com/styles.css\">", IrPlatformType.Q4Inc)]
+    [InlineData(
+        "<iframe src=\"https://cts.businesswire.com/feed\"></iframe>",
+        IrPlatformType.BusinessWire
+    )]
+    [InlineData(
+        "<script src=\"https://www.globenewswire.com/rss\"></script>",
+        IrPlatformType.Notified
+    )]
+    [InlineData("<a href=\"https://app.notified.com/login\">IR</a>", IrPlatformType.Notified)]
+    [InlineData(
+        "<script src=\"https://ir.nasdaq.com/feed.js\"></script>",
+        IrPlatformType.NasdaqIrInsight
+    )]
+    public void Classify_VendorMarkerPresent_ReturnsThatPlatform(
+        string html,
+        IrPlatformType expected
+    )
+    {
+        IrPlatformClassifier.Classify(html).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Classify_MarkerMatchIsCaseInsensitive()
+    {
+        IrPlatformClassifier
+            .Classify("<SCRIPT SRC=\"HTTPS://S1.Q4CDN.COM/A.JS\"></SCRIPT>")
+            .Should()
+            .Be(IrPlatformType.Q4Inc);
+    }
+
+    [Fact]
+    public void Classify_RealPageNoVendorMarker_ReturnsCustom()
+    {
+        // An IR page on a bespoke stack matches no vendor CDN — that's Custom, not
+        // Unknown (we did inspect a real page).
+        const string html =
+            "<html><head><title>Investor Relations - Acme</title></head>"
+            + "<body><script src=\"/assets/app.js\"></script></body></html>";
+
+        IrPlatformClassifier.Classify(html).Should().Be(IrPlatformType.Custom);
+    }
+}


### PR DESCRIPTION
## Summary

Fills in `CommonStock.IrPlatformType` (added in #3595) by classifying each company's investor-relations site as the discovery worker validates it. Classification reuses the page already fetched during discovery — no extra request — so it costs nothing on top of #581's IR-URL discovery. This is what routes each company to the right IR scraper in #583–#585.

## Code changes

- `IrPlatformClassifier` — deterministic vendor-marker matching against the page HTML: `q4cdn.com`/`q4inc.com` → Q4Inc, `businesswire.com` → BusinessWire, `notified.com`/`globenewswire.com` → Notified, `ir.nasdaq.com`/`nasdaqomx`/`irinsight` → NasdaqIrInsight. A real IR page matching no vendor → Custom; no page → Unknown.
- `InvestorRelationsProbeClient` now returns `IrDiscoveryResult` (URL + platform); `InvestorRelationsDiscoveryService` persists both.
- Unit tests for each signature, case-insensitivity, and the Custom fallback; the existing probe-client ceiling test adapted to the new return type.

Signatures are deterministic vendor domains (not fuzzy heuristics) and easy to extend as more platforms are confirmed.