### PR TITLE
fix(sec): resolve FTD feed symbols to class-share tickers when seeding CUSIPs

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -141,14 +141,15 @@ public class FtdImportService
         CancellationToken cancellationToken
     )
     {
+        var strippedAliases = BuildStrippedTickerAliases(tickerMap);
         var tickerToCusip = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var record in records)
         {
             if (string.IsNullOrEmpty(record.Cusip) || string.IsNullOrEmpty(record.Symbol))
                 continue;
-            if (!tickerMap.ContainsKey(record.Symbol))
+            if (!TryResolveSymbol(record.Symbol, tickerMap, strippedAliases, out var ticker))
                 continue;
-            tickerToCusip.TryAdd(record.Symbol, record.Cusip);
+            tickerToCusip.TryAdd(ticker, record.Cusip);
         }
 
         if (tickerToCusip.Count == 0)
@@ -180,6 +181,56 @@ public class FtdImportService
         return seeded;
     }
 
+    /// <summary>
+    /// The CNS fails feed strips the share-class separator from symbols ("BRKB",
+    /// "MOGA") while EDGAR tickers keep it ("BRK-B", "MOG-A"), so exact matching
+    /// permanently skips class-share issuers. Alias each stored ticker by its
+    /// separator-stripped form — but never shadow a real ticker, and drop a
+    /// stripped form two tickers collapse onto rather than guess.
+    /// </summary>
+    private static Dictionary<string, string> BuildStrippedTickerAliases(
+        Dictionary<string, Guid> tickerMap
+    )
+    {
+        var aliases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var ambiguous = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var ticker in tickerMap.Keys)
+        {
+            var stripped = string.Concat(ticker.Where(char.IsLetterOrDigit));
+            if (
+                stripped.Length == 0
+                || string.Equals(stripped, ticker, StringComparison.OrdinalIgnoreCase)
+            )
+                continue;
+            if (tickerMap.ContainsKey(stripped))
+                continue;
+            if (!aliases.TryAdd(stripped, ticker))
+                ambiguous.Add(stripped);
+        }
+
+        foreach (var key in ambiguous)
+            aliases.Remove(key);
+
+        return aliases;
+    }
+
+    private static bool TryResolveSymbol(
+        string symbol,
+        Dictionary<string, Guid> tickerMap,
+        Dictionary<string, string> strippedAliases,
+        out string ticker
+    )
+    {
+        if (tickerMap.ContainsKey(symbol))
+        {
+            ticker = symbol;
+            return true;
+        }
+
+        return strippedAliases.TryGetValue(symbol, out ticker);
+    }
+
     private async Task<int> ImportRecords(
         List<FtdRecord> records,
         Dictionary<string, Guid> tickerMap,
@@ -189,11 +240,13 @@ public class FtdImportService
         // Group by stock+date, keeping the latest record per day (FTD is cumulative)
         var grouped = new Dictionary<(Guid StockId, DateOnly Date), FailToDeliver>();
 
+        var strippedAliases = BuildStrippedTickerAliases(tickerMap);
         foreach (var record in records)
         {
             if (
                 string.IsNullOrEmpty(record.Symbol)
-                || !tickerMap.TryGetValue(record.Symbol, out var stockId)
+                || !TryResolveSymbol(record.Symbol, tickerMap, strippedAliases, out var ticker)
+                || !tickerMap.TryGetValue(ticker, out var stockId)
             )
             {
                 continue;

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsClassShareSymbolTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsClassShareSymbolTests.cs
@@ -1,0 +1,201 @@
+using System.Collections;
+using System.Reflection;
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.HostedService.Services;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// The SEC fails-to-deliver feed strips the class-share separator from symbols
+/// (Berkshire Hathaway B is "BRKB", Moog A is "MOGA") while EDGAR — and therefore
+/// CommonStock.Ticker — keeps it ("BRK-B", "MOG-A"). CUSIP seeding must bridge the
+/// two forms, otherwise class-share issuers never receive a CUSIP, stay hidden from
+/// the public portal, and none of their 13F holdings can map to the company
+/// (daniel3303/EquiblesCommercial#2508). Pin: a feed symbol that is the
+/// separator-stripped form of exactly one stored ticker seeds that stock's CUSIP.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FtdImportServiceSeedCusipsClassShareSymbolTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<EquiblesFinancialDbContext> _contexts = [];
+
+    public FtdImportServiceSeedCusipsClassShareSymbolTests(ParadeDbFixture fixture) =>
+        _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    [Fact]
+    public async Task SeedCusips_FeedSymbolWithoutClassSeparator_SeedsCusipOnHyphenatedTicker()
+    {
+        var berkshire = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BRK-B",
+            Name = "Berkshire Hathaway Inc",
+            Cik = "0001067983",
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(berkshire);
+            await seed.SaveChangesAsync();
+        }
+
+        var sut = BuildService();
+
+        // The real cnsfails feed line for Berkshire B carries symbol "BRKB".
+        var (records, recordType) = BuildRecords(("BRKB", "084670702"));
+        var tickerMap = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["BRK-B"] = berkshire.Id,
+        };
+
+        var seeded = await InvokeSeedCusips(sut, records, tickerMap);
+
+        seeded.Should().Be(1);
+        using var verify = FreshContext();
+        var persisted = await verify.Set<CommonStock>().FirstAsync(s => s.Id == berkshire.Id);
+        persisted.Cusip.Should().Be("084670702");
+    }
+
+    [Fact]
+    public async Task SeedCusips_StrippedSymbolCollidesWithRealTicker_SeedsOnlyTheExactMatch()
+    {
+        // "BFA" is both a real stored ticker AND the stripped form of "BF-A".
+        // The exact owner of the symbol must win; the class-share stock must
+        // NOT be seeded from an ambiguous symbol — guessing would attach the
+        // wrong CUSIP to the wrong company.
+        var exact = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BFA",
+            Name = "Exact Symbol Owner Inc",
+            Cik = "0000000010",
+        };
+        var classShare = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "BF-A",
+            Name = "Brown Forman Corp",
+            Cik = "0000014693",
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().AddRange(exact, classShare);
+            await seed.SaveChangesAsync();
+        }
+
+        var sut = BuildService();
+
+        var (records, _) = BuildRecords(("BFA", "111111111"));
+        var tickerMap = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["BFA"] = exact.Id,
+            ["BF-A"] = classShare.Id,
+        };
+
+        var seeded = await InvokeSeedCusips(sut, records, tickerMap);
+
+        seeded.Should().Be(1);
+        using var verify = FreshContext();
+        var exactAfter = await verify.Set<CommonStock>().FirstAsync(s => s.Id == exact.Id);
+        var classAfter = await verify.Set<CommonStock>().FirstAsync(s => s.Id == classShare.Id);
+        exactAfter.Cusip.Should().Be("111111111");
+        classAfter.Cusip.Should().BeNull();
+    }
+
+    private FtdImportService BuildService()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var ctx = FreshContext();
+                var sp = Substitute.For<IServiceProvider>();
+                sp.GetService(typeof(CommonStockRepository))
+                    .Returns(new CommonStockRepository(ctx));
+                sp.GetService(typeof(CommonStockManager))
+                    .Returns(
+                        new CommonStockManager(
+                            new CommonStockRepository(ctx),
+                            Substitute.For<IBus>()
+                        )
+                    );
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(sp);
+                return scope;
+            });
+
+        return new FtdImportService(
+            scopeFactory,
+            Substitute.For<ISecEdgarClient>(),
+            Substitute.For<ILogger<FtdImportService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(new WorkerOptions())
+        );
+    }
+
+    private static (IList Records, Type RecordType) BuildRecords(
+        params (string Symbol, string Cusip)[] rows
+    )
+    {
+        var recordType = typeof(FtdImportService).Assembly.GetType(
+            "Equibles.Sec.HostedService.Models.FtdRecord"
+        )!;
+        var list = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(recordType))!;
+        foreach (var (symbol, cusip) in rows)
+        {
+            var record = Activator.CreateInstance(recordType)!;
+            recordType.GetProperty("Symbol")!.SetValue(record, symbol);
+            recordType.GetProperty("Cusip")!.SetValue(record, cusip);
+            list.Add(record);
+        }
+        return (list, recordType);
+    }
+
+    private static async Task<int> InvokeSeedCusips(
+        FtdImportService sut,
+        IList records,
+        Dictionary<string, Guid> tickerMap
+    )
+    {
+        var seedCusips = typeof(FtdImportService).GetMethod(
+            "SeedCusips",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        )!;
+        return await (Task<int>)
+            seedCusips.Invoke(sut, [records, tickerMap, CancellationToken.None])!;
+    }
+}


