### PR TITLE
feat(congress): ingest annual disclosures with net-worth band rollup

### DIFF
--- a/src/Equibles.Congress.HostedService/CongressionalAnnualDisclosureScraperWorker.cs
+++ b/src/Equibles.Congress.HostedService/CongressionalAnnualDisclosureScraperWorker.cs
@@ -1,0 +1,32 @@
+using Equibles.Congress.HostedService.Services;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+
+namespace Equibles.Congress.HostedService;
+
+public class CongressionalAnnualDisclosureScraperWorker : BaseScraperWorker
+{
+    protected override string WorkerName => "Congressional annual disclosure scraper";
+
+    // Annual reports trickle in around filing deadlines; one pass a day keeps
+    // the bands current without hammering the Clerk and eFD endpoints.
+    protected override TimeSpan SleepInterval => TimeSpan.FromHours(24);
+    protected override ErrorSource ErrorSource => ErrorSource.CongressScraper;
+
+    public CongressionalAnnualDisclosureScraperWorker(
+        ILogger<CongressionalAnnualDisclosureScraperWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter
+    )
+        : base(logger, scopeFactory, errorReporter) { }
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var syncService =
+            scope.ServiceProvider.GetRequiredService<CongressionalAnnualDisclosureSyncService>();
+        await syncService.SyncAll(stoppingToken);
+        Logger.LogInformation("Congressional annual disclosure sync completed");
+    }
+}

--- a/src/Equibles.Congress.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Congress.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ public static class ServiceCollectionExtensions
         services.AutoWireServicesFrom<CongressionalTradeSyncService>();
 
         services.AddHostedService<CongressionalTradeScraperWorker>();
+        services.AddHostedService<CongressionalAnnualDisclosureScraperWorker>();
 
         return services;
     }

