### PR TITLE
feat(common-stocks): website discovery worker fed by prioritised sources, filings first, refs #3683

### DIFF
--- a/src/Equibles.CommonStocks.BusinessLogic/Websites/IWebsiteSource.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/Websites/IWebsiteSource.cs
@@ -1,0 +1,34 @@
+namespace Equibles.CommonStocks.BusinessLogic.Websites;
+
+/// <summary>
+/// A source of company-website candidates for stocks whose
+/// <c>CommonStock.Website</c> is still missing. Implementations live in the module
+/// that owns the underlying data (SEC filings, Wikidata, Yahoo, …) and are
+/// resolved together by the website discovery worker, which consults them in
+/// <see cref="Priority"/> order and only hands each source the stocks every
+/// earlier source left unfilled. Candidates are reachability-probed by the
+/// caller before anything persists, so sources return what their data says and
+/// need not validate the URL themselves.
+/// </summary>
+public interface IWebsiteSource
+{
+    /// <summary>
+    /// Consultation order: lower values are asked first. Convention: more
+    /// authoritative sources get lower values.
+    /// </summary>
+    int Priority { get; }
+
+    /// <summary>Short human-readable name for logs (e.g. "SEC filings").</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Returns a candidate website URL per stock id for every stock this source
+    /// has an answer for; stocks it knows nothing about are simply absent from
+    /// the result. Implementations are batch-oriented so bulk-friendly backends
+    /// (one query for many stocks) stay cheap.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, string>> FindWebsites(
+        IReadOnlyList<WebsiteSourceStock> stocks,
+        CancellationToken cancellationToken
+    );
+}

--- a/src/Equibles.CommonStocks.BusinessLogic/Websites/WebsiteSourceStock.cs
+++ b/src/Equibles.CommonStocks.BusinessLogic/Websites/WebsiteSourceStock.cs
@@ -1,0 +1,9 @@
+namespace Equibles.CommonStocks.BusinessLogic.Websites;
+
+/// <summary>
+/// The identifying slice of a <c>CommonStock</c> handed to
+/// <see cref="IWebsiteSource"/> implementations — enough for any backend to key
+/// its lookup (documents by stock id, Wikidata by CIK, Yahoo by ticker) without
+/// passing tracked entities between service scopes.
+/// </summary>
+public sealed record WebsiteSourceStock(Guid Id, string Ticker, string Cik);

--- a/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
+++ b/src/Equibles.CommonStocks.Data/Models/CommonStock.cs
@@ -28,6 +28,15 @@ public class CommonStock
     public string Website { get; set; }
 
     /// <summary>
+    /// When website discovery last tried to fill <see cref="Website"/> (UTC), stamped
+    /// when every source definitively missed. Null until first attempted. Stocks
+    /// attempted within the configured cooldown are skipped, so persistent misses back
+    /// off instead of re-occupying a batch slot every cycle. Transient source errors
+    /// are not stamped and retry on the next cycle.
+    /// </summary>
+    public DateTime? WebsiteCheckedAt { get; set; }
+
+    /// <summary>
     /// Absolute URL of the company's investor-relations page, discovered by
     /// probing common IR paths and subdomains of <see cref="Website"/>. Null
     /// until discovered (or when no IR page could be validated). Foundation for

--- a/src/Equibles.CommonStocks.HostedService/Configuration/WebsiteDiscoveryOptions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Configuration/WebsiteDiscoveryOptions.cs
@@ -1,0 +1,21 @@
+using Equibles.Worker;
+
+namespace Equibles.CommonStocks.HostedService.Configuration;
+
+public class WebsiteDiscoveryOptions : ScraperOptions
+{
+    /// <summary>
+    /// Maximum number of stocks attempted per cycle. Candidate validation is
+    /// network-bound, so a cycle works through a bounded batch and the remaining
+    /// stocks are picked up on the next cycle.
+    /// </summary>
+    public int BatchSize { get; set; } = 100;
+
+    /// <summary>
+    /// Days to wait before re-attempting a stock whose last discovery attempt found
+    /// no website in any source. Definitive misses are stamped on the stock, so
+    /// persistent misses back off for this window; transient source errors are not
+    /// stamped and retry on the next cycle.
+    /// </summary>
+    public int CheckCooldownDays { get; set; } = 30;
+}

--- a/src/Equibles.CommonStocks.HostedService/Equibles.CommonStocks.HostedService.csproj
+++ b/src/Equibles.CommonStocks.HostedService/Equibles.CommonStocks.HostedService.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
+    <ProjectReference Include="..\Equibles.CommonStocks.BusinessLogic\Equibles.CommonStocks.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Integrations.Common\Equibles.Integrations.Common.csproj" />

--- a/src/Equibles.CommonStocks.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -10,6 +10,22 @@ public static class ServiceCollectionExtensions
     {
         services.AutoWireServicesFrom<InvestorRelationsDiscoveryService>();
 
+        // Typed client for website reachability probes: short timeout, contact
+        // User-Agent, capped response size (the body is discarded; only the status
+        // matters).
+        services.AddHttpClient<WebsiteProbeClient>(client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(10);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(
+                "EquiblesBot/1.0 (+https://equibles.com)"
+            );
+            client.MaxResponseContentBufferSize = 2 * 1024 * 1024;
+        });
+
+        // Runs upstream of IR discovery: fills CommonStock.Website from the
+        // registered IWebsiteSource implementations (filings, Wikidata, Yahoo, ...).
+        services.AddHostedService<WebsiteDiscoveryWorker>();
+
         // Typed client: short timeout and a contact User-Agent, following many
         // redirects to land on the real IR page. Response size is capped so a
         // misbehaving host can't stream an unbounded body into memory.

