### PR TITLE
fix(common-stocks): retry the bare host when a "www."-prefixed IR site fails to resolve

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/WebsiteProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/WebsiteProbeClient.cs
@@ -44,6 +44,26 @@ public class WebsiteProbeClient
         if (normalized == null)
             return null;
 
+        if (await Probe(normalized, cancellationToken))
+            return normalized;
+
+        // A "www."-prefixed investor-relations host (e.g. "www.investor.acme.com",
+        // exactly as some filings disclose it) usually publishes no "www" CNAME even
+        // though the bare host serves the site, so a failed "www." probe retries the
+        // bare host instead of discarding a company that does have a reachable site.
+        var bareHost = WithoutWww(normalized);
+        if (bareHost != null && await Probe(bareHost, cancellationToken))
+            return bareHost;
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reachability-probes one absolute URL, returning true when the host serves a
+    /// success response and false on any miss (dead host, TLS error, timeout).
+    /// </summary>
+    private async Task<bool> Probe(string url, CancellationToken cancellationToken)
+    {
         try
         {
             await RateLimiter.WaitAsync();
@@ -51,11 +71,11 @@ public class WebsiteProbeClient
             // Headers-read: only the status matters, so don't download the body.
             // (HEAD would be cheaper still, but enough hosts mishandle it.)
             using var response = await _httpClient.GetAsync(
-                normalized,
+                url,
                 HttpCompletionOption.ResponseHeadersRead,
                 cancellationToken
             );
-            return response.IsSuccessStatusCode ? normalized : null;
+            return response.IsSuccessStatusCode;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -65,8 +85,8 @@ public class WebsiteProbeClient
         {
             // A dead host, TLS error, or timeout is a definitive miss for this
             // candidate, not worth reporting — the next source gets its turn.
-            _logger.LogDebug(ex, "Website probe failed for {Url}", normalized);
-            return null;
+            _logger.LogDebug(ex, "Website probe failed for {Url}", url);
+            return false;
         }
     }
 
@@ -97,5 +117,32 @@ public class WebsiteProbeClient
             return null;
 
         return normalized.Length > MaxUrlLength ? null : normalized;
+    }
+
+    /// <summary>
+    /// The same absolute URL with a leading "www." stripped from its host, or null
+    /// when the host doesn't start with "www." or stripping it would leave nothing
+    /// host-shaped (e.g. "www.com"). Backs the probe fallback: an over-qualified
+    /// host such as "www.investor.acme.com" resolves at its bare form
+    /// "investor.acme.com" when the "www." variant has no DNS record. The scheme and
+    /// any path are preserved unchanged.
+    /// </summary>
+    public static string WithoutWww(string normalizedUrl)
+    {
+        if (string.IsNullOrEmpty(normalizedUrl))
+            return null;
+
+        var schemeIndex = normalizedUrl.IndexOf("://", StringComparison.Ordinal);
+        if (schemeIndex < 0)
+            return null;
+
+        var hostStart = schemeIndex + 3;
+        if (!normalizedUrl.AsSpan(hostStart).StartsWith("www.", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var stripped = normalizedUrl.Remove(hostStart, 4);
+        var hostEnd = stripped.IndexOfAny(['/', ':', '?', '#'], hostStart);
+        var bareHost = hostEnd < 0 ? stripped[hostStart..] : stripped[hostStart..hostEnd];
+        return bareHost.Contains('.') ? stripped : null;
     }
 }

--- a/tests/Equibles.UnitTests/CommonStocks/WebsiteProbeClientWwwFallbackTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/WebsiteProbeClientWwwFallbackTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using Equibles.CommonStocks.HostedService.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+/// <summary>
+/// Contract: an investor-relations host disclosed with a leading "www."
+/// (e.g. "www.investor.sonoco.com") usually publishes no "www" CNAME even though
+/// the bare host serves the site. <c>WebsiteProbeClient.Validate</c> must retry
+/// the bare host when the "www." variant fails, and persist the resolvable bare
+/// host — otherwise a company with a reachable IR site is left with an empty
+/// <c>CommonStock.Website</c> (and no downstream IR discovery). The "www." variant
+/// still wins when it resolves, so hosts that do carry a "www" record are
+/// untouched.
+/// </summary>
+public class WebsiteProbeClientWwwFallbackTests
+{
+    [Theory]
+    [InlineData("https://www.investor.sonoco.com", "https://investor.sonoco.com")]
+    [InlineData("https://www.acme.com", "https://acme.com")]
+    [InlineData("https://www.acme.com/ir", "https://acme.com/ir")]
+    [InlineData("http://www.ir.trinitycap.com", "http://ir.trinitycap.com")]
+    public void WithoutWww_StripsLeadingWwwAndKeepsSchemeAndPath(string url, string expected)
+    {
+        WebsiteProbeClient.WithoutWww(url).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("https://acme.com")] // no leading www.
+    [InlineData("https://investor.acme.com")] // subdomain, but not www.
+    [InlineData("https://www.com")] // stripping would leave a TLD-less host
+    public void WithoutWww_ReturnsNull_WhenNoStrippableWwwHost(string url)
+    {
+        WebsiteProbeClient.WithoutWww(url).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Validate_WwwSubdomainFailsButBareResolves_ReturnsBareHost()
+    {
+        var handler = new ScriptedHandler(uri =>
+            uri.Host == "investor.sonoco.com" ? HttpStatusCode.OK : null
+        );
+        var sut = Build(handler);
+
+        var result = await sut.Validate("www.investor.sonoco.com", CancellationToken.None);
+
+        result.Should().Be("https://investor.sonoco.com");
+        handler
+            .Requested.Select(u => u.ToString())
+            .Should()
+            .ContainInOrder("https://www.investor.sonoco.com/", "https://investor.sonoco.com/");
+    }
+
+    [Fact]
+    public async Task Validate_WwwHostResolves_KeepsWwwHostWithoutFallbackProbe()
+    {
+        var handler = new ScriptedHandler(_ => HttpStatusCode.OK);
+        var sut = Build(handler);
+
+        var result = await sut.Validate("www.investor.agilent.com", CancellationToken.None);
+
+        result.Should().Be("https://www.investor.agilent.com");
+        handler
+            .Requested.Should()
+            .ContainSingle()
+            .Which.Host.Should()
+            .Be("www.investor.agilent.com");
+    }
+
+    [Fact]
+    public async Task Validate_BothVariantsFail_ReturnsNull()
+    {
+        var handler = new ScriptedHandler(_ => null);
+        var sut = Build(handler);
+
+        var result = await sut.Validate("www.investor.dead.com", CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    private static WebsiteProbeClient Build(HttpMessageHandler handler) =>
+        new(new HttpClient(handler), Substitute.For<ILogger<WebsiteProbeClient>>());
+
+    // Returns the scripted status for each probed URL; a null status throws, mimicking
+    // the DNS failure (NXDOMAIN) a missing "www" CNAME produces for HttpClient.
+    private sealed class ScriptedHandler : HttpMessageHandler
+    {
+        private readonly Func<Uri, HttpStatusCode?> _statusFor;
+
+        public ScriptedHandler(Func<Uri, HttpStatusCode?> statusFor) => _statusFor = statusFor;
+
+        public List<Uri> Requested { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            Requested.Add(request.RequestUri!);
+            var status = _statusFor(request.RequestUri!);
+            if (status == null)
+                throw new HttpRequestException("Name or service not known");
+
+            return Task.FromResult(new HttpResponseMessage(status.Value));
+        }
+    }
+}


### PR DESCRIPTION
Summary

Some companies disclose an investor-relations host with a leading `www.` (for example `www.investor.sonoco.com`), but investor-relations subdomains generally do not publish a `www` CNAME. The website-discovery probe therefore failed DNS on the `www.`-prefixed variant and gave up, leaving the company with an empty `CommonStock.Website` even though the bare host (`investor.sonoco.com`) resolves and serves the site. An empty website also blocks all downstream investor-relations discovery (IR page, news, events, call artefacts).

This was observed on production for `SON`, `TRIN`, `TYGO`, `SMA` and a steady stream of `www.(ir|investor|investors).<domain>` DNS failures in the worker logs, while the bare hosts resolve.

Code changes

- `WebsiteProbeClient` — factored the single HTTP reachability check into a private `Probe`, and `Validate` now retries the bare host when a `www.`-prefixed candidate fails, persisting the resolvable bare form. The `www.` variant still wins when it resolves, so the hosts that already carry a `www` record (e.g. `www.investor.agilent.com`) are unchanged. The fallback only fires on a failed primary probe, so there is no extra traffic for hosts that resolve first time.
- Added `WebsiteProbeClient.WithoutWww`, a pure helper that strips a leading `www.` from a host while preserving the scheme and path, returning null when no strippable host remains.
- Tests: `WebsiteProbeClientWwwFallbackTests` pins the host rewriting and the end-to-end fallback (a dead `www.` host that throws on DNS falls back to the resolvable bare host; a resolvable `www.` host is kept without a fallback probe; both-fail returns null).

Addresses the root cause behind daniel3303/EquiblesCommercial#3224 (the affected discovery code lives in this submodule; the commercial pin bump carries the fix and closes that issue).