--- a/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
+++ b/src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs
@@ -1,0 +1,339 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Congress.Repositories;
+using Equibles.Core.AutoWiring;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using FlexLabs.EntityFrameworkCore.Upsert;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Congress.HostedService.Services;
+
+/// <summary>
+/// Ingests congressional annual financial disclosures from both chambers and
+/// rolls each electronically-filed report into a
+/// <see cref="CongressionalAnnualDisclosure"/> with its net-worth band
+/// (Σ asset minimums − Σ liability maximums through Σ asset maximums −
+/// Σ liability minimums). Idempotent: a report already stored under the same
+/// source id is skipped, and a later-filed report (amendment) replaces the
+/// member-year row in place.
+/// </summary>
+[Service]
+public class CongressionalAnnualDisclosureSyncService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<CongressionalAnnualDisclosureSyncService> _logger;
+    private readonly WorkerOptions _workerOptions;
+    private readonly ErrorReporter _errorReporter;
+
+    // Electronic filing of congressional disclosures dates to the STOCK Act.
+    private const int EarliestCoverageYear = 2012;
+
+    // Without an explicit MinSyncDate, re-sync the last few coverage years:
+    // annual reports for year Y arrive throughout Y+1 (extensions push many to
+    // late Y+1) and amendments trail in afterwards.
+    private const int DefaultCoverageYearsBack = 2;
+
+    public CongressionalAnnualDisclosureSyncService(
+        IServiceScopeFactory scopeFactory,
+        IOptions<WorkerOptions> workerOptions,
+        ILogger<CongressionalAnnualDisclosureSyncService> logger,
+        ErrorReporter errorReporter
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _workerOptions = workerOptions.Value;
+        _logger = logger;
+        _errorReporter = errorReporter;
+    }
+
+    public async Task SyncAll(CancellationToken ct)
+    {
+        var currentYear = DateTime.UtcNow.Year;
+        var fromYear = Math.Max(
+            _workerOptions.MinSyncDate?.Year ?? currentYear - DefaultCoverageYearsBack,
+            EarliestCoverageYear
+        );
+
+        _logger.LogInformation(
+            "Starting congressional annual disclosure sync for coverage years {From}-{To}",
+            fromYear,
+            currentYear
+        );
+
+        var reports = new List<AnnualDisclosureReport>();
+
+        await FetchReports(
+            reports,
+            "House",
+            "CongressAnnual.SyncHouse",
+            async sp =>
+            {
+                var client = sp.GetRequiredService<HouseAnnualReportClient>();
+                var fetched = new List<AnnualDisclosureReport>();
+                for (var year = fromYear; year <= currentYear; year++)
+                    fetched.AddRange(await client.GetAnnualReports(year, ct));
+                return fetched;
+            },
+            ct
+        );
+
+        // Senate reports are searched by submitted date; reports covering year
+        // Y are filed from Y+1 onwards, and any late amendment of an older
+        // year inside the window still updates that year.
+        await FetchReports(
+            reports,
+            "Senate",
+            "CongressAnnual.SyncSenate",
+            sp =>
+                sp.GetRequiredService<SenateAnnualReportClient>()
+                    .GetAnnualReports(
+                        new DateOnly(fromYear + 1, 1, 1),
+                        DateOnly.FromDateTime(DateTime.UtcNow),
+                        ct
+                    ),
+            ct
+        );
+
+        if (reports.Count == 0)
+        {
+            _logger.LogInformation("No congressional annual disclosure reports found");
+            return;
+        }
+
+        await ProcessReports(reports, ct);
+    }
+
+    private async Task FetchReports(
+        List<AnnualDisclosureReport> target,
+        string sourceLabel,
+        string errorContext,
+        Func<IServiceProvider, Task<List<AnnualDisclosureReport>>> fetch,
+        CancellationToken ct
+    )
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var reports = await fetch(scope.ServiceProvider);
+            target.AddRange(reports);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch {Source} annual disclosure data", sourceLabel);
+            await _errorReporter.Report(
+                ErrorSource.CongressScraper,
+                errorContext,
+                ex.Message,
+                ex.StackTrace
+            );
+        }
+    }
+
+    private async Task ProcessReports(List<AnnualDisclosureReport> reports, CancellationToken ct)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        var memberRepository = scope.ServiceProvider.GetRequiredService<CongressMemberRepository>();
+        var disclosureRepository =
+            scope.ServiceProvider.GetRequiredService<CongressionalAnnualDisclosureRepository>();
+
+        var latest = SelectLatestReports(reports);
+        var members = await UpsertCongressMembers(latest, dbContext, memberRepository, ct);
+
+        int added = 0,
+            replaced = 0,
+            unchanged = 0;
+
+        foreach (var report in latest)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (!members.TryGetValue(report.MemberName, out var member))
+            {
+                _logger.LogWarning(
+                    "Congress member not found after upsert: {Name}",
+                    report.MemberName
+                );
+                continue;
+            }
+
+            var existing = await disclosureRepository
+                .GetAll()
+                .FirstOrDefaultAsync(
+                    d => d.CongressMemberId == member.Id && d.Year == report.Year,
+                    ct
+                );
+
+            if (existing == null)
+            {
+                dbContext.Add(BuildDisclosure(report, member));
+                added++;
+            }
+            else if (ShouldReplace(existing, report))
+            {
+                ReplaceDisclosure(existing, report, dbContext);
+                replaced++;
+            }
+            else
+            {
+                unchanged++;
+            }
+        }
+
+        await dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Congressional annual disclosure sync stored {Added} new and {Replaced} amended reports ({Unchanged} unchanged)",
+            added,
+            replaced,
+            unchanged
+        );
+    }
+
+    private async Task<Dictionary<string, CongressMember>> UpsertCongressMembers(
+        List<AnnualDisclosureReport> reports,
+        EquiblesFinancialDbContext dbContext,
+        CongressMemberRepository memberRepository,
+        CancellationToken ct
+    )
+    {
+        var distinctMembers = reports
+            .GroupBy(r => r.MemberName)
+            .Select(g => g.First())
+            .Select(r => new CongressMember { Name = r.MemberName, Position = r.Position })
+            .ToList();
+
+        await dbContext
+            .Set<CongressMember>()
+            .UpsertRange(distinctMembers)
+            .On(m => new { m.Name })
+            .WhenMatched(
+                (existing, incoming) => new CongressMember { Position = incoming.Position }
+            )
+            .RunAsync(ct);
+
+        var memberNames = distinctMembers.Select(m => m.Name).ToList();
+        return await memberRepository
+            .GetAll()
+            .Where(m => memberNames.Contains(m.Name))
+            .ToDictionaryAsync(m => m.Name, ct);
+    }
+
+    /// <summary>
+    /// One report per (member, position, year): the latest filed wins, and an
+    /// amendment beats the original on a same-day refiling.
+    /// </summary>
+    internal static List<AnnualDisclosureReport> SelectLatestReports(
+        IEnumerable<AnnualDisclosureReport> reports
+    ) =>
+        reports
+            .GroupBy(r => (r.MemberName, r.Position, r.Year))
+            .Select(g => g.OrderBy(r => r.FiledDate).ThenBy(r => r.IsAmendment).Last())
+            .ToList();
+
+    /// <summary>
+    /// Amendments replace the stored report in place: a different source
+    /// report filed on a later date (or an amendment refiled the same day)
+    /// wins; re-encountering the stored report id is a no-op.
+    /// </summary>
+    internal static bool ShouldReplace(
+        CongressionalAnnualDisclosure existing,
+        AnnualDisclosureReport incoming
+    )
+    {
+        if (incoming.ReportId == existing.ReportId)
+            return false;
+        if (incoming.FiledDate != existing.FiledDate)
+            return incoming.FiledDate > existing.FiledDate;
+        return incoming.IsAmendment;
+    }
+
+    /// <summary>
+    /// The net-worth band: minimum = Σ asset range minimums − Σ liability
+    /// range maximums; maximum = Σ asset range maximums − Σ liability range
+    /// minimums. Never a point estimate.
+    /// </summary>
+    internal static (long Minimum, long Maximum) ComputeNetWorthBand(
+        IReadOnlyList<AnnualDisclosureLineItem> lines
+    )
+    {
+        long assetMinimums = 0,
+            assetMaximums = 0,
+            liabilityMinimums = 0,
+            liabilityMaximums = 0;
+
+        foreach (var line in lines)
+        {
+            if (line.Kind == CongressionalDisclosureLineKind.Asset)
+            {
+                assetMinimums += line.RangeMinimum;
+                assetMaximums += line.RangeMaximum;
+            }
+            else
+            {
+                liabilityMinimums += line.RangeMinimum;
+                liabilityMaximums += line.RangeMaximum;
+            }
+        }
+
+        return (assetMinimums - liabilityMaximums, assetMaximums - liabilityMinimums);
+    }
+
+    private static CongressionalAnnualDisclosure BuildDisclosure(
+        AnnualDisclosureReport report,
+        CongressMember member
+    )
+    {
+        var (minimum, maximum) = ComputeNetWorthBand(report.Lines);
+        return new CongressionalAnnualDisclosure
+        {
+            CongressMemberId = member.Id,
+            Year = report.Year,
+            FiledDate = report.FiledDate,
+            ReportId = report.ReportId,
+            NetWorthMinimum = minimum,
+            NetWorthMaximum = maximum,
+            Lines = report.Lines.Select(BuildLine).ToList(),
+        };
+    }
+
+    private static void ReplaceDisclosure(
+        CongressionalAnnualDisclosure existing,
+        AnnualDisclosureReport report,
+        EquiblesFinancialDbContext dbContext
+    )
+    {
+        var (minimum, maximum) = ComputeNetWorthBand(report.Lines);
+        existing.FiledDate = report.FiledDate;
+        existing.ReportId = report.ReportId;
+        existing.NetWorthMinimum = minimum;
+        existing.NetWorthMaximum = maximum;
+
+        dbContext.RemoveRange(existing.Lines);
+        existing.Lines = report
+            .Lines.Select(l =>
+            {
+                var line = BuildLine(l);
+                line.CongressionalAnnualDisclosureId = existing.Id;
+                return line;
+            })
+            .ToList();
+    }
+
+    private static CongressionalDisclosureLine BuildLine(AnnualDisclosureLineItem item) =>
+        new()
+        {
+            Kind = item.Kind,
+            Description = item.Description,
+            RangeMinimum = item.RangeMinimum,
+            RangeMaximum = item.RangeMaximum,
+        };
+}

