### PR TITLE
test(common-stocks): pin IrRssFeed.ParseDate UTC normalisation under non-English culture

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/IrRssFeedParseDateTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/IrRssFeedParseDateTests.cs
@@ -1,0 +1,32 @@
+using System.Globalization;
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Pins IrRssFeed.ParseDate's contract: RSS pubDate values are RFC 2822 with
+/// English month/day names and a numeric offset, so they must parse and
+/// normalise to UTC regardless of the host culture — a CurrentCulture-bound
+/// parse would return null on any non-English server locale.
+/// </summary>
+public class IrRssFeedParseDateTests
+{
+    [Fact]
+    public void ParseDate_Rfc2822WithOffsetUnderGermanCulture_NormalisesToUtc()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var result = IrRssFeed.ParseDate("Tue, 10 Jun 2025 14:30:00 -0500");
+
+            result.Should().Be(new DateTime(2025, 6, 10, 19, 30, 0, DateTimeKind.Utc));
+            result!.Value.Kind.Should().Be(DateTimeKind.Utc, "the contract promises UTC");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Pins IrRssFeed.ParseDate's contract, previously untested directly: an RFC 2822 RSS pubDate with a numeric offset parses and normalises to UTC even under a non-English host culture (de-DE) — the class of failure where a CurrentCulture-bound parse silently returns null on non-English server locales.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/IrRssFeedParseDateTests.cs` — one fact asserting the UTC-shifted instant and DateTimeKind.Utc with the thread culture forced to de-DE.