### PR TITLE
docs(technical/mcp-tools): document GetShortSqueezeScores tool

### DIFF
--- a/docs/technical/mcp-tools.md
+++ b/docs/technical/mcp-tools.md
@@ -124,6 +124,7 @@ One section per module. Each tool name is exactly what the MCP client sees; the 
 - `GetShortInterest` — bi-monthly short-interest reports for a ticker.
 - `GetShortInterestSnapshot` — latest short-interest snapshot across tickers.
 - `GetLargestShortVolume` — stocks with the largest daily short volume for a single trading day (defaults to the latest available), sorted by short volume descending.
+- `GetShortSqueezeScores` — stocks ranked by a composite short-squeeze score (0–100, highest first): the equal-weight mean of peer-relative percentiles for short interest as a percent of shares outstanding, days to cover, and the recent change in the short share of total volume, computed across every stock reporting short interest at the latest FINRA settlement date (`ShortSqueezeScoreManager.Compute`).
 
 `OffExchangeVolumeTools`:
 


### PR DESCRIPTION
## Summary

- Documents the new GetShortSqueezeScores MCP tool (added in #3624) in the technical MCP tools catalog, which previously stopped at GetLargestShortVolume for ShortDataTools.

## Code changes

- `docs/technical/mcp-tools.md` — one bullet under ShortDataTools describing the composite 0-100 peer-relative score (short interest % of shares outstanding, days to cover, short-volume share trend) and its ShortSqueezeScoreManager.Compute source.