### PR TITLE
feat(fred): import the release calendar in the scraper cycle

### DIFF
--- a/src/Equibles.Fred.HostedService/FredScraperWorker.cs
+++ b/src/Equibles.Fred.HostedService/FredScraperWorker.cs
@@ -39,6 +39,9 @@ public class FredScraperWorker : BaseScraperWorker
         return true;
     }
 
-    protected override Task DoWork(CancellationToken stoppingToken) =>
-        RunImport<FredImportService>(stoppingToken);
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        await RunImport<FredImportService>(stoppingToken);
+        await RunImport<FredReleaseCalendarImportService>(stoppingToken);
+    }
 }

--- a/src/Equibles.Fred.HostedService/Services/FredReleaseCalendarImportService.cs
+++ b/src/Equibles.Fred.HostedService/Services/FredReleaseCalendarImportService.cs
@@ -1,0 +1,214 @@
+using System.Globalization;
+using Equibles.Core.AutoWiring;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Fred.Data.Models;
+using Equibles.Fred.Repositories;
+using Equibles.Integrations.Fred.Contracts;
+using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Fred.HostedService.Services;
+
+/// <summary>
+/// Imports the FRED release calendar: links each stored series to its parent
+/// release (/fred/series/release) and upserts the scheduled and realized
+/// publication dates of every tracked release (/fred/releases/dates). Runs
+/// after the observation import in the same scraper cycle.
+/// </summary>
+[Service]
+public class FredReleaseCalendarImportService : IImporter
+{
+    private const int InsertBatchSize = 1000;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<FredReleaseCalendarImportService> _logger;
+    private readonly IFredClient _fredClient;
+    private readonly ErrorReporter _errorReporter;
+
+    public FredReleaseCalendarImportService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<FredReleaseCalendarImportService> logger,
+        IFredClient fredClient,
+        ErrorReporter errorReporter
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _fredClient = fredClient;
+        _errorReporter = errorReporter;
+    }
+
+    public async Task Import(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await LinkSeriesToReleases(cancellationToken);
+            await ImportReleaseDates(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch the FRED release calendar, skipping cycle");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error importing the FRED release calendar");
+            await _errorReporter.Report(
+                ErrorSource.FredScraper,
+                "FredReleaseCalendarImport.Import",
+                ex.Message,
+                ex.StackTrace
+            );
+        }
+    }
+
+    private async Task LinkSeriesToReleases(CancellationToken cancellationToken)
+    {
+        List<FredSeries> unlinkedSeries;
+        using (var scope = _scopeFactory.CreateScope())
+        {
+            var seriesRepo = scope.ServiceProvider.GetRequiredService<FredSeriesRepository>();
+            unlinkedSeries = await seriesRepo
+                .GetAll()
+                .Where(s => s.FredReleaseId == null)
+                .ToListAsync(cancellationToken);
+        }
+
+        foreach (var series in unlinkedSeries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var record = await _fredClient.GetSeriesRelease(series.SeriesId);
+            if (record == null)
+            {
+                _logger.LogWarning(
+                    "FRED series {SeriesId} has no release in the API, skipping link",
+                    series.SeriesId
+                );
+                continue;
+            }
+
+            using var scope = _scopeFactory.CreateScope();
+            var releaseRepo = scope.ServiceProvider.GetRequiredService<FredReleaseRepository>();
+            var seriesRepo = scope.ServiceProvider.GetRequiredService<FredSeriesRepository>();
+
+            var release = await releaseRepo
+                .GetByReleaseId(record.Id)
+                .FirstOrDefaultAsync(cancellationToken);
+            if (release == null)
+            {
+                release = new FredRelease
+                {
+                    ReleaseId = record.Id,
+                    Name = record.Name,
+                    Link = record.Link,
+                    PressRelease = record.PressRelease,
+                };
+                releaseRepo.Add(release);
+                await releaseRepo.SaveChanges();
+
+                _logger.LogInformation(
+                    "Created FRED release {ReleaseId} ({Name})",
+                    release.ReleaseId,
+                    release.Name
+                );
+            }
+
+            var dbSeries = await seriesRepo.Get(series.Id);
+            dbSeries.FredReleaseId = release.Id;
+            await seriesRepo.SaveChanges();
+
+            _logger.LogDebug(
+                "Linked FRED series {SeriesId} to release {ReleaseId} ({Name})",
+                series.SeriesId,
+                release.ReleaseId,
+                release.Name
+            );
+        }
+    }
+
+    private async Task ImportReleaseDates(CancellationToken cancellationToken)
+    {
+        Dictionary<int, Guid> trackedReleases;
+        using (var scope = _scopeFactory.CreateScope())
+        {
+            var releaseRepo = scope.ServiceProvider.GetRequiredService<FredReleaseRepository>();
+            trackedReleases = await releaseRepo
+                .GetAll()
+                .ToDictionaryAsync(r => r.ReleaseId, r => r.Id, cancellationToken);
+        }
+
+        if (trackedReleases.Count == 0)
+        {
+            _logger.LogDebug("No FRED releases tracked yet, skipping release-date import");
+            return;
+        }
+
+        var records = await _fredClient.GetReleaseDates();
+
+        // The endpoint returns dates for every FRED release; keep only the ones
+        // belonging to releases our series actually link to.
+        var parsed = new List<(Guid ReleaseId, DateOnly Date)>();
+        foreach (var record in records)
+        {
+            if (!trackedReleases.TryGetValue(record.ReleaseId, out var releaseId))
+                continue;
+            if (
+                !DateOnly.TryParse(
+                    record.Date,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var date
+                )
+            )
+                continue;
+            parsed.Add((releaseId, date));
+        }
+
+        if (parsed.Count == 0)
+        {
+            _logger.LogDebug("No FRED release dates for tracked releases");
+            return;
+        }
+
+        var minDate = parsed.Min(p => p.Date);
+        var maxDate = parsed.Max(p => p.Date);
+
+        HashSet<(Guid, DateOnly)> existing;
+        using (var scope = _scopeFactory.CreateScope())
+        {
+            var dateRepo = scope.ServiceProvider.GetRequiredService<FredReleaseDateRepository>();
+            existing = (
+                await dateRepo
+                    .GetInRange(minDate, maxDate)
+                    .Select(d => new { d.FredReleaseId, d.Date })
+                    .ToListAsync(cancellationToken)
+            )
+                .Select(d => (d.FredReleaseId, d.Date))
+                .ToHashSet();
+        }
+
+        var newDates = parsed
+            .Where(p => !existing.Contains((p.ReleaseId, p.Date)))
+            .Distinct()
+            .Select(p => new FredReleaseDate { FredReleaseId = p.ReleaseId, Date = p.Date })
+            .ToList();
+
+        var totalInserted = await BatchPersister.Persist<
+            FredReleaseDate,
+            FredReleaseDateRepository
+        >(newDates, InsertBatchSize, _scopeFactory);
+
+        _logger.LogInformation(
+            "Imported {Count} FRED release dates across {Releases} tracked releases",
+            totalInserted,
+            trackedReleases.Count
+        );
+    }
+}

