### PR TITLE
test(mcp): align tool discovery expectations with new tools

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -403,6 +403,7 @@ public class McpModuleToolDiscoveryTests
                     "GetExemptOfferings",
                     "GetFundOperations",
                     "GetFundHoldings",
+                    "GetFundsHoldingStock",
                     "SearchInvestmentAdvisers",
                     "GetInvestmentAdviser",
                 }
@@ -429,6 +430,7 @@ public class McpModuleToolDiscoveryTests
                     "GetShortInterestSnapshot",
                     "GetLargestShortVolume",
                     "GetOffExchangeVolume",
+                    "GetShortSqueezeScores",
                 }
             },
             {


### PR DESCRIPTION
## Summary

- The MCP tool-discovery test pins the exact `[McpServerTool]` set per module assembly, but the expectations were not updated when `GetFundsHoldingStock` (Sec) and `GetShortSqueezeScores` (Finra) shipped — CI on main has been red since.
- Adds both tools to the expected sets; no production code changes.

## Code changes

- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — adds `GetFundsHoldingStock` to the `RagSearchTools` assembly set and `GetShortSqueezeScores` to the `ShortDataTools` assembly set.