### PR TITLE
feat(congress-mcp): add GetMemberNetWorth tool

### DIFF
--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -20,12 +20,14 @@ public class CongressTools
 {
     private readonly CongressionalTradeRepository _tradeRepository;
     private readonly CongressMemberRepository _memberRepository;
+    private readonly CongressionalAnnualDisclosureRepository _disclosureRepository;
     private readonly CommonStockRepository _commonStockRepository;
     private readonly McpToolRunner _runner;
 
     public CongressTools(
         CongressionalTradeRepository tradeRepository,
         CongressMemberRepository memberRepository,
+        CongressionalAnnualDisclosureRepository disclosureRepository,
         CommonStockRepository commonStockRepository,
         ErrorManager errorManager,
         ILogger<CongressTools> logger
@@ -33,6 +35,7 @@ public class CongressTools
     {
         _tradeRepository = tradeRepository;
         _memberRepository = memberRepository;
+        _disclosureRepository = disclosureRepository;
         _commonStockRepository = commonStockRepository;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
@@ -156,6 +159,62 @@ public class CongressTools
             $"memberName: {memberName}"
         );
     }
+
+    [McpServerTool(Name = "GetMemberNetWorth")]
+    [Description(
+        "Get a congress member's net worth history from their annual financial disclosures. Disclosed values are ranges, so every year is a band (minimum-maximum), never a point estimate. Only electronically filed reports are read: a missing year means no electronic filing, not zero net worth."
+    )]
+    public Task<string> GetMemberNetWorth(
+        [Description("Congress member name (e.g., 'Nancy Pelosi', 'Marsha Blackburn')")]
+            string memberName,
+        [Description("Maximum number of years to return (default: 20, newest first)")]
+            int maxResults = 20
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var member = await _memberRepository.GetByName(memberName.Trim());
+                if (member == null)
+                    return $"Member '{memberName}' not found. Use SearchCongressMembers to find the exact name.";
+
+                var disclosures = await _disclosureRepository
+                    .GetByMember(member)
+                    .OrderByDescending(d => d.Year)
+                    .Take(McpLimit.Clamp(maxResults))
+                    .Select(d => new
+                    {
+                        d.Year,
+                        d.FiledDate,
+                        d.NetWorthMinimum,
+                        d.NetWorthMaximum,
+                        AssetCount = d.Lines.Count(l =>
+                            l.Kind == CongressionalDisclosureLineKind.Asset
+                        ),
+                        LiabilityCount = d.Lines.Count(l =>
+                            l.Kind == CongressionalDisclosureLineKind.Liability
+                        ),
+                    })
+                    .ToListAsync();
+
+                return MarkdownTable.Render(
+                    disclosures,
+                    $"No electronically filed annual disclosure found for {member.Name} ({member.Position.NameForHumans()}). Paper filings are not read, so this does not mean zero net worth.",
+                    $"Net worth of {member.Name} ({member.Position.NameForHumans()}), as disclosed in annual financial reports (band = sum of disclosed asset minimums minus liability maximums, through asset maximums minus liability minimums):",
+                    "| Year | Filed | Net Worth Minimum | Net Worth Maximum | Assets | Liabilities |",
+                    "|------|-------|-------------------|-------------------|--------|-------------|",
+                    d =>
+                        $"| {d.Year} | {d.FiledDate:yyyy-MM-dd} | {FormatSignedAmount(d.NetWorthMinimum)} | {FormatSignedAmount(d.NetWorthMaximum)} | {d.AssetCount} | {d.LiabilityCount} |"
+                );
+            },
+            "GetMemberNetWorth",
+            $"memberName: {memberName}"
+        );
+    }
+
+    // Net worth bands can be negative (liabilities exceeding assets).
+    private static string FormatSignedAmount(long value) =>
+        value < 0 ? $"-${McpFormat.WholeNumber(-value)}" : $"${McpFormat.WholeNumber(value)}";
 
     [McpServerTool(Name = "SearchCongressMembers")]
     [Description(

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetCongressionalTradesCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetCongressionalTradesCultureInvarianceTests.cs
@@ -16,6 +16,7 @@ public class CongressToolsGetCongressionalTradesCultureInvarianceTests : ParadeD
         new(
             new CongressionalTradeRepository(DbContext),
             new CongressMemberRepository(DbContext),
+            new CongressionalAnnualDisclosureRepository(DbContext),
             new CommonStockRepository(DbContext),
             ErrorManager,
             NullLogger<CongressTools>()

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberNetWorthTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberNetWorthTests.cs
@@ -1,0 +1,126 @@
+using Equibles.CommonStocks.Repositories;
+using Equibles.Congress.Data.Models;
+using Equibles.Congress.Mcp.Tools;
+using Equibles.Congress.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp;
+
+/// <summary>
+/// Pins the GetMemberNetWorth MCP tool: every year renders as a band with its
+/// asset/liability counts (negative bounds keep their sign), and members
+/// without an electronic disclosure get the "not zero net worth" explanation
+/// rather than an empty table.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class CongressToolsGetMemberNetWorthTests : ParadeDbMcpTestBase
+{
+    public CongressToolsGetMemberNetWorthTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private CongressTools Sut() =>
+        new(
+            new CongressionalTradeRepository(DbContext),
+            new CongressMemberRepository(DbContext),
+            new CongressionalAnnualDisclosureRepository(DbContext),
+            new CommonStockRepository(DbContext),
+            ErrorManager,
+            NullLogger<CongressTools>()
+        );
+
+    [Fact]
+    public async Task GetMemberNetWorth_MemberWithDisclosures_RendersBandsNewestFirst()
+    {
+        var member = new CongressMember
+        {
+            Name = "Banded Member",
+            Position = CongressPosition.Representative,
+        };
+        DbContext.Add(member);
+        DbContext.Add(
+            new CongressionalAnnualDisclosure
+            {
+                CongressMemberId = member.Id,
+                Year = 2023,
+                FiledDate = new DateOnly(2024, 5, 15),
+                ReportId = "7000001",
+                NetWorthMinimum = -250_000,
+                NetWorthMaximum = 400_000,
+                Lines =
+                [
+                    new CongressionalDisclosureLine
+                    {
+                        Kind = CongressionalDisclosureLineKind.Asset,
+                        Description = "Savings",
+                        RangeMinimum = 250_000,
+                        RangeMaximum = 900_000,
+                    },
+                    new CongressionalDisclosureLine
+                    {
+                        Kind = CongressionalDisclosureLineKind.Liability,
+                        Description = "Mortgage (Bank)",
+                        RangeMinimum = 500_000,
+                        RangeMaximum = 500_000,
+                    },
+                ],
+            }
+        );
+        DbContext.Add(
+            new CongressionalAnnualDisclosure
+            {
+                CongressMemberId = member.Id,
+                Year = 2024,
+                FiledDate = new DateOnly(2025, 5, 15),
+                ReportId = "7000002",
+                NetWorthMinimum = 1_015_002,
+                NetWorthMaximum = 4_799_999,
+                Lines =
+                [
+                    new CongressionalDisclosureLine
+                    {
+                        Kind = CongressionalDisclosureLineKind.Asset,
+                        Description = "Apple Inc. (AAPL)",
+                        RangeMinimum = 1_000_001,
+                        RangeMaximum = 5_000_000,
+                    },
+                ],
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var result = await Sut().GetMemberNetWorth("Banded Member");
+
+        result.Should().Contain("Net worth of Banded Member (Representative)");
+        var year2024 = result.IndexOf("| 2024 |", StringComparison.Ordinal);
+        var year2023 = result.IndexOf("| 2023 |", StringComparison.Ordinal);
+        year2024.Should().BeGreaterThan(-1);
+        year2023.Should().BeGreaterThan(year2024, "years render newest first");
+        result.Should().Contain("| 2024 | 2025-05-15 | $1,015,002 | $4,799,999 | 1 | 0 |");
+        result
+            .Should()
+            .Contain(
+                "| 2023 | 2024-05-15 | -$250,000 | $400,000 | 1 | 1 |",
+                "negative bounds keep their sign"
+            );
+    }
+
+    [Fact]
+    public async Task GetMemberNetWorth_MemberWithoutDisclosures_ExplainsMissingIsNotZero()
+    {
+        var member = new CongressMember
+        {
+            Name = "Paper Filer",
+            Position = CongressPosition.Senator,
+        };
+        DbContext.Add(member);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+
+        var result = await Sut().GetMemberNetWorth("Paper Filer");
+
+        result.Should().Contain("No electronically filed annual disclosure");
+        result.Should().Contain("does not mean zero net worth");
+    }
+}

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberTradesCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberTradesCultureInvarianceTests.cs
@@ -16,6 +16,7 @@ public class CongressToolsGetMemberTradesCultureInvarianceTests : ParadeDbMcpTes
         new(
             new CongressionalTradeRepository(DbContext),
             new CongressMemberRepository(DbContext),
+            new CongressionalAnnualDisclosureRepository(DbContext),
             new CommonStockRepository(DbContext),
             ErrorManager,
             NullLogger<CongressTools>()

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberTradesUnknownTransactionTypeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberTradesUnknownTransactionTypeTests.cs
@@ -23,6 +23,7 @@ public class CongressToolsGetMemberTradesUnknownTransactionTypeTests : ParadeDbM
         new(
             new CongressionalTradeRepository(DbContext),
             new CongressMemberRepository(DbContext),
+            new CongressionalAnnualDisclosureRepository(DbContext),
             new CommonStockRepository(DbContext),
             ErrorManager,
             NullLogger<CongressTools>()
@@ -61,6 +62,7 @@ public class CongressToolsGetMemberTradesUnknownTransactionTypeTests : ParadeDbM
         var sut = new CongressTools(
             new CongressionalTradeRepository(verify),
             new CongressMemberRepository(verify),
+            new CongressionalAnnualDisclosureRepository(verify),
             new CommonStockRepository(verify),
             ErrorManager,
             NullLogger<CongressTools>()

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsLowercaseTransactionTypeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsLowercaseTransactionTypeTests.cs
@@ -26,6 +26,7 @@ public class CongressToolsLowercaseTransactionTypeTests : ParadeDbMcpTestBase
         new(
             new CongressionalTradeRepository(DbContext),
             new CongressMemberRepository(DbContext),
+            new CongressionalAnnualDisclosureRepository(DbContext),
             new CommonStockRepository(DbContext),
             ErrorManager,
             NullLogger<CongressTools>()

--- a/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/CongressToolsTests.cs
@@ -15,6 +15,7 @@ public class CongressToolsTests : ParadeDbMcpTestBase
         new(
             new CongressionalTradeRepository(DbContext),
             new CongressMemberRepository(DbContext),
+            new CongressionalAnnualDisclosureRepository(DbContext),
             new CommonStockRepository(DbContext),
             ErrorManager,
             NullLogger<CongressTools>()

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -415,7 +415,13 @@ public class McpModuleToolDiscoveryTests
             },
             {
                 typeof(CongressTools),
-                new[] { "GetCongressionalTrades", "GetMemberTrades", "SearchCongressMembers" }
+                new[]
+                {
+                    "GetCongressionalTrades",
+                    "GetMemberNetWorth",
+                    "GetMemberTrades",
+                    "SearchCongressMembers",
+                }
             },
             {
                 // ShortDataTools is the marker for the whole Equibles.Finra.Mcp


### PR DESCRIPTION
## Summary

- New `GetMemberNetWorth` MCP tool: a member's net-worth history from their annual financial disclosures, one band per year (newest first) with the filed date and asset/liability counts. The band framing is explicit in the tool description and the empty-state message ("a missing year means no electronic filing, not zero net worth"), and negative bounds keep their sign.
- Final OSS slice of the congressional net-worth tracker (EquiblesCommercial#2240).

## Code changes

- `src/Equibles.Congress.Mcp/Tools/CongressTools.cs` — the new tool plus the `CongressionalAnnualDisclosureRepository` dependency and a sign-aware amount formatter.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — Congress discovery expectations now include `GetMemberNetWorth` (kept in lockstep with the assembly scan).
- `tests/Equibles.IntegrationTests/Mcp/CongressToolsGetMemberNetWorthTests.cs` — bands render newest-first with counts and signed bounds; members without an electronic disclosure get the explanatory message.
- `tests/Equibles.IntegrationTests/Mcp/CongressTools*.cs` — constructions updated for the new repository dependency.