### PR TITLE
test(sec): pin RevenueBreakdownTools.Humanize PascalCase spacing on non-Member QName

### DIFF
--- a/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsHumanizePascalCaseSpacingTests.cs
+++ b/tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsHumanizePascalCaseSpacingTests.cs
@@ -1,0 +1,22 @@
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Contract (RevenueBreakdownTools.cs:221-223): the "everything else" branch
+/// of Humanize drops the "Member" suffix and spaces the PascalCase local
+/// name. A non-country QName with three PascalCase words and no "Member"
+/// suffix is the diagnostic input — it exercises the regex (lower→upper
+/// boundaries) without crossing the "country:" or "Member"-strip arms,
+/// so a regression in either side is isolated to this test.
+/// </summary>
+public class RevenueBreakdownToolsHumanizePascalCaseSpacingTests
+{
+    [Fact]
+    public void Humanize_NonCountryQNameWithoutMemberSuffix_SpacesPascalCaseLocalName()
+    {
+        var result = RevenueBreakdownTools.Humanize("us-gaap:StatementGeographicalAxis");
+
+        result.Should().Be("Statement Geographical Axis");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a direct unit test for `RevenueBreakdownTools.Humanize`, the XBRL member QName humanizer introduced in #3621. The existing `BuildAxisSeries` test only exercises the "Member"-stripped branch, so the PascalCase spacing regex (the `(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])` boundaries) is not directly pinned anywhere.
- Pins the "everything else" branch of Humanize: a non-`country:` QName with three PascalCase words and no `Member` suffix — a diagnostic input that exercises the regex without crossing the country/RegionInfo arm or the `Member` strip.

## Code changes

- `tests/Equibles.UnitTests/Sec/RevenueBreakdownToolsHumanizePascalCaseSpacingTests.cs` — asserts `Humanize("us-gaap:StatementGeographicalAxis") == "Statement Geographical Axis"`. A regression in the colon split, the regex, or the `Member` strip on this input would surface as a string mismatch.