### PR TITLE
feat(finra-mcp): add GetShortSqueezeScores tool

### DIFF
--- a/src/Equibles.Finra.Mcp/Equibles.Finra.Mcp.csproj
+++ b/src/Equibles.Finra.Mcp/Equibles.Finra.Mcp.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Mcp\Equibles.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Finra.Repositories\Equibles.Finra.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Finra.BusinessLogic\Equibles.Finra.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -6,6 +6,7 @@ using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Errors.Data.Models;
+using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Repositories;
 using Equibles.Mcp;
@@ -22,12 +23,14 @@ public class ShortDataTools
     private readonly DailyShortVolumeRepository _shortVolumeRepository;
     private readonly ShortInterestRepository _shortInterestRepository;
     private readonly CommonStockRepository _commonStockRepository;
+    private readonly ShortSqueezeScoreManager _shortSqueezeScoreManager;
     private readonly McpToolRunner _runner;
 
     public ShortDataTools(
         DailyShortVolumeRepository shortVolumeRepository,
         ShortInterestRepository shortInterestRepository,
         CommonStockRepository commonStockRepository,
+        ShortSqueezeScoreManager shortSqueezeScoreManager,
         ErrorManager errorManager,
         ILogger<ShortDataTools> logger
     )
@@ -35,6 +38,7 @@ public class ShortDataTools
         _shortVolumeRepository = shortVolumeRepository;
         _shortInterestRepository = shortInterestRepository;
         _commonStockRepository = commonStockRepository;
+        _shortSqueezeScoreManager = shortSqueezeScoreManager;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -263,4 +267,65 @@ public class ShortDataTools
     // Thin forwarder so existing reflection-based normalization tests still find the method.
     private Task<(CommonStock Stock, string Error)> ResolveStockByTicker(string ticker) =>
         _commonStockRepository.ResolveByTicker(ticker);
+
+    [McpServerTool(Name = "GetShortSqueezeScores")]
+    [Description(
+        "Get the stocks with the highest composite short-squeeze score — a peer-relative 0-100 rank built from short interest as a percent of shares outstanding, days to cover, and the recent change in the short share of total volume, each as a percentile across every stock reporting short interest at the latest FINRA settlement date. Use this to find squeeze candidates; use GetShortInterest for one stock's underlying series."
+    )]
+    public Task<string> GetShortSqueezeScores(
+        [Description("Maximum number of stocks to return (default: 25, highest score first)")]
+            int maxResults = 25
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var scores = await _shortSqueezeScoreManager.Compute();
+                if (scores.Count == 0)
+                    return "No short-squeeze scores available — no short interest data on file.";
+
+                var settlementDate = scores[0].SettlementDate;
+                var take = Math.Clamp(maxResults, 1, 200);
+                var sb = new System.Text.StringBuilder();
+                sb.AppendLine(
+                    $"# Highest short-squeeze scores — settlement {settlementDate:yyyy-MM-dd}"
+                );
+                sb.AppendLine();
+                sb.AppendLine(
+                    "Score = equal-weight mean of the available factor percentiles (0-100, peer-relative)."
+                );
+                sb.AppendLine();
+                sb.AppendLine(
+                    "| # | Ticker | Score | Short % of Shares | Days to Cover | Short-Volume Trend |"
+                );
+                sb.AppendLine(
+                    "|---|--------|-------|-------------------|---------------|--------------------|"
+                );
+                var rank = 1;
+                foreach (var score in scores.Take(take))
+                {
+                    var trend =
+                        score.ShortVolumeShareTrend == null
+                            ? "-"
+                            : (score.ShortVolumeShareTrend > 0 ? "+" : "")
+                                + score.ShortVolumeShareTrend.Value.ToString(
+                                    "P1",
+                                    CultureInfo.InvariantCulture
+                                );
+                    sb.AppendLine(
+                        $"| {rank++} | {score.Ticker} | {score.Score.ToString("0", CultureInfo.InvariantCulture)} | "
+                            + $"{score.ShortInterestPercentOfShares.ToString("P1", CultureInfo.InvariantCulture)} | "
+                            + $"{score.DaysToCover?.ToString("0.0", CultureInfo.InvariantCulture) ?? "-"} | {trend} |"
+                    );
+                }
+
+                if (scores.Count > take)
+                    sb.AppendLine($"\n({scores.Count - take} more scored stocks not shown.)");
+
+                return sb.ToString();
+            },
+            "GetShortSqueezeScores",
+            $"maxResults: {maxResults}"
+        );
+    }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
@@ -17,6 +18,11 @@ public class ShortDataToolsGetLargestShortVolumeCultureInvarianceTests : ParadeD
             new DailyShortVolumeRepository(DbContext),
             new ShortInterestRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext)
+            ),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
@@ -18,6 +19,11 @@ public class ShortDataToolsGetLargestShortVolumeNoResultsCultureInvarianceTests
             new DailyShortVolumeRepository(DbContext),
             new ShortInterestRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext)
