### PR TITLE
fix(holdings): collapse filing summaries to one row per accession before upsert

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -1049,7 +1049,20 @@ public class HoldingsImportService
             })
             .ToListAsync(cancellationToken);
 
+        // The upsert conflicts on AccessionNumber alone, and Postgres rejects a
+        // statement that touches the same conflict key twice (21000). An accession
+        // whose holdings rows disagree on grouping metadata (mixed amendment flag,
+        // inconsistent dates) yields several groups, so collapse to the dominant
+        // variant per accession instead of aborting the whole data set.
         var summaries = rows.Where(r => affected.Contains((r.InstitutionalHolderId, r.ReportDate)))
+            .GroupBy(r => r.AccessionNumber, StringComparer.Ordinal)
+            .Select(g =>
+                g.OrderByDescending(r => r.PositionCount)
+                    .ThenByDescending(r => r.FilingDate)
+                    .ThenByDescending(r => r.ReportDate)
+                    .ThenByDescending(r => r.IsAmendment)
+                    .First()
+            )
             .Select(r => new InstitutionalFiling
             {
                 AccessionNumber = r.AccessionNumber,

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceSyncFilingSummariesDuplicateAccessionTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceSyncFilingSummariesDuplicateAccessionTests.cs
@@ -1,0 +1,125 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.Configuration;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Contract for the filing-summary sync: <see cref="InstitutionalFiling"/> holds one
+/// row per accession, so when an accession's holdings rows disagree on grouping
+/// metadata (e.g. a mixed amendment flag), the sync must still produce exactly one
+/// summary row instead of handing the upsert two rows with the same conflict key —
+/// PostgreSQL rejects that with 21000 ("ON CONFLICT DO UPDATE command cannot affect
+/// row a second time") and the whole data set import aborts.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsImportServiceSyncFilingSummariesDuplicateAccessionTests : IAsyncLifetime
+{
+    private const string Accession = "0001234567-26-000123";
+    private const string Cik = "1234567";
+    private static readonly DateOnly ReportDate = new(2026, 3, 31);
+
+    private readonly ParadeDbFixture _fixture;
+
+    public HoldingsImportServiceSyncFilingSummariesDuplicateAccessionTests(
+        ParadeDbFixture fixture
+    ) => _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task SyncFilingSummaries_AccessionWithMixedAmendmentFlag_UpsertsSingleSummaryRow()
+    {
+        var holder = new InstitutionalHolder { Cik = Cik, Name = "Test Capital" };
+        var stock = new CommonStock { Ticker = "TST", Name = "Test Corp" };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Add(holder);
+            seed.Add(stock);
+            // Distinct ShareType keeps the rows clear of the holdings unique index;
+            // the mixed amendment flag is what splits the summary GROUP BY.
+            seed.Add(MakeHolding(holder, stock, ShareType.Shares, isAmendment: false, value: 100));
+            seed.Add(
+                MakeHolding(holder, stock, ShareType.Principal, isAmendment: true, value: 200)
+            );
+            await seed.SaveChangesAsync();
+        }
+
+        var context = new ImportContext
+        {
+            Submissions = new Dictionary<string, SubmissionRow>
+            {
+                [Accession] = new SubmissionRow
+                {
+                    AccessionNumber = Accession,
+                    Cik = Cik,
+                    PeriodOfReport = "2026-03-31",
+                },
+            },
+            CikToHolderId = new Dictionary<string, Guid> { [Cik] = holder.Id },
+        };
+
+        var act = async () => await InvokeSyncFilingSummaries(context);
+
+        await act.Should().NotThrowAsync();
+        await using var verify = _fixture.CreateDbContext();
+        var summaries = await verify
+            .Set<InstitutionalFiling>()
+            .Where(f => f.AccessionNumber == Accession)
+            .ToListAsync();
+        summaries.Should().ContainSingle();
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        InstitutionalHolder holder,
+        CommonStock stock,
+        ShareType shareType,
+        bool isAmendment,
+        long value
+    ) =>
+        new InstitutionalHolding
+        {
+            InstitutionalHolderId = holder.Id,
+            CommonStockId = stock.Id,
+            AccessionNumber = Accession,
+            FilingDate = new DateOnly(2026, 5, 15),
+            ReportDate = ReportDate,
+            IsAmendment = isAmendment,
+            Value = value,
+            Shares = 10,
+            ShareType = shareType,
+            FilingType = FilingType.Form13F,
+        };
+
+    private async Task InvokeSyncFilingSummaries(ImportContext context)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => _fixture.CreateDbContext());
+        await using var provider = services.BuildServiceProvider();
+
+        var service = new HoldingsImportService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<HoldingsImportService>.Instance,
+            Options.Create(new WorkerOptions()),
+            stockPriceProvider: null,
+            bus: null
+        );
+
+        var method = typeof(HoldingsImportService).GetMethod(
+            "SyncFilingSummaries",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        method.Should().NotBeNull();
+        await (Task)method.Invoke(service, [context, CancellationToken.None]);
+    }
+}


### PR DESCRIPTION
## Summary

- `SyncFilingSummaries` groups holdings by `(AccessionNumber, InstitutionalHolderId, FilingDate, ReportDate, IsAmendment)` but upserts with `.On(f => f.AccessionNumber)`. An accession whose rows disagree on any other grouping column (e.g. a mixed amendment flag in a bulk TSV) produced two summary rows with the same conflict key, PostgreSQL rejected the statement with `21000: ON CONFLICT DO UPDATE command cannot affect row a second time`, and the whole data set import was skipped. This hit production on the `01mar2026-31may2026_form13f.zip` bulk set.
- The summaries now collapse to the dominant variant per accession (most positions, then latest filing/report date, amendment last) before the upsert, so one metadata-inconsistent filing can no longer abort the quarterly import.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs` — group the summary rows by accession and pick a deterministic winner before `UpsertRange`.
- `tests/Equibles.IntegrationTests/Holdings/HoldingsImportServiceSyncFilingSummariesDuplicateAccessionTests.cs` — ParadeDB regression test seeding one accession with a mixed amendment flag; fails with the 21000 before the fix, asserts a single `InstitutionalFiling` row after.