### PR TITLE
fix(holdings): hold realtime sweep watermark back on failed imports

### DIFF
--- a/src/Equibles.Holdings.HostedService/Models/RealtimeIngestionResult.cs
+++ b/src/Equibles.Holdings.HostedService/Models/RealtimeIngestionResult.cs
@@ -1,10 +1,11 @@
 namespace Equibles.Holdings.HostedService.Models;
 
 /// <summary>
-/// Outcome of a real-time 13F sweep. <see cref="EarliestFailedDate"/> is the
-/// oldest daily-index date that could not be fetched this cycle (SEC throttling
-/// or a transient error), or null if every day in the window swept cleanly —
-/// the worker uses it to hold the sweep watermark back so failed days are
-/// re-swept next cycle.
+/// Outcome of a real-time sweep (13F or 13D/G). <see cref="EarliestFailedDate"/>
+/// is the oldest date this cycle left retryable work behind — a daily index that
+/// could not be fetched (SEC throttling or a transient error), or the filing
+/// date of a filing whose import threw — or null if the window swept cleanly.
+/// The worker uses it to hold the sweep watermark back so the failed work is
+/// re-swept next cycle, even after it ages out of the trailing window.
 /// </summary>
 public record RealtimeIngestionResult(int FilingsImported, DateOnly? EarliestFailedDate);

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13DGIngestionService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13DGIngestionService.cs
@@ -82,6 +82,10 @@ public class Realtime13DGIngestionService
             .ThenBy(e => e.AccessionNumber, StringComparer.Ordinal)
             .ToList();
 
+        // Seeded with the discovery-phase failure; per-filing import failures
+        // below pull it further back so the watermark re-covers them too.
+        var earliestRetryDate = earliestFailedDate;
+
         var totalImported = 0;
         foreach (var entry in sorted)
         {
@@ -121,7 +125,9 @@ public class Realtime13DGIngestionService
                 // A poisoned filing must cost only its own rows, never the sweep:
                 // skip it and leave it unrecorded so a later cycle retries it
                 // (e.g. once a fix for its defect deploys). Mirrors the per-entry
-                // isolation TryParseAndValidateEntry gives parse failures.
+                // isolation TryParseAndValidateEntry gives parse failures. Holding
+                // the watermark back keeps the filing re-discoverable even after
+                // it ages out of the trailing window (EquiblesCommercial#2850).
                 _logger.LogError(
                     ex,
                     "Failed to import {Form} {Accession} (CIK {Cik}); skipping filing",
@@ -129,12 +135,17 @@ public class Realtime13DGIngestionService
                     entry.AccessionNumber,
                     entry.Cik
                 );
+                if (earliestRetryDate == null || entry.DateFiled < earliestRetryDate)
+                    earliestRetryDate = entry.DateFiled;
                 continue;
             }
 
             // IsComplete=false is the import service's "retry later" contract (e.g.
             // NoTrackedStocks until CUSIPs seed) — recording it here would consume
-            // the filing forever (EquiblesCommercial#2850).
+            // the filing forever (EquiblesCommercial#2850). It deliberately does
+            // NOT hold the watermark back: an issuer that never seeds a CUSIP
+            // would wedge the sweep, so its retry is bounded by the trailing
+            // window instead.
             if (!importResult.IsComplete)
                 continue;
 
@@ -147,7 +158,7 @@ public class Realtime13DGIngestionService
             totalImported
         );
 
