### PR TITLE
feat(congress): annual financial disclosure data model with net-worth band rollup

### DIFF
--- a/src/Equibles.Congress.Data/CongressModuleConfiguration.cs
+++ b/src/Equibles.Congress.Data/CongressModuleConfiguration.cs
@@ -9,5 +9,7 @@ public class CongressModuleConfiguration : Equibles.Data.IFinancialModule
     {
         builder.Entity<CongressMember>();
         builder.Entity<CongressionalTrade>();
+        builder.Entity<CongressionalAnnualDisclosure>();
+        builder.Entity<CongressionalDisclosureLine>();
     }
 }

--- a/src/Equibles.Congress.Data/Models/CongressMember.cs
+++ b/src/Equibles.Congress.Data/Models/CongressMember.cs
@@ -17,5 +17,7 @@ public class CongressMember
 
     public virtual List<CongressionalTrade> Trades { get; set; } = [];
 
+    public virtual List<CongressionalAnnualDisclosure> AnnualDisclosures { get; set; } = [];
+
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 }

--- a/src/Equibles.Congress.Data/Models/CongressionalAnnualDisclosure.cs
+++ b/src/Equibles.Congress.Data/Models/CongressionalAnnualDisclosure.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Congress.Data.Models;
+
+/// <summary>
+/// One member's annual financial disclosure (Form A / eFD annual report) for one
+/// calendar year, ingested from electronically-filed reports only — scanned
+/// paper filings are never parsed, so a missing (member, year) row means "no
+/// electronic filing", not zero net worth. Disclosed values are ranges; the
+/// rollup is a band: <see cref="NetWorthMinimum"/> sums asset minimums minus
+/// liability maximums, <see cref="NetWorthMaximum"/> asset maximums minus
+/// liability minimums. Amendments replace the year's report in place — the
+/// latest filed report is the one represented here.
+/// </summary>
+[Index(nameof(CongressMemberId), nameof(Year), IsUnique = true)]
+[Index(nameof(Year))]
+public class CongressionalAnnualDisclosure
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CongressMemberId { get; set; }
+    public virtual CongressMember CongressMember { get; set; }
+
+    /// <summary>The calendar year the report covers (not the filing year).</summary>
+    public int Year { get; set; }
+
+    public DateOnly FiledDate { get; set; }
+
+    /// <summary>
+    /// The source system's identifier for the filed report (House Clerk DocID /
+    /// Senate eFD report id) — the provenance pointer for the stored lines.
+    /// </summary>
+    [Required]
+    [MaxLength(64)]
+    public string ReportId { get; set; }
+
+    /// <summary>Lower bound of the net-worth band, in dollars.</summary>
+    public long NetWorthMinimum { get; set; }
+
+    /// <summary>Upper bound of the net-worth band, in dollars.</summary>
+    public long NetWorthMaximum { get; set; }
+
+    public virtual List<CongressionalDisclosureLine> Lines { get; set; } = [];
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Congress.Data/Models/CongressionalDisclosureLine.cs
+++ b/src/Equibles.Congress.Data/Models/CongressionalDisclosureLine.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Congress.Data.Models;
+
+/// <summary>
+/// One asset or liability row of an annual disclosure, kept at the disclosed
+/// grain: a free-text description and the checked value range. Ranges are the
+/// form's own brackets ($1,000,001–$5,000,000); no point estimate is derived
+/// at this level.
+/// </summary>
+[Index(nameof(CongressionalAnnualDisclosureId))]
+public class CongressionalDisclosureLine
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CongressionalAnnualDisclosureId { get; set; }
+    public virtual CongressionalAnnualDisclosure CongressionalAnnualDisclosure { get; set; }
+
+    public CongressionalDisclosureLineKind Kind { get; set; }
+
+    [Required]
+    [MaxLength(512)]
+    public string Description { get; set; }
+
+    /// <summary>Lower bound of the disclosed range, in dollars.</summary>
+    public long RangeMinimum { get; set; }
+
+    /// <summary>Upper bound of the disclosed range, in dollars.</summary>
+    public long RangeMaximum { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.Congress.Data/Models/CongressionalDisclosureLineKind.cs
+++ b/src/Equibles.Congress.Data/Models/CongressionalDisclosureLineKind.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.Congress.Data.Models;
+
+public enum CongressionalDisclosureLineKind
+{
+    [Display(Name = "Asset")]
+    Asset,
+
+    [Display(Name = "Liability")]
+    Liability,
+}

--- a/src/Equibles.Congress.Repositories/CongressionalAnnualDisclosureRepository.cs
+++ b/src/Equibles.Congress.Repositories/CongressionalAnnualDisclosureRepository.cs
@@ -1,0 +1,20 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Data;
+
+namespace Equibles.Congress.Repositories;
+
+public class CongressionalAnnualDisclosureRepository : BaseRepository<CongressionalAnnualDisclosure>
+{
+    public CongressionalAnnualDisclosureRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<CongressionalAnnualDisclosure> GetByMember(CongressMember member)
+    {
+        return GetAll().Where(d => d.CongressMemberId == member.Id);
+    }
+
+    public IQueryable<CongressionalAnnualDisclosure> GetByYear(int year)
+    {
+        return GetAll().Where(d => d.Year == year);
+    }
+}

--- a/src/Equibles.Migrations/Migrations/20260611015609_AddCongressionalAnnualDisclosures.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260611015609_AddCongressionalAnnualDisclosures.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611015609_AddCongressionalAnnualDisclosures")]
+    partial class AddCongressionalAnnualDisclosures
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260611015609_AddCongressionalAnnualDisclosures.cs
+++ b/src/Equibles.Migrations/Migrations/20260611015609_AddCongressionalAnnualDisclosures.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCongressionalAnnualDisclosures : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CongressionalAnnualDisclosure",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CongressMemberId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Year = table.Column<int>(type: "integer", nullable: false),
+                    FiledDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    ReportId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    NetWorthMinimum = table.Column<long>(type: "bigint", nullable: false),
+                    NetWorthMaximum = table.Column<long>(type: "bigint", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CongressionalAnnualDisclosure", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CongressionalAnnualDisclosure_CongressMember_CongressMember~",
+                        column: x => x.CongressMemberId,
+                        principalTable: "CongressMember",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CongressionalDisclosureLine",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CongressionalAnnualDisclosureId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Kind = table.Column<int>(type: "integer", nullable: false),
+                    Description = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    RangeMinimum = table.Column<long>(type: "bigint", nullable: false),
+                    RangeMaximum = table.Column<long>(type: "bigint", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CongressionalDisclosureLine", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CongressionalDisclosureLine_CongressionalAnnualDisclosure_C~",
+                        column: x => x.CongressionalAnnualDisclosureId,
+                        principalTable: "CongressionalAnnualDisclosure",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CongressionalAnnualDisclosure_CongressMemberId_Year",
+                table: "CongressionalAnnualDisclosure",
+                columns: new[] { "CongressMemberId", "Year" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CongressionalAnnualDisclosure_Year",
+                table: "CongressionalAnnualDisclosure",
+                column: "Year");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CongressionalDisclosureLine_CongressionalAnnualDisclosureId",
+                table: "CongressionalDisclosureLine",
+                column: "CongressionalAnnualDisclosureId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CongressionalDisclosureLine");
+
+            migrationBuilder.DropTable(
+                name: "CongressionalAnnualDisclosure");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Data model for congressional annual financial disclosures (Form A / Senate eFD annual reports): `CongressionalAnnualDisclosure` — one electronically-filed report per member-year carrying the filed date, the source report id, and the net-worth band rollup (Σ asset minimums − Σ liability maximums through Σ asset maximums − Σ liability minimums) — plus `CongressionalDisclosureLine` keeping each asset/liability row at the disclosed range grain. Scanned paper filings are never stored, so a missing row means "no electronic filing", not zero.
- First slice of the net-worth tracker (EquiblesCommercial#2240); parsers and ingestion follow in their own PRs.

## Code changes

- `src/Equibles.Congress.Data/Models/` — `CongressionalAnnualDisclosure`, `CongressionalDisclosureLine`, `CongressionalDisclosureLineKind`; `AnnualDisclosures` navigation on `CongressMember`.
- `src/Equibles.Congress.Data/CongressModuleConfiguration.cs` — entity registration.
- `src/Equibles.Congress.Repositories/CongressionalAnnualDisclosureRepository.cs` — by-member and by-year queries.
- `src/Equibles.Migrations/Migrations/` — `AddCongressionalAnnualDisclosures` migration + snapshot.