### PR TITLE
feat(holdings): materialise per-holder quarterly AUM snapshots

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -106,6 +106,11 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
         // is needed beyond registering it.
         builder.Entity<StockQuarterlyActivity>();
 
+        // HolderQuarterlySnapshot likewise declares its composite
+        // (InstitutionalHolderId, ReportDate) key and ReportDate index as
+        // attributes.
+        builder.Entity<HolderQuarterlySnapshot>();
+
         // AumQuarterlySnapshot uses ReportDate as the primary key. The [Key]
         // attribute can't be paired with [DatabaseGenerated(None)] without EF
         // also treating it as identity-by-convention on integral types, but the

--- a/src/Equibles.Holdings.Data/Models/HolderQuarterlySnapshot.cs
+++ b/src/Equibles.Holdings.Data/Models/HolderQuarterlySnapshot.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.Data.Models;
+
+// Per-(holder, quarter) materialisation of the Form 13F AUM aggregates behind
+// the institutions browse ranking and the per-holder snapshot lookups. Deriving
+// these live meant grouping each holder's entire InstitutionalHolding history
+// per request (5-45s at production scale); concurrent traffic on the stock
+// holdings pages saturated the database with copies of that query. This table
+// holds one row per holder per quarter so those reads become indexed lookups.
+//
+// Rebuilt by HoldingsAggregateRefreshService.RebuildQuarter (drain worker), the
+// same DirtyAt-coalesced path that maintains AumQuarterlySnapshot — when a
+// quarter goes dirty its whole holder slice is recomputed and upserted. Only
+// Form 13F rows feed the aggregates: Schedule 13D/G rows share the holdings
+// table but carry event dates, and would otherwise hijack per-holder snapshots
+// the same way they hijacked the global aggregates (GH-2556).
+[PrimaryKey(nameof(InstitutionalHolderId), nameof(ReportDate))]
+[Index(nameof(ReportDate))]
+public class HolderQuarterlySnapshot
+{
+    public Guid InstitutionalHolderId { get; set; }
+
+    public DateOnly ReportDate { get; set; }
+
+    // Latest filing date among the quarter's 13F rows — amendments push it
+    // forward past the original filing.
+    public DateOnly FilingDate { get; set; }
+
+    public long Aum { get; set; }
+
+    // Raw row count for the quarter; one stock can contribute several rows
+    // (share/option classes, manager splits).
+    public int PositionCount { get; set; }
+
+    // Distinct stocks held in the quarter.
+    public int StockCount { get; set; }
+
+    public DateTime ComputedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs
+++ b/src/Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs
@@ -142,16 +142,38 @@ public class AumSnapshotRebuildWorker : BackgroundService
             .Select(s => s.ReportDate)
             .Distinct()
             .CountAsync(cancellationToken);
-        if (snapshotQuarters >= holdingQuarters && activityQuarters >= holdingQuarters)
+        // HolderQuarterlySnapshot is Form-13F-only, so its coverage is measured
+        // against distinct 13F quarters — Schedule 13D/G event dates inflate
+        // holdingQuarters but can never produce a holder snapshot row, and
+        // comparing against the all-types count would re-trigger the backfill
+        // on every boot.
+        var holder13FQuarters = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h => h.FilingType == FilingType.Form13F)
+            .Select(h => h.ReportDate)
+            .Distinct()
+            .CountAsync(cancellationToken);
+        var holderQuarters = await dbContext
+            .Set<HolderQuarterlySnapshot>()
+            .Select(s => s.ReportDate)
+            .Distinct()
+            .CountAsync(cancellationToken);
+        if (
+            snapshotQuarters >= holdingQuarters
+            && activityQuarters >= holdingQuarters
+            && holderQuarters >= holder13FQuarters
+        )
         {
             return;
         }
 
         _logger.LogInformation(
-            "Holdings snapshot coverage incomplete (AUM {Snapshots}, activity {Activity} of {Holdings} quarters) — running backfill with {Timeout}s command timeout",
+            "Holdings snapshot coverage incomplete (AUM {Snapshots}, activity {Activity} of {Holdings} quarters; holder {HolderQuarters} of {Holder13FQuarters} 13F quarters) — running backfill with {Timeout}s command timeout",
             snapshotQuarters,
             activityQuarters,
             holdingQuarters,
+            holderQuarters,
+            holder13FQuarters,
             BackfillCommandTimeout.TotalSeconds
         );
 

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -203,6 +203,83 @@ public class HoldingsAggregateRefreshService
         await UpsertAumSnapshot(dbContext, reportDate, cancellationToken);
         await UpsertSectorSnapshots(dbContext, reportDate, cancellationToken);
         await UpsertStockActivitySnapshots(dbContext, reportDate, cancellationToken);
