### PR TITLE
docs(guide): mention the ownership trend chart in the explore-stock tutorial

### DIFF
--- a/docs/guide/tutorial-explore-stock.md
+++ b/docs/guide/tutorial-explore-stock.md
@@ -25,6 +25,7 @@ Click **Institutional Holders**. This tab shows every institution that reported 
 - The institution's name (click it to see that institution's full portfolio).
 - Number of shares held, dollar value, and what percentage of the company's float they own.
 - A date picker to view holdings from previous quarters.
+- An **Institutional Ownership Trend** chart plotting total shares held per quarter (left axis) and the number of holders (right axis) — shares isolate real accumulation, unlike a dollar total that also moves with the price.
 - A **Download CSV** button to export the full holder list.
 
 ## Short Volume


### PR DESCRIPTION
## Summary

- The Institutional Holders section of the explore-stock tutorial now mentions the Institutional Ownership Trend chart shipped in #3635, so readers know what the new chart shows and why it plots shares rather than dollar value.

## Code changes

- `docs/guide/tutorial-explore-stock.md` — one bullet in the Institutional Holders walkthrough.