### PR TITLE
feat(common-stocks): scrape news and events from Nasdaq IR Insight sites

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Configuration/NasdaqIrInsightScraperOptions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Configuration/NasdaqIrInsightScraperOptions.cs
@@ -1,0 +1,13 @@
+using Equibles.Worker;
+
+namespace Equibles.CommonStocks.HostedService.Configuration;
+
+public class NasdaqIrInsightScraperOptions : ScraperOptions
+{
+    /// <summary>
+    /// Maximum number of Nasdaq IR Insight stocks scraped per cycle. The scrape is
+    /// network-bound and politely rate-limited, so a cycle works through a bounded
+    /// batch and the rest are picked up next cycle.
+    /// </summary>
+    public int BatchSize { get; set; } = 50;
+}

--- a/src/Equibles.CommonStocks.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -24,6 +24,20 @@ public static class ServiceCollectionExtensions
 
         services.AddHostedService<InvestorRelationsDiscoveryWorker>();
 
+        // Typed client for the Nasdaq IR Insight RSS feeds: short timeout, contact
+        // User-Agent, capped response size. The [Service] scraper itself is picked up
+        // by the AutoWireServicesFrom scan above (same assembly).
+        services.AddHttpClient<NasdaqIrInsightFeedClient>(client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(10);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(
+                "EquiblesBot/1.0 (+https://equibles.com)"
+            );
+            client.MaxResponseContentBufferSize = 4 * 1024 * 1024;
+        });
+
+        services.AddHostedService<NasdaqIrInsightScraperWorker>();
+
         return services;
     }
 }

