### PR TITLE
feat(web): render the institutional ownership trend chart on the holdings tab

### DIFF
--- a/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
+++ b/src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml
@@ -116,6 +116,13 @@
         }
     </div>
 
+    <!-- Ownership trend — shares held isolates accumulation/distribution from
+         price moves, which a USD total would conflate. Needs two points to draw
+         a line, hence the >= 2 guard. -->
+    @if (Model.OwnershipTrend.Count >= 2) {
+        <partial name="_ChartCard" model='("Institutional Ownership Trend", "ownership-trend-chart", "Total shares held and holder count per quarter", "h-[220px]", "mb-4")' />
+    }
+
     <!-- Top movers — most actionable quarterly signal at a glance.
          Buyers = New + Increased ranked by Δ shares desc; Sellers = Reduced + Sold out, ranked by Δ shares asc.
          Each card's "View all" jumps to the corresponding bucket panel below. -->
@@ -337,5 +344,47 @@
                 }
             </div>
         </div>
+    }
+
+    @if (Model.OwnershipTrend.Count >= 2) {
+        <partial name="_ChartJs" />
+        <script>
+        // Render the institutional ownership trend chart (waits for Chart.js bundle):
+        // total shares held per quarter on the left axis, distinct holder count on the right.
+        document.addEventListener('DOMContentLoaded', function() {
+            const ctx = document.getElementById('ownership-trend-chart');
+            if (!ctx || typeof Chart === 'undefined') return;
+
+            const labels = @Html.Json(Model.OwnershipTrend.Select(p => p.ReportDate.ToString("yyyy-MM-dd")).ToList());
+            const shares = @Html.Json(Model.OwnershipTrend.Select(p => p.TotalShares).ToList());
+            const holders = @Html.Json(Model.OwnershipTrend.Select(p => p.HolderCount).ToList());
+
+            // Compact tick labels for the shares axis (e.g. 1.2B, 350M, 40K)
+            const compact = v => v >= 1e9 ? (v/1e9).toFixed(1)+'B' : v >= 1e6 ? (v/1e6).toFixed(1)+'M' : v >= 1e3 ? (v/1e3).toFixed(0)+'K' : v;
+
+            new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: labels,
+                    datasets: [
+                        { label: 'Total Shares Held', data: shares, borderColor: 'oklch(35% 0.12 195)', backgroundColor: 'oklch(35% 0.12 195 / 0.1)', fill: true, tension: 0.3, pointRadius: 3, yAxisID: 'y' },
+                        { label: 'Holders', data: holders, borderColor: 'oklch(60% 0.22 25)', backgroundColor: 'oklch(60% 0.22 25)', tension: 0.3, pointRadius: 2, borderWidth: 2, yAxisID: 'y1' }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    scales: {
+                        y: { ticks: { callback: compact, font: { size: 10 } } },
+                        y1: { position: 'right', grid: { drawOnChartArea: false }, ticks: { font: { size: 10 } } }
+                    },
+                    plugins: {
+                        legend: { display: true, labels: { boxWidth: 12, font: { size: 10 } } },
+                        tooltip: { callbacks: { label: c => c.dataset.yAxisID === 'y1' ? c.dataset.label + ': ' + c.parsed.y.toLocaleString() : c.dataset.label + ': ' + c.parsed.y.toLocaleString() + ' shares' } }
+                    }
+                }
+            });
+        });
+        </script>
     }
 }

