### PR TITLE
feat(congress): parse Senate eFD annual reports

### DIFF
--- a/src/Equibles.Congress.HostedService/Models/SenateSearchResponse.cs
+++ b/src/Equibles.Congress.HostedService/Models/SenateSearchResponse.cs
@@ -1,0 +1,26 @@
+using Newtonsoft.Json;
+
+namespace Equibles.Congress.HostedService.Models;
+
+/// <summary>
+/// The eFD search endpoint's DataTables-style JSON envelope: each data row is
+/// a list of cell strings (first name, last name, office, report link HTML,
+/// date submitted).
+/// </summary>
+internal class SenateSearchResponse
+{
+    [JsonProperty("draw")]
+    public int Draw { get; set; }
+
+    [JsonProperty("recordsTotal")]
+    public int RecordsTotal { get; set; }
+
+    [JsonProperty("recordsFiltered")]
+    public int RecordsFiltered { get; set; }
+
+    [JsonProperty("data")]
+    public List<List<string>> Data { get; set; } = [];
+
+    [JsonProperty("result")]
+    public string Result { get; set; }
+}

--- a/src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs
@@ -1,0 +1,492 @@
+using System.Text.RegularExpressions;
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Core.AutoWiring;
+using Equibles.Integrations.Common.RateLimiter;
+using Equibles.Integrations.Common.Retry;
+using HtmlAgilityPack;
+using Newtonsoft.Json;
+using static Equibles.Congress.HostedService.Services.DisclosureParsingHelper;
+
+namespace Equibles.Congress.HostedService.Services;
+
+/// <summary>
+/// Searches and parses Senate eFD annual financial disclosure reports.
+/// Electronic filings render as HTML pages (Part 3 = assets, Part 7 =
+/// liabilities); scanned paper filings live under "/view/paper/" URLs and are
+/// skipped, so a missing report means "no electronic filing", not zero net
+/// worth. The coverage year and the amendment marker come from the search
+/// result's link text ("Annual Report for CY 2024 (Amendment 1)").
+/// </summary>
+[Service]
+public partial class SenateAnnualReportClient
+{
+    private static readonly IRateLimiter RateLimiter = new RateLimiter(
+        maxRequests: 5,
+        timeWindow: TimeSpan.FromSeconds(1)
+    );
+    private const int MaxRetries = 3;
+
+    private const string BaseUrl = "https://efdsearch.senate.gov";
+    private const string SearchDataUrl = BaseUrl + "/search/report/data/";
+    private const string AnnualReportTypeFilter = "[7]"; // Annual Report
+    private const string SenatorFilerTypeFilter = "[1]"; // Senator
+
+    private readonly ISenateBrowserSession _session;
+    private readonly ILogger<SenateAnnualReportClient> _logger;
+
+    public SenateAnnualReportClient(
+        ISenateBrowserSession session,
+        ILogger<SenateAnnualReportClient> logger
+    )
+    {
+        _session = session;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns every electronically-filed senator annual report submitted in
+    /// the window. Originals and amendments both appear; the caller keeps the
+    /// latest filed report per member-year.
+    /// </summary>
+    public async Task<List<AnnualDisclosureReport>> GetAnnualReports(
+        DateOnly submittedFrom,
+        DateOnly submittedTo,
+        CancellationToken ct
+    )
+    {
+        await _session.EnsureAuthenticated(ct);
+
+        var filings = await SearchAnnualReports(submittedFrom, submittedTo, ct);
+        _logger.LogInformation(
+            "Found {Count} Senate annual report filings submitted between {From} and {To}",
+            filings.Count,
+            submittedFrom,
+            submittedTo
+        );
+
+        var reports = new List<AnnualDisclosureReport>();
+
+        foreach (var filing in filings)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var report = await FetchAndParseReport(filing, ct);
+                if (report != null)
+                    reports.Add(report);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to parse Senate annual report for {Member} at {Url}",
+                    filing.MemberName,
+                    filing.ReportUrl
+                );
+            }
+        }
+
+        _logger.LogInformation(
+            "Parsed {Parsed} electronic Senate annual reports out of {Total} filings",
+            reports.Count,
+            filings.Count
+        );
+        return reports;
+    }
+
+    private async Task<List<SenateAnnualFiling>> SearchAnnualReports(
+        DateOnly from,
+        DateOnly to,
+        CancellationToken ct
+    )
+    {
+        var filings = new List<SenateAnnualFiling>();
+        var start = 0;
+        const int pageSize = 100;
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var formFields = new Dictionary<string, string>
+            {
+                ["report_types"] = AnnualReportTypeFilter,
+                ["filer_types"] = SenatorFilerTypeFilter,
+                ["submitted_start_date"] = $"{from:MM/dd/yyyy} 00:00:00",
+                ["submitted_end_date"] = $"{to:MM/dd/yyyy} 23:59:59",
+                ["first_name"] = "",
+                ["last_name"] = "",
+                ["senator_state"] = "",
+                ["start"] = start.ToString(),
+                ["length"] = pageSize.ToString(),
+            };
+
+            var json = await FetchWithRetry(SearchDataUrl, formFields, ct);
+            var result = JsonConvert.DeserializeObject<SenateSearchResponse>(json);
+
+            if (result?.Data == null || result.Data.Count == 0)
+                break;
+
+            foreach (var row in result.Data)
+            {
+                var filing = ParseSearchRow(row);
+                if (filing != null)
+                    filings.Add(filing);
+            }
+
+            _logger.LogDebug(
+                "Senate annual report search: fetched {Start}-{End} of {Total}",
+                start,
+                start + result.Data.Count,
+                result.RecordsTotal
+            );
+
+            start += pageSize;
+            if (start >= result.RecordsTotal)
+                break;
+        }
+
+        return filings;
+    }
+
+    internal static SenateAnnualFiling ParseSearchRow(List<string> row)
+    {
+        if (row.Count < 5)
+            return null;
+
+        var firstName = row[0]?.Trim() ?? "";
+        var lastName = row[1]?.Trim() ?? "";
+        var memberName = $"{firstName} {lastName}".Trim();
+        if (string.IsNullOrEmpty(memberName))
+            return null;
+
+        var linkHtml = row[3] ?? "";
+        var hrefMatch = HrefRegex().Match(linkHtml);
+        if (!hrefMatch.Success)
+            return null;
+
+        // The coverage year and the amendment marker only exist in the link
+        // text; rows that are not annual reports (e.g. candidate reports under
+        // the same report-type filter) never match.
+        var titleMatch = AnnualReportTitleRegex().Match(linkHtml);
+        if (!titleMatch.Success)
+            return null;
+
+        var reportPath = hrefMatch.Groups[1].Value;
+        var reportUrl = reportPath.StartsWith("http") ? reportPath : BaseUrl + reportPath;
+
+        if (!IsValidDisclosureUrl(reportUrl, BaseUrl))
+            return null;
+
+        // Skip paper filings (scanned images) — only HTML electronic filings
+        // are parseable.
+        if (reportUrl.Contains("/view/paper/", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        // eFD dates are US-format MM/dd/yyyy — parse culture-pinned, not with
+        // the host culture.
+        var dateSubmitted = ParseDate(row[4]?.Trim());
+        if (dateSubmitted == null)
+            return null;
+
+        return new SenateAnnualFiling(
+            memberName,
+            reportUrl,
+            int.Parse(titleMatch.Groups[1].Value),
+            dateSubmitted.Value,
+            titleMatch.Groups[2].Success
+        );
+    }
+
+    private async Task<AnnualDisclosureReport> FetchAndParseReport(
+        SenateAnnualFiling filing,
+        CancellationToken ct
+    )
+    {
+        var html = await FetchWithRetry(filing.ReportUrl, ct: ct);
+        var lines = ParseAnnualReportHtml(html);
+
+        if (lines == null)
+        {
+            _logger.LogWarning(
+                "Senate annual report at {Url} has no recognizable schedule layout; skipping",
+                filing.ReportUrl
+            );
+            return null;
+        }
+
+        return new AnnualDisclosureReport
+        {
+            MemberName = filing.MemberName,
+            Position = CongressPosition.Senator,
+            Year = filing.Year,
+            FiledDate = filing.DateSubmitted,
+            ReportId = ExtractReportId(filing.ReportUrl),
+            IsAmendment = filing.IsAmendment,
+            Lines = lines,
+        };
+    }
+
+    // The eFD report id is the GUID path segment: /search/view/annual/{id}/.
+    internal static string ExtractReportId(string reportUrl) =>
+        reportUrl.TrimEnd('/').Split('/')[^1];
+
+    /// <summary>
+    /// Parses the Part 3 (assets) and Part 7 (liabilities) tables out of an
+    /// e-filed annual report page. Returns null when the page carries no
+    /// "Part 3. Assets" heading — an unrecognized layout that must never be
+    /// read as a zero-asset report.
+    /// </summary>
+    internal static List<AnnualDisclosureLineItem> ParseAnnualReportHtml(string html)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        if (!doc.DocumentNode.InnerText.Contains("Part 3. Assets"))
+            return null;
+
+        var items = new List<AnnualDisclosureLineItem>();
+        var tables = doc.DocumentNode.SelectNodes("//table");
+        if (tables == null)
+            return items;
+
+        foreach (var table in tables)
+        {
+            var headers = ExtractHeaderTexts(table);
+            if (headers == null)
+                continue;
+
+            if (headers.Contains("asset") && headers.Contains("value"))
+                ParseAssetTable(table, headers, items);
+            else if (headers.Contains("creditor") && headers.Contains("amount"))
+                ParseLiabilityTable(table, headers, items);
+        }
+
+        return items;
+    }
+
+    private static List<string> ExtractHeaderTexts(HtmlNode table)
+    {
+        var headerNodes = table.SelectNodes(".//thead//th") ?? table.SelectNodes(".//tr[1]//th");
+        return headerNodes
+            ?.Select(h => HtmlEntity.DeEntitize(h.InnerText).Trim().ToLowerInvariant())
+            .ToList();
+    }
+
+    private static void ParseAssetTable(
+        HtmlNode table,
+        List<string> headers,
+        List<AnnualDisclosureLineItem> items
+    )
+    {
+        var assetColumn = headers.IndexOf("asset");
+        var valueColumn = headers.IndexOf("value");
+
+        foreach (var row in DataRows(table))
+        {
+            var cells = row.SelectNodes(".//td");
+            if (cells == null || cells.Count <= Math.Max(assetColumn, valueColumn))
+                continue;
+
+            var range = ParseRangeCell(CellText(cells[valueColumn]));
+            if (range == null)
+                continue;
+
+            var description = CellText(cells[assetColumn]);
+            if (string.IsNullOrEmpty(description))
+                continue;
+
+            items.Add(
+                new AnnualDisclosureLineItem
+                {
+                    Kind = CongressionalDisclosureLineKind.Asset,
+                    Description = Truncate(description, 512),
+                    RangeMinimum = range.Value.from,
+                    RangeMaximum = range.Value.to,
+                }
+            );
+        }
+    }
+
+    private static void ParseLiabilityTable(
+        HtmlNode table,
+        List<string> headers,
+        List<AnnualDisclosureLineItem> items
+    )
+    {
+        var typeColumn = headers.IndexOf("type");
+        var amountColumn = headers.IndexOf("amount");
+        var creditorColumn = headers.IndexOf("creditor");
+
+        foreach (var row in DataRows(table))
+        {
+            var cells = row.SelectNodes(".//td");
+            if (
+                cells == null
+                || cells.Count <= Math.Max(amountColumn, Math.Max(typeColumn, creditorColumn))
+            )
+                continue;
+
+            var range = ParseRangeCell(CellText(cells[amountColumn]));
+            if (range == null)
+                continue;
+
+            var type = CellText(cells[typeColumn]);
+            var creditor = CellText(cells[creditorColumn]);
+            var description = string.IsNullOrEmpty(creditor) ? type : $"{type} ({creditor})";
+            if (string.IsNullOrEmpty(description))
+                continue;
+
+            items.Add(
+                new AnnualDisclosureLineItem
+                {
+                    Kind = CongressionalDisclosureLineKind.Liability,
+                    Description = Truncate(description, 512),
+                    RangeMinimum = range.Value.from,
+                    RangeMaximum = range.Value.to,
+                }
+            );
+        }
+    }
+
+    private static IEnumerable<HtmlNode> DataRows(HtmlNode table) =>
+        table.SelectNodes(".//tbody//tr") ?? table.SelectNodes(".//tr")?.Skip(1) ?? [];
+
+    // The disclosed name lives in the cell's main text; ".muted" descendants
+    // carry secondary metadata (location, provider, comments) that is not part
+    // of the row's identity.
+    private static string CellText(HtmlNode cell)
+    {
+        var clone = cell.CloneNode(deep: true);
+        var muted = clone.SelectNodes(".//*[contains(@class, 'muted')]");
+        if (muted != null)
+        {
+            foreach (var node in muted)
+                node.Remove();
+        }
+        var text = HtmlEntity.DeEntitize(clone.InnerText);
+        return WhitespaceRegex().Replace(text, " ").Trim();
+    }
+
+    // A line item carries only the form's own brackets: "$X - $Y" or the
+    // open-top "Over $X". Sentinels ("--", "None", "Unascertainable") and any
+    // other cell content yield no line.
+    private static (long from, long to)? ParseRangeCell(string text)
+    {
+        if (CleanSentinel(text) == null)
+            return null;
+
+        var amounts = AmountRegex().Matches(text).Count;
+        var isParseableRange =
+            amounts >= 2
+            || (amounts == 1 && text.Contains("Over", StringComparison.OrdinalIgnoreCase));
+        if (!isParseableRange)
+            return null;
+
+        var range = ParseAmountRange(text);
+        return range is { from: 0, to: 0 } ? null : range;
+    }
+
+    private async Task<string> FetchWithRetry(
+        string url,
+        Dictionary<string, string> formFields = null,
+        CancellationToken ct = default
+    )
+    {
+        for (var attempt = 0; attempt <= MaxRetries; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+            await RateLimiter.WaitAsync();
+
+            SenateFetchResult result;
+            try
+            {
+                result = await _session.Fetch(url, formFields, ct);
+            }
+            catch (SenateBrowserException ex)
+            {
+                if (attempt >= MaxRetries)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Browser fetch failed for {Url} after {Attempts} attempt(s)",
+                        url,
+                        attempt + 1
+                    );
+                    throw;
+                }
+                var delay = RetryBackoff.Exponential(attempt);
+                _logger.LogWarning(
+                    "Browser fetch error for {Url}, retrying in {Delay}s (attempt {Attempt}/{MaxRetries}): {Message}",
+                    url,
+                    delay.TotalSeconds,
+                    attempt + 1,
+                    MaxRetries,
+                    ex.Message
+                );
+                await Task.Delay(delay, ct);
+                continue;
+            }
+
+            var isRetryable = result.Status == 429 || result.Status >= 500;
+            if (isRetryable && attempt < MaxRetries)
+            {
+                var delay = RetryBackoff.Exponential(attempt);
+                _logger.LogWarning(
+                    "Senate eFD returned {Status} for {Url}, retrying in {Delay}s (attempt {Attempt}/{MaxRetries})",
+                    result.Status,
+                    url,
+                    delay.TotalSeconds,
+                    attempt + 1,
+                    MaxRetries
+                );
+
+                if (result.Status == 429)
+                    RateLimiter.PauseFor(delay);
+
+                await Task.Delay(delay, ct);
+                continue;
+            }
+
+            if (result.Status is < 200 or >= 300)
+            {
+                _logger.LogError(
+                    "Senate eFD returned {Status} for {Url} after {Attempts} attempt(s)",
+                    result.Status,
+                    url,
+                    attempt + 1
+                );
+                throw new HttpRequestException(
+                    $"Senate eFD request failed with HTTP {result.Status}: {url}"
+                );
+            }
+
+            return result.Body;
+        }
+
+        throw new HttpRequestException(
+            $"Max retries ({MaxRetries}) exceeded for Senate eFD request: {url}"
+        );
+    }
+
+    // "Annual Report for CY 2024" with an optional "(Amendment N)" suffix —
+    // group 1 = coverage year, group 2 = amendment number when present.
+    [GeneratedRegex(@"Annual Report for CY (\d{4})(?:\s*\(Amendment\s+(\d+)\))?")]
+    private static partial Regex AnnualReportTitleRegex();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+
+    internal sealed record SenateAnnualFiling(
+        string MemberName,
+        string ReportUrl,
+        int Year,
+        DateOnly DateSubmitted,
+        bool IsAmendment
+    );
+}

