### PR TITLE
fix(holdings): exclude 13D/G stakes from fund scoring and the smart-money index

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
@@ -54,7 +54,8 @@ public class FundScoringManager
     /// <paramref name="benchmarkTicker"/>. Returns the saved score, or null when there isn't
     /// enough data to simulate (unknown benchmark, no 13F snapshots in range, missing benchmark
     /// prices, or a non-finite result). Recomputes in place — an existing score for the same
-    /// (holder, window, benchmark) is updated rather than duplicated.
+    /// (holder, window, benchmark) is updated rather than duplicated, and a stored score whose
+    /// simulation can no longer be run is deleted so the leaderboard never ranks stale data.
     /// </summary>
     public async Task<FundScore> ScoreHolder(
         InstitutionalHolder holder,
@@ -71,7 +72,13 @@ public class FundScoringManager
 
         var result = await RunBacktest(holder, asOf, windowYears, benchmarkStock);
         if (result == null || result.Points.Count == 0 || !IsStorable(result))
+        {
+            // A filer that stops being scoreable (e.g. only Schedule 13D/G filings on file)
+            // must also lose any previously stored score, or the alpha leaderboard keeps
+            // ranking it on a result that can never be recomputed.
+            await DeleteExistingScore(holder, windowYears, benchmarkTicker);
             return null;
+        }
 
         return await Upsert(holder, windowYears, benchmarkTicker, result);
     }
