### PR TITLE
fix(sec): index Document.CreationTime for ingestion-stats range scans

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260613000553_AddDocumentCreationTimeIndex.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260613000553_AddDocumentCreationTimeIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613000553_AddDocumentCreationTimeIndex")]
+    partial class AddDocumentCreationTimeIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260613000553_AddDocumentCreationTimeIndex.cs
+++ b/src/Equibles.Migrations/Migrations/20260613000553_AddDocumentCreationTimeIndex.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDocumentCreationTimeIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Document_CreationTime",
+                table: "Document",
+                column: "CreationTime");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Document_CreationTime",
+                table: "Document");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -13,6 +13,7 @@ namespace Equibles.Sec.Data.Models;
 [Index(nameof(AccessionNumber), IsUnique = false)]
 [Index(nameof(XbrlStatus), IsUnique = false)]
 [Index(nameof(XbrlStatus), nameof(XbrlFactsVersion))]
+[Index(nameof(CreationTime), IsUnique = false)]
 public class Document
 {
     public Guid Id { get; set; } = Guid.NewGuid();


### PR DESCRIPTION
## Summary

Dashboard ingestion stats (freshness panel + 14-day trend) aggregate over `Document.CreationTime`, which had no index — every load ran two full seq scans + hash aggregates over the multi-million-row `Document` table. This adds the missing index so those range scans are indexed.

Tracked in daniel3303/EquiblesCommercial#2932.

## Code changes

- `src/Equibles.Sec.Data/Models/Document.cs` — add `[Index(nameof(CreationTime))]`.
- `src/Equibles.Migrations/Migrations/` — scaffolded `AddDocumentCreationTimeIndex` migration (creates `IX_Document_CreationTime`) + snapshot update.