--- a/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
@@ -286,22 +286,4 @@ public class SenateDisclosureClient : IAsyncDisposable
     }
 
     private record SenateReport(string MemberName, string ReportUrl, DateOnly DateSubmitted);
-
-    private class SenateSearchResponse
-    {
-        [JsonProperty("draw")]
-        public int Draw { get; set; }
-
-        [JsonProperty("recordsTotal")]
-        public int RecordsTotal { get; set; }
-
-        [JsonProperty("recordsFiltered")]
-        public int RecordsFiltered { get; set; }
-
-        [JsonProperty("data")]
-        public List<List<string>> Data { get; set; } = [];
-
-        [JsonProperty("result")]
-        public string Result { get; set; }
-    }
 }

--- a/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientTests.cs
@@ -1,0 +1,220 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Services;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Tests for <see cref="SenateAnnualReportClient"/>. The annual report parser
+/// runs end-to-end against checked-in real eFD report pages (public-domain
+/// federal disclosures); the search/fetch flow runs against a stub
+/// <see cref="ISenateBrowserSession"/>.
+/// </summary>
+public class SenateAnnualReportClientTests
+{
+    // ---- report HTML parsing against real eFD pages ----
+
+    [Fact]
+    public void ParseAnnualReportHtml_RealLargeFiling_KeepsOnlyRowsWithDisclosedRanges()
+    {
+        // Blackburn CY 2024 (Amendment 1): 41 Part 3 rows of which 9 carry the
+        // "--" sentinel and 1 reads "Unascertainable" — only the 31 rows with
+        // a real bracket may materialize. One Part 7 liability.
+        var html = File.ReadAllText(FixturePath("senate-annual-blackburn-2024.html"));
+
+        var lines = SenateAnnualReportClient.ParseAnnualReportHtml(html);
+
+        lines.Should().NotBeNull();
+        lines.Count(l => l.Kind == CongressionalDisclosureLineKind.Asset).Should().Be(31);
+
+        var payflex = lines.Single(l => l.Description == "Payflex Systems USA INC");
+        payflex.RangeMinimum.Should().Be(15_001);
+        payflex.RangeMaximum.Should().Be(50_000);
+
+        var liability = lines
+            .Should()
+            .ContainSingle(l => l.Kind == CongressionalDisclosureLineKind.Liability)
+            .Subject;
+        liability.Description.Should().Be("Mortgage (JPMorgan Chase Bank, NA)");
+        liability.RangeMinimum.Should().Be(250_001);
+        liability.RangeMaximum.Should().Be(500_000);
+
+        // "Unascertainable" is not a bracket and must never be emitted.
+        lines
+            .Should()
+            .NotContain(l => l.Description.StartsWith("Principal Investment Plus Variable"));
+    }
+
+    [Fact]
+    public void ParseAnnualReportHtml_RealSmallFiling_ParsesExactRows()
+    {
+        // Slotkin CY 2024 (Amendment 1): every asset row has a bracket; the
+        // liability's creditor cell nests its location in a ".muted" div that
+        // must stay out of the description.
+        var html = File.ReadAllText(FixturePath("senate-annual-slotkin-2024.html"));
+
+        var lines = SenateAnnualReportClient.ParseAnnualReportHtml(html);
+
+        lines.Should().NotBeNull();
+        lines
+            .Select(l => (l.Kind, l.Description, l.RangeMinimum, l.RangeMaximum))
+            .Should()
+            .BeEquivalentTo([
+                (CongressionalDisclosureLineKind.Asset, "Comerica Bank", 250_001L, 500_000L),
+                (CongressionalDisclosureLineKind.Asset, "Comerica Bank", 1_001L, 15_000L),
+                (
+                    CongressionalDisclosureLineKind.Asset,
+                    "International Business Machines Corporation (IBM)",
+                    15_001L,
+                    50_000L
+                ),
+                (CongressionalDisclosureLineKind.Asset, "PNC Bank", 15_001L, 50_000L),
+                (
+                    CongressionalDisclosureLineKind.Asset,
+                    "KD - Kyndryl Holdings, Inc. Common Stock",
+                    1_001L,
+                    15_000L
+                ),
+                (CongressionalDisclosureLineKind.Asset, "PNC Bank", 1_001L, 15_000L),
+                (
+                    CongressionalDisclosureLineKind.Liability,
+                    "Mortgage (Bank of America)",
+                    100_001L,
+                    250_000L
+                ),
+            ]);
+    }
+
+    [Fact]
+    public void ParseAnnualReportHtml_PageWithoutAssetsHeading_ReturnsNull()
+    {
+        // An unrecognized layout (error page, redesign) must surface as null —
+        // never as a zero-asset report.
+        var lines = SenateAnnualReportClient.ParseAnnualReportHtml(
+            "<html><body><h1>Something else entirely</h1></body></html>"
+        );
+
+        lines.Should().BeNull();
+    }
+
+    // ---- search row parsing ----
+
+    private static List<string> SearchRow(string link) =>
+        ["Jane", "Doe", "Doe, Jane (Senator)", link, "08/20/2025"];
+
+    [Fact]
+    public void ParseSearchRow_AnnualReportWithAmendment_MapsYearAndAmendment()
+    {
+        var filing = SenateAnnualReportClient.ParseSearchRow(
+            SearchRow(
+                "<a href=\"/search/view/annual/8c41ca4c-ccda-483e-99ed-d7f27f8a5c8f/\" target=\"_blank\">Annual Report for CY 2024 (Amendment 1)</a>"
+            )
+        );
+
+        filing.Should().NotBeNull();
+        filing.MemberName.Should().Be("Jane Doe");
+        filing.Year.Should().Be(2024);
+        filing.IsAmendment.Should().BeTrue();
+        filing.DateSubmitted.Should().Be(new DateOnly(2025, 8, 20));
+        filing
+            .ReportUrl.Should()
+            .Be(
+                "https://efdsearch.senate.gov/search/view/annual/8c41ca4c-ccda-483e-99ed-d7f27f8a5c8f/"
+            );
+        SenateAnnualReportClient
+            .ExtractReportId(filing.ReportUrl)
+            .Should()
+            .Be("8c41ca4c-ccda-483e-99ed-d7f27f8a5c8f");
+    }
+
+    [Fact]
+    public void ParseSearchRow_CandidateReportLinkText_IsNotAnAnnualReport()
+    {
+        // Candidate reports share the eFD annual layout and report-type filter
+        // but are not senator annual reports — the link text is the tell.
+        var filing = SenateAnnualReportClient.ParseSearchRow(
+            SearchRow(
+                "<a href=\"/search/view/annual/54fca62e-0132-48a4-b315-40dbc1890b13/\" target=\"_blank\">Candidate Report </a>"
+            )
+        );
+
+        filing.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseSearchRow_PaperFiling_IsSkippedAsNonElectronic()
+    {
+        var filing = SenateAnnualReportClient.ParseSearchRow(
+            SearchRow(
+                "<a href=\"/search/view/paper/0b1463c4-2f01-4d21-9a4a-b07d654c0f43/\" target=\"_blank\">Annual Report for CY 2024</a>"
+            )
+        );
+
+        filing.Should().BeNull();
+    }
+
+    // ---- search + fetch flow against a stub browser session ----
+
+    [Fact]
+    public async Task GetAnnualReports_ElectronicFiling_MapsReportFieldsAndParsesLines()
+    {
+        var reportHtml = File.ReadAllText(FixturePath("senate-annual-slotkin-2024.html"));
+        var searchJson = JsonConvert.SerializeObject(
+            new
+            {
+                recordsTotal = 1,
+                data = new[]
+                {
+                    new[]
+                    {
+                        "Jane",
+                        "Doe",
+                        "Doe, Jane (Senator)",
+                        "<a href=\"/search/view/annual/25bb47de-6695-4a3e-8714-49df656bc5fa/\" target=\"_blank\">Annual Report for CY 2024 (Amendment 1)</a>",
+                        "10/10/2025",
+                    },
+                },
+            }
+        );
+        var session = Substitute.For<ISenateBrowserSession>();
+        session
+            .Fetch(
+                Arg.Is<string>(u => u.EndsWith("/search/report/data/")),
+                Arg.Any<Dictionary<string, string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(new SenateFetchResult { Status = 200, Body = searchJson });
+        session
+            .Fetch(
+                Arg.Is<string>(u => u.Contains("/search/view/annual/")),
+                Arg.Any<Dictionary<string, string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(new SenateFetchResult { Status = 200, Body = reportHtml });
+        var sut = new SenateAnnualReportClient(
+            session,
+            Substitute.For<ILogger<SenateAnnualReportClient>>()
+        );
+
+        var result = await sut.GetAnnualReports(
+            new DateOnly(2025, 1, 1),
+            new DateOnly(2025, 12, 31),
+            CancellationToken.None
+        );
+
+        var report = result.Should().ContainSingle().Subject;
+        report.MemberName.Should().Be("Jane Doe");
+        report.Position.Should().Be(CongressPosition.Senator);
+        report.Year.Should().Be(2024);
+        report.FiledDate.Should().Be(new DateOnly(2025, 10, 10));
+        report.ReportId.Should().Be("25bb47de-6695-4a3e-8714-49df656bc5fa");
+        report.IsAmendment.Should().BeTrue();
+        report.Lines.Should().HaveCount(7);
+        await session.Received(1).EnsureAuthenticated(Arg.Any<CancellationToken>());
+    }
+
+    private static string FixturePath(string fileName) =>
+        Path.Combine(AppContext.BaseDirectory, "TestAssets", "Congress", fileName);
+}

--- a/tests/Equibles.UnitTests/TestAssets/Congress/senate-annual-blackburn-2024.html
+++ b/tests/Equibles.UnitTests/TestAssets/Congress/senate-annual-blackburn-2024.html
@@ -1,0 +1,2401 @@
+<!DOCTYPE HTML>
+    <html lang="en">
+        <head>
+            <title>eFD: 
+	Annual Report for 2024 -
+	
+		Blackburn,
+	
+	
+		Marsha
+	
+
+	
+</title>
+            <meta name="robots" content="noindex">
+            <meta charset="utf-8">
+            <meta content="IE=edge" http-equiv="X-UA-Compatible">
+            <meta content="width=device-width, initial-scale=1" name="viewport">
+
+            
+	<style type="text/css">
+		.txtLogo {
+			display: none;
+		}
+	</style>
+
+
+
+            
+
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="shortcut icon" href="/static/images/favicon.ico" type="image/x-icon" />
+
+
+<link type="text/css" rel="stylesheet" media="all" href="/static/bootstrap-custom/theme-starter-site.css" />
+<link type="text/css" rel="stylesheet" media="all" href="/static/fontawesome/css/font-awesome.min.css" />
+<link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/smoothness/jquery-ui.css">
+
+<link type="text/css" rel="stylesheet" media="all" href="/static/css/main.css" />
+<link type="text/css" rel="stylesheet" media="all" href="/static/css/carousel.css" />
+<link type="text/css" rel="stylesheet" media="print" href="/static/css/print.css" />
+<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js" integrity="sha256-lSjKY0/srUM9BE3dPm+c4fBo1dky2v27Gdjm2uoZaL0=" crossorigin="anonymous"></script>
+
+<script src="https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js"
+        integrity="sha384-NHtbx1Hf6ctHNdZmU28YfhGjB63gcU1YU64ttM+c0RxMKNBj67j+N/axpqTfdffo"
+        crossorigin="anonymous"></script>
+
+<script src="/static/scripts/popper.min.js" type="text/javascript"></script>
+<script src="/static/bootstrap/js/bootstrap.min.js"></script>
+
+
+
+
+<script src="/static/scripts/jquery/jquery.placeholder.js"></script>
+<script src="/static/scripts/jquery/jquery.dPassword.js"></script>
+<script src="/static/scripts/jquery/modernizr.js"></script>
+<script src="/static/scripts/jquery/jquery.cooke.js"></script>
+<script src="/static/browser-detect.js"></script>
+
+<!-- PDF -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdfobject/2.1.1/pdfobject.js"
+        integrity="sha512-X6sgTijRHjRCltheFlgnf5Lm4NzCXVgfSNAHjHq4G8R03SBUTUVqFllStaiZflC4mEOtaPGRSWvcd3zFSl7eYg==" crossorigin="anonymous"></script>
+
+<script>
+    $(document).ready(function () {
+        if (!Modernizr.input.placeholder) {
+            $('[placeholder]').focus(function () {
+                var input = $(this);
+                if (input.val() == input.attr('placeholder')) {
+                    input.val('');
+                    input.removeClass('placeholder');
+                }
+            }).blur(function () {
+                var input = $(this);
+                if (input.val() == '' || input.val() == input.attr('placeholder')) {
+                    input.addClass('placeholder');
+                    input.val(input.attr('placeholder'));
+                }
+            }).blur();
+            $('[placeholder]').parents('form').submit(function () {
+                $(this).find('[placeholder]').each(function () {
+                    var input = $(this);
+                    if (input.val() == input.attr('placeholder')) {
+                        input.val('');
+                    }
+                })
+            });
+        }
+
+
+        //Popovers
+
+        //Initializes popovers and provides target containers
+        var i = 0;
+        $(document).find('[data-toggle="popover"]').each(function () {
+            ;
+            var popoverCount = 'popover' + i;
+            i++;
+            $(this).parent().addClass(popoverCount);
+            var popoverContainer = '.' + popoverCount;
+            $(this).popover({ container: popoverContainer });
+        });
+
+        //Hides popover if you click/touch away from it
+        $(document).on('click touchstart', function (e) {
+            $('[data-toggle="popover"],[data-original-title]').each(function () {
+                if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
+                    (($(this).popover('hide').data('bs.popover') || {}).inState || {}).click = false;
+                }
+            });
+        });
+
+        //Hides popover if press Esc
+        $(document).keydown(function (e) {
+            if (e.which === 27 && $(this).has('.popover')) {
+                $('.popover').popover('hide');
+            }
+        });
+
+        //Hides popover if you press close
+        $(document).click(function () {
+            $('button.close').click(function () {
+                $('.popover').popover('hide');
+            });
+        });
+    });
+
+
+</script>
+
+<script>
+    if (window.location.pathname != '/incompatible-browser/') {
+        if (BrowserDetect.browser == "Explorer" && parseInt(BrowserDetect.version, 10) < 11 ||
+            BrowserDetect.browser == "Chrome" && parseInt(BrowserDetect.version, 10) < 36 ||
+            BrowserDetect.browser == "Safari" && parseInt(BrowserDetect.version, 10) < 7 ||
+            BrowserDetect.browser == "Firefox" && parseInt(BrowserDetect.version, 10) < 31) {
+            window.location.replace("/incompatible-browser/");
+        }
+    }
+</script>
+
+            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        </head>
+
+        <body>
+            <div class="container-wrap" id="top">
+                <header class="container-fluid d-print-block txtLogo ">
+                    <small>United States Senate</small><br />
+                    Financial Disclosures
+                </header>
+                <nav class="navbar navbar-expand-lg navbar-light fixed-top d-print-none">
+                    <a href="#content" class="sr-only sr-only-focusable" tabindex="0">Skip to main content</a>
+
+                    <div class="navbar-brand" id="x"><img src="/static/images/logo.svg" alt="U.S. Senate Financial Disclosure logo"></div>
+                    <button class="navbar-toggler mr-2" type="button" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+
+                    <div class="collapse navbar-collapse justify-content-between" id="navbarContent">
+                        
+                            <ul class="navbar-nav" role="navigation">
+                                <li class="nav-item ">
+                                    <a class="nav-link" href="/search/">
+                                        <i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i>
+                                        Find Reports
+                                    </a>
+                                </li>
+                                
+                            </ul>
+                        
+                        <ul class="navbar-nav justify-content-end accountNav" role="navigation">
+                            
+                        </ul>
+                    </div>
+                </nav>
+                <main class="container-fluid pgContent" id="content">
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <!--Message Block-->
+                            
+    
+    
+    <div class="alert alert-danger" id="genericErrorMessageDiv" role="alert" aria-live="assertive" aria-relevant="all" style="display:none;">
+       <i class="fa fa-warning" title="Warning" aria-label="Warning"></i> <span id="genericErrorMessage"></span>
+    </div>
+
+                            <!--End Message Block-->
+
+                            
+	<style type="text/css">
+		.navbar-nav {
+			display: none;
+		}
+	</style>
+	<strong class="d-print-none return-search">
+		Return to the search tab to select another report.
+	</strong>
+	<div class="justify-content-between">
+		<div>
+			<h1 class="mb-2">
+				
+					Annual
+				
+					Report for
+				
+				Calendar 2024 
+				
+				
+					(Amendment 1)
+				
+			</h1>
+			<h2 class="filedReport">
+				
+					Mrs.
+				
+
+				
+					Marsha
+				
+
+				
+
+				
+					Blackburn
+				
+
+				
+
+				
+					
+						(Blackburn, Marsha)
+					
+				
+			</h2>
+			
+			<p class="muted font-weight-bold">
+				<i class="fa fa-folder-open"></i>
+				Filed 11/04/2025 @ 5:04 PM
+			</p>
+		</div>
+		<div>
+            <span class="d-print-none">
+                <a href="javascript:window.print()" class="btn btn-primary"><i class="fa fa-print mr-1" aria-hidden="true"></i> Print Report</a>
+            </span>
+		</div>
+	</div>
+
+	<hr>
+
+	<p>The following statements were checked before filing:</p>
+
+	<div class="mb-4">
+		<label class="form-check-label">
+			<input type="checkbox" name="filing_certified" disabled="disabled"
+					 checked="checked" class="form-check-input"/>
+			I certify that the statements I have made on this form are true, complete and correct to the best of my knowledge and belief.
+		</label>
+		<label class="form-check-label">
+			<input type="checkbox" name="filing_cannot_be_edited" disabled="disabled"
+					 checked="checked" class="form-check-input"/>
+			I understand that reports cannot be edited once filed. To make corrections, I will submit an
+			<em>electronic</em> amendment to this report.
+		</label>
+		<hr>
+		<label class="form-check-label">
+			<input type="checkbox" name="filing_omitted_assets" disabled="disabled"
+					 class="form-check-input"/>
+			I
+			<em>omitted</em> assets because they meet the three-part test for exemption.
+		</label>
+	</div>
+
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">
+				Part 1. Honoraria Payments or Payments to Charity in Lieu of Honoraria
+			</h3>
+			<p>
+				Did any individual or organization pay you or your spouse more than $200, or donate any amount to a charity on your or your spouse’s behalf, for an article, speech, or appearance?
+				<strong>
+					
+						No
+					
+				</strong>
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 2. Earned and Non-Investment Income</h3>
+			<p>
+				Did you or your spouse have reportable earned income or non-investment income?
+				<strong>
+					
+						Yes
+					
+				</strong>
+			</p>
+		</div>
+		
+			<div class="table-responsive">
+				<table class="table table-striped ">
+					<caption class="sr-only">List of payments added to this report</caption>
+					<thead>
+					<tr class="header">
+						<th scope="col"></th>
+						<th scope="col">&#35;</th>
+						<th scope="col">Who Was Paid</th>
+						<th scope="col">Type</th>
+						<th scope="col">Who Paid</th>
+						<th scope="col">Amount Paid</th>
+            <th scope="col" width="350">Comments</th>
+					</tr>
+					</thead>
+					<tbody>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								1</td>
+							<td>
+								Self
+
+							</td>
+							<td>
+								Pension
+								
+								
+							</td>
+							<td>
+								Tennessee Consolidated Retirement System<br>
+								<div class="muted">Nashville, TN</div>
+							</td>
+							
+								<td>$5,451.00</td>
+							
+              <td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								2</td>
+							<td>
+								Spouse
+
+							</td>
+							<td>
+								Salary
+								
+								
+							</td>
+							<td>
+								Strategic Sales Tactics Inc<br>
+								<div class="muted">Brentwood, TN</div>
+							</td>
+							
+								<td> > $1,000</td>
+							
+              <td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+					</tbody>
+				</table>
+			</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 3. Assets</h3>
+			<p>
+				Did you, your spouse, or dependent child own any asset that had a value of more than $1,000 or generated income of more than $200?
+				<strong>
+					
+						Yes
+					
+				</strong>
+			</p>
+		</div>
+		
+			<div class="table-responsive">
+				<table id="grid_items" class="table dataTable">
+					<caption class="sr-only">List of assets added to this report</caption>
+					<thead>
+					<tr class="header">
+						<th scope="col"></th>
+						<th scope="col">Asset</th>
+						<th scope="col">Asset Type</th>
+						<th scope="col">Owner</th>
+						<th scope="col">Value</th>
+						<th scope="col">Income Type</th>
+						<th scope="col">Income</th>
+					</tr>
+					</thead>
+					<tbody>
+					
+						<tr class="nowrap">
+							<td>1</td>
+							<td class="span4">
+								<strong>Payflex Systems USA INC</strong><div class="muted noWrap">(Omaha, NE)</div><div class="muted"><div class="muted"><em>Type: </em>Savings</div></div>
+							</td>
+							<td>Bank Deposit</td>
+							<td>Self</td>
+							<td>$15,001 - $50,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>2</td>
+							<td class="span4">
+								<strong class="marginit-right">Strategic Sales Tactics Inc.</strong><div class="muted"><em>Company:</em> Strategic Sales Tactics Inc (Brentwood, TN)&nbsp;<em>Description:</em>&nbsp;Marketing Consulting&nbsp;</div>
+							</td>
+							<td>Corporate Securities<div class="muted">Non-Public Stock</div></td>
+							<td>Spouse</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>3</td>
+							<td class="span4">
+								<strong class="marginit-right">Principal Investment Plus Variable Annuity</strong><div class="addUnderlyingAssets noWrap"></div><div class="muted"><em>Provider:</em> Principal Financial Group&nbsp;</div>
+							</td>
+							<td>Annuity<div class="muted">Variable Annuity</div></td>
+							<td>Spouse</td>
+							<td>--</td>
+							<td>
+								
+							</td>
+							<td></td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>3.1</td>
+							<td class="span4">
+								<strong class="marginit-right">Principal Diversified Income Division</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Spouse</td>
+							<td>$15,001 - $50,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>4</td>
+							<td class="span4">
+								<strong class="marginit-right">Principal Investment Plus Variable Annuity</strong><div class="addUnderlyingAssets noWrap"></div><div class="muted"><em>Provider:</em> Principal Financial Group&nbsp;</div>
+							</td>
+							<td>Annuity<div class="muted">Variable Annuity</div></td>
+							<td>Self</td>
+							<td>--</td>
+							<td>
+								
+							</td>
+							<td></td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>4.1</td>
+							<td class="span4">
+								<strong class="marginit-right">Principal Diversified Growth Division </strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$100,001 - $250,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>5</td>
+							<td class="span4">
+								<strong class="marginit-right">American Funds Brokerage Account</strong><div class="addUnderlyingAssets noWrap"></div><div class="muted"></div>
+							</td>
+							<td>Brokerage/Managed Account</td>
+							<td>Self</td>
+							<td>--</td>
+							<td>
+								
+							</td>
+							<td></td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>5.1</td>
+							<td class="span4">
+								<strong class="marginit-right"><a href="http://finance.yahoo.com/q?s=ABALX" target="_blank">ABALX</a> - American Funds American Balanced Fund Class A</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$15,001 - $50,000</td>
+							<td>
+								Dividends, Capital Gains
+							</td>
+							<td>$1,001 - $2,500</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>5.2</td>
+							<td class="span4">
+								<strong class="marginit-right"><a href="http://finance.yahoo.com/q?s=AIVSX" target="_blank">AIVSX</a> - American Funds Investment Company of America Class</strong><div class="muted"><em>Filer comment:  </em>Capital gains and dividend reinvestment increased value above $15,000</div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$15,001 - $50,000</td>
+							<td>
+								Dividends, Capital Gains
+							</td>
+							<td>$1,001 - $2,500</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>5.3</td>
+							<td class="span4">
+								<strong class="marginit-right"><a href="http://finance.yahoo.com/q?s=ANWPX" target="_blank">ANWPX</a> - American Funds New Perspective Fund Class A</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$100,001 - $250,000</td>
+							<td>
+								Dividends, Capital Gains
+							</td>
+							<td>$5,001 - $15,000</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>6</td>
+							<td class="span4">
+								<strong class="marginit-right">MetLife IRA</strong><div class="addUnderlyingAssets noWrap"></div><div class="muted"></div>
+							</td>
+							<td>Brokerage/Managed Account</td>
+							<td>Spouse</td>
+							<td>--</td>
+							<td>
+								
+							</td>
+							<td></td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>6.1</td>
+							<td class="span4">
+								<strong class="marginit-right">AB Global Dynamic Allocation Portfolio</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Spouse</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>6.2</td>
+							<td class="span4">
+								<strong class="marginit-right">Invesco Balanced Risk Allocation Portfolio</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Spouse</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>6.3</td>
+							<td class="span4">
+								<strong class="marginit-right">Blackrock Global Tactical Strategies Portfolio</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Spouse</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>6.4</td>
+							<td class="span4">
+								<strong class="marginit-right">JP Morgan Global Active Allocation Portfolio</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Spouse</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>6.5</td>
+							<td class="span4">
+								<strong class="marginit-right">BHLife Balanced Plus Portfolio</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Spouse</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>6.6</td>
+							<td class="span4">
+								<strong class="marginit-right">Schroeders Global Multi-Asset Portfolio</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Spouse</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>7</td>
+							<td class="span4">
+								<strong class="marginit-right">State of Tennessee Pension</strong><div class="muted"></div>
+							</td>
+							<td>Retirement Plans<div class="muted">Defined Benefit Pension Plan</div></td>
+							<td>Self</td>
+							<td>Unascertainable</td>
+							<td>
+								Other (Annual Pension Payment)
+							</td>
+							<td><br/>Other $5,138.46</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>8</td>
+							<td class="span4">
+								<strong>Pinnacle Bank</strong><div class="muted noWrap">(Nashville, TN)</div><div class="muted"><div class="muted"><em>Type: </em>Checking</div></div>
+							</td>
+							<td>Bank Deposit</td>
+							<td>Self</td>
+							<td>$100,001 - $250,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>9</td>
+							<td class="span4">
+								<strong>First Horizon</strong><div class="muted noWrap">(Memphis, TN)</div><div class="muted"><div class="muted"><em>Type: </em>Checking</div></div>
+							</td>
+							<td>Bank Deposit</td>
+							<td>Spouse</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								Interest
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>10</td>
+							<td class="span4">
+								<strong class="marginit-right">529 Account - grandchild 1</strong><div class="muted"><em>Institution:</em> Capital Group College America</div><div class="addUnderlyingAssets noWrap"></div><div class="muted"></div>
+							</td>
+							<td>Education Savings Plans<div class="muted">529 College Savings Plan</div></td>
+							<td>Self</td>
+							<td>--</td>
+							<td>
+								
+							</td>
+							<td></td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>10.1</td>
+							<td class="span4">
+								<strong class="marginit-right"><a href="http://finance.yahoo.com/q?s=CLBAX" target="_blank">CLBAX</a> - American Balanced Fund Class 529-A Shares</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>10.2</td>
+							<td class="span4">
+								<strong class="marginit-right"><a href="http://finance.yahoo.com/q?s=CICAX" target="_blank">CICAX</a> - The Investment Company of America Class 529-A S</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>11</td>
+							<td class="span4">
+								<strong class="marginit-right">529 Account - grandchild 3</strong><div class="muted"><em>Institution:</em> Capital Group College America</div><div class="addUnderlyingAssets noWrap"></div><div class="muted"></div>
+							</td>
+							<td>Education Savings Plans<div class="muted">529 College Savings Plan</div></td>
+							<td>Self</td>
+							<td>--</td>
+							<td>
+								
+							</td>
+							<td></td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>11.1</td>
+							<td class="span4">
+								<strong class="marginit-right"><a href="http://finance.yahoo.com/q?s=CCFAX" target="_blank">CCFAX</a> - American Funds College Fund 2036 Class 529-A</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>12</td>
+							<td class="span4">
+								<strong>M Financial Group</strong><div class="muted noWrap">(Portland, OR)</div><div class="muted"><div class="muted"><em>Type: </em>Money Market Account</div></div>
+							</td>
+							<td>Bank Deposit</td>
+							<td>Self</td>
+							<td>$100,001 - $250,000</td>
+							<td>
+								Interest
+							</td>
+							<td>$5,001 - $15,000</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>13</td>
+							<td class="span4">
+								<strong class="marginit-right">Jackson National Life Insurance Perspective II Variable and Fixed Annuity</strong><div class="addUnderlyingAssets noWrap"></div><div class="muted"></div>
+							</td>
+							<td>Life Insurance<div class="muted">Variable</div></td>
+							<td>Self</td>
+							<td>--</td>
+							<td>
+								
+							</td>
+							<td></td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>13.1</td>
+							<td class="span4">
+								<strong class="marginit-right">JNL/American Funds Growth A</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$15,001 - $50,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>13.2</td>
+							<td class="span4">
+								<strong class="marginit-right">JNL/Mellon Nasdaq 100 Index A</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$15,001 - $50,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>13.3</td>
+							<td class="span4">
+								<strong class="marginit-right">JNL/Newton Equity Income A</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$15,001 - $50,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>13.4</td>
+							<td class="span4">
+								<strong class="marginit-right">JNL/Mellon Dow Index A</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$15,001 - $50,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>13.5</td>
+							<td class="span4">
+								<strong class="marginit-right">JNL/JPMorgan MidCap Growth A</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>13.6</td>
+							<td class="span4">
+								<strong class="marginit-right">JNL/T. Rowe Price Established Growth A</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>13.7</td>
+							<td class="span4">
+								<strong class="marginit-right">JNL/Mellon Information Technology Sector A</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$15,001 - $50,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>13.8</td>
+							<td class="span4">
+								<strong class="marginit-right">JNL/Mellon Healthcare Sector A</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>13.9</td>
+							<td class="span4">
+								<strong class="marginit-right">JNL/T.Rowe Price Capital Appreciation A</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>14</td>
+							<td class="span4">
+								<strong class="marginit-right">529 Account - grandchild 2</strong><div class="muted"><em>Institution:</em> Capital Group College America</div><div class="addUnderlyingAssets noWrap"></div><div class="muted"></div>
+							</td>
+							<td>Education Savings Plans<div class="muted">529 College Savings Plan</div></td>
+							<td>Self</td>
+							<td>--</td>
+							<td>
+								
+							</td>
+							<td></td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>14.1</td>
+							<td class="span4">
+								<strong class="marginit-right"><a href="http://finance.yahoo.com/q?s=CLBAX" target="_blank">CLBAX</a> - American Balanced Fund Class 529-A Shares</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>14.2</td>
+							<td class="span4">
+								<strong class="marginit-right"><a href="http://finance.yahoo.com/q?s=CICAX" target="_blank">CICAX</a> - The Investment Company of America Class 529-A S</strong><div class="muted"></div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>15</td>
+							<td class="span4">
+								<strong class="marginit-right">529 Account - grandchild 4</strong><div class="muted"><em>Institution:</em> Capital Group College America</div><div class="addUnderlyingAssets noWrap"></div><div class="muted"></div>
+							</td>
+							<td>Education Savings Plans<div class="muted">529 College Savings Plan</div></td>
+							<td>Self</td>
+							<td>--</td>
+							<td>
+								
+							</td>
+							<td></td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>15.1</td>
+							<td class="span4">
+								<strong class="marginit-right"><a href="http://finance.yahoo.com/q?s=CDJAX" target="_blank">CDJAX</a> - American Funds College 2039 Fund Class 529-A</strong><div class="muted"><em>Filer comment:  </em>mulitple purchases below $1,000</div>
+							</td>
+							<td>Mutual Funds<div class="muted">Mutual Fund</div></td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+					</tbody>
+				</table>
+			</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 4a. Periodic Transaction Report Summary</h3>
+			<p>
+				In this section, electronically filed periodic transaction report (PTR) transactions are displayed for you.
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 4b. Transactions</h3>
+			<p>
+				Did you, your spouse, or dependent child buy, sell, or exchange an asset where the transaction exceeded $1,000 and was not reported on Part 4a?
+				<strong>
+					
+						Yes
+					
+				</strong>
+			</p>
+		</div>
+		
+			<div class="table-responsive">
+				<table class="table table-striped">
+					<caption class="sr-only">List of transactions added to this report</caption>
+					<thead>
+					<tr class="header">
+						<th scope="col"></th>
+						<th scope="col">&#35;</th>
+						<th scope="col">Owner</th>
+						<th scope="col">Ticker</th>
+						<th scope="col">Asset Name</th>
+						<th scope="col">Transaction Type</th>
+						<th scope="col">Transaction Date</th>
+						<th scope="col">Amount</th>
+						<th scope="col" width="350">Comments</th>
+					</tr>
+					</thead>
+					<tbody>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								1</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Healthcare Sector A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>01/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								2</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/JPMorgan MidCap Growth A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>01/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								3</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/T.Rowe Price Capital Appreciation A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>01/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								4</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Dow Index A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>01/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								5</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/T. Rowe Price Established Growth A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>01/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								6</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Information Technology Sector A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>01/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								7</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Newton Equity Income A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>01/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								8</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Nasdaq 100 Index A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>01/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								9</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/American Funds Growth A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>01/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								10</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Healthcare Sector A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>02/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								11</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/T.Rowe Price Capital Appreciation A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>02/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								12</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Dow Index A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>02/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								13</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/JPMorgan MidCap Growth A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>02/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								14</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Information Technology Sector A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>02/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								15</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Newton Equity Income A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>02/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								16</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Nasdaq 100 Index A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>02/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								17</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/T. Rowe Price Established Growth A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>02/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								18</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/American Funds Growth A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>02/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								19</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/T. Rowe Price Established Growth A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>03/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								20</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/JPMorgan MidCap Growth A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>03/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								21</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Healthcare Sector A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>03/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								22</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/T.Rowe Price Capital Appreciation A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>03/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								23</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Information Technology Sector A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>03/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								24</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Dow Index A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>03/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								25</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Nasdaq 100 Index A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>03/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								26</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Newton Equity Income A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>03/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								27</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/American Funds Growth A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>03/28/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								28</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Information Technology Sector A
+                                
+                            </td>
+							<td>Sale (Partial)</td>
+							<td>10/30/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								29</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Nasdaq 100 Index A
+                                
+                            </td>
+							<td>Sale (Partial)</td>
+							<td>10/30/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								30</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Dow Index A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>10/30/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								31</td>
+							<td>Self</td>
+							<td>
+                               
+                                    --
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    JNL/Mellon Healthcare Sector A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>10/30/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								32</td>
+							<td>Self</td>
+							<td>
+                               
+                                    <a href="https://finance.yahoo.com/quote/ABALX/" target="_blank">ABALX</a>
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    American Balanced Fund Class A Shs
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>12/16/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								33</td>
+							<td>Self</td>
+							<td>
+                               
+                                    <a href="https://finance.yahoo.com/quote/AIVSX/" target="_blank">AIVSX</a>
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    American Funds Investment CO of America A
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>12/17/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								34</td>
+							<td>Self</td>
+							<td>
+                               
+                                    <a href="https://finance.yahoo.com/quote/ANWPX/" target="_blank">ANWPX</a>
+                                
+
+                                
+							</td>
+							<td>
+                                
+                                    New Perspective Fund Class A Shares
+                                
+                            </td>
+							<td>Purchase</td>
+							<td>12/19/2024</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+					</tbody>
+				</table>
+			</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 5. Gifts</h3>
+			<p>
+				Did you, your spouse, or dependent child receive any reportable gift during the reporting period?
+				<strong>
+					
+						No
+					
+				</strong>
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 6. Travel</h3>
+			<p>
+				Did you, your spouse, or dependent child receive any <button data-toggle="popover" type="button" aria-haspopup="true" data-html="true" data-title="When is travel reportable? <button type='button' tabindex='0' id='jsPopoverClose' aria-label='close' class='close'><i class='fa fa-times' aria-hidden='true'><span class='sr-only'>Close</span></i></button>"data-template='<div class="popover popover__fixMedium" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>'class="btn btn-link popover--textButton font-weight-bold" data-placement="auto" data-content="<p>If you are reimbursed for more than one trip from the same sponsor, and the trips added together are worth more than $480, then you must report each trip individually, even if the reimbursement for each separate trip does not equal more than $480.</p>">reportable travel</button>?
+				<strong>
+					
+						No
+					
+				</strong>
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 7. Liabilities</h3>
+			<p>
+				Did you, your spouse, or dependent child have a reportable, non-revolving charge account liability worth more than $10,000 at any time or a revolving charge account whose value exceeded $10,000 as of the last day of the reporting period?
+				<strong>
+					
+						Yes
+					
+				</strong>
+			</p>
+		</div>
+		
+			<div class="table-responsive">
+				<table class="table table-striped">
+					<caption class="sr-only">List of liabilities added to this report</caption>
+					<thead>
+					<tr class="header">
+						<th scope="col"></th>
+						<th scope="col">&#35;</th>
+						<th scope="col">Incurred</th>
+						<th scope="col">Debtor</th>
+						<th scope="col">Type</th>
+						<th scope="col">Points</th>
+						<th scope="col">Rate<br>(Term)</th>
+						<th scope="col">Amount</th>
+						<th scope="col">Creditor</th>
+						<th scope="col" width="350">Comments</th>
+					</tr>
+					</thead>
+					<tbody>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								1</td>
+							<td>
+								2020
+							</td>
+							<td>Spouse</td>
+							<td>Mortgage
+								</td>
+							<td>
+								None</td>
+							<td>
+								2.5%<br>
+								
+														(30 year fixed)
+								
+							</td>
+							<td>$250,001 - $500,000</td>
+							<td>
+								JPMorgan Chase Bank, NA
+								<div class="muted">Monroe, LA</div>
+							</td>
+              <td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+					</tbody>
+				</table>
+			</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 8. Positions</h3>
+			<p>
+				Did you hold any reportable outside positions during the reporting period?
+				<strong>
+					
+						No
+					
+				</strong>
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 9. Agreements</h3>
+			<p>
+				Did you have any reportable agreement or arrangement with an outside entity?
+				<strong>
+					
+						Yes
+					
+				</strong>
+			</p>
+		</div>
+		
+			<div class="table-responsive">
+				<table class="table table-striped ">
+					<caption class="sr-only">List of agreements or arrangements added to this report</caption>
+					<thead>
+					<tr class="header">
+						<th scope="col"></th>
+						<th scope="col">&#35;</th>
+						<th scope="col">Date</th>
+						<th scope="col">Parties Involved</th>
+						<th scope="col">Type</th>
+						<th scope="col">Status and Terms</th>
+            <th scope="col" width="350">Comments</th>
+					</tr>
+					</thead>
+					<tbody>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								1</td>
+							<td>
+								Feb 2002
+							</td>
+							<td>
+								State of Tennessee
+								<div class="muted">Nashville, TN</div>
+							</td>
+							<td>Other
+								
+									<div class="muted">(Legislative Pension)</div>
+							</td>
+							<td>Legislative Pension with the State of TN</td>
+              <td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								2</td>
+							<td>
+								Mar 2025
+							</td>
+							<td>
+								Brave Books
+								<div class="muted">Conroe, TX</div>
+							</td>
+							<td>Other
+								
+									<div class="muted">(Publishing Agreement)</div>
+							</td>
+							<td>Agreement with Brave Books LLC to publish and distribute a children’s book, entitled Camilla Can Vote, authored by Senator Blackburn and her adult child (initial publication in 2020). Authors agreed to remit to Brave Books LLC an advanced payment of the cost of the print run, and Brave Books LLC agreed to publish and distribute the book through SkyTree Book Fairs, and provide the net proceeds from SkyTree sales to the authors.</td>
+              <td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+					</tbody>
+				</table>
+			</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 10. Compensation</h3>
+			<p>
+				<em>Only required if you are a candidate or this is your first report</em>: Did any person or entity pay more than $5,000 to you or for services provided by you?
+				<strong>
+					
+						This is not my first report.
+					
+				</strong>
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Attachments & Comments</h3>
+
+			
+				<em class="muted">No attachments added.</em>
+			
+
+			
+				<br/>
+				<em class="text-muted">No comments added.</em>
+			
+		</div>
+	</section>
+
+                        </div>
+                    </div>
+                </main>
+
+               <footer id="footer" class="footer d-print-none">
+
+                </footer>
+            </div><!-- end #wrap -->
+        </body>
+    </html>

--- a/tests/Equibles.UnitTests/TestAssets/Congress/senate-annual-slotkin-2024.html
+++ b/tests/Equibles.UnitTests/TestAssets/Congress/senate-annual-slotkin-2024.html
@@ -1,0 +1,695 @@
+<!DOCTYPE HTML>
+    <html lang="en">
+        <head>
+            <title>eFD: 
+	Annual Report for 2024 -
+	
+		Slotkin,
+	
+	
+		Elissa
+	
+
+	
+</title>
+            <meta name="robots" content="noindex">
+            <meta charset="utf-8">
+            <meta content="IE=edge" http-equiv="X-UA-Compatible">
+            <meta content="width=device-width, initial-scale=1" name="viewport">
+
+            
+	<style type="text/css">
+		.txtLogo {
+			display: none;
+		}
+	</style>
+
+
+
+            
+
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="shortcut icon" href="/static/images/favicon.ico" type="image/x-icon" />
+
+
+<link type="text/css" rel="stylesheet" media="all" href="/static/bootstrap-custom/theme-starter-site.css" />
+<link type="text/css" rel="stylesheet" media="all" href="/static/fontawesome/css/font-awesome.min.css" />
+<link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/smoothness/jquery-ui.css">
+
+<link type="text/css" rel="stylesheet" media="all" href="/static/css/main.css" />
+<link type="text/css" rel="stylesheet" media="all" href="/static/css/carousel.css" />
+<link type="text/css" rel="stylesheet" media="print" href="/static/css/print.css" />
+<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js" integrity="sha256-lSjKY0/srUM9BE3dPm+c4fBo1dky2v27Gdjm2uoZaL0=" crossorigin="anonymous"></script>
+
+<script src="https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js"
+        integrity="sha384-NHtbx1Hf6ctHNdZmU28YfhGjB63gcU1YU64ttM+c0RxMKNBj67j+N/axpqTfdffo"
+        crossorigin="anonymous"></script>
+
+<script src="/static/scripts/popper.min.js" type="text/javascript"></script>
+<script src="/static/bootstrap/js/bootstrap.min.js"></script>
+
+
+
+
+<script src="/static/scripts/jquery/jquery.placeholder.js"></script>
+<script src="/static/scripts/jquery/jquery.dPassword.js"></script>
+<script src="/static/scripts/jquery/modernizr.js"></script>
+<script src="/static/scripts/jquery/jquery.cooke.js"></script>
+<script src="/static/browser-detect.js"></script>
+
+<!-- PDF -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdfobject/2.1.1/pdfobject.js"
+        integrity="sha512-X6sgTijRHjRCltheFlgnf5Lm4NzCXVgfSNAHjHq4G8R03SBUTUVqFllStaiZflC4mEOtaPGRSWvcd3zFSl7eYg==" crossorigin="anonymous"></script>
+
+<script>
+    $(document).ready(function () {
+        if (!Modernizr.input.placeholder) {
+            $('[placeholder]').focus(function () {
+                var input = $(this);
+                if (input.val() == input.attr('placeholder')) {
+                    input.val('');
+                    input.removeClass('placeholder');
+                }
+            }).blur(function () {
+                var input = $(this);
+                if (input.val() == '' || input.val() == input.attr('placeholder')) {
+                    input.addClass('placeholder');
+                    input.val(input.attr('placeholder'));
+                }
+            }).blur();
+            $('[placeholder]').parents('form').submit(function () {
+                $(this).find('[placeholder]').each(function () {
+                    var input = $(this);
+                    if (input.val() == input.attr('placeholder')) {
+                        input.val('');
+                    }
+                })
+            });
+        }
+
+
+        //Popovers
+
+        //Initializes popovers and provides target containers
+        var i = 0;
+        $(document).find('[data-toggle="popover"]').each(function () {
+            ;
+            var popoverCount = 'popover' + i;
+            i++;
+            $(this).parent().addClass(popoverCount);
+            var popoverContainer = '.' + popoverCount;
+            $(this).popover({ container: popoverContainer });
+        });
+
+        //Hides popover if you click/touch away from it
+        $(document).on('click touchstart', function (e) {
+            $('[data-toggle="popover"],[data-original-title]').each(function () {
+                if (!$(this).is(e.target) && $(this).has(e.target).length === 0 && $('.popover').has(e.target).length === 0) {
+                    (($(this).popover('hide').data('bs.popover') || {}).inState || {}).click = false;
+                }
+            });
+        });
+
+        //Hides popover if press Esc
+        $(document).keydown(function (e) {
+            if (e.which === 27 && $(this).has('.popover')) {
+                $('.popover').popover('hide');
+            }
+        });
+
+        //Hides popover if you press close
+        $(document).click(function () {
+            $('button.close').click(function () {
+                $('.popover').popover('hide');
+            });
+        });
+    });
+
+
+</script>
+
+<script>
+    if (window.location.pathname != '/incompatible-browser/') {
+        if (BrowserDetect.browser == "Explorer" && parseInt(BrowserDetect.version, 10) < 11 ||
+            BrowserDetect.browser == "Chrome" && parseInt(BrowserDetect.version, 10) < 36 ||
+            BrowserDetect.browser == "Safari" && parseInt(BrowserDetect.version, 10) < 7 ||
+            BrowserDetect.browser == "Firefox" && parseInt(BrowserDetect.version, 10) < 31) {
+            window.location.replace("/incompatible-browser/");
+        }
+    }
+</script>
+
+            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        </head>
+
+        <body>
+            <div class="container-wrap" id="top">
+                <header class="container-fluid d-print-block txtLogo ">
+                    <small>United States Senate</small><br />
+                    Financial Disclosures
+                </header>
+                <nav class="navbar navbar-expand-lg navbar-light fixed-top d-print-none">
+                    <a href="#content" class="sr-only sr-only-focusable" tabindex="0">Skip to main content</a>
+
+                    <div class="navbar-brand" id="x"><img src="/static/images/logo.svg" alt="U.S. Senate Financial Disclosure logo"></div>
+                    <button class="navbar-toggler mr-2" type="button" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+
+                    <div class="collapse navbar-collapse justify-content-between" id="navbarContent">
+                        
+                            <ul class="navbar-nav" role="navigation">
+                                <li class="nav-item ">
+                                    <a class="nav-link" href="/search/">
+                                        <i class="fa fa-search fa-fw fa-lg" aria-hidden="true"></i>
+                                        Find Reports
+                                    </a>
+                                </li>
+                                
+                            </ul>
+                        
+                        <ul class="navbar-nav justify-content-end accountNav" role="navigation">
+                            
+                        </ul>
+                    </div>
+                </nav>
+                <main class="container-fluid pgContent" id="content">
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <!--Message Block-->
+                            
+    
+    
+    <div class="alert alert-danger" id="genericErrorMessageDiv" role="alert" aria-live="assertive" aria-relevant="all" style="display:none;">
+       <i class="fa fa-warning" title="Warning" aria-label="Warning"></i> <span id="genericErrorMessage"></span>
+    </div>
+
+                            <!--End Message Block-->
+
+                            
+	<style type="text/css">
+		.navbar-nav {
+			display: none;
+		}
+	</style>
+	<strong class="d-print-none return-search">
+		Return to the search tab to select another report.
+	</strong>
+	<div class="justify-content-between">
+		<div>
+			<h1 class="mb-2">
+				
+					Annual
+				
+					Report for
+				
+				Calendar 2024 
+				
+				
+					(Amendment 1)
+				
+			</h1>
+			<h2 class="filedReport">
+				
+					Ms.
+				
+
+				
+					Elissa
+				
+
+				
+
+				
+					Slotkin
+				
+
+				
+
+				
+					
+						(Slotkin, Elissa)
+					
+				
+			</h2>
+			
+			<p class="muted font-weight-bold">
+				<i class="fa fa-folder-open"></i>
+				Filed 10/10/2025 @ 12:11 PM
+			</p>
+		</div>
+		<div>
+            <span class="d-print-none">
+                <a href="javascript:window.print()" class="btn btn-primary"><i class="fa fa-print mr-1" aria-hidden="true"></i> Print Report</a>
+            </span>
+		</div>
+	</div>
+
+	<hr>
+
+	<p>The following statements were checked before filing:</p>
+
+	<div class="mb-4">
+		<label class="form-check-label">
+			<input type="checkbox" name="filing_certified" disabled="disabled"
+					 checked="checked" class="form-check-input"/>
+			I certify that the statements I have made on this form are true, complete and correct to the best of my knowledge and belief.
+		</label>
+		<label class="form-check-label">
+			<input type="checkbox" name="filing_cannot_be_edited" disabled="disabled"
+					 checked="checked" class="form-check-input"/>
+			I understand that reports cannot be edited once filed. To make corrections, I will submit an
+			<em>electronic</em> amendment to this report.
+		</label>
+		<hr>
+		<label class="form-check-label">
+			<input type="checkbox" name="filing_omitted_assets" disabled="disabled"
+					 class="form-check-input"/>
+			I
+			<em>omitted</em> assets because they meet the three-part test for exemption.
+		</label>
+	</div>
+
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">
+				Part 1. Honoraria Payments or Payments to Charity in Lieu of Honoraria
+			</h3>
+			<p>
+				Did any individual or organization pay you or your spouse more than $200, or donate any amount to a charity on your or your spouse’s behalf, for an article, speech, or appearance?
+				<strong>
+					
+						No
+					
+				</strong>
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 2. Earned and Non-Investment Income</h3>
+			<p>
+				Did you or your spouse have reportable earned income or non-investment income?
+				<strong>
+					
+						No
+					
+				</strong>
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 3. Assets</h3>
+			<p>
+				Did you, your spouse, or dependent child own any asset that had a value of more than $1,000 or generated income of more than $200?
+				<strong>
+					
+						Yes
+					
+				</strong>
+			</p>
+		</div>
+		
+			<div class="table-responsive">
+				<table id="grid_items" class="table dataTable">
+					<caption class="sr-only">List of assets added to this report</caption>
+					<thead>
+					<tr class="header">
+						<th scope="col"></th>
+						<th scope="col">Asset</th>
+						<th scope="col">Asset Type</th>
+						<th scope="col">Owner</th>
+						<th scope="col">Value</th>
+						<th scope="col">Income Type</th>
+						<th scope="col">Income</th>
+					</tr>
+					</thead>
+					<tbody>
+					
+						<tr class="nowrap">
+							<td>1</td>
+							<td class="span4">
+								<strong>Comerica Bank</strong><div class="muted noWrap">(Dallas, Texas)</div><div class="muted"><div class="muted"><em>Type: </em>Checking</div></div>
+							</td>
+							<td>Bank Deposit</td>
+							<td>Self</td>
+							<td>$250,001 - $500,000</td>
+							<td>
+								Interest
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>2</td>
+							<td class="span4">
+								<strong>Comerica Bank</strong><div class="muted noWrap">(Dallas, Texas)</div><div class="muted"><div class="muted"><em>Type: </em>Savings</div></div>
+							</td>
+							<td>Bank Deposit</td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								Interest
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>3</td>
+							<td class="span4">
+								<strong class="marginit-right">International Business Machines Corporation (IBM)</strong><div class="muted"></div>
+							</td>
+							<td>Corporate Securities<div class="muted">Stock</div></td>
+							<td>Self</td>
+							<td>$15,001 - $50,000</td>
+							<td>
+								Dividends
+							</td>
+							<td>$1,001 - $2,500</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>4</td>
+							<td class="span4">
+								<strong>PNC Bank</strong><div class="muted noWrap">(Pittsburgh, Pennsylvania)</div><div class="muted"><div class="muted"><em>Type: </em>Checking</div></div>
+							</td>
+							<td>Bank Deposit</td>
+							<td>Self</td>
+							<td>$15,001 - $50,000</td>
+							<td>
+								Interest
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>5</td>
+							<td class="span4">
+								<strong class="marginit-right"><a href="http://finance.yahoo.com/q?s=KD" target="_blank">KD</a> - Kyndryl Holdings, Inc. Common Stock</strong><div class="muted"><em>Filer comment:  </em>I never purchased this stock. IBM split shares in 2021 and the value exceeded $1000 in 2024.</div>
+							</td>
+							<td>Corporate Securities<div class="muted">Stock</div></td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								Interest
+							</td>
+							<td>$201 - $1,000</td>
+						</tr>
+					
+						<tr class="nowrap">
+							<td>6</td>
+							<td class="span4">
+								<strong>PNC Bank</strong><div class="muted noWrap">(Pittsburgh, Pennsylvania)</div><div class="muted"><div class="muted"><em>Type: </em>Money Market Account</div></div>
+							</td>
+							<td>Bank Deposit</td>
+							<td>Self</td>
+							<td>$1,001 - $15,000</td>
+							<td>
+								None
+							</td>
+							<td>None (or less than $201)</td>
+						</tr>
+					
+					</tbody>
+				</table>
+			</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 4a. Periodic Transaction Report Summary</h3>
+			<p>
+				In this section, electronically filed periodic transaction report (PTR) transactions are displayed for you.
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 4b. Transactions</h3>
+			<p>
+				Did you, your spouse, or dependent child buy, sell, or exchange an asset where the transaction exceeded $1,000 and was not reported on Part 4a?
+				<strong>
+					
+						No
+					
+				</strong>
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 5. Gifts</h3>
+			<p>
+				Did you, your spouse, or dependent child receive any reportable gift during the reporting period?
+				<strong>
+					
+						No
+					
+				</strong>
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 6. Travel</h3>
+			<p>
+				Did you, your spouse, or dependent child receive any <button data-toggle="popover" type="button" aria-haspopup="true" data-html="true" data-title="When is travel reportable? <button type='button' tabindex='0' id='jsPopoverClose' aria-label='close' class='close'><i class='fa fa-times' aria-hidden='true'><span class='sr-only'>Close</span></i></button>"data-template='<div class="popover popover__fixMedium" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>'class="btn btn-link popover--textButton font-weight-bold" data-placement="auto" data-content="<p>If you are reimbursed for more than one trip from the same sponsor, and the trips added together are worth more than $480, then you must report each trip individually, even if the reimbursement for each separate trip does not equal more than $480.</p>">reportable travel</button>?
+				<strong>
+					
+						No
+					
+				</strong>
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 7. Liabilities</h3>
+			<p>
+				Did you, your spouse, or dependent child have a reportable, non-revolving charge account liability worth more than $10,000 at any time or a revolving charge account whose value exceeded $10,000 as of the last day of the reporting period?
+				<strong>
+					
+						Yes
+					
+				</strong>
+			</p>
+		</div>
+		
+			<div class="table-responsive">
+				<table class="table table-striped">
+					<caption class="sr-only">List of liabilities added to this report</caption>
+					<thead>
+					<tr class="header">
+						<th scope="col"></th>
+						<th scope="col">&#35;</th>
+						<th scope="col">Incurred</th>
+						<th scope="col">Debtor</th>
+						<th scope="col">Type</th>
+						<th scope="col">Points</th>
+						<th scope="col">Rate<br>(Term)</th>
+						<th scope="col">Amount</th>
+						<th scope="col">Creditor</th>
+						<th scope="col" width="350">Comments</th>
+					</tr>
+					</thead>
+					<tbody>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								1</td>
+							<td>
+								2011
+							</td>
+							<td>Self</td>
+							<td>Mortgage
+								</td>
+							<td>
+								0</td>
+							<td>
+								4.875%<br>
+								
+														(30 year fixed)
+								
+							</td>
+							<td>$100,001 - $250,000</td>
+							<td>
+								Bank of America
+								<div class="muted">Charlotte, North Carolina</div>
+							</td>
+              <td>
+                <div class="mb-2">
+                  <small>
+                    
+                      <span class="text-muted">n/a</span>
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+					</tbody>
+				</table>
+			</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 8. Positions</h3>
+			<p>
+				Did you hold any reportable outside positions during the reporting period?
+				<strong>
+					
+						Yes
+					
+				</strong>
+			</p>
+		</div>
+		
+			<div class="table-responsive">
+				<table class="table table-striped">
+					<caption class="sr-only">List of outside employment added to this report</caption>
+					<thead>
+					<tr class="header">
+						<th scope="col"></th>
+						<th scope="col">&#35;</th>
+						<th scope="col">Position Dates</th>
+						<th scope="col">Position Held</th>
+						<th scope="col">Entity</th>
+						<th scope="col">Entity Type</th>
+						<th scope="col" width="350">Comments</th>
+					</tr>
+					</thead>
+					<tbody>
+					
+						<tr class="nowrap">
+							<td>
+							</td>
+							<td>
+								1</td>
+							<td>
+								Feb 2017 to
+								May 2025
+							</td>
+							<td>
+								Officer
+								
+							</td>
+							<td>
+								Pin Point Consultants
+								<div class="muted">
+									Holly, Michigan
+								</div>
+							</td>
+							<td>
+								Company
+								
+							</td>
+							<td>
+                <div class="mb-2">
+                  <small>
+                    
+                      Business has been inactive since 2017 and never generated any income or revenue. Business was permanently closed in May 2025.
+                    
+                  </small>
+                </div>
+              </td>
+						</tr>
+					
+					</tbody>
+				</table>
+			</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 9. Agreements</h3>
+			<p>
+				Did you have any reportable agreement or arrangement with an outside entity?
+				<strong>
+					
+						No
+					
+				</strong>
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Part 10. Compensation</h3>
+			<p>
+				<em>Only required if you are a candidate or this is your first report</em>: Did any person or entity pay more than $5,000 to you or for services provided by you?
+				<strong>
+					
+						This is not my first report.
+					
+				</strong>
+			</p>
+		</div>
+		
+	</section>
+
+	<section class="card mb-2">
+		<div class="card-body">
+			<h3 class="h4">Attachments & Comments</h3>
+
+			
+				<em class="muted">No attachments added.</em>
+			
+
+			
+				<br/>
+				<em class="text-muted">No comments added.</em>
+			
+		</div>
+	</section>
+
+                        </div>
+                    </div>
+                </main>
+
+               <footer id="footer" class="footer d-print-none">
+
+                </footer>
+            </div><!-- end #wrap -->
+        </body>
+    </html>


### PR DESCRIPTION
## Summary

- Parser for Senate eFD annual financial disclosure reports: `SenateAnnualReportClient` searches the eFD endpoint (report type 7, filer type 1 = senators) over a submitted-date window, reads the coverage year and amendment marker from the result link text ("Annual Report for CY 2024 (Amendment 1)"), fetches each e-filed report page through the existing browser session, and extracts Part 3 (assets) and Part 7 (liabilities) rows at the disclosed range grain — the Senate half of the net-worth band data from #3653.
- Electronic-only policy: scanned paper filings live under "/view/paper/" URLs and are skipped at search time; a page without the "Part 3. Assets" heading parses to null so an unrecognized layout can never read as a zero-asset report. Sentinel value cells ("--", "Unascertainable") are never materialized, and a range cell only counts when it carries the form's own bracket ("$X - $Y" / "Over $X").
- Fourth slice of the congressional net-worth tracker (EquiblesCommercial#2240); the ingestion worker comes next.

## Code changes

- `src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs` — new `[Service]` client: paginated eFD search with the session-based fetch/retry pattern, link-text year/amendment extraction, HtmlAgilityPack table parsing keyed on header names (assets: "asset"+"value"; liabilities: "creditor"+"amount") with ".muted" metadata stripped from cell text, and culture-pinned date parsing (eFD dates are US-format).
- `src/Equibles.Congress.HostedService/Models/SenateSearchResponse.cs` — the eFD search JSON envelope, promoted from a private nested class in `SenateDisclosureClient` so both Senate clients share it.
- `src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs` — drops the now-shared nested response class; no behavior change.
- `tests/Equibles.UnitTests/Congress/SenateAnnualReportClientTests.cs` — 7 tests: two checked-in real eFD pages (31-asset report with sentinel rows dropped; 7-line report pinned exactly incl. muted-metadata stripping), unrecognized-layout null, search-row mapping (year/amendment/report id), candidate-report and paper-filing exclusion, and the full search→fetch flow against a stub browser session.
- `tests/Equibles.UnitTests/TestAssets/Congress/senate-annual-blackburn-2024.html`, `senate-annual-slotkin-2024.html` — public-domain federal disclosure cassettes.