@@ -83,10 +90,10 @@ public class FundScoringManager
         CommonStock benchmarkStock
     )
     {
-        var reportDates = await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync();
+        var reportDates = await _holdingRepository.Get13FReportDatesByHolder(holder).ToListAsync();
         if (reportDates.Count == 0)
             return null;
-        // GetReportDatesByHolder returns latest-first; SelectRelevantSnapshotDates needs
+        // Get13FReportDatesByHolder returns latest-first; SelectRelevantSnapshotDates needs
         // earliest-first so the "last snapshot before the window" lands on the most recent one.
         reportDates.Sort();
 
@@ -98,7 +105,7 @@ public class FundScoringManager
             return null;
 
         var holdings = await _holdingRepository
-            .GetHistoryByHolder(holder)
+            .Get13FHistoryByHolder(holder)
             .Where(h => relevant.Contains(h.ReportDate))
             .Select(h => new HoldingRow(
                 h.ReportDate,
@@ -159,6 +166,20 @@ public class FundScoringManager
 
         await _fundScoreRepository.SaveChanges();
         return score;
+    }
+
+    private async Task DeleteExistingScore(
+        InstitutionalHolder holder,
+        int windowYears,
+        string benchmarkTicker
+    )
+    {
+        var existing = await _fundScoreRepository.GetByHolder(holder, windowYears, benchmarkTicker);
+        if (existing == null)
+            return;
+
+        _fundScoreRepository.Delete(existing);
+        await _fundScoreRepository.SaveChanges();
     }
 
     // All snapshots whose rebalance date falls in [from, to], plus the latest one whose rebalance

--- a/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/SmartMoneyIndexManager.cs
@@ -147,16 +147,18 @@ public class SmartMoneyIndexManager
 
     private async Task<BacktestQuarterSnapshot> LoadLatestPortfolio(InstitutionalHolder holder)
     {
-        var reportDates = await _holdingRepository.GetReportDatesByHolder(holder).ToListAsync();
+        // 13F dates only: a fund's latest filing can be a Schedule 13D/G event date, whose single
+        // disclosed stake would otherwise replace the real portfolio as a 100%-weight "holding".
+        var reportDates = await _holdingRepository.Get13FReportDatesByHolder(holder).ToListAsync();
         if (reportDates.Count == 0)
             return null;
 
-        // GetReportDatesByHolder returns latest-first; the index reflects each fund's freshest 13F.
+        // Get13FReportDatesByHolder returns latest-first; the index reflects each fund's freshest 13F.
         var latest = reportDates[0];
 
         var positions = await _holdingRepository
-            .GetByHolder(holder, latest)
-            .Where(h => h.OptionType == null && h.Value > 0)
+            .Get13FHistoryByHolder(holder)
+            .Where(h => h.ReportDate == latest && h.OptionType == null && h.Value > 0)
             .GroupBy(h => h.CommonStockId)
             .Select(g => new { StockId = g.Key, Value = g.Sum(h => h.Value) })
             .ToListAsync();

--- a/src/Equibles.Holdings.HostedService/FundScoringWorker.cs
+++ b/src/Equibles.Holdings.HostedService/FundScoringWorker.cs
@@ -7,10 +7,12 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.Holdings.HostedService;
 
 /// <summary>
-/// Periodically (re)computes the fund score for every filer that has 13F holdings, so the
+/// Periodically (re)computes the fund score for every filer that has holdings on file, so the
 /// institutions leaderboard can rank the universe by alpha vs the benchmark. A score depends on
 /// daily prices as well as quarterly 13F filings, so the job refreshes daily even though the
-/// underlying portfolio only changes each quarter.
+/// underlying portfolio only changes each quarter. Filers without 13F snapshots (Schedule
+/// 13D/G-only) are still visited: scoring them yields nothing, which prunes any stale score
+/// they may have accumulated.
 /// <para>
 /// Each filer is scored in its own DI scope: the backtest can load thousands of price rows, so a
 /// single shared context's change tracker would balloon across the run, and a fault scoring one
@@ -79,8 +81,8 @@ public class FundScoringWorker : BackgroundService
     }
 
     /// <summary>
-    /// Scores every filer with 13F holdings as of today, returning how many produced a score.
-    /// Internal so the worker's batch behaviour can be driven directly in tests.
+    /// Scores every filer with holdings on file as of today, returning how many produced a
+    /// score. Internal so the worker's batch behaviour can be driven directly in tests.
     /// </summary>
     internal async Task<int> ScoreAllHolders(CancellationToken cancellationToken)
     {

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -76,6 +76,15 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         return GetAll().Where(h => h.InstitutionalHolderId == holder.Id);
     }
 
+    // 13F-only view of one holder's history. Schedule 13D/G rows share this table but
+    // describe a single stake at an event date, not a portfolio at a quarter end, so
+    // portfolio reconstruction (fund scoring, backtests, the smart-money index) must
+    // exclude them or a later 13D/G filing replaces the fund's real portfolio.
+    public IQueryable<InstitutionalHolding> Get13FHistoryByHolder(InstitutionalHolder holder)
+    {
+        return GetHistoryByHolder(holder).Where(h => h.FilingType == FilingType.Form13F);
+    }
+
     // Latest dates first — callers consistently treat index 0 as the newest filing window.
     public IQueryable<DateOnly> GetAvailableReportDates() =>
         GetAll().DistinctReportDatesDescending();
@@ -87,6 +96,11 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     // Latest dates first — see GetAvailableReportDates for the ordering contract.
     public IQueryable<DateOnly> GetReportDatesByHolder(InstitutionalHolder holder) =>
         GetHistoryByHolder(holder).DistinctReportDatesDescending();
+
+    // Latest 13F quarter-end dates first — see Get13FHistoryByHolder for why 13D/G
+    // event dates are excluded.
+    public IQueryable<DateOnly> Get13FReportDatesByHolder(InstitutionalHolder holder) =>
+        Get13FHistoryByHolder(holder).DistinctReportDatesDescending();
 
     public IQueryable<InstitutionalHolding> GetByAccessionNumber(string accessionNumber)
     {

--- a/tests/Equibles.IntegrationTests/Holdings/FundScoringManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/FundScoringManagerTests.cs
@@ -115,6 +115,93 @@ public class FundScoringManagerTests : IDisposable
         score.Should().BeNull();
     }
 
+    [Fact]
+    public async Task ScoreHolder_Later13DGStakeOnMooningStock_ScoresThe13FPortfolioOnly()
+    {
+        var holder = SeedDoublingPortfolioAgainstFlatBenchmark();
+
+        // A Schedule 13D stake filed after the last 13F quarter, on a stock that then 50x's.
+        // Treated as a portfolio snapshot it would rotate the whole simulation into that stock;
+        // it must be ignored because a 13D/G describes a single stake, not the fund's portfolio.
+        var moon = new CommonStock { Ticker = "MOON", Name = "Mooning Co" };
+        _dbContext.Set<CommonStock>().Add(moon);
+        AddPrice(moon, new DateOnly(2025, 6, 1), 1m);
+        AddPrice(moon, AsOf, 50m);
+        Add13DStake(holder, moon, eventDate: new DateOnly(2025, 6, 1));
+
+        var score = await _manager.ScoreHolder(
+            holder,
+            AsOf,
+            windowYears: 3,
+            benchmarkTicker: "SPY"
+        );
+
+        score.Should().NotBeNull();
+        // Same result as without the 13D row: the 13F portfolio doubles => ~+100% total return.
+        score.PortfolioTotalReturnPercent.Should().BeApproximately(100m, 0.5m);
+    }
+
+    [Fact]
+    public async Task ScoreHolder_FilerWithOnly13DGStakes_ReturnsNullAndDeletesStaleScore()
+    {
+        SeedBenchmark();
+        var moon = new CommonStock { Ticker = "MOON", Name = "Mooning Co" };
+        _dbContext.Set<CommonStock>().Add(moon);
+        AddPrice(moon, new DateOnly(2025, 6, 1), 1m);
+        AddPrice(moon, AsOf, 50m);
+
+        var activist = new InstitutionalHolder { Cik = "0007654321", Name = "Activist Person" };
+        _dbContext.Set<InstitutionalHolder>().Add(activist);
+        _dbContext.SaveChanges();
+        Add13DStake(activist, moon, eventDate: new DateOnly(2025, 6, 1));
+
+        // A score persisted before 13D/G rows were excluded from scoring.
+        _dbContext
+            .Set<FundScore>()
+            .Add(
+                new FundScore
+                {
+                    InstitutionalHolderId = activist.Id,
+                    WindowYears = 3,
+                    BenchmarkTicker = "SPY",
+                    WindowStart = WindowStart,
+                    WindowEnd = AsOf,
+                    AlphaPercent = 444_167m,
+                }
+            );
+        _dbContext.SaveChanges();
+
+        var score = await _manager.ScoreHolder(
+            activist,
+            AsOf,
+            windowYears: 3,
+            benchmarkTicker: "SPY"
+        );
+
+        score.Should().BeNull();
+        // The stale score is pruned, not just skipped — otherwise the leaderboard keeps it.
+        _fundScoreRepository.GetByHolder(activist).Should().BeEmpty();
+    }
+
+    private void Add13DStake(InstitutionalHolder holder, CommonStock stock, DateOnly eventDate)
+    {
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .Add(
+                new InstitutionalHolding
+                {
+                    InstitutionalHolderId = holder.Id,
+                    CommonStockId = stock.Id,
+                    ReportDate = eventDate,
+                    FilingDate = eventDate.AddDays(5),
+                    FilingType = FilingType.Schedule13D,
+                    Shares = 1_000_000,
+                    Value = 1_000_000,
+                }
+            );
+        _dbContext.SaveChanges();
+    }
+
     private InstitutionalHolder SeedDoublingPortfolioAgainstFlatBenchmark()
     {
         SeedBenchmark();

--- a/tests/Equibles.IntegrationTests/Holdings/SmartMoneyIndexManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/SmartMoneyIndexManagerTests.cs
@@ -137,6 +137,54 @@ public class SmartMoneyIndexManagerTests : IDisposable
         result.Reason.Should().Contain("no holdings on file");
     }
 
+    [Fact]
+    public async Task Build_FundWithLater13DGStake_BuildsFromItsLatest13FPortfolio()
+    {
+        SeedBenchmark();
+        var doubler = AddStock("AAA", "Alpha Co", start: 100m, end: 200m);
+        var flat = AddStock("BBB", "Beta Co", start: 100m, end: 100m);
+        var stake = AddStock("MOON", "Mooning Co", start: 100m, end: 100m);
+
+        var first = SeedFund("0000000001", alpha: 30m, (doubler, 60), (flat, 40));
+        SeedFund("0000000002", alpha: 20m, (doubler, 50), (flat, 50));
+        SeedFund("0000000003", alpha: 10m, (doubler, 70), (flat, 30));
+
+        // The top fund files a Schedule 13D after its latest 13F quarter. The event-date row is
+        // a single stake, not a portfolio — it must not become the fund's "latest portfolio"
+        // (a 100%-weight single holding) nor shift the construction date to the event date.
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .Add(
+                new InstitutionalHolding
+                {
+                    InstitutionalHolderId = first.Id,
+                    CommonStockId = stake.Id,
+                    ReportDate = new DateOnly(2025, 12, 1),
+                    FilingDate = new DateOnly(2025, 12, 6),
+                    FilingType = FilingType.Schedule13D,
+                    Shares = 1_000_000,
+                    Value = 1_000_000,
+                }
+            );
+        _dbContext.SaveChanges();
+
+        var result = await _manager.Build(
+            AsOf,
+            topFunds: 10,
+            maxConstituents: 25,
+            minConsensus: 2,
+            windowYears: 3,
+            benchmarkTicker: "SPY"
+        );
+
+        result.Reason.Should().BeNull();
+        result.FundCount.Should().Be(3);
+        result.ConstructionDate.Should().Be(ReportDate);
+        result.Constituents.Select(c => c.Ticker).Should().BeEquivalentTo(["AAA", "BBB"]);
+        result.Constituents.Single(c => c.Ticker == "AAA").HeldByCount.Should().Be(3);
+        result.Constituents.Single(c => c.Ticker == "BBB").HeldByCount.Should().Be(3);
+    }
+
     private void SeedBenchmark()
     {
         AddStock("SPY", "S&P 500 ETF", start: 100m, end: 100m);


### PR DESCRIPTION
## Summary

Fixes #3685 — the fund-score leaderboard and the smart-money index treated Schedule 13D/13G rows as 13F portfolio snapshots. A 13D/G describes a single stake at an event date, so 13D/G-only filers got scored as one-stock portfolios (production top 20 by alpha: 18 of 20 were 13D/G-only filers, "alpha" up to 444,167%), and a fund's later 13D/G filing replaced its real portfolio with a single 100%-weight holding in the index. The public smart-money-index page degenerated to one OTC stock at 100% weight with a ~31x one-day chart spike.

## Code changes

- `InstitutionalHoldingRepository` — new `Get13FHistoryByHolder` / `Get13FReportDatesByHolder` building blocks that exclude 13D/G rows from a holder's portfolio history.
- `FundScoringManager` — `RunBacktest` now builds snapshots from 13F rows only; `ScoreHolder` deletes a previously stored score when the simulation can no longer be run, so stale 13D/G-era scores are pruned by the daily scoring cycle without manual SQL.
- `SmartMoneyIndexManager.LoadLatestPortfolio` — latest portfolio is now the freshest **13F** quarter (dates and positions), not the freshest filing of any type.
- `FundScoringWorker` — doc comments updated: every filer with holdings is still visited on purpose, so unscoreable filers get their stale scores pruned.
- `FundScoringManagerTests` / `SmartMoneyIndexManagerTests` — three regression tests: a later 13D stake on a mooning stock doesn't rotate the scored portfolio, a 13D/G-only filer returns null and loses its stale score, and the index builds from the latest 13F portfolio with the construction date unmoved by the event date.

## Verification

- `dotnet build Equibles.sln` — 0 errors.
- `tests/Equibles.UnitTests` — 2784 passed.
- `tests/Equibles.IntegrationTests` — 1933 passed (full suite).