-        return new RealtimeIngestionResult(totalImported, earliestFailedDate);
+        return new RealtimeIngestionResult(totalImported, earliestRetryDate);
     }
 
     private async Task<Parsed13DGFiling> TryParseAndValidateEntry(

--- a/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/Realtime13FIngestionService.cs
@@ -80,6 +80,10 @@ public class Realtime13FIngestionService
             .ThenBy(e => e.AccessionNumber, StringComparer.Ordinal)
             .ToList();
 
+        // Seeded with the discovery-phase failure; per-filing import failures
+        // below pull it further back so the watermark re-covers them too.
+        var earliestRetryDate = earliestFailedDate;
+
         var totalImported = 0;
         foreach (var entry in sorted)
         {
@@ -105,10 +109,46 @@ public class Realtime13FIngestionService
                 filing.PeriodOfReport
             );
 
-            using (var archive = _archiveBuilder.Build([filing]))
+            ImportResult importResult;
+            try
             {
-                await _importService.ImportDataSet(archive, minReportDate, cancellationToken);
+                using var archive = _archiveBuilder.Build([filing]);
+                importResult = await _importService.ImportDataSet(
+                    archive,
+                    minReportDate,
+                    cancellationToken
+                );
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // A poisoned filing must cost only its own rows, never the sweep
+                // (EquiblesCommercial#2510): skip it and leave it unrecorded so a
+                // later cycle retries it. Holding the watermark back keeps the
+                // filing re-discoverable even after it ages out of the trailing
+                // window (EquiblesCommercial#2850).
+                _logger.LogError(
+                    ex,
+                    "Failed to import 13F-HR {Accession} (CIK {Cik}); skipping filing",
+                    entry.AccessionNumber,
+                    entry.Cik
+                );
+                if (earliestRetryDate == null || entry.DateFiled < earliestRetryDate)
+                    earliestRetryDate = entry.DateFiled;
+                continue;
+            }
+
+            // IsComplete=false is the import service's "retry later" contract (e.g.
+            // NoTrackedStocks until CUSIPs seed) — recording it here would consume
+            // the filing forever (EquiblesCommercial#2850). It deliberately does
+            // NOT hold the watermark back: a filing whose issuers never seed a
+            // CUSIP would wedge the sweep, so its retry is bounded by the trailing
+            // window instead — and the quarterly bulk import reconciles it anyway.
+            if (!importResult.IsComplete)
+                continue;
 
             await RecordProcessed([entry.AccessionNumber], cancellationToken);
             totalImported++;
@@ -119,7 +159,7 @@ public class Realtime13FIngestionService
             totalImported
         );
 
-        return new RealtimeIngestionResult(totalImported, earliestFailedDate);
+        return new RealtimeIngestionResult(totalImported, earliestRetryDate);
     }
 
     private async Task<Parsed13FFiling> TryParseAndValidateEntry(

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13DGIngestionIncompleteImportTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13DGIngestionIncompleteImportTests.cs
@@ -190,6 +190,11 @@ public class Realtime13DGIngestionIncompleteImportTests : IAsyncLifetime
         );
 
         result.FilingsImported.Should().Be(0, "an incomplete import is not an import");
+        result
+            .EarliestFailedDate.Should()
+            .BeNull(
+                "an incomplete import must not hold the watermark back — an issuer that never seeds a CUSIP would wedge the sweep"
+            );
 
         using var verify = FreshContext();
         var processed = await verify

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13DGIngestionPoisonedFilingTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13DGIngestionPoisonedFilingTests.cs
@@ -26,7 +26,10 @@ namespace Equibles.IntegrationTests.Holdings;
 /// processed, so every later cycle replayed the sweep and died at the same
 /// filing — coverage froze at its date. Pin: a poisoned filing costs only its
 /// own rows; the sweep continues, later filings import, and the poisoned
-/// accession stays unrecorded so a later cycle can retry it after a fix.
+/// accession stays unrecorded so a later cycle can retry it after a fix. The
+/// sweep result also reports the failed filing's date so the worker holds the
+/// watermark back — without that, the filing falls out of the trailing
+/// re-sweep window after 14 days and is lost forever (EquiblesCommercial#2850).
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class Realtime13DGIngestionPoisonedFilingTests : IAsyncLifetime
@@ -241,6 +244,12 @@ public class Realtime13DGIngestionPoisonedFilingTests : IAsyncLifetime
         );
 
         result.FilingsImported.Should().Be(1, "the clean filing must survive the poisoned one");
