### PR TITLE
feat(finra): add composite short-squeeze score over stored short data

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -163,6 +163,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.CommonStocks.Hoste
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.InvestorRelations.Mcp", "src\Equibles.InvestorRelations.Mcp\Equibles.InvestorRelations.Mcp.csproj", "{7E757C1B-7801-4110-8C94-ACED64B36CAC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Finra.BusinessLogic", "src\Equibles.Finra.BusinessLogic\Equibles.Finra.BusinessLogic.csproj", "{93D079ED-711C-47C9-9C12-513ADE703C9C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1109,6 +1111,18 @@ Global
 		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Release|x64.Build.0 = Release|Any CPU
 		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Release|x86.ActiveCfg = Release|Any CPU
 		{7E757C1B-7801-4110-8C94-ACED64B36CAC}.Release|x86.Build.0 = Release|Any CPU
+		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Debug|x64.Build.0 = Debug|Any CPU
+		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Debug|x86.Build.0 = Debug|Any CPU
+		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Release|x64.ActiveCfg = Release|Any CPU
+		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Release|x64.Build.0 = Release|Any CPU
+		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Release|x86.ActiveCfg = Release|Any CPU
+		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1192,6 +1206,7 @@ Global
 		{946B8E31-D1FC-4649-9E0E-DCF389C97979} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{FFED11B2-5BED-4ABF-939E-D18589C1B07B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{7E757C1B-7801-4110-8C94-ACED64B36CAC} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{93D079ED-711C-47C9-9C12-513ADE703C9C} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.Finra.BusinessLogic/Equibles.Finra.BusinessLogic.csproj
+++ b/src/Equibles.Finra.BusinessLogic/Equibles.Finra.BusinessLogic.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Equibles.Core.AutoWiring" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Finra.Repositories\Equibles.Finra.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezeScore.cs
+++ b/src/Equibles.Finra.BusinessLogic/Models/ShortSqueezeScore.cs
@@ -1,0 +1,37 @@
+namespace Equibles.Finra.BusinessLogic.Models;
+
+/// <summary>
+/// One stock's composite short-squeeze score for a FINRA settlement date: the raw
+/// factor values and each factor's 0–100 percentile across the scored universe, with
+/// <see cref="Score"/> the equal-weight mean of the available factor percentiles.
+/// Factors a stock lacks data for are null and simply drop out of its mean.
+/// </summary>
+public class ShortSqueezeScore
+{
+    public Guid CommonStockId { get; set; }
+
+    public string Ticker { get; set; }
+
+    public DateOnly SettlementDate { get; set; }
+
+    /// <summary>Current short position as a fraction of shares outstanding (0–1 scale).</summary>
+    public decimal ShortInterestPercentOfShares { get; set; }
+
+    /// <summary>FINRA days-to-cover; computed from the average daily volume when not reported.</summary>
+    public decimal? DaysToCover { get; set; }
+
+    /// <summary>
+    /// Change in the short share of total volume: the most recent two weeks' pooled
+    /// short-volume ratio minus the prior two weeks'. Positive = rising pressure.
+    /// </summary>
+    public decimal? ShortVolumeShareTrend { get; set; }
+
+    public double ShortInterestPercentile { get; set; }
+
+    public double? DaysToCoverPercentile { get; set; }
+
+    public double? ShortVolumeTrendPercentile { get; set; }
+
+    /// <summary>Composite 0–100 score: the mean of the available factor percentiles.</summary>
+    public double Score { get; set; }
+}

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -1,0 +1,255 @@
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.AutoWiring;
+using Equibles.Finra.BusinessLogic.Models;
+using Equibles.Finra.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Finra.BusinessLogic;
+
+/// <summary>
+/// Computes a composite 0–100 short-squeeze score per stock from data already stored —
+/// no scraper and no per-ticker heuristics. Three factors, each normalized to a
+/// percentile across the scored universe so the score is peer-relative:
+/// <list type="bullet">
+/// <item>short interest as a fraction of shares outstanding,</item>
+/// <item>days-to-cover (FINRA-reported, or short position ÷ average daily volume),</item>
+/// <item>the change in the short share of total volume between the last two weeks and
+/// the two before them (rising = pressure building).</item>
+/// </list>
+/// The composite is the equal-weight mean of the factor percentiles a stock has data
+/// for — weights are deliberate and documented rather than tuned. The universe is every
+/// stock reporting short interest at the latest settlement date with a known
+/// shares-outstanding count.
+/// </summary>
+[Service]
+public class ShortSqueezeScoreManager
+{
+    /// <summary>Each trend window pools two calendar weeks of daily short-volume rows.</summary>
+    public const int TrendWindowDays = 14;
+
+    private readonly ShortInterestRepository _shortInterestRepository;
+    private readonly DailyShortVolumeRepository _dailyShortVolumeRepository;
+    private readonly CommonStockRepository _commonStockRepository;
+
+    public ShortSqueezeScoreManager(
+        ShortInterestRepository shortInterestRepository,
+        DailyShortVolumeRepository dailyShortVolumeRepository,
+        CommonStockRepository commonStockRepository
+    )
+    {
+        _shortInterestRepository = shortInterestRepository;
+        _dailyShortVolumeRepository = dailyShortVolumeRepository;
+        _commonStockRepository = commonStockRepository;
+    }
+
+    public async Task<List<ShortSqueezeScore>> Compute(
+        CancellationToken cancellationToken = default
+    )
+    {
+        var settlementDate = await _shortInterestRepository
+            .GetLatestSettlementDate()
+            .FirstOrDefaultAsync(cancellationToken);
+        if (settlementDate == default)
+        {
+            return [];
+        }
+
+        var shortInterests = await _shortInterestRepository
+            .GetBySettlementDate(settlementDate)
+            .ToListAsync(cancellationToken);
+
+        var stockIds = shortInterests.Select(s => s.CommonStockId).Distinct().ToList();
+        var stocks = await _commonStockRepository
+            .GetAll()
+            .Where(s => stockIds.Contains(s.Id) && s.SharesOutStanding > 0)
+            .Select(s => new
+            {
+                s.Id,
+                s.Ticker,
+                s.SharesOutStanding,
+            })
+            .ToDictionaryAsync(s => s.Id, cancellationToken);
+
+        var trends = await LoadShortVolumeTrends(stockIds, settlementDate, cancellationToken);
+
+        var scores = new List<ShortSqueezeScore>();
+        foreach (var shortInterest in shortInterests)
+        {
+            if (!stocks.TryGetValue(shortInterest.CommonStockId, out var stock))
+            {
+                continue;
+            }
+
+            var daysToCover = shortInterest.DaysToCover;
+            if (daysToCover == null && shortInterest.AverageDailyVolume > 0)
+            {
+                daysToCover =
+                    shortInterest.CurrentShortPosition
+                    / (decimal)shortInterest.AverageDailyVolume.Value;
+            }
+
+            scores.Add(
+                new ShortSqueezeScore
+                {
+                    CommonStockId = stock.Id,
+                    Ticker = stock.Ticker,
+                    SettlementDate = settlementDate,
+                    ShortInterestPercentOfShares =
+                        shortInterest.CurrentShortPosition / (decimal)stock.SharesOutStanding,
+                    DaysToCover = daysToCover,
+                    // TryGetValue, not GetValueOrDefault: a stock with no volume data
+                    // must carry a null trend (factor drops out), never a zero trend.
+                    ShortVolumeShareTrend = trends.TryGetValue(stock.Id, out var trend)
+                        ? trend
+                        : null,
+                }
+            );
+        }
+
+        ApplyPercentiles(scores);
+        return scores.OrderByDescending(s => s.Score).ToList();
+    }
+
+    /// <summary>
+    /// Pools each stock's daily short-volume rows (summed across venues) into two
+    /// adjacent calendar windows ending at the settlement date and returns the change
+    /// in the pooled short-volume ratio. Stocks lacking volume in either window get no
+    /// trend — the factor drops out of their composite rather than defaulting.
+    /// </summary>
+    private async Task<Dictionary<Guid, decimal>> LoadShortVolumeTrends(
+        List<Guid> stockIds,
+        DateOnly settlementDate,
+        CancellationToken cancellationToken
+    )
+    {
+        var midCutoff = settlementDate.AddDays(-TrendWindowDays);
+        var farCutoff = settlementDate.AddDays(-TrendWindowDays * 2);
+
+        var windows = await _dailyShortVolumeRepository
+            .GetAll()
+            .Where(v =>
+                v.Date > farCutoff && v.Date <= settlementDate && stockIds.Contains(v.CommonStockId)
+            )
+            .GroupBy(v => new { v.CommonStockId, Recent = v.Date > midCutoff })
+            .Select(g => new
+            {
+                g.Key.CommonStockId,
+                g.Key.Recent,
+                ShortVolume = g.Sum(v => v.ShortVolume),
+                TotalVolume = g.Sum(v => v.TotalVolume),
+            })
+            .ToListAsync(cancellationToken);
+
+        var trends = new Dictionary<Guid, decimal>();
+        foreach (var group in windows.GroupBy(w => w.CommonStockId))
+        {
+            var recent = group.FirstOrDefault(w => w.Recent);
+            var prior = group.FirstOrDefault(w => !w.Recent);
+            if (recent is not { TotalVolume: > 0 } || prior is not { TotalVolume: > 0 })
+            {
+                continue;
+            }
+
+            trends[group.Key] =
+                recent.ShortVolume / (decimal)recent.TotalVolume
+                - prior.ShortVolume / (decimal)prior.TotalVolume;
+        }
+
+        return trends;
+    }
+
+    private static void ApplyPercentiles(List<ShortSqueezeScore> scores)
+    {
+        var shortInterestPercentiles = Percentiles(
+            scores.Select(s => (s.CommonStockId, s.ShortInterestPercentOfShares))
+        );
+        var daysToCoverPercentiles = Percentiles(
+            scores
+                .Where(s => s.DaysToCover != null)
+                .Select(s => (s.CommonStockId, s.DaysToCover.Value))
+        );
+        var trendPercentiles = Percentiles(
+            scores
+                .Where(s => s.ShortVolumeShareTrend != null)
+                .Select(s => (s.CommonStockId, s.ShortVolumeShareTrend.Value))
+        );
+
+        foreach (var score in scores)
+        {
+            score.ShortInterestPercentile = shortInterestPercentiles[score.CommonStockId];
+            score.DaysToCoverPercentile = daysToCoverPercentiles.TryGetValue(
+                score.CommonStockId,
+                out var daysToCover
+            )
+                ? daysToCover
+                : null;
+            score.ShortVolumeTrendPercentile = trendPercentiles.TryGetValue(
+                score.CommonStockId,
+                out var trend
+            )
+                ? trend
+                : null;
+
+            double total = score.ShortInterestPercentile;
+            var factors = 1;
+            if (score.DaysToCoverPercentile != null)
+            {
+                total += score.DaysToCoverPercentile.Value;
+                factors++;
+            }
+
+            if (score.ShortVolumeTrendPercentile != null)
+            {
+                total += score.ShortVolumeTrendPercentile.Value;
+                factors++;
+            }
+
+            score.Score = Math.Round(total / factors, 2);
+        }
+    }
+
+    /// <summary>
+    /// Average-rank percentiles on a 0–100 scale: ties share the mean of the ranks
+    /// they span, a single-entry set sits at 50, and the extremes map to 0 and 100 —
+    /// the standard peer-relative normalization.
+    /// </summary>
+    private static Dictionary<Guid, double> Percentiles(
+        IEnumerable<(Guid Id, decimal Value)> values
+    )
+    {
+        var entries = values.ToList();
+        var result = new Dictionary<Guid, double>(entries.Count);
+        if (entries.Count == 0)
+        {
+            return result;
+        }
+
+        if (entries.Count == 1)
+        {
+            result[entries[0].Id] = 50;
+            return result;
+        }
+
+        var ordered = entries.OrderBy(e => e.Value).ToList();
+        var index = 0;
+        while (index < ordered.Count)
+        {
+            var tieEnd = index;
+            while (tieEnd + 1 < ordered.Count && ordered[tieEnd + 1].Value == ordered[index].Value)
+            {
+                tieEnd++;
+            }
+
+            var averageRank = (index + tieEnd) / 2.0;
+            var percentile = averageRank / (ordered.Count - 1) * 100;
+            for (var i = index; i <= tieEnd; i++)
+            {
+                result[ordered[i].Id] = percentile;
+            }
+
+            index = tieEnd + 1;
+        }
+
+        return result;
+    }
+}

--- a/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
+++ b/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\..\src\Equibles.CommonStocks.Data\Equibles.CommonStocks.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.CommonStocks.BusinessLogic\Equibles.CommonStocks.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Finra.BusinessLogic\Equibles.Finra.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Holdings.Data\Equibles.Holdings.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Holdings.BusinessLogic\Equibles.Holdings.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Holdings.HostedService\Equibles.Holdings.HostedService.csproj" />

--- a/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
@@ -1,0 +1,192 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Finra.BusinessLogic;
+using Equibles.Finra.Data;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Finra;
+
+public class ShortSqueezeScoreManagerTests : IDisposable
+{
+    private static readonly DateOnly SettlementDate = new(2026, 1, 15);
+
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly ShortSqueezeScoreManager _manager;
+
+    public ShortSqueezeScoreManagerTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new FinraModuleConfiguration(),
+            new CommonStocksModuleConfiguration()
+        );
+        _manager = new ShortSqueezeScoreManager(
+            new ShortInterestRepository(_dbContext),
+            new DailyShortVolumeRepository(_dbContext),
+            new CommonStockRepository(_dbContext)
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task Compute_RanksUniverseByCompositePercentiles()
+    {
+        // Three stocks ordered the same way on every factor: HOT shorted hardest with
+        // the slowest cover and a rising short-volume share, COLD the opposite, MID
+        // between — so the composite must rank HOT > MID > COLD with the extremes at
+        // the percentile bounds.
+        var hot = SeedStock("HOT", sharesOutstanding: 1_000_000);
+        var mid = SeedStock("MID", sharesOutstanding: 1_000_000);
+        var cold = SeedStock("COLD", sharesOutstanding: 1_000_000);
+        SeedShortInterest(hot, shortPosition: 300_000, daysToCover: 8m);
+        SeedShortInterest(mid, shortPosition: 150_000, daysToCover: 4m);
+        SeedShortInterest(cold, shortPosition: 50_000, daysToCover: 1m);
+        // Short-volume share moves +20pp for HOT, stays flat for MID, −20pp for COLD.
+        SeedShortVolume(hot, priorShort: 300, recentShort: 500);
+        SeedShortVolume(mid, priorShort: 400, recentShort: 400);
+        SeedShortVolume(cold, priorShort: 500, recentShort: 300);
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        scores.Select(s => s.Ticker).Should().Equal("HOT", "MID", "COLD");
+        scores[0].Score.Should().Be(100);
+        scores[1].Score.Should().Be(50);
+        scores[2].Score.Should().Be(0);
+        scores[0].SettlementDate.Should().Be(SettlementDate);
+        scores[0].ShortInterestPercentOfShares.Should().Be(0.3m);
+        scores[0].DaysToCover.Should().Be(8m);
+        scores[0].ShortVolumeShareTrend.Should().Be(0.2m);
+        scores[0].DaysToCoverPercentile.Should().Be(100);
+        scores[0].ShortVolumeTrendPercentile.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task Compute_StockWithoutVolumeRows_DropsTrendFactorFromItsMean()
+    {
+        // NOVOL has no daily short-volume rows, so its trend factor must be null and
+        // its composite the mean of the two remaining percentiles — not a defaulted
+        // zero that would sink it below peers with identical short interest.
+        var withVolume = SeedStock("HASVOL", sharesOutstanding: 1_000_000);
+        var withoutVolume = SeedStock("NOVOL", sharesOutstanding: 1_000_000);
+        SeedShortInterest(withVolume, shortPosition: 100_000, daysToCover: 2m);
+        SeedShortInterest(withoutVolume, shortPosition: 200_000, daysToCover: 5m);
+        SeedShortVolume(withVolume, priorShort: 300, recentShort: 500);
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        var noVolume = scores.Single(s => s.Ticker == "NOVOL");
+        noVolume.ShortVolumeShareTrend.Should().BeNull();
+        noVolume.ShortVolumeTrendPercentile.Should().BeNull();
+        // Both of NOVOL's available factors sit at the top of a two-stock universe.
+        noVolume.Score.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task Compute_ReportedDaysToCoverMissing_ComputedFromAverageDailyVolume()
+    {
+        var stock = SeedStock("CALC", sharesOutstanding: 1_000_000);
+        _dbContext
+            .Set<ShortInterest>()
+            .Add(
+                new ShortInterest
+                {
+                    CommonStockId = stock.Id,
+                    SettlementDate = SettlementDate,
+                    CurrentShortPosition = 120_000,
+                    AverageDailyVolume = 40_000,
+                    DaysToCover = null,
+                }
+            );
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        scores.Single().DaysToCover.Should().Be(3m);
+    }
+
+    [Fact]
+    public async Task Compute_NoShortInterestData_ReturnsEmpty()
+    {
+        var scores = await _manager.Compute();
+
+        scores.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Compute_UnknownSharesOutstanding_ExcludesStockFromUniverse()
+    {
+        // SharesOutStanding == 0 means "unknown" across the codebase — a percent of an
+        // unknown denominator is meaningless, so the stock must not be scored at all.
+        var known = SeedStock("KNOWN", sharesOutstanding: 1_000_000);
+        var unknown = SeedStock("UNKNOWN", sharesOutstanding: 0);
+        SeedShortInterest(known, shortPosition: 100_000, daysToCover: 2m);
+        SeedShortInterest(unknown, shortPosition: 900_000, daysToCover: 9m);
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        scores.Select(s => s.Ticker).Should().Equal("KNOWN");
+    }
+
+    private CommonStock SeedStock(string ticker, long sharesOutstanding)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Corp.",
+            Cik = ticker,
+            SharesOutStanding = sharesOutstanding,
+        };
+        _dbContext.Set<CommonStock>().Add(stock);
+        return stock;
+    }
+
+    private void SeedShortInterest(CommonStock stock, long shortPosition, decimal daysToCover)
+    {
+        _dbContext
+            .Set<ShortInterest>()
+            .Add(
+                new ShortInterest
+                {
+                    CommonStockId = stock.Id,
+                    SettlementDate = SettlementDate,
+                    CurrentShortPosition = shortPosition,
+                    DaysToCover = daysToCover,
+                }
+            );
+    }
+
+    // One row in the prior window and one in the recent window, constant total volume,
+    // so the pooled short-volume share trend is exactly (recentShort - priorShort) / 1000.
+    private void SeedShortVolume(CommonStock stock, long priorShort, long recentShort)
+    {
+        _dbContext
+            .Set<DailyShortVolume>()
+            .AddRange(
+                new DailyShortVolume
+                {
+                    CommonStockId = stock.Id,
+                    Date = SettlementDate.AddDays(-20),
+                    ShortVolume = priorShort,
+                    TotalVolume = 1000,
+                    Market = "Q",
+                },
+                new DailyShortVolume
+                {
+                    CommonStockId = stock.Id,
+                    Date = SettlementDate.AddDays(-5),
+                    ShortVolume = recentShort,
+                    TotalVolume = 1000,
+                    Market = "Q",
+                }
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Equibles.Finra.BusinessLogic` with a `ShortSqueezeScoreManager` that synthesises a peer-relative 0–100 short-squeeze score per stock from data already ingested — no new scraper, no per-ticker heuristics.
- Three documented factors, each normalized to an average-rank percentile across the universe (every stock reporting short interest at the latest settlement date with a known share count): short interest as a fraction of shares outstanding; days-to-cover (FINRA-reported, or short position ÷ average daily volume when unreported); and the change in the pooled short share of total volume between the last two calendar weeks and the two before.
- The composite is the equal-weight mean of the factor percentiles a stock has data for — a missing factor drops out of that stock's mean instead of defaulting to zero.

## Code changes

- `src/Equibles.Finra.BusinessLogic/` — new project: `ShortSqueezeScoreManager` (`[Service]`) + `ShortSqueezeScore` result model; references Finra and CommonStocks repositories only.
- `Equibles.sln` — adds the project.
- `tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs` — five tests: composite ranking with percentile bounds, missing-volume factor drop-out, days-to-cover fallback computation, empty universe, and unknown-shares exclusion.