### PR TITLE
fix(holdings): degrade an unstorable 13D/G percent-of-class to null

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/Filing13DGXmlParser.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Filing13DGXmlParser.cs
@@ -228,6 +228,12 @@ public class Filing13DGXmlParser
             ? (long)value
             : 0;
 
+    // The storage cap of the holdings percent columns (numeric(7,4)). The form reports
+    // 0-100, so a value past the cap is filer garbage (a fat-fingered "5,000" parses as
+    // 5000) — it degrades to null like any unparseable field rather than aborting the
+    // whole batch flush with a numeric-overflow error.
+    private const decimal MaxStorablePercent = 999.9999m;
+
     private static decimal? ParsePercent(string raw) =>
         decimal.TryParse(
             raw?.Replace(",", string.Empty),
@@ -235,6 +241,7 @@ public class Filing13DGXmlParser
             CultureInfo.InvariantCulture,
             out var value
         )
+        && Math.Abs(value) <= MaxStorablePercent
             ? value
             : null;
 }

--- a/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserPercentOverflowTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserPercentOverflowTests.cs
@@ -1,0 +1,62 @@
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+// Adversarial: the parser documents itself as resilient — every unparseable
+// field degrades to a default so "the filing is never silently dropped". A
+// percent-of-class that parses as a decimal but exceeds the holdings columns'
+// numeric(7,4) storage cap (999.9999) must follow the same contract and
+// degrade to null, not flow into the entity and abort the whole batch flush
+// with a numeric-overflow error downstream.
+public class Filing13DGXmlParserPercentOverflowTests
+{
+    private readonly Filing13DGXmlParser _sut = new();
+
+    private static string MinimalFilingWithPercentOfClass(string percentOfClass) =>
+        $"""
+            <edgarSubmission>
+              <headerData>
+                <submissionType>SCHEDULE 13D</submissionType>
+              </headerData>
+              <coverPageHeader>
+                <issuerInfo>
+                  <issuerName>Test Issuer Inc.</issuerName>
+                </issuerInfo>
+                <reportingPersonInfo>
+                  <reportingPersonName>Overflow Holder LP</reportingPersonName>
+                  <percentOfClass>{percentOfClass}</percentOfClass>
+                </reportingPersonInfo>
+              </coverPageHeader>
+            </edgarSubmission>
+            """;
+
+    private decimal? ParsedPercent(string percentOfClass) =>
+        _sut.ParseFiling(
+                MinimalFilingWithPercentOfClass(percentOfClass),
+                accessionNumber: "0001140361-25-000002",
+                cik: "0001234567",
+                filingDate: new DateOnly(2025, 1, 1)
+            )
+            .ReportingPersons.Single()
+            .PercentOfClass;
+
+    // A fat-fingered cover-page value like "5,000" parses to 5000 once the thousands
+    // separator is stripped — past the storage cap, so it degrades to null.
+    [Theory]
+    [InlineData("5,000")]
+    [InlineData("1000")]
+    [InlineData("-1000")]
+    public void ParseFiling_PercentBeyondTheStorageCap_DegradesToNull(string raw)
+    {
+        ParsedPercent(raw).Should().BeNull();
+    }
+
+    // The cap itself and ordinary form values stay faithful.
+    [Theory]
+    [InlineData("999.9999", 999.9999)]
+    [InlineData("9.8", 9.8)]
+    public void ParseFiling_PercentWithinTheStorageCap_IsKept(string raw, double expected)
+    {
+        ParsedPercent(raw).Should().Be((decimal)expected);
+    }
+}


### PR DESCRIPTION
## Summary

- `Filing13DGXmlParser.ParsePercent` accepted any decimal, so a fat-fingered cover-page percent like `5,000` (5000 after separator stripping) flowed unchecked into the `numeric(7,4)` holdings columns and aborted the whole batch flush with `22003: numeric field overflow` — discarding every holding in the filing (the numeric sibling of the `TitleOfClass` 22001 issue).
- A percent past the 999.9999 storage cap has no legitimate reading (the form reports 0–100), so it now degrades to `null` exactly like an unparseable field, per the parser's documented "the filing is never silently dropped" contract. In-range values, including the cap itself, stay faithful.

## Code changes

- `src/Equibles.Holdings.HostedService/Services/Filing13DGXmlParser.cs` — `MaxStorablePercent` guard in `ParsePercent` (`Math.Abs(value) <= 999.9999m`).
- `tests/Equibles.UnitTests/Holdings/Filing13DGXmlParserPercentOverflowTests.cs` — 5 cases mirroring the share-overflow suite: `5,000`/`1000`/`-1000` degrade to null; `999.9999`/`9.8` are kept.