+        result
+            .EarliestFailedDate.Should()
+            .Be(
+                new DateOnly(2025, 5, 6),
+                "a failed import must hold the watermark back so the filing is re-swept even after the trailing window passes"
+            );
 
         using var verify = FreshContext();
         var cleanHoldings = await verify

--- a/tests/Equibles.IntegrationTests/Holdings/Realtime13FIngestionIncompleteImportTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/Realtime13FIngestionIncompleteImportTests.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Text;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.Configuration;
 using Equibles.Core.Contracts;
@@ -21,26 +20,26 @@ using Xunit;
 namespace Equibles.IntegrationTests.Holdings;
 
 /// <summary>
-/// Crash-safety invariant of Realtime13FIngestionService: record the ledger
-/// only after the import succeeded — a failure inside ImportDataSet must NOT
-/// write the accession to the ProcessedFiling ledger, otherwise the next sweep
-/// treats it as done and the filing is lost forever. The failing filing costs
-/// only its own rows (the sweep survives, EquiblesCommercial#2510) and its
-/// filing date holds the watermark back so it stays re-discoverable even past
-/// the trailing re-sweep window (EquiblesCommercial#2850). The next healthy
-/// sweep must re-ingest it.
+/// 13F twin of the 13D/G incomplete-import pin (EquiblesCommercial#2850): the
+/// import service returns IsComplete=false for the NoTrackedStocks outcome —
+/// its own contract says "leave the data set unprocessed so a later cycle
+/// backfills it once CUSIPs exist" — but the 13F realtime sweep recorded the
+/// accession in ProcessedFiling anyway, consuming the filing forever. Pin: an
+/// incomplete import stays unrecorded and uncounted, keeping the filing
+/// retryable, and does not hold the watermark back (the quarterly bulk import
+/// reconciles it regardless).
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
-public class Realtime13FIngestionCrashSafetyTests : IAsyncLifetime
+public class Realtime13FIngestionIncompleteImportTests : IAsyncLifetime
 {
-    private const string Cik = "1067983";
-    private const string Cusip = "037833100";
+    private const string Accession = "0004000000-26-000001";
+    private const string UntrackedCusip = "999999999";
 
     private readonly ParadeDbFixture _fixture;
     private readonly List<EquiblesFinancialDbContext> _contexts = [];
     private readonly CultureInfo _previousCulture;
 
-    public Realtime13FIngestionCrashSafetyTests(ParadeDbFixture fixture)
+    public Realtime13FIngestionIncompleteImportTests(ParadeDbFixture fixture)
     {
         _fixture = fixture;
         _previousCulture = CultureInfo.CurrentCulture;
@@ -92,22 +91,22 @@ public class Realtime13FIngestionCrashSafetyTests : IAsyncLifetime
     private static string PrimaryDoc() =>
         """
             <edgarSubmission xmlns="http://www.sec.gov/edgar/thirteenffiler">
-              <headerData><filerInfo><filer><credentials><cik>0001067983</cik></credentials></filer></filerInfo></headerData>
+              <headerData><filerInfo><filer><credentials><cik>0001067984</cik></credentials></filer></filerInfo></headerData>
               <formData><coverPage>
                 <reportCalendarOrQuarter>09-30-2024</reportCalendarOrQuarter>
                 <isAmendment>false</isAmendment>
-                <filingManager><name>BIG FUND</name></filingManager>
-                <form13FFileNumber>028-1</form13FFileNumber>
+                <filingManager><name>UNSEEDED FUND</name></filingManager>
+                <form13FFileNumber>028-2</form13FFileNumber>
               </coverPage></formData>
             </edgarSubmission>
             """;
 
     private static string InfoTable() =>
-        """
+        $"""
             <informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable">
               <infoTable>
-                <nameOfIssuer>APPLE INC</nameOfIssuer><titleOfClass>COM</titleOfClass>
-                <cusip>037833100</cusip><value>1</value>
+                <nameOfIssuer>UNSEEDED ISSUER INC</nameOfIssuer><titleOfClass>COM</titleOfClass>
+                <cusip>{UntrackedCusip}</cusip><value>1</value>
                 <shrsOrPrnAmt><sshPrnamt>1000</sshPrnamt><sshPrnamtType>SH</sshPrnamtType></shrsOrPrnAmt>
                 <investmentDiscretion>SOLE</investmentDiscretion>
                 <votingAuthority><Sole>1000</Sole><Shared>0</Shared><None>0</None></votingAuthority>
@@ -115,39 +114,24 @@ public class Realtime13FIngestionCrashSafetyTests : IAsyncLifetime
             </informationTable>
             """;
 
-    private static EdgarDailyIndexEntry Entry() =>
-        new()
+    [Fact]
+    public async Task IngestRecentFilings_ImportReportsIncomplete_LeavesAccessionUnrecordedForRetry()
+    {
+        // No CommonStock is seeded for the filing's CUSIP, so the import maps no
+        // tracked stock and returns IsComplete=false ("retry once CUSIPs exist").
+        var entry = new EdgarDailyIndexEntry
         {
             FormType = "13F-HR",
-            CompanyName = "BIG FUND",
-            Cik = Cik,
+            CompanyName = "UNSEEDED FUND",
+            Cik = "1067984",
             DateFiled = new DateOnly(2024, 11, 20),
-            AccessionNumber = "ACC-ORIG",
+            AccessionNumber = Accession,
         };
-
-    [Fact]
-    public async Task IngestRecentFilings_ImportFailsMidSweep_DoesNotRecordLedgerSoNextSweepRetries()
-    {
-        using (var seed = FreshContext())
-        {
-            seed.Set<CommonStock>()
-                .Add(
-                    new CommonStock
-                    {
-                        Id = Guid.NewGuid(),
-                        Ticker = "AAPL",
-                        Name = "Apple Inc",
-                        Cik = "0000320193",
-                        Cusip = Cusip,
-                    }
-                );
-            await seed.SaveChangesAsync();
-        }
 
         var edgar = Substitute.For<ISecEdgarClient>();
         edgar
             .GetDailyIndex(Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
-            .Returns(_ => [Entry()]);
+            .Returns(_ => [entry]);
         edgar
             .GetFilingArtifactNames(
                 Arg.Any<string>(),
@@ -173,25 +157,13 @@ public class Realtime13FIngestionCrashSafetyTests : IAsyncLifetime
 
         var scopeFactory = CreateScopeFactory();
 
-        // The import path resolves closing prices; throw on the FIRST sweep so
-        // ImportDataSet fails mid-flight, then succeed on every later call.
         var prices = Substitute.For<IStockPriceProvider>();
-        var priceCalls = 0;
         prices
             .GetClosingPrices(
                 Arg.Any<IEnumerable<(Guid, DateOnly)>>(),
                 Arg.Any<CancellationToken>()
             )
-            .Returns(ci =>
-            {
-                if (Interlocked.Increment(ref priceCalls) == 1)
-                    throw new InvalidOperationException("price service unavailable");
-
-                var dict = new Dictionary<(Guid, DateOnly), decimal>();
-                foreach (var (id, date) in ci.ArgAt<IEnumerable<(Guid, DateOnly)>>(0))
-                    dict[(id, date)] = 100m;
-                return Task.FromResult(dict);
-            });
+            .Returns(Task.FromResult(new Dictionary<(Guid, DateOnly), decimal>()));
 
         var importService = new HoldingsImportService(
             scopeFactory,
@@ -209,53 +181,30 @@ public class Realtime13FIngestionCrashSafetyTests : IAsyncLifetime
             Substitute.For<ILogger<Realtime13FIngestionService>>()
         );
 
-        var today = new DateOnly(2024, 11, 25);
-        var minReportDate = new DateOnly(2024, 1, 1);
-
-        // Sweep 1 — the import blows up. The sweep survives, the ledger MUST stay
-        // empty, and the failed filing's date must hold the watermark back.
-        var firstSweep = await ingestion.IngestRecentFilings(
-            today,
-            1,
-            minReportDate,
+        var result = await ingestion.IngestRecentFilings(
+            today: new DateOnly(2024, 11, 25),
+            lookbackDays: 1,
+            minReportDate: new DateOnly(2024, 1, 1),
             CancellationToken.None
         );
-        firstSweep.FilingsImported.Should().Be(0, "the only filing in the window failed to import");
-        firstSweep
+
+        result.FilingsImported.Should().Be(0, "an incomplete import is not an import");
+        result
             .EarliestFailedDate.Should()
-            .Be(
-                new DateOnly(2024, 11, 20),
-                "a failed import must hold the watermark back so the filing is re-swept even after the trailing window passes"
+            .BeNull(
+                "an incomplete import must not hold the watermark back — the quarterly bulk import reconciles it"
             );
 
-        using (var afterFailure = FreshContext())
-        {
-            var recorded = await afterFailure
-                .Set<ProcessedFiling>()
-                .AnyAsync(p => p.AccessionNumber == "ACC-ORIG");
-            recorded.Should().BeFalse("a crash before import completes must not record the ledger");
-        }
-
-        // Sweep 2 — prices now resolve; the filing must be re-ingested, not skipped.
-        var imported = await ingestion.IngestRecentFilings(
-            today,
-            1,
-            minReportDate,
-            CancellationToken.None
-        );
-
-        imported.FilingsImported.Should().Be(1);
-
         using var verify = FreshContext();
-        var holdings = await verify
-            .Set<InstitutionalHolding>()
-            .Where(h => h.Cusip == Cusip)
+        var processed = await verify
+            .Set<ProcessedFiling>()
+            .Select(p => p.AccessionNumber)
             .ToListAsync();
-
-        holdings
+        processed
             .Should()
-            .ContainSingle("the retried sweep must land the holdings the failed sweep dropped");
-        holdings[0].Shares.Should().Be(1000);
-        holdings[0].AccessionNumber.Should().Be("ACC-ORIG");
+            .NotContain(
+                Accession,
+                "an incomplete import must stay unrecorded so a later cycle retries it"
+            );
     }
 }


### PR DESCRIPTION
## Summary

Closes the last durable-retry gap in the realtime sweeps (daniel3303/EquiblesCommercial#2850, defect 2). A filing whose import threw was left unrecorded (retryable), but the sweep watermark still advanced to today — once the filing's index date aged past the 14-day trailing re-sweep window it became permanently unreachable (e.g. the 45 transient-DNS casualties from the 2026-06-10 deploy restart). The 13F path additionally had both original defects: a thrown import aborted the whole sweep, and `ImportDataSet`'s result was discarded so `IsComplete: false` outcomes were recorded in `ProcessedFiling` and consumed forever.

Now both services report the filing date of a failed import through `RealtimeIngestionResult.EarliestFailedDate` (the same channel daily-index fetch failures already use), so the worker holds the watermark back and the window re-covers the filing next cycle — `ComputeWindowStart` already extends past the trailing window when the watermark is older. Incomplete imports (`IsComplete: false`, e.g. NoTrackedStocks) deliberately do NOT hold the watermark: an issuer that never seeds a CUSIP would wedge the sweep, so their retry stays bounded by the trailing window.

## Code changes

- `Realtime13DGIngestionService` — a thrown per-filing import pulls the returned `EarliestFailedDate` back to the entry's filing date.
- `Realtime13FIngestionService` — per-entry try/catch (a poisoned filing costs only its own rows instead of aborting the sweep), `RecordProcessed` gated on `IsComplete`, and the same watermark holdback.
- `RealtimeIngestionResult` — doc updated: `EarliestFailedDate` covers both fetch and import failures.
- Tests: poisoned-filing and crash-safety tests now pin the watermark holdback (the 13F one previously pinned the whole-sweep throw); incomplete-import tests pin that incomplete imports do NOT hold the watermark; new `Realtime13FIngestionIncompleteImportTests` pins the 13F `IsComplete` gate.

## Verification

Full unit suite 2841 passed; all 205 Holdings integration tests (Testcontainers ParadeDB) passed, including the 15 realtime-sweep tests.