### PR TITLE
feat(sec-facts): add FinancialFact.DimensionsKey and XBRL-extraction tracking

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260610013258_AddFinancialFactDimensionsKeyAndXbrlFactsTracking.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260610013258_AddFinancialFactDimensionsKeyAndXbrlFactsTracking.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610013258_AddFinancialFactDimensionsKeyAndXbrlFactsTracking")]
+    partial class AddFinancialFactDimensionsKeyAndXbrlFactsTracking
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260610013258_AddFinancialFactDimensionsKeyAndXbrlFactsTracking.cs
+++ b/src/Equibles.Migrations/Migrations/20260610013258_AddFinancialFactDimensionsKeyAndXbrlFactsTracking.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFinancialFactDimensionsKeyAndXbrlFactsTracking : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_FinancialFact_CommonStockId_FinancialConceptId_Unit_PeriodS~",
+                table: "FinancialFact");
+
+            migrationBuilder.AddColumn<string>(
+                name: "DimensionsKey",
+                table: "FinancialFact",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "XbrlFactsAttempts",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "XbrlFactsVersion",
+                table: "Document",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FinancialFact_CommonStockId_FinancialConceptId_Unit_PeriodS~",
+                table: "FinancialFact",
+                columns: new[] { "CommonStockId", "FinancialConceptId", "Unit", "PeriodStart", "PeriodEnd", "AccessionNumber", "DimensionsKey" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Document_XbrlStatus_XbrlFactsVersion",
+                table: "Document",
+                columns: new[] { "XbrlStatus", "XbrlFactsVersion" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_FinancialFact_CommonStockId_FinancialConceptId_Unit_PeriodS~",
+                table: "FinancialFact");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Document_XbrlStatus_XbrlFactsVersion",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "DimensionsKey",
+                table: "FinancialFact");
+
+            migrationBuilder.DropColumn(
+                name: "XbrlFactsAttempts",
+                table: "Document");
+
+            migrationBuilder.DropColumn(
+                name: "XbrlFactsVersion",
+                table: "Document");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FinancialFact_CommonStockId_FinancialConceptId_Unit_PeriodS~",
+                table: "FinancialFact",
+                columns: new[] { "CommonStockId", "FinancialConceptId", "Unit", "PeriodStart", "PeriodEnd", "AccessionNumber" },
+                unique: true);
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -12,6 +12,7 @@ namespace Equibles.Sec.Data.Models;
 [Index(nameof(ReportingForDate), IsUnique = false)]
 [Index(nameof(AccessionNumber), IsUnique = false)]
 [Index(nameof(XbrlStatus), IsUnique = false)]
+[Index(nameof(XbrlStatus), nameof(XbrlFactsVersion))]
 public class Document
 {
     public Guid Id { get; set; } = Guid.NewGuid();
@@ -90,6 +91,23 @@ public class Document
     /// <see cref="XbrlCaptureStatus.NotChecked"/>.
     /// </summary>
     public int XbrlCaptureAttempts { get; set; }
+
+    /// <summary>
+    /// Version of the dimensional-fact extractor that last processed this document's
+    /// captured XBRL envelope. 0 = never extracted; the extraction sweep selects
+    /// <see cref="XbrlCaptureStatus.Captured"/> documents whose version is below the
+    /// extractor's current one, so bumping the extractor version reprocesses the corpus
+    /// (same pattern as the N-PORT / insider ParserVersion reprocess).
+    /// </summary>
+    public int XbrlFactsVersion { get; set; }
+
+    /// <summary>
+    /// How many times the dimensional-fact extraction has failed on this document. The
+    /// sweep stops selecting a document at its retry ceiling so one unparseable envelope
+    /// can't starve the queue. Only meaningful while <see cref="XbrlFactsVersion"/> is
+    /// below the extractor's current version.
+    /// </summary>
+    public int XbrlFactsAttempts { get; set; }
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFact.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFact.cs
@@ -24,6 +24,7 @@ namespace Equibles.Sec.FinancialFacts.Data.Models;
     nameof(PeriodStart),
     nameof(PeriodEnd),
     nameof(AccessionNumber),
+    nameof(DimensionsKey),
     IsUnique = true
 )]
 public class FinancialFact
