### PR TITLE
feat(common-stocks): add IR news, events, and earnings-calendar models

### DIFF
--- a/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
+++ b/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
@@ -11,5 +11,8 @@ public class CommonStocksModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<CommonStock>();
         builder.Entity<Industry>();
         builder.Entity<Sector>();
+        builder.Entity<IrNewsItem>();
+        builder.Entity<IrEvent>();
+        builder.Entity<EarningsCalendarEntry>();
     }
 }

--- a/src/Equibles.CommonStocks.Data/Models/EarningsCalendarEntry.cs
+++ b/src/Equibles.CommonStocks.Data/Models/EarningsCalendarEntry.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CommonStocks.Data.Models;
+
+/// <summary>
+/// An upcoming (or recently past) earnings release date for a company's fiscal
+/// quarter, scraped from its IR earnings calendar. One row per fiscal period:
+/// the unique (CommonStockId, FiscalYear, FiscalQuarter) index lets a later scrape
+/// update a previously-estimated date to a confirmed one in place rather than
+/// inserting a duplicate.
+/// </summary>
+[Index(nameof(CommonStockId), nameof(FiscalYear), nameof(FiscalQuarter), IsUnique = true)]
+[Index(nameof(ScheduledDate))]
+public class EarningsCalendarEntry
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    public int FiscalYear { get; set; }
+
+    /// <summary>Fiscal quarter, 1-4.</summary>
+    public int FiscalQuarter { get; set; }
+
+    /// <summary>The release date as scheduled by the company.</summary>
+    public DateOnly ScheduledDate { get; set; }
+
+    /// <summary>
+    /// True when the company has confirmed the date; false when it is still the
+    /// platform's estimate. A later scrape can flip this without changing identity.
+    /// </summary>
+    public bool IsConfirmed { get; set; }
+
+    /// <summary>Source page URL when the platform provides one; otherwise null.</summary>
+    [MaxLength(1024)]
+    public string Url { get; set; }
+
+    /// <summary>The IR platform this entry was scraped from.</summary>
+    public IrPlatformType Source { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.CommonStocks.Data/Models/IrEvent.cs
+++ b/src/Equibles.CommonStocks.Data/Models/IrEvent.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CommonStocks.Data.Models;
+
+/// <summary>
+/// A scheduled investor-relations event (earnings webcast, conference appearance,
+/// presentation, shareholder meeting) for a company, scraped from its IR website.
+/// The unique (CommonStockId, StartDateTime, Title) index makes re-scraping
+/// idempotent without depending on a stable event URL, which several platforms omit.
+/// </summary>
+[Index(nameof(CommonStockId), nameof(StartDateTime), nameof(Title), IsUnique = true)]
+[Index(nameof(CommonStockId), nameof(StartDateTime))]
+public class IrEvent
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    [MaxLength(512)]
+    public string Title { get; set; }
+
+    /// <summary>When the event starts, in UTC.</summary>
+    public DateTime StartDateTime { get; set; }
+
+    public IrEventType Type { get; set; }
+
+    /// <summary>Registration / webcast URL when the source provides one; otherwise null.</summary>
+    [MaxLength(1024)]
+    public string Url { get; set; }
+
+    /// <summary>The IR platform this event was scraped from.</summary>
+    public IrPlatformType Source { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.CommonStocks.Data/Models/IrEventType.cs
+++ b/src/Equibles.CommonStocks.Data/Models/IrEventType.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.CommonStocks.Data.Models;
+
+/// <summary>
+/// Kind of investor-relations event, normalised across the various labels the
+/// source platforms use. <see cref="Unknown"/> when the scraper cannot map the
+/// source label to a known kind.
+/// </summary>
+public enum IrEventType
+{
+    [Display(Name = "Unknown")]
+    Unknown = 0,
+
+    [Display(Name = "Earnings call")]
+    EarningsCall = 1,
+
+    [Display(Name = "Conference")]
+    Conference = 2,
+
+    [Display(Name = "Presentation")]
+    Presentation = 3,
+
+    [Display(Name = "Shareholder meeting")]
+    ShareholderMeeting = 4,
+
+    [Display(Name = "Webcast")]
+    Webcast = 5,
+
+    [Display(Name = "Other")]
+    Other = 6,
+}

--- a/src/Equibles.CommonStocks.Data/Models/IrNewsItem.cs
+++ b/src/Equibles.CommonStocks.Data/Models/IrNewsItem.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.CommonStocks.Data.Models;
+
+/// <summary>
+/// A single investor-relations news item (press release) for a company, scraped
+/// from its IR website. The unique (CommonStockId, Url) index makes re-scraping
+/// idempotent: the same release at the same URL is inserted once. <see cref="Source"/>
+/// records which platform produced it so the same story carried by more than one
+/// wire service can be reconciled when aggregating for display.
+/// </summary>
+[Index(nameof(CommonStockId), nameof(Url), IsUnique = true)]
+[Index(nameof(CommonStockId), nameof(PublishedAt))]
+public class IrNewsItem
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    [MaxLength(512)]
+    public string Title { get; set; }
+
+    [MaxLength(1024)]
+    public string Url { get; set; }
+
+    /// <summary>When the release was published, in UTC.</summary>
+    public DateTime PublishedAt { get; set; }
+
+    /// <summary>Short teaser / summary when the source provides one; otherwise null.</summary>
+    [MaxLength(4000)]
+    public string Summary { get; set; }
+
+    /// <summary>The IR platform this item was scraped from.</summary>
+    public IrPlatformType Source { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.CommonStocks.Repositories/EarningsCalendarEntryRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/EarningsCalendarEntryRepository.cs
@@ -1,0 +1,16 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+
+namespace Equibles.CommonStocks.Repositories;
+
+public class EarningsCalendarEntryRepository : BaseRepository<EarningsCalendarEntry>
+{
+    public EarningsCalendarEntryRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    /// <summary>A stock's earnings calendar entries, soonest scheduled date first.</summary>
+    public IQueryable<EarningsCalendarEntry> GetByStock(CommonStock stock)
+    {
+        return GetAll().Where(e => e.CommonStockId == stock.Id).OrderBy(e => e.ScheduledDate);
+    }
+}

--- a/src/Equibles.CommonStocks.Repositories/IrEventRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/IrEventRepository.cs
@@ -1,0 +1,16 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+
+namespace Equibles.CommonStocks.Repositories;
+
+public class IrEventRepository : BaseRepository<IrEvent>
+{
+    public IrEventRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    /// <summary>A stock's IR events, soonest first.</summary>
+    public IQueryable<IrEvent> GetByStock(CommonStock stock)
+    {
+        return GetAll().Where(e => e.CommonStockId == stock.Id).OrderBy(e => e.StartDateTime);
+    }
+}

--- a/src/Equibles.CommonStocks.Repositories/IrNewsItemRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/IrNewsItemRepository.cs
@@ -1,0 +1,18 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+
+namespace Equibles.CommonStocks.Repositories;
+
+public class IrNewsItemRepository : BaseRepository<IrNewsItem>
+{
+    public IrNewsItemRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    /// <summary>A stock's IR news items, newest first.</summary>
+    public IQueryable<IrNewsItem> GetByStock(CommonStock stock)
+    {
+        return GetAll()
+            .Where(n => n.CommonStockId == stock.Id)
+            .OrderByDescending(n => n.PublishedAt);
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260609154026_AddIrNewsEventsAndEarningsCalendar.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260609154026_AddIrNewsEventsAndEarningsCalendar.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609154026_AddIrNewsEventsAndEarningsCalendar")]
+    partial class AddIrNewsEventsAndEarningsCalendar
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260609154026_AddIrNewsEventsAndEarningsCalendar.cs
+++ b/src/Equibles.Migrations/Migrations/20260609154026_AddIrNewsEventsAndEarningsCalendar.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIrNewsEventsAndEarningsCalendar : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EarningsCalendarEntry",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FiscalYear = table.Column<int>(type: "integer", nullable: false),
+                    FiscalQuarter = table.Column<int>(type: "integer", nullable: false),
+                    ScheduledDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    IsConfirmed = table.Column<bool>(type: "boolean", nullable: false),
+                    Url = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    Source = table.Column<int>(type: "integer", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EarningsCalendarEntry", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EarningsCalendarEntry_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "IrEvent",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    StartDateTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Type = table.Column<int>(type: "integer", nullable: false),
+                    Url = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    Source = table.Column<int>(type: "integer", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IrEvent", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_IrEvent_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "IrNewsItem",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    Url = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    PublishedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Summary = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    Source = table.Column<int>(type: "integer", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IrNewsItem", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_IrNewsItem_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EarningsCalendarEntry_CommonStockId_FiscalYear_FiscalQuarter",
+                table: "EarningsCalendarEntry",
+                columns: new[] { "CommonStockId", "FiscalYear", "FiscalQuarter" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EarningsCalendarEntry_ScheduledDate",
+                table: "EarningsCalendarEntry",
+                column: "ScheduledDate");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IrEvent_CommonStockId_StartDateTime",
+                table: "IrEvent",
+                columns: new[] { "CommonStockId", "StartDateTime" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IrEvent_CommonStockId_StartDateTime_Title",
+                table: "IrEvent",
+                columns: new[] { "CommonStockId", "StartDateTime", "Title" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IrNewsItem_CommonStockId_PublishedAt",
+                table: "IrNewsItem",
+                columns: new[] { "CommonStockId", "PublishedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IrNewsItem_CommonStockId_Url",
+                table: "IrNewsItem",
+                columns: new[] { "CommonStockId", "Url" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EarningsCalendarEntry");
+
+            migrationBuilder.DropTable(
+                name: "IrEvent");
+
+            migrationBuilder.DropTable(
+                name: "IrNewsItem");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the unified persistence target the investor-relations scrapers (#583/#584/#585) will write to, so all platform scrapers share one schema rather than each defining throwaway entities.
- Three entities on `CommonStock`: `IrNewsItem` (press releases), `IrEvent` (webcasts / conferences / presentations, typed via `IrEventType`), and `EarningsCalendarEntry` (upcoming release dates).
- Each carries a `Source` (`IrPlatformType`) for provenance and cross-source dedup, and a unique index that makes re-scraping idempotent (insert-or-skip; a previously-estimated earnings date can be promoted to confirmed in place).
- Refs #586.

## Code changes

- `src/Equibles.CommonStocks.Data/Models/IrNewsItem.cs`, `IrEvent.cs`, `IrEventType.cs`, `EarningsCalendarEntry.cs` — new entities + the event-kind enum.
- `src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs` — registers the three entities.
- `src/Equibles.CommonStocks.Repositories/IrNewsItemRepository.cs`, `IrEventRepository.cs`, `EarningsCalendarEntryRepository.cs` — `BaseRepository<T>` repos with a `GetByStock` query each.
- `src/Equibles.Migrations/Migrations/*_AddIrNewsEventsAndEarningsCalendar.cs` (+ snapshot) — creates the three tables and their indexes.