### PR TITLE
feat(sec): add DEF 14A document type and include proxies in the scraper form set

### DIFF
--- a/src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs
+++ b/src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs
@@ -57,4 +57,7 @@ public enum DocumentTypeFilter
 
     [Display(Name = "NPORT-P/A")]
     NportPa,
+
+    [Display(Name = "DEF 14A")]
+    Def14A,
 }

--- a/src/Equibles.Sec.Data/Models/DocumentType.cs
+++ b/src/Equibles.Sec.Data/Models/DocumentType.cs
@@ -33,6 +33,7 @@ public sealed class DocumentType
     public static readonly DocumentType NCenA = new("NCenA", "N-CEN/A");
     public static readonly DocumentType NportP = new("NportP", "NPORT-P");
     public static readonly DocumentType NportPa = new("NportPa", "NPORT-P/A");
+    public static readonly DocumentType Def14A = new("Def14A", "DEF 14A");
     public static readonly DocumentType Other = new("Other", "Other");
 
     private static readonly ConcurrentDictionary<string, DocumentType> AllByValue = new(
@@ -56,6 +57,7 @@ public sealed class DocumentType
             new KeyValuePair<string, DocumentType>(NCenA.Value, NCenA),
             new KeyValuePair<string, DocumentType>(NportP.Value, NportP),
             new KeyValuePair<string, DocumentType>(NportPa.Value, NportPa),
+            new KeyValuePair<string, DocumentType>(Def14A.Value, Def14A),
             new KeyValuePair<string, DocumentType>(Other.Value, Other),
         },
         StringComparer.OrdinalIgnoreCase
@@ -82,6 +84,7 @@ public sealed class DocumentType
             new KeyValuePair<string, DocumentType>(NCenA.DisplayName, NCenA),
             new KeyValuePair<string, DocumentType>(NportP.DisplayName, NportP),
             new KeyValuePair<string, DocumentType>(NportPa.DisplayName, NportPa),
+            new KeyValuePair<string, DocumentType>(Def14A.DisplayName, Def14A),
             new KeyValuePair<string, DocumentType>(Other.DisplayName, Other),
         },
         StringComparer.OrdinalIgnoreCase

--- a/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs
@@ -18,5 +18,6 @@ public class DocumentScraperOptions
         DocumentType.NCenA,
         DocumentType.NportP,
         DocumentType.NportPa,
+        DocumentType.Def14A,
     ];
 }

--- a/src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs
@@ -26,6 +26,7 @@ public static class DocumentTypeExtensions
             { DocumentType.NCenA, DocumentTypeFilter.NCenA },
             { DocumentType.NportP, DocumentTypeFilter.NportP },
             { DocumentType.NportPa, DocumentTypeFilter.NportPa },
+            { DocumentType.Def14A, DocumentTypeFilter.Def14A },
         };
 
     public static DocumentTypeFilter? ToSecEdgarFilter(this DocumentType docType)

--- a/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
+++ b/tests/Equibles.UnitTests/Core/ConfigurationTests.cs
@@ -144,7 +144,7 @@ public class ConfigurationTests
         options
             .DocumentTypesToSync.Should()
             .NotBeNull()
-            .And.HaveCount(12)
+            .And.HaveCount(13)
             .And.ContainInOrder(
                 DocumentType.TenK,
                 DocumentType.TenQ,
@@ -157,7 +157,8 @@ public class ConfigurationTests
                 DocumentType.NCen,
                 DocumentType.NCenA,
                 DocumentType.NportP,
-                DocumentType.NportPa
+                DocumentType.NportPa,
+                DocumentType.Def14A
             );
     }
 

--- a/tests/Equibles.UnitTests/Sec/DocumentTypeExtensionsTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeExtensionsTests.cs
@@ -25,6 +25,7 @@ public class DocumentTypeExtensionsTests
     [InlineData("NCenA", DocumentTypeFilter.NCenA)]
     [InlineData("NportP", DocumentTypeFilter.NportP)]
     [InlineData("NportPa", DocumentTypeFilter.NportPa)]
+    [InlineData("Def14A", DocumentTypeFilter.Def14A)]
     public void ToSecEdgarFilter_MappedType_ReturnsCorrectFilter(
         string documentTypeValue,
         DocumentTypeFilter expectedFilter

--- a/tests/Equibles.UnitTests/Sec/DocumentTypeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/DocumentTypeTests.cs
@@ -9,6 +9,7 @@ public class DocumentTypeTests
     [InlineData("TenQ")]
     [InlineData("EightK")]
     [InlineData("FormFour")]
+    [InlineData("Def14A")]
     public void FromValue_ReturnsCorrectType(string value)
     {
         var result = DocumentType.FromValue(value);
@@ -50,6 +51,7 @@ public class DocumentTypeTests
     [InlineData("N-CEN/A", "NCenA")]
     [InlineData("NPORT-P", "NportP")]
     [InlineData("NPORT-P/A", "NportPa")]
+    [InlineData("DEF 14A", "Def14A")]
     public void FromDisplayName_ReturnsCorrectType(string displayName, string expectedValue)
     {
         var result = DocumentType.FromDisplayName(displayName);


### PR DESCRIPTION
## Summary

- Adds `Def14A` ("DEF 14A") to the `DocumentType` smart enum and to both lookup registries, so definitive proxy statements are a first-class document type.
- Maps it to a new `DocumentTypeFilter.Def14A` EDGAR filter and includes it in the document scraper's default form set, so proxies are collected alongside the existing forms. Proxies flow through the standard HTML→Markdown pipeline (no dedicated filing processor), which also makes officer/director extraction possible downstream.

## Code changes

- `src/Equibles.Sec.Data/Models/DocumentType.cs` — new `Def14A` instance + registry entries.
- `src/Equibles.Integrations.Sec/Models/DocumentTypeFilter.cs` — new filter value with the exact EDGAR form name `DEF 14A`.
- `src/Equibles.Sec.HostedService/Extensions/DocumentTypeExtensions.cs` — mapping entry.
- `src/Equibles.Sec.HostedService/Configuration/DocumentScraperOptions.cs` — added to the default `DocumentTypesToSync`.
- `tests/Equibles.UnitTests` — extended `DocumentTypeTests`, `DocumentTypeExtensionsTests`, and the scraper-options default test to cover the new type.