### PR TITLE
feat(sec): backfill Document.Items onto historical 8-Ks from the submissions feed

### DIFF
--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -53,7 +53,9 @@ public class Document
     /// Comma-joined SEC item numbers reported by this filing, e.g. <c>"2.02,9.01"</c> on an
     /// 8-K. Lets a consumer pick out earnings-release 8-Ks (Item 2.02 "Results of Operations
     /// and Financial Condition") without re-parsing. Null for forms that carry no items and
-    /// for legacy rows ingested before capture.
+    /// for legacy rows ingested before capture; the empty string is the backfill's terminal
+    /// "checked, nothing found in the feed" marker (consumers treat both as no items, but
+    /// only null rows are still pending backfill).
     /// </summary>
     [MaxLength(256)]
     public string Items { get; set; }

--- a/src/Equibles.Sec.HostedService/Configuration/FilingItemsBackfillOptions.cs
+++ b/src/Equibles.Sec.HostedService/Configuration/FilingItemsBackfillOptions.cs
@@ -1,0 +1,22 @@
+namespace Equibles.Sec.HostedService.Configuration;
+
+/// <summary>
+/// Controls the historical sweep that stamps <c>Document.Items</c> onto 8-K rows ingested
+/// before item capture went live. Forward capture needs no switch — it reads the item list
+/// from the submissions feed already fetched for ingest — so this only governs the backfill.
+/// </summary>
+public class FilingItemsBackfillOptions
+{
+    /// <summary>
+    /// Off by default — the sweep is a one-time operation that re-fetches each pending
+    /// company's submissions feed (plus its archive pages) and so spends the shared EDGAR
+    /// budget; opt in via <c>FilingItemsBackfill__Enabled=true</c>.
+    /// </summary>
+    public bool Enabled { get; set; } = false;
+
+    /// <summary>
+    /// How many companies are swept per cycle. Each company costs one submissions-feed
+    /// fetch plus its archive pages, and stamps every one of its pending 8-Ks in one go.
+    /// </summary>
+    public int BatchSize { get; set; } = 8;
+}

--- a/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.Sec.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICompanySyncService, CompanySyncService>();
         services.AddScoped<XbrlEnvelopeCaptureService>();
         services.AddScoped<XbrlBackfillService>();
+        services.AddScoped<FilingItemsBackfillService>();
         services.AddScoped<IDocumentScraper, DocumentScraper>();
         // Primary IWebsiteSource (consumed by the CommonStocks website discovery
         // worker): the website disclosure mandated in the stocks' own stored filings.
@@ -32,6 +33,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<FtdScraperWorker>();
         services.AddHostedService<FormAdvScraperWorker>();
         services.AddHostedService<XbrlBackfillWorker>();
+        services.AddHostedService<FilingItemsBackfillWorker>();
         services.AddHostedService<InsiderFilingReprocessWorker>();
         services.AddHostedService<NportFilingReprocessWorker>();
 

