### PR TITLE
feat(yahoo): last-resort website source from the asset profile, closes #3683

### DIFF
--- a/src/Equibles.Yahoo.HostedService/Equibles.Yahoo.HostedService.csproj
+++ b/src/Equibles.Yahoo.HostedService/Equibles.Yahoo.HostedService.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
+    <ProjectReference Include="..\Equibles.CommonStocks.BusinessLogic\Equibles.CommonStocks.BusinessLogic.csproj" />
     <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Yahoo.Repositories\Equibles.Yahoo.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Integrations.Yahoo\Equibles.Integrations.Yahoo.csproj" />

--- a/src/Equibles.Yahoo.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Yahoo.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.BusinessLogic.Websites;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Contracts;
 using Equibles.Yahoo.HostedService.Services;
@@ -14,6 +15,11 @@ public static class ServiceCollectionExtensions
 
         // Yahoo is the OSS source of stock prices for Holdings valuation.
         services.AddScoped<IStockPriceProvider, YahooStockPriceProvider>();
+
+        // Last-resort IWebsiteSource (consumed by the CommonStocks website
+        // discovery worker): the Yahoo asset profile, for the long tail the
+        // filings and Wikidata sources leave unfilled.
+        services.AddScoped<IWebsiteSource, YahooWebsiteSource>();
 
         services.AddHostedService<YahooPriceScraperWorker>();
 

