### PR TITLE
test(congress): pin HouseDisclosureClient.IsContinuationLine classifying wrapped-amount-only lines

### DIFF
--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientIsContinuationLineWrappedAmountTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientIsContinuationLineWrappedAmountTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// Contract (HouseDisclosureClient.cs:321-328): a continuation line "continues
+/// the current row's asset name or amount" — the false-positive guards are
+/// empty/whitespace, field labels (a colon), and footer notes (a leading '*').
+/// The remaining case — the line is not a fresh transaction anchor — is the
+/// true positive. A wrapped-amount-only line is the diagnostic input: it has
+/// no anchor (no "S/P + MM/DD/YYYY"), no colon, no asterisk, and is the
+/// shape a PDF parser produces when an asset description overflows onto the
+/// next line and only the dollar range survives.
+/// </summary>
+public class HouseDisclosureClientIsContinuationLineWrappedAmountTests
+{
+    [Fact]
+    public void IsContinuationLine_WrappedAmountOnly_ClassifiesAsContinuation()
+    {
+        var method = typeof(HouseDisclosureClient).GetMethod(
+            "IsContinuationLine",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        method.Should().NotBeNull();
+
+        var result = (bool)method!.Invoke(null, ["$5,000,000"])!;
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a direct unit test for the `HouseDisclosureClient.IsContinuationLine` private static helper, which has no direct test today. The existing `HouseDisclosureClientPtrPdfParseTests` integration test exercises the full parse flow; this is the first test that pins the helper's "wrapped amount is a continuation" contract in isolation.

## Code changes

- `tests/Equibles.UnitTests/Congress/HouseDisclosureClientIsContinuationLineWrappedAmountTests.cs` — invokes the private static helper via reflection and asserts that a wrapped-amount-only line (`"$5,000,000"`, the shape a PDF parser produces when an asset description overflows and only the dollar range survives on the next line) is classified as a continuation. A regression in the empty/colon/asterisk guards or the `TransactionAnchorRegex` negative check would surface here.