--- a/src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs
@@ -198,10 +198,10 @@ public partial class HouseAnnualReportClient
 
         var pdfBytes = await response.Content.ReadAsByteArrayAsync(ct);
 
-        List<AnnualDisclosureLineItem> lines;
+        HouseAnnualReportContent content;
         try
         {
-            lines = ParseAnnualReportPdf(pdfBytes);
+            content = ParseAnnualReportPdf(pdfBytes);
         }
         catch (Exception ex)
         {
@@ -214,7 +214,7 @@ public partial class HouseAnnualReportClient
             return null;
         }
 
-        if (lines == null)
+        if (content == null)
         {
             // No Schedule A header in the extracted text: a scanned paper
             // filing (image-only pages) — the electronic-only policy skips it.
@@ -222,6 +222,20 @@ public partial class HouseAnnualReportClient
                 "House annual report DocID {DocId} for {Member} has no extractable schedules; skipping as non-electronic",
                 filing.DocId,
                 filing.MemberName
+            );
+            return null;
+        }
+
+        if (!IsMemberFilerStatus(content.FilerStatus))
+        {
+            // The preamble's own "Status:" field is authoritative: candidate
+            // reports ("Congressional Candidate") are not member disclosures
+            // and must never enter the member net-worth data.
+            _logger.LogDebug(
+                "House annual report DocID {DocId} for {Member} has filer status '{Status}'; skipping non-member report",
+                filing.DocId,
+                filing.MemberName,
+                content.FilerStatus
             );
             return null;
         }
