### PR TITLE
fix(financial-facts): exclude dimensional facts from consolidated statement reads

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -110,7 +110,7 @@ public class FinancialFactsTools
                     return $"No '{concept}' data has been ingested for {stock.Ticker}.";
 
                 var facts = await _financialFactRepository
-                    .GetByStock(stock)
+                    .GetConsolidatedByStock(stock)
                     .Where(f => conceptPriority.Keys.Contains(f.FinancialConceptId))
                     .ToListAsync();
 
@@ -213,7 +213,7 @@ public class FinancialFactsTools
 
                 var stockIds = stocks.Select(s => s.Id).ToList();
                 var facts = await _financialFactRepository
-                    .GetByStocks(stockIds)
+                    .GetConsolidatedByStocks(stockIds)
                     .Where(f =>
                         f.FiscalYear == fiscalYear
                         && f.FiscalPeriod == period

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -114,7 +114,7 @@ public class FinancialStatementTools
                 var conceptIds = concepts.Select(c => c.Id).ToHashSet();
 
                 var facts = await _financialFactRepository
-                    .GetByStock(stock)
+                    .GetConsolidatedByStock(stock)
                     .Where(f =>
                         f.FiscalYear == selectedYear
                         && f.FiscalPeriod == selectedPeriod
@@ -198,7 +198,7 @@ public class FinancialStatementTools
     )> ResolveStatementPeriod(CommonStock stock, int? year, SecFiscalPeriod? requestedPeriod)
     {
         var availablePeriods = await _financialFactRepository
-            .GetByStock(stock)
+            .GetConsolidatedByStock(stock)
             .Select(f => new { f.FiscalYear, f.FiscalPeriod })
             .Distinct()
             .ToListAsync();

--- a/src/Equibles.Sec.FinancialFacts.Repositories/FinancialFactRepository.cs
+++ b/src/Equibles.Sec.FinancialFacts.Repositories/FinancialFactRepository.cs
@@ -18,4 +18,26 @@ public class FinancialFactRepository : BaseRepository<FinancialFact>
     {
         return GetAll().Where(f => stockIds.Contains(f.CommonStockId));
     }
+
+    /// <summary>
+    /// Facts for the consolidated (no-dimension) context only — the figures the
+    /// SEC Company Facts API reports, identified by an empty
+    /// <see cref="FinancialFact.DimensionsKey"/>. Excludes the dimensional
+    /// segment/geography/product rows the XBRL extractor adds: those share a
+    /// concept, period and accession with their consolidated sibling, so a
+    /// per-concept "latest filed" collapse would otherwise pick a segment value
+    /// (e.g. iPhone revenue) in place of the total non-deterministically. Every
+    /// statement/figure read path that renders consolidated numbers must use
+    /// this, not <see cref="GetByStock"/>.
+    /// </summary>
+    public IQueryable<FinancialFact> GetConsolidatedByStock(CommonStock stock)
+    {
+        return GetByStock(stock).Where(f => f.DimensionsKey == "");
+    }
+
+    /// <inheritdoc cref="GetConsolidatedByStock"/>
+    public IQueryable<FinancialFact> GetConsolidatedByStocks(IReadOnlyCollection<Guid> stockIds)
+    {
+        return GetByStocks(stockIds).Where(f => f.DimensionsKey == "");
+    }
 }

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -510,7 +510,7 @@ public class StockTabService
         // covered by the [CommonStockId, FiscalYear, FiscalPeriod] index, and
         // keeping them separate avoids loading every fact just to list periods.
         var periodKeys = await _financialFactRepository
-            .GetByStock(stock)
+            .GetConsolidatedByStock(stock)
             .Select(f => new { f.FiscalYear, f.FiscalPeriod })
             .Distinct()
             .ToListAsync();
@@ -555,7 +555,7 @@ public class StockTabService
         var conceptIds = concepts.Select(c => c.Id).ToHashSet();
 
         var facts = await _financialFactRepository
-            .GetByStock(stock)
+            .GetConsolidatedByStock(stock)
             .Where(f =>
                 f.FiscalYear == fiscalYear
                 && f.FiscalPeriod == fiscalPeriod
@@ -627,7 +627,7 @@ public class StockTabService
         if (epsConcept != Guid.Empty)
         {
             var epsFact = await _financialFactRepository
-                .GetByStock(stock)
+                .GetConsolidatedByStock(stock)
                 .Where(f =>
                     f.FinancialConceptId == epsConcept && f.FiscalPeriod == SecFiscalPeriod.FullYear
                 )

--- a/tests/Equibles.IntegrationTests/Web/StocksControllerFinancialsTabTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StocksControllerFinancialsTabTests.cs
@@ -268,4 +268,106 @@ public class StocksControllerFinancialsTabTests : IDisposable
         tab.SelectedYear.Should().Be(2023);
         tab.SelectedPeriod.Should().Be(SecFiscalPeriod.FullYear);
     }
+
+    [Fact]
+    public async Task Financials_DimensionalSegmentFactForSameConcept_ExcludedSoConsolidatedTotalWins()
+    {
+        // The XBRL extractor persists dimensional (segment/geography/product) facts
+        // that share a concept, period and accession with their consolidated
+        // sibling, discriminated only by a non-empty DimensionsKey. The statement
+        // must render the consolidated total, never a segment. Here the dimensional
+        // row (iPhone revenue, 39bn) is filed LATER than the consolidated total
+        // (400bn): a per-concept "latest filed" collapse that forgot to exclude
+        // dimensional rows would surface 39bn, so this pins that they are filtered
+        // out at the query (GetConsolidatedByStock), not merely out-sorted.
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        var revenueConcept = new FinancialConcept
+        {
+            Id = Guid.NewGuid(),
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "Revenues",
+            Label = "Revenues",
+        };
+        _dbContext.Set<CommonStock>().Add(stock);
+        _dbContext.Set<FinancialConcept>().Add(revenueConcept);
+
+        FinancialFact Revenue(decimal value, DateOnly filed, string accn, string dimensionsKey) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                CommonStockId = stock.Id,
+                FinancialConceptId = revenueConcept.Id,
+                Unit = "USD",
+                PeriodType = FactPeriodType.Duration,
+                PeriodStart = new DateOnly(2023, 1, 1),
+                PeriodEnd = new DateOnly(2023, 12, 31),
+                Value = value,
+                FiscalYear = 2023,
+                FiscalPeriod = SecFiscalPeriod.FullYear,
+                Form = DocumentType.TenK,
+                FiledDate = filed,
+                AccessionNumber = accn,
+                DimensionsKey = dimensionsKey,
+            };
+
+        _dbContext
+            .Set<FinancialFact>()
+            .AddRange(
+                // Consolidated total — empty DimensionsKey, the only context the
+                // Company Facts API reports.
+                Revenue(400_000_000_000m, new DateOnly(2024, 1, 15), "0000320193-24-000001", ""),
+                // iPhone segment cut — non-empty DimensionsKey, filed later so it
+                // would win a naive latest-filed pick.
+                Revenue(
+                    39_000_000_000m,
+                    new DateOnly(2024, 6, 1),
+                    "0000320193-24-000001",
+                    "e3b0c44298fc1c149afbf4c8996fb924"
+                )
+            );
+        await _dbContext.SaveChangesAsync();
+
+        var stockTabService = new StockTabService(
+            new InstitutionalHoldingRepository(_dbContext),
+            new InstitutionalHolderRepository(_dbContext),
+            new DailyShortVolumeRepository(_dbContext),
+            new ShortInterestRepository(_dbContext),
+            new FailToDeliverRepository(_dbContext),
+            new DocumentRepository(_dbContext),
+            new InsiderTransactionRepository(_dbContext),
+            new Form144FilingRepository(_dbContext),
+            new FormDFilingRepository(_dbContext),
+            new NCenFilingRepository(_dbContext),
+            new NportFilingRepository(_dbContext),
+            new CongressionalTradeRepository(_dbContext),
+            new DailyStockPriceRepository(_dbContext),
+            new FinancialFactRepository(_dbContext),
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
+        );
+
+        var tab = await stockTabService.LoadFinancialsTab(
+            stock,
+            FinancialStatementType.IncomeStatement,
+            year: null,
+            period: null
+        );
+
+        var revenueLine = tab.Lines.Should().Contain(l => l.Label == "Revenue").Subject;
+        revenueLine.HasValue.Should().BeTrue();
+        revenueLine
+            .Value.Should()
+            .Be(
+                400_000_000_000m,
+                "the consolidated total wins; the later-filed segment cut is excluded"
+            );
+        // The dimensional row shares the period, so it must not add a phantom option.
+        tab.AvailablePeriods.Should().ContainSingle();
+    }
 }


### PR DESCRIPTION
Fixes #3619.

**Root cause** — dimensional facts (`XbrlFactExtractionService`) share concept + period + accession (and filing date) with their consolidated sibling, discriminated only by a non-empty `DimensionsKey`. The consolidated read paths didn't filter them out, so the per-concept "latest filed" collapse (`LatestPerGroup` / `PickBestFact`) could non-deterministically pick a segment value (e.g. iPhone revenue) in place of the consolidated total once dimensions are populated.

**Fix** — add `FinancialFactRepository.GetConsolidatedByStock(s)` (`DimensionsKey == ""`) and route every consolidated read through it:
- web Financials tab — statement lines, available periods, key-metrics EPS/PE
- MCP `GetFinancialStatement` / `GetFinancialFact` / `CompareFinancialFact`

`GetByStock(s)` stays unfiltered for a future dimensional view.

**Testing** — new integration test seeds a consolidated total plus a later-filed dimensional cut for the same concept/period and asserts the total wins; it fails (returns the segment value) without the filter. CSharpier clean; targeted suites green (Financials tab 3/3, fact/statement unit 50/50, MCP tools 32/32).