### PR TITLE
fix(sec): derive XBRL backfill accession from the EDGAR source URL

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/XbrlBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/XbrlBackfillService.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Equibles.Integrations.Sec.Contracts;
 using Equibles.Integrations.Sec.Models;
 using Equibles.Sec.Data.Models;
@@ -21,6 +22,14 @@ public class XbrlBackfillService
     // unfetchable filing (deleted/superseded on EDGAR, unparseable) can't sit at the head of
     // the newest-first queue and starve every older document behind it.
     private const int MaxAttempts = 5;
+
+    // Rows ingested before AccessionNumber existed carry it only inside the stored EDGAR
+    // full-submission URL (https://www.sec.gov/Archives/edgar/data/{cik}/{accession}.txt).
+    // The accession is the file name; recovering it makes those rows backfillable.
+    private static readonly Regex EdgarSourceUrlAccession = new(
+        @"/Archives/edgar/data/\d+/(\d{10}-\d{2}-\d{6})\.txt$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase
+    );
 
     private readonly DocumentRepository _documentRepository;
     private readonly ISecEdgarClient _secEdgarClient;
@@ -55,14 +64,19 @@ public class XbrlBackfillService
             return result;
         }
 
-        // Only documents that came from a filing (an accession to re-fetch) and whose issuer
-        // has a CIK qualify; legacy/paper rows have neither. Documents that have exhausted
-        // their retry ceiling are dropped from the working set so they can't block the queue.
-        // Newest first so recent filings fill in soonest.
+        // Only documents that came from a filing and whose issuer has a CIK qualify: either
+        // they carry the accession directly, or it can be recovered from the stored EDGAR
+        // submission URL (rows ingested before AccessionNumber existed). Non-EDGAR documents
+        // (e.g. earnings-call transcripts) have neither and are never selected. Documents
+        // that have exhausted their retry ceiling are dropped from the working set so they
+        // can't block the queue. Newest first so recent filings fill in soonest.
         var query = _documentRepository
             .GetByXbrlStatus(XbrlCaptureStatus.NotChecked)
             .Where(d =>
-                d.AccessionNumber != null
+                (
+                    d.AccessionNumber != null
+                    || (d.SourceUrl != null && d.SourceUrl.Contains("/Archives/edgar/data/"))
+                )
                 && d.CommonStock.Cik != null
                 && d.XbrlCaptureAttempts < MaxAttempts
             );
@@ -85,6 +99,24 @@ public class XbrlBackfillService
             // Count the attempt up front so a fetch/parse failure still advances the retry
             // ceiling and the document eventually drops out of the working set.
             document.XbrlCaptureAttempts++;
+
+            // Recover the accession for legacy rows and persist it (UpdateXbrl /
+            // PersistAttempt save it alongside the outcome) so later consumers can link the
+            // filing without re-deriving. A URL that matched the broad SQL filter but not
+            // the strict accession shape can never be fetched — record the failure and let
+            // the attempt ceiling walk it out of the working set.
+            document.AccessionNumber ??= DeriveAccessionNumber(document.SourceUrl);
+            if (document.AccessionNumber == null)
+            {
+                result.Failed++;
+                _logger.LogWarning(
+                    "XBRL backfill cannot derive an accession number from SourceUrl {SourceUrl} for document {DocumentId}.",
+                    document.SourceUrl,
+                    document.Id
+                );
+                await PersistAttempt();
+                continue;
+            }
 
             try
             {
@@ -133,6 +165,17 @@ public class XbrlBackfillService
         }
 
         return result;
+    }
+
+    private static string DeriveAccessionNumber(string sourceUrl)
+    {
+        if (string.IsNullOrEmpty(sourceUrl))
+        {
+            return null;
+        }
+
+        var match = EdgarSourceUrlAccession.Match(sourceUrl);
+        return match.Success ? match.Groups[1].Value : null;
     }
 
     // Saves the bumped attempt count after a fetch failure. Best-effort: a save failure here

--- a/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs
@@ -49,7 +49,12 @@ public class XbrlBackfillServiceTests : ParadeDbMcpTestBase
         return apple;
     }
 
-    private async Task SeedDocument(Guid companyId, string accessionNumber, DateOnly reportingDate)
+    private async Task SeedDocument(
+        Guid companyId,
+        string accessionNumber,
+        DateOnly reportingDate,
+        string sourceUrl = null
+    )
     {
         await using var seed = Fixture.CreateDbContext();
         var content = new File
@@ -73,6 +78,7 @@ public class XbrlBackfillServiceTests : ParadeDbMcpTestBase
                     ReportingDate = reportingDate,
                     ReportingForDate = reportingDate,
                     AccessionNumber = accessionNumber,
+                    SourceUrl = sourceUrl,
                     XbrlStatus = XbrlCaptureStatus.NotChecked,
                 }
             );
@@ -242,5 +248,82 @@ public class XbrlBackfillServiceTests : ParadeDbMcpTestBase
         var result = await BuildSut(StubClient(InlineSubmission)).Backfill(batchSize: 10, null);
 
         result.Processed.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Backfill_DerivesAccessionFromEdgarSourceUrl()
