### PR TITLE
feat(sec-mcp): add GetFundsHoldingStock reverse fund-ownership tool

### DIFF
--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -84,6 +84,75 @@ public class NportTools
         );
     }
 
+    [McpServerTool(Name = "GetFundsHoldingStock")]
+    [Description(
+        "Get the registered investment companies (mutual funds and ETFs) holding a given stock, from SEC Form NPORT-P portfolio reports. The stock's CUSIP is matched against the holding rows on each fund series' most recent report, so an exited position never shows as current. Returns the fund's registrant and series, the reporting period, the position size, its U.S.-dollar value, its share of the fund's net assets and the payoff profile (Long/Short), largest positions first. Use this to see which funds and ETFs own a stock and how concentrated each position is."
+    )]
+    public Task<string> GetFundsHoldingStock(
+        [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Maximum number of fund positions to return, largest first (default: 20)")]
+            int maxResults = 20
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
+
+                if (string.IsNullOrEmpty(stock.Cusip))
+                    return $"No CUSIP is on record for {ticker}, so its fund ownership cannot be resolved from Form NPORT-P reports.";
+
+                var currentPositions = _nportRepository
+                    .GetHoldingsByCusip(stock.Cusip)
+                    .Join(
+                        _nportRepository.GetLatestPerSeries(DateOnly.MinValue),
+                        h => h.NportFilingId,
+                        f => f.Id,
+                        (h, f) =>
+                            new
+                            {
+                                f.RegistrantName,
+                                f.SeriesName,
+                                f.ReportPeriodDate,
+                                h.Balance,
+                                h.Units,
+                                h.ValueUsd,
+                                h.PercentValue,
+                                h.PayoffProfile,
+                            }
+                    );
+
+                var totalCount = await currentPositions.CountAsync();
+                if (totalCount == 0)
+                    return $"No fund reports a position in {ticker} on its most recent Form NPORT-P.";
+
+                var positions = await currentPositions
+                    .OrderByDescending(p => p.ValueUsd)
+                    .Take(maxResults)
+                    .ToListAsync();
+
+                var result = MarkdownTable.Start(
+                    $"Funds holding {stock.Name} ({ticker}) on each series' most recent Form NPORT-P — "
+                        + $"{totalCount} current fund positions, showing the largest {positions.Count}:",
+                    "| Registrant | Series | Report Date | Balance | Units | Value (USD) | % Net Assets | Long/Short |",
+                    "|------------|--------|-------------|---------|-------|-------------|--------------|------------|"
+                );
+
+                result.AppendRows(
+                    positions,
+                    p =>
+                        $"| {p.RegistrantName ?? "-"} | {p.SeriesName ?? "-"} | {p.ReportPeriodDate:yyyy-MM-dd} | {FormatAmount(p.Balance)} | {p.Units ?? "-"} | ${FormatAmount(p.ValueUsd)} | {FormatPercent(p.PercentValue)} | {p.PayoffProfile ?? "-"} |"
+                );
+
+                return result.ToString();
+            },
+            "GetFundsHoldingStock",
+            $"ticker: {ticker}"
+        );
+    }
+
     private static string FormatAmount(decimal value) => McpFormat.Invariant(value, "N2");
 
     private static string FormatPercent(decimal value) => McpFormat.Invariant(value, "N2") + "%";

