### PR TITLE
feat(fred-mcp): add GetEconomicCalendar tool

### DIFF
--- a/src/Equibles.Fred.Mcp/Tools/FredTools.cs
+++ b/src/Equibles.Fred.Mcp/Tools/FredTools.cs
@@ -17,17 +17,20 @@ public class FredTools
 {
     private readonly FredSeriesRepository _seriesRepository;
     private readonly FredObservationRepository _observationRepository;
+    private readonly FredReleaseDateRepository _releaseDateRepository;
     private readonly McpToolRunner _runner;
 
     public FredTools(
         FredSeriesRepository seriesRepository,
         FredObservationRepository observationRepository,
+        FredReleaseDateRepository releaseDateRepository,
         ErrorManager errorManager,
         ILogger<FredTools> logger
     )
     {
         _seriesRepository = seriesRepository;
         _observationRepository = observationRepository;
+        _releaseDateRepository = releaseDateRepository;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -201,6 +204,59 @@ public class FredTools
             },
             "SearchEconomicIndicators",
             $"query: {query}"
+        );
+    }
+
+    [McpServerTool(Name = "GetEconomicCalendar")]
+    [Description(
+        "Get the economic release calendar — scheduled (upcoming) and recent publication dates of US macro data releases (CPI, Employment Situation, GDP, and the other tracked indicators), with the FRED series each release updates. Defaults to the next 30 days. Use GetEconomicIndicator to fetch a series' data after it prints."
+    )]
+    public Task<string> GetEconomicCalendar(
+        [Description("Start date in YYYY-MM-DD format (defaults to today, UTC)")]
+            string startDate = null,
+        [Description("End date in YYYY-MM-DD format (defaults to 30 days after the start date)")]
+            string endDate = null,
+        [Description("Maximum number of release dates to return (default: 100, chronological)")]
+            int maxResults = 100
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var today = DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = McpToolExecutor.ParseDateOr(startDate, today);
+                var end = McpToolExecutor.ParseDateOr(endDate, start.AddDays(30));
+
+                maxResults = McpLimit.Clamp(maxResults);
+
+                var entries = await _releaseDateRepository
+                    .GetInRange(start, end)
+                    .OrderBy(d => d.Date)
+                    .ThenBy(d => d.FredRelease.Name)
+                    .Take(maxResults)
+                    .Select(d => new
+                    {
+                        d.Date,
+                        ReleaseName = d.FredRelease.Name,
+                        Series = d
+                            .FredRelease.Series.OrderBy(s => s.SeriesId)
+                            .Select(s => s.SeriesId)
+                            .ToList(),
+                    })
+                    .ToListAsync();
+
+                return MarkdownTable.Render(
+                    entries,
+                    $"No economic releases between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
+                    $"Economic release calendar ({start:yyyy-MM-dd} to {end:yyyy-MM-dd}):",
+                    "| Date | Release | Series Updated |",
+                    "|------|---------|----------------|",
+                    e =>
+                        $"| {e.Date:yyyy-MM-dd} | {e.ReleaseName} | {string.Join(", ", e.Series)} |"
+                );
+            },
+            "GetEconomicCalendar",
+            $"startDate: {startDate}, endDate: {endDate}"
         );
     }
 }

