### PR TITLE
feat(common-stocks): challenge-aware stealth fallback in IR discovery (2/3)

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
@@ -6,7 +6,10 @@ namespace Equibles.CommonStocks.HostedService.Services;
 /// <summary>
 /// Probes a company's candidate investor-relations URLs over HTTP and returns the
 /// first one that resolves to a validated IR page. Registered as a typed
-/// <see cref="HttpClient"/> client (see <c>AddCommonStocksWorker</c>).
+/// <see cref="HttpClient"/> client (see <c>AddCommonStocksWorker</c>). When a host
+/// answers with a bot-protection challenge instead of the page and the stealth
+/// fetch path is enabled, the candidate is re-fetched through
+/// <see cref="IStealthBrowserClient"/> and the rendered page is validated instead.
 /// </summary>
 public class InvestorRelationsProbeClient
 {
@@ -20,14 +23,17 @@ public class InvestorRelationsProbeClient
     );
 
     private readonly HttpClient _httpClient;
+    private readonly IStealthBrowserClient _stealthClient;
     private readonly ILogger<InvestorRelationsProbeClient> _logger;
 
     public InvestorRelationsProbeClient(
         HttpClient httpClient,
+        IStealthBrowserClient stealthClient,
         ILogger<InvestorRelationsProbeClient> logger
     )
     {
         _httpClient = httpClient;
+        _stealthClient = stealthClient;
         _logger = logger;
     }
 
@@ -66,31 +72,39 @@ public class InvestorRelationsProbeClient
         {
             await RateLimiter.WaitAsync();
 
-            using var response = await _httpClient.GetAsync(url, cancellationToken);
-            if (!response.IsSuccessStatusCode)
-                return null;
+            string body;
+            using (var response = await _httpClient.GetAsync(url, cancellationToken))
+            {
+                // Only HTML is worth reading: it can be keyword-validated, and a bot
+                // wall serves its challenge as HTML too. PDFs, JSON login walls, etc.
+                // carry nothing useful — skip the body entirely.
+                var mediaType = response.Content.Headers.ContentType?.MediaType;
+                var isHtml = string.Equals(
+                    mediaType,
+                    "text/html",
+                    StringComparison.OrdinalIgnoreCase
+                );
+                body = isHtml ? await response.Content.ReadAsStringAsync(cancellationToken) : null;
 
-            // Only HTML is worth keyword-validating; skip PDFs, redirects to login
-            // walls that serve JSON, etc.
-            var mediaType = response.Content.Headers.ContentType?.MediaType;
-            if (!string.Equals(mediaType, "text/html", StringComparison.OrdinalIgnoreCase))
-                return null;
+                if (response.IsSuccessStatusCode && body != null)
+                {
+                    // Prefer where the request actually landed after redirects, falling
+                    // back to the probed URL when that overruns the column ceiling.
+                    var finalUrl = response.RequestMessage?.RequestUri?.ToString() ?? url;
+                    var direct = BuildResult(body, finalUrl, url);
+                    if (direct != null)
+                        return direct;
+                }
+            }
 
-            var html = await response.Content.ReadAsStringAsync(cancellationToken);
-            if (!InvestorRelationsPageValidator.IsInvestorRelationsPage(html))
-                return null;
+            // Bot wall: a 2xx challenge stub that didn't validate, or a hard block
+            // (e.g. Akamai 403 "Access Denied") whose body still carries the vendor
+            // signature. When the stealth path is configured, render the candidate
+            // and validate that instead — the only way a walled host ever resolves.
+            if (_stealthClient.IsEnabled && StealthChallengeDetector.IsChallenge(body))
+                return await ResolveViaStealth(url, cancellationToken);
 
-            // Prefer where the request actually landed after redirects, falling back
-            // to the probed URL. Stay within the column ceiling.
-            var finalUrl = response.RequestMessage?.RequestUri?.ToString() ?? url;
-            if (finalUrl.Length > MaxUrlLength)
-                finalUrl = url;
-            if (finalUrl.Length > MaxUrlLength)
-                return null;
-
-            // Classify the platform from the page we already fetched — no second request.
-            var platform = IrPlatformClassifier.Classify(html);
-            return new IrDiscoveryResult(finalUrl, platform);
+            return null;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -103,5 +117,48 @@ public class InvestorRelationsProbeClient
             _logger.LogDebug(ex, "Investor relations probe failed for {Url}", url);
             return null;
         }
