### PR TITLE
feat(common-stocks): stealth fallback for the Q4/Nasdaq IR feed clients (3/3)

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/CloakBrowserStealthClient.cs
@@ -9,8 +9,8 @@ namespace Equibles.CommonStocks.HostedService.Services;
 
 /// <summary>
 /// <see cref="IStealthBrowserClient"/> backed by a CloakBrowser <c>cloakserve</c>
-/// sidecar. Connects to the sidecar's Chrome DevTools Protocol endpoint, renders
-/// the page in the stealth Chromium, and returns the final HTML. The sidecar is an
+/// sidecar. Connects to the sidecar's Chrome DevTools Protocol endpoint and renders
+/// the page (or fetches a resource) through the stealth Chromium. The sidecar is an
 /// opt-in, digest-pinned container (compose <c>--profile stealth</c>); when it is
 /// not configured this client reports <see cref="IsEnabled"/> false and never runs,
 /// so the default build neither talks to nor depends on the third-party binary.
@@ -18,6 +18,17 @@ namespace Equibles.CommonStocks.HostedService.Services;
 [Service(ServiceLifetime.Singleton, typeof(IStealthBrowserClient))]
 public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
 {
+    // Pulls a resource from within the cleared page context, returning the raw bytes
+    // the server sent (e.g. an RSS feed) rather than the rendered DOM. Runs after the
+    // page has navigated to the origin and cleared its bot challenge, so the request
+    // rides the clearance cookie.
+    private const string InPageFetchScript = """
+        async (url) => {
+            const response = await fetch(url, { credentials: 'include' });
+            return response.ok ? await response.text() : null;
+        }
+        """;
+
     private readonly StealthFetchOptions _options;
     private readonly ILogger<CloakBrowserStealthClient> _logger;
 
@@ -43,7 +54,46 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
 
     public bool IsEnabled => _options.Enabled && !string.IsNullOrWhiteSpace(_options.SidecarUrl);
 
-    public async Task<string> FetchHtml(string url, CancellationToken cancellationToken)
+    public Task<string> FetchHtml(string url, CancellationToken cancellationToken) =>
+        RunInStealthPage(
+            url,
+            async page =>
+            {
+                await Navigate(page, url);
+                return await page.ContentAsync();
+            },
+            cancellationToken
+        );
+
+    public Task<string> FetchRaw(string url, CancellationToken cancellationToken)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return Task.FromResult<string>(null);
+
+        return RunInStealthPage(
+            url,
+            async page =>
+            {
+                // Land on the origin first so the bot challenge clears and its
+                // clearance cookie is set; the in-page fetch then rides that cleared
+                // session and returns the raw document the parser needs.
+                await Navigate(page, uri.GetLeftPart(UriPartial.Authority));
+                return await page.EvaluateAsync<string>(InPageFetchScript, url);
+            },
+            cancellationToken
+        );
+    }
+
+    /// <summary>
+    /// Connects to the sidecar, runs <paramref name="action"/> against a fresh page
+    /// in an isolated context, and disconnects. Returns null (degrading to a miss)
+    /// when the engine is disabled or the connection/navigation/render fails.
+    /// </summary>
+    private async Task<string> RunInStealthPage(
+        string url,
+        Func<IPage, Task<string>> action,
+        CancellationToken cancellationToken
+    )
     {
         if (!IsEnabled)
             return null;
@@ -53,7 +103,7 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
         {
             var playwright = await EnsureDriver(cancellationToken);
 
-            // cloakserve speaks CDP over WebSocket; connect, render, disconnect.
+            // cloakserve speaks CDP over WebSocket; connect, work, disconnect.
             await using var browser = await playwright.Chromium.ConnectOverCDPAsync(
                 _options.SidecarUrl
             );
@@ -61,15 +111,7 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
             try
             {
                 var page = await context.NewPageAsync();
-                await page.GotoAsync(
-                    url,
-                    new PageGotoOptions
-                    {
-                        WaitUntil = WaitUntilState.NetworkIdle,
-                        Timeout = _options.RenderTimeoutSeconds * 1000,
-                    }
-                );
-                return await page.ContentAsync();
+                return await action(page);
             }
             finally
             {
@@ -89,6 +131,16 @@ public class CloakBrowserStealthClient : IStealthBrowserClient, IAsyncDisposable
             return null;
         }
     }
+
+    private Task Navigate(IPage page, string url) =>
+        page.GotoAsync(
+            url,
+            new PageGotoOptions
+            {
+                WaitUntil = WaitUntilState.NetworkIdle,
+                Timeout = _options.RenderTimeoutSeconds * 1000,
+            }
+        );
 
     private async Task<IPlaywright> EnsureDriver(CancellationToken cancellationToken)
     {

--- a/src/Equibles.CommonStocks.HostedService/Services/IStealthBrowserClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/IStealthBrowserClient.cs
@@ -24,4 +24,13 @@ public interface IStealthBrowserClient
     /// single walled host never fails the whole discovery batch.
     /// </summary>
     Task<string> FetchHtml(string url, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Clears the host's bot challenge in the stealth browser, then fetches
+    /// <paramref name="url"/> from within that cleared page context and returns the
+    /// raw response body. Unlike <see cref="FetchHtml"/> this returns the bytes the
+    /// server sent rather than the rendered DOM, so a feed (RSS/XML) parser sees the
+    /// real document. Returns null when the engine is disabled or the fetch fails.
+    /// </summary>
+    Task<string> FetchRaw(string url, CancellationToken cancellationToken);
 }

--- a/src/Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightFeedClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/NasdaqIrInsightFeedClient.cs
@@ -22,20 +22,25 @@ public class NasdaqIrInsightFeedClient
     );
 
     private readonly HttpClient _httpClient;
+    private readonly IStealthBrowserClient _stealthClient;
     private readonly ILogger<NasdaqIrInsightFeedClient> _logger;
 
     public NasdaqIrInsightFeedClient(
         HttpClient httpClient,
+        IStealthBrowserClient stealthClient,
         ILogger<NasdaqIrInsightFeedClient> logger
     )
     {
         _httpClient = httpClient;
+        _stealthClient = stealthClient;
         _logger = logger;
     }
 
     /// <summary>
     /// Combines an IR base URL with a feed path and returns the feed body, or null
-    /// when the feed is missing, errors, or is not XML.
+    /// when the feed is missing, errors, or is not XML. When a bot-protected host
+    /// answers with a challenge instead of the feed and the stealth path is enabled,
+    /// the feed is pulled through the cleared stealth session instead.
     /// </summary>
     public async Task<string> Fetch(
         string irBaseUrl,
@@ -51,14 +56,26 @@ public class NasdaqIrInsightFeedClient
             await RateLimiter.WaitAsync();
 
             using var response = await _httpClient.GetAsync(feedUrl, cancellationToken);
-            if (!response.IsSuccessStatusCode)
-                return null;
 
             var mediaType = response.Content.Headers.ContentType?.MediaType;
-            if (mediaType == null || !mediaType.Contains("xml", StringComparison.OrdinalIgnoreCase))
-                return null;
+            var isXml =
+                mediaType != null && mediaType.Contains("xml", StringComparison.OrdinalIgnoreCase);
 
-            return await response.Content.ReadAsStringAsync(cancellationToken);
+            if (response.IsSuccessStatusCode && isXml)
+                return await response.Content.ReadAsStringAsync(cancellationToken);
+
+            // A bot wall answers the feed with an HTML challenge stub (or a hard
+            // block) rather than XML. When the stealth path is on and the body
+            // carries a challenge signature, pull the feed through the cleared
+            // stealth session; otherwise this is a genuine miss.
+            if (_stealthClient.IsEnabled)
+            {
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+                if (StealthChallengeDetector.IsChallenge(body))
+                    return await _stealthClient.FetchRaw(feedUrl, cancellationToken);
+            }
+
+            return null;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/Equibles.CommonStocks.HostedService/Services/Q4IncFeedClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/Q4IncFeedClient.cs
@@ -22,17 +22,25 @@ public class Q4IncFeedClient
     );
 
     private readonly HttpClient _httpClient;
+    private readonly IStealthBrowserClient _stealthClient;
     private readonly ILogger<Q4IncFeedClient> _logger;
 
-    public Q4IncFeedClient(HttpClient httpClient, ILogger<Q4IncFeedClient> logger)
+    public Q4IncFeedClient(
+        HttpClient httpClient,
+        IStealthBrowserClient stealthClient,
+        ILogger<Q4IncFeedClient> logger
+    )
     {
         _httpClient = httpClient;
+        _stealthClient = stealthClient;
         _logger = logger;
     }
 
     /// <summary>
     /// Combines an IR base URL with a feed path and returns the feed body, or null
-    /// when the feed is missing, errors, or is not XML.
+    /// when the feed is missing, errors, or is not XML. When a bot-protected host
+    /// answers with a challenge instead of the feed and the stealth path is enabled,
+    /// the feed is pulled through the cleared stealth session instead.
     /// </summary>
     public async Task<string> Fetch(
         string irBaseUrl,
@@ -48,14 +56,26 @@ public class Q4IncFeedClient
             await RateLimiter.WaitAsync();
 
             using var response = await _httpClient.GetAsync(feedUrl, cancellationToken);
-            if (!response.IsSuccessStatusCode)
-                return null;
 
             var mediaType = response.Content.Headers.ContentType?.MediaType;
-            if (mediaType == null || !mediaType.Contains("xml", StringComparison.OrdinalIgnoreCase))
-                return null;
+            var isXml =
+                mediaType != null && mediaType.Contains("xml", StringComparison.OrdinalIgnoreCase);
 
-            return await response.Content.ReadAsStringAsync(cancellationToken);
+            if (response.IsSuccessStatusCode && isXml)
+                return await response.Content.ReadAsStringAsync(cancellationToken);
+
+            // A bot wall answers the feed with an HTML challenge stub (or a hard
+            // block) rather than XML. When the stealth path is on and the body
+            // carries a challenge signature, pull the feed through the cleared
+            // stealth session; otherwise this is a genuine miss.
+            if (_stealthClient.IsEnabled)
+            {
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+                if (StealthChallengeDetector.IsChallenge(body))
+                    return await _stealthClient.FetchRaw(feedUrl, cancellationToken);
+            }
+
+            return null;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/tests/Equibles.UnitTests/CommonStocks/NasdaqIrInsightFeedClientFetchTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/NasdaqIrInsightFeedClientFetchTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Text;
+using Equibles.CommonStocks.HostedService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Pins NasdaqIrInsightFeedClient.Fetch's bot-challenge fallback: a host that
+/// answers the feed with a challenge stub instead of XML is pulled through the
+/// cleared stealth session when it is enabled, and is a plain miss when it is not.
+/// </summary>
+public class NasdaqIrInsightFeedClientFetchTests
+{
+    private const string AkamaiBlock =
+        "<html><head><title>Access Denied</title></head>"
+        + "<body>You don't have permission to access this resource.</body></html>";
+
+    private const string FeedXml =
+        "<?xml version=\"1.0\"?><rss version=\"2.0\"><channel><title>Events</title></channel></rss>";
+
+    [Fact]
+    public async Task Fetch_BotChallenge_StealthEnabled_PullsFeedThroughStealth()
+    {
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(true);
+        stealth.FetchRaw(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(FeedXml);
+
+        // Akamai serves its block as HTML with a 403; the body still carries the
+        // vendor signature, so the stealth session clears it and returns the feed.
+        var client = new NasdaqIrInsightFeedClient(
+            new HttpClient(new StubHandler(HttpStatusCode.Forbidden, "text/html", AkamaiBlock)),
+            stealth,
+            NullLogger<NasdaqIrInsightFeedClient>.Instance
+        );
+
+        var result = await client.Fetch(
+            "https://investors.example.com/",
+            NasdaqIrInsightFeedClient.EventsFeedPath,
+            CancellationToken.None
+        );
+
+        result.Should().Be(FeedXml);
+        await stealth
+            .Received(1)
+            .FetchRaw("https://investors.example.com/rss/events.xml", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Fetch_BotChallenge_StealthDisabled_ReturnsNull()
+    {
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(false);
+
+        var client = new NasdaqIrInsightFeedClient(
+            new HttpClient(new StubHandler(HttpStatusCode.Forbidden, "text/html", AkamaiBlock)),
+            stealth,
+            NullLogger<NasdaqIrInsightFeedClient>.Instance
+        );
+
+        var result = await client.Fetch(
+            "https://investors.example.com/",
+            NasdaqIrInsightFeedClient.EventsFeedPath,
+            CancellationToken.None
+        );
+
+        result.Should().BeNull();
+        await stealth.DidNotReceive().FetchRaw(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Fetch_XmlFeed_ReturnsBodyWithoutStealth()
+    {
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(true);
+
+        var client = new NasdaqIrInsightFeedClient(
+            new HttpClient(new StubHandler(HttpStatusCode.OK, "application/rss+xml", FeedXml)),
+            stealth,
+            NullLogger<NasdaqIrInsightFeedClient>.Instance
+        );
+
+        var result = await client.Fetch(
+            "https://investors.example.com/",
+            NasdaqIrInsightFeedClient.EventsFeedPath,
+            CancellationToken.None
+        );
+
+        result.Should().Be(FeedXml);
+        await stealth.DidNotReceive().FetchRaw(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _mediaType;
+        private readonly string _body;
+
+        public StubHandler(HttpStatusCode status, string mediaType, string body)
+        {
+            _status = status;
+            _mediaType = mediaType;
+            _body = body;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(_status)
+                {
+                    Content = new StringContent(_body, Encoding.UTF8, _mediaType),
+                }
+            );
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/Q4IncFeedClientFetchTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/Q4IncFeedClientFetchTests.cs
@@ -2,32 +2,39 @@ using System.Net;
 using System.Text;
 using Equibles.CommonStocks.HostedService.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace Equibles.UnitTests.CommonStocks;
 
 /// <summary>
-/// Pins Q4IncFeedClient.Fetch's contract: it returns null for a non-XML
-/// response so callers can skip the feed. IR sites commonly serve an HTML
-/// error page with HTTP 200, so a status-code-only check would hand that HTML
-/// to the RSS parser as if it were feed data.
+/// Pins Q4IncFeedClient.Fetch's contract: it returns null for a non-XML response so
+/// callers can skip the feed, and — when the stealth path is enabled — pulls the
+/// feed through the cleared stealth session when a bot wall answers with a challenge
+/// stub instead of XML.
 /// </summary>
 public class Q4IncFeedClientFetchTests
 {
+    private const string IncapsulaStub =
+        "<html><head><script src=\"/_Incapsula_Resource?SWJIYLWA=719d\"></script></head>"
+        + "<body>Request unsuccessful.</body></html>";
+
+    private const string FeedXml =
+        "<?xml version=\"1.0\"?><rss version=\"2.0\"><channel><title>News</title></channel></rss>";
+
     [Fact]
     public async Task Fetch_HtmlBodyWithOkStatus_ReturnsNull()
     {
-        var handler = new StubHandler(
-            new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(
-                    "<html><body>Page not found</body></html>",
-                    Encoding.UTF8,
-                    "text/html"
-                ),
-            }
-        );
+        // An ordinary HTML error page (not a bot challenge) is not a feed: a
+        // status-code-only check would hand it to the RSS parser as if it were data.
         var client = new Q4IncFeedClient(
-            new HttpClient(handler),
+            new HttpClient(
+                new StubHandler(
+                    HttpStatusCode.OK,
+                    "text/html",
+                    "<html><body>Page not found</body></html>"
+                )
+            ),
+            DisabledStealth(),
             NullLogger<Q4IncFeedClient>.Instance
         );
 
@@ -40,15 +47,85 @@ public class Q4IncFeedClientFetchTests
         result.Should().BeNull("an HTML body is not a feed, regardless of the 200 status");
     }
 
+    [Fact]
+    public async Task Fetch_BotChallenge_StealthEnabled_PullsFeedThroughStealth()
+    {
+        // The plain fetch is answered by a challenge stub; the stealth session clears
+        // the wall and returns the raw feed XML the parser needs.
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(true);
+        stealth.FetchRaw(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(FeedXml);
+
+        var client = new Q4IncFeedClient(
+            new HttpClient(new StubHandler(HttpStatusCode.OK, "text/html", IncapsulaStub)),
+            stealth,
+            NullLogger<Q4IncFeedClient>.Instance
+        );
+
+        var result = await client.Fetch(
+            "https://ir.example.com/",
+            Q4IncFeedClient.NewsFeedPath,
+            CancellationToken.None
+        );
+
+        result.Should().Be(FeedXml);
+        await stealth
+            .Received(1)
+            .FetchRaw("https://ir.example.com/rss/pressrelease.aspx", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Fetch_BotChallenge_StealthDisabled_ReturnsNull()
+    {
+        // With the sidecar off, a challenge is a plain miss and the stealth path is
+        // never touched.
+        var stealth = DisabledStealth();
+
+        var client = new Q4IncFeedClient(
+            new HttpClient(new StubHandler(HttpStatusCode.OK, "text/html", IncapsulaStub)),
+            stealth,
+            NullLogger<Q4IncFeedClient>.Instance
+        );
+
+        var result = await client.Fetch(
+            "https://ir.example.com/",
+            Q4IncFeedClient.NewsFeedPath,
+            CancellationToken.None
+        );
+
+        result.Should().BeNull();
+        await stealth.DidNotReceive().FetchRaw(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    private static IStealthBrowserClient DisabledStealth()
+    {
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(false);
+        return stealth;
+    }
+
     private sealed class StubHandler : HttpMessageHandler
     {
-        private readonly HttpResponseMessage _response;
+        private readonly HttpStatusCode _status;
+        private readonly string _mediaType;
+        private readonly string _body;
 
-        public StubHandler(HttpResponseMessage response) => _response = response;
+        public StubHandler(HttpStatusCode status, string mediaType, string body)
+        {
+            _status = status;
+            _mediaType = mediaType;
+            _body = body;
+        }
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken
-        ) => Task.FromResult(_response);
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(_status)
+                {
+                    Content = new StringContent(_body, Encoding.UTF8, _mediaType),
+                }
+            );
     }
 }


### PR DESCRIPTION
## Summary

Final slice of the stealth-browser fetch path (closes #3700). Slices 1 and 2 landed the sidecar, the `IStealthBrowserClient`, the challenge detector, and the discovery-probe fallback. This slice applies the same fallback to the IR RSS feed clients so news and events resolve on walled hosts too.

A bot wall answers an IR feed request with an HTML challenge stub (or a hard 403 block) instead of XML, so the feed clients record a miss and walled issuers never get news/events.

## Code changes

- **`IStealthBrowserClient.FetchRaw`** — clears the host's challenge in the stealth browser, then fetches the resource from within that cleared page context and returns the **raw bytes** (the feed XML) rather than the rendered DOM, so the RSS parser sees the real document. `CloakBrowserStealthClient` implements it by landing on the origin and running an in-page `fetch()` over the cleared session (the same technique the Senate disclosure scraper uses to ride a cleared Akamai session); the connect/context/dispose boilerplate is now shared with `FetchHtml`.
- **`Q4IncFeedClient` / `NasdaqIrInsightFeedClient`** — read the response body when it is not the expected XML and, when the stealth path is enabled and the body carries a challenge signature, pull the feed via `FetchRaw`.
- With the sidecar disabled (the default), both feeds behave exactly as before.

## Verification

- `dotnet build` of `Equibles.UnitTests` — clean.
- Feed-client tests for both clients: challenge + stealth on pulls the feed through `FetchRaw`; challenge + stealth off is a miss; a real XML feed never touches stealth. Existing Q4 non-XML test updated for the new constructor. 22/22 stealth-related tests green.
- csharpier — clean.

With all three slices merged, the worker can resolve the IR URL, news, and events for issuers behind an Incapsula/Akamai bot wall when the opt-in `--profile stealth` sidecar is running.