### PR TITLE
fix(tests): add GetEconomicCalendar to FredTools discovery expectations

### DIFF
--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -356,6 +356,7 @@ public class McpModuleToolDiscoveryTests
                 typeof(FredTools),
                 new[]
                 {
+                    "GetEconomicCalendar",
                     "GetEconomicIndicator",
                     "GetLatestEconomicData",
                     "SearchEconomicIndicators",


### PR DESCRIPTION
## Summary

- The unit suite has been red on main since #3649 shipped the `GetEconomicCalendar` FRED MCP tool without updating the discovery expectations — `McpModuleToolDiscoveryTests` pins each module's exact tool list, and the FredTools assembly now exposes 4 tools. This was failing the `build-and-test` check on every PR. Closes #3654.

## Code changes

- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — `GetEconomicCalendar` added to the FredTools expected tool names (same shape as #3630 did for the Holdings/Finra tools).