### PR TITLE
fix(sec): key NPORT latest-per-series on registrant + series id, never name text

### DIFF
--- a/src/Equibles.Sec.Repositories/NportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NportFilingRepository.cs
@@ -21,10 +21,15 @@ public class NportFilingRepository : SecFilingRepositoryBase<NportFiling>
 
     /// <summary>
     /// Each fund series' most recent NPORT report whose portfolio is as of the floor date or
-    /// later. Series are keyed by registrant + series name — <see cref="NportFiling.SeriesId"/>
-    /// is absent on almost every filing. The latest report is the one with the greatest report
-    /// period, breaking ties by filing date and then accession number so amendments and
-    /// re-filings of the same period win.
+    /// later. Series identity never compares name text — the same fund's name varies across
+    /// filings ("and"/"&amp;", "Inc"/"Inc.", stray spaces, legal renames), which would freeze a
+    /// stale "latest" report under every spelling. Within a stock, filings carrying the same
+    /// non-empty <see cref="NportFiling.SeriesId"/> are the same series; filings carrying
+    /// different non-empty ids are genuinely different series and never supersede each other;
+    /// and an id-less filing belongs to the registrant's single fund (listed closed-end funds
+    /// file with no series id at all), so it shares identity with every filing of its stock.
+    /// The latest report is the one with the greatest report period, breaking ties by filing
+    /// date and then accession number so amendments and re-filings of the same period win.
     /// </summary>
     public IQueryable<NportFiling> GetLatestPerSeries(DateOnly floor)
     {
@@ -32,7 +37,11 @@ public class NportFilingRepository : SecFilingRepositoryBase<NportFiling>
         return filings.Where(f =>
             !filings.Any(f2 =>
                 f2.CommonStockId == f.CommonStockId
-                && f2.SeriesName == f.SeriesName
+                && (
+                    f2.SeriesId == f.SeriesId
+                    || string.IsNullOrEmpty(f.SeriesId)
+                    || string.IsNullOrEmpty(f2.SeriesId)
+                )
                 && (
                     f2.ReportPeriodDate > f.ReportPeriodDate
                     || (f2.ReportPeriodDate == f.ReportPeriodDate && f2.FilingDate > f.FilingDate)

--- a/tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs
@@ -42,7 +42,8 @@ public class NportFilingRepositoryTests : IDisposable
         Guid commonStockId,
         string accessionNumber = "0000036405-24-000002",
         DateOnly? filingDate = null,
-        string seriesName = "Vanguard 500 Index Fund"
+        string seriesName = "Vanguard 500 Index Fund",
+        string seriesId = "S000002277"
     )
     {
         return new NportFiling
@@ -54,7 +55,7 @@ public class NportFilingRepositoryTests : IDisposable
             IsAmendment = false,
             RegistrantName = "VANGUARD INDEX FUNDS",
             SeriesName = seriesName,
-            SeriesId = "S000002277",
+            SeriesId = seriesId,
             SeriesLei = "5493007GHODQRGNTGS28",
             ReportPeriodDate = new DateOnly(2024, 12, 31),
             ReportPeriodEnd = new DateOnly(2025, 12, 31),
@@ -203,14 +204,16 @@ public class NportFilingRepositoryTests : IDisposable
             stock.Id,
             "0000036405-25-000003",
             new DateOnly(2025, 1, 15),
-            "Vanguard Growth Index Fund"
+            "Vanguard Growth Index Fund",
+            "S000002278"
         );
         otherSeries.ReportPeriodDate = new DateOnly(2024, 12, 31);
         var belowFloor = CreateFiling(
             stock.Id,
             "0000036405-23-000004",
             new DateOnly(2023, 1, 15),
-            "Vanguard Stale Fund"
+            "Vanguard Stale Fund",
+            "S000002279"
         );
         belowFloor.ReportPeriodDate = new DateOnly(2022, 12, 31);
         _repository.Add(older);
@@ -223,6 +226,121 @@ public class NportFilingRepositoryTests : IDisposable
 
         result.Should().HaveCount(2);
         result.Select(f => f.Id).Should().BeEquivalentTo([newest.Id, otherSeries.Id]);
+    }
+
+    // A listed closed-end fund files with no series id, and its name text drifts across filings
+    // ("Inc" vs "Inc.", stray spaces, a legal rename). All such filings are the registrant's
+    // single fund, so only the newest report may surface — name variants must never each freeze
+    // their own stale "latest".
+    [Fact]
+    public async Task GetLatestPerSeries_IdlessNameVariants_CollapseToTheNewestReport()
+    {
+        var stock = CreateStock("CLM", "0000814083");
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var renamed = CreateFiling(
+            stock.Id,
+            "0001752724-21-000001",
+            new DateOnly(2021, 8, 20),
+            "Cornerstone Strategic Value Fund, Inc.",
+            seriesId: null
+        );
+        renamed.ReportPeriodDate = new DateOnly(2021, 6, 30);
+        var straySpace = CreateFiling(
+            stock.Id,
+            "0001752724-25-000002",
+            new DateOnly(2025, 8, 22),
+            "Cornerstone Strategic Investment Fund , Inc",
+            seriesId: null
+        );
+        straySpace.ReportPeriodDate = new DateOnly(2025, 6, 30);
+        var newest = CreateFiling(
+            stock.Id,
+            "0000910472-26-000003",
+            new DateOnly(2026, 5, 21),
+            "Cornerstone Strategic Investment Fund, Inc.",
+            seriesId: null
+        );
+        newest.ReportPeriodDate = new DateOnly(2026, 3, 31);
+        _repository.Add(renamed);
+        _repository.Add(straySpace);
+        _repository.Add(newest);
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetLatestPerSeries(DateOnly.MinValue).ToListAsync();
+
+        result.Should().ContainSingle().Which.Id.Should().Be(newest.Id);
+    }
+
+    // Some funds report their series id only on part of their filings. An id-less report is the
+    // registrant's single fund, so a newer id-carrying report of the same stock supersedes it —
+    // otherwise the fund's pre-id era would survive as a second, stale "series".
+    [Fact]
+    public async Task GetLatestPerSeries_IdlessOlderReport_SupersededByNewerIdCarryingReport()
+    {
+        var stock = CreateStock("FMN", "0001212422");
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var idless = CreateFiling(
+            stock.Id,
+            "0001623632-21-000001",
+            new DateOnly(2021, 7, 28),
+            "Federated Premier Municipal Income Fund",
+            seriesId: null
+        );
+        idless.ReportPeriodDate = new DateOnly(2021, 5, 31);
+        var idCarrying = CreateFiling(
+            stock.Id,
+            "0001623632-26-000002",
+            new DateOnly(2026, 1, 28),
+            "Federated Hermes Premier Municipal Income Fund",
+            "S000011351"
+        );
+        idCarrying.ReportPeriodDate = new DateOnly(2025, 11, 30);
+        _repository.Add(idless);
+        _repository.Add(idCarrying);
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetLatestPerSeries(DateOnly.MinValue).ToListAsync();
+
+        result.Should().ContainSingle().Which.Id.Should().Be(idCarrying.Id);
+    }
+
+    // Two filings carrying different non-empty series ids are genuinely different series of the
+    // same registrant — a shared or similar name must not collapse them.
+    [Fact]
+    public async Task GetLatestPerSeries_DistinctSeriesIdsWithSameName_BothSurvive()
+    {
+        var stock = CreateStock();
+        _dbContext.Set<CommonStock>().Add(stock);
+        await _dbContext.SaveChangesAsync();
+
+        var seriesA = CreateFiling(
+            stock.Id,
+            "0000036405-26-000001",
+            new DateOnly(2026, 1, 15),
+            "Vanguard Index Fund",
+            "S000002277"
+        );
+        seriesA.ReportPeriodDate = new DateOnly(2025, 12, 31);
+        var seriesB = CreateFiling(
+            stock.Id,
+            "0000036405-26-000002",
+            new DateOnly(2026, 2, 15),
+            "Vanguard Index Fund",
+            "S000002278"
+        );
+        seriesB.ReportPeriodDate = new DateOnly(2026, 1, 31);
+        _repository.Add(seriesA);
+        _repository.Add(seriesB);
+        await _repository.SaveChanges();
+
+        var result = await _repository.GetLatestPerSeries(DateOnly.MinValue).ToListAsync();
+
+        result.Should().HaveCount(2);
+        result.Select(f => f.Id).Should().BeEquivalentTo([seriesA.Id, seriesB.Id]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `NportFilingRepository.GetLatestPerSeries` keyed series identity on `CommonStockId + SeriesName`, so name-text variants across filings ("and"/"&", "Inc"/"Inc.", stray spaces, legal renames) each froze their own stale "latest" report — the same closed-end fund surfaced up to five times with report dates years apart (Cornerstone ×5, BlackRock CII ×4, Herzfeld's rename shown as two concurrent funds). Closes #3696.
- Series identity now never compares name text. Within a stock: filings carrying the same non-empty `SeriesId` are the same series; filings carrying different non-empty ids are genuinely different series and never supersede each other; an id-less filing belongs to the registrant's single fund — listed closed-end funds file with no series id anywhere in the submission (verified against the raw EDGAR submissions), so the registrant is the fund.
- Query-only fix: no parser change, no migration, no backfill — it corrects existing data immediately. Tie-breaking (report period, then filing date, then accession number) is unchanged.

## Code changes

- `src/Equibles.Sec.Repositories/NportFilingRepository.cs` — replaced the `SeriesName` equality in the anti-join with the id-aware identity (`SeriesId` equal, or either side id-less); rewrote the doc comment to state the identity rule and why name text is never compared.
- `tests/Equibles.IntegrationTests/Sec/NportFilingRepositoryTests.cs` — `CreateFiling` gains a `seriesId` parameter; the two-series case now uses distinct ids (the real-world shape); new regression tests: id-less name variants collapse to the newest report, an id-less older report is superseded by a newer id-carrying one, and distinct series ids with the same name both survive.