### PR TITLE
feat(sec): index NportHolding.Cusip and add reverse-lookup repository queries

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260609232334_AddNportHoldingCusipIndex.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260609232334_AddNportHoldingCusipIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609232334_AddNportHoldingCusipIndex")]
+    partial class AddNportHoldingCusipIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260609232334_AddNportHoldingCusipIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260609232334_AddNportHoldingCusipIndex.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNportHoldingCusipIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_NportHolding_Cusip",
+                table: "NportHolding",
+                column: "Cusip");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_NportHolding_Cusip",
+                table: "NportHolding");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/NportHolding.cs
+++ b/src/Equibles.Sec.Data/Models/NportHolding.cs
@@ -12,6 +12,7 @@ namespace Equibles.Sec.Data.Models;
 /// "DE" derivative; issuer "CORP" corporate, "RF" registered fund).
 /// </summary>
 [Index(nameof(NportFilingId))]
+[Index(nameof(Cusip))]
 public class NportHolding
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]

--- a/src/Equibles.Sec.Repositories/NportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NportFilingRepository.cs
@@ -12,4 +12,37 @@ public class NportFilingRepository : SecFilingRepositoryBase<NportFiling>
     {
         return DbContext.Set<NportHolding>().Where(h => h.NportFilingId == filing.Id);
     }
+
+    /// <summary>The reported holding rows carrying the given CUSIP, across all NPORT filings.</summary>
+    public IQueryable<NportHolding> GetHoldingsByCusip(string cusip)
+    {
+        return DbContext.Set<NportHolding>().Where(h => h.Cusip == cusip);
+    }
+
+    /// <summary>
+    /// Each fund series' most recent NPORT report whose portfolio is as of the floor date or
+    /// later. Series are keyed by registrant + series name — <see cref="NportFiling.SeriesId"/>
+    /// is absent on almost every filing. The latest report is the one with the greatest report
+    /// period, breaking ties by filing date and then accession number so amendments and
+    /// re-filings of the same period win.
+    /// </summary>
+    public IQueryable<NportFiling> GetLatestPerSeries(DateOnly floor)
+    {
+        var filings = GetAll().Where(f => f.ReportPeriodDate >= floor);
+        return filings.Where(f =>
+            !filings.Any(f2 =>
+                f2.CommonStockId == f.CommonStockId
+                && f2.SeriesName == f.SeriesName
+                && (
+                    f2.ReportPeriodDate > f.ReportPeriodDate
+                    || (f2.ReportPeriodDate == f.ReportPeriodDate && f2.FilingDate > f.FilingDate)
+                    || (
+                        f2.ReportPeriodDate == f.ReportPeriodDate
+                        && f2.FilingDate == f.FilingDate
+                        && string.Compare(f2.AccessionNumber, f.AccessionNumber) > 0
+                    )
+                )
+            )
+        );
+    }
 }

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs
@@ -187,4 +187,86 @@ public class NportFilingRepositoryTests : IDisposable
                 h.Name == "AT&T Inc" && h.Cusip == "00206R102" && h.AssetCategory == "EC"
             );
     }
+
+    [Fact]
+    public async Task GetLatestPerSeries_ReturnsTheNewestReportPerSeries()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var older = CreateFiling(stock.Id, "0000036405-24-000001", new DateOnly(2024, 11, 20));
+        older.ReportPeriodDate = new DateOnly(2024, 10, 31);
+        var newest = CreateFiling(stock.Id, "0000036405-25-000002", new DateOnly(2025, 1, 15));
+        newest.ReportPeriodDate = new DateOnly(2024, 12, 31);
+        var otherSeries = CreateFiling(
+            stock.Id,
+            "0000036405-25-000003",
+            new DateOnly(2025, 1, 15),
+            "Vanguard Growth Index Fund"
+        );
+        otherSeries.ReportPeriodDate = new DateOnly(2024, 12, 31);
+        var belowFloor = CreateFiling(
+            stock.Id,
+            "0000036405-23-000004",
+            new DateOnly(2023, 1, 15),
+            "Vanguard Stale Fund"
+        );
+        belowFloor.ReportPeriodDate = new DateOnly(2022, 12, 31);
+        _repository.Add(older);
+        _repository.Add(newest);
+        _repository.Add(otherSeries);
+        _repository.Add(belowFloor);
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetLatestPerSeries(new DateOnly(2024, 1, 1)).ToListAsync();
+
+        result.Should().HaveCount(2);
+        result.Select(f => f.Id).Should().BeEquivalentTo([newest.Id, otherSeries.Id]);
+    }
+
+    [Fact]
+    public async Task GetHoldingsByCusip_ReturnsOnlyRowsCarryingThatCusip()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+        var filing = CreateFiling(stock.Id);
+        filing.Holdings.Add(
+            new NportHolding
+            {
+                Name = "APPLE INC",
+                Cusip = "037833100",
+                Balance = 100m,
+                Units = "NS",
+                Currency = "USD",
+                ValueUsd = 25_000m,
+                PercentValue = 2.17m,
+                PayoffProfile = "Long",
+                AssetCategory = "EC",
+                IssuerCategory = "CORP",
+            }
+        );
+        filing.Holdings.Add(
+            new NportHolding
+            {
+                Name = "MICROSOFT CORP",
+                Cusip = "594918104",
+                Balance = 50m,
+                Units = "NS",
+                Currency = "USD",
+                ValueUsd = 21_000m,
+                PercentValue = 1.83m,
+                PayoffProfile = "Long",
+                AssetCategory = "EC",
+                IssuerCategory = "CORP",
+            }
+        );
+        _repository.Add(filing);
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetHoldingsByCusip("037833100").ToListAsync();
+
+        result.Should().ContainSingle().Which.Name.Should().Be("APPLE INC");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds the data-side building blocks for a "which funds hold this stock" reverse lookup over NPORT-P data: a `Cusip` index on `NportHolding` (the holdings table is ~24.7M rows in a real deployment, so the lookup needs it) and two repository queries.
- `GetHoldingsByCusip(cusip)` returns the holding rows carrying a CUSIP across all filings; `GetLatestPerSeries(floor)` returns each fund series' most recent report (keyed on registrant + series name since `SeriesId` is absent on almost every filing), with filing-date and accession-number tie-breakers so amendments win.

## Code changes

- `src/Equibles.Sec.Data/Models/NportHolding.cs` — `[Index(nameof(Cusip))]`.
- `src/Equibles.Sec.Repositories/NportFilingRepository.cs` — the two new queries.
- `src/Equibles.Migrations/Migrations/20260609232334_AddNportHoldingCusipIndex.*` + snapshot — index migration.
- `tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs` — latest-per-series selection (newest period wins, stale series floored out) and CUSIP filtering.