### PR TITLE
test(sec): pin SecSgmlEnvelope.TryGetTagLine tab-separated multi-word normalization

### DIFF
--- a/tests/Equibles.UnitTests/Sec/SecSgmlEnvelopeTryGetTagLineTabSeparatorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SecSgmlEnvelopeTryGetTagLineTabSeparatorTests.cs
@@ -1,0 +1,25 @@
+using Equibles.Sec.BusinessLogic;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Contract (SecSgmlEnvelope.cs:35-37): the helper returns the "full
+/// single-line value of an SGML header tag, whitespace-normalized but with
+/// every token kept". A tab-separated multi-word form type ("DEF\t14A") is
+/// the diagnostic input: a bug in the split char set, the join delimiter, or
+/// the line-walk bounds surfaces as a wrong return value — single space
+/// joined "DEF 14A" is the only value that satisfies the contract.
+/// </summary>
+public class SecSgmlEnvelopeTryGetTagLineTabSeparatorTests
+{
+    [Fact]
+    public void TryGetTagLine_TabSeparatedMultiWord_NormalizesToSingleSpaceJoinedTokens()
+    {
+        var block = "<TYPE>DEF\t14A\n<FILENAME>proxy.htm\n";
+
+        var found = SecSgmlEnvelope.TryGetTagLine(block, "TYPE", out var value);
+
+        found.Should().BeTrue();
+        value.Should().Be("DEF 14A");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a direct unit test for the new `SecSgmlEnvelope.TryGetTagLine` helper introduced in #3672. The XML doc promises a "full single-line value … whitespace-normalized but with every token kept", and a tab-separated multi-word form type is the most diagnostic input: a bug in the split char set, the join delimiter, or the line-walk bounds surfaces as a wrong return value.

## Code changes

- `tests/Equibles.UnitTests/Sec/SecSgmlEnvelopeTryGetTagLineTabSeparatorTests.cs` — new test asserting that `<TYPE>DEF\t14A\n…` returns `true` and `value == "DEF 14A"` (the only value that satisfies the contract: both tokens kept, separator normalized to a single space).