### PR TITLE
fix(sec): accept multi-word form types like DEF 14A in the HTML normalizer

### DIFF
--- a/src/Equibles.Sec.BusinessLogic/SecDocumentHtmlNormalizer.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecDocumentHtmlNormalizer.cs
@@ -52,13 +52,22 @@ public class SecDocumentHtmlNormalizer : ISecDocumentHtmlNormalizer
         return tempDoc.Body?.InnerHtml ?? string.Empty;
     }
 
-    private bool IsAllowedDocumentType(string documentType)
+    // The TYPE line may carry a descriptive trailer after the bare form name
+    // ("10-K   Annual Report") AND the form name itself may contain spaces
+    // ("DEF 14A"), so match the longest token prefix that is a registered display
+    // name before falling back to the exhibit check on the first token.
+    private bool IsAllowedDocumentType(string documentTypeLine)
     {
-        if (DocumentType.FromDisplayName(documentType) != null)
+        var tokens = documentTypeLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        for (var take = tokens.Length; take >= 1; take--)
         {
-            return true;
+            if (DocumentType.FromDisplayName(string.Join(' ', tokens[..take])) != null)
+            {
+                return true;
+            }
         }
 
+        var documentType = tokens.Length > 0 ? tokens[0] : documentTypeLine;
         if (documentType.StartsWith("EX-"))
         {
             var exNumberPart = documentType.Substring(3);
@@ -97,7 +106,9 @@ public class SecDocumentHtmlNormalizer : ISecDocumentHtmlNormalizer
             var block = searchText.Substring(blockStart, blockEnd - blockStart + endTag.Length);
             pos = blockEnd + endTag.Length;
 
-            var typeText = ExtractSgmlTagValue(block, "TYPE");
+            var typeText = SecSgmlEnvelope.TryGetTagLine(block, "TYPE", out var typeLine)
+                ? typeLine
+                : null;
             if (string.IsNullOrEmpty(typeText) || !IsAllowedDocumentType(typeText))
                 continue;
 

--- a/src/Equibles.Sec.BusinessLogic/SecSgmlEnvelope.cs
+++ b/src/Equibles.Sec.BusinessLogic/SecSgmlEnvelope.cs
@@ -31,4 +31,32 @@ internal static class SecSgmlEnvelope
         value = raw.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)[0];
         return true;
     }
+
+    // Reads the full single-line value of an SGML header tag, whitespace-normalized but with
+    // every token kept. Multi-word form types ("DEF 14A") need the whole line — the caller
+    // decides how much of it is the value versus a descriptive trailer.
+    public static bool TryGetTagLine(string block, string tagName, out string value)
+    {
+        value = string.Empty;
+        var tagMarker = $"<{tagName}>";
+        var idx = block.IndexOf(tagMarker, StringComparison.OrdinalIgnoreCase);
+        if (idx == -1)
+            return false;
+
+        var valueStart = idx + tagMarker.Length;
+        var end = valueStart;
+        while (end < block.Length && block[end] != '\n' && block[end] != '\r' && block[end] != '<')
+        {
+            end++;
+        }
+
+        var tokens = block
+            .Substring(valueStart, end - valueStart)
+            .Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0)
+            return false;
+
+        value = string.Join(' ', tokens);
+        return true;
+    }
 }

--- a/tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerMultiWordTypeTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerMultiWordTypeTests.cs
@@ -1,0 +1,71 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SecDocumentHtmlNormalizerMultiWordTypeTests
+{
+    private readonly SecDocumentHtmlNormalizer _sut = new();
+
+    [Fact]
+    public void Normalize_MultiWordFormType_IsAllowed()
+    {
+        // "DEF 14A" contains a space, so a first-token read of the TYPE line
+        // yields "DEF" and the proxy is silently dropped from the pipeline.
+        // The normalizer must match the multi-word display name.
+        var sgml = """
+            <DOCUMENT>
+            <TYPE>DEF 14A
+            <FILENAME>proxy.htm
+            <TEXT>
+            <html><body><p>Proxy statement body</p></body></html>
+            </TEXT>
+            </DOCUMENT>
+            """;
+
+        var result = _sut.Normalize(sgml);
+
+        result.Should().Contain("Proxy statement body");
+    }
+
+    [Fact]
+    public void Normalize_SingleWordTypeWithDescriptiveTrailer_IsStillAllowed()
+    {
+        // SEC sometimes appends a descriptive trailer after the bare form name
+        // ("10-K   Annual Report"). The longest-prefix match must fall back to
+        // the bare token so trailers keep working.
+        var sgml = """
+            <DOCUMENT>
+            <TYPE>10-K   Annual Report
+            <FILENAME>annual.htm
+            <TEXT>
+            <html><body><p>Annual report body</p></body></html>
+            </TEXT>
+            </DOCUMENT>
+            """;
+
+        var result = _sut.Normalize(sgml);
+
+        result.Should().Contain("Annual report body");
+    }
+
+    [Fact]
+    public void Normalize_UnknownMultiWordType_IsFiltered()
+    {
+        // No token prefix of "PRE 14A" is a registered display name (preliminary
+        // proxies are deliberately not collected) and it is not an exhibit, so
+        // the document block must stay filtered out.
+        var sgml = """
+            <DOCUMENT>
+            <TYPE>PRE 14A
+            <FILENAME>prelim.htm
+            <TEXT>
+            <html><body><p>Preliminary proxy body</p></body></html>
+            </TEXT>
+            </DOCUMENT>
+            """;
+
+        var result = _sut.Normalize(sgml);
+
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- The SGML envelope reader returns only the first whitespace token of a TYPE line, so `<TYPE>DEF 14A` reads as `DEF` and the normalizer silently filters the proxy out — every DEF 14A produced an empty document. Found while building proxy fixtures against the real pipeline.
- The normalizer now reads the whole TYPE line and matches the longest token prefix against registered display names, falling back to the first token so descriptive trailers ("10-K   Annual Report") keep working.

## Code changes

- `src/Equibles.Sec.BusinessLogic/SecSgmlEnvelope.cs` — new `TryGetTagLine` that keeps every token of the line (whitespace-normalized); `TryGetTagValue` unchanged for existing callers.
- `src/Equibles.Sec.BusinessLogic/SecDocumentHtmlNormalizer.cs` — TYPE is read via `TryGetTagLine`; `IsAllowedDocumentType` does longest-prefix display-name matching with the exhibit check on the first token.
- `tests/Equibles.UnitTests/Sec/SecDocumentHtmlNormalizerMultiWordTypeTests.cs` — pins DEF 14A allowed, trailer fallback still allowed, and unknown multi-word types (PRE 14A) still filtered.