### PR TITLE
feat(common-stocks): stealth-browser fetch client + opt-in sidecar (1/3)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,50 @@ services:
       embedding:
         condition: service_healthy
 
+  # Stealth browser (opt-in): docker compose --profile stealth up
+  #
+  # Third-party stealth Chromium (CloakBrowser, https://github.com/CloakHQ/CloakBrowser)
+  # used only to render investor-relations sites that answer a plain request with an
+  # Incapsula/Akamai bot challenge. The compiled binary is an opaque, anonymous
+  # third party under its own BINARY-LICENSE.md ("free to use, no redistribution").
+  # Supply-chain caution: keep it isolated to this container, pinned by digest, with
+  # no host secrets and no volume mounts; its CDP port is never published to the host.
+  # Review the binary licence for your own use before enabling in production. Default
+  # off, so the stock stack never pulls it.
+  cloakbrowser:
+    image: cloakhq/cloakbrowser:0.3.31@sha256:61dee1b490ee8f74b040bc02c3d5384c7f64420b87ccaa26a33f213d07df3f73
+    profiles: ["stealth"]
+    command: ["cloakserve", "--idle-timeout=300"]
+    # Internal-only: the worker reaches it at http://cloakbrowser:9222 over the
+    # compose network. Never map this to the host — it is a remote browser endpoint.
+    expose:
+      - "9222"
+    restart: unless-stopped
+
+  # Worker with the stealth fetch fallback enabled (use --profile stealth)
+  worker-stealth:
+    build:
+      context: .
+      dockerfile: src/Equibles.Worker.Host/Dockerfile
+    profiles: ["stealth"]
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      ConnectionStrings__DefaultConnection: "Host=db;Database=equibles;Username=postgres;Password=postgres"
+      ConnectionStrings__TransportConnection: "Host=db;Database=equibles;Username=postgres;Password=postgres"
+      MassTransit__RunMigration: "true"
+      Sec__ContactEmail: ${SEC_CONTACT_EMAIL}
+      Embedding__Enabled: "false"
+      InvestorRelationsDiscovery__StealthFetch__Enabled: "true"
+      InvestorRelationsDiscovery__StealthFetch__SidecarUrl: "http://cloakbrowser:9222"
+      MinimumLogLevel: ${MINIMUM_LOG_LEVEL:-Warning}
+    depends_on:
+      web:
+        condition: service_healthy
+      cloakbrowser:
+        condition: service_started
+
 volumes:
   db-data:
   web-keys:

--- a/src/Equibles.CommonStocks.HostedService/Configuration/StealthFetchOptions.cs
+++ b/src/Equibles.CommonStocks.HostedService/Configuration/StealthFetchOptions.cs
@@ -1,0 +1,38 @@
+namespace Equibles.CommonStocks.HostedService.Configuration;
+
+/// <summary>
+/// Configuration for the optional stealth-browser fetch fallback, used when an IR
+/// host answers a plain HTTP request with a bot-protection challenge instead of the
+/// page. Bound from the <c>InvestorRelationsDiscovery:StealthFetch</c> section.
+/// Disabled by default, so the stock build behaves exactly as before and carries no
+/// dependency on the sidecar.
+/// </summary>
+public class StealthFetchOptions
+{
+    /// <summary>
+    /// Whether the stealth fallback is active. When false (the default), a bot-
+    /// challenge response is recorded as a miss, exactly as before.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Chrome DevTools Protocol endpoint of the stealth-browser sidecar (e.g.
+    /// <c>http://cloakbrowser:9222</c>). Required when <see cref="Enabled"/> is true;
+    /// an empty value keeps the fallback inert.
+    /// </summary>
+    public string SidecarUrl { get; set; }
+
+    /// <summary>
+    /// Per-page render timeout in seconds. A walled page often has to clear its
+    /// challenge before the real content loads, so this is more generous than the
+    /// plain HTTP probe timeout.
+    /// </summary>
+    public int RenderTimeoutSeconds { get; set; } = 45;
+
+    /// <summary>
+    /// Maximum number of concurrent stealth renders. Stealth fetches are expensive
+    /// and politeness-sensitive, so they are bounded well below the plain-HTTP rate
+    /// to avoid escalating a solvable challenge into a hard block.
+    /// </summary>
+    public int MaxConcurrency { get; set; } = 2;
+}

