### PR TITLE
feat(common-stocks): Wikidata website source joined on the SEC CIK, refs #3683

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -165,6 +165,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.InvestorRelations.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Finra.BusinessLogic", "src\Equibles.Finra.BusinessLogic\Equibles.Finra.BusinessLogic.csproj", "{93D079ED-711C-47C9-9C12-513ADE703C9C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Integrations.Wikidata", "src\Equibles.Integrations.Wikidata\Equibles.Integrations.Wikidata.csproj", "{34598F2B-3BFA-46E6-9EE5-63816F78B959}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1123,6 +1125,18 @@ Global
 		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Release|x64.Build.0 = Release|Any CPU
 		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Release|x86.ActiveCfg = Release|Any CPU
 		{93D079ED-711C-47C9-9C12-513ADE703C9C}.Release|x86.Build.0 = Release|Any CPU
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Debug|x64.Build.0 = Debug|Any CPU
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Debug|x86.Build.0 = Debug|Any CPU
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Release|x64.ActiveCfg = Release|Any CPU
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Release|x64.Build.0 = Release|Any CPU
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Release|x86.ActiveCfg = Release|Any CPU
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1207,6 +1221,7 @@ Global
 		{FFED11B2-5BED-4ABF-939E-D18589C1B07B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{7E757C1B-7801-4110-8C94-ACED64B36CAC} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{93D079ED-711C-47C9-9C12-513ADE703C9C} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{34598F2B-3BFA-46E6-9EE5-63816F78B959} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.CommonStocks.HostedService/Equibles.CommonStocks.HostedService.csproj
+++ b/src/Equibles.CommonStocks.HostedService/Equibles.CommonStocks.HostedService.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.Integrations.Common\Equibles.Integrations.Common.csproj" />
+    <ProjectReference Include="..\Equibles.Integrations.Wikidata\Equibles.Integrations.Wikidata.csproj" />
     <ProjectReference Include="..\Equibles.Worker\Equibles.Worker.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.CommonStocks.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.BusinessLogic.Websites;
 using Equibles.CommonStocks.HostedService.Services;
 using Equibles.Core.AutoWiring;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,6 +10,11 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddCommonStocksWorker(this IServiceCollection services)
     {
         services.AutoWireServicesFrom<InvestorRelationsDiscoveryService>();
+        services.AutoWireServicesFrom<Equibles.Integrations.Wikidata.WikidataClient>();
+
+        // Secondary IWebsiteSource: Wikidata's official-website fact joined on the
+        // SEC CIK (the filings source registered by the Sec module is the primary).
+        services.AddScoped<IWebsiteSource, WikidataWebsiteSource>();
 
         // Typed client for website reachability probes: short timeout, contact
         // User-Agent, capped response size (the body is discarded; only the status

--- a/src/Equibles.CommonStocks.HostedService/Services/WikidataWebsiteSource.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/WikidataWebsiteSource.cs
@@ -1,0 +1,46 @@
+using Equibles.CommonStocks.BusinessLogic.Websites;
+using Equibles.Integrations.Wikidata.Contracts;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Website source backed by Wikidata: joins the stocks' SEC CIK to the entity's
+/// official website (one bulk SPARQL query per batch). Secondary to the filings
+/// source — community-maintained rather than self-reported — but an exact-key
+/// match that also covers companies whose stored filings carry no disclosure
+/// (e.g. foreign issuers). A stale entry fails the caller's reachability probe
+/// and falls through to the next source.
+/// </summary>
+public class WikidataWebsiteSource : IWebsiteSource
+{
+    private readonly IWikidataClient _wikidataClient;
+
+    public WikidataWebsiteSource(IWikidataClient wikidataClient)
+    {
+        _wikidataClient = wikidataClient;
+    }
+
+    public int Priority => 20;
+
+    public string Name => "Wikidata";
+
+    public async Task<IReadOnlyDictionary<Guid, string>> FindWebsites(
+        IReadOnlyList<WebsiteSourceStock> stocks,
+        CancellationToken cancellationToken
+    )
+    {
+        var stocksByCik = stocks
+            .Where(s => !string.IsNullOrWhiteSpace(s.Cik))
+            .GroupBy(s => s.Cik)
+            .ToDictionary(g => g.Key, g => g.First());
+        if (stocksByCik.Count == 0)
+            return new Dictionary<Guid, string>();
+
+        var websitesByCik = await _wikidataClient.GetOfficialWebsitesByCik(
+            stocksByCik.Keys,
+            cancellationToken
+        );
+
+        return websitesByCik.ToDictionary(pair => stocksByCik[pair.Key].Id, pair => pair.Value);
+    }
+}

--- a/src/Equibles.Integrations.Wikidata/Contracts/IWikidataClient.cs
+++ b/src/Equibles.Integrations.Wikidata/Contracts/IWikidataClient.cs
@@ -1,0 +1,16 @@
+namespace Equibles.Integrations.Wikidata.Contracts;
+
+public interface IWikidataClient
+{
+    /// <summary>
+    /// Returns the official website (P856) of each company whose SEC CIK (P5531)
+    /// appears in <paramref name="ciks"/>, keyed by the CIK as passed in. CIKs are
+    /// matched zero-padded to 10 digits — Wikidata's storage format — so callers
+    /// may pass either padded or bare values. CIKs Wikidata doesn't know (or knows
+    /// without a website) are absent from the result.
+    /// </summary>
+    Task<IReadOnlyDictionary<string, string>> GetOfficialWebsitesByCik(
+        IReadOnlyCollection<string> ciks,
+        CancellationToken cancellationToken
+    );
+}

--- a/src/Equibles.Integrations.Wikidata/Equibles.Integrations.Wikidata.csproj
+++ b/src/Equibles.Integrations.Wikidata/Equibles.Integrations.Wikidata.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Equibles.Core.AutoWiring" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Integrations.Common\Equibles.Integrations.Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.Integrations.Wikidata/Models/SparqlBinding.cs
+++ b/src/Equibles.Integrations.Wikidata/Models/SparqlBinding.cs
@@ -1,0 +1,11 @@
+namespace Equibles.Integrations.Wikidata.Models;
+
+/// <summary>
+/// One result row; property names mirror the variable names selected by the
+/// query (<c>?cik ?website</c>).
+/// </summary>
+public class SparqlBinding
+{
+    public SparqlValue Cik { get; set; }
+    public SparqlValue Website { get; set; }
+}

--- a/src/Equibles.Integrations.Wikidata/Models/SparqlResults.cs
+++ b/src/Equibles.Integrations.Wikidata/Models/SparqlResults.cs
@@ -1,0 +1,6 @@
+namespace Equibles.Integrations.Wikidata.Models;
+
+public class SparqlResults
+{
+    public List<SparqlBinding> Bindings { get; set; } = [];
+}

--- a/src/Equibles.Integrations.Wikidata/Models/SparqlResultsResponse.cs
+++ b/src/Equibles.Integrations.Wikidata/Models/SparqlResultsResponse.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Integrations.Wikidata.Models;
+
+/// <summary>
+/// The W3C SPARQL 1.1 query-results JSON envelope, reduced to the slice this
+/// integration reads (<c>results.bindings[].{var}.value</c>).
+/// </summary>
+public class SparqlResultsResponse
+{
+    public SparqlResults Results { get; set; } = new();
+}

--- a/src/Equibles.Integrations.Wikidata/Models/SparqlValue.cs
+++ b/src/Equibles.Integrations.Wikidata/Models/SparqlValue.cs
@@ -1,0 +1,6 @@
+namespace Equibles.Integrations.Wikidata.Models;
+
+public class SparqlValue
+{
+    public string Value { get; set; }
+}

--- a/src/Equibles.Integrations.Wikidata/WikidataClient.cs
+++ b/src/Equibles.Integrations.Wikidata/WikidataClient.cs
@@ -1,0 +1,125 @@
+using Equibles.Core.AutoWiring;
+using Equibles.Integrations.Common.RateLimiter;
+using Equibles.Integrations.Wikidata.Contracts;
+using Equibles.Integrations.Wikidata.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Equibles.Integrations.Wikidata;
+
+/// <summary>
+/// Reads company facts from the Wikidata SPARQL endpoint. Wikidata stores the
+/// SEC CIK (property P5531) zero-padded to 10 digits, which makes it an
+/// exact-match join key — no ticker or name fuzziness.
+/// </summary>
+[Service(ServiceLifetime.Scoped, typeof(IWikidataClient))]
+public class WikidataClient : IWikidataClient
+{
+    private const string Endpoint = "https://query.wikidata.org/sparql";
+
+    // The Wikidata query service requires a descriptive User-Agent with a
+    // contact address; anonymous clients get throttled or blocked.
+    private const string UserAgent = "EquiblesBot/1.0 (+https://equibles.com)";
+
+    // CIKs per SPARQL VALUES clause. Bounded so the GET URL stays well under
+    // length limits and a single query stays cheap for the endpoint.
+    private const int ChunkSize = 200;
+
+    private const int PaddedCikLength = 10;
+
+    // Polite shared throttle: WDQS is a shared public service.
+    private static readonly IRateLimiter RateLimiter = new RateLimiter(
+        maxRequests: 1,
+        timeWindow: TimeSpan.FromSeconds(1)
+    );
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<WikidataClient> _logger;
+
+    public WikidataClient(HttpClient httpClient, ILogger<WikidataClient> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyDictionary<string, string>> GetOfficialWebsitesByCik(
+        IReadOnlyCollection<string> ciks,
+        CancellationToken cancellationToken
+    )
+    {
+        // Padded → as-passed, so results key back to the caller's format. Only
+        // digit-shaped CIKs are queryable (and safe to inline in the query).
+        var paddedToOriginal = new Dictionary<string, string>();
+        foreach (var cik in ciks)
+        {
+            var trimmed = cik?.Trim();
+            if (!string.IsNullOrEmpty(trimmed) && trimmed.All(char.IsAsciiDigit))
+                paddedToOriginal.TryAdd(trimmed.PadLeft(PaddedCikLength, '0'), cik);
+        }
+
+        var websites = new Dictionary<string, string>();
+        foreach (var chunk in paddedToOriginal.Keys.Chunk(ChunkSize))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            foreach (var binding in await Query(chunk, cancellationToken))
+            {
+                var paddedCik = binding.Cik?.Value;
+                var website = binding.Website?.Value;
+                if (paddedCik == null || string.IsNullOrWhiteSpace(website))
+                    continue;
+                if (!paddedToOriginal.TryGetValue(paddedCik, out var originalCik))
+                    continue;
+
+                // P856 often holds many localised variants (apple.com/de/, …);
+                // the shortest URL is the canonical root. Ordinal tie-break keeps
+                // the pick deterministic.
+                if (
+                    !websites.TryGetValue(originalCik, out var current)
+                    || website.Length < current.Length
+                    || (
+                        website.Length == current.Length
+                        && string.CompareOrdinal(website, current) < 0
+                    )
+                )
+                    websites[originalCik] = website;
+            }
+        }
+
+        _logger.LogDebug(
+            "Wikidata resolved websites for {Found} of {Requested} CIKs",
+            websites.Count,
+            paddedToOriginal.Count
+        );
+        return websites;
+    }
+
+    private async Task<List<SparqlBinding>> Query(
+        IReadOnlyCollection<string> paddedCiks,
+        CancellationToken cancellationToken
+    )
+    {
+        var values = string.Join(' ', paddedCiks.Select(cik => $"\"{cik}\""));
+        var sparql =
+            "SELECT ?cik ?website WHERE { "
+            + $"VALUES ?cik {{ {values} }} "
+            + "?item wdt:P5531 ?cik ; wdt:P856 ?website . }";
+
+        await RateLimiter.WaitAsync();
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"{Endpoint}?query={Uri.EscapeDataString(sparql)}"
+        );
+        request.Headers.Accept.ParseAdd("application/sparql-results+json");
+        request.Headers.UserAgent.ParseAdd(UserAgent);
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var parsed = JsonConvert.DeserializeObject<SparqlResultsResponse>(json);
+        return parsed?.Results?.Bindings ?? [];
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/WikidataWebsiteSourceTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/WikidataWebsiteSourceTests.cs
@@ -1,0 +1,61 @@
+using Equibles.CommonStocks.BusinessLogic.Websites;
+using Equibles.CommonStocks.HostedService.Services;
+using Equibles.Integrations.Wikidata.Contracts;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Contract: <c>WikidataWebsiteSource</c> queries the client by the stocks' CIKs
+/// and maps the answers back to stock ids; stocks without a CIK are skipped
+/// without a query, and an empty batch never hits the client.
+/// </summary>
+public class WikidataWebsiteSourceTests
+{
+    [Fact]
+    public async Task AnswersAreKeyedBackToStockIds()
+    {
+        var withAnswer = new WebsiteSourceStock(Guid.NewGuid(), "AAPL", "320193");
+        var withoutAnswer = new WebsiteSourceStock(Guid.NewGuid(), "ZZZZ", "999999");
+        var client = Substitute.For<IWikidataClient>();
+        client
+            .GetOfficialWebsitesByCik(
+                Arg.Is<IReadOnlyCollection<string>>(c => c.Contains("320193")),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(new Dictionary<string, string> { ["320193"] = "https://apple.com/" });
+
+        var result = await new WikidataWebsiteSource(client).FindWebsites(
+            [withAnswer, withoutAnswer],
+            CancellationToken.None
+        );
+
+        result
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(new KeyValuePair<Guid, string>(withAnswer.Id, "https://apple.com/"));
+    }
+
+    [Fact]
+    public async Task StocksWithoutCik_AreNotQueried()
+    {
+        var noCik = new WebsiteSourceStock(Guid.NewGuid(), "AAA", null);
+        var blankCik = new WebsiteSourceStock(Guid.NewGuid(), "BBB", " ");
+        var client = Substitute.For<IWikidataClient>();
+
+        var result = await new WikidataWebsiteSource(client).FindWebsites(
+            [noCik, blankCik],
+            CancellationToken.None
+        );
+
+        result.Should().BeEmpty();
+        await client
+            .DidNotReceive()
+            .GetOfficialWebsitesByCik(
+                Arg.Any<IReadOnlyCollection<string>>(),
+                Arg.Any<CancellationToken>()
+            );
+    }
+}

--- a/tests/Equibles.UnitTests/Integrations/WikidataClientTests.cs
+++ b/tests/Equibles.UnitTests/Integrations/WikidataClientTests.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using System.Text;
+using Equibles.Integrations.Wikidata;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.Integrations;
+
+/// <summary>
+/// Contract: <c>WikidataClient.GetOfficialWebsitesByCik</c> pads CIKs to
+/// Wikidata's 10-digit P5531 format for the query but keys results by the CIK as
+/// passed, picks the canonical root among P856's many localised variants (the
+/// shortest URL, ordinal tie-break), chunks large inputs into bounded queries,
+/// and never queries non-digit CIKs.
+/// </summary>
+public class WikidataClientTests
+{
+    private static string SparqlJson(params (string Cik, string Website)[] rows)
+    {
+        var bindings = rows.Select(r => new
+        {
+            cik = new { type = "literal", value = r.Cik },
+            website = new { type = "uri", value = r.Website },
+        });
+        return JsonConvert.SerializeObject(new { results = new { bindings } });
+    }
+
+    private static (WikidataClient Client, RecordingHandler Handler) BuildSut(
+        params string[] responses
+    )
+    {
+        var handler = new RecordingHandler(responses);
+        return (
+            new WikidataClient(new HttpClient(handler), Substitute.For<ILogger<WikidataClient>>()),
+            handler
+        );
+    }
+
+    [Fact]
+    public async Task BareCik_IsPaddedForTheQuery_AndKeysTheResultAsPassed()
+    {
+        var (client, handler) = BuildSut(SparqlJson(("0000320193", "https://apple.com/")));
+
+        var result = await client.GetOfficialWebsitesByCik(["320193"], CancellationToken.None);
+
+        handler.RequestedQueries.Should().ContainSingle().Which.Should().Contain("\"0000320193\"");
+        result
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(new KeyValuePair<string, string>("320193", "https://apple.com/"));
+    }
+
+    [Fact]
+    public async Task ManyLocalisedWebsites_ShortestUrlWins()
+    {
+        var (client, _) = BuildSut(
+            SparqlJson(
+                ("0000320193", "https://apple.com/de/"),
+                ("0000320193", "https://apple.com/"),
+                ("0000320193", "https://apple.com.cn/")
+            )
+        );
+
+        var result = await client.GetOfficialWebsitesByCik(["320193"], CancellationToken.None);
+
+        result["320193"].Should().Be("https://apple.com/");
+    }
+
+    [Fact]
+    public async Task UnknownCiks_AreAbsentFromTheResult()
+    {
+        var (client, _) = BuildSut(SparqlJson(("0000320193", "https://apple.com/")));
+
+        var result = await client.GetOfficialWebsitesByCik(
+            ["320193", "999999"],
+            CancellationToken.None
+        );
+
+        result.Should().HaveCount(1).And.ContainKey("320193");
+    }
+
+    [Fact]
+    public async Task NonDigitCiks_AreNeverQueried()
+    {
+        var (client, handler) = BuildSut(SparqlJson());
+
+        var result = await client.GetOfficialWebsitesByCik(
+            ["abc", "", null, "12 34"],
+            CancellationToken.None
+        );
+
+        result.Should().BeEmpty();
+        handler.RequestedQueries.Should().BeEmpty("nothing digit-shaped was left to query");
+    }
+
+    [Fact]
+    public async Task MoreCiksThanChunkSize_AreSplitAcrossQueries()
+    {
+        var (client, handler) = BuildSut(SparqlJson(), SparqlJson());
+        var ciks = Enumerable.Range(1, 201).Select(i => i.ToString()).ToList();
+
+        await client.GetOfficialWebsitesByCik(ciks, CancellationToken.None);
+
+        handler.RequestedQueries.Should().HaveCount(2);
+        handler.RequestedQueries[0].Should().Contain("\"0000000001\"");
+        handler.RequestedQueries[1].Should().Contain("\"0000000201\"");
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<string> _responses;
+
+        public RecordingHandler(IEnumerable<string> responses) => _responses = new(responses);
+
+        public List<string> RequestedQueries { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            RequestedQueries.Add(Uri.UnescapeDataString(request.RequestUri!.Query));
+            var body = _responses.Count > 0 ? _responses.Dequeue() : "{}";
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        body,
+                        Encoding.UTF8,
+                        "application/sparql-results+json"
+                    ),
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the secondary website source for the discovery worker (refs #3683): Wikidata's official-website fact (P856) joined on the SEC CIK (P5531) — an exact-key match covering ~3,350 listed companies, including foreign issuers whose stored filings carry no website disclosure.
- One bulk SPARQL query per 200 CIKs, rate-limited and sent with the contact User-Agent the Wikidata query service requires. A stale community entry fails the worker's reachability probe and falls through to the next source.

## Code changes

- `src/Equibles.Integrations.Wikidata/` — new integration project: `IWikidataClient` + `WikidataClient` (pads CIKs to Wikidata's 10-digit P5531 format, keys results by the caller's format, picks the canonical root among P856's localised variants via shortest-URL with ordinal tie-break, chunks queries, only digit-shaped CIKs are queryable), SPARQL results JSON models.
- `src/Equibles.CommonStocks.HostedService/Services/WikidataWebsiteSource.cs` — `IWebsiteSource` (priority 20) mapping stock CIKs to client answers and back to stock ids.
- `src/Equibles.CommonStocks.HostedService/` — project reference + DI wiring (autowire client, register source).
- `Equibles.sln` — new project.
- `tests/Equibles.UnitTests/` — client tests (padding/keying, shortest-URL pick, unknown CIKs absent, non-digit CIKs never queried, chunk split) and source tests (id mapping, no-CIK stocks skipped without a query).