### PR TITLE
fix(insider-trading): emit noSecuritiesOwned sentinel from the shared parser

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
@@ -97,8 +97,44 @@ public static class InsiderFilingParser
             InsiderSecurityKind.Derivative
         );
 
+        // A Form 3 with <noSecuritiesOwned>1</noSecuritiesOwned> reports that the owner
+        // holds none of the issuer's securities — a legitimate filing whose tables are
+        // empty by design. Emit a single 0-shares sentinel so this parse (the shared
+        // source of truth) yields the same one row the ingest pipeline stores. Without
+        // it the reprocess pipeline, which replays this parse, re-derives zero rows and
+        // logs a phantom "stored 1 but re-parsed 0" divergence for every such filing.
+        if (transactions.Count == 0 && DeclaresNoSecuritiesOwned(root))
+            AddParsed(BuildNoSecuritiesOwnedSentinel(owner, companyId, filing));
+
         return transactions;
     }
+
+    // Form 3 initial statements set <noSecuritiesOwned> to 1 when the reporting owner
+    // holds none of the issuer's securities; both ownership tables are then empty.
+    internal static bool DeclaresNoSecuritiesOwned(XElement root) =>
+        ParseBool(root.Element("noSecuritiesOwned")?.Value);
+
+    // The 0-shares row recorded for a noSecuritiesOwned Form 3 — the owner's zero
+    // baseline. No security exists to classify, so SecurityKind stays Unknown; the
+    // 0 price is valid by design (nothing to validate or repair). Mirrors the row the
+    // ingest pipeline persists so a re-parse reproduces it exactly.
+    internal static InsiderTransaction BuildNoSecuritiesOwnedSentinel(
+        InsiderOwner owner,
+        Guid companyId,
+        FilingData filing
+    ) =>
+        new()
+        {
+            InsiderOwnerId = owner.Id,
+            CommonStockId = companyId,
+            FilingDate = filing.FilingDate,
+            TransactionDate = filing.ReportDate,
+            TransactionCode = TransactionCode.Other,
+            AccessionNumber = filing.AccessionNumber,
+            SecurityTitle = "No Securities Owned",
+            IsPriceValid = true,
+            ParserVersion = InsiderTransaction.CurrentParserVersion,
+        };
 
     /// <summary>
     /// Sanitize and parse an ownership filing payload into its <c>ownershipDocument</c>

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserNoSecuritiesOwnedSentinelTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserNoSecuritiesOwnedSentinelTests.cs
@@ -1,0 +1,114 @@
+using System.Xml.Linq;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingParserNoSecuritiesOwnedSentinelTests
+{
+    // Recorded payload from SEC accession 0001466258-23-000203 — a Form 3 for
+    // Trane Technologies plc (TT) where the reporting owner holds none of the
+    // issuer's securities: <noSecuritiesOwned>1</noSecuritiesOwned> with empty
+    // ownership tables. This is the exact shape that re-parsed to zero rows during
+    // the reprocess sweep (thousands of "has 1 stored rows but re-parsed 0"
+    // warnings), because the parser dropped these while the ingest pipeline stored
+    // a 0-shares sentinel for them.
+    private const string NoSecuritiesOwnedForm3 = """
+        <?xml version="1.0"?>
+        <ownershipDocument>
+            <schemaVersion>X0206</schemaVersion>
+            <documentType>3</documentType>
+            <periodOfReport>2023-10-03</periodOfReport>
+            <noSecuritiesOwned>1</noSecuritiesOwned>
+            <issuer>
+                <issuerCik>0001466258</issuerCik>
+                <issuerName>Trane Technologies plc</issuerName>
+                <issuerTradingSymbol>TT</issuerTradingSymbol>
+            </issuer>
+            <reportingOwner>
+                <reportingOwnerId>
+                    <rptOwnerCik>0001996403</rptOwnerCik>
+                    <rptOwnerName>de Jesus Assis Ana Paula</rptOwnerName>
+                </reportingOwnerId>
+                <reportingOwnerRelationship>
+                    <isDirector>1</isDirector>
+                </reportingOwnerRelationship>
+            </reportingOwner>
+            <nonDerivativeTable></nonDerivativeTable>
+            <derivativeTable></derivativeTable>
+            <footnotes></footnotes>
+        </ownershipDocument>
+        """;
+
+    [Fact]
+    public void ParseTransactions_NoSecuritiesOwnedForm3_ProducesSingleZeroSharesSentinel()
+    {
+        // Contract: a Form 3 declaring noSecuritiesOwned is a real, empty-table filing.
+        // The parser is the single source of truth shared by the ingest and reprocess
+        // pipelines, so it must reproduce the 0-shares "No Securities Owned" sentinel
+        // the ingest pipeline persists — not silently drop the filing to zero rows.
+        var root = InsiderFilingParser.TryGetOwnershipRoot(NoSecuritiesOwnedForm3);
+        root.Should().NotBeNull();
+
+        var filing = new FilingData
+        {
+            AccessionNumber = "0001466258-23-000203",
+            FilingDate = new DateOnly(2023, 10, 5),
+            ReportDate = new DateOnly(2023, 10, 3),
+        };
+
+        var result = InsiderFilingParser.ParseTransactions(
+            root,
+            new InsiderOwner { Id = Guid.NewGuid() },
+            Guid.NewGuid(),
+            filing,
+            isAmendment: false
+        );
+
+        var sentinel = result.Should().ContainSingle().Subject;
+        sentinel.SecurityTitle.Should().Be("No Securities Owned");
+        sentinel.Shares.Should().Be(0);
+        sentinel.SharesOwnedAfter.Should().Be(0);
+        sentinel.PricePerShare.Should().Be(0);
+        sentinel.TransactionOrder.Should().Be(0);
+        sentinel.TransactionCode.Should().Be(TransactionCode.Other);
+        sentinel.TransactionDate.Should().Be(filing.ReportDate);
+        sentinel.SecurityKind.Should().Be(InsiderSecurityKind.Unknown);
+        sentinel.IsPriceValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseTransactions_EmptyTablesWithoutNoSecuritiesOwned_ProducesNoRows()
+    {
+        // Guard the gate: an empty-table filing that does NOT declare noSecuritiesOwned
+        // (e.g. a Form 4 the parser couldn't read) must not get a bogus sentinel — that
+        // would mask a genuine parse gap. Such filings still re-parse to zero.
+        var root = XElement.Parse(
+            """
+            <ownershipDocument>
+                <documentType>4</documentType>
+                <nonDerivativeTable></nonDerivativeTable>
+                <derivativeTable></derivativeTable>
+            </ownershipDocument>
+            """
+        );
+
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000000000-24-000001",
+            FilingDate = new DateOnly(2024, 2, 1),
+            ReportDate = new DateOnly(2024, 1, 31),
+        };
+
+        var result = InsiderFilingParser.ParseTransactions(
+            root,
+            new InsiderOwner { Id = Guid.NewGuid() },
+            Guid.NewGuid(),
+            filing,
+            isAmendment: false
+        );
+
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

The insider parser documents itself as the single source of truth shared by the ingest and reprocess pipelines, but the 0-shares sentinel for Form 3 filings that declare `<noSecuritiesOwned>1</noSecuritiesOwned>` was created only in `InsiderTradingFilingProcessor` (ingest). The shared `InsiderFilingParser.ParseTransactions` dropped those filings to zero rows.

Effect: the reprocess sweep replays the parse and re-derives 0 rows against a stored count of 1, logging `has 1 stored rows but re-parsed 0` for every such filing (thousands per day in production). The latent risk is worse — a fresh ingest that ever routes one of these filings through the parser alone would store it empty.

Root cause confirmed against real EDGAR payloads: every sampled affected accession is a Form 3 with `noSecuritiesOwned=1` and empty ownership tables (e.g. 0001466258-23-000203, 0001466593-23-000013, 0001467623-25-000021).

## Code changes

- `InsiderFilingParser.ParseTransactions` — after walking both tables, if no rows were produced **and** the document declares `noSecuritiesOwned`, emit a single 0-shares "No Securities Owned" sentinel (TransactionOrder 0, SecurityKind Unknown, valid 0 price). Two small helpers added: `DeclaresNoSecuritiesOwned` and `BuildNoSecuritiesOwnedSentinel`. The row mirrors what the ingest processor persists, so ingest stays byte-identical (ReportedPricePerShare is non-nullable, defaults 0; the price validator returns valid for 0-price rows) and reprocess now reproduces the stored row instead of flagging a divergence.
- The gate on `noSecuritiesOwned` means a genuinely unparseable filing (no declaration) still surfaces as zero rows rather than a bogus sentinel — the processor's empty-table fallback is untouched.
- Regression test from a real recorded Form 3 payload (accession 0001466258-23-000203): asserts a single zero-shares sentinel; a second test guards that empty tables without the declaration produce no rows.

Verified failing-before / passing-after on the new test; all 69 insider parser/processor/reprocess unit tests pass; csharpier clean.