+    {
+        // Rows ingested before AccessionNumber existed carry it only inside the stored EDGAR
+        // submission URL — the backfill must recover it, fetch the filing, and persist the
+        // derived accession alongside the capture outcome.
+        var company = await SeedCompany();
+        await SeedDocument(
+            company.Id,
+            accessionNumber: null,
+            new DateOnly(2024, 2, 1),
+            sourceUrl: "https://www.sec.gov/Archives/edgar/data/0000320193/0000320193-24-000123.txt"
+        );
+        DbContext.ChangeTracker.Clear();
+
+        var client = StubClient(InlineSubmission);
+        var result = await BuildSut(client).Backfill(batchSize: 10, null);
+
+        result.Captured.Should().Be(1);
+        await client.Received(1).GetDocumentContent("0000320193-24-000123", "0000320193");
+
+        await using var verify = Fixture.CreateDbContext();
+        var doc = await verify.Set<Document>().SingleAsync(d => d.CommonStockId == company.Id);
+        doc.AccessionNumber.Should().Be("0000320193-24-000123");
+        doc.XbrlStatus.Should().Be(XbrlCaptureStatus.Captured);
+    }
+
+    [Fact]
+    public async Task Backfill_NeverSelectsNonEdgarSourceUrl()
+    {
+        // Documents from other providers (e.g. earnings-call transcripts) have no filing to
+        // re-fetch — they must not be selected, so they can't burn cycles or EDGAR budget.
+        var company = await SeedCompany();
+        await SeedDocument(
+            company.Id,
+            accessionNumber: null,
+            new DateOnly(2024, 2, 1),
+            sourceUrl: "https://www.alphavantage.co/query?function=EARNINGS_CALL_TRANSCRIPT&symbol=AAPL&quarter=2024Q1"
+        );
+        DbContext.ChangeTracker.Clear();
+
+        var result = await BuildSut(StubClient(InlineSubmission)).Backfill(batchSize: 10, null);
+
+        result.Processed.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Backfill_UnparseableEdgarSourceUrl_DropsOutAfterRetryCeiling()
+    {
+        // An EDGAR-looking URL that doesn't carry a well-formed accession can never be
+        // fetched; each cycle records a failure and bumps the attempt count so the document
+        // leaves the working set at the ceiling instead of being reselected forever.
+        var company = await SeedCompany();
+        await SeedDocument(
+            company.Id,
+            accessionNumber: null,
+            new DateOnly(2024, 2, 1),
+            sourceUrl: "https://www.sec.gov/Archives/edgar/data/0000320193/index.json"
+        );
+        DbContext.ChangeTracker.Clear();
+
+        var sut = BuildSut(StubClient(InlineSubmission));
+        for (var cycle = 0; cycle < 5; cycle++)
+        {
+            var cycleResult = await sut.Backfill(batchSize: 1, null);
+            cycleResult.Failed.Should().Be(1);
+        }
+
+        var afterCeiling = await sut.Backfill(batchSize: 1, null);
+        afterCeiling.Processed.Should().Be(0);
+
+        await using var verify = Fixture.CreateDbContext();
+        var doc = await verify.Set<Document>().SingleAsync(d => d.CommonStockId == company.Id);
+        doc.AccessionNumber.Should().BeNull();
+        doc.XbrlCaptureAttempts.Should().Be(5);
     }
 }


### PR DESCRIPTION
## Summary

- The XBRL backfill only selects documents with a non-null `AccessionNumber`, but every document ingested before that column existed has it as NULL — in production that is the entire historical corpus (660k+ rows), so the backfill has been running every cycle and processing 0 documents.
- Those legacy rows all store the EDGAR full-submission URL (`https://www.sec.gov/Archives/edgar/data/{cik}/{accession}.txt`) in `SourceUrl`, so the accession is recoverable. The backfill now also selects EDGAR-sourced rows without an accession, derives the accession from the URL, persists it on the document, and proceeds with the normal fetch/capture flow.
- Non-EDGAR documents (e.g. earnings-call transcripts with provider URLs) never match the EDGAR pattern and stay unselected, so they can't burn EDGAR budget. An EDGAR-looking URL without a well-formed accession records a failure and leaves the working set at the existing 5-attempt ceiling.

## Code changes

- `src/Equibles.Sec.HostedService/Services/XbrlBackfillService.cs` — selection accepts `AccessionNumber != null` OR an EDGAR `SourceUrl`; derives and persists the accession from the URL (strict `\d{10}-\d{2}-\d{6}` shape) before fetching; underivable URLs count as failures and ride the attempt ceiling out of the working set.
- `tests/Equibles.IntegrationTests/Sec/XbrlBackfillServiceTests.cs` — new tests: derivation captures the filing and persists the derived accession; non-EDGAR source URLs are never selected; an unparseable EDGAR-looking URL drops out after the retry ceiling.