### PR TITLE
feat(common-stocks): back off IR discovery probes with a per-stock cooldown

### DIFF
--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -44,6 +44,14 @@ public class CommonStock
     /// </summary>
     public IrPlatformType IrPlatformType { get; set; }
 
+    /// <summary>
+    /// When IR discovery last probed this stock's website (UTC), stamped on every
+    /// definitive outcome — an IR page found, or every candidate validated as a miss.
+    /// Null until first probed. Stocks probed within the configured cooldown are
+    /// skipped, so persistent misses back off instead of being re-probed every cycle.
+    /// </summary>
+    public DateTime? InvestorRelationsCheckedAt { get; set; }
+
     public double MarketCapitalization { get; set; }
     public long SharesOutStanding { get; set; }
 

--- a/src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs
@@ -24,4 +24,12 @@ public class InvestorRelationsDiscoveryOptions : ScraperOptions
     /// <c>https://ir.acme.com</c>). Tried after the path candidates.
     /// </summary>
     public List<string> CandidateSubdomains { get; set; } = ["ir", "investors", "investor"];
+
+    /// <summary>
+    /// Days to wait before re-probing a stock whose last discovery attempt found no
+    /// IR page. Definitive misses are stamped on the stock, so persistent misses back
+    /// off for this window; transient probe errors are not stamped and retry on the
+    /// next cycle.
+    /// </summary>
+    public int ProbeCooldownDays { get; set; } = 30;
 }

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs
@@ -1,3 +1,5 @@
+using System.Linq.Expressions;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.HostedService.Configuration;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
@@ -65,11 +67,15 @@ public class InvestorRelationsDiscoveryService : IImporter
                     _options.CandidateSubdomains,
                     cancellationToken
                 );
-                // No IR page found this cycle. The stock stays null and is re-probed
-                // next cycle. TODO(#581 follow-up): record a last-attempted timestamp
-                // so persistent misses aren't re-probed every cycle.
+                // Definitive miss — every candidate was probed and none validated. Stamp
+                // the attempt so the stock backs off for the cooldown window instead of
+                // re-occupying a batch slot (and starving the rest of the universe) every
+                // cycle. Transient errors below deliberately skip the stamp.
                 if (result == null)
+                {
+                    await MarkChecked(candidate.Id);
                     continue;
+                }
 
                 if (await Persist(candidate.Id, result))
                 {
@@ -113,8 +119,9 @@ public class InvestorRelationsDiscoveryService : IImporter
         using var scope = _scopeFactory.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
 
+        var cutoff = DateTime.UtcNow.AddDays(-_options.ProbeCooldownDays);
         var rows = await repo.GetAll()
-            .Where(s => s.Website != null && s.Website != "" && s.InvestorRelationsUrl == null)
+            .Where(PendingDiscovery(cutoff))
             .OrderBy(s => s.Ticker)
             .Take(_options.BatchSize)
             .Select(s => new
@@ -141,8 +148,36 @@ public class InvestorRelationsDiscoveryService : IImporter
 
         stock.InvestorRelationsUrl = result.Url;
         stock.IrPlatformType = result.Platform;
+        stock.InvestorRelationsCheckedAt = DateTime.UtcNow;
         await repo.SaveChanges();
         return true;
+    }
+
+    private async Task MarkChecked(Guid commonStockId)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        var stock = await repo.Get(commonStockId);
+        if (stock == null)
+            return;
+
+        stock.InvestorRelationsCheckedAt = DateTime.UtcNow;
+        await repo.SaveChanges();
+    }
+
+    /// <summary>
+    /// Stocks eligible for an IR discovery probe: a known website, no discovered IR
+    /// page yet, and no probe since <paramref name="cutoff"/> (never-probed stocks are
+    /// always eligible).
+    /// </summary>
+    public static Expression<Func<CommonStock, bool>> PendingDiscovery(DateTime cutoff)
+    {
+        return s =>
+            s.Website != null
+            && s.Website != ""
+            && s.InvestorRelationsUrl == null
+            && (s.InvestorRelationsCheckedAt == null || s.InvestorRelationsCheckedAt < cutoff);
     }
 
     private sealed record CandidateStock(Guid Id, string Ticker, string Website);

