### PR TITLE
fix(sec): treat blank CommonStock.Website as missing in company sync, refs #3683

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
+++ b/src/Equibles.Sec.HostedService/Services/CompanySyncService.cs
@@ -174,7 +174,9 @@ public class CompanySyncService : ICompanySyncService
     {
         var existingStock = state.ExistingStocks.First(cs => cs.Cik == secCompany.Cik);
         var normalizedName = NormalizeCompanyName(secCompany.Name);
-        var missingWebsite = existingStock.Website == null;
+        // Empty string counts as missing: the SEC metadata website field is blank for most
+        // companies, and rows that captured that blank must stay eligible for a refill.
+        var missingWebsite = string.IsNullOrEmpty(existingStock.Website);
         var needsUpdate =
             existingStock.Ticker != primaryTicker
             || existingStock.Name != normalizedName
@@ -670,7 +672,10 @@ public class CompanySyncService : ICompanySyncService
         try
         {
             var metadata = await _secEdgarClient.GetCompanyMetadata(cik);
-            return metadata?.Website?.Trim();
+            var website = metadata?.Website?.Trim();
+            // Normalise the SEC's usual blank answer to null so it is stored as "still
+            // missing" rather than masquerading as a captured website.
+            return string.IsNullOrEmpty(website) ? null : website;
         }
         catch (HttpRequestException ex)
         {

--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingWebsiteRefillTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingWebsiteRefillTests.cs
@@ -1,0 +1,163 @@
+using System.Reflection;
+using Equibles.CommonStocks.BusinessLogic;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.HostedService.Services;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins <c>UpdateExistingStock</c>'s website refill gate. The SEC metadata
+/// website field is blank for most companies, so rows that captured that
+/// blank hold <c>""</c> — they must count as missing (eligible for a refill)
+/// and a blank fetch result must be stored as null, not as a captured
+/// empty-string website that permanently blocks every later source.
+/// </summary>
+public class CompanySyncServiceUpdateExistingWebsiteRefillTests
+{
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[] { new CommonStocksModuleConfiguration() }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static CompanySyncService BuildSut(ISecEdgarClient edgarClient) =>
+        new(
+            Substitute.For<IServiceScopeFactory>(),
+            edgarClient,
+            Options.Create(new WorkerOptions()),
+            Substitute.For<ILogger<CompanySyncService>>(),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            )
+        );
+
+    private static object BuildState(EquiblesFinancialDbContext db, CommonStock existingStock)
+    {
+        var t = typeof(CompanySyncService).GetNestedType("StockSyncState", BindingFlags.NonPublic);
+        var s = Activator.CreateInstance(t);
+        void Set(string n, object v) => t.GetProperty(n).SetValue(s, v);
+        Set("SecCiks", new HashSet<string> { existingStock.Cik });
+        Set("ExistingStocks", new List<CommonStock> { existingStock });
+        Set("ExistingCiks", new HashSet<string> { existingStock.Cik });
+        Set("ExistingPrimaryTickers", new HashSet<string> { existingStock.Ticker });
+        Set("PrimaryTickerToStock", new Dictionary<string, CommonStock>());
+        Set("SecondaryCikToParent", new Dictionary<string, CommonStock>());
+        Set("CommonStockRepository", new CommonStockRepository(db));
+        Set(
+            "CommonStockManager",
+            new CommonStockManager(new CommonStockRepository(db), Substitute.For<IBus>())
+        );
+        Set("DbContext", db);
+        return s;
+    }
+
+    private static Task Invoke(
+        CompanySyncService sut,
+        CompanyInfo secCompany,
+        string primaryTicker,
+        object state
+    )
+    {
+        var m = typeof(CompanySyncService).GetMethod(
+            "UpdateExistingStock",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        return (Task)m.Invoke(sut, [secCompany, primaryTicker, new List<string>(), state]);
+    }
+
+    private static async Task<(EquiblesFinancialDbContext Db, CommonStock Stock)> SeedStock(
+        string website
+    )
+    {
+        var db = NewDb();
+        db.Set<CommonStock>()
+            .Add(
+                new CommonStock
+                {
+                    Cik = "0000000002",
+                    Ticker = "EXM",
+                    Name = "Example Corp",
+                    Website = website,
+                }
+            );
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+        var stock = await db.Set<CommonStock>().FirstAsync(s => s.Cik == "0000000002");
+        return (db, stock);
+    }
+
+    private static CompanyInfo UnchangedCompanyInfo() =>
+        new()
+        {
+            Cik = "0000000002",
+            Name = "Example Corp",
+            Tickers = ["EXM"],
+        };
+
+    [Fact]
+    public async Task EmptyStringWebsite_CountsAsMissing_AndIsRefilled()
+    {
+        var (db, stock) = await SeedStock("");
+        using var _ = db;
+        var edgar = Substitute.For<ISecEdgarClient>();
+        edgar
+            .GetCompanyMetadata("0000000002")
+            .Returns(new CompanyMetadata { Website = "https://www.example.com" });
+
+        await Invoke(BuildSut(edgar), UnchangedCompanyInfo(), "EXM", BuildState(db, stock));
+
+        var updated = await db.Set<CommonStock>().FirstAsync(s => s.Cik == "0000000002");
+        updated.Website.Should().Be("https://www.example.com");
+    }
+
+    [Fact]
+    public async Task BlankFetchResult_IsStoredAsNull_NotEmptyString()
+    {
+        var (db, stock) = await SeedStock("");
+        using var _ = db;
+        var edgar = Substitute.For<ISecEdgarClient>();
+        edgar.GetCompanyMetadata("0000000002").Returns(new CompanyMetadata { Website = "" });
+
+        await Invoke(BuildSut(edgar), UnchangedCompanyInfo(), "EXM", BuildState(db, stock));
+
+        var updated = await db.Set<CommonStock>().FirstAsync(s => s.Cik == "0000000002");
+        updated.Website.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExistingWebsite_IsNotRefetched()
+    {
+        var (db, stock) = await SeedStock("https://www.already-set.com");
+        using var _ = db;
+        var edgar = Substitute.For<ISecEdgarClient>();
+
+        await Invoke(BuildSut(edgar), UnchangedCompanyInfo(), "EXM", BuildState(db, stock));
+
+        await edgar.DidNotReceive().GetCompanyMetadata(Arg.Any<string>());
+        var updated = await db.Set<CommonStock>().FirstAsync(s => s.Cik == "0000000002");
+        updated.Website.Should().Be("https://www.already-set.com");
+    }
+}


### PR DESCRIPTION
## Summary

- The SEC submissions metadata `website` field is blank for nearly every company, and `CompanySyncService` stored that blank as `""` — production has 8,077 of 8,325 stocks with an empty-string website. The refill gate was `Website == null`, so those rows could never be filled again, starving the investor-relations discovery pipeline (refs #3683).
- Treat empty string as missing so blank rows stay eligible for a refill, and normalise a blank fetch result to null so a blank SEC answer is stored as "still missing" rather than a captured website.

## Code changes

- `src/Equibles.Sec.HostedService/Services/CompanySyncService.cs` — `missingWebsite` gate now uses `string.IsNullOrEmpty`; `FetchWebsite` returns null instead of `""` when the SEC metadata has no website.
- `tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingWebsiteRefillTests.cs` — pins the three behaviors: empty-string website is refilled, blank fetch stores null, an already-set website is not refetched.