### PR TITLE
test(congress): add skipped repro for annual report incomplete-range bug

### DIFF
--- a/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientIncompleteRangeTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientIncompleteRangeTests.cs
@@ -1,0 +1,38 @@
+using Equibles.Congress.HostedService.Services;
+using static Equibles.Congress.HostedService.Services.HouseAnnualReportClient;
+
+namespace Equibles.UnitTests.Congress;
+
+public class HouseAnnualReportClientIncompleteRangeTests
+{
+    private static List<ScheduleToken> Tokens(params (string text, double left)[] words) =>
+        words.Select(w => new ScheduleToken(w.text, w.left)).ToList();
+
+    [Fact(
+        Skip = "GH-3656 — incomplete range cell is emitted as a fabricated (0, X) bracket instead of being dropped"
+    )]
+    public void ParseScheduleLines_RangeUpperBoundNeverArrives_DropsTheRow()
+    {
+        // Line items must carry "the form's own brackets". A range cell that
+        // opens with "$1,000,001 -" whose wrapped upper bound never arrives
+        // (truncated document) is not a bracket the filer checked — the row
+        // must be dropped, not emitted as a fabricated (0, $1,000,001) range.
+        var result = HouseAnnualReportClient.ParseScheduleLines([
+            Tokens(("S", 22), ("A:", 92)),
+            Tokens(
+                ("Asset", 25),
+                ("Owner", 241),
+                ("Value", 280),
+                ("of", 311),
+                ("Asset", 323),
+                ("Income", 363),
+                ("Type(s)", 402),
+                ("Income", 445)
+            ),
+            Tokens(("Truncated", 25), ("Asset", 68), ("SP", 241), ("$1,000,001", 280), ("-", 329)),
+        ]);
+
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adversarial test against `HouseAnnualReportClient.ParseScheduleLines`: a Schedule A range cell that opens with "$1,000,001 -" whose wrapped upper bound never arrives must be dropped, not emitted as a fabricated (0, $1,000,001) bracket. The assertion fails today — tracked as #3656.

## Code changes

- `tests/Equibles.UnitTests/Congress/HouseAnnualReportClientIncompleteRangeTests.cs` — one token-level test, skipped — see GH-3656; un-skip as part of the fix.