### PR TITLE
fix(finra): drop FINRA's zero-volume days-to-cover sentinel from the squeeze score

### DIFF
--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -81,7 +81,15 @@ public class ShortSqueezeScoreManager
             }
 
             var daysToCover = shortInterest.DaysToCover;
-            if (daysToCover == null && shortInterest.AverageDailyVolume > 0)
+            if (shortInterest.AverageDailyVolume == 0)
+            {
+                // FINRA reports days-to-cover as a 1000.0 sentinel when a listing has
+                // zero average daily volume — a division-by-zero placeholder, not a
+                // measurement. Drop the factor so untradeable shells aren't ranked as
+                // top squeeze risk on the sentinel alone.
+                daysToCover = null;
+            }
+            else if (daysToCover == null && shortInterest.AverageDailyVolume > 0)
             {
                 daysToCover =
                     shortInterest.CurrentShortPosition

--- a/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs
@@ -113,6 +113,39 @@ public class ShortSqueezeScoreManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task Compute_ZeroAverageDailyVolume_DropsDaysToCoverFactor()
+    {
+        // FINRA publishes days-to-cover as a 1000.0 sentinel when a listing has zero
+        // average daily volume — a division-by-zero placeholder, not a measurement.
+        // The factor must drop out (like a missing trend) so an untradeable shell
+        // can't outrank genuinely squeezed stocks on the sentinel alone.
+        var shell = SeedStock("SHEL", sharesOutstanding: 2_000_000);
+        var real = SeedStock("REAL", sharesOutstanding: 1_000_000);
+        _dbContext
+            .Set<ShortInterest>()
+            .Add(
+                new ShortInterest
+                {
+                    CommonStockId = shell.Id,
+                    SettlementDate = SettlementDate,
+                    CurrentShortPosition = 200_000,
+                    AverageDailyVolume = 0,
+                    DaysToCover = 1000m,
+                }
+            );
+        SeedShortInterest(real, shortPosition: 300_000, daysToCover: 12m);
+        await _dbContext.SaveChangesAsync();
+
+        var scores = await _manager.Compute();
+
+        var sentinel = scores.Single(s => s.Ticker == "SHEL");
+        sentinel.DaysToCover.Should().BeNull("a zero-volume sentinel is not a measurement");
+        sentinel.DaysToCoverPercentile.Should().BeNull();
+        // REAL leads on every remaining factor, so it must outrank the shell.
+        scores.Select(s => s.Ticker).Should().Equal("REAL", "SHEL");
+    }
+
+    [Fact]
     public async Task Compute_NoShortInterestData_ReturnsEmpty()
     {
         var scores = await _manager.Compute();


### PR DESCRIPTION
## Summary

- FINRA publishes `daysToCoverQuantity` as a `1000.0` sentinel when a listing has zero average daily volume — a division-by-zero placeholder, not a measurement. The squeeze score fed it into the days-to-cover percentile as-is, so completely untradeable shells ranked in the top 10 squeeze candidates (observed in production: PC at #9 with score 94 on 9.8% short interest, carried entirely by the sentinel).
- `ShortSqueezeScoreManager` now nulls the days-to-cover factor when `AverageDailyVolume == 0`, so the factor drops out of the composite the same way a missing short-volume trend already does. Rows with a null (unreported) average daily volume keep their reported days-to-cover unchanged.

## Code changes

- `src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs` — zero-ADV guard nulls `daysToCover` before scoring.
- `tests/Equibles.IntegrationTests/Finra/ShortSqueezeScoreManagerTests.cs` — regression test: a zero-ADV sentinel row scores with a null days-to-cover factor and ranks below a genuinely squeezed stock (failed before the fix, found 1000).