### PR TITLE
fix(mcp): translate wrongly-typed tool arguments into invalid-params results

### DIFF
--- a/src/Equibles.Mcp/InvalidParamsTranslatingTool.cs
+++ b/src/Equibles.Mcp/InvalidParamsTranslatingTool.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -7,10 +8,12 @@ namespace Equibles.Mcp;
 /// <summary>
 /// Decorates a registered <see cref="McpServerTool"/> so that a missing or malformed
 /// required argument — which the SDK's binder surfaces as an
-/// <see cref="ArgumentException"/> before the tool body ever runs — comes back to the
-/// client as a structured invalid-parameters tool result naming the tool, instead of
-/// an opaque "an error occurred" message. A client's input mistake is not a server
-/// fault, so it is logged at information level rather than error.
+/// <see cref="ArgumentException"/> (missing argument) or a
+/// <see cref="JsonException"/> (argument of the wrong JSON type, e.g. an array where
+/// a string is declared) before the tool body ever runs — comes back to the client as
+/// a structured invalid-parameters tool result naming the tool, instead of an opaque
+/// "an error occurred" message. A client's input mistake is not a server fault, so it
+/// is logged at information level rather than error.
 /// </summary>
 public class InvalidParamsTranslatingTool : McpServerTool
 {
@@ -39,7 +42,7 @@ public class InvalidParamsTranslatingTool : McpServerTool
         {
             return await _inner.InvokeAsync(request, cancellationToken);
         }
-        catch (ArgumentException ex)
+        catch (Exception ex) when (ex is ArgumentException or JsonException)
         {
             _logger.LogInformation(
                 "Rejected call to {ToolName} with invalid arguments: {Reason}",

--- a/tests/Equibles.IntegrationTests/Mcp/Server/McpServerMismatchedArgumentTypeTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/Server/McpServerMismatchedArgumentTypeTests.cs
@@ -1,0 +1,82 @@
+using Equibles.IntegrationTests.Helpers;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace Equibles.IntegrationTests.Mcp.Server;
+
+/// <summary>
+/// A client that sends a required argument with the wrong JSON type — an array where
+/// the tool declares a string — made a mistake in its request, not in our server: the
+/// SDK's binder throws <see cref="System.Text.Json.JsonException"/> before the tool
+/// body runs, and without translation that surfaces as an unhandled exception logged
+/// at error level with an opaque message. The contract pinned here is that such a call
+/// comes back as a structured tool error — <c>IsError</c> with a message naming the
+/// tool and calling out invalid parameters — so the client can fix its request and the
+/// server's error log stays meaningful.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class McpServerMismatchedArgumentTypeTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _paradeDb;
+    private McpServerFixture _serverFixture;
+
+    public McpServerMismatchedArgumentTypeTests(ParadeDbFixture paradeDb)
+    {
+        _paradeDb = paradeDb;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _paradeDb.ResetAsync();
+        _serverFixture = new McpServerFixture(_paradeDb);
+        await _serverFixture.InitializeAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_serverFixture is not null)
+        {
+            await ((IAsyncLifetime)_serverFixture).DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task CallTool_GetLatestPricesWithArrayForStringTickers_ReturnsInvalidParamsError()
+    {
+        var httpClient = _serverFixture.CreateClient();
+        httpClient.BaseAddress = new Uri("http://localhost/");
+
+        var transport = new HttpClientTransport(
+            new HttpClientTransportOptions
+            {
+                Endpoint = new Uri("http://localhost/mcp"),
+                TransportMode = HttpTransportMode.StreamableHttp,
+            },
+            httpClient
+        );
+
+        await using var client = await McpClient.CreateAsync(transport);
+
+        // GetLatestPrices declares 'tickers' as a comma-separated string — sending a
+        // JSON array instead is the natural mistake for a client to make and trips
+        // the binder's deserialization rather than its missing-argument check.
+        var result = await client.CallToolAsync(
+            toolName: "GetLatestPrices",
+            arguments: new Dictionary<string, object> { ["tickers"] = new[] { "AAPL", "MSFT" } }
+        );
+
+        result
+            .IsError.Should()
+            .Be(true, "a call with a wrongly-typed argument cannot have succeeded");
+
+        var text = string.Concat(result.Content.OfType<TextContentBlock>().Select(b => b.Text));
+        text.Should()
+            .Contain(
+                "Invalid parameters",
+                "the client should be told its arguments were the problem, not given an opaque server error"
+            );
+        text.Should()
+            .Contain("GetLatestPrices", "the error should name the tool that rejected the call");
+    }
+}


### PR DESCRIPTION
## Summary

- Calling an MCP tool with a required argument of the wrong JSON type (e.g. an array where a string is declared, `{"tickers": ["AAPL"]}` against `GetLatestPrices`) returned the opaque "An error occurred invoking …" sentinel and logged a `JsonException` stack at error level, even though the fault is the client's request.
- The SDK binder surfaces a missing argument as `ArgumentException` (already translated since #3609) but a wrongly-typed one as `System.Text.Json.JsonException`; `InvalidParamsTranslatingTool` now translates both into a structured "Invalid parameters for {tool}" result logged at information level.
- A `JsonException` thrown inside a tool body cannot be misclassified: tool bodies run inside `McpToolExecutor.Execute`, which catches all exceptions before they reach this decorator, so the widened catch only ever sees binder-stage failures.

## Code changes

- `src/Equibles.Mcp/InvalidParamsTranslatingTool.cs` — widen the catch to `ArgumentException or JsonException` via an exception filter; update the XML doc to cover both binder failure modes.
- `tests/Equibles.IntegrationTests/Mcp/Server/McpServerMismatchedArgumentTypeTests.cs` — new integration test mirroring `McpServerMissingRequiredArgumentTests`, sending a JSON array for the string `tickers` parameter and asserting the structured invalid-params result naming the tool.