### PR TITLE
fix(congress): parse eFD row dates culture-pinned

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs
@@ -169,13 +169,16 @@ public class SenateDisclosureClient : IAsyncDisposable
         if (reportUrl.Contains("/view/paper/", StringComparison.OrdinalIgnoreCase))
             return null;
 
-        if (!DateOnly.TryParse(row[4]?.Trim(), out var dateSubmitted))
+        // eFD dates are US MM/dd/yyyy — parse culture-pinned, not with the
+        // host culture (GH-3659).
+        var dateSubmitted = ParseDate(row[4]?.Trim());
+        if (dateSubmitted == null)
         {
             _logger.LogDebug("Skipping Senate report with unparseable date: {Date}", row[4]);
             return null;
         }
 
-        return new SenateReport(memberName, reportUrl, dateSubmitted);
+        return new SenateReport(memberName, reportUrl, dateSubmitted.Value);
     }
 
     private async Task<List<DisclosureTransaction>> FetchAndParseReport(

--- a/tests/Equibles.UnitTests/Congress/SenateDisclosureClientParseReportRowDateCultureTests.cs
+++ b/tests/Equibles.UnitTests/Congress/SenateDisclosureClientParseReportRowDateCultureTests.cs
@@ -1,0 +1,49 @@
+using System.Globalization;
+using System.Reflection;
+using Equibles.Congress.HostedService.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.Congress;
+
+public class SenateDisclosureClientParseReportRowDateCultureTests
+{
+    private static readonly MethodInfo ParseReportRowMethod =
+        typeof(SenateDisclosureClient).GetMethod(
+            "ParseReportRow",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+    // eFD dates are US MM/dd/yyyy. Parsing the row with the host culture drops
+    // every day-ambiguous report on a dd/MM host (08/20/2025 has no month 20),
+    // silently skipping the filing — the row must parse identically everywhere.
+    [Fact]
+    public void ParseReportRow_UsDateOnNonUsHostCulture_StillParsesTheReport()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("pt-PT");
+        try
+        {
+            var sut = new SenateDisclosureClient(
+                Substitute.For<ISenateBrowserSession>(),
+                Substitute.For<ILogger<SenateDisclosureClient>>()
+            );
+            var row = new List<string>
+            {
+                "Jane",
+                "Doe",
+                "Doe, Jane (Senator)",
+                "<a href=\"/search/view/ptr/3a3528d3-9133-4e54-9af6-31effe2a69e7/\">Periodic Transaction Report</a>",
+                "08/20/2025",
+            };
+
+            var report = ParseReportRowMethod.Invoke(sut, [row]);
+
+            report.Should().NotBeNull("a US-format date must parse regardless of host culture");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `SenateDisclosureClient.ParseReportRow` parsed the eFD "date submitted" cell with the host culture, so day-ambiguous US dates like 08/20/2025 failed on dd/MM hosts and the report was silently skipped. The row now parses through `DisclosureParsingHelper.ParseDate` (en-US pinned with an invariant exact-format fallback) — the same helper the annual-report client already uses. Closes #3659.

## Code changes

- `src/Equibles.Congress.HostedService/Services/SenateDisclosureClient.cs` — culture-pinned date parse in the row parser.
- `tests/Equibles.UnitTests/Congress/SenateDisclosureClientParseReportRowDateCultureTests.cs` — regression under pt-PT; fails pre-fix, passes now.