### PR TITLE
feat(fred): release calendar entities, client endpoints and migration

### DIFF
--- a/src/Equibles.Fred.Data/FredModuleConfiguration.cs
+++ b/src/Equibles.Fred.Data/FredModuleConfiguration.cs
@@ -9,5 +9,7 @@ public class FredModuleConfiguration : Equibles.Data.IFinancialModule
     {
         builder.Entity<FredSeries>();
         builder.Entity<FredObservation>();
+        builder.Entity<FredRelease>();
+        builder.Entity<FredReleaseDate>();
     }
 }

--- a/src/Equibles.Fred.Data/Models/FredRelease.cs
+++ b/src/Equibles.Fred.Data/Models/FredRelease.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Fred.Data.Models;
+
+[Index(nameof(ReleaseId), IsUnique = true)]
+public class FredRelease
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    // FRED's numeric release id (e.g. 10 = "Consumer Price Index").
+    public int ReleaseId { get; set; }
+
+    [Required]
+    [MaxLength(256)]
+    public string Name { get; set; }
+
+    [MaxLength(512)]
+    public string Link { get; set; }
+
+    public bool PressRelease { get; set; }
+
+    public virtual ICollection<FredSeries> Series { get; set; } = [];
+
+    public virtual ICollection<FredReleaseDate> ReleaseDates { get; set; } = [];
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Fred.Data/Models/FredReleaseDate.cs
+++ b/src/Equibles.Fred.Data/Models/FredReleaseDate.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Fred.Data.Models;
+
+// A scheduled or realized publication date of a FRED release. Future dates come from
+// the FRED release calendar (include_release_dates_with_no_data=true).
+[Index(nameof(FredReleaseId), nameof(Date), IsUnique = true)]
+[Index(nameof(Date))]
+public class FredReleaseDate
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid FredReleaseId { get; set; }
+    public virtual FredRelease FredRelease { get; set; }
+
+    public DateOnly Date { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Fred.Data/Models/FredSeries.cs
+++ b/src/Equibles.Fred.Data/Models/FredSeries.cs
@@ -33,6 +33,9 @@ public class FredSeries
 
     public DateTime? LastUpdated { get; set; }
 
+    public Guid? FredReleaseId { get; set; }
+    public virtual FredRelease FredRelease { get; set; }
+
     public virtual ICollection<FredObservation> Observations { get; set; } = [];
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;

--- a/src/Equibles.Fred.Repositories/FredReleaseDateRepository.cs
+++ b/src/Equibles.Fred.Repositories/FredReleaseDateRepository.cs
@@ -1,0 +1,20 @@
+using Equibles.Data;
+using Equibles.Fred.Data.Models;
+
+namespace Equibles.Fred.Repositories;
+
+public class FredReleaseDateRepository : BaseRepository<FredReleaseDate>
+{
+    public FredReleaseDateRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<FredReleaseDate> GetByRelease(FredRelease release)
+    {
+        return GetAll().Where(d => d.FredReleaseId == release.Id);
+    }
+
+    public IQueryable<FredReleaseDate> GetInRange(DateOnly startDate, DateOnly endDate)
+    {
+        return GetAll().Where(d => d.Date >= startDate && d.Date <= endDate);
+    }
+}

--- a/src/Equibles.Fred.Repositories/FredReleaseRepository.cs
+++ b/src/Equibles.Fred.Repositories/FredReleaseRepository.cs
@@ -1,0 +1,15 @@
+using Equibles.Data;
+using Equibles.Fred.Data.Models;
+
+namespace Equibles.Fred.Repositories;
+
+public class FredReleaseRepository : BaseRepository<FredRelease>
+{
+    public FredReleaseRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<FredRelease> GetByReleaseId(int releaseId)
+    {
+        return GetAll().Where(r => r.ReleaseId == releaseId);
+    }
+}

--- a/src/Equibles.Integrations.Fred/Contracts/IFredClient.cs
+++ b/src/Equibles.Integrations.Fred/Contracts/IFredClient.cs
@@ -7,4 +7,6 @@ public interface IFredClient
     bool IsConfigured { get; }
     Task<FredSeriesRecord> GetSeriesMetadata(string seriesId);
     Task<List<FredObservationRecord>> GetObservations(string seriesId, DateOnly? startDate = null);
+    Task<FredReleaseRecord> GetSeriesRelease(string seriesId);
+    Task<List<FredReleaseDateRecord>> GetReleaseDates(DateOnly? realtimeStart = null);
 }

--- a/src/Equibles.Integrations.Fred/FredClient.cs
+++ b/src/Equibles.Integrations.Fred/FredClient.cs
@@ -18,6 +18,9 @@ public class FredClient : IFredClient
     private const int MaxRetries = 3;
     private const int MaxObservationsPerRequest = 100000;
 