### PR DESCRIPTION
## Summary

Class-share issuers (Berkshire Hathaway `BRK-B`, Brown-Forman `BF-A`, Moog `MOG-A`) never received a CUSIP because the SEC fails-to-deliver feed strips the class separator from its symbols (`BRKB`, `BFA`, `MOGA`) and `FtdImportService` matched them against stored tickers exactly. Without a CUSIP these companies stay hidden from the commercial portal and none of their 13F holdings can map to the company — Berkshire had zero institutional holdings on record. Full evidence: daniel3303/EquiblesCommercial#2508.

## Code changes

- `Equibles.Sec.HostedService/Services/FtdImportService.cs` — `BuildStrippedTickerAliases` builds a separator-stripped alias map over the ticker map (skipping aliases that would shadow a real ticker and dropping stripped forms two tickers collapse onto); `TryResolveSymbol` tries exact then alias. Used by both `SeedCusips` and `ImportRecords`, so the FTD quantity rows for class-share stocks import too.
- `tests/Equibles.IntegrationTests/Sec/FtdImportServiceSeedCusipsClassShareSymbolTests.cs` — regression pins: `BRKB` seeds the CUSIP onto `BRK-B` (failed before the fix), and an exact ticker that equals another ticker's stripped form wins while the ambiguous class-share stock is left untouched.

Sec unit (972) and integration (363) suites green.