### PR TITLE
test(common-stocks): pin IrEventClassifier earnings-over-conference precedence

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/IrEventClassifierClassifyTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/IrEventClassifierClassifyTests.cs
@@ -1,0 +1,22 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Pins IrEventClassifier's precedence on a combined label: the most common
+/// real-world event title, "Q3 2025 Earnings Conference Call", matches both
+/// the earnings and the conference keywords and must classify as an earnings
+/// call — a keyword reordering would silently flip every quarterly call to
+/// Conference.
+/// </summary>
+public class IrEventClassifierClassifyTests
+{
+    [Fact]
+    public void Classify_EarningsConferenceCallTitle_ClassifiesAsEarningsCall()
+    {
+        var result = IrEventClassifier.Classify("Q3 2025 Earnings Conference Call");
+
+        result.Should().Be(IrEventType.EarningsCall);
+    }
+}


### PR DESCRIPTION
## Summary

- Pins IrEventClassifier's keyword precedence on the most common combined label: "Q3 2025 Earnings Conference Call" matches both the earnings and conference keywords and must classify as EarningsCall — a keyword reordering would silently flip every quarterly call to Conference. The classifier had no direct tests.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/IrEventClassifierClassifyTests.cs` — one fact pinning the combined-label classification.