+            ),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
@@ -17,6 +18,11 @@ public class ShortDataToolsGetShortInterestCultureInvarianceTests : ParadeDbMcpT
             new DailyShortVolumeRepository(DbContext),
             new ShortInterestRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext)
+            ),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
@@ -17,6 +18,11 @@ public class ShortDataToolsGetShortInterestSnapshotCultureInvarianceTests : Para
             new DailyShortVolumeRepository(DbContext),
             new ShortInterestRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext)
+            ),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
@@ -26,6 +27,11 @@ public class ShortDataToolsGetShortInterestSnapshotNoResultsCultureInvarianceTes
             new DailyShortVolumeRepository(DbContext),
             new ShortInterestRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext)
+            ),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -1,0 +1,92 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.BusinessLogic;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.Mcp.Tools;
+using Equibles.Finra.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+[Collection(ParadeDbCollection.Name)]
+public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
+{
+    private ShortDataTools Sut() =>
+        new(
+            new DailyShortVolumeRepository(DbContext),
+            new ShortInterestRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext)
+            ),
+            ErrorManager,
+            NullLogger<ShortDataTools>()
+        );
+
+    public ShortDataToolsGetShortSqueezeScoresTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    // The tool renders the scored universe highest-composite first, anchored to the
+    // latest settlement date, and says so plainly when nothing is scored.
+    [Fact]
+    public async Task GetShortSqueezeScores_RanksScoredStocksHighestFirst()
+    {
+        var settlement = new DateOnly(2026, 4, 15);
+        var hot = new CommonStock
+        {
+            Ticker = "HOT",
+            Name = "Hot Corp",
+            Cik = "0000000101",
+            SharesOutStanding = 1_000_000,
+        };
+        var cold = new CommonStock
+        {
+            Ticker = "COLD",
+            Name = "Cold Corp",
+            Cik = "0000000102",
+            SharesOutStanding = 1_000_000,
+        };
+        DbContext.Set<CommonStock>().AddRange(hot, cold);
+        DbContext
+            .Set<ShortInterest>()
+            .AddRange(
+                new ShortInterest
+                {
+                    CommonStockId = hot.Id,
+                    SettlementDate = settlement,
+                    CurrentShortPosition = 300_000,
+                    DaysToCover = 8m,
+                },
+                new ShortInterest
+                {
+                    CommonStockId = cold.Id,
+                    SettlementDate = settlement,
+                    CurrentShortPosition = 50_000,
+                    DaysToCover = 1m,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortSqueezeScores();
+
+        result.Should().Contain("settlement 2026-04-15");
+        result
+            .IndexOf("| 1 | HOT |")
+            .Should()
+            .BeGreaterThan(0, "the harder-shorted stock ranks first");
+        result.IndexOf("| 2 | COLD |").Should().BeGreaterThan(result.IndexOf("| 1 | HOT |"));
+        result.Should().Contain("30.0");
+    }
+
+    [Fact]
+    public async Task GetShortSqueezeScores_NoData_SaysSo()
+    {
+        var result = await Sut().GetShortSqueezeScores();
+
+        result.Should().Contain("No short-squeeze scores available");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortVolumeCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
@@ -17,6 +18,11 @@ public class ShortDataToolsGetShortVolumeCultureInvarianceTests : ParadeDbMcpTes
             new DailyShortVolumeRepository(DbContext),
             new ShortInterestRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext)
+            ),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
@@ -16,6 +17,11 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
             new DailyShortVolumeRepository(DbContext),
             new ShortInterestRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext)
+            ),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsZeroChangeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsZeroChangeTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.Finra.BusinessLogic;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
@@ -28,6 +29,11 @@ public class ShortDataToolsZeroChangeTests : ParadeDbMcpTestBase
             new DailyShortVolumeRepository(DbContext),
             new ShortInterestRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new ShortSqueezeScoreManager(
+                new ShortInterestRepository(DbContext),
+                new DailyShortVolumeRepository(DbContext),
+                new CommonStockRepository(DbContext)
+            ),
             ErrorManager,
             NullLogger<ShortDataTools>()
         );


### PR DESCRIPTION
## Summary

- Adds the `GetShortSqueezeScores` MCP tool to `ShortDataTools`: the composite short-squeeze score universe (from #3623's `ShortSqueezeScoreManager`) ranked highest first for the latest settlement date, with each stock's factor values (short % of shares, days to cover, short-volume trend) in a markdown table. Culture-invariant rendering like the sibling tools.

## Code changes

- `src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs` — the new tool + `ShortSqueezeScoreManager` dependency; `Equibles.Finra.Mcp.csproj` references `Equibles.Finra.BusinessLogic`.
- `tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs` — ranking + no-data rendering against ParadeDB.
- Existing `ShortDataTools` test construction sites updated for the new constructor.