@@ -235,22 +249,50 @@ public partial class HouseAnnualReportClient
             FiledDate = filing.FilingDate,
             ReportId = filing.DocId,
             IsAmendment = filing.IsAmendment,
-            Lines = lines,
+            Lines = content.Lines,
         };
     }
 
+    // Member and member-elect reports stay; anything else ("Congressional
+    // Candidate", "Officer or Employee") is not a member disclosure. A missing
+    // status keeps the report — the index only lists annual filing types and
+    // dropping data on a preamble-format drift would be worse.
+    internal static bool IsMemberFilerStatus(string filerStatus) =>
+        filerStatus == null || filerStatus.Contains("Member", StringComparison.OrdinalIgnoreCase);
+
     /// <summary>
-    /// Parses Schedule A (assets) and Schedule D (liabilities) rows out of an
-    /// annual report PDF. Returns null when the document carries no Schedule A
-    /// header — the signature of a scanned (non-electronic) filing.
+    /// Parses the preamble filer status plus the Schedule A (assets) and
+    /// Schedule D (liabilities) rows out of an annual report PDF. Returns null
+    /// when the document carries no Schedule A header — the signature of a
+    /// scanned (non-electronic) filing.
     /// </summary>
-    internal static List<AnnualDisclosureLineItem> ParseAnnualReportPdf(byte[] pdfBytes)
+    internal static HouseAnnualReportContent ParseAnnualReportPdf(byte[] pdfBytes)
     {
         using var document = PdfDocument.Open(pdfBytes);
         var lines = new List<List<ScheduleToken>>();
         foreach (var page in document.GetPages())
             lines.AddRange(ExtractTokenLines(page));
-        return ParseScheduleLines(lines);
+
+        var items = ParseScheduleLines(lines);
+        return items == null
+            ? null
+            : new HouseAnnualReportContent(ExtractFilerStatus(lines), items);
+    }
+
+    // The preamble renders "Status: Member" / "Status: Congressional
+    // Candidate" before the first schedule header.
+    internal static string ExtractFilerStatus(IReadOnlyList<List<ScheduleToken>> lines)
+    {
+        foreach (var line in lines)
+        {
+            if (line.Count == 0)
+                continue;
+            if (MatchScheduleHeader(line) != '\0')
+                return null;
+            if (line[0].Text == "Status:" && line.Count > 1)
+                return string.Join(" ", line.Skip(1).Select(t => t.Text));
+        }
+        return null;
     }
 
     // Cluster words by their vertical position into visual lines, then order
@@ -592,6 +634,16 @@ public partial class HouseAnnualReportClient
     private static partial Regex RepeatedWhitespaceRegex();
 
     internal sealed record ScheduleToken(string Text, double Left);