+    // The /fred/releases/dates endpoint caps its page size at 1000.
+    private const int MaxReleaseDatesPerRequest = 1000;
+
     // FRED allows 120 requests/minute — use 100 to stay safely under
     private static readonly IRateLimiter RateLimiter = new Common.RateLimiter.RateLimiter(
         maxRequests: 100,
@@ -104,6 +107,60 @@ public class FredClient : IFredClient
             seriesId
         );
         return allObservations;
+    }
+
+    public async Task<FredReleaseRecord> GetSeriesRelease(string seriesId)
+    {
+        _logger.LogDebug("Fetching FRED release for series {SeriesId}", seriesId);
+
+        var url =
+            $"{ApiBaseUrl}/fred/series/release?series_id={seriesId}&api_key={_options.ApiKey}&file_type=json";
+        var content = await SendWithRetry(url);
+        var response = JsonConvert.DeserializeObject<FredReleasesResponse>(content);
+
+        return response?.Releases?.FirstOrDefault();
+    }
+
+    public async Task<List<FredReleaseDateRecord>> GetReleaseDates(DateOnly? realtimeStart = null)
+    {
+        _logger.LogDebug("Fetching FRED release dates from {RealtimeStart}", realtimeStart);
+
+        var allReleaseDates = new List<FredReleaseDateRecord>();
+        var offset = 0;
+
+        while (true)
+        {
+            // include_release_dates_with_no_data=true is what surfaces future scheduled
+            // dates from the FRED release calendar — without it only realized dates return.
+            var url =
+                $"{ApiBaseUrl}/fred/releases/dates"
+                + $"?api_key={_options.ApiKey}"
+                + $"&file_type=json"
+                + $"&include_release_dates_with_no_data=true"
+                + $"&sort_order=asc"
+                + $"&limit={MaxReleaseDatesPerRequest}"
+                + $"&offset={offset}";
+
+            if (realtimeStart.HasValue)
+            {
+                url += $"&realtime_start={realtimeStart.Value:yyyy-MM-dd}";
+            }
+
+            var content = await SendWithRetry(url);
+            var response = JsonConvert.DeserializeObject<FredReleasesDatesResponse>(content);
+
+            if (response?.ReleaseDates == null || response.ReleaseDates.Count == 0)
+                break;
+
+            allReleaseDates.AddRange(response.ReleaseDates);
+
+            if (allReleaseDates.Count >= response.Count)
+                break;
+            offset += response.ReleaseDates.Count;
+        }
+
+        _logger.LogDebug("Fetched {Count} FRED release dates", allReleaseDates.Count);
+        return allReleaseDates;
     }
 
     private async Task<string> SendWithRetry(string url)

--- a/src/Equibles.Integrations.Fred/Models/FredReleasesDatesResponse.cs
+++ b/src/Equibles.Integrations.Fred/Models/FredReleasesDatesResponse.cs
@@ -1,0 +1,30 @@
+using Newtonsoft.Json;
+
+namespace Equibles.Integrations.Fred.Models;
+
+public class FredReleasesDatesResponse
+{
+    [JsonProperty("count")]
+    public int Count { get; set; }
+
+    [JsonProperty("offset")]
+    public int Offset { get; set; }
+
+    [JsonProperty("limit")]
+    public int Limit { get; set; }
+
+    [JsonProperty("release_dates")]
+    public List<FredReleaseDateRecord> ReleaseDates { get; set; } = [];
+}
+
+public class FredReleaseDateRecord
+{
+    [JsonProperty("release_id")]
+    public int ReleaseId { get; set; }
+
+    [JsonProperty("release_name")]
+    public string ReleaseName { get; set; }
+
+    [JsonProperty("date")]
+    public string Date { get; set; }
+}

