### PR TITLE
fix(sec): eager-load Content and CommonStock in GetWithContent

### DIFF
--- a/src/Equibles.Sec.Repositories/DocumentRepository.cs
+++ b/src/Equibles.Sec.Repositories/DocumentRepository.cs
@@ -52,7 +52,10 @@ public class DocumentRepository : BaseRepository<Document>
 
     public async Task<Document> GetWithContent(Guid id)
     {
-        return await GetAll().FirstOrDefaultAsync(d => d.Id == id);
+        return await GetAll()
+            .Include(d => d.Content)
+            .Include(d => d.CommonStock)
+            .FirstOrDefaultAsync(d => d.Id == id);
     }
 
     public IQueryable<Document> GetByDateRange(DateOnly? fromDate = null, DateOnly? toDate = null)

--- a/tests/Equibles.IntegrationTests/Sec/DocumentRepositoryGetWithContentEagerLoadsTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/DocumentRepositoryGetWithContentEagerLoadsTests.cs
@@ -1,0 +1,63 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.Data.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Pins <see cref="DocumentRepository.GetWithContent"/>: it must eager-load the
+/// Content and CommonStock navigations the document viewer dereferences while
+/// rendering. Lazy-loading proxies are enabled process-wide, so a GetWithContent
+/// that omits the Includes makes each render open a fresh per-navigation
+/// connection (Castle proxy -> LazyLoader.Load), which under concurrent traffic
+/// exhausts the Portal connection pool.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class DocumentRepositoryGetWithContentEagerLoadsTests : ParadeDbMcpTestBase
+{
+    public DocumentRepositoryGetWithContentEagerLoadsTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    [Fact]
+    public async Task GetWithContent_LoadsContentAndCommonStock_WithoutLazyLoading()
+    {
+        var stock = new CommonStock { Ticker = "AAPL", Name = "Apple Inc." };
+        var file = new File
+        {
+            Name = "10k",
+            Extension = "htm",
+            ContentType = "text/html",
+            Size = 100,
+            FileContent = new FileContent { Bytes = new byte[] { 0x01 } },
+        };
+        var document = new Document
+        {
+            CommonStock = stock,
+            Content = file,
+            ContentId = file.Id,
+            DocumentType = DocumentType.TenK,
+            ReportingDate = new DateOnly(2025, 1, 15),
+        };
+        DbContext.Add(stock);
+        DbContext.Add(file);
+        DbContext.Add(document);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        await using var verify = Fixture.CreateDbContext();
+        var sut = new DocumentRepository(verify);
+
+        var loaded = await sut.GetWithContent(document.Id);
+
+        loaded.Should().NotBeNull();
+        // IsLoaded reports eager loading without dereferencing the navigation —
+        // dereferencing would itself lazily load it and mask the regression.
+        verify.Entry(loaded).Reference(d => d.Content).IsLoaded.Should().BeTrue();
+        verify.Entry(loaded).Reference(d => d.CommonStock).IsLoaded.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- `DocumentRepository.GetWithContent` returned the document with no `Include`s, despite its name. Callers that dereference `Content` or `CommonStock` while rendering (the document viewer) triggered EF Core lazy loading.
- With lazy-loading proxies enabled process-wide, each navigation opened a fresh per-navigation connection (`Castle.Proxies.DocumentProxy.get_Content()` → `LazyLoader.Load`), exhausting the connection pool under concurrent traffic and surfacing as unhandled 500s.
- Eager-load both navigations the callers read.

## Code changes

- `src/Equibles.Sec.Repositories/DocumentRepository.cs` — `GetWithContent` now `.Include(d => d.Content).Include(d => d.CommonStock)`.
- `tests/Equibles.IntegrationTests/Sec/DocumentRepositoryGetWithContentEagerLoadsTests.cs` — integration test asserting both references are loaded without lazy loading (fails before the fix, passes after).