+        await UpsertHolderSnapshots(dbContext, reportDate, cancellationToken);
+    }
+
+    // Per-(holder, quarter) AUM aggregates for the institutions browse ranking
+    // and per-holder snapshot lookups. Form 13F rows only — Schedule 13D/G rows
+    // share the holdings table but carry event dates and single positions, and
+    // would otherwise corrupt the per-holder totals. The same quarter-bounded
+    // shape as the other steps: the ReportDate-leading covering index narrows
+    // the scan to one quarter's slice before the per-holder GROUP BY runs.
+    private static async Task UpsertHolderSnapshots(
+        EquiblesFinancialDbContext dbContext,
+        DateOnly reportDate,
+        CancellationToken cancellationToken
+    )
+    {
+        var aggregates = await dbContext
+            .Set<InstitutionalHolding>()
+            .Where(h => h.ReportDate == reportDate && h.FilingType == FilingType.Form13F)
+            .GroupBy(h => h.InstitutionalHolderId)
+            .Select(g => new
+            {
+                InstitutionalHolderId = g.Key,
+                FilingDate = g.Max(h => h.FilingDate),
+                Aum = g.Sum(h => h.Value),
+                PositionCount = g.Count(),
+                StockCount = g.Select(h => h.CommonStockId).Distinct().Count(),
+            })
+            .ToListAsync(cancellationToken);
+
+        var computedAt = DateTime.UtcNow;
+        var snapshots = aggregates
+            .Select(a => new HolderQuarterlySnapshot
+            {
+                InstitutionalHolderId = a.InstitutionalHolderId,
+                ReportDate = reportDate,
+                FilingDate = a.FilingDate,
+                Aum = a.Aum,
+                PositionCount = a.PositionCount,
+                StockCount = a.StockCount,
+                ComputedAt = computedAt,
+            })
+            .ToList();
+
+        if (snapshots.Count > 0)
+        {
+            // Single INSERT … ON CONFLICT (InstitutionalHolderId, ReportDate)
+            // DO UPDATE … for the whole batch. Race-free against a parallel
+            // rebuild of the same quarter.
+            await dbContext
+                .Set<HolderQuarterlySnapshot>()
+                .UpsertRange(snapshots)
+                .On(s => new { s.InstitutionalHolderId, s.ReportDate })
+                .WhenMatched(
+                    (_, incoming) =>
+                        new HolderQuarterlySnapshot
+                        {
+                            FilingDate = incoming.FilingDate,
+                            Aum = incoming.Aum,
+                            PositionCount = incoming.PositionCount,
+                            StockCount = incoming.StockCount,
+                            ComputedAt = incoming.ComputedAt,
+                        }
+                )
+                .RunAsync(cancellationToken);
+        }
+
+        // Holders with no remaining 13F rows for this quarter (amendment wiped
+        // the filing, or the rows were 13D/G all along) — drop their stale rows
+        // so the ranking can't surface a phantom filer. When `snapshots` is
+        // empty this collapses to "delete every holder row for this quarter".
+        var currentHolderIds = snapshots.Select(s => s.InstitutionalHolderId).ToList();
+        await dbContext
+            .Set<HolderQuarterlySnapshot>()
+            .Where(s =>
+                s.ReportDate == reportDate && !currentHolderIds.Contains(s.InstitutionalHolderId)
+            )
+            .ExecuteDeleteAsync(cancellationToken);
     }
 
     private static async Task UpsertAumSnapshot(

--- a/src/Equibles.Holdings.Repositories/HolderQuarterlySnapshotRepository.cs
+++ b/src/Equibles.Holdings.Repositories/HolderQuarterlySnapshotRepository.cs
@@ -1,0 +1,10 @@
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+
+namespace Equibles.Holdings.Repositories;
+
+public class HolderQuarterlySnapshotRepository : BaseRepository<HolderQuarterlySnapshot>
+{
+    public HolderQuarterlySnapshotRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+}

--- a/src/Equibles.Migrations/Migrations/20260610161456_AddHolderQuarterlySnapshot.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260610161456_AddHolderQuarterlySnapshot.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610161456_AddHolderQuarterlySnapshot")]
+    partial class AddHolderQuarterlySnapshot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260610161456_AddHolderQuarterlySnapshot.cs
+++ b/src/Equibles.Migrations/Migrations/20260610161456_AddHolderQuarterlySnapshot.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHolderQuarterlySnapshot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "HolderQuarterlySnapshot",
+                columns: table => new
+                {
+                    InstitutionalHolderId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ReportDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    FilingDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    Aum = table.Column<long>(type: "bigint", nullable: false),
+                    PositionCount = table.Column<int>(type: "integer", nullable: false),
+                    StockCount = table.Column<int>(type: "integer", nullable: false),
+                    ComputedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_HolderQuarterlySnapshot", x => new { x.InstitutionalHolderId, x.ReportDate });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HolderQuarterlySnapshot_ReportDate",
+                table: "HolderQuarterlySnapshot",
+                column: "ReportDate");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "HolderQuarterlySnapshot");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/AumSnapshotRebuildWorkerTests.cs
@@ -168,6 +168,91 @@ public class AumSnapshotRebuildWorkerTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ExecuteAsync_HolderSnapshotsMissing_BackfillsDespiteFullAumCoverage()
+    {
+        // Deploy scenario for the holder snapshot table: AUM and activity
+        // snapshots already cover every quarter, the newly-added holder table
+        // is empty. The coverage gate must still trigger the full backfill —
+        // the daily safety-net alone only reaches the 4 most recent quarters,
+        // so without the gate the oldest quarter would never materialise.
+        // Five quarters seeded so the oldest lies beyond the safety-net.
+        var quarters = Enumerable
+            .Range(0, 5)
+            .Select(i => new DateOnly(2023, 12, 31).AddMonths(3 * i))
+            .ToList();
+        InstitutionalHolder holder;
+        CommonStock aapl;
+        await using (var seed = FreshContext())
+        {
+            var tech = new Sector { Name = "Technology" };
+            seed.Add(tech);
+            await seed.SaveChangesAsync();
+            var industry = new Industry { Name = "Software", SectorId = tech.Id };
+            seed.Add(industry);
+            await seed.SaveChangesAsync();
+            aapl = new CommonStock
+            {
+                Ticker = "AAPL",
+                Name = "Apple",
+                Cik = "C0000320193",
+                IndustryId = industry.Id,
+            };
+            seed.Add(aapl);
+            holder = new InstitutionalHolder { Cik = "H001", Name = "Holder H001" };
+            seed.Add(holder);
+            await seed.SaveChangesAsync();
+            foreach (var quarter in quarters)
+            {
+                seed.Add(MakeHolding(aapl, holder, quarter, 100_000, $"acc-{quarter}"));
+                seed.Add(
+                    new AumQuarterlySnapshot
+                    {
+                        ReportDate = quarter,
+                        TotalValue = 100_000,
+                        FilerCount = 1,
+                        PositionCount = 1,
+                        StockCount = 1,
+                        FilingCount = 1,
+                    }
+                );
+                seed.Add(
+                    new StockQuarterlyActivity
+                    {
+                        CommonStockId = aapl.Id,
+                        ReportDate = quarter,
+                        CurrentShares = 1_000,
+                        CurrentValue = 100_000,
+                        CurrentFilerCount = 1,
+                    }
+                );
+            }
+            await seed.SaveChangesAsync();
+        }
+
+        var scopeFactory = ScopeFactory();
+        var refreshService = new HoldingsAggregateRefreshService(
+            scopeFactory,
+            NullLogger<HoldingsAggregateRefreshService>.Instance
+        );
+        var worker = new InstantTickWorker(scopeFactory, refreshService);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await worker.StartAsync(cts.Token);
+        await Task.Delay(TimeSpan.FromMilliseconds(500), cts.Token);
+        await worker.StopAsync(CancellationToken.None);
+
+        await using var read = FreshContext();
+        var holderQuarters = await read.Set<HolderQuarterlySnapshot>()
+            .Where(s => s.InstitutionalHolderId == holder.Id)
+            .Select(s => s.ReportDate)
+            .OrderBy(d => d)
+            .ToListAsync();
+        holderQuarters
+            .Should()
+            .Equal(quarters, "the backfill covers every quarter, not just the safety-net window");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_NoHoldings_DoesNotCreatePhantomSnapshotRows()
     {
         // No holdings seeded — the worker should not invent rows out of nothing.

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceHolderSnapshotTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceHolderSnapshotTests.cs
@@ -1,0 +1,278 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Contract for the per-holder slice of
+/// <see cref="HoldingsAggregateRefreshService"/>: after
+/// <c>RebuildQuarterAsync</c>, <see cref="HolderQuarterlySnapshot"/> holds one
+/// row per (holder, quarter) whose AUM / position count / stock count /
+/// filing date match what the live Form-13F-only aggregate over the same
+/// holdings would produce — 13D/G rows excluded, stale holder rows removed.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsAggregateRefreshServiceHolderSnapshotTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<Equibles.Data.EquiblesFinancialDbContext> _contexts = [];
+
+    public HoldingsAggregateRefreshServiceHolderSnapshotTests(ParadeDbFixture fixture) =>
+        _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Equibles.Data.EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    private static readonly DateOnly Q4 = new(2024, 12, 31);
+
+    private HoldingsAggregateRefreshService BuildService()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(_ => CreateScopeFromFixture());
+        return new HoldingsAggregateRefreshService(
+            scopeFactory,
+            NullLogger<HoldingsAggregateRefreshService>.Instance
+        );
+    }
+
+    private IServiceScope CreateScopeFromFixture()
+    {
+        var ctx = FreshContext();
+        var scope = Substitute.For<IServiceScope>();
+        var provider = Substitute.For<IServiceProvider>();
+        provider.GetService(typeof(Equibles.Data.EquiblesFinancialDbContext)).Returns(ctx);
+        scope.ServiceProvider.Returns(provider);
+        return scope;
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_AggregatesPerHolder_AumPositionAndStockCounts()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var aapl = await SeedStock(seed, "AAPL", industry);
+        var msft = await SeedStock(seed, "MSFT", industry);
+        var holderA = await SeedHolder(seed, "H001");
+        var holderB = await SeedHolder(seed, "H002");
+        seed.AddRange(
+            // Holder A holds AAPL twice (shares + principal rows) and MSFT once:
+            // three positions, two distinct stocks.
+            MakeHolding(aapl, holderA, Q4, 100_000, "acc-a"),
+            MakeHolding(aapl, holderA, Q4, 50_000, "acc-a", shareType: ShareType.Principal),
+            MakeHolding(msft, holderA, Q4, 200_000, "acc-a"),
+            MakeHolding(msft, holderB, Q4, 700_000, "acc-b")
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(Q4, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var a = await read.Set<HolderQuarterlySnapshot>()
+            .SingleAsync(s => s.InstitutionalHolderId == holderA.Id && s.ReportDate == Q4);
+        a.Aum.Should().Be(350_000);
+        a.PositionCount.Should().Be(3);
+        a.StockCount.Should().Be(2, "two AAPL rows are still one distinct stock");
+        a.FilingDate.Should().Be(Q4.AddDays(45));
+
+        var b = await read.Set<HolderQuarterlySnapshot>()
+            .SingleAsync(s => s.InstitutionalHolderId == holderB.Id && s.ReportDate == Q4);
+        b.Aum.Should().Be(700_000);
+        b.PositionCount.Should().Be(1);
+        b.StockCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_Excludes13DGRows_FromHolderAggregates()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var aapl = await SeedStock(seed, "AAPL", industry);
+        var holder13F = await SeedHolder(seed, "H001");
+        var holder13D = await SeedHolder(seed, "H002");
+        seed.AddRange(
+            MakeHolding(aapl, holder13F, Q4, 100_000, "acc-13f"),
+            // Same holder also has a 13D event-date row in the quarter — it
+            // must not inflate the 13F AUM.
+            MakeHolding(
+                aapl,
+                holder13F,
+                Q4,
+                999_000_000,
+                "acc-13d",
+                filingType: FilingType.Schedule13D
+            ),
+            // A holder with only 13D/G rows must not appear at all.
+            MakeHolding(aapl, holder13D, Q4, 500_000, "acc-13g", filingType: FilingType.Schedule13G)
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(Q4, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var rows = await read.Set<HolderQuarterlySnapshot>()
+            .Where(s => s.ReportDate == Q4)
+            .ToListAsync();
+        rows.Should().HaveCount(1, "only the 13F filer has a snapshot row");
+        rows[0].InstitutionalHolderId.Should().Be(holder13F.Id);
+        rows[0].Aum.Should().Be(100_000);
+        rows[0].PositionCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_FilingDate_IsLatestAcrossTheQuartersRows()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var aapl = await SeedStock(seed, "AAPL", industry);
+        var msft = await SeedStock(seed, "MSFT", industry);
+        var holder = await SeedHolder(seed, "H001");
+        var original = MakeHolding(aapl, holder, Q4, 100_000, "acc-orig");
+        var amendment = MakeHolding(msft, holder, Q4, 200_000, "acc-amend");
+        amendment.FilingDate = Q4.AddDays(90);
+        seed.AddRange(original, amendment);
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(Q4, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var row = await read.Set<HolderQuarterlySnapshot>()
+            .SingleAsync(s => s.InstitutionalHolderId == holder.Id && s.ReportDate == Q4);
+        row.FilingDate.Should().Be(Q4.AddDays(90), "the amendment filed later wins");
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_RemovesStaleHolderRows_AndUpdatesExisting()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var aapl = await SeedStock(seed, "AAPL", industry);
+        var holder = await SeedHolder(seed, "H001");
+        var goneHolder = await SeedHolder(seed, "H002");
+        seed.Add(MakeHolding(aapl, holder, Q4, 100_000, "acc-q4"));
+        // Stale snapshot rows from a previous rebuild: one for a holder whose
+        // 13F rows have since been deleted, one for the surviving holder with
+        // outdated aggregates.
+        seed.AddRange(
+            new HolderQuarterlySnapshot
+            {
+                InstitutionalHolderId = goneHolder.Id,
+                ReportDate = Q4,
+                FilingDate = Q4.AddDays(45),
+                Aum = 42,
+                PositionCount = 1,
+                StockCount = 1,
+            },
+            new HolderQuarterlySnapshot
+            {
+                InstitutionalHolderId = holder.Id,
+                ReportDate = Q4,
+                FilingDate = Q4.AddDays(1),
+                Aum = 1,
+                PositionCount = 99,
+                StockCount = 99,
+            }
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(Q4, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var rows = await read.Set<HolderQuarterlySnapshot>()
+            .Where(s => s.ReportDate == Q4)
+            .ToListAsync();
+        rows.Should().HaveCount(1, "the holder with no remaining 13F rows is dropped");
+        rows[0].InstitutionalHolderId.Should().Be(holder.Id);
+        rows[0].Aum.Should().Be(100_000, "the surviving holder's row is overwritten in place");
+        rows[0].PositionCount.Should().Be(1);
+    }
+
+    private static async Task<Guid> SeedTaxonomy(Equibles.Data.EquiblesFinancialDbContext ctx)
+    {
+        var sector = new Sector { Name = "Technology" };
+        ctx.Add(sector);
+        await ctx.SaveChangesAsync();
+        var industry = new Industry { Name = "Software", SectorId = sector.Id };
+        ctx.Add(industry);
+        await ctx.SaveChangesAsync();
+        return industry.Id;
+    }
+
+    private static async Task<CommonStock> SeedStock(
+        Equibles.Data.EquiblesFinancialDbContext ctx,
+        string ticker,
+        Guid industryId
+    )
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Corp.",
+            Cik = $"C{Guid.NewGuid().GetHashCode() & int.MaxValue:D8}",
+            IndustryId = industryId,
+        };
+        ctx.Add(stock);
+        await ctx.SaveChangesAsync();
+        return stock;
+    }
+
+    private static async Task<InstitutionalHolder> SeedHolder(
+        Equibles.Data.EquiblesFinancialDbContext ctx,
+        string cik
+    )
+    {
+        var holder = new InstitutionalHolder { Cik = cik, Name = $"Holder {cik}" };
+        ctx.Add(holder);
+        await ctx.SaveChangesAsync();
+        return holder;
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long value,
+        string accession,
+        ShareType shareType = ShareType.Shares,
+        FilingType filingType = FilingType.Form13F
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = value / 100,
+            Value = value,
+            ShareType = shareType,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = accession,
+            FilingType = filingType,
+            // CUSIP column is varchar(9). Derive a deterministic 9-char value
+            // from the stock so the holding-row unique key stays disambiguated
+            // across the test seeds.
+            Cusip =
+                $"{stock.Ticker[..Math.Min(4, stock.Ticker.Length)]}{stock.Id.GetHashCode():X8}"[
+                    ..9
+                ],
+        };
+}


### PR DESCRIPTION
## Summary

Adds `HolderQuarterlySnapshot` — a per-(holder, quarter) materialisation of the Form 13F AUM aggregates (AUM, position count, distinct stock count, latest filing date). Deriving these live grouped each holder's entire `InstitutionalHolding` history per request (5-45s at production scale) and saturated the database under concurrent traffic on the stock holdings pages. The table becomes the fourth snapshot behind the existing `Filings13FImported` → dirty-flag → drain-worker pipeline, so reads turn into indexed lookups while writes stay coalesced per dirty quarter.

Closes #3627.

## Code changes

- `Equibles.Holdings.Data/Models/HolderQuarterlySnapshot.cs` — new entity, composite PK (InstitutionalHolderId, ReportDate) + ReportDate index; registered in `HoldingsModuleConfiguration`.
- `Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs` — new `UpsertHolderSnapshots` step in `RebuildQuarterInScope`: quarter-bounded, 13F-only GROUP BY per holder, FlexLabs upsert on the composite key, stale-holder delete (mirrors the sector/stock steps).
- `Equibles.Holdings.HostedService/AumSnapshotRebuildWorker.cs` — first-boot coverage gate now also checks holder snapshot coverage, measured against distinct **13F** quarters (13D/G event dates inflate the all-types quarter count and would re-trigger the backfill forever).
- `Equibles.Holdings.Repositories/HolderQuarterlySnapshotRepository.cs` — standard `BaseRepository` for downstream readers.
- `Equibles.Migrations` — `AddHolderQuarterlySnapshot` migration.
- Tests: new `HoldingsAggregateRefreshServiceHolderSnapshotTests` (per-holder aggregation, 13D/G exclusion, max filing date, stale-row removal/in-place update) and a rebuild-worker test pinning the deploy scenario (AUM/activity fully covered, holder table empty → full backfill beyond the safety-net window). Full Holdings integration namespace green (197 tests).
