### PR TITLE
fix(mcp): translate missing required tool arguments into structured invalid-params results

### DIFF
--- a/src/Equibles.Mcp/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Mcp/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
 
 namespace Equibles.Mcp.Extensions;
 
@@ -12,6 +14,51 @@ public static class ServiceCollectionExtensions
         var mcpServerBuilder = services.AddMcpServer().WithHttpTransport();
         var mcpBuilder = new EquiblesMcpBuilder(services, mcpServerBuilder);
         configureMcp(mcpBuilder);
+        WrapToolsWithInvalidParamsTranslation(services);
         return services;
+    }
+
+    // The SDK's argument binder throws before any tool body runs, so per-tool
+    // try/catch can't reach it — every registered tool is decorated instead (see
+    // InvalidParamsTranslatingTool).
+    private static void WrapToolsWithInvalidParamsTranslation(IServiceCollection services)
+    {
+        for (var i = 0; i < services.Count; i++)
+        {
+            var descriptor = services[i];
+            if (descriptor.IsKeyedService || descriptor.ServiceType != typeof(McpServerTool))
+            {
+                continue;
+            }
+
+            var inner = descriptor;
+            services[i] = ServiceDescriptor.Describe(
+                typeof(McpServerTool),
+                provider => new InvalidParamsTranslatingTool(
+                    ResolveInner(provider, inner),
+                    provider.GetRequiredService<ILogger<InvalidParamsTranslatingTool>>()
+                ),
+                descriptor.Lifetime
+            );
+        }
+    }
+
+    private static McpServerTool ResolveInner(
+        IServiceProvider provider,
+        ServiceDescriptor descriptor
+    )
+    {
+        if (descriptor.ImplementationInstance is McpServerTool instance)
+        {
+            return instance;
+        }
+
+        if (descriptor.ImplementationFactory is not null)
+        {
+            return (McpServerTool)descriptor.ImplementationFactory(provider);
+        }
+
+        return (McpServerTool)
+            ActivatorUtilities.CreateInstance(provider, descriptor.ImplementationType);
     }
 }