--- a/src/Equibles.CommonStocks.HostedService/Services/WebsiteDiscoveryService.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/WebsiteDiscoveryService.cs
@@ -1,0 +1,215 @@
+using System.Linq.Expressions;
+using Equibles.CommonStocks.BusinessLogic.Websites;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.HostedService.Configuration;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.AutoWiring;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Fills in <c>CommonStock.Website</c> for stocks that don't have one yet, one
+/// bounded batch per cycle. Candidate URLs come from the registered
+/// <see cref="IWebsiteSource"/> implementations, consulted in priority order so
+/// each source only sees the stocks every more-authoritative source left
+/// unfilled; the first candidate that survives a reachability probe wins.
+/// Upstream of IR discovery: stocks without a website can never get an IR page,
+/// news, events, or call artefacts.
+/// </summary>
+[Service]
+public class WebsiteDiscoveryService : IImporter
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IReadOnlyList<IWebsiteSource> _sources;
+    private readonly WebsiteProbeClient _probeClient;
+    private readonly ErrorReporter _errorReporter;
+    private readonly ILogger<WebsiteDiscoveryService> _logger;
+    private readonly WebsiteDiscoveryOptions _options;
+
+    public WebsiteDiscoveryService(
+        IServiceScopeFactory scopeFactory,
+        IEnumerable<IWebsiteSource> sources,
+        WebsiteProbeClient probeClient,
+        ErrorReporter errorReporter,
+        ILogger<WebsiteDiscoveryService> logger,
+        IOptions<WebsiteDiscoveryOptions> options
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _sources = sources.OrderBy(s => s.Priority).ToList();
+        _probeClient = probeClient;
+        _errorReporter = errorReporter;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    public async Task Import(CancellationToken cancellationToken)
+    {
+        if (_sources.Count == 0)
+        {
+            _logger.LogInformation("Website discovery: no website sources registered");
+            return;
+        }
+
+        var batch = await LoadCandidates(cancellationToken);
+        if (batch.Count == 0)
+        {
+            _logger.LogInformation("Website discovery: no stocks pending discovery");
+            return;
+        }
+
+        _logger.LogInformation(
+            "Website discovery: attempting {Count} stocks across {Sources} sources",
+            batch.Count,
+            _sources.Count
+        );
+
+        var remaining = batch;
+        var discovered = 0;
+        var anySourceFailed = false;
+        foreach (var source in _sources)
+        {
+            if (remaining.Count == 0)
+                break;
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            IReadOnlyDictionary<Guid, string> candidates;
+            try
+            {
+                candidates = await source.FindWebsites(remaining, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // A failing source must not block the less-authoritative ones —
+                // its stocks simply fall through, and the batch skips the
+                // definitive-miss stamp so they retry next cycle.
+                anySourceFailed = true;
+                _logger.LogError(ex, "Website source {Source} failed", source.Name);
+                await _errorReporter.Report(
+                    ErrorSource.WebsiteDiscovery,
+                    $"FindWebsites({source.Name})",
+                    ex.Message,
+                    ex.StackTrace
+                );
+                continue;
+            }
+
+            var unfilled = new List<WebsiteSourceStock>();
+            foreach (var stock in remaining)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var validated = candidates.TryGetValue(stock.Id, out var candidate)
+                    ? await _probeClient.Validate(candidate, cancellationToken)
+                    : null;
+                if (validated != null && await Persist(stock.Id, validated))
+                {
+                    discovered++;
+                    _logger.LogDebug(
+                        "Discovered website for {Ticker} via {Source}: {Url}",
+                        stock.Ticker,
+                        source.Name,
+                        validated
+                    );
+                }
+                else
+                {
+                    unfilled.Add(stock);
+                }
+            }
+
+            remaining = unfilled;
+        }
+
+        // Every source definitively missed these stocks — stamp the attempt so they
+        // back off for the cooldown window instead of re-occupying a batch slot every
+        // cycle. Skipped when a source errored: those stocks deserve a clean retry.
+        if (!anySourceFailed)
+        {
+            foreach (var stock in remaining)
+                await MarkChecked(stock.Id);
+        }
+
+        _logger.LogInformation(
+            "Website discovery complete. Discovered {Discovered} websites, {Missed} missed",
+            discovered,
+            remaining.Count
+        );
+    }
+
+    private async Task<List<WebsiteSourceStock>> LoadCandidates(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        var cutoff = DateTime.UtcNow.AddDays(-_options.CheckCooldownDays);
+        var rows = await repo.GetAll()
+            .Where(PendingDiscovery(cutoff))
+            .OrderBy(s => s.Ticker)
+            .Take(_options.BatchSize)
+            .Select(s => new
+            {
+                s.Id,
+                s.Ticker,
+                s.Cik,
+            })
+            .ToListAsync(cancellationToken);
+
+        return rows.Select(r => new WebsiteSourceStock(r.Id, r.Ticker, r.Cik)).ToList();
+    }
+
+    private async Task<bool> Persist(Guid commonStockId, string website)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        var stock = await repo.Get(commonStockId);
+        // The stock may have been deleted, or filled in by an overlapping run,
+        // between loading the batch and persisting — leave an existing value alone.
+        if (stock == null || !string.IsNullOrEmpty(stock.Website))
+            return false;
+
+        stock.Website = website;
+        stock.WebsiteCheckedAt = DateTime.UtcNow;
+        await repo.SaveChanges();
+        return true;
+    }
+
+    private async Task MarkChecked(Guid commonStockId)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        var stock = await repo.Get(commonStockId);
+        if (stock == null)
+            return;
+
+        stock.WebsiteCheckedAt = DateTime.UtcNow;
+        await repo.SaveChanges();
+    }
+
+    /// <summary>
+    /// Stocks eligible for a website discovery attempt: no website yet (empty string
+    /// counts as missing — SEC metadata blanks were historically stored as "") and no
+    /// attempt since <paramref name="cutoff"/> (never-attempted stocks are always
+    /// eligible).
+    /// </summary>
+    public static Expression<Func<CommonStock, bool>> PendingDiscovery(DateTime cutoff)
+    {
+        return s =>
+            (s.Website == null || s.Website == "")
+            && (s.WebsiteCheckedAt == null || s.WebsiteCheckedAt < cutoff);
+    }
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/WebsiteProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/WebsiteProbeClient.cs
@@ -1,0 +1,101 @@
+using Equibles.Integrations.Common.RateLimiter;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Reachability-probes a candidate company-website URL and returns it in
+/// normalised form when the host answers, or null when it doesn't. The probe is
+/// the gate between what an <c>IWebsiteSource</c> claims and what gets persisted
+/// to <c>CommonStock.Website</c>, so a stale or mis-extracted URL fails closed.
+/// Registered as a typed <see cref="HttpClient"/> client (see
+/// <c>AddCommonStocksWorker</c>).
+/// </summary>
+public class WebsiteProbeClient
+{
+    // Column ceiling for CommonStock.Website.
+    private const int MaxUrlLength = 256;
+
+    // Polite shared throttle so a discovery cycle doesn't hammer many sites at once.
+    private static readonly IRateLimiter RateLimiter = new RateLimiter(
+        maxRequests: 5,
+        timeWindow: TimeSpan.FromSeconds(1)
+    );
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<WebsiteProbeClient> _logger;
+
+    public WebsiteProbeClient(HttpClient httpClient, ILogger<WebsiteProbeClient> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the normalised absolute URL when <paramref name="candidate"/> parses
+    /// as an http(s) URL and the host serves a success response, or null otherwise.
+    /// The candidate URL is what gets stored (not the post-redirect landing page):
+    /// it is the company's disclosed address, and downstream IR discovery derives
+    /// its probe candidates from it.
+    /// </summary>
+    public async Task<string> Validate(string candidate, CancellationToken cancellationToken)
+    {
+        var normalized = Normalize(candidate);
+        if (normalized == null)
+            return null;
+
+        try
+        {
+            await RateLimiter.WaitAsync();
+
+            // Headers-read: only the status matters, so don't download the body.
+            // (HEAD would be cheaper still, but enough hosts mishandle it.)
+            using var response = await _httpClient.GetAsync(
+                normalized,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken
+            );
+            return response.IsSuccessStatusCode ? normalized : null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A dead host, TLS error, or timeout is a definitive miss for this
+            // candidate, not worth reporting — the next source gets its turn.
+            _logger.LogDebug(ex, "Website probe failed for {Url}", normalized);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Normalises a candidate to an absolute http(s) URL within the column ceiling:
+    /// trims, assumes https when the scheme is omitted (filings usually disclose
+    /// "www.acme.com"), and rejects anything that doesn't parse to an http(s) host.
+    /// </summary>
+    public static string Normalize(string candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+            return null;
+
+        var normalized = candidate.Trim();
+        if (!normalized.Contains("://"))
+            normalized = "https://" + normalized;
+
+        if (
+            !Uri.TryCreate(normalized, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            || string.IsNullOrEmpty(uri.Host)
+            || !uri.Host.Contains('.')
+            // A userinfo part means the candidate wasn't a bare web address — e.g.
+            // "mailto:ir@acme.com" parses as user "mailto:ir" at host "acme.com"
+            // once the https:// prefix is applied.
+            || !string.IsNullOrEmpty(uri.UserInfo)
+        )
+            return null;
+
+        return normalized.Length > MaxUrlLength ? null : normalized;
+    }
+}

--- a/src/Equibles.CommonStocks.HostedService/WebsiteDiscoveryWorker.cs
+++ b/src/Equibles.CommonStocks.HostedService/WebsiteDiscoveryWorker.cs
@@ -1,0 +1,37 @@
+using Equibles.CommonStocks.HostedService.Configuration;
+using Equibles.CommonStocks.HostedService.Services;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.CommonStocks.HostedService;
+
+/// <summary>
+/// Periodically discovers each company's website from the registered
+/// <c>IWebsiteSource</c> implementations, filling in <c>CommonStock.Website</c>
+/// incrementally. Runs upstream of <see cref="InvestorRelationsDiscoveryWorker"/>,
+/// which needs the website to probe for an IR page.
+/// </summary>
+public class WebsiteDiscoveryWorker : BaseScraperWorker
+{
+    protected override string WorkerName => "Website discovery";
+    protected override TimeSpan SleepInterval { get; }
+    protected override ErrorSource ErrorSource => ErrorSource.WebsiteDiscovery;
+
+    public WebsiteDiscoveryWorker(
+        ILogger<WebsiteDiscoveryWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<WebsiteDiscoveryOptions> options
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
+    }
+
+    protected override Task DoWork(CancellationToken stoppingToken) =>
+        RunImport<WebsiteDiscoveryService>(stoppingToken);
+}

--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -22,6 +22,7 @@ public sealed class ErrorSource
     public static readonly ErrorSource TranscriptScraper = new("TranscriptScraper");
     public static readonly ErrorSource InsiderTradingReprocess = new("InsiderTradingReprocess");
     public static readonly ErrorSource NportReprocess = new("NportReprocess");
+    public static readonly ErrorSource WebsiteDiscovery = new("WebsiteDiscovery");
     public static readonly ErrorSource InvestorRelationsDiscovery = new(
         "InvestorRelationsDiscovery"
     );
@@ -46,6 +47,7 @@ public sealed class ErrorSource
             TranscriptScraper,
             InsiderTradingReprocess,
             NportReprocess,
+            WebsiteDiscovery,
             InvestorRelationsDiscovery,
             InvestorRelationsScraper,
             Other,

--- a/src/Equibles.Migrations/Migrations/20260612121304_AddCommonStockWebsiteCheckedAt.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260612121304_AddCommonStockWebsiteCheckedAt.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260612121304_AddCommonStockWebsiteCheckedAt")]
+    partial class AddCommonStockWebsiteCheckedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260612121304_AddCommonStockWebsiteCheckedAt.cs
+++ b/src/Equibles.Migrations/Migrations/20260612121304_AddCommonStockWebsiteCheckedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommonStockWebsiteCheckedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "WebsiteCheckedAt",
+                table: "CommonStock",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "WebsiteCheckedAt",
+                table: "CommonStock");
+        }
+    }
+}

