### PR TITLE
feat(investor-relations): unified IR news/events/earnings-calendar models

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -161,6 +161,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Holdings.BusinessL
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.CommonStocks.HostedService", "src\Equibles.CommonStocks.HostedService\Equibles.CommonStocks.HostedService.csproj", "{FFED11B2-5BED-4ABF-939E-D18589C1B07B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.InvestorRelations.Data", "src\Equibles.InvestorRelations.Data\Equibles.InvestorRelations.Data.csproj", "{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.InvestorRelations.Repositories", "src\Equibles.InvestorRelations.Repositories\Equibles.InvestorRelations.Repositories.csproj", "{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1095,6 +1099,30 @@ Global
 		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Release|x64.Build.0 = Release|Any CPU
 		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Release|x86.ActiveCfg = Release|Any CPU
 		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Release|x86.Build.0 = Release|Any CPU
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}.Debug|x64.Build.0 = Debug|Any CPU
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}.Debug|x86.Build.0 = Debug|Any CPU
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}.Release|x64.ActiveCfg = Release|Any CPU
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}.Release|x64.Build.0 = Release|Any CPU
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}.Release|x86.ActiveCfg = Release|Any CPU
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E}.Release|x86.Build.0 = Release|Any CPU
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}.Debug|x64.Build.0 = Debug|Any CPU
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}.Debug|x86.Build.0 = Debug|Any CPU
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}.Release|x64.ActiveCfg = Release|Any CPU
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}.Release|x64.Build.0 = Release|Any CPU
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}.Release|x86.ActiveCfg = Release|Any CPU
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1177,6 +1205,8 @@ Global
 		{77F0FC50-E234-49F3-9A43-46253DE68A0F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{946B8E31-D1FC-4649-9E0E-DCF389C97979} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{FFED11B2-5BED-4ABF-939E-D18589C1B07B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{9C1AA3C1-810C-4980-A723-F6CE55AC9E4E} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{BAFB5E9C-5536-4027-BD2D-E4C48AB11245} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.InvestorRelations.Data/Equibles.InvestorRelations.Data.csproj
+++ b/src/Equibles.InvestorRelations.Data/Equibles.InvestorRelations.Data.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.CommonStocks.Data\Equibles.CommonStocks.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.InvestorRelations.Data/Extensions/ModuleBuilderExtensions.cs
+++ b/src/Equibles.InvestorRelations.Data/Extensions/ModuleBuilderExtensions.cs
@@ -1,0 +1,13 @@
+using Equibles.CommonStocks.Data.Extensions;
+using Equibles.Data;
+
+namespace Equibles.InvestorRelations.Data.Extensions;
+
+public static class ModuleBuilderExtensions
+{
+    public static EquiblesModuleBuilder AddInvestorRelations(this EquiblesModuleBuilder builder)
+    {
+        builder.AddCommonStocks();
+        return builder.AddModule<InvestorRelationsModuleConfiguration>();
+    }
+}

--- a/src/Equibles.InvestorRelations.Data/InvestorRelationsModuleConfiguration.cs
+++ b/src/Equibles.InvestorRelations.Data/InvestorRelationsModuleConfiguration.cs
@@ -1,0 +1,14 @@
+using Equibles.InvestorRelations.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.InvestorRelations.Data;
+
+public class InvestorRelationsModuleConfiguration : Equibles.Data.IFinancialModule
+{
+    public void ConfigureEntities(ModelBuilder builder)
+    {
+        builder.Entity<IrNewsItem>();
+        builder.Entity<IrEvent>();
+        builder.Entity<EarningsCalendarEntry>();
+    }
+}

--- a/src/Equibles.InvestorRelations.Data/Models/EarningsCalendarEntry.cs
+++ b/src/Equibles.InvestorRelations.Data/Models/EarningsCalendarEntry.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.InvestorRelations.Data.Models;
+
+// A forward-looking earnings date scraped from a company's investor relations page.
+// Distinct from filed transcripts (those are retrospective): one entry per company per
+// scheduled report date, so (CommonStockId, ScheduledDate) is the natural key.
+[Index(nameof(CommonStockId), nameof(ScheduledDate), IsUnique = true)]
+[Index(nameof(ScheduledDate))]
+public class EarningsCalendarEntry
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    public DateOnly ScheduledDate { get; set; }
+
+    public EarningsFiscalPeriod FiscalPeriod { get; set; }
+
+    public int? FiscalYear { get; set; }
+
+    public EarningsCallTimeOfDay TimeOfDay { get; set; }
+
+    // True when the company has confirmed the date; false when it is an estimate.
+    public bool IsConfirmed { get; set; }
+
+    [MaxLength(512)]
+    public string Url { get; set; }
+
+    public IrPlatformType Source { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.InvestorRelations.Data/Models/EarningsCallTimeOfDay.cs
+++ b/src/Equibles.InvestorRelations.Data/Models/EarningsCallTimeOfDay.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.InvestorRelations.Data.Models;
+
+public enum EarningsCallTimeOfDay
+{
+    [Display(Name = "Unspecified")]
+    Unspecified,
+
+    [Display(Name = "Before Market Open")]
+    BeforeMarketOpen,
+
+    [Display(Name = "After Market Close")]
+    AfterMarketClose,
+}

--- a/src/Equibles.InvestorRelations.Data/Models/EarningsFiscalPeriod.cs
+++ b/src/Equibles.InvestorRelations.Data/Models/EarningsFiscalPeriod.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.InvestorRelations.Data.Models;
+
+public enum EarningsFiscalPeriod
+{
+    [Display(Name = "Unknown")]
+    Unknown,
+
+    [Display(Name = "Q1")]
+    Q1,
+
+    [Display(Name = "Q2")]
+    Q2,
+
+    [Display(Name = "Q3")]
+    Q3,
+
+    [Display(Name = "Q4")]
+    Q4,
+
+    [Display(Name = "Full Year")]
+    FullYear,
+}

--- a/src/Equibles.InvestorRelations.Data/Models/IrEvent.cs
+++ b/src/Equibles.InvestorRelations.Data/Models/IrEvent.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.InvestorRelations.Data.Models;
+
+// An investor relations event — earnings call, conference appearance, webcast, annual
+// meeting, etc. (CommonStockId, Title, ScheduledDate) is the natural key so re-scraping
+// the same listing does not duplicate it.
+[Index(nameof(CommonStockId), nameof(Title), nameof(ScheduledDate), IsUnique = true)]
+[Index(nameof(ScheduledDate))]
+public class IrEvent
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    [Required]
+    [MaxLength(512)]
+    public string Title { get; set; }
+
+    public IrEventType EventType { get; set; }
+
+    public DateTime ScheduledDate { get; set; }
+
+    // Webcast / registration link when published.
+    [MaxLength(512)]
+    public string Url { get; set; }
+
+    [MaxLength(256)]
+    public string Location { get; set; }
+
+    public IrPlatformType Source { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.InvestorRelations.Data/Models/IrEventType.cs
+++ b/src/Equibles.InvestorRelations.Data/Models/IrEventType.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.InvestorRelations.Data.Models;
+
+public enum IrEventType
+{
+    [Display(Name = "Other")]
+    Other,
+
+    [Display(Name = "Earnings Call")]
+    EarningsCall,
+
+    [Display(Name = "Conference")]
+    Conference,
+
+    [Display(Name = "Webcast")]
+    Webcast,
+
+    [Display(Name = "Shareholder Meeting")]
+    ShareholderMeeting,
+
+    [Display(Name = "Presentation")]
+    Presentation,
+}

--- a/src/Equibles.InvestorRelations.Data/Models/IrNewsItem.cs
+++ b/src/Equibles.InvestorRelations.Data/Models/IrNewsItem.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.InvestorRelations.Data.Models;
+
+// A press release / news item scraped from a company's investor relations page.
+// The (CommonStockId, Url) pair is the natural key: the same article always lives at
+// the same canonical URL, so re-scraping is idempotent.
+[Index(nameof(CommonStockId), nameof(Url), IsUnique = true)]
+[Index(nameof(PublishedDate))]
+public class IrNewsItem
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    [Required]
+    [MaxLength(512)]
+    public string Title { get; set; }
+
+    [Required]
+    [MaxLength(512)]
+    public string Url { get; set; }
+
+    [MaxLength(4000)]
+    public string Summary { get; set; }
+
+    public DateOnly PublishedDate { get; set; }
+
+    // The IR platform the item was scraped from, so multi-source rows stay attributable.
+    public IrPlatformType Source { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.InvestorRelations.Repositories/EarningsCalendarEntryRepository.cs
+++ b/src/Equibles.InvestorRelations.Repositories/EarningsCalendarEntryRepository.cs
@@ -1,0 +1,30 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.InvestorRelations.Data.Models;
+
+namespace Equibles.InvestorRelations.Repositories;
+
+public class EarningsCalendarEntryRepository : BaseRepository<EarningsCalendarEntry>
+{
+    public EarningsCalendarEntryRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<EarningsCalendarEntry> GetByStock(CommonStock stock)
+    {
+        return GetAll()
+            .Where(e => e.CommonStockId == stock.Id)
+            .OrderByDescending(e => e.ScheduledDate);
+    }
+
+    public IQueryable<EarningsCalendarEntry> GetUpcoming(CommonStock stock, DateOnly asOf)
+    {
+        return GetAll()
+            .Where(e => e.CommonStockId == stock.Id && e.ScheduledDate >= asOf)
+            .OrderBy(e => e.ScheduledDate);
+    }
+
+    public IQueryable<EarningsCalendarEntry> GetByStockAndDate(CommonStock stock, DateOnly date)
+    {
+        return GetAll().Where(e => e.CommonStockId == stock.Id && e.ScheduledDate == date);
+    }
+}

--- a/src/Equibles.InvestorRelations.Repositories/Equibles.InvestorRelations.Repositories.csproj
+++ b/src/Equibles.InvestorRelations.Repositories/Equibles.InvestorRelations.Repositories.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.InvestorRelations.Data\Equibles.InvestorRelations.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.InvestorRelations.Repositories/IrEventRepository.cs
+++ b/src/Equibles.InvestorRelations.Repositories/IrEventRepository.cs
@@ -1,0 +1,37 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.InvestorRelations.Data.Models;
+
+namespace Equibles.InvestorRelations.Repositories;
+
+public class IrEventRepository : BaseRepository<IrEvent>
+{
+    public IrEventRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<IrEvent> GetByStock(CommonStock stock)
+    {
+        return GetAll()
+            .Where(e => e.CommonStockId == stock.Id)
+            .OrderByDescending(e => e.ScheduledDate);
+    }
+
+    public IQueryable<IrEvent> GetUpcoming(CommonStock stock, DateTime asOf)
+    {
+        return GetAll()
+            .Where(e => e.CommonStockId == stock.Id && e.ScheduledDate >= asOf)
+            .OrderBy(e => e.ScheduledDate);
+    }
+
+    public IQueryable<IrEvent> GetByStockTitleAndDate(
+        CommonStock stock,
+        string title,
+        DateTime scheduledDate
+    )
+    {
+        return GetAll()
+            .Where(e =>
+                e.CommonStockId == stock.Id && e.Title == title && e.ScheduledDate == scheduledDate
+            );
+    }
+}

--- a/src/Equibles.InvestorRelations.Repositories/IrNewsItemRepository.cs
+++ b/src/Equibles.InvestorRelations.Repositories/IrNewsItemRepository.cs
@@ -1,0 +1,23 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.InvestorRelations.Data.Models;
+
+namespace Equibles.InvestorRelations.Repositories;
+
+public class IrNewsItemRepository : BaseRepository<IrNewsItem>
+{
+    public IrNewsItemRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<IrNewsItem> GetByStock(CommonStock stock)
+    {
+        return GetAll()
+            .Where(n => n.CommonStockId == stock.Id)
+            .OrderByDescending(n => n.PublishedDate);
+    }
+
+    public IQueryable<IrNewsItem> GetByStockAndUrl(CommonStock stock, string url)
+    {
+        return GetAll().Where(n => n.CommonStockId == stock.Id && n.Url == url);
+    }
+}

--- a/src/Equibles.Migrations/DesignTimeDbContextFactory.cs
+++ b/src/Equibles.Migrations/DesignTimeDbContextFactory.cs
@@ -8,6 +8,7 @@ using Equibles.Finra.Data;
 using Equibles.Fred.Data;
 using Equibles.Holdings.Data;
 using Equibles.InsiderTrading.Data;
+using Equibles.InvestorRelations.Data;
 using Equibles.Media.Data;
 using Equibles.ParadeDB.EntityFrameworkCore;
 using Equibles.Sec.Data;
@@ -57,6 +58,7 @@ public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<EquiblesFi
             new YahooModuleConfiguration(),
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration(),
+            new InvestorRelationsModuleConfiguration(),
             new SecModuleConfiguration(),
             new FinancialFactsModuleConfiguration(),
             new MediaModuleConfiguration(),

--- a/src/Equibles.Migrations/Equibles.Migrations.csproj
+++ b/src/Equibles.Migrations/Equibles.Migrations.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\Equibles.Yahoo.Data\Equibles.Yahoo.Data.csproj" />
     <ProjectReference Include="..\Equibles.Cftc.Data\Equibles.Cftc.Data.csproj" />
     <ProjectReference Include="..\Equibles.Cboe.Data\Equibles.Cboe.Data.csproj" />
+    <ProjectReference Include="..\Equibles.InvestorRelations.Data\Equibles.InvestorRelations.Data.csproj" />
     <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Data\Equibles.Sec.FinancialFacts.Data.csproj" />
   </ItemGroup>

--- a/src/Equibles.Migrations/Migrations/20260609155128_AddInvestorRelationsModels.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260609155128_AddInvestorRelationsModels.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609155128_AddInvestorRelationsModels")]
+    partial class AddInvestorRelationsModels
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260609155128_AddInvestorRelationsModels.cs
+++ b/src/Equibles.Migrations/Migrations/20260609155128_AddInvestorRelationsModels.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvestorRelationsModels : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EarningsCalendarEntry",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ScheduledDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    FiscalPeriod = table.Column<int>(type: "integer", nullable: false),
+                    FiscalYear = table.Column<int>(type: "integer", nullable: true),
+                    TimeOfDay = table.Column<int>(type: "integer", nullable: false),
+                    IsConfirmed = table.Column<bool>(type: "boolean", nullable: false),
+                    Url = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    Source = table.Column<int>(type: "integer", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EarningsCalendarEntry", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EarningsCalendarEntry_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "IrEvent",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    EventType = table.Column<int>(type: "integer", nullable: false),
+                    ScheduledDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Url = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    Location = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Source = table.Column<int>(type: "integer", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IrEvent", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_IrEvent_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "IrNewsItem",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    Url = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    Summary = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    PublishedDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    Source = table.Column<int>(type: "integer", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IrNewsItem", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_IrNewsItem_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EarningsCalendarEntry_CommonStockId_ScheduledDate",
+                table: "EarningsCalendarEntry",
+                columns: new[] { "CommonStockId", "ScheduledDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EarningsCalendarEntry_ScheduledDate",
+                table: "EarningsCalendarEntry",
+                column: "ScheduledDate");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IrEvent_CommonStockId_Title_ScheduledDate",
+                table: "IrEvent",
+                columns: new[] { "CommonStockId", "Title", "ScheduledDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IrEvent_ScheduledDate",
+                table: "IrEvent",
+                column: "ScheduledDate");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IrNewsItem_CommonStockId_Url",
+                table: "IrNewsItem",
+                columns: new[] { "CommonStockId", "Url" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IrNewsItem_PublishedDate",
+                table: "IrNewsItem",
+                column: "PublishedDate");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EarningsCalendarEntry");
+
+            migrationBuilder.DropTable(
+                name: "IrEvent");
+
+            migrationBuilder.DropTable(
+                name: "IrNewsItem");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `Equibles.InvestorRelations` data module — the destination schema that investor-relations platform scrapers (Nasdaq IR Insight, Q4, Business Wire) persist into. Until now the IR-page URL and platform type were discovered and classified, but there was nowhere to store the scraped content.
- Three entities, each foreign-keyed to `CommonStock` with a natural-key unique index so re-scraping the same source is idempotent.

## Code changes

- `Equibles.InvestorRelations.Data` — `IrNewsItem` (unique `CommonStockId+Url`), `IrEvent` (unique `CommonStockId+Title+ScheduledDate`, with `IrEventType`), `EarningsCalendarEntry` (unique `CommonStockId+ScheduledDate`, with `EarningsFiscalPeriod`/`EarningsCallTimeOfDay`); `InvestorRelationsModuleConfiguration : IFinancialModule`; `AddInvestorRelations()` builder extension (depends on `AddCommonStocks()`).
- `Equibles.InvestorRelations.Repositories` — repositories for the three entities.
- `Equibles.Migrations` — registered the module in the design-time factory and added the `AddInvestorRelationsModels` financial migration.