+    }
+
+    private async Task<IrDiscoveryResult> ResolveViaStealth(
+        string url,
+        CancellationToken cancellationToken
+    )
+    {
+        var html = await _stealthClient.FetchHtml(url, cancellationToken);
+        if (html == null)
+            return null;
+
+        // The stealth fetch follows redirects internally, so the candidate is the
+        // best URL we have for the rendered page.
+        var result = BuildResult(html, url, url);
+        if (result != null)
+            _logger.LogInformation(
+                "Investor relations page resolved via stealth fetch for {Url}",
+                url
+            );
+
+        return result;
+    }
+
+    /// <summary>
+    /// Validates rendered HTML and, when it is an IR page, builds the result with the
+    /// classified platform. Uses <paramref name="preferredUrl"/>, falling back to
+    /// <paramref name="fallbackUrl"/> when it overruns the column ceiling; returns
+    /// null when neither fits or the page does not validate.
+    /// </summary>
+    private static IrDiscoveryResult BuildResult(
+        string html,
+        string preferredUrl,
+        string fallbackUrl
+    )
+    {
+        if (!InvestorRelationsPageValidator.IsInvestorRelationsPage(html))
+            return null;
+
+        var url = preferredUrl.Length > MaxUrlLength ? fallbackUrl : preferredUrl;
+        if (url.Length > MaxUrlLength)
+            return null;
+
+        return new IrDiscoveryResult(url, IrPlatformClassifier.Classify(html));
     }
 }

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
@@ -1,11 +1,127 @@
 using System.Net;
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.HostedService.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace Equibles.UnitTests.CommonStocks;
 
 public class InvestorRelationsProbeClientTests
 {
+    private const string IncapsulaStub =
+        "<html><head><script src=\"/_Incapsula_Resource?SWJIYLWA=719d\"></script>"
+        + "</head><body>Request unsuccessful.</body></html>";
+
+    private const string RenderedIrPage =
+        "<html><head><title>Investor Relations - Emergent</title></head>"
+        + "<body><h1>Quarterly results</h1></body></html>";
+
+    [Fact]
+    public async Task Discover_RedirectLandsOnUrlAboveColumnCeiling_FallsBackToProbedCandidate()
+    {
+        // Contract: the returned URL must stay within CommonStock.InvestorRelationsUrl's
+        // 256-char ceiling. When a probe lands (after redirects) on a longer URL, the
+        // short probed candidate must be returned instead of the over-long final URL.
+        var overLongFinalUrl = "https://acme.com/" + new string('a', 300);
+        var client = new InvestorRelationsProbeClient(
+            new HttpClient(new LongFinalUrlHandler(overLongFinalUrl)),
+            DisabledStealth(),
+            NullLogger<InvestorRelationsProbeClient>.Instance
+        );
+
+        var result = await client.Discover("https://acme.com", ["ir"], [], CancellationToken.None);
+
+        result!.Url.Should().Be("https://acme.com/ir");
+        result.Url.Length.Should().BeLessThanOrEqualTo(256);
+    }
+
+    [Fact]
+    public async Task Discover_BotChallenge_StealthEnabled_ResolvesRenderedPage()
+    {
+        // The plain probe sees only the challenge stub; the stealth fetch renders the
+        // real IR page, which validates — the candidate URL becomes the result.
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(true);
+        stealth.FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(RenderedIrPage);
+
+        var client = new InvestorRelationsProbeClient(
+            new HttpClient(new ConstantHandler(HttpStatusCode.OK, "text/html", IncapsulaStub)),
+            stealth,
+            NullLogger<InvestorRelationsProbeClient>.Instance
+        );
+
+        var result = await client.Discover(
+            "emergentbiosolutions.com",
+            ["investors"],
+            [],
+            CancellationToken.None
+        );
+
+        result.Should().NotBeNull();
+        result!.Url.Should().Be("https://emergentbiosolutions.com/investors");
+        result.Platform.Should().Be(IrPlatformType.Custom);
+        await stealth.Received(1).FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Discover_BotChallenge_StealthDisabled_RecordsMissAndNeverRenders()
+    {
+        // With the sidecar off, behaviour is unchanged: the challenge is an
+        // unvalidated miss and the stealth path is never touched.
+        var stealth = DisabledStealth();
+
+        var client = new InvestorRelationsProbeClient(
+            new HttpClient(new ConstantHandler(HttpStatusCode.OK, "text/html", IncapsulaStub)),
+            stealth,
+            NullLogger<InvestorRelationsProbeClient>.Instance
+        );
+
+        var result = await client.Discover(
+            "emergentbiosolutions.com",
+            ["investors"],
+            [],
+            CancellationToken.None
+        );
+
+        result.Should().BeNull();
+        await stealth.DidNotReceive().FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Discover_DirectIrPage_ResolvesWithoutStealth()
+    {
+        // A reachable IR page resolves on the plain path even when stealth is enabled —
+        // the fallback only fires on a recognised challenge, not on every fetch.
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(true);
+
+        var client = new InvestorRelationsProbeClient(
+            new HttpClient(
+                new ConstantHandler(
+                    HttpStatusCode.OK,
+                    "text/html",
+                    "<html><head><title>Investor Relations - Acme</title></head><body></body></html>"
+                )
+            ),
+            stealth,
+            NullLogger<InvestorRelationsProbeClient>.Instance
+        );
+
+        var result = await client.Discover("acme.com", ["investors"], [], CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Url.Should().Be("https://acme.com/investors");
+        await stealth.DidNotReceive().FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    private static IStealthBrowserClient DisabledStealth()
+    {
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(false);
+        return stealth;
+    }
+
     // Returns a valid IR page (title alone satisfies the validator) but reports a
     // post-redirect RequestUri far longer than the 256-char column ceiling.
     private sealed class LongFinalUrlHandler : HttpMessageHandler
@@ -23,7 +139,7 @@ public class InvestorRelationsProbeClientTests
             {
                 Content = new StringContent(
                     "<html><head><title>Investor Relations</title></head><body>Welcome</body></html>",
-                    System.Text.Encoding.UTF8,
+                    Encoding.UTF8,
                     "text/html"
                 ),
                 // Explicitly set so HttpClient doesn't overwrite it: simulates the
@@ -34,21 +150,31 @@ public class InvestorRelationsProbeClientTests
         }
     }
 
-    [Fact]
-    public async Task Discover_RedirectLandsOnUrlAboveColumnCeiling_FallsBackToProbedCandidate()
+    // Returns a fixed status, content-type, and body for every request.
+    private sealed class ConstantHandler : HttpMessageHandler
     {
-        // Contract: the returned URL must stay within CommonStock.InvestorRelationsUrl's
-        // 256-char ceiling. When a probe lands (after redirects) on a longer URL, the
-        // short probed candidate must be returned instead of the over-long final URL.
-        var overLongFinalUrl = "https://acme.com/" + new string('a', 300);
-        var client = new InvestorRelationsProbeClient(
-            new HttpClient(new LongFinalUrlHandler(overLongFinalUrl)),
-            NullLogger<InvestorRelationsProbeClient>.Instance
-        );
+        private readonly HttpStatusCode _status;
+        private readonly string _mediaType;
+        private readonly string _body;
 
-        var result = await client.Discover("https://acme.com", ["ir"], [], CancellationToken.None);
+        public ConstantHandler(HttpStatusCode status, string mediaType, string body)
+        {
+            _status = status;
+            _mediaType = mediaType;
+            _body = body;
+        }
 
-        result!.Url.Should().Be("https://acme.com/ir");
-        result.Url.Length.Should().BeLessThanOrEqualTo(256);
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            return Task.FromResult(
+                new HttpResponseMessage(_status)
+                {
+                    Content = new StringContent(_body, Encoding.UTF8, _mediaType),
+                }
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Second slice of the stealth-browser fetch path (refs #3700). Slice 1 landed the `IStealthBrowserClient`, the challenge detector, and the opt-in sidecar; this slice wires them into the discovery probe so a bot-walled host actually resolves to an `InvestorRelationsUrl`.

When a candidate IR host answers a plain `HttpClient` request with an Incapsula/Akamai challenge stub (or a hard 403 "Access Denied"), the probe finds no IR keywords and records a false miss. Now the probe recognises the challenge and — when the stealth path is enabled — re-fetches the candidate through the stealth browser and validates the rendered HTML instead.

## Code changes

- **`InvestorRelationsProbeClient`** — injects `IStealthBrowserClient`. `TryResolve` reads the HTML body on both success and error responses (a hard block still carries the vendor marker), validates the direct response first, and routes a recognised `StealthChallengeDetector` hit to a stealth re-fetch. Validate + classify + the 256-char URL-length clamp are shared between the direct and stealth paths. A stealth-resolved page logs at information level so uplift on previously-walled hosts is measurable.
- With the sidecar disabled (the default), the fallback is never taken and behaviour is unchanged.

## Verification

- `dotnet build` of `Equibles.UnitTests` (references `CommonStocks.HostedService`) — clean.
- New probe-client tests: challenge + stealth on resolves the rendered page; challenge + stealth off records a miss and never renders; a direct IR page resolves without touching stealth. Existing column-ceiling test updated for the new constructor. 16/16 green.
- csharpier — clean.

The same fallback for the Q4/Nasdaq feed clients follows in slice 3 (closes #3700).