--- a/src/Equibles.CommonStocks.HostedService/NasdaqIrInsightScraperWorker.cs
+++ b/src/Equibles.CommonStocks.HostedService/NasdaqIrInsightScraperWorker.cs
@@ -1,0 +1,35 @@
+using Equibles.CommonStocks.HostedService.Configuration;
+using Equibles.CommonStocks.HostedService.Services;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.CommonStocks.HostedService;
+
+/// <summary>
+/// Periodically scrapes news and events from the IR sites of stocks classified as
+/// running on Nasdaq IR Insight, filling IrNewsItem / IrEvent.
+/// </summary>
+public class NasdaqIrInsightScraperWorker : BaseScraperWorker
+{
+    protected override string WorkerName => "Nasdaq IR Insight scrape";
+    protected override TimeSpan SleepInterval { get; }
+    protected override ErrorSource ErrorSource => ErrorSource.InvestorRelationsScraper;
+
+    public NasdaqIrInsightScraperWorker(
+        ILogger<NasdaqIrInsightScraperWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<NasdaqIrInsightScraperOptions> options
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
+    }
+
+    protected override Task DoWork(CancellationToken stoppingToken) =>
+        RunImport<NasdaqIrInsightScraperService>(stoppingToken);
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/IrFeedItems.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/IrFeedItems.cs
@@ -1,0 +1,19 @@
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>A press release parsed from a Nasdaq IR Insight news RSS feed.</summary>
+public sealed record ParsedIrNewsItem(
+    string Title,
+    string Url,
+    string Summary,
+    DateTime PublishedAtUtc
+);
+
+/// <summary>An event parsed from a Nasdaq IR Insight events RSS feed.</summary>
+public sealed record ParsedIrEvent(
+    string Title,
+    string Url,
+    DateTime StartDateTimeUtc,
+    IrEventType Type
+);

--- a/src/Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightFeedClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightFeedClient.cs
@@ -1,0 +1,88 @@
+using Equibles.Integrations.Common.RateLimiter;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Fetches the RSS feeds published by a Nasdaq IR Insight-hosted IR site. Registered
+/// as a typed <see cref="HttpClient"/> client (see <c>AddCommonStocksWorker</c>).
+/// Returns null on any non-success or non-XML response so the caller can skip the
+/// feed without treating an outage as data.
+/// </summary>
+public class NasdaqIrInsightFeedClient
+{
+    // Relative feed paths a Nasdaq IR Insight site exposes off its IR base URL.
+    public const string NewsFeedPath = "rss/news-releases.xml";
+    public const string EventsFeedPath = "rss/events.xml";
+
+    // Polite shared throttle across feed fetches.
+    private static readonly IRateLimiter RateLimiter = new RateLimiter(
+        maxRequests: 5,
+        timeWindow: TimeSpan.FromSeconds(1)
+    );
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<NasdaqIrInsightFeedClient> _logger;
+
+    public NasdaqIrInsightFeedClient(
+        HttpClient httpClient,
+        ILogger<NasdaqIrInsightFeedClient> logger
+    )
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Combines an IR base URL with a feed path and returns the feed body, or null
+    /// when the feed is missing, errors, or is not XML.
+    /// </summary>
+    public async Task<string> Fetch(
+        string irBaseUrl,
+        string feedPath,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!TryBuildFeedUrl(irBaseUrl, feedPath, out var feedUrl))
+            return null;
+
+        try
+        {
+            await RateLimiter.WaitAsync();
+
+            using var response = await _httpClient.GetAsync(feedUrl, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var mediaType = response.Content.Headers.ContentType?.MediaType;
+            if (mediaType == null || !mediaType.Contains("xml", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            return await response.Content.ReadAsStringAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Investor relations feed fetch failed for {Url}", feedUrl);
+            return null;
+        }
+    }
+
+    private static bool TryBuildFeedUrl(string irBaseUrl, string feedPath, out string feedUrl)
+    {
+        feedUrl = null;
+        if (string.IsNullOrWhiteSpace(irBaseUrl))
+            return false;
+
+        // The IR base is the discovered IR landing page; feeds live at the site root,
+        // so resolve the path against the origin rather than the landing path.
+        if (!Uri.TryCreate(irBaseUrl, UriKind.Absolute, out var baseUri))
+            return false;
+
+        feedUrl = new Uri(baseUri, "/" + feedPath).ToString();
+        return true;
+    }
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightFeedParser.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightFeedParser.cs
@@ -1,0 +1,142 @@
+using System.Globalization;
+using System.Xml.Linq;
+using Equibles.CommonStocks.Data.Models;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Parses the RSS feeds a Nasdaq IR Insight-hosted IR site publishes — news
+/// releases (<c>/rss/news-releases.xml</c>) and events (<c>/rss/events.xml</c>) —
+/// into typed items. Pure (no I/O) so it is unit-testable against recorded feed
+/// fixtures. Items missing a required field or carrying an unparseable date are
+/// skipped rather than guessed, to keep the persisted data trustworthy.
+/// </summary>
+public static class NasdaqIrInsightFeedParser
+{
+    // Column ceilings on IrNewsItem / IrEvent. Defensive truncation so an unusually
+    // long source value can't fail the insert.
+    private const int MaxTitle = 512;
+    private const int MaxUrl = 1024;
+    private const int MaxSummary = 4000;
+
+    public static IReadOnlyList<ParsedIrNewsItem> ParseNews(string xml)
+    {
+        var items = new List<ParsedIrNewsItem>();
+        foreach (var item in Items(xml))
+        {
+            var title = Trim(Value(item, "title"), MaxTitle);
+            var url = Trim(Value(item, "link"), MaxUrl);
+            var published = ParseDate(Value(item, "pubDate"));
+            if (title == null || url == null || published == null)
+                continue;
+
+            var summary = Trim(Value(item, "description"), MaxSummary);
+            items.Add(new ParsedIrNewsItem(title, url, summary, published.Value));
+        }
+
+        return items;
+    }
+
+    public static IReadOnlyList<ParsedIrEvent> ParseEvents(string xml)
+    {
+        var events = new List<ParsedIrEvent>();
+        foreach (var item in Items(xml))
+        {
+            var rawTitle = Value(item, "title");
+            var url = Trim(Value(item, "link"), MaxUrl);
+            var start = ParseDate(Value(item, "pubDate"));
+            var title = Trim(CleanEventTitle(rawTitle), MaxTitle);
+            if (title == null || url == null || start == null)
+                continue;
+
+            events.Add(new ParsedIrEvent(title, url, start.Value, ClassifyEventType(title)));
+        }
+
+        return events;
+    }
+
+    private static IEnumerable<XElement> Items(string xml)
+    {
+        if (string.IsNullOrWhiteSpace(xml))
+            return [];
+
+        XDocument document;
+        try
+        {
+            document = XDocument.Parse(xml);
+        }
+        catch (System.Xml.XmlException)
+        {
+            return [];
+        }
+
+        return document.Descendants("item");
+    }
+
+    private static string Value(XElement item, string name)
+    {
+        var text = item.Element(name)?.Value;
+        return string.IsNullOrWhiteSpace(text) ? null : text.Trim();
+    }
+
+    // Event titles arrive prefixed with the date, e.g.
+    // "June 9, 2026 8:15 AM EDT : Morgan Stanley US Financials Conference".
+    // Keep only the human label after the " : " separator; the authoritative start
+    // time comes from pubDate, never from re-parsing this prefix.
+    private static string CleanEventTitle(string rawTitle)
+    {
+        if (string.IsNullOrWhiteSpace(rawTitle))
+            return null;
+
+        var separator = rawTitle.IndexOf(" : ", StringComparison.Ordinal);
+        var label = separator >= 0 ? rawTitle[(separator + 3)..] : rawTitle;
+        label = label.Trim();
+        return label.Length == 0 ? null : label;
+    }
+
+    // Maps the event's own label to a normalised kind. Unknown when no label
+    // matches — never a guess. (See IrEventType.)
+    private static IrEventType ClassifyEventType(string title)
+    {
+        var t = title.ToLowerInvariant();
+        if (t.Contains("earnings"))
+            return IrEventType.EarningsCall;
+        if (t.Contains("annual meeting") || t.Contains("shareholder") || t.Contains("stockholder"))
+            return IrEventType.ShareholderMeeting;
+        if (t.Contains("conference"))
+            return IrEventType.Conference;
+        if (t.Contains("investor day") || t.Contains("analyst day") || t.Contains("presentation"))
+            return IrEventType.Presentation;
+        if (t.Contains("webcast"))
+            return IrEventType.Webcast;
+        return IrEventType.Unknown;
+    }
+
+    private static DateTime? ParseDate(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        if (
+            DateTimeOffset.TryParse(
+                value,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var parsed
+            )
+        )
+        {
+            return parsed.UtcDateTime;
+        }
+
+        return null;
+    }
+
+    private static string Trim(string value, int max)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        value = value.Trim();
+        return value.Length <= max ? value : value[..max];
+    }
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightScraperService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightScraperService.cs
@@ -1,0 +1,192 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.HostedService.Configuration;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.AutoWiring;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Scrapes news and events from the RSS feeds of stocks whose IR site runs on
+/// Nasdaq IR Insight, persisting them into IrNewsItem / IrEvent. Insertion is
+/// idempotent by natural key, so re-running a cycle never duplicates rows.
+/// </summary>
+[Service]
+public class NasdaqIrInsightScraperService : IImporter
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly NasdaqIrInsightFeedClient _feedClient;
+    private readonly ErrorReporter _errorReporter;
+    private readonly ILogger<NasdaqIrInsightScraperService> _logger;
+    private readonly NasdaqIrInsightScraperOptions _options;
+
+    public NasdaqIrInsightScraperService(
+        IServiceScopeFactory scopeFactory,
+        NasdaqIrInsightFeedClient feedClient,
+        ErrorReporter errorReporter,
+        ILogger<NasdaqIrInsightScraperService> logger,
+        IOptions<NasdaqIrInsightScraperOptions> options
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _feedClient = feedClient;
+        _errorReporter = errorReporter;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    public async Task Import(CancellationToken cancellationToken)
+    {
+        var batch = await LoadCandidates(cancellationToken);
+        if (batch.Count == 0)
+        {
+            _logger.LogInformation("Nasdaq IR Insight scrape: no classified stocks to scrape");
+            return;
+        }
+
+        _logger.LogInformation("Nasdaq IR Insight scrape: scraping {Count} stocks", batch.Count);
+
+        var inserted = 0;
+        foreach (var candidate in batch)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                inserted += await ScrapeStock(candidate, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error scraping IR feeds for {Ticker}", candidate.Ticker);
+                await _errorReporter.Report(
+                    ErrorSource.InvestorRelationsScraper,
+                    $"Scrape({candidate.Ticker})",
+                    ex.Message,
+                    ex.StackTrace
+                );
+            }
+        }
+
+        _logger.LogInformation(
+            "Nasdaq IR Insight scrape complete. Inserted {Count} new IR rows",
+            inserted
+        );
+    }
+
+    private async Task<int> ScrapeStock(
+        CandidateStock candidate,
+        CancellationToken cancellationToken
+    )
+    {
+        var stock = new CommonStock { Id = candidate.Id };
+
+        var newsXml = await _feedClient.Fetch(
+            candidate.IrUrl,
+            NasdaqIrInsightFeedClient.NewsFeedPath,
+            cancellationToken
+        );
+        var eventsXml = await _feedClient.Fetch(
+            candidate.IrUrl,
+            NasdaqIrInsightFeedClient.EventsFeedPath,
+            cancellationToken
+        );
+
+        var news = newsXml == null ? [] : NasdaqIrInsightFeedParser.ParseNews(newsXml);
+        var events = eventsXml == null ? [] : NasdaqIrInsightFeedParser.ParseEvents(eventsXml);
+        if (news.Count == 0 && events.Count == 0)
+            return 0;
+
+        using var scope = _scopeFactory.CreateScope();
+        var newsRepo = scope.ServiceProvider.GetRequiredService<IrNewsItemRepository>();
+        var eventRepo = scope.ServiceProvider.GetRequiredService<IrEventRepository>();
+
+        var existingUrls = (
+            await newsRepo.GetByStock(stock).Select(n => n.Url).ToListAsync(cancellationToken)
+        ).ToHashSet();
+        var existingEvents = (
+            await eventRepo
+                .GetByStock(stock)
+                .Select(e => new { e.StartDateTime, e.Title })
+                .ToListAsync(cancellationToken)
+        )
+            .Select(e => (e.StartDateTime, e.Title))
+            .ToHashSet();
+
+        var added = 0;
+        foreach (var item in news)
+        {
+            if (!existingUrls.Add(item.Url))
+                continue;
+            newsRepo.Add(
+                new IrNewsItem
+                {
+                    CommonStockId = candidate.Id,
+                    Title = item.Title,
+                    Url = item.Url,
+                    Summary = item.Summary,
+                    PublishedAt = item.PublishedAtUtc,
+                    Source = IrPlatformType.NasdaqIrInsight,
+                }
+            );
+            added++;
+        }
+
+        foreach (var ev in events)
+        {
+            if (!existingEvents.Add((ev.StartDateTimeUtc, ev.Title)))
+                continue;
+            eventRepo.Add(
+                new IrEvent
+                {
+                    CommonStockId = candidate.Id,
+                    Title = ev.Title,
+                    StartDateTime = ev.StartDateTimeUtc,
+                    Type = ev.Type,
+                    Url = ev.Url,
+                    Source = IrPlatformType.NasdaqIrInsight,
+                }
+            );
+            added++;
+        }
+
+        if (added > 0)
+            await newsRepo.SaveChanges();
+
+        return added;
+    }
+
+    private async Task<List<CandidateStock>> LoadCandidates(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        var rows = await repo.GetAll()
+            .Where(s =>
+                s.IrPlatformType == IrPlatformType.NasdaqIrInsight && s.InvestorRelationsUrl != null
+            )
+            .OrderBy(s => s.Ticker)
+            .Take(_options.BatchSize)
+            .Select(s => new
+            {
+                s.Id,
+                s.Ticker,
+                s.InvestorRelationsUrl,
+            })
+            .ToListAsync(cancellationToken);
+
+        return rows.Select(r => new CandidateStock(r.Id, r.Ticker, r.InvestorRelationsUrl))
+            .ToList();
+    }
+
+    private sealed record CandidateStock(Guid Id, string Ticker, string IrUrl);
+}

--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -25,6 +25,7 @@ public sealed class ErrorSource
     public static readonly ErrorSource InvestorRelationsDiscovery = new(
         "InvestorRelationsDiscovery"
     );
+    public static readonly ErrorSource InvestorRelationsScraper = new("InvestorRelationsScraper");
     public static readonly ErrorSource Other = new("Other");
 
     public static IEnumerable<ErrorSource> GetAll() =>
@@ -46,6 +47,7 @@ public sealed class ErrorSource
             InsiderTradingReprocess,
             NportReprocess,
             InvestorRelationsDiscovery,
+            InvestorRelationsScraper,
             Other,
         ];
 

--- a/tests/Equibles.UnitTests/CommonStocks/NasdaqIrInsightFeedParserTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/NasdaqIrInsightFeedParserTests.cs
@@ -1,0 +1,59 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.HostedService.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+// Record-replay: parse frozen Nasdaq IR Insight RSS fixtures and assert exact values.
+// A diff here means the parser regressed against the recorded feed shape.
+public class NasdaqIrInsightFeedParserTests
+{
+    private static string NewsFeed() =>
+        File.ReadAllText("TestAssets/InvestorRelations/nasdaq-news.xml");
+
+    private static string EventsFeed() =>
+        File.ReadAllText("TestAssets/InvestorRelations/nasdaq-events.xml");
+
+    [Fact]
+    public void ParseNews_NasdaqFeed_MapsFirstItemExactly()
+    {
+        var items = NasdaqIrInsightFeedParser.ParseNews(NewsFeed());
+
+        items.Should().HaveCount(10);
+        var first = items[0];
+        first
+            .Title.Should()
+            .Be("Nasdaq Launches Economic Institute, Debuts New AI Research Series");
+        first
+            .Url.Should()
+            .Be(
+                "https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-launches-economic-institute-debuts-new-ai-research-series"
+            );
+        // pubDate "Tue, 09 Jun 2026 06:00:00 -0400" must normalise to UTC.
+        first.PublishedAtUtc.Should().Be(new DateTime(2026, 6, 9, 10, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void ParseEvents_StripsDatePrefixAndNormalisesPubDateToUtc()
+    {
+        var events = NasdaqIrInsightFeedParser.ParseEvents(EventsFeed());
+
+        events.Should().HaveCount(10);
+        var first = events[0];
+        // Title prefix "June 9, 2026 8:15 AM EDT : " must be stripped to the clean label.
+        first.Title.Should().Be("Morgan Stanley US Financials Conference");
+        // The authoritative start time comes from pubDate (08:15 -0400 -> 12:15 UTC),
+        // never from re-parsing the title prefix.
+        first.StartDateTimeUtc.Should().Be(new DateTime(2026, 6, 9, 12, 15, 0, DateTimeKind.Utc));
+        first.Type.Should().Be(IrEventType.Conference);
+    }
+
+    [Fact]
+    public void ParseNews_MalformedXml_ReturnsEmptyWithoutThrowing()
+    {
+        var items = NasdaqIrInsightFeedParser.ParseNews("<rss><channel><item>broken");
+
+        items.Should().BeEmpty();
+    }
+}

--- a/tests/Equibles.UnitTests/TestAssets/InvestorRelations/nasdaq-events.xml
+++ b/tests/Equibles.UnitTests/TestAssets/InvestorRelations/nasdaq-events.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0" xml:base="https://ir.nasdaq.com/">
+  <channel>
+    <title>Nasdaq, Inc. Events</title>
+    <link>https://ir.nasdaq.com/</link>
+    <description>Nasdaq, Inc. Events</description>
+    <language>en</language>
+    
+    <item>
+  <title>June 9, 2026 8:15 AM EDT : Morgan Stanley US Financials Conference </title>
+  <link>https://ir.nasdaq.com/events/event-details/morgan-stanley-us-financials-conference-0</link>
+  <description/>
+  <pubDate>Tue, 09 Jun 2026 08:15:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. Events</dc:creator>
+    <guid isPermaLink="false">110486</guid>
+    </item>
+
+<item>
+  <title>June 4, 2026 9:00 AM EDT : Piper Sandler Global Exchange &amp; Fintech Conference</title>
+  <link>https://ir.nasdaq.com/events/event-details/piper-sandler-global-exchange-fintech-conference</link>
+  <description/>
+  <pubDate>Thu, 04 Jun 2026 09:00:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. Events</dc:creator>
+    <guid isPermaLink="false">110481</guid>
+    </item>
+
+<item>
+  <title>June 3, 2026 11:40 AM EDT : William Blair 46th Annual Growth Stock Conference</title>
+  <link>https://ir.nasdaq.com/events/event-details/william-blair-46th-annual-growth-stock-conference</link>
+  <description/>
+  <pubDate>Wed, 03 Jun 2026 11:40:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. Events</dc:creator>
+    <guid isPermaLink="false">110476</guid>
+    </item>
+
+<item>
+  <title>April 23, 2026 8:00 AM EDT : Nasdaq First Quarter 2026 Results</title>
+  <link>https://ir.nasdaq.com/events/event-details/nasdaq-first-quarter-2026-results</link>
+  <description/>
+  <pubDate>Thu, 23 Apr 2026 08:00:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. Events</dc:creator>
+    <guid isPermaLink="false">110166</guid>
+    </item>
+
+<item>
+  <title>March 12, 2026 8:40 AM EDT : 2026 Bank of America Information and Business Services Conference</title>
+  <link>https://ir.nasdaq.com/events/event-details/2026-bank-america-information-and-business-services-conference</link>
+  <description/>
+  <pubDate>Thu, 12 Mar 2026 08:40:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. Events</dc:creator>
+    <guid isPermaLink="false">110116</guid>
+    </item>
+
+<item>
+  <title>March 4, 2026 8:05 AM EST : Raymond James 47th Annual Institutional Investor Conference</title>
+  <link>https://ir.nasdaq.com/events/event-details/raymond-james-47th-annual-institutional-investor-conference</link>
+  <description/>
+  <pubDate>Wed, 04 Mar 2026 08:05:00 -0500</pubDate>
+    <dc:creator>Nasdaq, Inc. Events</dc:creator>
+    <guid isPermaLink="false">110066</guid>
+    </item>
+
+<item>
+  <title>March 2, 2026 11:30 AM EST : Morgan Stanley Technology, Media &amp; Telecom Conference</title>
+  <link>https://ir.nasdaq.com/events/event-details/morgan-stanley-technology-media-telecom-conference</link>
+  <description/>
+  <pubDate>Mon, 02 Mar 2026 11:30:00 -0500</pubDate>
+    <dc:creator>Nasdaq, Inc. Events</dc:creator>
+    <guid isPermaLink="false">110061</guid>
+    </item>
+
+<item>
+  <title>February 25, 2026 8:00 AM EST : Nasdaq 2026 Investor Day</title>
+  <link>https://ir.nasdaq.com/events/event-details/nasdaq-2026-investor-day</link>
+  <description/>
+  <pubDate>Wed, 25 Feb 2026 08:00:00 -0500</pubDate>
+    <dc:creator>Nasdaq, Inc. Events</dc:creator>
+    <guid isPermaLink="false">109896</guid>
+    </item>
+
+<item>
+  <title>January 29, 2026 8:00 AM EST : Nasdaq Fourth Quarter 2025 Results</title>
+  <link>https://ir.nasdaq.com/events/event-details/nasdaq-fourth-quarter-2025-results</link>
+  <description/>
+  <pubDate>Thu, 29 Jan 2026 08:00:00 -0500</pubDate>
+    <dc:creator>Nasdaq, Inc. Events</dc:creator>
+    <guid isPermaLink="false">109131</guid>
+    </item>
+
+<item>
+  <title>December 10, 2025 1:00 PM EST : Goldman Sachs 2025 Financial Services Conference</title>
+  <link>https://ir.nasdaq.com/events/event-details/goldman-sachs-2025-financial-services-conference</link>
+  <description/>
+  <pubDate>Wed, 10 Dec 2025 13:00:00 -0500</pubDate>
+    <dc:creator>Nasdaq, Inc. Events</dc:creator>
+    <guid isPermaLink="false">109746</guid>
+    </item>
+
+
+  </channel>
+</rss>

--- a/tests/Equibles.UnitTests/TestAssets/InvestorRelations/nasdaq-news.xml
+++ b/tests/Equibles.UnitTests/TestAssets/InvestorRelations/nasdaq-news.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0" xml:base="https://ir.nasdaq.com/">
+  <channel>
+    <title>Nasdaq, Inc. News Releases</title>
+    <link>https://ir.nasdaq.com/</link>
+    <description>Nasdaq, Inc. News Releases</description>
+    <language>en</language>
+    
+    <item>
+  <title>Nasdaq Launches Economic Institute, Debuts New AI Research Series</title>
+  <link>https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-launches-economic-institute-debuts-new-ai-research-series</link>
+  <description>The Nasdaq Economic Institute will serve as a dedicated platform for original research, expert analysis, and convenings of market participants, policymakers, and regulators on the most critical issues shaping the financial ecosystem The Institute releases its inaugural AI research series, with the</description>
+  <pubDate>Tue, 09 Jun 2026 06:00:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. News Releases</dc:creator>
+    <guid isPermaLink="false">110511</guid>
+    </item>
+
+<item>
+  <title>Nasdaq Halts JIADE LIMITED</title>
+  <link>https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-halts-jiade-limited</link>
+  <description>NEW YORK, June 08, 2026 (GLOBE NEWSWIRE) -- The Nasdaq Stock Market ® (Nasdaq: NDAQ) &amp;nbsp; announced that trading is halted in JIADE LIMITED (Nasdaq: JDZG) for additional information requested from the company. Nasdaq halted JDZG at 17:15:41 on&amp;nbsp;June 4, 2026; the last closing price of the company’s</description>
+  <pubDate>Mon, 08 Jun 2026 09:00:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. News Releases</dc:creator>
+    <guid isPermaLink="false">110506</guid>
+    </item>
+
+<item>
+  <title>Nasdaq Reports May 2026 Volumes</title>
+  <link>https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-reports-may-2026-volumes</link>
+  <description>NEW YORK, June 03, 2026 (GLOBE NEWSWIRE) -- Nasdaq (Nasdaq: NDAQ) today reported monthly volumes for May 2026 on its Investor Relations website. A data sheet showing this information can be found at:&amp;nbsp; https://ir.nasdaq.com/financials/volume-statistics.&amp;nbsp; About Nasdaq Nasdaq (Nasdaq: NDAQ) is a</description>
+  <pubDate>Wed, 03 Jun 2026 16:05:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. News Releases</dc:creator>
+    <guid isPermaLink="false">110501</guid>
+    </item>
+
+<item>
+  <title>Nasdaq Resumes Trading in TJGC Group Limited</title>
+  <link>https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-resumes-trading-tjgc-group-limited</link>
+  <description>NEW YORK, June 03, 2026 (GLOBE NEWSWIRE) -- The Nasdaq Stock Market ® (Nasdaq: NDAQ) announced that trading will resume in TJGC Group Limited (Nasdaq: TJGC) at 12:00 p.m. Eastern Time on June 3, 2026. Trading in the company’s ordinary shares was halted on May 15, 2026 at 18:50:47 Eastern Time.</description>
+  <pubDate>Wed, 03 Jun 2026 11:30:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. News Releases</dc:creator>
+    <guid isPermaLink="false">110496</guid>
+    </item>
+
+<item>
+  <title>Nasdaq Executives to Present at Upcoming Investor Conferences</title>
+  <link>https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-executives-present-upcoming-investor-conferences-6</link>
+  <description>NEW YORK, May 28, 2026 (GLOBE NEWSWIRE) -- Nasdaq (Nasdaq: NDAQ) will be presenting at the following conferences in June with webcasts available at Nasdaq’s Investor Relations website: https://ir.nasdaq.com/. Who: Adena Friedman, Chair &amp;amp; CEO, Nasdaq What: William Blair 46 th Annual Growth Stock</description>
+  <pubDate>Thu, 28 May 2026 16:05:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. News Releases</dc:creator>
+    <guid isPermaLink="false">110491</guid>
+    </item>
+
+<item>
+  <title>Nasdaq Announces Mid-Month Open Short Interest Positions in Nasdaq Stocks as of Settlement Date May 15, 2026</title>
+  <link>https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-announces-mid-month-open-short-interest-positions-207</link>
+  <description>NEW YORK, May 27, 2026 (GLOBE NEWSWIRE) -- At the end of the settlement date of May 15, 2026, short interest in 3,727 Nasdaq Global Market SM securities totaled 17,000,786,423 shares compared with 16,707,836,595 shares in 3,714 Global Market issues reported for the prior settlement date of April</description>
+  <pubDate>Wed, 27 May 2026 16:05:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. News Releases</dc:creator>
+    <guid isPermaLink="false">110466</guid>
+    </item>
+
+<item>
+  <title>Nasdaq Halts TJGC Group Limited</title>
+  <link>https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-halts-tjgc-group-limited</link>
+  <description>NEW YORK, May 19, 2026 (GLOBE NEWSWIRE) -- The Nasdaq Stock Market ® (Nasdaq: NDAQ) &amp;nbsp; announced that trading is halted in TJGC Group Limited (Nasdaq: TJGC) for additional information requested from the company. Nasdaq halted TJGC at 18:50:47 on&amp;nbsp;May 15, 2026; the last closing price of the company’s</description>
+  <pubDate>Tue, 19 May 2026 09:00:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. News Releases</dc:creator>
+    <guid isPermaLink="false">110456</guid>
+    </item>
+
+<item>
+  <title>Nasdaq Announces 2026 Annual Meeting of Shareholders</title>
+  <link>https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-announces-2026-annual-meeting-shareholders</link>
+  <description>NEW YORK, May 14, 2026 (GLOBE NEWSWIRE) -- Nasdaq, Inc. (Nasdaq: NDAQ) has scheduled its 2026 Annual Meeting of Shareholders for June 10, 2026, at 8:00 AM ET. The virtual meeting website can be accessed 15 minutes prior to the meeting by visiting: www.virtualshareholdermeeting.com/NDAQ2026.&amp;nbsp;&amp;nbsp;</description>
+  <pubDate>Thu, 14 May 2026 16:05:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. News Releases</dc:creator>
+    <guid isPermaLink="false">110441</guid>
+    </item>
+
+<item>
+  <title>Delisting of Securities from The Nasdaq Stock Market</title>
+  <link>https://ir.nasdaq.com/news-releases/news-release-details/delisting-securities-nasdaq-stock-market-6</link>
+  <description>NEW YORK, May 11, 2026 (GLOBE NEWSWIRE) -- The Nasdaq Stock Market announced today that it will delist the ordinary shares of MingZhu Logistics Holdings Limited. MingZhu Logistics Holdings Limited’s ordinary shares were suspended on December 12, 2025 and have not traded on Nasdaq since that time.</description>
+  <pubDate>Mon, 11 May 2026 16:05:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. News Releases</dc:creator>
+    <guid isPermaLink="false">110426</guid>
+    </item>
+
+<item>
+  <title>Nasdaq Announces End-of-Month Open Short Interest Positions in Nasdaq Stocks as of Settlement Date April 30, 2026</title>
+  <link>https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-announces-end-month-open-short-interest-positions-223</link>
+  <description>NEW YORK, May 11, 2026 (GLOBE NEWSWIRE) -- At the end of the settlement date of April 30, 2026, short interest in 3,714 Nasdaq Global Market SM securities totaled 16,707,836,595 shares compared with 16,579,123,734 shares in 3,689 Global Market issues reported for the prior settlement date of April</description>
+  <pubDate>Mon, 11 May 2026 16:05:00 -0400</pubDate>
+    <dc:creator>Nasdaq, Inc. News Releases</dc:creator>
+    <guid isPermaLink="false">110421</guid>
+    </item>
+
+
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary

- First investor-relations platform scraper (#583). A worker scrapes the `news-releases` and `events` RSS feeds published by IR sites running on Nasdaq IR Insight — the platform already recorded on `CommonStock.IrPlatformType` by the classifier — and persists them into the `IrNewsItem` / `IrEvent` models.
- The feed parser is pure and pinned with recorded-feed fixtures (exact-value asserts); insertion is idempotent by natural key, so re-running a cycle never duplicates rows.

## Code changes

- `Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightFeedParser.cs` — parses the two RSS feeds into typed items; skips (never guesses) items with a missing field or unparseable date; normalises the event label to `IrEventType` (Unknown when unmatched).
- `NasdaqIrInsightFeedClient.cs` — typed `HttpClient` resolving the feed URLs off the stock's IR base URL, rate-limited, XML-only.
- `NasdaqIrInsightScraperService.cs` (+ `NasdaqIrInsightScraperWorker`, options, registration) — selects `NasdaqIrInsight`-classified stocks, fetches + parses + idempotently inserts.
- `Equibles.Errors.Data/Models/ErrorSource.cs` — adds `InvestorRelationsScraper`.
- `tests/Equibles.UnitTests` — record-replay parser tests against recorded Nasdaq feeds.

## Notes

Earnings-call events are typed `EarningsCall`; the structured fiscal-quarter earnings calendar (`EarningsCalendarEntry`) needs a dedicated source and is intentionally left for a follow-up rather than regex-guessed from event titles, to hold the financial-data accuracy bar.

Refs #586, #583