--- a/src/Equibles.Integrations.Fred/Models/FredReleasesResponse.cs
+++ b/src/Equibles.Integrations.Fred/Models/FredReleasesResponse.cs
@@ -1,0 +1,27 @@
+using Newtonsoft.Json;
+
+namespace Equibles.Integrations.Fred.Models;
+
+public class FredReleasesResponse
+{
+    [JsonProperty("releases")]
+    public List<FredReleaseRecord> Releases { get; set; } = [];
+}
+
+public class FredReleaseRecord
+{
+    [JsonProperty("id")]
+    public int Id { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    [JsonProperty("press_release")]
+    public bool PressRelease { get; set; }
+
+    [JsonProperty("link")]
+    public string Link { get; set; }
+
+    [JsonProperty("notes")]
+    public string Notes { get; set; }
+}

--- a/src/Equibles.Migrations/Migrations/20260610181203_AddFredReleaseCalendar.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260610181203_AddFredReleaseCalendar.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610181203_AddFredReleaseCalendar")]
+    partial class AddFredReleaseCalendar
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260610181203_AddFredReleaseCalendar.cs
+++ b/src/Equibles.Migrations/Migrations/20260610181203_AddFredReleaseCalendar.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFredReleaseCalendar : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "FredReleaseId",
+                table: "FredSeries",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "FredRelease",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ReleaseId = table.Column<int>(type: "integer", nullable: false),
+                    Name = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Link = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    PressRelease = table.Column<bool>(type: "boolean", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FredRelease", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "FredReleaseDate",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    FredReleaseId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Date = table.Column<DateOnly>(type: "date", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FredReleaseDate", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FredReleaseDate_FredRelease_FredReleaseId",
+                        column: x => x.FredReleaseId,
+                        principalTable: "FredRelease",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FredSeries_FredReleaseId",
+                table: "FredSeries",
+                column: "FredReleaseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FredRelease_ReleaseId",
+                table: "FredRelease",
+                column: "ReleaseId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FredReleaseDate_Date",
+                table: "FredReleaseDate",
+                column: "Date");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FredReleaseDate_FredReleaseId_Date",
+                table: "FredReleaseDate",
+                columns: new[] { "FredReleaseId", "Date" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_FredSeries_FredRelease_FredReleaseId",
+                table: "FredSeries",
+                column: "FredReleaseId",
+                principalTable: "FredRelease",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_FredSeries_FredRelease_FredReleaseId",
+                table: "FredSeries");
+
+            migrationBuilder.DropTable(
+                name: "FredReleaseDate");
+
+            migrationBuilder.DropTable(
+                name: "FredRelease");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FredSeries_FredReleaseId",
+                table: "FredSeries");
+
+            migrationBuilder.DropColumn(
+                name: "FredReleaseId",
+                table: "FredSeries");
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Fred/FredClientGetReleaseDatesTests.cs
+++ b/tests/Equibles.IntegrationTests/Fred/FredClientGetReleaseDatesTests.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using Equibles.Integrations.Fred;
+using Equibles.Integrations.Fred.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Fred;
+
+/// <summary>
+/// `GetReleaseDates` feeds the economic release calendar. Pin three contracts:
+/// the URL must request `include_release_dates_with_no_data=true` (that flag is
+/// what surfaces FUTURE scheduled dates — dropping it silently empties the
+/// upcoming calendar), the optional `realtime_start` must be appended in
+/// yyyy-MM-dd, and the offset pagination must accumulate across pages (the
+/// endpoint caps pages at 1000 rows).
+/// </summary>
+public class FredClientGetReleaseDatesTests
+{
+    [Fact]
+    public async Task GetReleaseDates_RequestsFutureDates_AndPaginatesUntilCountReached()
+    {
+        var page1 = """
+            {"count":3,"offset":0,"limit":1000,"release_dates":[
+                {"release_id":10,"release_name":"Consumer Price Index","date":"2026-06-11"},
+                {"release_id":50,"release_name":"Employment Situation","date":"2026-06-12"}
+            ]}
+            """;
+        var page2 = """
+            {"count":3,"offset":2,"limit":1000,"release_dates":[
+                {"release_id":53,"release_name":"Gross Domestic Product","date":"2026-06-25"}
+            ]}
+            """;
+        var handler = new ScriptedHandler(page1, page2);
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new FredOptions { ApiKey = "test-key" });
+        var sut = new FredClient(httpClient, Substitute.For<ILogger<FredClient>>(), options);
+
+        var result = await sut.GetReleaseDates();
+
+        result.Should().HaveCount(3);
+        result.Select(d => d.ReleaseId).Should().Equal(10, 50, 53);
+        result.Select(d => d.Date).Should().Equal("2026-06-11", "2026-06-12", "2026-06-25");
+        result[0].ReleaseName.Should().Be("Consumer Price Index");
+
+        handler.Requests.Should().HaveCount(2);
+        var firstQuery = handler.Requests[0].RequestUri!.Query;
+        handler.Requests[0].RequestUri!.AbsolutePath.Should().Be("/fred/releases/dates");
+        firstQuery.Should().Contain("include_release_dates_with_no_data=true");
+        firstQuery.Should().NotContain("realtime_start");
+        handler.Requests[1].RequestUri!.Query.Should().Contain("offset=2");
+    }
+
+    [Fact]
+    public async Task GetReleaseDates_RealtimeStartSupplied_AppendsRealtimeStartParameter()
+    {
+        var empty = """{"count":0,"offset":0,"limit":1000,"release_dates":[]}""";
+        var handler = new ScriptedHandler(empty);
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new FredOptions { ApiKey = "test-key" });
+        var sut = new FredClient(httpClient, Substitute.For<ILogger<FredClient>>(), options);
+
+        var result = await sut.GetReleaseDates(new DateOnly(2026, 1, 1));
+
+        result.Should().BeEmpty();
+        handler.Requests.Should().HaveCount(1);
+        handler.Requests[0].RequestUri!.Query.Should().Contain("realtime_start=2026-01-01");
+    }
+
+    private sealed class ScriptedHandler : HttpMessageHandler
+    {
+        private readonly Queue<string> _responses;
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        public ScriptedHandler(params string[] responses)
+        {
+            _responses = new Queue<string>(responses);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            Requests.Add(request);
+            if (_responses.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    "ScriptedHandler exhausted — pagination loop made more calls than expected."
+                );
+            }
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responses.Dequeue()),
+                }
+            );
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Fred/FredClientGetSeriesReleaseTests.cs
+++ b/tests/Equibles.IntegrationTests/Fred/FredClientGetSeriesReleaseTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using Equibles.Integrations.Fred;
+using Equibles.Integrations.Fred.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Fred;
+
+/// <summary>
+/// `GetSeriesRelease` resolves the FRED release a series belongs to via
+/// `/fred/series/release`. Pin the URL contract (endpoint + series_id) and the
+/// JSON field mapping (snake_case `press_release` → PressRelease) so the
+/// release-calendar importer keeps linking series to the right release.
+/// </summary>
+public class FredClientGetSeriesReleaseTests
+{
+    [Fact]
+    public async Task GetSeriesRelease_ParsesReleaseRecord_AndCallsSeriesReleaseEndpoint()
+    {
+        var payload = """
+            {"releases":[{
+                "id":10,
+                "realtime_start":"2026-06-10",
+                "realtime_end":"2026-06-10",
+                "name":"Consumer Price Index",
+                "press_release":true,
+                "link":"http://www.bls.gov/cpi/"
+            }]}
+            """;
+        var handler = new CapturingHandler(payload);
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new FredOptions { ApiKey = "test-key" });
+        var sut = new FredClient(httpClient, Substitute.For<ILogger<FredClient>>(), options);
+
+        var release = await sut.GetSeriesRelease("CPIAUCSL");
+
+        release.Should().NotBeNull();
+        release!.Id.Should().Be(10);
+        release.Name.Should().Be("Consumer Price Index");
+        release.PressRelease.Should().BeTrue();
+        release.Link.Should().Be("http://www.bls.gov/cpi/");
+
+        handler.Requests.Should().HaveCount(1);
+        var uri = handler.Requests[0].RequestUri!;
+        uri.AbsolutePath.Should().Be("/fred/series/release");
+        uri.Query.Should().Contain("series_id=CPIAUCSL");
+    }
+
+    [Fact]
+    public async Task GetSeriesRelease_EmptyReleases_ReturnsNull()
+    {
+        var handler = new CapturingHandler("""{"releases":[]}""");
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new FredOptions { ApiKey = "test-key" });
+        var sut = new FredClient(httpClient, Substitute.For<ILogger<FredClient>>(), options);
+
+        var release = await sut.GetSeriesRelease("UNKNOWN");
+
+        release.Should().BeNull();
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private readonly string _payload;
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        public CapturingHandler(string payload)
+        {
+            _payload = payload;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            Requests.Add(request);
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_payload) }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First of three PRs adding an economic release calendar to the Fred module: forward-looking publication dates for the macro series we already ingest (CPI, NFP, GDP, FOMC-adjacent releases, etc.), sourced from FRED's releases API.

This PR adds the data model and the API client surface; the importer and the MCP tool follow in separate PRs.

## Code changes

- `Equibles.Fred.Data`: new `FredRelease` (FRED's numeric release id, name, link, press-release flag) and `FredReleaseDate` (release + date, unique per pair) entities; `FredSeries` gains an optional `FredReleaseId` link; both registered in `FredModuleConfiguration`.
- `Equibles.Fred.Repositories`: `FredReleaseRepository` (lookup by FRED release id) and `FredReleaseDateRepository` (by release, by date range).
- `Equibles.Integrations.Fred`: `IFredClient.GetSeriesRelease` (`/fred/series/release`) and `GetReleaseDates` (`/fred/releases/dates`, offset-paginated at the endpoint's 1000-row cap, `include_release_dates_with_no_data=true` so future scheduled dates are returned, optional `realtime_start`); response models for both endpoints.
- `Equibles.Migrations`: `AddFredReleaseCalendar` migration.
- Tests: URL/pagination/parsing pins for both new client methods (4 tests).