--- a/src/Equibles.Yahoo.HostedService/Services/YahooWebsiteSource.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooWebsiteSource.cs
@@ -1,0 +1,66 @@
+using Equibles.CommonStocks.BusinessLogic.Websites;
+using Equibles.Integrations.Yahoo.Contracts;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Yahoo.HostedService.Services;
+
+/// <summary>
+/// Last-resort website source backed by the Yahoo Finance asset profile, keyed
+/// by ticker. Lowest priority: it only sees the long tail the filings and
+/// Wikidata sources left unfilled, keeping the dependency on Yahoo's unofficial
+/// endpoint as small as possible. One profile request per stock, so a
+/// per-ticker failure must not sink the rest of the batch.
+/// </summary>
+public class YahooWebsiteSource : IWebsiteSource
+{
+    private readonly IYahooFinanceClient _yahooClient;
+    private readonly ILogger<YahooWebsiteSource> _logger;
+
+    public YahooWebsiteSource(IYahooFinanceClient yahooClient, ILogger<YahooWebsiteSource> logger)
+    {
+        _yahooClient = yahooClient;
+        _logger = logger;
+    }
+
+    public int Priority => 30;
+
+    public string Name => "Yahoo asset profile";
+
+    public async Task<IReadOnlyDictionary<Guid, string>> FindWebsites(
+        IReadOnlyList<WebsiteSourceStock> stocks,
+        CancellationToken cancellationToken
+    )
+    {
+        var results = new Dictionary<Guid, string>();
+        foreach (var stock in stocks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (string.IsNullOrWhiteSpace(stock.Ticker))
+                continue;
+
+            try
+            {
+                var website = (await _yahooClient.GetCompanyProfile(stock.Ticker))?.Website;
+                if (!string.IsNullOrWhiteSpace(website))
+                    results[stock.Id] = website;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (HttpRequestException ex)
+            {
+                // An unknown ticker or transient Yahoo hiccup is expected for the
+                // long tail this source serves; skip the stock, keep the batch.
+                _logger.LogDebug(
+                    ex,
+                    "Yahoo asset profile lookup failed for {Ticker}",
+                    stock.Ticker
+                );
+            }
+        }
+
+        return results;
+    }
+}

--- a/tests/Equibles.UnitTests/Yahoo/YahooWebsiteSourceTests.cs
+++ b/tests/Equibles.UnitTests/Yahoo/YahooWebsiteSourceTests.cs
@@ -1,0 +1,84 @@
+using Equibles.CommonStocks.BusinessLogic.Websites;
+using Equibles.Integrations.Yahoo.Contracts;
+using Equibles.Integrations.Yahoo.Models;
+using Equibles.Yahoo.HostedService.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Equibles.UnitTests.Yahoo;
+
+/// <summary>
+/// Contract: <c>YahooWebsiteSource</c> looks up each stock's asset profile by
+/// ticker and returns the profile website where present; blank websites and
+/// ticker-less stocks are absent from the result, and a per-ticker HTTP failure
+/// skips that stock without sinking the rest of the batch.
+/// </summary>
+public class YahooWebsiteSourceTests
+{
+    private static YahooWebsiteSource BuildSut(IYahooFinanceClient client) =>
+        new(client, Substitute.For<ILogger<YahooWebsiteSource>>());
+
+    [Fact]
+    public async Task ProfileWebsites_AreKeyedByStockId()
+    {
+        var withWebsite = new WebsiteSourceStock(Guid.NewGuid(), "AAPL", "320193");
+        var blankWebsite = new WebsiteSourceStock(Guid.NewGuid(), "ZZZZ", "999999");
+        var client = Substitute.For<IYahooFinanceClient>();
+        client
+            .GetCompanyProfile("AAPL")
+            .Returns(new CompanyProfile { Website = "https://www.apple.com" });
+        client.GetCompanyProfile("ZZZZ").Returns(new CompanyProfile { Website = " " });
+
+        var result = await BuildSut(client)
+            .FindWebsites([withWebsite, blankWebsite], CancellationToken.None);
+
+        result
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(new KeyValuePair<Guid, string>(withWebsite.Id, "https://www.apple.com"));
+    }
+
+    [Fact]
+    public async Task PerTickerHttpFailure_SkipsTheStock_NotTheBatch()
+    {
+        var failing = new WebsiteSourceStock(Guid.NewGuid(), "DEAD", "111111");
+        var healthy = new WebsiteSourceStock(Guid.NewGuid(), "AAPL", "320193");
+        var client = Substitute.For<IYahooFinanceClient>();
+        client.GetCompanyProfile("DEAD").ThrowsAsync(new HttpRequestException("404"));
+        client
+            .GetCompanyProfile("AAPL")
+            .Returns(new CompanyProfile { Website = "https://www.apple.com" });
+
+        var result = await BuildSut(client)
+            .FindWebsites([failing, healthy], CancellationToken.None);
+
+        result.Should().ContainSingle().Which.Key.Should().Be(healthy.Id);
+    }
+
+    [Fact]
+    public async Task TickerlessStocks_AreNeverLookedUp()
+    {
+        var noTicker = new WebsiteSourceStock(Guid.NewGuid(), null, "111111");
+        var client = Substitute.For<IYahooFinanceClient>();
+
+        var result = await BuildSut(client).FindWebsites([noTicker], CancellationToken.None);
+
+        result.Should().BeEmpty();
+        await client.DidNotReceive().GetCompanyProfile(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task NullProfile_LeavesTheStockAbsent()
+    {
+        var stock = new WebsiteSourceStock(Guid.NewGuid(), "AAPL", "320193");
+        var client = Substitute.For<IYahooFinanceClient>();
+        client.GetCompanyProfile("AAPL").Returns((CompanyProfile)null);
+
+        var result = await BuildSut(client).FindWebsites([stock], CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the final tier of the website-fill pipeline (closes #3683): a Yahoo asset-profile `IWebsiteSource` at the lowest priority, so it only serves the long tail the filings (priority 10) and Wikidata (priority 20) sources leave unfilled — keeping the dependency on Yahoo's unofficial endpoint as small as possible.
- With this, the website discovery worker has its full source chain: SEC company-sync metadata upstream (#3684), stored-filings extraction (#3688), Wikidata CIK join (#3689), Yahoo backoff (this PR).

## Code changes

- `src/Equibles.Yahoo.HostedService/Services/YahooWebsiteSource.cs` — `IWebsiteSource` (priority 30): one `GetCompanyProfile` lookup per ticker, blank websites and ticker-less stocks skipped, per-ticker `HttpRequestException` skips the stock without sinking the batch.
- `src/Equibles.Yahoo.HostedService/` — DI registration in `AddYahooWorker` + project reference to CommonStocks.BusinessLogic.
- `tests/Equibles.UnitTests/Yahoo/YahooWebsiteSourceTests.cs` — id keying, blank-website absence, per-ticker failure isolation, ticker-less skip, null-profile handling.