### PR TITLE
fix(sec): eager-load the content bytes in DocumentRepository.GetWithContent

### DIFF
--- a/src/Equibles.Sec.Repositories/DocumentRepository.cs
+++ b/src/Equibles.Sec.Repositories/DocumentRepository.cs
@@ -52,8 +52,13 @@ public class DocumentRepository : BaseRepository<Document>
 
     public async Task<Document> GetWithContent(Guid id)
     {
+        // The content bytes ride along eagerly: leaving File.FileContent to a lazy load
+        // lets an aborted or transient load mid-request corrupt the navigation's loaded
+        // state (the reference is non-null by construction) and crash the page instead
+        // of rendering the document.
         return await GetAll()
             .Include(d => d.Content)
+                .ThenInclude(f => f.FileContent)
             .Include(d => d.CommonStock)
             .FirstOrDefaultAsync(d => d.Id == id);
     }


### PR DESCRIPTION
## Summary

- `GetWithContent` included `Content` (the File row) but left `File.FileContent` — the actual bytes — to a lazy load at read time. Under a saturated pool an aborted or transient lazy load makes EF mark the navigation unloaded on a reference that is non-null by construction (`File.FileContent { get; set; } = new()`), which throws `InvalidOperationException: The navigation 'File.FileContent' cannot have 'IsLoaded' set to false…` and turns a readable document page into a 500 (observed 1,380 times in one day on the commercial deployment).
- Adding the `ThenInclude` makes the method honour its name: the document comes back with its content materialised, no later lazy hop.

## Code changes

- `src/Equibles.Sec.Repositories/DocumentRepository.cs` — `GetWithContent` adds `.ThenInclude(f => f.FileContent)` with a WHY comment.