### PR TITLE
fix(sec): skip exchange-null EDGAR ticker rows when parsing active companies

### DIFF
--- a/src/Equibles.Integrations.Sec/SecEdgarClient.cs
+++ b/src/Equibles.Integrations.Sec/SecEdgarClient.cs
@@ -919,6 +919,7 @@ public class SecEdgarClient : ISecEdgarClient
         var cikIndex = response.Fields.IndexOf("cik");
         var nameIndex = response.Fields.IndexOf("name");
         var tickerIndex = response.Fields.IndexOf("ticker");
+        var exchangeIndex = response.Fields.IndexOf("exchange");
 
         if (cikIndex == -1 || nameIndex == -1 || tickerIndex == -1)
             return [];
@@ -939,6 +940,20 @@ public class SecEdgarClient : ISecEdgarClient
                     out var cik,
                     out var name,
                     out var ticker
+                )
+            )
+                continue;
+
+            // EDGAR lists private/pre-listing registrants with exchange-null
+            // ticker rows (e.g. SpaceX as "SPCX"). Those symbols are recycled
+            // by real instruments, so creating a company from such a row lets
+            // price enrichment attach another instrument's data. Skip the row;
+            // a registrant with no exchange-listed row is not a listed company.
+            if (
+                exchangeIndex != -1
+                && (
+                    row.Count <= exchangeIndex
+                    || string.IsNullOrWhiteSpace(row[exchangeIndex]?.ToString())
                 )
             )
                 continue;

--- a/tests/Equibles.UnitTests/Sec/SecEdgarClientParseCompaniesExchangeNullTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecEdgarClientParseCompaniesExchangeNullTests.cs
@@ -1,0 +1,66 @@
+using System.Collections;
+using System.Reflection;
+using Equibles.Integrations.Sec;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// EDGAR's company_tickers_exchange.json carries ticker rows with a null
+/// exchange — private or pre-listing registrants (SpaceX is listed as "SPCX",
+/// exchange null). Those symbols are recycled by real instruments on
+/// exchanges, so creating a company from such a row lets the Yahoo enrichment
+/// attach another instrument's prices and market cap (the $1.77T SpaceX
+/// phantom, EquiblesCommercial#2515). Pin: exchange-null rows never produce a
+/// company or a ticker; a company keeps only its exchange-listed rows.
+/// </summary>
+public class SecEdgarClientParseCompaniesExchangeNullTests
+{
+    private static readonly MethodInfo ParseCompaniesFromResponseMethod =
+        typeof(SecEdgarClient).GetMethod(
+            "ParseCompaniesFromResponse",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+    private static List<CompanyInfo> Parse(List<List<object>> data)
+    {
+        var responseType = typeof(SecEdgarClient).Assembly.GetType(
+            "Equibles.Integrations.Sec.Models.Responses.CompanyTickersResponse"
+        );
+        var response = Activator.CreateInstance(responseType);
+        responseType
+            .GetProperty("Fields")!
+            .SetValue(response, new List<string> { "cik", "name", "ticker", "exchange" });
+        responseType.GetProperty("Data")!.SetValue(response, data);
+
+        var result = (IEnumerable)ParseCompaniesFromResponseMethod.Invoke(null, [response]);
+        return result.Cast<CompanyInfo>().ToList();
+    }
+
+    [Fact]
+    public void ParseCompaniesFromResponse_ExchangeNullRows_NeverBecomeCompaniesOrTickers()
+    {
+        var companies = Parse([
+            // Private registrant: every ticker row is exchange-null (SpaceX).
+            new() { "0001181412", "SPACE EXPLORATION TECHNOLOGIES CORP", "SPCX", null },
+            // Listed company.
+            new() { "0000789019", "Microsoft Corp", "MSFT", "Nasdaq" },
+            // Mixed: an exchange-null row precedes the real listing — the
+            // company survives with only the exchange-listed ticker.
+            new() { "0001362988", "Aircastle LTD", "AYR", null },
+            new() { "0001362988", "Aircastle LTD", "AYR-PA", "NYSE" },
+        ]);
+
+        companies
+            .Should()
+            .NotContain(
+                c => c.Cik == "0001181412",
+                "an all-null-exchange registrant is not a listed company"
+            );
+
+        var mixed = companies.Single(c => c.Cik == "0001362988");
+        mixed.Tickers.Should().Equal(["AYR-PA"], "only exchange-listed ticker rows survive");
+
+        companies.Single(c => c.Cik == "0000789019").Tickers.Should().Equal(["MSFT"]);
+    }
+}


### PR DESCRIPTION
## Summary

EDGAR's `company_tickers_exchange.json` lists private/pre-listing registrants with `exchange: null` ticker rows — SpaceX is in there as `SPCX` (227 null rows today). The company sync ignored the exchange column, so those registrants became CommonStock rows, and because their symbols are recycled by real instruments, Yahoo enrichment attached another instrument's data — production carries a Space Exploration Technologies row with a $1.77T market cap and price history. Evidence: daniel3303/EquiblesCommercial#2515.

## Code changes

- `Equibles.Integrations.Sec/SecEdgarClient.cs` — `ParseCompaniesFromResponse` resolves the `exchange` column and skips rows with a null/blank exchange (tolerant: if the column is absent from the payload, behavior is unchanged). Companies whose rows are all exchange-null never enter the active set; mixed companies keep only their exchange-listed tickers.
- `tests/Equibles.UnitTests/Sec/SecEdgarClientParseCompaniesExchangeNullTests.cs` — regression: an all-null registrant (SpaceX) produces no company, a mixed company keeps only its listed ticker, a normal company is untouched. Failed before the fix.

Sec unit suite (973) and CompanySync integration tests (18) green. Existing phantom rows in production drop out of the SEC feed's active set on the next company sync, where the existing obsolete-stock handling applies; any that linger can be cleaned up separately.