--- a/tests/Equibles.IntegrationTests/Mcp/FredToolsGetEconomicCalendarTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FredToolsGetEconomicCalendarTests.cs
@@ -1,0 +1,107 @@
+using Equibles.Fred.Data.Models;
+using Equibles.Fred.Mcp.Tools;
+using Equibles.Fred.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// GetEconomicCalendar renders the stored FRED release calendar. Pin the core
+/// contract: dates inside the requested range render chronologically with the
+/// release name and the series the release updates, dates outside the range
+/// are excluded, and an empty range returns the no-data message instead of an
+/// empty table.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FredToolsGetEconomicCalendarTests : ParadeDbMcpTestBase
+{
+    private FredRelease _cpiRelease;
+    private FredRelease _employmentRelease;
+
+    public FredToolsGetEconomicCalendarTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private FredTools Sut() =>
+        new(
+            new FredSeriesRepository(DbContext),
+            new FredObservationRepository(DbContext),
+            new FredReleaseDateRepository(DbContext),
+            ErrorManager,
+            NullLogger<FredTools>()
+        );
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        _cpiRelease = new FredRelease { ReleaseId = 10, Name = "Consumer Price Index" };
+        _employmentRelease = new FredRelease { ReleaseId = 50, Name = "Employment Situation" };
+        DbContext.Set<FredRelease>().AddRange(_cpiRelease, _employmentRelease);
+
+        DbContext
+            .Set<FredSeries>()
+            .AddRange(
+                new FredSeries
+                {
+                    SeriesId = "CPIAUCSL",
+                    Title = "Consumer Price Index for All Urban Consumers",
+                    Category = FredSeriesCategory.Inflation,
+                    FredReleaseId = _cpiRelease.Id,
+                },
+                new FredSeries
+                {
+                    SeriesId = "CPILFESL",
+                    Title = "CPI Less Food and Energy",
+                    Category = FredSeriesCategory.Inflation,
+                    FredReleaseId = _cpiRelease.Id,
+                },
+                new FredSeries
+                {
+                    SeriesId = "UNRATE",
+                    Title = "Unemployment Rate",
+                    Category = FredSeriesCategory.Employment,
+                    FredReleaseId = _employmentRelease.Id,
+                }
+            );
+
+        DbContext
+            .Set<FredReleaseDate>()
+            .AddRange(
+                new FredReleaseDate
+                {
+                    FredReleaseId = _employmentRelease.Id,
+                    Date = new(2026, 6, 5),
+                },
+                new FredReleaseDate { FredReleaseId = _cpiRelease.Id, Date = new(2026, 6, 11) },
+                // Outside the queried range — must not render.
+                new FredReleaseDate { FredReleaseId = _cpiRelease.Id, Date = new(2026, 8, 12) }
+            );
+
+        await DbContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetEconomicCalendar_RangeWithReleases_RendersChronologicalRowsWithSeries()
+    {
+        var result = await Sut().GetEconomicCalendar("2026-06-01", "2026-06-30");
+
+        result.Should().Contain("| 2026-06-05 | Employment Situation | UNRATE |");
+        result.Should().Contain("| 2026-06-11 | Consumer Price Index | CPIAUCSL, CPILFESL |");
+        result.Should().NotContain("2026-08-12");
+
+        // Chronological: the employment print comes before the CPI print.
+        result
+            .IndexOf("Employment Situation", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(result.IndexOf("Consumer Price Index", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetEconomicCalendar_EmptyRange_ReturnsNoDataMessage()
+    {
+        var result = await Sut().GetEconomicCalendar("2026-09-01", "2026-09-30");
+
+        result.Should().Contain("No economic releases between 2026-09-01 and 2026-09-30.");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/FredToolsGetEconomicIndicatorCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FredToolsGetEconomicIndicatorCultureInvarianceTests.cs
@@ -14,6 +14,7 @@ public class FredToolsGetEconomicIndicatorCultureInvarianceTests : ParadeDbMcpTe
         new(
             new FredSeriesRepository(DbContext),
             new FredObservationRepository(DbContext),
+            new FredReleaseDateRepository(DbContext),
             ErrorManager,
             NullLogger<FredTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/FredToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/FredToolsTests.cs
@@ -20,6 +20,7 @@ public class FredToolsTests : ParadeDbMcpTestBase
         new(
             new FredSeriesRepository(DbContext),
             new FredObservationRepository(DbContext),
+            new FredReleaseDateRepository(DbContext),
             ErrorManager,
             NullLogger<FredTools>()
         );


### PR DESCRIPTION
## Summary

Final OSS PR of the release-calendar series (#3647 model/client, #3648 importer). Adds a `GetEconomicCalendar` MCP tool so agents can ask what macro prints are coming: scheduled and recent release dates with the FRED series each release updates.

## Code changes

- `Equibles.Fred.Mcp/Tools/FredTools.cs`: new `GetEconomicCalendar(startDate, endDate, maxResults)` — defaults to the next 30 days from today (UTC), renders a chronological markdown table of date / release / series; constructor gains `FredReleaseDateRepository`.
- Tests: range filtering + chronological render with shared-release series lists, and the empty-range message; existing FredTools test fixtures updated for the new constructor (27 green).