### PR TITLE
fix(finra): guard out-of-range DaysToCover when building the squeeze universe

### DIFF
--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -54,8 +54,24 @@ public class ShortSqueezeScoreManager
             return [];
         }
 
+        // Guard DaysToCover with a server-side range check so a single FINRA-feed artifact whose
+        // stored value falls outside System.Decimal can't throw OverflowException while the batch
+        // is materialized and take down every page that builds the squeeze universe (the screener,
+        // the squeeze board). The comparison runs in Postgres numeric space, so an out-of-range
+        // figure never reaches the System.Decimal reader; it is treated as missing and the factor
+        // is recomputed from the short position and average daily volume below, exactly as when
+        // FINRA omits days-to-cover.
         var shortInterests = await _shortInterestRepository
             .GetBySettlementDate(settlementDate)
+            .Select(s => new
+            {
+                s.CommonStockId,
+                s.CurrentShortPosition,
+                s.AverageDailyVolume,
+                DaysToCover = s.DaysToCover >= decimal.MinValue && s.DaysToCover <= decimal.MaxValue
+                    ? s.DaysToCover
+                    : null,
+            })
             .ToListAsync(cancellationToken);
 
         var stockIds = shortInterests.Select(s => s.CommonStockId).Distinct().ToList();


### PR DESCRIPTION
## Summary

- A FINRA-feed `ShortInterest` row whose stored `DaysToCover` (a `numeric` column) falls outside `System.Decimal`'s range threw `OverflowException` while `ShortSqueezeScoreManager.Compute` materialized the latest settlement batch (`GetBySettlementDate(...).ToListAsync()`).
- That failed the whole squeeze-score build, taking down every page that reads the cached squeeze universe — most visibly the stock screener, which 500'd for all visitors on a single bad row.
- Same failure class as the net-insider-buy overflow already guarded in the commercial screener provider: read the overflow-prone value in a range that the System.Decimal reader can represent, and treat anything outside it as missing.

## Code changes

- `src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs` — project `DaysToCover` through a server-side range check (`>= decimal.MinValue && <= decimal.MaxValue ? value : null`) instead of materializing the raw entity. The comparison runs in Postgres numeric space, so an out-of-range figure never reaches the `System.Decimal` reader; it is treated as missing and the factor is recomputed from the short position and average daily volume, exactly as when FINRA omits days-to-cover. In-range values are unchanged.

A regression test that reproduces the crash (out-of-range `DaysToCover` → no exception) lands in the commercial integration suite, where the squeeze manager's Postgres behavior is covered.