--- a/src/Equibles.Sec.BusinessLogic/Websites/FilingWebsiteExtractor.cs
+++ b/src/Equibles.Sec.BusinessLogic/Websites/FilingWebsiteExtractor.cs
@@ -1,0 +1,108 @@
+using System.Text.RegularExpressions;
+
+namespace Equibles.Sec.BusinessLogic.Websites;
+
+/// <summary>
+/// Extracts the company's own website host from filing text. Regulation S-K
+/// Item 101(e) requires the 10-K to disclose the registrant's website address
+/// ("Our website address is www.acme.com", "available on our corporate website,
+/// www.acme.com"), and DEF 14A proxies carry the same disclosure — so this reads
+/// a mandated self-reported fact, not a guess. A URL only counts when its
+/// immediately preceding context says it is the company's own website, which
+/// excludes the SEC's, the exchange's, or any third party's URL appearing in the
+/// same passage.
+/// </summary>
+public static partial class FilingWebsiteExtractor
+{
+    // Window of text before a URL that must contain a self-reference for the URL
+    // to count. Disclosure phrasings keep the possessive close ("our website
+    // address is", "on its corporate website,"), so a tight window keeps a
+    // self-reference from leaking onto a later third-party URL in the sentence.
+    private const int ContextWindow = 90;
+
+    /// <summary>
+    /// Returns the disclosed website host (e.g. <c>www.apple.com</c>, no scheme or
+    /// path) or null when the text carries no self-referenced website. When the
+    /// filing discloses both a corporate and an investor-relations address, the
+    /// corporate one wins — downstream IR discovery derives the IR page from it.
+    /// </summary>
+    public static string Extract(string filingText)
+    {
+        if (string.IsNullOrWhiteSpace(filingText))
+            return null;
+
+        string firstInvestorRelationsHost = null;
+        foreach (Match match in UrlRegex().Matches(filingText))
+        {
+            var host = HostOf(match.Value);
+            if (host == null || IsExcludedHost(host))
+                continue;
+
+            var contextStart = Math.Max(0, match.Index - ContextWindow);
+            var context = filingText[contextStart..match.Index];
+            // Classify against the self-reference nearest to the URL, not the whole
+            // window: an earlier IR phrase ("our investor relations website, ir.acme.com,
+            // … our company website is www.acme.com") would otherwise bleed onto the
+            // corporate URL and misclassify it.
+            var selfReferences = SelfReferenceRegex().Matches(context);
+            if (selfReferences.Count == 0)
+                continue;
+
+            // Prefer the corporate host over an investor-relations one, regardless of
+            // which the filing discloses first.
+            if (!IsInvestorRelationsCandidate(host, selfReferences[^1].Value))
+                return host;
+
+            firstInvestorRelationsHost ??= host;
+        }
+
+        return firstInvestorRelationsHost;
+    }
+
+    /// <summary>
+    /// Reduces a matched URL to its bare host: scheme and path stripped, trailing
+    /// sentence punctuation removed, lower-cased. Null when nothing host-shaped
+    /// remains.
+    /// </summary>
+    private static string HostOf(string url)
+    {
+        var host = url.Trim().TrimEnd('.', ',', ';', ':', ')', '"', '\'');
+        var schemeIndex = host.IndexOf("://", StringComparison.Ordinal);
+        if (schemeIndex >= 0)
+            host = host[(schemeIndex + 3)..];
+        var slashIndex = host.IndexOf('/');
+        if (slashIndex >= 0)
+            host = host[..slashIndex];
+
+        return host.Contains('.') ? host.ToLowerInvariant() : null;
+    }
+
+    // Filings routinely point at the SEC's own site in the same passage
+    // ("the SEC maintains a website at www.sec.gov"); never the company's.
+    private static bool IsExcludedHost(string host) =>
+        host == "sec.gov" || host.EndsWith(".sec.gov", StringComparison.Ordinal);
+
+    // An IR-flavoured candidate: the disclosure phrase called it an
+    // investor-relations website, or the host itself is an investor/ir subdomain.
+    private static bool IsInvestorRelationsCandidate(string host, string selfReference) =>
+        selfReference.Contains("investor", StringComparison.OrdinalIgnoreCase)
+        || host.StartsWith("investor", StringComparison.Ordinal)
+        || host.StartsWith("ir.", StringComparison.Ordinal);
+
+    // A URL-shaped token: optional scheme, dotted host ending in an alphabetic
+    // TLD, optional path. The lookbehind keeps email-address domains out.
+    [GeneratedRegex(
+        @"(?<![@\w.])(?:https?://)?(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}(?:/[^\s,;)""']*)?",
+        RegexOptions.IgnoreCase
+    )]
+    private static partial Regex UrlRegex();
+
+    // The company referring to its own website just before the URL: "our website
+    // address is", "on its corporate website,", "the Company's investor relations
+    // website at", "the Registrant maintains a website at", …
+    [GeneratedRegex(
+        @"(?:\bour\b|\bits\b|company(?:['’]s)?|registrant(?:['’]s)?|corporation(?:['’]s)?)[a-z\s,'’-]{0,40}?(?:website|web\s+site|internet\s+(?:web\s+)?(?:site|address))",
+        RegexOptions.IgnoreCase
+    )]
+    private static partial Regex SelfReferenceRegex();
+}

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.BusinessLogic.Websites;
 using Equibles.Core.AutoWiring;
 using Equibles.Sec.HostedService.Contracts;
 using Equibles.Sec.HostedService.Services;
