### PR TITLE
chore(wikidata): pin the rate limiter to half the documented WDQS allowance

### DIFF
--- a/src/Equibles.Integrations.Wikidata/WikidataClient.cs
+++ b/src/Equibles.Integrations.Wikidata/WikidataClient.cs
@@ -28,10 +28,15 @@ public class WikidataClient : IWikidataClient
 
     private const int PaddedCikLength = 10;
 
-    // Polite shared throttle: WDQS is a shared public service.
+    // Half of the documented WDQS allowance, by construction: the service grants
+    // each client (user agent + IP) 60 seconds of query processing time per
+    // 60-second window (https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual,
+    // "Query limits"). Our bounded VALUES queries cost well under 1 second of
+    // processing each and run sequentially, so 30 requests per 60 seconds consumes
+    // at most 30 of the allowed 60 processing-seconds.
     private static readonly IRateLimiter RateLimiter = new RateLimiter(
-        maxRequests: 1,
-        timeWindow: TimeSpan.FromSeconds(1)
+        maxRequests: 30,
+        timeWindow: TimeSpan.FromSeconds(60)
     );
 
     private readonly HttpClient _httpClient;


### PR DESCRIPTION
## Summary

- Replaces the arbitrary 1-request-per-second throttle with one derived from the Wikidata Query Service's documented limits: each client gets 60 seconds of query processing time per 60-second window (plus 5 parallel queries per IP; 429 when throttled). Our bounded VALUES queries run sequentially and cost well under 1 second of processing each, so 30 requests per 60 seconds consumes at most half the allowance by construction.
- Net effect on throughput is a wash for normal batches (30 chunks/min = 6,000 CIKs/min) while giving a documented, defensible ceiling instead of a guess.

## Code changes

- `src/Equibles.Integrations.Wikidata/WikidataClient.cs` — rate limiter 1/1s → 30/60s, with the derivation and the WDQS user-manual reference in the comment.