+
+    /// <summary>
+    /// An e-filed annual report's extracted content: the preamble's filer
+    /// status ("Member", "Congressional Candidate", …) and the asset/liability
+    /// line items.
+    /// </summary>
+    internal sealed record HouseAnnualReportContent(
+        string FilerStatus,
+        List<AnnualDisclosureLineItem> Lines
+    );
 
     private sealed record AnnualFiling(
         string MemberName,

--- a/tests/Equibles.IntegrationTests/Congress/CongressionalAnnualDisclosureSyncServiceProcessTests.cs
+++ b/tests/Equibles.IntegrationTests/Congress/CongressionalAnnualDisclosureSyncServiceProcessTests.cs
@@ -1,0 +1,193 @@
+using System.Reflection;
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Congress.HostedService.Services;
+using Equibles.Congress.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Congress;
+
+/// <summary>
+/// Pins the annual disclosure persistence flow end-to-end against a real
+/// Postgres: a new report upserts the member and stores the disclosure with
+/// its band rollup and lines; a later amendment replaces the member-year row
+/// in place (same row, new report id, fresh lines); re-running the same
+/// report is a no-op.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class CongressionalAnnualDisclosureSyncServiceProcessTests : ParadeDbMcpTestBase
+{
+    public CongressionalAnnualDisclosureSyncServiceProcessTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private static readonly MethodInfo ProcessReportsMethod =
+        typeof(CongressionalAnnualDisclosureSyncService).GetMethod(
+            "ProcessReports",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+    private static Task ProcessReports(
+        CongressionalAnnualDisclosureSyncService sut,
+        List<AnnualDisclosureReport> reports
+    ) => (Task)ProcessReportsMethod.Invoke(sut, [reports, CancellationToken.None]);
+
+    private CongressionalAnnualDisclosureSyncService BuildSut()
+    {
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(EquiblesFinancialDbContext), DbContext),
+            (typeof(CongressMemberRepository), new CongressMemberRepository(DbContext)),
+            (
+                typeof(CongressionalAnnualDisclosureRepository),
+                new CongressionalAnnualDisclosureRepository(DbContext)
+            )
+        );
+        return new CongressionalAnnualDisclosureSyncService(
+            scopeFactory,
+            Options.Create(new WorkerOptions()),
+            Substitute.For<ILogger<CongressionalAnnualDisclosureSyncService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+    }
+
+    private static AnnualDisclosureReport Report(
+        string reportId,
+        DateOnly filed,
+        bool amendment,
+        params AnnualDisclosureLineItem[] lines
+    ) =>
+        new()
+        {
+            MemberName = "Jane Doe",
+            Position = CongressPosition.Representative,
+            Year = 2024,
+            FiledDate = filed,
+            ReportId = reportId,
+            IsAmendment = amendment,
+            Lines = lines.ToList(),
+        };
+
+    private static AnnualDisclosureLineItem Line(
+        CongressionalDisclosureLineKind kind,
+        string description,
+        long minimum,
+        long maximum
+    ) =>
+        new()
+        {
+            Kind = kind,
+            Description = description,
+            RangeMinimum = minimum,
+            RangeMaximum = maximum,
+        };
+
+    [Fact]
+    public async Task ProcessReports_NewReport_UpsertsMemberAndStoresBandAndLines()
+    {
+        var report = Report(
+            "10066169",
+            new DateOnly(2025, 5, 15),
+            amendment: false,
+            Line(CongressionalDisclosureLineKind.Asset, "Apple Inc. (AAPL)", 1_000_001, 5_000_000),
+            Line(CongressionalDisclosureLineKind.Liability, "Mortgage (Bank)", 250_001, 500_000)
+        );
+
+        await ProcessReports(BuildSut(), [report]);
+
+        await using var verify = Fixture.CreateDbContext();
+        var member = await verify
+            .Set<CongressMember>()
+            .AsNoTracking()
+            .SingleAsync(m => m.Name == "Jane Doe");
+        member.Position.Should().Be(CongressPosition.Representative);
+
+        var disclosure = await verify
+            .Set<CongressionalAnnualDisclosure>()
+            .AsNoTracking()
+            .Include(d => d.Lines)
+            .SingleAsync();
+        disclosure.CongressMemberId.Should().Be(member.Id);
+        disclosure.Year.Should().Be(2024);
+        disclosure.ReportId.Should().Be("10066169");
+        disclosure.NetWorthMinimum.Should().Be(1_000_001 - 500_000);
+        disclosure.NetWorthMaximum.Should().Be(5_000_000 - 250_001);
+        disclosure.Lines.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ProcessReports_Amendment_ReplacesTheMemberYearRowInPlace()
+    {
+        var original = Report(
+            "10066169",
+            new DateOnly(2025, 5, 15),
+            amendment: false,
+            Line(CongressionalDisclosureLineKind.Asset, "Apple Inc. (AAPL)", 1_000_001, 5_000_000)
+        );
+        var sut = BuildSut();
+        await ProcessReports(sut, [original]);
+        var originalId = await DbContext
+            .Set<CongressionalAnnualDisclosure>()
+            .AsNoTracking()
+            .Select(d => d.Id)
+            .SingleAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var amendment = Report(
+            "10074000",
+            new DateOnly(2025, 11, 4),
+            amendment: true,
+            Line(CongressionalDisclosureLineKind.Asset, "NVIDIA (NVDA)", 5_000_001, 25_000_000),
+            Line(CongressionalDisclosureLineKind.Asset, "Visa Inc. (V)", 15_001, 50_000)
+        );
+        await ProcessReports(sut, [amendment]);
+
+        await using var verify = Fixture.CreateDbContext();
+        var disclosure = await verify
+            .Set<CongressionalAnnualDisclosure>()
+            .AsNoTracking()
+            .Include(d => d.Lines)
+            .SingleAsync();
+        disclosure.Id.Should().Be(originalId, "amendments replace the year's report in place");
+        disclosure.ReportId.Should().Be("10074000");
+        disclosure.FiledDate.Should().Be(new DateOnly(2025, 11, 4));
+        disclosure.NetWorthMinimum.Should().Be(5_000_001 + 15_001);
+        disclosure.NetWorthMaximum.Should().Be(25_000_000 + 50_000);
+        disclosure.Lines.Should().HaveCount(2);
+        disclosure.Lines.Should().OnlyContain(l => l.Description != "Apple Inc. (AAPL)");
+    }
+
+    [Fact]
+    public async Task ProcessReports_SameReportAgain_IsIdempotent()
+    {
+        var report = Report(
+            "10066169",
+            new DateOnly(2025, 5, 15),
+            amendment: false,
+            Line(CongressionalDisclosureLineKind.Asset, "Apple Inc. (AAPL)", 1_000_001, 5_000_000)
+        );
+        var sut = BuildSut();
+        await ProcessReports(sut, [report]);
+        DbContext.ChangeTracker.Clear();
+
+        await ProcessReports(sut, [report]);
+
+        await using var verify = Fixture.CreateDbContext();
+        (await verify.Set<CongressionalAnnualDisclosure>().AsNoTracking().CountAsync())
+            .Should()
+            .Be(1);
+        (await verify.Set<CongressionalDisclosureLine>().AsNoTracking().CountAsync())
+            .Should()
+            .Be(1);
+    }
+}

--- a/tests/Equibles.UnitTests/Congress/CongressionalAnnualDisclosureSyncServiceTests.cs
+++ b/tests/Equibles.UnitTests/Congress/CongressionalAnnualDisclosureSyncServiceTests.cs
@@ -1,0 +1,146 @@
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.HostedService.Models;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Pure-logic tests for the annual disclosure sync: the net-worth band
+/// arithmetic, the latest-report-wins selection, and the in-place replacement
+/// rule. The DB flow is covered by the integration tier.
+/// </summary>
+public class CongressionalAnnualDisclosureSyncServiceTests
+{
+    private static AnnualDisclosureLineItem Asset(long minimum, long maximum) =>
+        new()
+        {
+            Kind = CongressionalDisclosureLineKind.Asset,
+            Description = "Asset",
+            RangeMinimum = minimum,
+            RangeMaximum = maximum,
+        };
+
+    private static AnnualDisclosureLineItem Liability(long minimum, long maximum) =>
+        new()
+        {
+            Kind = CongressionalDisclosureLineKind.Liability,
+            Description = "Liability",
+            RangeMinimum = minimum,
+            RangeMaximum = maximum,
+        };
+
+    private static AnnualDisclosureReport Report(
+        string member,
+        int year,
+        DateOnly filed,
+        bool amendment,
+        string reportId
+    ) =>
+        new()
+        {
+            MemberName = member,
+            Position = CongressPosition.Representative,
+            Year = year,
+            FiledDate = filed,
+            ReportId = reportId,
+            IsAmendment = amendment,
+        };
+
+    [Fact]
+    public void ComputeNetWorthBand_AssetsAndLiabilities_FollowsTheBandMethodology()
+    {
+        // Minimum = asset minimums − liability maximums; maximum = asset
+        // maximums − liability minimums. The band brackets the truth from
+        // both sides — never a point estimate.
+        var (minimum, maximum) = CongressionalAnnualDisclosureSyncService.ComputeNetWorthBand([
+            Asset(1_000_001, 5_000_000),
+            Asset(15_001, 50_000),
+            Liability(250_001, 500_000),
+        ]);
+
+        minimum.Should().Be(1_000_001 + 15_001 - 500_000);
+        maximum.Should().Be(5_000_000 + 50_000 - 250_001);
+    }
+
+    [Fact]
+    public void SelectLatestReports_AmendmentAndOriginal_KeepsTheLatestPerMemberYear()
+    {
+        var original = Report("Jane Doe", 2024, new DateOnly(2025, 5, 15), false, "1001");
+        var amendment = Report("Jane Doe", 2024, new DateOnly(2025, 11, 4), true, "1002");
+        var otherYear = Report("Jane Doe", 2023, new DateOnly(2024, 5, 15), false, "0901");
+        var otherMember = Report("John Roe", 2024, new DateOnly(2025, 5, 15), false, "1003");
+
+        var latest = CongressionalAnnualDisclosureSyncService.SelectLatestReports([
+            amendment,
+            original,
+            otherYear,
+            otherMember,
+        ]);
+
+        latest.Should().HaveCount(3);
+        latest
+            .Single(r => r.MemberName == "Jane Doe" && r.Year == 2024)
+            .ReportId.Should()
+            .Be("1002", "the amendment was filed later and replaces the original");
+        latest.Should().Contain(otherYear).And.Contain(otherMember);
+    }
+
+    [Fact]
+    public void SelectLatestReports_SameDayAmendment_BeatsTheOriginal()
+    {
+        var sameDay = new DateOnly(2025, 5, 15);
+        var original = Report("Jane Doe", 2024, sameDay, false, "1001");
+        var amendment = Report("Jane Doe", 2024, sameDay, true, "1002");
+
+        var latest = CongressionalAnnualDisclosureSyncService.SelectLatestReports([
+            amendment,
+            original,
+        ]);
+
+        latest.Should().ContainSingle().Which.ReportId.Should().Be("1002");
+    }
+
+    [Theory]
+    [InlineData("1001", "2025-05-15", false, false)] // same source report → no-op
+    [InlineData("1002", "2025-11-04", false, true)] // later filing replaces
+    [InlineData("1002", "2025-01-01", false, false)] // earlier filing never replaces
+    [InlineData("1002", "2025-05-15", true, true)] // same-day amendment replaces
+    [InlineData("1002", "2025-05-15", false, false)] // same-day non-amendment does not
+    public void ShouldReplace_AppliesTheLatestFiledWinsRule(
+        string incomingReportId,
+        string incomingFiled,
+        bool incomingIsAmendment,
+        bool expected
+    )
+    {
+        var existing = new CongressionalAnnualDisclosure
+        {
+            ReportId = "1001",
+            FiledDate = new DateOnly(2025, 5, 15),
+            Year = 2024,
+        };
+        var incoming = Report(
+            "Jane Doe",
+            2024,
+            DateOnly.Parse(incomingFiled),
+            incomingIsAmendment,
+            incomingReportId
+        );
+
+        CongressionalAnnualDisclosureSyncService
+            .ShouldReplace(existing, incoming)
+            .Should()
+            .Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Member", true)]
+    [InlineData("Member-elect", true)]
+    [InlineData("Congressional Candidate", false)]
+    [InlineData("Officer or Employee", false)]
+    [InlineData(null, true)]
+    public void IsMemberFilerStatus_GatesNonMemberReports(string status, bool expected)
+    {
+        HouseAnnualReportClient.IsMemberFilerStatus(status).Should().Be(expected);
+    }
+}

--- a/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseAnnualReportClientTests.cs
@@ -32,9 +32,11 @@ public class HouseAnnualReportClientTests
         // crossing a page break without a repeated column header.
         var bytes = File.ReadAllBytes(FixturePath("house-annual-pelosi-2024.pdf"));
 
-        var lines = HouseAnnualReportClient.ParseAnnualReportPdf(bytes);
+        var content = HouseAnnualReportClient.ParseAnnualReportPdf(bytes);
 
-        lines.Should().NotBeNull();
+        content.Should().NotBeNull();
+        content.FilerStatus.Should().Be("Member");
+        var lines = content.Lines;
         lines.Count(l => l.Kind == CongressionalDisclosureLineKind.Asset).Should().Be(59);
         lines.Count(l => l.Kind == CongressionalDisclosureLineKind.Liability).Should().Be(9);
 
@@ -87,11 +89,12 @@ public class HouseAnnualReportClientTests
         // description, and the creditor must fold in.
         var bytes = File.ReadAllBytes(FixturePath("house-annual-aoc-2024.pdf"));
 
-        var lines = HouseAnnualReportClient.ParseAnnualReportPdf(bytes);
+        var content = HouseAnnualReportClient.ParseAnnualReportPdf(bytes);
 
-        lines.Should().NotBeNull();
-        lines
-            .Select(l => (l.Kind, l.Description, l.RangeMinimum, l.RangeMaximum))
+        content.Should().NotBeNull();
+        content.FilerStatus.Should().Be("Member");
+        content
+            .Lines.Select(l => (l.Kind, l.Description, l.RangeMinimum, l.RangeMaximum))
             .Should()
             .BeEquivalentTo([
                 (
@@ -128,9 +131,9 @@ public class HouseAnnualReportClientTests
         // Scanned paper filings are image-only: no extractable words, so no
         // Schedule A header — the electronic-only policy reports them as null,
         // never as an empty (zero net worth) report.
-        var lines = HouseAnnualReportClient.ParseAnnualReportPdf(BuildTextlessPdf());
+        var content = HouseAnnualReportClient.ParseAnnualReportPdf(BuildTextlessPdf());
 
-        lines.Should().BeNull();
+        content.Should().BeNull();
     }
 
     // ---- token-level schedule parsing ----


### PR DESCRIPTION
## Summary

- Ingestion for congressional annual financial disclosures: `CongressionalAnnualDisclosureSyncService` pulls House reports per coverage year ({year}FD.zip) and Senate reports by submitted-date window, keeps the latest filed report per member-year (amendments beat originals, including same-day refilings), upserts the member, and stores each report as a `CongressionalAnnualDisclosure` with its net-worth band (Σ asset minimums − Σ liability maximums through Σ asset maximums − Σ liability minimums) plus the disclosed lines.
- Idempotent and amendment-aware: re-encountering the stored report id is a no-op; a later-filed report replaces the member-year row in place (same row id, new report id, fresh lines). Default incremental window is the last two coverage years (extensions push many filings deep into Y+1); `MinSyncDate` widens it for backfills, floored at 2012 (STOCK Act).
- House member gate: the report preamble's own "Status:" field is now extracted and non-member filings ("Congressional Candidate") are skipped, so candidate reports can never enter the member net-worth data.
- New daily `CongressionalAnnualDisclosureScraperWorker` registered alongside the trade scraper in `AddCongressWorker()`.
- Fifth slice of the congressional net-worth tracker (EquiblesCommercial#2240); the commercial pin bump and the portal surfaces come next.

## Code changes

- `src/Equibles.Congress.HostedService/Services/CongressionalAnnualDisclosureSyncService.cs` — new `[Service]` sync: chamber fetches with per-source error reporting, `SelectLatestReports`, `ShouldReplace`, `ComputeNetWorthBand`, FlexLabs member upsert, in-place replacement of disclosures and lines.
- `src/Equibles.Congress.HostedService/CongressionalAnnualDisclosureScraperWorker.cs` — daily worker invoking the sync; registered in `Extensions/ServiceCollectionExtensions.cs`.
- `src/Equibles.Congress.HostedService/Services/HouseAnnualReportClient.cs` — `ParseAnnualReportPdf` now returns the preamble filer status alongside the lines (`HouseAnnualReportContent`); non-member reports are skipped with the new `IsMemberFilerStatus` gate.
- `tests/Equibles.UnitTests/Congress/CongressionalAnnualDisclosureSyncServiceTests.cs` — band arithmetic, latest-report selection (incl. same-day amendment), the replacement rule matrix, and the filer-status gate.
- `tests/Equibles.UnitTests/Congress/HouseAnnualReportClientTests.cs` — updated for the content result; both real cassettes now also pin `FilerStatus == "Member"`.
- `tests/Equibles.IntegrationTests/Congress/CongressionalAnnualDisclosureSyncServiceProcessTests.cs` — real-Postgres persistence flow: new report stores member + band + lines, amendment replaces in place, re-run is idempotent.