### PR TITLE
feat(investor-relations): MCP tools for IR news and events

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -161,6 +161,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Holdings.BusinessL
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.CommonStocks.HostedService", "src\Equibles.CommonStocks.HostedService\Equibles.CommonStocks.HostedService.csproj", "{FFED11B2-5BED-4ABF-939E-D18589C1B07B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.InvestorRelations.Mcp", "src\Equibles.InvestorRelations.Mcp\Equibles.InvestorRelations.Mcp.csproj", "{7E757C1B-7801-4110-8C94-ACED64B36CAC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1095,6 +1097,18 @@ Global
 		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Release|x64.Build.0 = Release|Any CPU
 		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Release|x86.ActiveCfg = Release|Any CPU
 		{FFED11B2-5BED-4ABF-939E-D18589C1B07B}.Release|x86.Build.0 = Release|Any CPU
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Debug|x64.Build.0 = Debug|Any CPU
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Debug|x86.Build.0 = Debug|Any CPU
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Release|x64.ActiveCfg = Release|Any CPU
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Release|x64.Build.0 = Release|Any CPU
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Release|x86.ActiveCfg = Release|Any CPU
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1177,6 +1191,7 @@ Global
 		{77F0FC50-E234-49F3-9A43-46253DE68A0F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{946B8E31-D1FC-4649-9E0E-DCF389C97979} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{FFED11B2-5BED-4ABF-939E-D18589C1B07B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{7E757C1B-7801-4110-8C94-ACED64B36CAC} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.InvestorRelations.Mcp/Equibles.InvestorRelations.Mcp.csproj
+++ b/src/Equibles.InvestorRelations.Mcp/Equibles.InvestorRelations.Mcp.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Mcp\Equibles.Mcp.csproj" />
+    <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.InvestorRelations.Mcp/Extensions/McpBuilderExtensions.cs
+++ b/src/Equibles.InvestorRelations.Mcp/Extensions/McpBuilderExtensions.cs
@@ -1,0 +1,12 @@
+using Equibles.InvestorRelations.Mcp.Tools;
+using Equibles.Mcp;
+
+namespace Equibles.InvestorRelations.Mcp.Extensions;
+
+public static class McpBuilderExtensions
+{
+    public static EquiblesMcpBuilder AddInvestorRelations(this EquiblesMcpBuilder builder)
+    {
+        return builder.AddModule<AssemblyMcpModule<InvestorRelationsTools>>();
+    }
+}

--- a/src/Equibles.InvestorRelations.Mcp/Tools/InvestorRelationsTools.cs
+++ b/src/Equibles.InvestorRelations.Mcp/Tools/InvestorRelationsTools.cs
@@ -1,0 +1,134 @@
+using System.ComponentModel;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
+using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Equibles.InvestorRelations.Mcp.Tools;
+
+[McpServerToolType]
+public class InvestorRelationsTools
+{
+    private readonly CommonStockRepository _commonStockRepository;
+    private readonly IrNewsItemRepository _newsRepository;
+    private readonly IrEventRepository _eventRepository;
+    private readonly McpToolRunner _runner;
+
+    public InvestorRelationsTools(
+        CommonStockRepository commonStockRepository,
+        IrNewsItemRepository newsRepository,
+        IrEventRepository eventRepository,
+        ErrorManager errorManager,
+        ILogger<InvestorRelationsTools> logger
+    )
+    {
+        _commonStockRepository = commonStockRepository;
+        _newsRepository = newsRepository;
+        _eventRepository = eventRepository;
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
+    }
+
+    [McpServerTool(Name = "GetInvestorRelationsNews")]
+    [Description(
+        "Get recent investor-relations press releases for a stock, scraped from the company's IR website. Returns the most recent news items (headline, publish date, and link) in reverse-chronological order. Use this to see a company's latest official announcements straight from its IR page, distinct from third-party news."
+    )]
+    public Task<string> GetInvestorRelationsNews(
+        [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Maximum number of news items to return (default: 20)")] int maxResults = 20
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
+
+                maxResults = McpLimit.Clamp(maxResults);
+                var news = await _newsRepository.GetByStock(stock).Take(maxResults).ToListAsync();
+
+                if (news.Count == 0)
+                    return $"No investor relations news available for {ticker}.";
+
+                var builder = new StringBuilder();
+                builder.AppendLine($"Investor relations news for {stock.Ticker} ({stock.Name}):");
+                builder.AppendLine();
+                foreach (var item in news)
+                {
+                    builder.AppendLine($"- {item.PublishedAt:yyyy-MM-dd}: {item.Title}");
+                    builder.AppendLine($"  {item.Url}");
+                }
+
+                return builder.ToString();
+            },
+            "GetInvestorRelationsNews",
+            $"ticker: {ticker}"
+        );
+    }
+
+    [McpServerTool(Name = "GetInvestorRelationsEvents")]
+    [Description(
+        "Get upcoming investor-relations events for a stock — earnings webcasts, conference appearances, presentations, and shareholder meetings — scraped from the company's IR website. Returns events scheduled from now onward, soonest first. Use this to see what an investor-relations program has on the calendar."
+    )]
+    public Task<string> GetInvestorRelationsEvents(
+        [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Maximum number of events to return (default: 20)")] int maxResults = 20
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
+
+                maxResults = McpLimit.Clamp(maxResults);
+                var now = DateTime.UtcNow;
+                var events = await _eventRepository
+                    .GetByStock(stock)
+                    .Where(e => e.StartDateTime >= now)
+                    .Take(maxResults)
+                    .ToListAsync();
+
+                if (events.Count == 0)
+                    return $"No upcoming investor relations events available for {ticker}.";
+
+                var builder = new StringBuilder();
+                builder.AppendLine(
+                    $"Upcoming investor relations events for {stock.Ticker} ({stock.Name}):"
+                );
+                builder.AppendLine();
+                foreach (var ev in events)
+                {
+                    builder.AppendLine(
+                        $"- {ev.StartDateTime:yyyy-MM-dd HH:mm} UTC [{EventTypeLabel(ev.Type)}]: {ev.Title}"
+                    );
+                    if (!string.IsNullOrEmpty(ev.Url))
+                        builder.AppendLine($"  {ev.Url}");
+                }
+
+                return builder.ToString();
+            },
+            "GetInvestorRelationsEvents",
+            $"ticker: {ticker}"
+        );
+    }
+
+    private static string EventTypeLabel(IrEventType type) =>
+        type switch
+        {
+            IrEventType.EarningsCall => "Earnings call",
+            IrEventType.Conference => "Conference",
+            IrEventType.Presentation => "Presentation",
+            IrEventType.ShareholderMeeting => "Shareholder meeting",
+            IrEventType.Webcast => "Webcast",
+            _ => "Event",
+        };
+}

--- a/src/Equibles.Mcp.Server/Equibles.Mcp.Server.csproj
+++ b/src/Equibles.Mcp.Server/Equibles.Mcp.Server.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Mcp\Equibles.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Holdings.Mcp\Equibles.Holdings.Mcp.csproj" />
+    <ProjectReference Include="..\Equibles.InvestorRelations.Mcp\Equibles.InvestorRelations.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.InsiderTrading.Mcp\Equibles.InsiderTrading.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Sec.Mcp\Equibles.Sec.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Mcp\Equibles.Sec.FinancialFacts.Mcp.csproj" />

--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -15,6 +15,7 @@ using Equibles.Fred.Data.Extensions;
 using Equibles.Fred.Mcp.Extensions;
 using Equibles.Holdings.Data.Extensions;
 using Equibles.Holdings.Mcp.Extensions;
+using Equibles.InvestorRelations.Mcp.Extensions;
 using Equibles.InsiderTrading.Data.Extensions;
 using Equibles.InsiderTrading.Mcp.Extensions;
 using Equibles.Mcp.Contracts;
@@ -80,6 +81,7 @@ public partial class Program
         builder.Services.AddEquiblesMcp(mcp =>
         {
             mcp.AddHoldings();
+            mcp.AddInvestorRelations();
             mcp.AddInsiderTrading();
             mcp.AddFred();
             mcp.AddSec();


### PR DESCRIPTION
## Summary

- Exposes the scraped investor-relations data over MCP (#586): `GetInvestorRelationsNews` (recent press releases) and `GetInvestorRelationsEvents` (upcoming events), keyed by ticker.

## Code changes

- New `Equibles.InvestorRelations.Mcp` module (`InvestorRelationsTools` + `AddInvestorRelations()` builder extension), following the per-module MCP pattern and the shared `McpToolRunner`.
- Wired `mcp.AddInvestorRelations()` into `Equibles.Mcp.Server`.

Refs #586