### PR TITLE
fix(holdings): clamp cover-page strings to their column bounds on new holders

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -439,7 +439,7 @@ public class HoldingsImportService
 
     // Submissions whose CIK has no holder row yet become new InstitutionalHolder
     // records populated from the cover page where available.
-    private void CreateMissingHolders(
+    internal void CreateMissingHolders(
         ImportContext context,
         List<InstitutionalHolder> existingHolders,
         InstitutionalHolderRepository holderRepo,
@@ -457,14 +457,17 @@ public class HoldingsImportService
 
             context.CoverPages.TryGetValue(submission.AccessionNumber, out var coverPage);
 
+            // Cover-page strings are unbounded in the source TSV/XML; one over-length
+            // value rejects the whole batch flush (22001) and discards the filing's
+            // rows, so each is clamped to its column bound.
             var holder = new InstitutionalHolder
             {
                 Cik = submission.Cik,
-                Name = coverPage?.CompanyName,
-                City = coverPage?.City,
-                StateOrCountry = coverPage?.StateOrCountry,
-                Form13FFileNumber = coverPage?.Form13FFileNumber,
-                CrdNumber = coverPage?.CrdNumber,
+                Name = ClampLength(coverPage?.CompanyName, 512),
+                City = ClampLength(coverPage?.City, 128),
+                StateOrCountry = ClampLength(coverPage?.StateOrCountry, 64),
+                Form13FFileNumber = ClampLength(coverPage?.Form13FFileNumber, 32),
+                CrdNumber = ClampLength(coverPage?.CrdNumber, 32),
                 Classification = FundClassifierService.Classify(coverPage?.CompanyName),
                 ConfidentialTreatmentRequested = IsYes(coverPage?.ConfidentialTreatment),
             };
@@ -473,6 +476,14 @@ public class HoldingsImportService
             cikToHolderId[submission.Cik] = holder.Id;
             existingCiks.Add(submission.Cik);
         }
+    }
+
+    // Truncates a parsed string to its destination column bound. The cover page is
+    // free text; a value past the bound is malformed, and storing the prefix beats
+    // losing the filer's whole batch to a 22001 abort.
+    internal static string ClampLength(string value, int maxLength)
+    {
+        return value != null && value.Length > maxLength ? value[..maxLength] : value;
     }
 
     private async Task ParseOtherManagers(

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCoverPageClampTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCoverPageClampTests.cs
@@ -1,0 +1,83 @@
+using Equibles.Core.Configuration;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Import contract from the 22001 batch aborts: every cover-page string mapped onto a new
+/// InstitutionalHolder must fit its column, because one over-length value rejects the whole
+/// batch flush and the filing's rows are silently discarded. The City column is
+/// varchar(128) and the cover page is unbounded.
+/// </summary>
+public class HoldingsImportServiceCoverPageClampTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+
+    public HoldingsImportServiceCoverPageClampTests()
+    {
+        _dbContext = TestDbContextFactory.Create(new HoldingsModuleConfiguration());
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public void CreateMissingHolders_OverlongCoverPageCity_IsClampedToTheColumnBound()
+    {
+        var service = new HoldingsImportService(
+            Substitute.For<IServiceScopeFactory>(),
+            NullLogger<HoldingsImportService>.Instance,
+            Options.Create(new WorkerOptions()),
+            Substitute.For<IStockPriceProvider>(),
+            Substitute.For<IBus>()
+        );
+
+        var longCity = new string('X', 200);
+        var context = new ImportContext
+        {
+            Submissions = new Dictionary<string, SubmissionRow>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ACC-CLAMP-1"] = new SubmissionRow
+                {
+                    AccessionNumber = "ACC-CLAMP-1",
+                    Cik = "0009990001",
+                    FormType = "13F-HR",
+                },
+            },
+            CoverPages = new Dictionary<string, CoverPageRow>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ACC-CLAMP-1"] = new CoverPageRow
+                {
+                    AccessionNumber = "ACC-CLAMP-1",
+                    CompanyName = "Clamp Test Advisors LP",
+                    City = longCity,
+                },
+            },
+        };
+
+        var holderRepo = new InstitutionalHolderRepository(_dbContext);
+        var cikToHolderId = new Dictionary<string, Guid>();
+
+        service.CreateMissingHolders(context, [], holderRepo, cikToHolderId);
+
+        var added = _dbContext.ChangeTracker.Entries<InstitutionalHolder>().Single().Entity;
+        added.City.Should().NotBeNull();
+        added
+            .City.Length.Should()
+            .BeLessThanOrEqualTo(
+                128,
+                "an over-length cover-page city must be clamped to the varchar(128) column or the batch flush aborts with 22001"
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- New `InstitutionalHolder` rows took cover-page strings unbounded; a city longer than the varchar(128) column rejected the whole batch flush with `22001` and silently discarded the filing's rows (seen recurring in production).
- `CreateMissingHolders` now clamps each cover-page string (name, city, state, file number, CRD) to its column bound via a small `ClampLength` helper — storing the prefix beats losing the filer's whole batch.
- `CreateMissingHolders` becomes internal so the regression test can drive it directly (the project already exposes internals to the test assemblies).

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — clamp the five cover-page strings; add `ClampLength`.
- `tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceCoverPageClampTests.cs` — regression test: a 200-char cover-page city lands clamped to 128.