--- a/src/Equibles.Mcp/InvalidParamsTranslatingTool.cs
+++ b/src/Equibles.Mcp/InvalidParamsTranslatingTool.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Equibles.Mcp;
+
+/// <summary>
+/// Decorates a registered <see cref="McpServerTool"/> so that a missing or malformed
+/// required argument — which the SDK's binder surfaces as an
+/// <see cref="ArgumentException"/> before the tool body ever runs — comes back to the
+/// client as a structured invalid-parameters tool result naming the tool, instead of
+/// an opaque "an error occurred" message. A client's input mistake is not a server
+/// fault, so it is logged at information level rather than error.
+/// </summary>
+public class InvalidParamsTranslatingTool : McpServerTool
+{
+    private readonly McpServerTool _inner;
+    private readonly ILogger<InvalidParamsTranslatingTool> _logger;
+
+    public InvalidParamsTranslatingTool(
+        McpServerTool inner,
+        ILogger<InvalidParamsTranslatingTool> logger
+    )
+    {
+        _inner = inner;
+        _logger = logger;
+    }
+
+    public override Tool ProtocolTool => _inner.ProtocolTool;
+
+    public override IReadOnlyList<object> Metadata => _inner.Metadata;
+
+    public override async ValueTask<CallToolResult> InvokeAsync(
+        RequestContext<CallToolRequestParams> request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        try
+        {
+            return await _inner.InvokeAsync(request, cancellationToken);
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogInformation(
+                "Rejected call to {ToolName} with invalid arguments: {Reason}",
+                ProtocolTool.Name,
+                ex.Message
+            );
+            return new CallToolResult
+            {
+                IsError = true,
+                Content =
+                [
+                    new TextContentBlock
+                    {
+                        Text = $"Invalid parameters for {ProtocolTool.Name}: {ex.Message}",
+                    },
+                ],
+            };
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/Server/McpServerMissingRequiredArgumentTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Server/McpServerMissingRequiredArgumentTests.cs
@@ -1,0 +1,80 @@
+using Equibles.IntegrationTests.Helpers;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp.Server;
+
+/// <summary>
+/// A client that omits a required tool argument made a mistake in its request, not in
+/// our server: the SDK's binder throws <see cref="ArgumentException"/> before the tool
+/// body runs, and without translation that surfaces as an unhandled exception the
+/// dispatcher logs at error level with an opaque message. The contract pinned here is
+/// that such a call comes back as a structured tool error — <c>IsError</c> with a
+/// message naming the tool and calling out invalid parameters — so the client can fix
+/// its request and the server's error log stays meaningful.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class McpServerMissingRequiredArgumentTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _paradeDb;
+    private McpServerFixture _serverFixture;
+
+    public McpServerMissingRequiredArgumentTests(ParadeDbFixture paradeDb)
+    {
+        _paradeDb = paradeDb;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _paradeDb.ResetAsync();
+        _serverFixture = new McpServerFixture(_paradeDb);
+        await _serverFixture.InitializeAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_serverFixture is not null)
+        {
+            await ((IAsyncLifetime)_serverFixture).DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task CallTool_GetLatestPricesWithoutRequiredTickers_ReturnsInvalidParamsError()
+    {
+        var httpClient = _serverFixture.CreateClient();
+        httpClient.BaseAddress = new Uri("http://localhost/");
+
+        var transport = new HttpClientTransport(
+            new HttpClientTransportOptions
+            {
+                Endpoint = new Uri("http://localhost/mcp"),
+                TransportMode = HttpTransportMode.StreamableHttp,
+            },
+            httpClient
+        );
+
+        await using var client = await McpClient.CreateAsync(transport);
+
+        // GetLatestPrices declares 'tickers' with no default — omitting it is the
+        // simplest possible malformed request a real MCP client can produce.
+        var result = await client.CallToolAsync(
+            toolName: "GetLatestPrices",
+            arguments: new Dictionary<string, object>()
+        );
+
+        result
+            .IsError.Should()
+            .Be(true, "a call missing a required argument cannot have succeeded");
+
+        var text = string.Concat(result.Content.OfType<TextContentBlock>().Select(b => b.Text));
+        text.Should()
+            .Contain(
+                "Invalid parameters",
+                "the client should be told its arguments were the problem, not given an opaque server error"
+            );
+        text.Should()
+            .Contain("GetLatestPrices", "the error should name the tool that rejected the call");
+    }
+}


### PR DESCRIPTION
## Summary

Calling any MCP tool without a required parameter (e.g. `GetLatestPrices` without `tickers`) made the SDK's argument binder throw `ArgumentException` before the tool method ran — the dispatcher logged "threw an unhandled exception" at error level and the client received an opaque "An error occurred invoking '<tool>'." The per-tool `McpToolRunner` wrapping can never reach this because binding happens before the tool body.

Fix: `AddEquiblesMcp` now decorates every registered `McpServerTool` with `InvalidParamsTranslatingTool`, which catches the binder's `ArgumentException` and returns a structured tool error (`IsError`, "Invalid parameters for <tool>: <reason>"), logged at information level — a client's input mistake is not a server fault. Valid calls pass through untouched.

Refs daniel3303/EquiblesCommercial#2328 (submodule bump there follows).

## Code changes

- `src/Equibles.Mcp/InvalidParamsTranslatingTool.cs` — new delegating `McpServerTool` decorator; forwards `ProtocolTool`/`Metadata`, translates `ArgumentException` from `InvokeAsync`.
- `src/Equibles.Mcp/Extensions/ServiceCollectionExtensions.cs` — after module registration, rewrites each `McpServerTool` service descriptor to wrap the original tool (instance/factory/type all handled; keyed services skipped).
- `tests/Equibles.IntegrationTests/Mcp/Server/McpServerMissingRequiredArgumentTests.cs` — regression test over the real HTTP dispatch path: failed pre-fix with the opaque message, passes post-fix.

Build green; unit suite 2712 green; MCP integration tests 328 green (including the existing happy-path invocation test, proving the decorator is transparent for valid calls); csharpier clean.