### PR TITLE
fix(holdings): only prune fund scores when no 13F snapshots remain

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
@@ -54,8 +54,9 @@ public class FundScoringManager
     /// <paramref name="benchmarkTicker"/>. Returns the saved score, or null when there isn't
     /// enough data to simulate (unknown benchmark, no 13F snapshots in range, missing benchmark
     /// prices, or a non-finite result). Recomputes in place — an existing score for the same
-    /// (holder, window, benchmark) is updated rather than duplicated, and a stored score whose
-    /// simulation can no longer be run is deleted so the leaderboard never ranks stale data.
+    /// (holder, window, benchmark) is updated rather than duplicated. A stored score is deleted
+    /// only when the filer has no 13F snapshots left to score (e.g. a Schedule 13D/G-only
+    /// filer); transient failures keep the previous score in place.
     /// </summary>
     public async Task<FundScore> ScoreHolder(
         InstitutionalHolder holder,
@@ -70,20 +71,29 @@ public class FundScoringManager
         if (benchmarkStock == null)
             return null;
 
-        var result = await RunBacktest(holder, asOf, windowYears, benchmarkStock);
+        var (result, has13FSnapshots) = await RunBacktest(
+            holder,
+            asOf,
+            windowYears,
+            benchmarkStock
+        );
         if (result == null || result.Points.Count == 0 || !IsStorable(result))
         {
-            // A filer that stops being scoreable (e.g. only Schedule 13D/G filings on file)
-            // must also lose any previously stored score, or the alpha leaderboard keeps
-            // ranking it on a result that can never be recomputed.
-            await DeleteExistingScore(holder, windowYears, benchmarkTicker);
+            // Prune the stored score only when the filer structurally has nothing to score
+            // (no 13F snapshots for the window — e.g. a Schedule 13D/G-only filer), or the
+            // alpha leaderboard keeps ranking it on a result that can never be recomputed.
+            // Transient failures (a benchmark price gap, a non-finite simulation) keep the
+            // previous score: deleting on those would wipe the whole leaderboard over a
+            // one-cycle data hiccup.
+            if (!has13FSnapshots)
+                await DeleteExistingScore(holder, windowYears, benchmarkTicker);
             return null;
         }
 
         return await Upsert(holder, windowYears, benchmarkTicker, result);
     }
 
-    private async Task<BacktestResult> RunBacktest(
+    private async Task<(BacktestResult Result, bool Has13FSnapshots)> RunBacktest(
         InstitutionalHolder holder,
         DateOnly asOf,
         int windowYears,
@@ -92,7 +102,7 @@ public class FundScoringManager
     {
         var reportDates = await _holdingRepository.Get13FReportDatesByHolder(holder).ToListAsync();
         if (reportDates.Count == 0)
-            return null;
+            return (null, false);
         // Get13FReportDatesByHolder returns latest-first; SelectRelevantSnapshotDates needs
         // earliest-first so the "last snapshot before the window" lands on the most recent one.
         reportDates.Sort();
@@ -102,7 +112,7 @@ public class FundScoringManager
 
         var relevant = SelectRelevantSnapshotDates(reportDates, from, to);
         if (relevant.Count == 0)
-            return null;
+            return (null, false);
 
         var holdings = await _holdingRepository
             .Get13FHistoryByHolder(holder)
@@ -124,7 +134,7 @@ public class FundScoringManager
             .Distinct()
             .ToList();
 
-        return await BacktestPriceLoader.RunBacktest(
+        var backtest = await BacktestPriceLoader.RunBacktest(
             _priceRepository,
             snapshots,
             stockIds,
@@ -132,6 +142,7 @@ public class FundScoringManager
             from,
             to
         );
+        return (backtest, true);
     }
 
     private async Task<FundScore> Upsert(

--- a/tests/Equibles.IntegrationTests/Holdings/FundScoringManagerTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/FundScoringManagerTests.cs
@@ -142,6 +142,62 @@ public class FundScoringManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task ScoreHolder_BenchmarkPricesMissing_ReturnsNullButKeepsExistingScore()
+    {
+        // Benchmark stock exists but has no prices in the window — a transient data gap, not
+        // a structural "nothing to score". The previous score must survive the failed cycle;
+        // pruning here would wipe the whole leaderboard whenever the price feed lags.
+        var benchmark = new CommonStock { Ticker = "SPY", Name = "S&P 500 ETF" };
+        _dbContext.Set<CommonStock>().Add(benchmark);
+
+        var held = new CommonStock { Ticker = "AAA", Name = "Alpha Co" };
+        _dbContext.Set<CommonStock>().Add(held);
+        AddPrice(held, new DateOnly(2022, 12, 20), 100m);
+        AddPrice(held, AsOf, 200m);
+
+        var holder = new InstitutionalHolder { Cik = "0001234567", Name = "Doubler Capital" };
+        _dbContext.Set<InstitutionalHolder>().Add(holder);
+        _dbContext
+            .Set<InstitutionalHolding>()
+            .Add(
+                new InstitutionalHolding
+                {
+                    InstitutionalHolderId = holder.Id,
+                    CommonStockId = held.Id,
+                    ReportDate = new DateOnly(2022, 9, 30),
+                    FilingDate = new DateOnly(2022, 11, 10),
+                    Shares = 1000,
+                    Value = 100_000,
+                }
+            );
+
+        _dbContext
+            .Set<FundScore>()
+            .Add(
+                new FundScore
+                {
+                    InstitutionalHolderId = holder.Id,
+                    WindowYears = 3,
+                    BenchmarkTicker = "SPY",
+                    WindowStart = WindowStart,
+                    WindowEnd = AsOf,
+                    AlphaPercent = 42m,
+                }
+            );
+        _dbContext.SaveChanges();
+
+        var score = await _manager.ScoreHolder(
+            holder,
+            AsOf,
+            windowYears: 3,
+            benchmarkTicker: "SPY"
+        );
+
+        score.Should().BeNull();
+        _fundScoreRepository.GetByHolder(holder).Should().ContainSingle(s => s.AlphaPercent == 42m);
+    }
+
+    [Fact]
     public async Task ScoreHolder_FilerWithOnly13DGStakes_ReturnsNullAndDeletesStaleScore()
     {
         SeedBenchmark();


### PR DESCRIPTION
## Summary

Hardens the stale-score pruning introduced in #3686 (refs #3685). `ScoreHolder` deleted the stored `FundScore` whenever the backtest returned no usable result — but `BacktestPriceLoader.RunBacktest` also returns null on a transient benchmark price gap (empty SPY series in the window). In that state every holder in the daily cycle would fail the same way, so one lagging price feed would wipe the entire leaderboard (and empty the smart-money index) until scores were recomputed.

## Code changes

- `FundScoringManager.RunBacktest` now also reports whether the holder structurally has 13F snapshots for the window (`(BacktestResult, bool Has13FSnapshots)`).
- `ScoreHolder` prunes the stored score only in the structural case (no 13F snapshots — e.g. a Schedule 13D/G-only filer). Transient failures (benchmark price gap, non-finite simulation) return null and keep the previous score, matching the pre-#3686 resilience.
- New regression test: benchmark stock with no prices in the window returns null but keeps the existing score; the 13D/G-only pruning test still passes.

## Verification

- `dotnet build Equibles.sln` — 0 errors.
- `tests/Equibles.UnitTests` — 2784 passed; `tests/Equibles.IntegrationTests` — 1934 passed (full suites).
