### PR TITLE
fix(sec): default the XBRL backfill off now the historical sweep has drained

### DIFF
--- a/src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs
@@ -13,11 +13,13 @@ public class XbrlCaptureOptions
 
     /// <summary>
     /// When true (and <see cref="Enabled"/> is true), a background worker walks documents
-    /// ingested before capture and fills in their XBRL envelope. Separate from forward
-    /// capture so an operator can disable the historical sweep — which re-fetches each
-    /// pending filing's submission and so spends the shared EDGAR budget — independently.
+    /// ingested before capture and fills in their XBRL envelope. Off by default — the
+    /// historical sweep is a one-time operation that re-fetches each pending filing's
+    /// submission and so spends the shared EDGAR budget; opt in for a deliberate
+    /// re-sweep (e.g. after a capture/extraction change) via
+    /// <c>XbrlCapture__BackfillEnabled=true</c>.
     /// </summary>
-    public bool BackfillEnabled { get; set; } = true;
+    public bool BackfillEnabled { get; set; } = false;
 
     /// <summary>How many pending documents the backfill processes per cycle.</summary>
     public int BackfillBatchSize { get; set; } = 32;


### PR DESCRIPTION
## Summary

- Reverts `XbrlCaptureOptions.BackfillEnabled` to default `false`. The backfill was defaulted on for the one-time historical sweep over documents ingested before XBRL capture existed; that sweep has drained (every cycle selects 0 documents), and leaving it on keeps an idle worker re-querying every 5 minutes and ready to re-fetch submissions against the shared EDGAR budget.
- Forward capture (`Enabled`) stays defaulted on — it adds no extra EDGAR round-trip. A deliberate re-sweep remains available via `XbrlCapture__BackfillEnabled=true`.

## Code changes

- `src/Equibles.Sec.HostedService/Configuration/XbrlCaptureOptions.cs` — `BackfillEnabled` default `true` → `false`, doc comment updated to state the opt-in posture.