### PR TITLE
fix(holdings): widen InstitutionalHolding.TitleOfClass to varchar(512)

### DIFF
--- a/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
+++ b/src/Equibles.Holdings.Data/Models/InstitutionalHolding.cs
@@ -47,7 +47,10 @@ public class InstitutionalHolding
     [Column(TypeName = "numeric(7,4)")]
     public decimal? PercentOfClass { get; set; }
 
-    [MaxLength(128)]
+    // 13D/G cover pages report fully spelled-out class descriptions that can far
+    // exceed the short titles 13F info tables carry, so the column is wider than
+    // the other identifier fields.
+    [MaxLength(512)]
     public string TitleOfClass { get; set; }
 
     [MaxLength(9)]

--- a/src/Equibles.Migrations/Migrations/20260610013221_WidenInstitutionalHoldingTitleOfClass.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260610013221_WidenInstitutionalHoldingTitleOfClass.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610013221_WidenInstitutionalHoldingTitleOfClass")]
+    partial class WidenInstitutionalHoldingTitleOfClass
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260610013221_WidenInstitutionalHoldingTitleOfClass.cs
+++ b/src/Equibles.Migrations/Migrations/20260610013221_WidenInstitutionalHoldingTitleOfClass.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class WidenInstitutionalHoldingTitleOfClass : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "TitleOfClass",
+                table: "InstitutionalHolding",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "TitleOfClass",
+                table: "InstitutionalHolding",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512,
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The 13D/G realtime ingestion batch flush fails with `22001: value too long for type character varying(128)` when a filing reports a title-of-class longer than 128 characters — the whole batch save aborts and the filing's holdings rows are discarded. 13D/G cover pages carry fully spelled-out class descriptions (series, par value, conversion terms) that routinely exceed the short titles 13F info tables use. Widening the column preserves the source value exactly instead of truncating, keeping stored data faithful to the filing.

Surfaced in production: daniel3303/EquiblesCommercial#2480.

## Code changes

- `Equibles.Holdings.Data/Models/InstitutionalHolding.cs` — `TitleOfClass` `[MaxLength(128)]` → `[MaxLength(512)]` with a comment on why this column is wider.
- `Equibles.Migrations/Migrations/20260610013221_WidenInstitutionalHoldingTitleOfClass.*` — scaffolded migration altering the column to `character varying(512)` (pure widen, no data change).
- Snapshot updated by the scaffold.