### PR TITLE
test(common-stocks): cover the remaining two challenge markers in StealthChallengeDetector

### DIFF
--- a/tests/Equibles.UnitTests/CommonStocks/StealthChallengeDetectorTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/StealthChallengeDetectorTests.cs
@@ -26,6 +26,13 @@ public class StealthChallengeDetectorTests
     [InlineData("<html><head><title>Access Denied</title></head><body></body></html>")]
     [InlineData("<html><body>You don't have permission to access this resource.</body></html>")]
     [InlineData("<html><body>Access denied, Code 1011</body></html>")]
+    [InlineData(
+        "<html><body><div>Request unsuccessful.</div><footer>Powered by Incapsula</footer></body></html>"
+    )]
+    [InlineData(
+        "<html><body><h1>Pardon the interruption</h1>"
+            + "<p>As you were browsing, something about your browser made us think you were a bot.</p></body></html>"
+    )]
     public void IsChallenge_VendorChallengeMarker_ReturnsTrue(string body)
     {
         // A bot-protection stub carries a vendor marker and none of the real page, so


### PR DESCRIPTION
## Summary

`StealthChallengeDetector.IsChallenge` decides whether a non-validating IR fetch is a bot-protection stub worth an (expensive, rate-limited) stealth re-fetch. It matches eight vendor markers, but the regression theory only had a positive case for six of them. `"powered by incapsula"` (Incapsula interstitial footer) and `"pardon the interruption"` (Imperva interstitial copy) were untested, so a typo or accidental removal of either marker string would silently stop routing those walled responses through the stealth path and record a false miss — with no test going red.

## Code changes

- `tests/Equibles.UnitTests/CommonStocks/StealthChallengeDetectorTests.cs` — add two `InlineData` rows to the existing `IsChallenge_VendorChallengeMarker_ReturnsTrue` theory, one fixture body per previously-uncovered marker. Test-only; no production change.

All 14 `StealthChallengeDetectorTests` pass; csharpier clean.