--- a/tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs
@@ -1,0 +1,147 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Mcp.Tools;
+using Equibles.Sec.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+public class NportFundsHoldingStockToolTests : IDisposable
+{
+    private const string HeldCusip = "037833100";
+
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly NportTools _tools;
+
+    public NportFundsHoldingStockToolTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new SecTestModuleConfiguration()
+        );
+        _tools = new NportTools(
+            new NportFilingRepository(_dbContext),
+            new CommonStockRepository(_dbContext),
+            errorManager: null,
+            NullLogger<NportTools>.Instance
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task GetFundsHoldingStock_StockWithoutCusip_ReturnsNoCusipMessage()
+    {
+        SeedStock("NOCU", cusip: null);
+
+        var result = await _tools.GetFundsHoldingStock("NOCU");
+
+        result.Should().Contain("No CUSIP is on record for NOCU");
+    }
+
+    [Fact]
+    public async Task GetFundsHoldingStock_NoFundHoldsTheStock_ReturnsEmptyMessage()
+    {
+        SeedStock("AAPL", HeldCusip);
+
+        var result = await _tools.GetFundsHoldingStock("AAPL");
+
+        result.Should().Contain("No fund reports a position in AAPL");
+    }
+
+    [Fact]
+    public async Task GetFundsHoldingStock_FundHoldsStockOnLatestReport_ReturnsThePosition()
+    {
+        SeedStock("AAPL", HeldCusip);
+        var fund = SeedStock("VOO", cusip: null, cik: "0000036405");
+
+        var filing = MakeFiling(fund.Id, "acc-current", new DateOnly(2025, 1, 31));
+        filing.Holdings.Add(MakeHolding(HeldCusip, 5_000_000m));
+        _dbContext.Set<NportFiling>().Add(filing);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundsHoldingStock("AAPL");
+
+        result.Should().Contain("VANGUARD INDEX FUNDS");
+        result.Should().Contain("Vanguard 500 Index Fund");
+        result.Should().Contain("1 current fund positions");
+    }
+
+    [Fact]
+    public async Task GetFundsHoldingStock_PositionOnlyOnAnOlderReport_IsExcluded()
+    {
+        // The fund held the stock on an older report but not on its latest one — the
+        // position was exited, so the reverse lookup must not show it as current.
+        SeedStock("AAPL", HeldCusip);
+        var fund = SeedStock("VOO", cusip: null, cik: "0000036405");
+
+        var older = MakeFiling(fund.Id, "acc-older", new DateOnly(2024, 6, 30));
+        older.Holdings.Add(MakeHolding(HeldCusip, 5_000_000m));
+        _dbContext.Set<NportFiling>().Add(older);
+
+        var latest = MakeFiling(fund.Id, "acc-latest", new DateOnly(2025, 1, 31));
+        latest.Holdings.Add(MakeHolding("XXXXXXXXX", 1_000_000m));
+        _dbContext.Set<NportFiling>().Add(latest);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _tools.GetFundsHoldingStock("AAPL");
+
+        result.Should().Contain("No fund reports a position in AAPL");
+    }
+
+    private CommonStock SeedStock(string ticker, string cusip, string cik = null)
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = ticker == "VOO" ? "Vanguard 500 Index Fund" : $"{ticker} Inc.",
+            Cik = cik ?? $"00009430{Math.Abs(ticker.GetHashCode()) % 100:D2}",
+            Cusip = cusip,
+        };
+        _dbContext.Set<CommonStock>().Add(stock);
+        _dbContext.SaveChanges();
+        return stock;
+    }
+
+    private static NportFiling MakeFiling(Guid stockId, string accession, DateOnly filingDate)
+    {
+        return new NportFiling
+        {
+            CommonStockId = stockId,
+            AccessionNumber = accession,
+            FilingDate = filingDate,
+            IsAmendment = false,
+            RegistrantName = "VANGUARD INDEX FUNDS",
+            SeriesName = "Vanguard 500 Index Fund",
+            SeriesId = "S000002277",
+            ReportPeriodDate = filingDate.AddMonths(-1),
+            ReportPeriodEnd = filingDate,
+            TotalAssets = 1_200_000_000m,
+            TotalLiabilities = 50_000_000m,
+            NetAssets = 1_150_000_000m,
+        };
+    }
+
+    private static NportHolding MakeHolding(string cusip, decimal valueUsd)
+    {
+        return new NportHolding
+        {
+            Name = "Apple Inc.",
+            Cusip = cusip,
+            Balance = valueUsd / 250m,
+            Units = "NS",
+            Currency = "USD",
+            ValueUsd = valueUsd,
+            PercentValue = 0.43m,
+            PayoffProfile = "Long",
+            AssetCategory = "EC",
+            IssuerCategory = "CORP",
+            InvestmentCountry = "US",
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `GetFundsHoldingStock` MCP tool to the Sec module's NPORT tools: the reverse of `GetFundHoldings` — which registered funds and ETFs hold a given stock.
- The stock's CUSIP is matched against the holding rows on each fund series' most recent NPORT-P report (the same latest-per-series restriction the existing queries use), so an exited position never shows as current. Returns registrant, series, reporting period, position size, USD value, % of net assets and payoff profile, largest first.
- Stocks without a CUSIP return an explanatory message instead of an empty table.

## Code changes

- `src/Equibles.Sec.Mcp/Tools/NportTools.cs` — new `GetFundsHoldingStock` tool composing `GetHoldingsByCusip` with `GetLatestPerSeries`.
- `tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs` — four tests: no-CUSIP message, empty result, current position rendered, exited (older-report-only) position excluded.