--- a/src/Equibles.Sec.HostedService/FilingItemsBackfillWorker.cs
+++ b/src/Equibles.Sec.HostedService/FilingItemsBackfillWorker.cs
@@ -1,0 +1,77 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.Sec.HostedService.Configuration;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Worker;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.Sec.HostedService;
+
+/// <summary>
+/// Backfills <c>Document.Items</c> for 8-Ks ingested before item capture was enabled. Runs
+/// alongside the live scraper (sharing the EDGAR request budget) and is gated on an opt-in
+/// switch, so the historical sweep only runs when an operator asks for it.
+/// </summary>
+public class FilingItemsBackfillWorker : BaseScraperWorker
+{
+    private readonly IConfiguration _configuration;
+    private readonly FilingItemsBackfillOptions _options;
+
+    protected override string WorkerName => "Filing items backfill";
+
+    // A historical sweep, not a latency-sensitive job: a longer interval keeps it from
+    // re-querying and re-spending the shared EDGAR budget when the queue is drained or
+    // stuck on companies whose feed cannot be fetched.
+    protected override TimeSpan SleepInterval => TimeSpan.FromMinutes(5);
+    protected override ErrorSource ErrorSource => ErrorSource.DocumentScraper;
+
+    // Yield to the live SEC scrapers at deploy time before spending the shared EDGAR budget
+    // on the historical sweep.
+    protected override TimeSpan StartupDelay => TimeSpan.FromMinutes(10);
+
+    public FilingItemsBackfillWorker(
+        ILogger<FilingItemsBackfillWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<FilingItemsBackfillOptions> options,
+        IConfiguration configuration
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        _options = options.Value;
+        _configuration = configuration;
+    }
+
+    protected override bool ValidateConfiguration() =>
+        ValidateSecContactEmail(
+            _configuration,
+            "Filing items backfill",
+            treatWhitespaceAsAbsent: true
+        );
+
+    protected override async Task DoWork(CancellationToken stoppingToken)
+    {
+        if (!_options.Enabled)
+        {
+            Logger.LogDebug("Filing-items backfill disabled; skipping cycle.");
+            return;
+        }
+
+        await using var scope = ScopeFactory.CreateAsyncScope();
+        var backfillService =
+            scope.ServiceProvider.GetRequiredService<FilingItemsBackfillService>();
+        var result = await backfillService.Backfill(_options.BatchSize, stoppingToken);
+
+        Logger.LogInformation(
+            "Filing-items backfill cycle complete. Companies: {Companies}, Stamped: {Stamped}, "
+                + "NotFound: {NotFound}, Failed: {Failed}",
+            result.Companies,
+            result.Stamped,
+            result.NotFound,
+            result.Failed
+        );
+    }
+}

--- a/src/Equibles.Sec.HostedService/Models/FilingItemsBackfillResult.cs
+++ b/src/Equibles.Sec.HostedService/Models/FilingItemsBackfillResult.cs
@@ -1,0 +1,20 @@
+namespace Equibles.Sec.HostedService.Models;
+
+/// <summary>Per-cycle tally of what the filing-items backfill did, for logging.</summary>
+public class FilingItemsBackfillResult
+{
+    /// <summary>Companies whose submissions feed was fetched and whose 8-Ks were stamped.</summary>
+    public int Companies { get; set; }
+
+    /// <summary>Documents stamped with a non-empty item list from the feed.</summary>
+    public int Stamped { get; set; }
+
+    /// <summary>
+    /// Documents checked but absent from the feed (or carrying no items there) — marked
+    /// with the empty-string terminal value so they are not re-selected.
+    /// </summary>
+    public int NotFound { get; set; }
+
+    /// <summary>Companies whose fetch or save failed; their documents retry next cycle.</summary>
+    public int Failed { get; set; }
+}

