### PR TITLE
fix(congress): pin eFD search dates to the invariant culture

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Equibles.Congress.Data.Models;
 using Equibles.Congress.HostedService.Models;
@@ -117,8 +118,13 @@ public partial class SenateAnnualReportClient
             {
                 ["report_types"] = AnnualReportTypeFilter,
                 ["filer_types"] = SenatorFilerTypeFilter,
-                ["submitted_start_date"] = $"{from:MM/dd/yyyy} 00:00:00",
-                ["submitted_end_date"] = $"{to:MM/dd/yyyy} 23:59:59",
+                // eFD expects US-format dates; "/" in a custom format is the
+                // culture date-separator placeholder, so pin the invariant
+                // culture or a de-DE host posts "01.01.2025" (GH-3660).
+                ["submitted_start_date"] =
+                    $"{from.ToString("MM/dd/yyyy", CultureInfo.InvariantCulture)} 00:00:00",
+                ["submitted_end_date"] =
+                    $"{to.ToString("MM/dd/yyyy", CultureInfo.InvariantCulture)} 23:59:59",
                 ["first_name"] = "",
                 ["last_name"] = "",
                 ["senator_state"] = "",

--- a/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Equibles.Congress.Data.Models;
 using Equibles.Congress.HostedService.Models;
 using Equibles.Core.AutoWiring;
@@ -100,8 +101,13 @@ public class SenateDisclosureClient : IAsyncDisposable
             {
                 ["report_types"] = PtrReportTypeFilter,
                 ["filer_types"] = "[]",
-                ["submitted_start_date"] = $"{from:MM/dd/yyyy} 00:00:00",
-                ["submitted_end_date"] = $"{to:MM/dd/yyyy} 23:59:59",
+                // eFD expects US-format dates; "/" in a custom format is the
+                // culture date-separator placeholder, so pin the invariant
+                // culture or a de-DE host posts "01.01.2025" (GH-3660).
+                ["submitted_start_date"] =
+                    $"{from.ToString("MM/dd/yyyy", CultureInfo.InvariantCulture)} 00:00:00",
+                ["submitted_end_date"] =
+                    $"{to.ToString("MM/dd/yyyy", CultureInfo.InvariantCulture)} 23:59:59",
                 ["first_name"] = "",
                 ["last_name"] = "",
                 ["senator_state"] = "",

--- a/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientSearchDateCultureTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateAnnualReportClientSearchDateCultureTests.cs
@@ -7,9 +7,7 @@ namespace Equibles.UnitTests.Congress;
 
 public class SenateAnnualReportClientSearchDateCultureTests
 {
-    [Fact(
-        Skip = "GH-3660 — search dates are posted with the host culture's date separator instead of US format"
-    )]
+    [Fact]
     public async Task GetAnnualReports_NonUsHostCulture_SendsUsFormattedSubmittedDates()
     {
         // eFD only understands US MM/dd/yyyy dates. The "MM/dd/yyyy" custom


### PR DESCRIPTION
## Summary

- Both Senate clients built the eFD search form with `$"{from:MM/dd/yyyy}"`, where "/" is the culture date-separator placeholder — a de-DE host posts `01.01.2025 00:00:00` and the search window is misread, silently dropping reports. Dates now format with `CultureInfo.InvariantCulture` in the annual-report and PTR search requests. Closes #3660.

## Code changes

- `src/Equibles.Congress.HostedService/Services/SenateAnnualReportClient.cs`, `SenateDisclosureClient.cs` — invariant-culture date formatting for `submitted_start_date`/`submitted_end_date`.
- `tests/Equibles.UnitTests/Congress/SenateAnnualReportClientSearchDateCultureTests.cs` — the GH-3660 repro un-skipped; fails on pre-fix code under de-DE, passes now.