@@ -88,6 +89,20 @@ public class FinancialFact
     /// <summary>SEC standardized frame label, e.g. <c>CY2024Q1I</c>; null if absent.</summary>
     [MaxLength(32)]
     public string Frame { get; set; }
+
+    /// <summary>
+    /// Canonical fingerprint of this fact's explicit XBRL dimensions: the empty
+    /// string for the consolidated (no-dimension) context — every API-sourced
+    /// fact — and a lowercase hex SHA-256 of the ordinal-sorted
+    /// <c>axis=member|axis=member</c> QName pairs for dimensional facts. Part of
+    /// the natural-key unique index so a segment/product/geography cut never
+    /// collides with its consolidated sibling on the same concept, period and
+    /// accession. Defaulted (not null) because the index must stay NULL-free —
+    /// Postgres treats NULLs as distinct in unique indexes.
+    /// </summary>
+    [Required(AllowEmptyStrings = true)]
+    [MaxLength(64)]
+    public string DimensionsKey { get; set; } = string.Empty;
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -396,6 +396,8 @@ public class FinancialFactsImportService
         await dbContext
             .Set<FinancialFact>()
             .UpsertRange(items)
+            // Must name the unique index's full column list (including
+            // DimensionsKey) or Postgres can't infer the ON CONFLICT target.
             .On(f => new
             {
                 f.CommonStockId,
@@ -404,6 +406,7 @@ public class FinancialFactsImportService
                 f.PeriodStart,
                 f.PeriodEnd,
                 f.AccessionNumber,
+                f.DimensionsKey,
             })
             .WhenMatched(
                 (existing, incoming) =>
@@ -526,7 +529,8 @@ public class FinancialFactsImportService
                         f.Unit,
                         f.PeriodStart,
                         f.PeriodEnd,
-                        f.AccessionNumber
+                        f.AccessionNumber,
+                        f.DimensionsKey
                     ),
                 f => f.FiledDate
             )


### PR DESCRIPTION
## Summary

Slice 1/3 of #877 (Refs #877 — does not close it). Prepares the schema for dimensional-fact extraction: a dimensional fact (e.g. revenue tagged `srt:ProductOrServiceAxis` → `aapl:IPhoneMember`) shares (stock, concept, unit, period, accession) with its consolidated sibling, so today's unique index cannot hold both. Adds the discriminator plus the per-document extraction bookkeeping the upcoming sweep needs.

## Code changes

- `src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFact.cs` — new `DimensionsKey` column: empty string for the consolidated (no-dimension) context, lowercase hex SHA-256 of the ordinal-sorted `axis=member|…` QName pairs for dimensional facts; appended to the natural-key unique index (NULL-free so Postgres unique semantics hold).
- `src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs` — the API importer's `ON CONFLICT` target and in-batch collapse now name the full new index column list (required for Postgres conflict-target inference); behavior otherwise unchanged (API rows always carry the empty key).
- `src/Equibles.Sec.Data/Models/Document.cs` — `XbrlFactsVersion` + `XbrlFactsAttempts` columns and an `(XbrlStatus, XbrlFactsVersion)` index so the extraction sweep is version-stamped, re-runnable on extractor upgrades, and protected by a retry ceiling (same pattern as the N-PORT/insider reprocess).
- `src/Equibles.Migrations/Migrations/20260610013258_AddFinancialFactDimensionsKeyAndXbrlFactsTracking*` — generated migration (additive columns + index swap).

Verified: solution build green, csharpier check clean, 47 FinancialFacts unit tests green, 439 Sec/migration integration tests green (Testcontainers applies the new migration).