--- a/src/Equibles.Sec.HostedService/Services/FilingItemsBackfillService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FilingItemsBackfillService.cs
@@ -1,0 +1,173 @@
+using System.Text.RegularExpressions;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Models;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Equibles.Sec.HostedService.Services;
+
+/// <summary>
+/// Stamps <c>Document.Items</c> onto 8-K rows ingested before item capture went live, so the
+/// earnings-release consumers (Item 2.02) can match historical filings. Each cycle picks the
+/// companies with pending 8-Ks (newest filings first), re-fetches each company's submissions
+/// feed once — <see cref="ISecEdgarClient.GetCompanyFilings"/> already walks the archive pages,
+/// so the whole filing history is covered — and stamps every pending 8-K by accession number.
+/// </summary>
+/// <remarks>
+/// A document whose accession is absent from the feed (or carries no items there) is stamped
+/// with the empty string: a terminal "checked, nothing found" marker distinct from the null
+/// "never checked" state, so the corpus drains instead of re-selecting the same companies
+/// forever. Consumers treat empty and null alike (no items), so the marker changes nothing
+/// for them. The sweep is deliberately not bounded by the worker minimum sync date — stamping
+/// must cover every pending 8-K of a selected company, or the leftovers would re-select the
+/// company every cycle.
+/// </remarks>
+public class FilingItemsBackfillService
+{
+    // Rows ingested before AccessionNumber existed carry it only inside the stored EDGAR
+    // full-submission URL; the accession is the file name. Same recovery as the XBRL
+    // backfill — kept as a private copy because that one is pinned in place by tests.
+    private static readonly Regex EdgarSourceUrlAccession = new(
+        @"/Archives/edgar/data/\d+/(\d{10}-\d{2}-\d{6})\.txt$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase
+    );
+
+    private readonly DocumentRepository _documentRepository;
+    private readonly ISecEdgarClient _secEdgarClient;
+    private readonly ILogger<FilingItemsBackfillService> _logger;
+
+    public FilingItemsBackfillService(
+        DocumentRepository documentRepository,
+        ISecEdgarClient secEdgarClient,
+        ILogger<FilingItemsBackfillService> logger
+    )
+    {
+        _documentRepository = documentRepository;
+        _secEdgarClient = secEdgarClient;
+        _logger = logger;
+    }
+
+    public async Task<FilingItemsBackfillResult> Backfill(
+        int companyBatchSize,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var result = new FilingItemsBackfillResult();
+        if (companyBatchSize <= 0)
+        {
+            return result;
+        }
+
+        // Companies with pending 8-Ks, ordered by their most recent filing so recent
+        // quarters become linkable soonest. Companies without a CIK can never be fetched
+        // and are simply never selected.
+        var companies = await PendingEightKs()
+            .GroupBy(d => d.CommonStockId)
+            .Select(g => new { StockId = g.Key, LatestReportingDate = g.Max(d => d.ReportingDate) })
+            .OrderByDescending(x => x.LatestReportingDate)
+            .Take(companyBatchSize)
+            .ToListAsync(cancellationToken);
+
+        foreach (var company in companies)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Per-company failures are isolated: the documents stay null and the company is
+            // retried on a later cycle, while the rest of the batch still progresses.
+            try
+            {
+                await BackfillCompany(company.StockId, result, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                result.Failed++;
+                _logger.LogWarning(
+                    ex,
+                    "Filing-items backfill failed for stock {StockId}; will retry next cycle.",
+                    company.StockId
+                );
+            }
+        }
+
+        return result;
+    }
+
+    private async Task BackfillCompany(
+        Guid stockId,
+        FilingItemsBackfillResult result,
+        CancellationToken cancellationToken
+    )
+    {
+        var documents = await PendingEightKs()
+            .Where(d => d.CommonStockId == stockId)
+            .Include(d => d.CommonStock)
+            .ToListAsync(cancellationToken);
+        if (documents.Count == 0)
+        {
+            return;
+        }
+
+        var stock = documents[0].CommonStock;
+        var filings = await _secEdgarClient.GetCompanyFilings(stock.Cik, DocumentTypeFilter.EightK);
+        var itemsByAccession = filings
+            .Where(f => !string.IsNullOrEmpty(f.AccessionNumber))
+            .DistinctBy(f => f.AccessionNumber)
+            .ToDictionary(f => f.AccessionNumber, f => f.Items);
+
+        var stamped = 0;
+        foreach (var document in documents)
+        {
+            // Recover the accession for legacy rows; it is persisted alongside the items so
+            // later consumers can link the filing without re-deriving.
+            document.AccessionNumber ??= DeriveAccessionNumber(document.SourceUrl);
+
+            string items = null;
+            if (document.AccessionNumber != null)
+            {
+                itemsByAccession.TryGetValue(document.AccessionNumber, out items);
+            }
+
+            if (string.IsNullOrWhiteSpace(items))
+            {
+                // Terminal marker — see the class remarks.
+                document.Items = string.Empty;
+                result.NotFound++;
+            }
+            else
+            {
+                document.Items = items;
+                stamped++;
+            }
+        }
+
+        await _documentRepository.SaveChanges();
+        result.Companies++;
+        result.Stamped += stamped;
+
+        _logger.LogInformation(
+            "Filing-items backfill stamped {Stamped} of {Total} pending 8-Ks for {Ticker}.",
+            stamped,
+            documents.Count,
+            stock.Ticker
+        );
+    }
+
+    private IQueryable<Document> PendingEightKs() =>
+        _documentRepository
+            .GetByDocumentType(DocumentType.EightK)
+            .Where(d => d.Items == null && d.CommonStock.Cik != null);
+
+    private static string DeriveAccessionNumber(string sourceUrl)
+    {
+        if (string.IsNullOrEmpty(sourceUrl))
+        {
+            return null;
+        }
+
+        var match = EdgarSourceUrlAccession.Match(sourceUrl);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+}

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -79,6 +79,9 @@ builder.Services.Configure<Equibles.Sec.HostedService.Configuration.FormAdvScrap
 builder.Services.Configure<Equibles.Sec.HostedService.Configuration.XbrlCaptureOptions>(
     builder.Configuration.GetSection("XbrlCapture")
 );
+builder.Services.Configure<Equibles.Sec.HostedService.Configuration.FilingItemsBackfillOptions>(
+    builder.Configuration.GetSection("FilingItemsBackfill")
+);
 builder.Services.Configure<FinancialFactsScraperOptions>(
     builder.Configuration.GetSection("FinancialFactsScraper")
 );

--- a/tests/Equibles.IntegrationTests/Sec/FilingItemsBackfillServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FilingItemsBackfillServiceTests.cs
@@ -1,0 +1,321 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Sec;
+
+/// <summary>
+/// Exercises <see cref="FilingItemsBackfillService"/> against real Postgres: pending 8-Ks
+/// (null <c>Items</c>) get their item list stamped from the re-fetched submissions feed by
+/// accession number, feed misses are marked with the empty-string terminal value so the
+/// corpus drains, and a feed failure leaves the company pending for a later retry.
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class FilingItemsBackfillServiceTests : ParadeDbMcpTestBase
+{
+    public FilingItemsBackfillServiceTests(ParadeDbFixture fixture)
+        : base(fixture) { }
+
+    private async Task<CommonStock> SeedCompany(string ticker, string cik)
+    {
+        var company = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = ticker,
+            Name = $"{ticker} Inc.",
+            Cik = cik,
+        };
+        await using var seed = Fixture.CreateDbContext();
+        seed.Set<CommonStock>().Add(company);
+        await seed.SaveChangesAsync();
+        return company;
+    }
+
+    private async Task<Guid> SeedEightK(
+        Guid companyId,
+        string accessionNumber,
+        DateOnly reportingDate,
+        string sourceUrl = null,
+        string items = null
+    )
+    {
+        await using var seed = Fixture.CreateDbContext();
+        var content = new File
+        {
+            Id = Guid.NewGuid(),
+            Name = "content",
+            Extension = "txt",
+            ContentType = "text/plain",
+            Size = 4,
+            FileContent = new() { Bytes = "body"u8.ToArray() },
+        };
+        seed.Set<File>().Add(content);
+        var document = new Document
+        {
+            Id = Guid.NewGuid(),
+            CommonStockId = companyId,
+            Content = content,
+            DocumentType = DocumentType.EightK,
+            ReportingDate = reportingDate,
+            ReportingForDate = reportingDate,
+            AccessionNumber = accessionNumber,
+            SourceUrl = sourceUrl,
+            Items = items,
+        };
+        seed.Set<Document>().Add(document);
+        await seed.SaveChangesAsync();
+        return document.Id;
+    }
+
+    private FilingItemsBackfillService BuildSut(ISecEdgarClient secEdgarClient) =>
+        new(
+            new DocumentRepository(DbContext),
+            secEdgarClient,
+            NullLogger<FilingItemsBackfillService>()
+        );
+
+    private static ISecEdgarClient StubClient(params FilingData[] filings)
+    {
+        var client = Substitute.For<ISecEdgarClient>();
+        client
+            .GetCompanyFilings(
+                Arg.Any<string>(),
+                Arg.Any<DocumentTypeFilter?>(),
+                Arg.Any<DateOnly?>(),
+                Arg.Any<DateOnly?>()
+            )
+            .Returns(filings.ToList());
+        return client;
+    }
+
+    private static FilingData EightKFiling(string accessionNumber, string items) =>
+        new()
+        {
+            Cik = "0000320193",
+            AccessionNumber = accessionNumber,
+            Form = "8-K",
+            Items = items,
+            FilingDate = new DateOnly(2024, 2, 1),
+            ReportDate = new DateOnly(2024, 2, 1),
+        };
+
+    [Fact]
+    public async Task Backfill_StampsPendingEightKsByAccessionAndMarksFeedlessOnes()
+    {
+        var company = await SeedCompany("ITM1", "0000320193");
+        await SeedEightK(company.Id, "0000320193-24-000001", new DateOnly(2024, 2, 1));
+        await SeedEightK(company.Id, "0000320193-24-000002", new DateOnly(2024, 5, 1));
+        DbContext.ChangeTracker.Clear();
+
+        var client = StubClient(
+            EightKFiling("0000320193-24-000001", "2.02,9.01"),
+            EightKFiling("0000320193-24-000002", null)
+        );
+        var result = await BuildSut(client).Backfill(companyBatchSize: 10);
+
+        result.Companies.Should().Be(1);
+        result.Stamped.Should().Be(1);
+        result.NotFound.Should().Be(1);
+
+        await using var verify = Fixture.CreateDbContext();
+        var stampedDoc = await verify
+            .Set<Document>()
+            .SingleAsync(d => d.AccessionNumber == "0000320193-24-000001");
+        var feedlessDoc = await verify
+            .Set<Document>()
+            .SingleAsync(d => d.AccessionNumber == "0000320193-24-000002");
+        stampedDoc.Items.Should().Be("2.02,9.01");
+        feedlessDoc.Items.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public async Task Backfill_DerivesAccessionFromLegacySourceUrlAndPersistsIt()
+    {
+        var company = await SeedCompany("ITM2", "0000320193");
+        var documentId = await SeedEightK(
+            company.Id,
+            accessionNumber: null,
+            new DateOnly(2015, 4, 1),
+            sourceUrl: "https://www.sec.gov/Archives/edgar/data/320193/0000320193-15-000005.txt"
+        );
+        DbContext.ChangeTracker.Clear();
+
+        var client = StubClient(EightKFiling("0000320193-15-000005", "2.02"));
+        var result = await BuildSut(client).Backfill(companyBatchSize: 10);
+
+        result.Stamped.Should().Be(1);
+
+        await using var verify = Fixture.CreateDbContext();
+        var document = await verify.Set<Document>().SingleAsync(d => d.Id == documentId);
+        document.Items.Should().Be("2.02");
+        document.AccessionNumber.Should().Be("0000320193-15-000005");
+    }
+
+    [Fact]
+    public async Task Backfill_TerminalMarkerDrainsTheCorpus()
+    {
+        // A document the feed can never match (no accession, underivable URL) must be marked
+        // on the first sweep so the company is not re-fetched forever.
+        var company = await SeedCompany("ITM3", "0000320193");
+        await SeedEightK(company.Id, accessionNumber: null, new DateOnly(2024, 2, 1));
+        DbContext.ChangeTracker.Clear();
+
+        var client = StubClient(EightKFiling("0000320193-24-000009", "2.02"));
+        var sut = BuildSut(client);
+
+        var first = await sut.Backfill(companyBatchSize: 10);
+        var second = await sut.Backfill(companyBatchSize: 10);
+
+        first.NotFound.Should().Be(1);
+        second.Companies.Should().Be(0);
+        await client
+            .Received(1)
+            .GetCompanyFilings(
+                Arg.Any<string>(),
+                Arg.Any<DocumentTypeFilter?>(),
+                Arg.Any<DateOnly?>(),
+                Arg.Any<DateOnly?>()
+            );
+    }
+
+    [Fact]
+    public async Task Backfill_FeedFailure_LeavesDocumentsPendingForRetry()
+    {
+        var company = await SeedCompany("ITM4", "0000320193");
+        var documentId = await SeedEightK(
+            company.Id,
+            "0000320193-24-000010",
+            new DateOnly(2024, 2, 1)
+        );
+        DbContext.ChangeTracker.Clear();
+
+        var failing = Substitute.For<ISecEdgarClient>();
+        failing
+            .GetCompanyFilings(
+                Arg.Any<string>(),
+                Arg.Any<DocumentTypeFilter?>(),
+                Arg.Any<DateOnly?>(),
+                Arg.Any<DateOnly?>()
+            )
+            .ThrowsAsync(new HttpRequestException("EDGAR unavailable"));
+        var result = await BuildSut(failing).Backfill(companyBatchSize: 10);
+
+        result.Failed.Should().Be(1);
+        result.Companies.Should().Be(0);
+
+        await using (var verify = Fixture.CreateDbContext())
+        {
+            var document = await verify.Set<Document>().SingleAsync(d => d.Id == documentId);
+            document.Items.Should().BeNull("a failed company must stay pending for retry");
+        }
+
+        // A later cycle with a healthy feed picks the company up again and stamps it.
+        DbContext.ChangeTracker.Clear();
+        var retry = await BuildSut(StubClient(EightKFiling("0000320193-24-000010", "2.02")))
+            .Backfill(companyBatchSize: 10);
+        retry.Stamped.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Backfill_BatchSizeBoundsCompaniesPerCycle_NewestFilingsFirst()
+    {
+        var older = await SeedCompany("ITM5", "0000100001");
+        var newer = await SeedCompany("ITM6", "0000100002");
+        await SeedEightK(older.Id, "0000100001-20-000001", new DateOnly(2020, 1, 1));
+        await SeedEightK(newer.Id, "0000100002-24-000001", new DateOnly(2024, 1, 1));
+        DbContext.ChangeTracker.Clear();
+
+        var client = StubClient(
+            EightKFiling("0000100001-20-000001", "2.02"),
+            EightKFiling("0000100002-24-000001", "2.02")
+        );
+        var result = await BuildSut(client).Backfill(companyBatchSize: 1);
+
+        result.Companies.Should().Be(1);
+
+        await using var verify = Fixture.CreateDbContext();
+        var newerDoc = await verify
+            .Set<Document>()
+            .SingleAsync(d => d.AccessionNumber == "0000100002-24-000001");
+        var olderDoc = await verify
+            .Set<Document>()
+            .SingleAsync(d => d.AccessionNumber == "0000100001-20-000001");
+        newerDoc.Items.Should().Be("2.02", "the company with the newest pending 8-K goes first");
+        olderDoc.Items.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Backfill_OneFailingCompany_DoesNotAbortTheRestOfTheBatch()
+    {
+        // The newest-first ordering puts the failing company first; the healthy one must
+        // still be fetched and stamped in the same cycle.
+        var failingCompany = await SeedCompany("ITM8", "0000200001");
+        var healthyCompany = await SeedCompany("ITM9", "0000200002");
+        await SeedEightK(failingCompany.Id, "0000200001-24-000001", new DateOnly(2024, 6, 1));
+        await SeedEightK(healthyCompany.Id, "0000200002-24-000001", new DateOnly(2024, 1, 1));
+        DbContext.ChangeTracker.Clear();
+
+        var client = Substitute.For<ISecEdgarClient>();
+        client
+            .GetCompanyFilings(
+                "0000200001",
+                Arg.Any<DocumentTypeFilter?>(),
+                Arg.Any<DateOnly?>(),
+                Arg.Any<DateOnly?>()
+            )
+            .ThrowsAsync(new HttpRequestException("EDGAR unavailable"));
+        client
+            .GetCompanyFilings(
+                "0000200002",
+                Arg.Any<DocumentTypeFilter?>(),
+                Arg.Any<DateOnly?>(),
+                Arg.Any<DateOnly?>()
+            )
+            .Returns([EightKFiling("0000200002-24-000001", "2.02")]);
+        var result = await BuildSut(client).Backfill(companyBatchSize: 10);
+
+        result.Failed.Should().Be(1);
+        result.Companies.Should().Be(1);
+        result.Stamped.Should().Be(1);
+
+        await using var verify = Fixture.CreateDbContext();
+        var failed = await verify
+            .Set<Document>()
+            .SingleAsync(d => d.AccessionNumber == "0000200001-24-000001");
+        var stamped = await verify
+            .Set<Document>()
+            .SingleAsync(d => d.AccessionNumber == "0000200002-24-000001");
+        failed.Items.Should().BeNull();
+        stamped.Items.Should().Be("2.02");
+    }
+
+    [Fact]
+    public async Task Backfill_CompanyWithoutCik_IsNeverSelected()
+    {
+        var company = await SeedCompany("ITM7", cik: null);
+        await SeedEightK(company.Id, "0000100003-24-000001", new DateOnly(2024, 1, 1));
+        DbContext.ChangeTracker.Clear();
+
+        var client = StubClient();
+        var result = await BuildSut(client).Backfill(companyBatchSize: 10);
+
+        result.Companies.Should().Be(0);
+        await client
+            .DidNotReceive()
+            .GetCompanyFilings(
+                Arg.Any<string>(),
+                Arg.Any<DocumentTypeFilter?>(),
+                Arg.Any<DateOnly?>(),
+                Arg.Any<DateOnly?>()
+            );
+    }
+}


### PR DESCRIPTION
## Summary

Historical 8-K `Document` rows carry `Items = NULL` because item capture only went live recently, so consumers that key on the item list (e.g. picking out Item 2.02 earnings releases) can never match them. This adds an opt-in backfill worker that stamps `Items` onto the existing 8-K corpus.

Fixes the OSS half of daniel3303/EquiblesCommercial#2979.

Design (mirrors the XBRL backfill precedent):

- Per cycle, the companies with pending 8-Ks (`Items IS NULL`, CIK known) are selected newest-filing-first, bounded by `FilingItemsBackfill:BatchSize` (default 8).
- Each company's submissions feed is fetched once via the existing `GetCompanyFilings` — it already walks the paginated archive files and maps the parallel `items` array, so the whole filing history costs one feed walk — and every pending 8-K is stamped by accession number.
- Accessions for legacy rows are recovered from the stored EDGAR submission URL and persisted (same recovery as the XBRL backfill; kept as a private copy because that one is reflection-pinned by tests).
- A document absent from the feed (or carrying no items there) is stamped with the empty string — a terminal "checked, nothing found" marker distinct from the null "never checked" state — so the corpus drains instead of re-selecting the same companies forever. Consumers treat both as "no items".
- Per-company failures are isolated and retried on later cycles; the sweep is deliberately not bounded by the worker minimum sync date so stamping per company is exhaustive (required for terminality).
- Off by default; opt in via `FilingItemsBackfill__Enabled=true`.

## Code changes

- `Equibles.Sec.HostedService/Services/FilingItemsBackfillService.cs` (new) — selection, feed fetch, accession matching, terminal marker, per-company save.
- `Equibles.Sec.HostedService/FilingItemsBackfillWorker.cs` (new) — opt-in gated `BaseScraperWorker` (5-min cycles, 10-min startup yield, SEC contact-email validation).
- `Configuration/FilingItemsBackfillOptions.cs`, `Models/FilingItemsBackfillResult.cs` (new).
- `Extensions/ServiceCollectionExtensions.cs` — register service + hosted worker.
- `Equibles.Worker.Host/Program.cs` — bind the `FilingItemsBackfill` section.
- `Equibles.Sec.Data/Models/Document.cs` — document the empty-string terminal marker on `Items`.
- `tests/Equibles.IntegrationTests/Sec/FilingItemsBackfillServiceTests.cs` (new) — 7 tests against real Postgres: stamp-by-accession + feed-miss marker, legacy-URL accession derivation, terminal-marker drain (single fetch), feed-failure retry, batch bound with newest-first ordering, failure isolation across the batch, CIK-less never selected.

## Verification

- `Equibles.Sec.HostedService`, `Equibles.Worker.Host`, and both test projects build clean; `csharpier check .` passes.
- New suite green (7/7); full Sec-scoped suites green (372 integration + 899 unit).