@@ -22,6 +23,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<XbrlEnvelopeCaptureService>();
         services.AddScoped<XbrlBackfillService>();
         services.AddScoped<IDocumentScraper, DocumentScraper>();
+        // Primary IWebsiteSource (consumed by the CommonStocks website discovery
+        // worker): the website disclosure mandated in the stocks' own stored filings.
+        services.AddScoped<IWebsiteSource, FilingsWebsiteSource>();
 
         services.AddHostedService<SecScraperWorker>();
         services.AddHostedService<DocumentProcessorWorker>();

--- a/src/Equibles.Sec.HostedService/Services/FilingsWebsiteSource.cs
+++ b/src/Equibles.Sec.HostedService/Services/FilingsWebsiteSource.cs
@@ -1,0 +1,112 @@
+using System.Text;
+using Equibles.CommonStocks.BusinessLogic.Websites;
+using Equibles.Sec.BusinessLogic.Websites;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Website source backed by the stocks' own stored SEC filings — the primary
+/// source: Regulation S-K Item 101(e) makes the 10-K website disclosure
+/// mandatory, DEF 14A carries the same disclosure, and a 10-Q occasionally
+/// repeats it (the only filing available for companies that haven't reached
+/// their first fiscal year-end). Reads documents already in the database, so it
+/// costs no external traffic.
+/// </summary>
+public class FilingsWebsiteSource : IWebsiteSource
+{
+    // Filing types carrying the website disclosure, most reliable first.
+    private static readonly DocumentType[] FilingTypes =
+    [
+        DocumentType.TenK,
+        DocumentType.Def14A,
+        DocumentType.TenQ,
+    ];
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<FilingsWebsiteSource> _logger;
+
+    public FilingsWebsiteSource(
+        IServiceScopeFactory scopeFactory,
+        ILogger<FilingsWebsiteSource> logger
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public int Priority => 10;
+
+    public string Name => "SEC filings";
+
+    public async Task<IReadOnlyDictionary<Guid, string>> FindWebsites(
+        IReadOnlyList<WebsiteSourceStock> stocks,
+        CancellationToken cancellationToken
+    )
+    {
+        var results = new Dictionary<Guid, string>();
+        foreach (var stock in stocks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var website = await ExtractForStock(stock.Id, cancellationToken);
+            if (website != null)
+                results[stock.Id] = website;
+        }
+
+        return results;
+    }
+
+    private async Task<string> ExtractForStock(Guid stockId, CancellationToken cancellationToken)
+    {
+        foreach (var filingType in FilingTypes)
+        {
+            var text = await LoadLatestFilingText(stockId, filingType, cancellationToken);
+            var website = FilingWebsiteExtractor.Extract(text);
+            if (website != null)
+            {
+                _logger.LogDebug(
+                    "Extracted website {Website} from latest {FilingType} of stock {StockId}",
+                    website,
+                    filingType,
+                    stockId
+                );
+                return website;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Loads the normalised text of the stock's most recent filing of
+    /// <paramref name="filingType"/>, or null when it has none. Content bytes are
+    /// large, so each document gets its own short-lived scope instead of
+    /// accumulating in one change tracker for the whole batch.
+    /// </summary>
+    private async Task<string> LoadLatestFilingText(
+        Guid stockId,
+        DocumentType filingType,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<DocumentRepository>();
+
+        var documentId = await repo.GetAll()
+            .Where(d => d.CommonStockId == stockId && d.DocumentType == filingType)
+            .OrderByDescending(d => d.ReportingDate)
+            .Select(d => (Guid?)d.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (documentId == null)
+            return null;
+
+        var document = await repo.GetWithContent(documentId.Value);
+        var bytes = document?.Content?.FileContent?.Bytes;
+        return bytes is { Length: > 0 } ? Encoding.UTF8.GetString(bytes) : null;
+    }
+}

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -100,6 +100,9 @@ builder.Services.Configure<Equibles.Cftc.HostedService.Configuration.CftcScraper
 builder.Services.Configure<Equibles.Cboe.HostedService.Configuration.CboeScraperOptions>(
     builder.Configuration.GetSection("CboeScraper")
 );
+builder.Services.Configure<WebsiteDiscoveryOptions>(
+    builder.Configuration.GetSection("WebsiteDiscovery")
+);
 builder.Services.Configure<InvestorRelationsDiscoveryOptions>(
     builder.Configuration.GetSection("InvestorRelationsDiscovery")
 );

--- a/tests/Equibles.UnitTests/CommonStocks/WebsiteDiscoveryServiceTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/WebsiteDiscoveryServiceTests.cs
@@ -1,0 +1,271 @@
+using System.Net;
+using Equibles.CommonStocks.BusinessLogic.Websites;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.HostedService.Configuration;
+using Equibles.CommonStocks.HostedService.Services;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Contract: <c>WebsiteDiscoveryService.Import</c> consults the registered
+/// <c>IWebsiteSource</c>s in priority order, only hands later sources the stocks
+/// earlier sources left unfilled, persists the first candidate that survives the
+/// reachability probe, stamps definitive misses for the cooldown back-off, and
+/// skips the stamp when a source errored so those stocks retry cleanly.
+/// </summary>
+public class WebsiteDiscoveryServiceTests
+{
+    private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>
+        new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot())
+            .EnableServiceProviderCaching(false)
+            .Options;
+
+    private static EquiblesFinancialDbContext NewContext(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[] { new CommonStocksModuleConfiguration() }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static IServiceScopeFactory ScopeFactory(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => NewContext(options));
+        services.AddScoped<CommonStockRepository>();
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+
+    private static WebsiteDiscoveryService BuildSut(
+        DbContextOptions<EquiblesFinancialDbContext> options,
+        IEnumerable<IWebsiteSource> sources,
+        HttpStatusCode probeStatus = HttpStatusCode.OK
+    )
+    {
+        var probe = new WebsiteProbeClient(
+            new HttpClient(new FixedStatusHandler(probeStatus)),
+            Substitute.For<ILogger<WebsiteProbeClient>>()
+        );
+        return new WebsiteDiscoveryService(
+            ScopeFactory(options),
+            sources,
+            probe,
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Substitute.For<ILogger<WebsiteDiscoveryService>>(),
+            Options.Create(new WebsiteDiscoveryOptions())
+        );
+    }
+
+    private static async Task<CommonStock> SeedStock(
+        DbContextOptions<EquiblesFinancialDbContext> options,
+        string ticker,
+        string website = null,
+        DateTime? checkedAt = null
+    )
+    {
+        using var ctx = NewContext(options);
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Cik = ticker.PadLeft(10, '0'),
+            Name = ticker + " Inc",
+            Website = website,
+            WebsiteCheckedAt = checkedAt,
+        };
+        ctx.Set<CommonStock>().Add(stock);
+        await ctx.SaveChangesAsync();
+        return stock;
+    }
+
+    private static async Task<CommonStock> Reload(
+        DbContextOptions<EquiblesFinancialDbContext> options,
+        Guid id
+    )
+    {
+        using var ctx = NewContext(options);
+        return await ctx.Set<CommonStock>().FirstAsync(s => s.Id == id);
+    }
+
+    [Fact]
+    public async Task HigherPrioritySourceWins_AndLaterSourcesOnlySeeUnfilledStocks()
+    {
+        var options = NewDbOptions();
+        var filled = await SeedStock(options, "AAA");
+        var leftover = await SeedStock(options, "BBB");
+        var primary = new StubSource(
+            priority: 10,
+            answers: new Dictionary<string, string> { ["AAA"] = "www.aaa.com" }
+        );
+        var fallback = new StubSource(
+            priority: 20,
+            answers: new Dictionary<string, string> { ["BBB"] = "www.bbb.com" }
+        );
+
+        await BuildSut(options, [fallback, primary]).Import(CancellationToken.None);
+
+        (await Reload(options, filled.Id)).Website.Should().Be("https://www.aaa.com");
+        (await Reload(options, leftover.Id)).Website.Should().Be("https://www.bbb.com");
+        primary.SeenTickers.Should().BeEquivalentTo(["AAA", "BBB"]);
+        fallback
+            .SeenTickers.Should()
+            .BeEquivalentTo(["BBB"], "AAA was already filled by the primary source");
+    }
+
+    [Fact]
+    public async Task DefinitiveMissAcrossAllSources_StampsTheAttempt()
+    {
+        var options = NewDbOptions();
+        var stock = await SeedStock(options, "AAA");
+
+        await BuildSut(options, [new StubSource(10, [])]).Import(CancellationToken.None);
+
+        var reloaded = await Reload(options, stock.Id);
+        reloaded.Website.Should().BeNull();
+        reloaded.WebsiteCheckedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task FailedProbe_FallsThroughToNextSource()
+    {
+        var options = NewDbOptions();
+        var stock = await SeedStock(options, "AAA");
+        var primary = new StubSource(
+            10,
+            new Dictionary<string, string> { ["AAA"] = "www.dead-host.com" }
+        );
+
+        await BuildSut(options, [primary], HttpStatusCode.NotFound).Import(CancellationToken.None);
+
+        var reloaded = await Reload(options, stock.Id);
+        reloaded.Website.Should().BeNull("the only candidate failed the reachability probe");
+        reloaded
+            .WebsiteCheckedAt.Should()
+            .NotBeNull("a probed-and-dead candidate is a definitive miss");
+    }
+
+    [Fact]
+    public async Task ThrowingSource_DoesNotBlockOthers_AndSkipsTheMissStamp()
+    {
+        var options = NewDbOptions();
+        var found = await SeedStock(options, "AAA");
+        var missed = await SeedStock(options, "BBB");
+        var broken = new ThrowingSource(priority: 10);
+        var working = new StubSource(
+            20,
+            new Dictionary<string, string> { ["AAA"] = "www.aaa.com" }
+        );
+
+        await BuildSut(options, [broken, working]).Import(CancellationToken.None);
+
+        (await Reload(options, found.Id)).Website.Should().Be("https://www.aaa.com");
+        var reloadedMiss = await Reload(options, missed.Id);
+        reloadedMiss.Website.Should().BeNull();
+        reloadedMiss
+            .WebsiteCheckedAt.Should()
+            .BeNull("a stock unanswered while a source errored deserves a clean retry next cycle");
+    }
+
+    [Fact]
+    public async Task StocksInsideCooldown_AreNotAttempted()
+    {
+        var options = NewDbOptions();
+        await SeedStock(options, "AAA", checkedAt: DateTime.UtcNow.AddDays(-1));
+        var eligible = await SeedStock(options, "BBB", checkedAt: DateTime.UtcNow.AddDays(-90));
+        var source = new StubSource(10, new Dictionary<string, string> { ["BBB"] = "www.bbb.com" });
+
+        await BuildSut(options, [source]).Import(CancellationToken.None);
+
+        source
+            .SeenTickers.Should()
+            .BeEquivalentTo(["BBB"], "AAA was attempted within the cooldown window");
+        (await Reload(options, eligible.Id)).Website.Should().Be("https://www.bbb.com");
+    }
+
+    [Fact]
+    public async Task FilledStocks_AreNeverCandidates()
+    {
+        var options = NewDbOptions();
+        await SeedStock(options, "AAA", website: "https://www.already.com");
+        var source = new StubSource(10, []);
+
+        await BuildSut(options, [source]).Import(CancellationToken.None);
+
+        source.SeenTickers.Should().BeEmpty();
+    }
+
+    private sealed class StubSource : IWebsiteSource
+    {
+        private readonly Dictionary<string, string> _answers;
+
+        public StubSource(int priority, Dictionary<string, string> answers)
+        {
+            Priority = priority;
+            _answers = answers;
+        }
+
+        public List<string> SeenTickers { get; } = [];
+
+        public int Priority { get; }
+
+        public string Name => $"stub-{Priority}";
+
+        public Task<IReadOnlyDictionary<Guid, string>> FindWebsites(
+            IReadOnlyList<WebsiteSourceStock> stocks,
+            CancellationToken cancellationToken
+        )
+        {
+            SeenTickers.AddRange(stocks.Select(s => s.Ticker));
+            IReadOnlyDictionary<Guid, string> result = stocks
+                .Where(s => _answers.ContainsKey(s.Ticker))
+                .ToDictionary(s => s.Id, s => _answers[s.Ticker]);
+            return Task.FromResult(result);
+        }
+    }
+
+    private sealed class ThrowingSource : IWebsiteSource
+    {
+        public ThrowingSource(int priority) => Priority = priority;
+
+        public int Priority { get; }
+
+        public string Name => "throwing";
+
+        public Task<IReadOnlyDictionary<Guid, string>> FindWebsites(
+            IReadOnlyList<WebsiteSourceStock> stocks,
+            CancellationToken cancellationToken
+        ) => throw new InvalidOperationException("source backend down");
+    }
+
+    private sealed class FixedStatusHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+
+        public FixedStatusHandler(HttpStatusCode status) => _status = status;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) => Task.FromResult(new HttpResponseMessage(_status));
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/WebsiteProbeClientNormalizeTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/WebsiteProbeClientNormalizeTests.cs
@@ -1,0 +1,44 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Contract: <c>WebsiteProbeClient.Normalize</c> turns a source candidate into
+/// the absolute http(s) URL that would be probed and persisted — https assumed
+/// when the scheme is omitted, non-web schemes and host-less values rejected,
+/// and anything beyond the <c>CommonStock.Website</c> column ceiling rejected.
+/// </summary>
+public class WebsiteProbeClientNormalizeTests
+{
+    [Theory]
+    [InlineData("www.acme.com", "https://www.acme.com")]
+    [InlineData("acme.com", "https://acme.com")]
+    [InlineData("  www.acme.com  ", "https://www.acme.com")]
+    [InlineData("http://acme.com", "http://acme.com")]
+    [InlineData("https://www.acme.com/about", "https://www.acme.com/about")]
+    public void WebUrls_NormalizeToAbsoluteHttp(string candidate, string expected)
+    {
+        WebsiteProbeClient.Normalize(candidate).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("ftp://acme.com")]
+    [InlineData("mailto:ir@acme.com")]
+    [InlineData("localhost")]
+    [InlineData("not a url")]
+    public void NonWebCandidates_AreRejected(string candidate)
+    {
+        WebsiteProbeClient.Normalize(candidate).Should().BeNull();
+    }
+
+    [Fact]
+    public void CandidateBeyondColumnCeiling_IsRejected()
+    {
+        var candidate = "www.acme.com/" + new string('a', 256);
+
+        WebsiteProbeClient.Normalize(candidate).Should().BeNull();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FilingWebsiteExtractorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FilingWebsiteExtractorTests.cs
@@ -1,0 +1,149 @@
+using Equibles.Sec.BusinessLogic.Websites;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Contract: <c>FilingWebsiteExtractor.Extract</c> returns the company's own
+/// disclosed website host from filing text (the Reg S-K Item 101(e) disclosure),
+/// preferring the corporate host over an investor-relations one, and never
+/// returns a third party's URL (the SEC's site, an email domain, a URL with no
+/// self-reference context). Snippets below are modelled on real 10-K / 10-Q
+/// phrasings (Apple, NVIDIA, generic small-cap).
+/// </summary>
+public class FilingWebsiteExtractorTests
+{
+    [Fact]
+    public void PlainDisclosure_ReturnsHost()
+    {
+        var text = "Our website address is www.acme.com. We make our reports available there.";
+
+        FilingWebsiteExtractor.Extract(text).Should().Be("www.acme.com");
+    }
+
+    [Fact]
+    public void AppleStyle_CorporateAndIrHosts_PrefersCorporate()
+    {
+        var text =
+            "The Company periodically provides certain information for investors on its "
+            + "corporate website, www.apple.com, and its investor relations website, "
+            + "investor.apple.com.";
+
+        FilingWebsiteExtractor.Extract(text).Should().Be("www.apple.com");
+    }
+
+    [Fact]
+    public void IrHostDisclosedFirst_CorporateHostStillWins()
+    {
+        var text =
+            "We use our investor relations website, investor.nvidia.com, to publish "
+            + "material information. Our company website is www.nvidia.com.";
+
+        FilingWebsiteExtractor.Extract(text).Should().Be("www.nvidia.com");
+    }
+
+    [Fact]
+    public void IrOnlyDisclosure_FallsBackToIrHost()
+    {
+        var text =
+            "We announce material financial information to our investors using our "
+            + "investor relations website, ir.acme.com, press releases and SEC filings.";
+
+        FilingWebsiteExtractor.Extract(text).Should().Be("ir.acme.com");
+    }
+
+    [Fact]
+    public void SecWebsiteReference_IsNeverReturned()
+    {
+        var text =
+            "The SEC maintains a website that contains reports, proxy and information "
+            + "statements at www.sec.gov. Our website address is www.acme.com.";
+
+        FilingWebsiteExtractor.Extract(text).Should().Be("www.acme.com");
+    }
+
+    [Fact]
+    public void OnlySecWebsite_ReturnsNull()
+    {
+        var text =
+            "The SEC maintains a website that contains reports, proxy and information "
+            + "statements regarding issuers at www.sec.gov.";
+
+        FilingWebsiteExtractor.Extract(text).Should().BeNull();
+    }
+
+    [Fact]
+    public void UrlWithoutSelfReferenceContext_ReturnsNull()
+    {
+        var text = "Reports are also distributed through www.businesswire.com to the public.";
+
+        FilingWebsiteExtractor.Extract(text).Should().BeNull();
+    }
+
+    [Fact]
+    public void SchemeAndPath_AreStripped()
+    {
+        var text = "Information is available on our website at https://www.acme.com/investors.";
+
+        FilingWebsiteExtractor.Extract(text).Should().Be("www.acme.com");
+    }
+
+    [Fact]
+    public void CompanyPossessive_WithParentheses_ReturnsHost()
+    {
+        var text = "Copies are posted on the Company's website (www.acme.com) without charge.";
+
+        FilingWebsiteExtractor.Extract(text).Should().Be("www.acme.com");
+    }
+
+    [Fact]
+    public void InternetAddressPhrasing_ReturnsHost()
+    {
+        var text =
+            "Our Internet address is acme.com. Information on our website is not part of this report.";
+
+        FilingWebsiteExtractor.Extract(text).Should().Be("acme.com");
+    }
+
+    [Fact]
+    public void EmailAddressDomain_IsNotAWebsite()
+    {
+        var text = "Questions about our website may be sent to webmaster@acme.com by shareholders.";
+
+        FilingWebsiteExtractor.Extract(text).Should().BeNull();
+    }
+
+    [Fact]
+    public void TrailingSentencePunctuation_IsTrimmed()
+    {
+        var text =
+            "These reports are available free of charge on our corporate website, www.acme.com.";
+
+        FilingWebsiteExtractor.Extract(text).Should().Be("www.acme.com");
+    }
+
+    [Fact]
+    public void HostIsLowerCased()
+    {
+        var text = "Our website address is WWW.Acme.COM and reports are available there.";
+
+        FilingWebsiteExtractor.Extract(text).Should().Be("www.acme.com");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("No URLs anywhere in this text.")]
+    public void MissingOrUrlFreeText_ReturnsNull(string text)
+    {
+        FilingWebsiteExtractor.Extract(text).Should().BeNull();
+    }
+
+    [Fact]
+    public void RegistrantPhrasing_ReturnsHost()
+    {
+        var text = "The Registrant maintains a website at www.acme.com where filings are posted.";
+
+        FilingWebsiteExtractor.Extract(text).Should().Be("www.acme.com");
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FilingsWebsiteSourceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FilingsWebsiteSourceTests.cs
@@ -1,0 +1,206 @@
+using System.Text;
+using Equibles.CommonStocks.BusinessLogic.Websites;
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.Media.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Contract: <c>FilingsWebsiteSource</c> reads the website disclosure from the
+/// stock's most recent stored filing, trying 10-K first (where the disclosure is
+/// mandated), then DEF 14A, then 10-Q — and reads the most recent filing of a
+/// type, since a company's website can change over its filing history.
+/// </summary>
+public class FilingsWebsiteSourceTests
+{
+    private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>
+        new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot())
+            .EnableServiceProviderCaching(false)
+            .Options;
+
+    private static EquiblesFinancialDbContext NewContext(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new DocumentOnlyModuleConfiguration(),
+                new MediaModuleConfiguration(),
+            }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static FilingsWebsiteSource BuildSut(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => NewContext(options));
+        services.AddScoped<DocumentRepository>();
+        return new FilingsWebsiteSource(
+            services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
+            Substitute.For<ILogger<FilingsWebsiteSource>>()
+        );
+    }
+
+    private static async Task SeedFiling(
+        DbContextOptions<EquiblesFinancialDbContext> options,
+        Guid stockId,
+        DocumentType type,
+        DateOnly reportingDate,
+        string text
+    )
+    {
+        using var ctx = NewContext(options);
+        // GetWithContent eagerly includes the CommonStock principal, so the
+        // document's stock must exist for the row to materialise.
+        if (!await ctx.Set<CommonStock>().AnyAsync(cs => cs.Id == stockId))
+            ctx.Set<CommonStock>()
+                .Add(
+                    new CommonStock
+                    {
+                        Id = stockId,
+                        Ticker = stockId.ToString("N")[..8],
+                        Cik = stockId.ToString("N")[..10],
+                        Name = "Seeded Stock",
+                    }
+                );
+        ctx.Set<Document>()
+            .Add(
+                new Document
+                {
+                    CommonStockId = stockId,
+                    DocumentType = type,
+                    ReportingDate = reportingDate,
+                    Content = new File
+                    {
+                        Name = "filing",
+                        Extension = "txt",
+                        ContentType = "text/plain",
+                        FileContent = { Bytes = Encoding.UTF8.GetBytes(text) },
+                    },
+                }
+            );
+        await ctx.SaveChangesAsync();
+    }
+
+    private static WebsiteSourceStock Stock(Guid id) => new(id, "EXM", "0000000002");
+
+    [Fact]
+    public async Task TenKDisclosure_Wins_OverProxyAndTenQ()
+    {
+        var options = NewDbOptions();
+        var stockId = Guid.NewGuid();
+        await SeedFiling(
+            options,
+            stockId,
+            DocumentType.TenK,
+            new DateOnly(2025, 9, 27),
+            "Our website address is www.from-10k.com."
+        );
+        await SeedFiling(
+            options,
+            stockId,
+            DocumentType.Def14A,
+            new DateOnly(2026, 1, 10),
+            "Materials are posted on our website at www.from-proxy.com."
+        );
+
+        var results = await BuildSut(options)
+            .FindWebsites([Stock(stockId)], CancellationToken.None);
+
+        results.Should().ContainSingle().Which.Value.Should().Be("www.from-10k.com");
+    }
+
+    [Fact]
+    public async Task MostRecentTenK_IsTheOneRead()
+    {
+        var options = NewDbOptions();
+        var stockId = Guid.NewGuid();
+        await SeedFiling(
+            options,
+            stockId,
+            DocumentType.TenK,
+            new DateOnly(2024, 9, 28),
+            "Our website address is www.old-domain.com."
+        );
+        await SeedFiling(
+            options,
+            stockId,
+            DocumentType.TenK,
+            new DateOnly(2025, 9, 27),
+            "Our website address is www.new-domain.com."
+        );
+
+        var results = await BuildSut(options)
+            .FindWebsites([Stock(stockId)], CancellationToken.None);
+
+        results[stockId].Should().Be("www.new-domain.com");
+    }
+
+    [Fact]
+    public async Task NoTenK_FallsBackToProxy_ThenTenQ()
+    {
+        var options = NewDbOptions();
+        var proxyOnly = Guid.NewGuid();
+        var tenQOnly = Guid.NewGuid();
+        await SeedFiling(
+            options,
+            proxyOnly,
+            DocumentType.Def14A,
+            new DateOnly(2026, 1, 10),
+            "Materials are posted on our website at www.from-proxy.com."
+        );
+        await SeedFiling(
+            options,
+            tenQOnly,
+            DocumentType.TenQ,
+            new DateOnly(2026, 3, 31),
+            "We provide information for investors on our corporate website, www.from-10q.com."
+        );
+
+        var results = await BuildSut(options)
+            .FindWebsites([Stock(proxyOnly), Stock(tenQOnly)], CancellationToken.None);
+
+        results[proxyOnly].Should().Be("www.from-proxy.com");
+        results[tenQOnly].Should().Be("www.from-10q.com");
+    }
+
+    [Fact]
+    public async Task StocksWithoutFilingsOrDisclosures_AreAbsentFromTheResult()
+    {
+        var options = NewDbOptions();
+        var noFilings = Guid.NewGuid();
+        var noDisclosure = Guid.NewGuid();
+        await SeedFiling(
+            options,
+            noDisclosure,
+            DocumentType.TenK,
+            new DateOnly(2025, 9, 27),
+            "This filing never mentions an address of any kind."
+        );
+
+        var results = await BuildSut(options)
+            .FindWebsites([Stock(noFilings), Stock(noDisclosure)], CancellationToken.None);
+
+        results.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the core of the website-fill pipeline (refs #3683): a `WebsiteDiscoveryWorker` that fills `CommonStock.Website` for stocks that have none, batching them through priority-ordered `IWebsiteSource` implementations and persisting the first candidate that survives a reachability probe.
- Ships the primary source: `FilingsWebsiteSource` extracts the website disclosure mandated by Regulation S-K Item 101(e) from the stock's stored filings (latest 10-K, falling back to DEF 14A, then 10-Q) — no external traffic, reads documents already in the database.
- Runs upstream of IR discovery, which currently idles in production because every stock's website is blank. Wikidata and Yahoo sources follow in separate PRs.

## Code changes

- `src/Equibles.CommonStocks.BusinessLogic/Websites/` — new `IWebsiteSource` contract (priority-ordered, batch-oriented) and `WebsiteSourceStock` DTO.
- `src/Equibles.CommonStocks.HostedService/` — new `WebsiteDiscoveryWorker` + `WebsiteDiscoveryService` (consults sources in priority order, later sources only see unfilled stocks, definitive misses stamped for a cooldown back-off, source errors skip the stamp so those stocks retry), `WebsiteProbeClient` (normalises and reachability-probes candidates, headers-read only), `WebsiteDiscoveryOptions`; DI registrations and a project reference to CommonStocks.BusinessLogic.
- `src/Equibles.Sec.BusinessLogic/Websites/FilingWebsiteExtractor.cs` — pure extraction of the self-referenced website host from filing text; prefers the corporate host over an investor-relations one regardless of disclosure order; never returns the SEC's own site or email domains.
- `src/Equibles.Sec.HostedService/` — `FilingsWebsiteSource` (priority 10) + registration in `AddSecWorker`.
- `src/Equibles.CommonStocks.Data/Models/CommonStock.cs` + `src/Equibles.Migrations/` — new nullable `WebsiteCheckedAt` column (attempt stamp) with migration.
- `src/Equibles.Errors.Data/Models/ErrorSource.cs` — new `WebsiteDiscovery` source.
- `src/Equibles.Worker.Host/Program.cs` — binds `WebsiteDiscovery` options section.
- `tests/Equibles.UnitTests/` — 31 new tests: extractor disclosure corpus (Apple/NVIDIA/registrant phrasings, SEC-site and email exclusion, IR-before-corporate ordering), probe normalisation, discovery-service orchestration (priority, fallback on failed probe, miss stamping, cooldown, error isolation), filings source type-preference and recency.