--- a/src/Equibles.Migrations/Migrations/20260609203126_AddInvestorRelationsCheckedAtToCommonStock.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260609203126_AddInvestorRelationsCheckedAtToCommonStock.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609203126_AddInvestorRelationsCheckedAtToCommonStock")]
+    partial class AddInvestorRelationsCheckedAtToCommonStock
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260609203126_AddInvestorRelationsCheckedAtToCommonStock.cs
+++ b/src/Equibles.Migrations/Migrations/20260609203126_AddInvestorRelationsCheckedAtToCommonStock.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvestorRelationsCheckedAtToCommonStock : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "InvestorRelationsCheckedAt",
+                table: "CommonStock",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InvestorRelationsCheckedAt",
+                table: "CommonStock");
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsDiscoveryServicePendingDiscoveryTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsDiscoveryServicePendingDiscoveryTests.cs
@@ -1,0 +1,47 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class InvestorRelationsDiscoveryServicePendingDiscoveryTests
+{
+    private static readonly DateTime Cutoff = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Theory]
+    [InlineData(null, true)] // never probed → always eligible
+    [InlineData("2026-05-15", true)] // probed before the cutoff → cooldown elapsed
+    [InlineData("2026-06-05", false)] // probed within the cooldown → backs off
+    public void PendingDiscovery_CheckedAt_GatesOnCooldownCutoff(string checkedAt, bool expected)
+    {
+        // Contract: persistent misses back off — a stock probed within the cooldown
+        // window is skipped, while never-probed stocks and stocks whose cooldown has
+        // elapsed are eligible again.
+        var stock = new CommonStock
+        {
+            Website = "https://acme.com",
+            InvestorRelationsCheckedAt =
+                checkedAt == null ? null : DateTime.Parse(checkedAt).ToUniversalTime(),
+        };
+
+        var eligible = InvestorRelationsDiscoveryService.PendingDiscovery(Cutoff).Compile();
+
+        eligible(stock).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null, null, false)] // no website → nothing to probe
+    [InlineData("", null, false)] // empty website → nothing to probe
+    [InlineData("https://acme.com", "https://ir.acme.com", false)] // already discovered
+    public void PendingDiscovery_WebsiteAndIrUrl_ExcludeNonCandidates(
+        string website,
+        string irUrl,
+        bool expected
+    )
+    {
+        var stock = new CommonStock { Website = website, InvestorRelationsUrl = irUrl };
+
+        var eligible = InvestorRelationsDiscoveryService.PendingDiscovery(Cutoff).Compile();
+
+        eligible(stock).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary

- The IR discovery worker re-probed every stock with a website but no discovered IR page on each cycle, so the same first `BatchSize` persistent misses were probed forever — wasting outbound requests and starving the rest of the universe from ever being probed.
- Adds nullable `CommonStock.InvestorRelationsCheckedAt`, stamped on every definitive probe outcome (IR page found, or all candidates validated as misses). Stocks probed within a configurable `ProbeCooldownDays` window (default 30) are skipped; transient probe errors are not stamped, so they retry on the next cycle. Never-probed stocks remain immediately eligible.

Backend for daniel3303/EquiblesCommercial#2370.

## Code changes

- `src/Equibles.CommonStocks.Data/Models/CommonStock.cs` — new nullable `InvestorRelationsCheckedAt` (UTC).
- `src/Equibles.CommonStocks.HostedService/Configuration/InvestorRelationsDiscoveryOptions.cs` — new `ProbeCooldownDays` setting (default 30).
- `src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsDiscoveryService.cs` — candidate query now filters through the static `PendingDiscovery(cutoff)` predicate; definitive misses call `MarkChecked`, successful discoveries stamp the timestamp in `Persist`.
- `src/Equibles.Migrations/Migrations/20260609203126_AddInvestorRelationsCheckedAtToCommonStock.*` — additive nullable-column migration + snapshot.
- `tests/Equibles.UnitTests/CommonStocks/InvestorRelationsDiscoveryServicePendingDiscoveryTests.cs` — pins the eligibility predicate (cooldown gating, website/IR-url exclusions).