--- a/src/Equibles.CommonStocks.HostedService/Equibles.CommonStocks.HostedService.csproj
+++ b/src/Equibles.CommonStocks.HostedService/Equibles.CommonStocks.HostedService.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Playwright" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
@@ -1,0 +1,119 @@
+using Equibles.CommonStocks.HostedService.Configuration;
+using Equibles.Core.AutoWiring;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Playwright;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// <see cref="IStealthBrowserClient"/> backed by a CloakBrowser <c>cloakserve</c>
+/// sidecar. Connects to the sidecar's Chrome DevTools Protocol endpoint, renders
+/// the page in the stealth Chromium, and returns the final HTML. The sidecar is an
+/// opt-in, digest-pinned container (compose <c>--profile stealth</c>); when it is
+/// not configured this client reports <see cref="IsEnabled"/> false and never runs,
+/// so the default build neither talks to nor depends on the third-party binary.
+/// </summary>
+[Service(ServiceLifetime.Singleton, typeof(IStealthBrowserClient))]
+public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
+{
+    private readonly StealthFetchOptions _options;
+    private readonly ILogger<CloakBrowserStealthClient> _logger;
+
+    // Stealth renders are expensive and politeness-sensitive, so concurrency is
+    // capped well below the plain-HTTP probe rate.
+    private readonly SemaphoreSlim _concurrencyLimiter;
+
+    // The Playwright driver is reused across fetches; a fresh browser connection and
+    // context are taken per fetch so walled hosts never share cookie/fingerprint
+    // state.
+    private readonly SemaphoreSlim _driverLock = new(1, 1);
+    private IPlaywright _playwright;
+
+    public CloakBrowserStealthClient(
+        IOptions<StealthFetchOptions> options,
+        ILogger<CloakBrowserStealthClient> logger
+    )
+    {
+        _options = options.Value;
+        _logger = logger;
+        _concurrencyLimiter = new SemaphoreSlim(Math.Max(1, _options.MaxConcurrency));
+    }
+
+    public bool IsEnabled => _options.Enabled && !string.IsNullOrWhiteSpace(_options.SidecarUrl);
+
+    public async Task<string> FetchHtml(string url, CancellationToken cancellationToken)
+    {
+        if (!IsEnabled)
+            return null;
+
+        await _concurrencyLimiter.WaitAsync(cancellationToken);
+        try
+        {
+            var playwright = await EnsureDriver(cancellationToken);
+
+            // cloakserve speaks CDP over WebSocket; connect, render, disconnect.
+            await using var browser = await playwright.Chromium.ConnectOverCDPAsync(
+                _options.SidecarUrl
+            );
+            var context = await browser.NewContextAsync();
+            try
+            {
+                var page = await context.NewPageAsync();
+                await page.GotoAsync(
+                    url,
+                    new PageGotoOptions
+                    {
+                        WaitUntil = WaitUntilState.NetworkIdle,
+                        Timeout = _options.RenderTimeoutSeconds * 1000,
+                    }
+                );
+                return await page.ContentAsync();
+            }
+            finally
+            {
+                await context.CloseAsync();
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (PlaywrightException ex)
+        {
+            // Connection refused, navigation failure, or render timeout. Enabled-but-
+            // broken is a misconfiguration worth surfacing, but the caller still
+            // degrades to a miss rather than failing the batch.
+            _logger.LogWarning(ex, "Stealth fetch failed for {Url}", url);
+            return null;
+        }
+    }
+
+    private async Task<IPlaywright> EnsureDriver(CancellationToken cancellationToken)
+    {
+        if (_playwright != null)
+            return _playwright;
+
+        await _driverLock.WaitAsync(cancellationToken);
+        try
+        {
+            _playwright ??= await Playwright.CreateAsync();
+            return _playwright;
+        }
+        finally
+        {
+            _driverLock.Release();
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        _playwright?.Dispose();
+        _playwright = null;
+        _concurrencyLimiter.Dispose();
+        _driverLock.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/IStealthBrowserClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/IStealthBrowserClient.cs
@@ -1,0 +1,27 @@
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Renders a URL through a stealth browser and returns the final HTML. Used as a
+/// fallback when a plain <see cref="HttpClient"/> fetch is answered by a bot-
+/// protection challenge (Imperva Incapsula, Akamai) instead of the real page. The
+/// backing engine — a containerised stealth Chromium, a hosted unblocker, or any
+/// future replacement — sits behind this interface so the discovery and feed code
+/// is never hard-coupled to one binary.
+/// </summary>
+public interface IStealthBrowserClient
+{
+    /// <summary>
+    /// True when a stealth engine is configured and enabled. Callers check this
+    /// before attempting a stealth re-fetch, so behaviour is unchanged when the
+    /// sidecar is absent (the default).
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    /// Navigates to <paramref name="url"/> through the stealth browser and returns
+    /// the rendered HTML, or null when the engine is disabled or the page could not
+    /// be rendered. A render failure degrades to null rather than throwing so a
+    /// single walled host never fails the whole discovery batch.
+    /// </summary>
+    Task<string> FetchHtml(string url, CancellationToken cancellationToken);
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/StealthChallengeDetector.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/StealthChallengeDetector.cs
@@ -1,0 +1,43 @@
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Recognises the bot-protection challenge stubs that Imperva Incapsula and Akamai
+/// return in place of a real page. A challenge response is a small HTML (or text)
+/// body carrying vendor-specific markers and none of the page's actual content, so
+/// a plain fetch finds no IR keywords and records a false miss. Detecting it lets
+/// the caller re-fetch through the stealth-browser path. Pure logic (no I/O) so it
+/// is unit-testable against fixture bodies.
+/// </summary>
+public static class StealthChallengeDetector
+{
+    // Markers that appear only in a challenge / interstitial / hard-block response,
+    // never in a genuine IR page. Kept deliberately specific: the detector decides
+    // whether a non-validating response is worth an (expensive, rate-limited)
+    // stealth re-fetch, so a broad marker like a bare "akamai" CDN reference — which
+    // legitimate pages carry — would route the whole universe through the sidecar.
+    // Matched case-insensitively against the raw response body.
+    private static readonly string[] ChallengeMarkers =
+    [
+        "_incapsula_resource", // Incapsula challenge bootstrap script
+        "incapsula incident id", // Incapsula block page
+        "powered by incapsula", // Incapsula interstitial footer
+        "errors.edgesuite.net", // Akamai error/interstitial asset host
+        "you don't have permission to access", // Akamai "Access Denied" body
+        "access denied", // Akamai / generic WAF block title
+        "code 1011", // Provider hard lock seen on walled IR and webcast hosts
+        "pardon the interruption", // Imperva interstitial copy
+    ];
+
+    /// <summary>
+    /// True when <paramref name="body"/> looks like a bot-protection challenge stub
+    /// rather than a real page.
+    /// </summary>
+    public static bool IsChallenge(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return false;
+
+        var haystack = body.ToLowerInvariant();
+        return ChallengeMarkers.Any(haystack.Contains);
+    }
+}

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -109,6 +109,9 @@ builder.Services.Configure<WebsiteDiscoveryOptions>(
 builder.Services.Configure<InvestorRelationsDiscoveryOptions>(
     builder.Configuration.GetSection("InvestorRelationsDiscovery")
 );
+builder.Services.Configure<Equibles.CommonStocks.HostedService.Configuration.StealthFetchOptions>(
+    builder.Configuration.GetSection("InvestorRelationsDiscovery:StealthFetch")
+);
 
 // Without this bind, IOptions<EmbeddingConfig> is always default (Enabled=false),
 // so GenerateEmbeddingBatch short-circuits and no embeddings are ever produced —

--- a/tests/Equibles.UnitTests/CommonStocks/StealthChallengeDetectorTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/StealthChallengeDetectorTests.cs
@@ -1,0 +1,62 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class StealthChallengeDetectorTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsChallenge_NoBody_ReturnsFalse(string body)
+    {
+        // Nothing to inspect is not a challenge — the caller already treats a missing
+        // body as a plain miss.
+        StealthChallengeDetector.IsChallenge(body).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(
+        "<html><head><script src=\"/_Incapsula_Resource?SWJIYLWA=719d\"></script></head><body></body></html>"
+    )]
+    [InlineData("<html><body>Request unsuccessful. Incapsula incident ID: 1234-5678</body></html>")]
+    [InlineData(
+        "<html><head><script src=\"https://errors.edgesuite.net/x.js\"></script></head></html>"
+    )]
+    [InlineData("<html><head><title>Access Denied</title></head><body></body></html>")]
+    [InlineData("<html><body>You don't have permission to access this resource.</body></html>")]
+    [InlineData("<html><body>Access denied, Code 1011</body></html>")]
+    public void IsChallenge_VendorChallengeMarker_ReturnsTrue(string body)
+    {
+        // A bot-protection stub carries a vendor marker and none of the real page, so
+        // the plain probe would record a false miss; detecting it routes the fetch
+        // through the stealth path instead.
+        StealthChallengeDetector.IsChallenge(body).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsChallenge_MarkerMatchIsCaseInsensitive()
+    {
+        StealthChallengeDetector
+            .IsChallenge("<SCRIPT SRC=\"/_INCAPSULA_RESOURCE?A=1\"></SCRIPT>")
+            .Should()
+            .BeTrue();
+    }
+
+    [Theory]
+    [InlineData(
+        "<html><head><title>Investor Relations - Acme</title></head>"
+            + "<body><h1>Quarterly results</h1><p>Press releases and SEC filings.</p></body></html>"
+    )]
+    [InlineData(
+        "<html><head><title>Home</title></head><body>"
+            + "<img src=\"https://cdn.akamai.com/logo.png\">Welcome</body></html>"
+    )]
+    public void IsChallenge_RealPage_ReturnsFalse(string body)
+    {
+        // A genuine page — including one that merely loads assets from a CDN such as
+        // Akamai — must not be mistaken for a challenge, or every miss would be routed
+        // through the expensive stealth path.
+        StealthChallengeDetector.IsChallenge(body).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

First slice of the stealth-browser fetch path for investor-relations discovery (refs #3700). Many issuers front their IR portal with Imperva Incapsula / Akamai bot protection, which answers a plain `HttpClient` request with a JavaScript-challenge stub or an "Access Denied" 1011 instead of the page — so the probe finds no IR keywords and records a false miss. About 6,800 of 8,325 stocks have no IR URL, and bot-walled hosts are a structural slice of that gap that never self-heals on retry.

This slice lands the foundation; the challenge-aware fallback that consumes it (discovery service, then the Q4/Nasdaq feed clients) follows in slices 2 and 3.

## Code changes

- **`IStealthBrowserClient`** — swappable `URL -> rendered HTML` abstraction so the discovery and feed code is never hard-coupled to one engine.
- **`CloakBrowserStealthClient`** — connects to a CloakBrowser `cloakserve` sidecar over the Chrome DevTools Protocol (Playwright `ConnectOverCDP`), renders the page, and returns the final HTML. Reports `IsEnabled` false and never runs when the sidecar is not configured, so the default build neither talks to nor depends on the third-party binary. Driver reused across fetches; a fresh browser/context per fetch keeps walled hosts isolated; concurrency capped.
- **`StealthChallengeDetector`** — pure, unit-tested recogniser for Incapsula/Akamai challenge stubs. Markers are deliberately high-precision: the detector decides whether a non-validating response is worth an expensive, rate-limited stealth re-fetch, so a bare CDN reference that legitimate pages carry must not match.
- **`StealthFetchOptions`** — bound from `InvestorRelationsDiscovery:StealthFetch` (enabled flag, sidecar URL, render timeout, concurrency cap), disabled by default.
- **`docker-compose.yml`** — opt-in `--profile stealth` `cloakbrowser` sidecar pinned by digest, CDP port kept off the host, plus a `worker-stealth` variant that mirrors the existing `--profile embedding` pattern. Supply-chain caveat (opaque third-party binary, its own `BINARY-LICENSE.md`, isolate + no host secrets, review licence before production) documented in the compose comment.

With the sidecar off (the default) behaviour is unchanged.

## Verification

- `dotnet build` of `Equibles.CommonStocks.HostedService`, `Equibles.Worker.Host`, and `Equibles.UnitTests` — clean.
- New `StealthChallengeDetectorTests` (12 cases) — all green.
- csharpier — clean.