--- a/tests/Equibles.FunctionalTests/Tests/StocksHoldingsOwnershipTrendSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/StocksHoldingsOwnershipTrendSeededTests.cs
@@ -1,0 +1,87 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.FunctionalTests.Fixtures;
+using Equibles.Holdings.Data.Models;
+using FluentAssertions;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Equibles.FunctionalTests.Tests;
+
+[Collection(FunctionalTestCollection.Name)]
+[Trait("Category", "Functional")]
+public class StocksHoldingsOwnershipTrendSeededTests
+{
+    private readonly WebAppFixture _web;
+    private readonly PlaywrightFixture _playwright;
+
+    public StocksHoldingsOwnershipTrendSeededTests(WebAppFixture web, PlaywrightFixture playwright)
+    {
+        _web = web;
+        _playwright = playwright;
+    }
+
+    [Fact]
+    public async Task Holdings_GetForStockWithTwoQuarters_RendersOwnershipTrendChart()
+    {
+        // Two quarters with different share totals so the trend has two points.
+        // Pins the golden path end to end through the real host: the chart card,
+        // its canvas, and the seeded per-quarter series all render.
+        var stockId = Guid.NewGuid();
+        await _web.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            var holder = new InstitutionalHolder { Cik = "H0000001", Name = "Test Holder" };
+            db.Add(holder);
+            foreach (
+                var (reportDate, shares) in new[]
+                {
+                    (new DateOnly(2025, 9, 30), 100_000L),
+                    (new DateOnly(2025, 12, 31), 150_000L),
+                }
+            )
+            {
+                db.Add(
+                    new InstitutionalHolding
+                    {
+                        CommonStockId = stockId,
+                        InstitutionalHolder = holder,
+                        ReportDate = reportDate,
+                        FilingDate = reportDate.AddDays(45),
+                        Shares = shares,
+                        Value = shares * 10,
+                        ShareType = ShareType.Shares,
+                        InvestmentDiscretion = InvestmentDiscretion.Sole,
+                        AccessionNumber = $"acc-{reportDate:yyyyMMdd}-0001",
+                    }
+                );
+            }
+            await Task.CompletedTask;
+        });
+
+        var page = await _playwright.NewPageAsync(_web.BaseUrl);
+        var response = await page.GotoAsync("/stocks/aapl/holdings");
+
+        response.Should().NotBeNull();
+        response!.Status.Should().Be(200);
+
+        // The Chart.js bundle (wwwroot/dist) is a build artifact absent from the
+        // test harness, so chart *execution* can't be asserted here — the canvas
+        // markup and the seeded per-quarter series in the inline script are.
+        var canvas = page.Locator("#ownership-trend-chart");
+        await Assertions.Expect(canvas).ToHaveCountAsync(1);
+        await Assertions.Expect(canvas).ToBeVisibleAsync();
+
+        var content = await page.ContentAsync();
+        content.Should().Contain("2025-09-30", "the prior quarter labels the x-axis");
+        content.Should().Contain("100000", "the prior quarter's total shares feed the series");
+        content.Should().Contain("150000", "the current quarter's total shares feed the series");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Web/HoldingsTabOwnershipTrendViewRenderingTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/HoldingsTabOwnershipTrendViewRenderingTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// End-to-end coverage of the holdings tab's Institutional Ownership Trend chart
+/// through the real Web host: with two seeded quarters the chart card and its
+/// per-quarter shares/holder-count series render; with a single quarter the
+/// chart is omitted (one point cannot draw a trend line).
+/// </summary>
+[Collection(WebHostCollection.Name)]
+public class HoldingsTabOwnershipTrendViewRenderingTests
+{
+    private readonly WebHostFixture _fixture;
+
+    public HoldingsTabOwnershipTrendViewRenderingTests(WebHostFixture fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    public async Task GetHoldings_TwoQuarters_RendersOwnershipTrendChartWithSeries()
+    {
+        var stockId = Guid.NewGuid();
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            var holder = new InstitutionalHolder { Cik = "H0000001", Name = "Test Holder" };
+            db.Add(holder);
+            db.Add(MakeHolding(stockId, holder, new DateOnly(2024, 9, 30), 123_456));
+            db.Add(MakeHolding(stockId, holder, new DateOnly(2024, 12, 31), 654_321));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Stocks/AAPL/Holdings");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().Contain("Institutional Ownership Trend", "the chart card renders");
+        html.Should().Contain("ownership-trend-chart", "the chart canvas renders");
+        html.Should().Contain("2024-09-30", "the prior quarter is a chart label");
+        html.Should().Contain("123456", "the prior quarter's total shares feed the series");
+        html.Should().Contain("654321", "the current quarter's total shares feed the series");
+    }
+
+    [Fact]
+    public async Task GetHoldings_SingleQuarter_OmitsOwnershipTrendChart()
+    {
+        var stockId = Guid.NewGuid();
+        await _fixture.ResetAndSeedAsync(async db =>
+        {
+            db.Add(
+                new CommonStock
+                {
+                    Id = stockId,
+                    Ticker = "AAPL",
+                    Name = "Apple Inc.",
+                    Cik = "0000320193",
+                }
+            );
+            var holder = new InstitutionalHolder { Cik = "H0000001", Name = "Test Holder" };
+            db.Add(holder);
+            db.Add(MakeHolding(stockId, holder, new DateOnly(2024, 12, 31), 1_000));
+            await Task.CompletedTask;
+        });
+
+        var response = await _fixture.Client.GetAsync("/Stocks/AAPL/Holdings");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var html = await response.Content.ReadAsStringAsync();
+        html.Should().NotContain("ownership-trend-chart", "one quarter cannot draw a trend line");
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        Guid stockId,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long shares
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            InstitutionalHolder = holder,
+            ReportDate = reportDate,
+            FilingDate = reportDate.AddDays(45),
+            Shares = shares,
+            Value = shares * 10,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = $"acc-{reportDate:yyyyMMdd}-0001",
+        };
+}


### PR DESCRIPTION
## Summary

- Slice 2/2 for #2883 (closes it): renders the Institutional Ownership Trend chart on the stock holdings tab — total shares held per 13F report date on the left axis with compact tick labels, distinct holder count on the right axis — following the existing dual-axis Chart.js pattern from the short-volume tab.
- The chart appears in both the regular and combined views whenever at least two report dates exist; one point can't draw a trend, so single-quarter stocks omit it.

## Code changes

- `src/Equibles.Web/Views/Stocks/_HoldingsTab.cshtml` — `_ChartCard` between the header stats and the top movers, plus the dual-axis Chart.js setup fed by `Model.OwnershipTrend`.
- `tests/Equibles.IntegrationTests/Web/HoldingsTabOwnershipTrendViewRenderingTests.cs` — real-host render: two quarters show the card, labels, and both share totals; one quarter omits the chart.
- `tests/Equibles.FunctionalTests/Tests/StocksHoldingsOwnershipTrendSeededTests.cs` — Playwright golden path: canvas present and visible with the seeded series in the page (chart execution itself isn't assertable — the Vite bundle is a build artifact absent from the harness).

Closes #2883.