### PR TITLE
fix(ci): exclude captured test assets from csharpier formatting gate

### DIFF
--- a/.csharpierignore
+++ b/.csharpierignore
@@ -11,3 +11,7 @@ worktrees/
 
 ## Node / front-end assets (if any sneak in)
 node_modules/
+
+## Captured test payloads (cassettes) — real upstream responses committed verbatim.
+## Reformatting them churns golden files, so never gate them on formatting.
+**/TestAssets/


### PR DESCRIPTION
## Summary

The CI `lint` job has been red on `main` because `dotnet csharpier check .` flags captured XML test payloads under `tests/Equibles.UnitTests/TestAssets/` (13D/G filings, Nasdaq IR RSS feeds) as "Was not formatted". Since `build-and-test` depends on `lint`, every run skipped the test job, so CI provided no test signal.

These files are cassette assets — real upstream responses committed verbatim — and must never be reformatted: re-indenting them churns golden files and defeats the point of capturing exact payloads. This adds `**/TestAssets/` to `.csharpierignore`.

Note: the workflow itself was not at fault. It already runs `dotnet tool restore` before `dotnet csharpier check .`, which resolves the repo-pinned tool (1.2.6). The pinned tool reproduces the same failures on a clean `main` checkout, so the earlier "workflow uses a different csharpier version" theory was a stale-tree artifact.

## Code changes

- `.csharpierignore` — add `**/TestAssets/` with a comment explaining why captured payloads are exempt from the formatting gate.

## Verification

- `dotnet tool run csharpier check .` on clean `main`: 5 errors (the TestAssets XML files).
- With this change: `Checked 2589 files` — clean.

Closes #3602