### PR TITLE
feat(web): clamp the price tab history to the configured minimum sync date

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       Fred__ApiKey: ${Fred__ApiKey:-}
       MinimumLogLevel: ${MINIMUM_LOG_LEVEL:-Warning}
       CheckForUpdates: ${CHECK_FOR_UPDATES:-true}
+      # Same backfill floor the worker uses — historical charts/tables clamp to it.
+      Worker__MinSyncDate: ${Worker__MinSyncDate:-}
     volumes:
       - web-keys:/app/keys
     depends_on:

--- a/src/Equibles.Web/Program.cs
+++ b/src/Equibles.Web/Program.cs
@@ -82,6 +82,12 @@ public partial class Program
             builder.Configuration.GetSection("Auth").Get<AuthSettings>() ?? new AuthSettings();
         builder.Services.Configure<AuthSettings>(builder.Configuration.GetSection("Auth"));
 
+        // Worker:MinSyncDate marks the scrapers' backfill floor; historical views
+        // clamp their series to it so partial pre-floor data never renders.
+        builder.Services.Configure<Equibles.Core.Configuration.WorkerOptions>(
+            builder.Configuration.GetSection("Worker")
+        );
+
         builder
             .Services.AddAuthentication(EnvAuthHandler.SchemeName)
             .AddScheme<AuthenticationSchemeOptions, EnvAuthHandler>(

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -3,6 +3,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Congress.Repositories;
 using Equibles.Core.AutoWiring;
+using Equibles.Core.Configuration;
 using Equibles.Core.Extensions;
 using Equibles.Data.Extensions;
 using Equibles.Finra.Repositories;
@@ -18,6 +19,7 @@ using Equibles.Web.ViewModels.Stocks;
 using Equibles.Yahoo.Data.Models;
 using Equibles.Yahoo.Repositories;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace Equibles.Web.Services;
 
@@ -43,6 +45,11 @@ public class StockTabService
     private readonly FinancialConceptRepository _financialConceptRepository;
     private readonly CommonStockRepository _commonStockRepository;
 
+    // Data before the configured sync floor is partial — the scrapers only
+    // backfill from it — so historical series clamp to it rather than render
+    // misleading low/zero readings. Null = no floor configured, no clamp.
+    private readonly DateOnly? _minSyncDate;
+
     // Benchmark the Price tab compares each stock's returns against.
     private const string BenchmarkTicker = "SPY";
 
@@ -67,9 +74,13 @@ public class StockTabService
         DailyStockPriceRepository dailyStockPriceRepository,
         FinancialFactRepository financialFactRepository,
         FinancialConceptRepository financialConceptRepository,
-        CommonStockRepository commonStockRepository
+        CommonStockRepository commonStockRepository,
+        IOptions<WorkerOptions> workerOptions = null
     )
     {
+        _minSyncDate = workerOptions?.Value.MinSyncDate is { } floor
+            ? DateOnly.FromDateTime(floor)
+            : null;
         _institutionalHoldingRepository = institutionalHoldingRepository;
         _institutionalHolderRepository = institutionalHolderRepository;
         _dailyShortVolumeRepository = dailyShortVolumeRepository;
@@ -389,10 +400,14 @@ public class StockTabService
 
     public async Task<PriceTabViewModel> LoadPriceTab(CommonStock stock)
     {
-        var prices = await _dailyStockPriceRepository
-            .GetByStock(stock)
-            .OrderBy(p => p.Date)
-            .ToListAsync();
+        var priceQuery = _dailyStockPriceRepository.GetByStock(stock);
+        if (_minSyncDate is { } minDate)
+        {
+            // Clamp the indicators too: derived series (SMA, RSI, MACD) over
+            // partial pre-floor data would be just as misleading as the chart.
+            priceQuery = priceQuery.Where(p => p.Date >= minDate);
+        }
+        var prices = await priceQuery.OrderBy(p => p.Date).ToListAsync();
 
         var closePrices = prices.Select(p => p.Close).ToList();
         var (macdLine, macdSignal, macdHistogram) = TechnicalIndicatorService.ComputeMacd(

--- a/tests/Equibles.IntegrationTests/Web/StockTabServicePriceTabMinSyncDateTests.cs
+++ b/tests/Equibles.IntegrationTests/Web/StockTabServicePriceTabMinSyncDateTests.cs
@@ -1,0 +1,134 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Congress.Data;
+using Equibles.Congress.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Finra.Data;
+using Equibles.Finra.Repositories;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Repositories;
+using Equibles.InsiderTrading.Data;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.Data;
+using Equibles.Sec.FinancialFacts.Data;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Equibles.Sec.Repositories;
+using Equibles.Web.Services;
+using Equibles.Yahoo.Data;
+using Equibles.Yahoo.Data.Models;
+using Equibles.Yahoo.Repositories;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.IntegrationTests.Web;
+
+/// <summary>
+/// Pins the Worker:MinSyncDate clamp on the price tab: rows before the
+/// configured backfill floor are partial (the scrapers never revisit them), so
+/// they must not feed the chart or the derived indicator series; with no floor
+/// configured the full history renders unchanged.
+/// </summary>
+public class StockTabServicePriceTabMinSyncDateTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+
+    public StockTabServicePriceTabMinSyncDateTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new MediaModuleConfiguration(),
+            new SecTestModuleConfiguration(),
+            new FinancialFactsModuleConfiguration(),
+            new FinraModuleConfiguration(),
+            new HoldingsModuleConfiguration(),
+            new InsiderTradingModuleConfiguration(),
+            new CongressModuleConfiguration(),
+            new YahooModuleConfiguration()
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task LoadPriceTab_PricesBeforeMinSyncDate_AreExcludedFromSeries()
+    {
+        var stock = SeedStockWithPricesAround(new DateOnly(2024, 6, 1));
+
+        var sut = CreateService(new WorkerOptions { MinSyncDate = new DateTime(2024, 6, 1) });
+        var result = await sut.LoadPriceTab(stock);
+
+        result.Prices.Should().HaveCount(5, "only the floor date and later render");
+        result.Prices.First().Date.Should().Be(new DateOnly(2024, 6, 1), "the floor is inclusive");
+        // Derived series must align with the clamped prices, not the full history.
+        result.Sma20.Should().HaveCount(5);
+        result.Rsi14.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task LoadPriceTab_NoMinSyncDateConfigured_RendersFullHistory()
+    {
+        var stock = SeedStockWithPricesAround(new DateOnly(2024, 6, 1));
+
+        var sut = CreateService(workerOptions: null);
+        var result = await sut.LoadPriceTab(stock);
+
+        result.Prices.Should().HaveCount(10, "no floor means no clamp");
+        result.Prices.First().Date.Should().Be(new DateOnly(2024, 5, 27));
+    }
+
+    // Seeds 5 consecutive daily rows before the pivot date and 5 from it onward.
+    private CommonStock SeedStockWithPricesAround(DateOnly pivot)
+    {
+        var stock = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "0000320193",
+        };
+        _dbContext.Set<CommonStock>().Add(stock);
+        for (var i = -5; i < 5; i++)
+        {
+            _dbContext
+                .Set<DailyStockPrice>()
+                .Add(
+                    new DailyStockPrice
+                    {
+                        CommonStockId = stock.Id,
+                        Date = pivot.AddDays(i),
+                        Open = 100m,
+                        High = 102m,
+                        Low = 99m,
+                        Close = 101m,
+                        AdjustedClose = 101m,
+                        Volume = 1_000_000,
+                    }
+                );
+        }
+        _dbContext.SaveChanges();
+        return stock;
+    }
+
+    private StockTabService CreateService(WorkerOptions workerOptions) =>
+        new(
+            new InstitutionalHoldingRepository(_dbContext),
+            new InstitutionalHolderRepository(_dbContext),
+            new DailyShortVolumeRepository(_dbContext),
+            new ShortInterestRepository(_dbContext),
+            new FailToDeliverRepository(_dbContext),
+            new DocumentRepository(_dbContext),
+            new InsiderTransactionRepository(_dbContext),
+            new Form144FilingRepository(_dbContext),
+            new FormDFilingRepository(_dbContext),
+            new NCenFilingRepository(_dbContext),
+            new NportFilingRepository(_dbContext),
+            new CongressionalTradeRepository(_dbContext),
+            new DailyStockPriceRepository(_dbContext),
+            new FinancialFactRepository(_dbContext),
+            new FinancialConceptRepository(_dbContext),
+            new CommonStockRepository(_dbContext),
+            workerOptions == null ? null : Options.Create(workerOptions)
+        );
+}


### PR DESCRIPTION
## Summary

- Slice 1/3 for #2884 (Refs #2884, does not close it): historical data before `Worker:MinSyncDate` is partial — the scrapers only backfill from that floor — so the price tab now starts its chart, table, and derived indicator series (SMA, RSI, MACD, Bollinger) at the floor instead of rendering misleading low/zero readings.
- The floor is threaded into the web tier for the first time: docker-compose passes `Worker__MinSyncDate` to the web service and Program binds the `Worker` section; an unset floor leaves behaviour exactly unchanged.

## Code changes

- `docker-compose.yml` — pass `Worker__MinSyncDate` to the web service (the worker already receives it via env_file).
- `src/Equibles.Web/Program.cs` — bind `WorkerOptions` from the `Worker` configuration section.
- `src/Equibles.Web/Services/StockTabService.cs` — optional `IOptions<WorkerOptions>` constructor parameter resolving the floor once; `LoadPriceTab` filters `Date >= floor` at the query.
- `tests/Equibles.IntegrationTests/Web/StockTabServicePriceTabMinSyncDateTests.cs` — pins inclusive-floor clamping (prices + aligned indicator series) and the unchanged no-floor path.