--- a/tests/Equibles.IntegrationTests/Fred/FredReleaseCalendarImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Fred/FredReleaseCalendarImportServiceTests.cs
@@ -1,0 +1,182 @@
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Fred.Data;
+using Equibles.Fred.Data.Models;
+using Equibles.Fred.HostedService.Services;
+using Equibles.Fred.Repositories;
+using Equibles.Integrations.Fred.Contracts;
+using Equibles.Integrations.Fred.Models;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Fred;
+
+/// <summary>
+/// The release-calendar importer has two jobs: link every stored series to its
+/// FRED release (creating the release once, even when several series share it)
+/// and persist the scheduled/realized dates of tracked releases only. Pin both,
+/// plus the dedup against already-stored dates — re-inserting would violate the
+/// (release, date) unique index on every cycle after the first.
+/// </summary>
+public class FredReleaseCalendarImportServiceTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly FredSeriesRepository _seriesRepo;
+    private readonly FredReleaseRepository _releaseRepo;
+    private readonly FredReleaseDateRepository _dateRepo;
+    private readonly IFredClient _fredClient;
+    private readonly FredReleaseCalendarImportService _sut;
+
+    public FredReleaseCalendarImportServiceTests()
+    {
+        _dbContext = TestDbContextFactory.Create(new FredModuleConfiguration());
+        _seriesRepo = new FredSeriesRepository(_dbContext);
+        _releaseRepo = new FredReleaseRepository(_dbContext);
+        _dateRepo = new FredReleaseDateRepository(_dbContext);
+        _fredClient = Substitute.For<IFredClient>();
+
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(FredSeriesRepository), _seriesRepo),
+            (typeof(FredReleaseRepository), _releaseRepo),
+            (typeof(FredReleaseDateRepository), _dateRepo)
+        );
+        _sut = new FredReleaseCalendarImportService(
+            scopeFactory,
+            Substitute.For<ILogger<FredReleaseCalendarImportService>>(),
+            _fredClient,
+            Substitute.For<ErrorReporter>(
+                Substitute.For<Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task Import_TwoSeriesSharingARelease_CreatesOneReleaseAndKeepsOnlyTrackedDates()
+    {
+        _seriesRepo.Add(new FredSeries { SeriesId = "CPIAUCSL", Title = "CPI All Items" });
+        _seriesRepo.Add(new FredSeries { SeriesId = "CPILFESL", Title = "CPI Core" });
+        await _seriesRepo.SaveChanges();
+
+        var cpiRelease = new FredReleaseRecord
+        {
+            Id = 10,
+            Name = "Consumer Price Index",
+            PressRelease = true,
+            Link = "http://www.bls.gov/cpi/",
+        };
+        _fredClient.GetSeriesRelease("CPIAUCSL").Returns(Task.FromResult(cpiRelease));
+        _fredClient.GetSeriesRelease("CPILFESL").Returns(Task.FromResult(cpiRelease));
+        _fredClient
+            .GetReleaseDates(Arg.Any<DateOnly?>())
+            .Returns(
+                Task.FromResult(
+                    new List<FredReleaseDateRecord>
+                    {
+                        new()
+                        {
+                            ReleaseId = 10,
+                            ReleaseName = "Consumer Price Index",
+                            Date = "2026-06-11",
+                        },
+                        new()
+                        {
+                            ReleaseId = 10,
+                            ReleaseName = "Consumer Price Index",
+                            Date = "2026-07-14",
+                        },
+                        // Untracked release — no series of ours links to it.
+                        new()
+                        {
+                            ReleaseId = 99,
+                            ReleaseName = "Some Other Release",
+                            Date = "2026-06-12",
+                        },
+                        // Malformed date — must be skipped, not crash the cycle.
+                        new()
+                        {
+                            ReleaseId = 10,
+                            ReleaseName = "Consumer Price Index",
+                            Date = "not-a-date",
+                        },
+                    }
+                )
+            );
+
+        await _sut.Import(CancellationToken.None);
+
+        var releases = _releaseRepo.GetAll().ToList();
+        releases.Should().HaveCount(1, "both series share FRED release 10");
+        releases[0].ReleaseId.Should().Be(10);
+        releases[0].Name.Should().Be("Consumer Price Index");
+        releases[0].PressRelease.Should().BeTrue();
+
+        var series = _seriesRepo.GetAll().ToList();
+        series.Should().OnlyContain(s => s.FredReleaseId == releases[0].Id);
+
+        var dates = _dateRepo.GetAll().ToList();
+        dates.Should().HaveCount(2, "only tracked releases' parseable dates are stored");
+        dates
+            .Select(d => d.Date)
+            .Should()
+            .BeEquivalentTo([new DateOnly(2026, 6, 11), new DateOnly(2026, 7, 14)]);
+        dates.Should().OnlyContain(d => d.FredReleaseId == releases[0].Id);
+    }
+
+    [Fact]
+    public async Task Import_DateAlreadyStored_InsertsOnlyTheNewDate()
+    {
+        var release = new FredRelease { ReleaseId = 10, Name = "Consumer Price Index" };
+        _releaseRepo.Add(release);
+        await _releaseRepo.SaveChanges();
+        _seriesRepo.Add(
+            new FredSeries
+            {
+                SeriesId = "CPIAUCSL",
+                Title = "CPI All Items",
+                FredReleaseId = release.Id,
+            }
+        );
+        await _seriesRepo.SaveChanges();
+        _dateRepo.Add(new FredReleaseDate { FredReleaseId = release.Id, Date = new(2026, 6, 11) });
+        await _dateRepo.SaveChanges();
+
+        _fredClient
+            .GetReleaseDates(Arg.Any<DateOnly?>())
+            .Returns(
+                Task.FromResult(
+                    new List<FredReleaseDateRecord>
+                    {
+                        new()
+                        {
+                            ReleaseId = 10,
+                            ReleaseName = "Consumer Price Index",
+                            Date = "2026-06-11",
+                        },
+                        new()
+                        {
+                            ReleaseId = 10,
+                            ReleaseName = "Consumer Price Index",
+                            Date = "2026-07-14",
+                        },
+                    }
+                )
+            );
+
+        await _sut.Import(CancellationToken.None);
+
+        // Every series is already linked, so no series/release lookups happen.
+        await _fredClient.DidNotReceive().GetSeriesRelease(Arg.Any<string>());
+
+        var dates = _dateRepo.GetAll().ToList();
+        dates.Should().HaveCount(2, "the already-stored date must not be duplicated");
+        dates
+            .Select(d => d.Date)
+            .Should()
+            .BeEquivalentTo([new DateOnly(2026, 6, 11), new DateOnly(2026, 7, 14)]);
+    }
+}


### PR DESCRIPTION
## Summary

Second of three release-calendar PRs (model/client landed in #3647). The FRED scraper now also imports the release calendar each cycle: every stored series gets linked to its parent FRED release, and the scheduled + realized publication dates of tracked releases are persisted — including future dates, which is what makes a forward-looking economic calendar possible.

## Code changes

- `Equibles.Fred.HostedService`: new `FredReleaseCalendarImportService` (`IImporter`) — links unlinked series via `GetSeriesRelease` (creating each shared `FredRelease` once), then fetches `GetReleaseDates`, keeps only tracked releases' parseable dates, dedups against stored `(release, date)` pairs and batch-inserts the rest.
- `FredScraperWorker.DoWork` runs the calendar import after the observation import.
- Tests: shared-release linking + untracked/malformed-date filtering, and incremental-cycle dedup (2 tests, suite at 63 green).