### PR TITLE
feat(government-contracts): add USAspending federal contracts module

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
@@ -174,6 +174,16 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.HostedService", "src\Equibles.FdaCatalysts.HostedService\Equibles.FdaCatalysts.HostedService.csproj", "{65E4C514-1A49-445F-92E0-D87B37F072A1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.Mcp", "src\Equibles.FdaCatalysts.Mcp\Equibles.FdaCatalysts.Mcp.csproj", "{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.GovernmentContracts.Data", "src\Equibles.GovernmentContracts.Data\Equibles.GovernmentContracts.Data.csproj", "{06258A0C-E886-4B16-8351-BA6DA77942C7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.GovernmentContracts.Repositories", "src\Equibles.GovernmentContracts.Repositories\Equibles.GovernmentContracts.Repositories.csproj", "{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Integrations.GovernmentContracts", "src\Equibles.Integrations.GovernmentContracts\Equibles.Integrations.GovernmentContracts.csproj", "{5376726C-12F9-4B30-A930-FA1548017724}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.GovernmentContracts.HostedService", "src\Equibles.GovernmentContracts.HostedService\Equibles.GovernmentContracts.HostedService.csproj", "{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.GovernmentContracts.Mcp", "src\Equibles.GovernmentContracts.Mcp\Equibles.GovernmentContracts.Mcp.csproj", "{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1193,6 +1203,66 @@ Global
 		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Release|x64.Build.0 = Release|Any CPU
 		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Release|x86.ActiveCfg = Release|Any CPU
 		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Release|x86.Build.0 = Release|Any CPU
+		{06258A0C-E886-4B16-8351-BA6DA77942C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06258A0C-E886-4B16-8351-BA6DA77942C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06258A0C-E886-4B16-8351-BA6DA77942C7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{06258A0C-E886-4B16-8351-BA6DA77942C7}.Debug|x64.Build.0 = Debug|Any CPU
+		{06258A0C-E886-4B16-8351-BA6DA77942C7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{06258A0C-E886-4B16-8351-BA6DA77942C7}.Debug|x86.Build.0 = Debug|Any CPU
+		{06258A0C-E886-4B16-8351-BA6DA77942C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06258A0C-E886-4B16-8351-BA6DA77942C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06258A0C-E886-4B16-8351-BA6DA77942C7}.Release|x64.ActiveCfg = Release|Any CPU
+		{06258A0C-E886-4B16-8351-BA6DA77942C7}.Release|x64.Build.0 = Release|Any CPU
+		{06258A0C-E886-4B16-8351-BA6DA77942C7}.Release|x86.ActiveCfg = Release|Any CPU
+		{06258A0C-E886-4B16-8351-BA6DA77942C7}.Release|x86.Build.0 = Release|Any CPU
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}.Debug|x64.Build.0 = Debug|Any CPU
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}.Debug|x86.Build.0 = Debug|Any CPU
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}.Release|x64.ActiveCfg = Release|Any CPU
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}.Release|x64.Build.0 = Release|Any CPU
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}.Release|x86.ActiveCfg = Release|Any CPU
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3}.Release|x86.Build.0 = Release|Any CPU
+		{5376726C-12F9-4B30-A930-FA1548017724}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5376726C-12F9-4B30-A930-FA1548017724}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5376726C-12F9-4B30-A930-FA1548017724}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5376726C-12F9-4B30-A930-FA1548017724}.Debug|x64.Build.0 = Debug|Any CPU
+		{5376726C-12F9-4B30-A930-FA1548017724}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5376726C-12F9-4B30-A930-FA1548017724}.Debug|x86.Build.0 = Debug|Any CPU
+		{5376726C-12F9-4B30-A930-FA1548017724}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5376726C-12F9-4B30-A930-FA1548017724}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5376726C-12F9-4B30-A930-FA1548017724}.Release|x64.ActiveCfg = Release|Any CPU
+		{5376726C-12F9-4B30-A930-FA1548017724}.Release|x64.Build.0 = Release|Any CPU
+		{5376726C-12F9-4B30-A930-FA1548017724}.Release|x86.ActiveCfg = Release|Any CPU
+		{5376726C-12F9-4B30-A930-FA1548017724}.Release|x86.Build.0 = Release|Any CPU
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}.Debug|x64.Build.0 = Debug|Any CPU
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}.Debug|x86.Build.0 = Debug|Any CPU
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}.Release|x64.ActiveCfg = Release|Any CPU
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}.Release|x64.Build.0 = Release|Any CPU
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}.Release|x86.ActiveCfg = Release|Any CPU
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2}.Release|x86.Build.0 = Release|Any CPU
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Debug|x64.Build.0 = Debug|Any CPU
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Debug|x86.Build.0 = Debug|Any CPU
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Release|x64.ActiveCfg = Release|Any CPU
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Release|x64.Build.0 = Release|Any CPU
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Release|x86.ActiveCfg = Release|Any CPU
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1282,6 +1352,11 @@ Global
 		{50271682-2648-41F7-9B01-292259615318} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{65E4C514-1A49-445F-92E0-D87B37F072A1} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{06258A0C-E886-4B16-8351-BA6DA77942C7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{C31F67A7-CCBA-408F-8EE7-92B75DFB3BB3} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{5376726C-12F9-4B30-A930-FA1548017724} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{82C3625E-39A9-4CDC-814F-D5CEF6A6ECF2} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{94E1EADA-3DBE-4D1D-9E18-9A287F2F3B11} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -19,6 +19,9 @@ public sealed class ErrorSource
     public static readonly ErrorSource YahooPriceScraper = new("YahooPriceScraper");
     public static readonly ErrorSource CftcScraper = new("CftcScraper");
     public static readonly ErrorSource CboeScraper = new("CboeScraper");
+    public static readonly ErrorSource GovernmentContractsScraper = new(
+        "GovernmentContractsScraper"
+    );
     public static readonly ErrorSource TranscriptScraper = new("TranscriptScraper");
     public static readonly ErrorSource InsiderTradingReprocess = new("InsiderTradingReprocess");
     public static readonly ErrorSource NportReprocess = new("NportReprocess");
@@ -46,6 +49,7 @@ public sealed class ErrorSource
             YahooPriceScraper,
             CftcScraper,
             CboeScraper,
+            GovernmentContractsScraper,
             TranscriptScraper,
             InsiderTradingReprocess,
             NportReprocess,

--- a/src/Equibles.GovernmentContracts.Data/Equibles.GovernmentContracts.Data.csproj
+++ b/src/Equibles.GovernmentContracts.Data/Equibles.GovernmentContracts.Data.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.CommonStocks.Data\Equibles.CommonStocks.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.GovernmentContracts.Data/Extensions/ModuleBuilderExtensions.cs
+++ b/src/Equibles.GovernmentContracts.Data/Extensions/ModuleBuilderExtensions.cs
@@ -1,0 +1,11 @@
+using Equibles.Data;
+
+namespace Equibles.GovernmentContracts.Data.Extensions;
+
+public static class ModuleBuilderExtensions
+{
+    public static EquiblesModuleBuilder AddGovernmentContracts(this EquiblesModuleBuilder builder)
+    {
+        return builder.AddModule<GovernmentContractsModuleConfiguration>();
+    }
+}

--- a/src/Equibles.GovernmentContracts.Data/GovernmentContractsModuleConfiguration.cs
+++ b/src/Equibles.GovernmentContracts.Data/GovernmentContractsModuleConfiguration.cs
@@ -1,0 +1,12 @@
+using Equibles.GovernmentContracts.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.GovernmentContracts.Data;
+
+public class GovernmentContractsModuleConfiguration : Equibles.Data.IFinancialModule
+{
+    public void ConfigureEntities(ModelBuilder builder)
+    {
+        builder.Entity<GovernmentContract>();
+    }
+}

--- a/src/Equibles.GovernmentContracts.Data/Models/GovernmentContract.cs
+++ b/src/Equibles.GovernmentContracts.Data/Models/GovernmentContract.cs
@@ -1,0 +1,76 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Equibles.CommonStocks.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.GovernmentContracts.Data.Models;
+
+/// <summary>
+/// A federal procurement contract award (from USAspending.gov) that has been
+/// resolved to a public company in our <see cref="CommonStock"/> universe.
+/// Awards that do not resolve to a public filer are not persisted.
+/// </summary>
+[Index(nameof(AwardUniqueKey), IsUnique = true)]
+[Index(nameof(CommonStockId), nameof(ActionDate))]
+[Index(nameof(ActionDate))]
+public class GovernmentContract
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid CommonStockId { get; set; }
+    public virtual CommonStock CommonStock { get; set; }
+
+    /// <summary>
+    /// USAspending's globally-unique award identifier (the award-detail slug,
+    /// <c>generated_internal_id</c>). Used as the idempotency key so re-scraping
+    /// updates the existing row rather than inserting a duplicate.
+    /// </summary>
+    [Required]
+    [MaxLength(128)]
+    public string AwardUniqueKey { get; set; }
+
+    /// <summary>Human-readable contract/PIID award number.</summary>
+    [MaxLength(128)]
+    public string AwardId { get; set; }
+
+    [Required]
+    [MaxLength(512)]
+    public string RecipientName { get; set; }
+
+    /// <summary>USAspending recipient hash (level-qualified), for cross-reference.</summary>
+    [MaxLength(64)]
+    public string RecipientId { get; set; }
+
+    public GovernmentContractAwardType AwardType { get; set; }
+
+    [MaxLength(256)]
+    public string AwardingAgency { get; set; }
+
+    /// <summary>Total award value (current obligated + potential), in US dollars.</summary>
+    public decimal Amount { get; set; }
+
+    /// <summary>Total outlays disbursed against the award to date, in US dollars.</summary>
+    public decimal? TotalOutlays { get; set; }
+
+    /// <summary>The award action date — the period-of-performance start.</summary>
+    public DateOnly? ActionDate { get; set; }
+
+    /// <summary>The period-of-performance current end date.</summary>
+    public DateOnly? EndDate { get; set; }
+
+    /// <summary>USAspending's last-modified date for the award; drives incremental scraping.</summary>
+    public DateOnly? LastModifiedDate { get; set; }
+
+    [MaxLength(8)]
+    public string NaicsCode { get; set; }
+
+    [MaxLength(8)]
+    public string PscCode { get; set; }
+
+    // Award descriptions are free-form and occasionally long; left untyped (text)
+    // so a long value never overflows and silently discards the save.
+    public string Description { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.GovernmentContracts.Data/Models/GovernmentContractAwardType.cs
+++ b/src/Equibles.GovernmentContracts.Data/Models/GovernmentContractAwardType.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.GovernmentContracts.Data.Models;
+
+/// <summary>
+/// The USAspending contract award type, mapped from the federal procurement
+/// award_type_codes A/B/C/D. Grants, loans and other assistance are out of scope —
+/// this module tracks procurement contracts only.
+/// </summary>
+public enum GovernmentContractAwardType
+{
+    [Display(Name = "Unknown")]
+    Unknown = 0,
+
+    [Display(Name = "BPA Call")]
+    BpaCall = 1,
+
+    [Display(Name = "Purchase Order")]
+    PurchaseOrder = 2,
+
+    [Display(Name = "Delivery Order")]
+    DeliveryOrder = 3,
+
+    [Display(Name = "Definitive Contract")]
+    DefinitiveContract = 4,
+}

--- a/src/Equibles.GovernmentContracts.HostedService/Configuration/GovernmentContractsScraperOptions.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Configuration/GovernmentContractsScraperOptions.cs
@@ -1,0 +1,18 @@
+using Equibles.Worker;
+
+namespace Equibles.GovernmentContracts.HostedService.Configuration;
+
+public class GovernmentContractsScraperOptions : ScraperOptions
+{
+    /// <summary>
+    /// Awards below this dollar value are ignored — federal procurement is dominated by
+    /// a long tail of small actions, and only material awards move a public company.
+    /// </summary>
+    public decimal MinimumAwardAmount { get; set; } = 1_000_000m;
+
+    /// <summary>
+    /// Width (in days) of each action-date window fetched per API call. Narrow enough to
+    /// stay under USAspending's 10,000-record deep-pagination ceiling for a window.
+    /// </summary>
+    public int WindowDays { get; set; } = 7;
+}

--- a/src/Equibles.GovernmentContracts.HostedService/Equibles.GovernmentContracts.HostedService.csproj
+++ b/src/Equibles.GovernmentContracts.HostedService/Equibles.GovernmentContracts.HostedService.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Equibles.Core.AutoWiring" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
+    <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.GovernmentContracts.Repositories\Equibles.GovernmentContracts.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Integrations.GovernmentContracts\Equibles.Integrations.GovernmentContracts.csproj" />
+    <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
+    <ProjectReference Include="..\Equibles.Worker\Equibles.Worker.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.GovernmentContracts.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using Equibles.Core.AutoWiring;
+using Equibles.GovernmentContracts.HostedService.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.GovernmentContracts.HostedService.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddGovernmentContractsWorker(this IServiceCollection services)
+    {
+        services.AutoWireServicesFrom<GovernmentContractsImportService>();
+        services.AutoWireServicesFrom<Equibles.Integrations.GovernmentContracts.UsaSpendingClient>();
+
+        services.AddHostedService<GovernmentContractsScraperWorker>();
+
+        return services;
+    }
+}

--- a/src/Equibles.GovernmentContracts.HostedService/GovernmentContractsScraperWorker.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/GovernmentContractsScraperWorker.cs
@@ -1,0 +1,29 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.GovernmentContracts.HostedService.Configuration;
+using Equibles.GovernmentContracts.HostedService.Services;
+using Equibles.Worker;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.GovernmentContracts.HostedService;
+
+public class GovernmentContractsScraperWorker : BaseScraperWorker
+{
+    protected override string WorkerName => "Government contracts scraper";
+    protected override TimeSpan SleepInterval { get; }
+    protected override ErrorSource ErrorSource => ErrorSource.GovernmentContractsScraper;
+
+    public GovernmentContractsScraperWorker(
+        ILogger<GovernmentContractsScraperWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<GovernmentContractsScraperOptions> options
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
+    }
+
+    protected override Task DoWork(CancellationToken stoppingToken) =>
+        RunImport<GovernmentContractsImportService>(stoppingToken);
+}

--- a/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/GovernmentContractsImportService.cs
@@ -1,0 +1,204 @@
+using Equibles.Core.AutoWiring;
+using Equibles.Core.Configuration;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.GovernmentContracts.Data.Models;
+using Equibles.GovernmentContracts.HostedService.Configuration;
+using Equibles.GovernmentContracts.Repositories;
+using Equibles.Integrations.GovernmentContracts.Contracts;
+using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Equibles.GovernmentContracts.HostedService.Services;
+
+[Service]
+public class GovernmentContractsImportService : IImporter
+{
+    private const int InsertBatchSize = 1000;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<GovernmentContractsImportService> _logger;
+    private readonly IUsaSpendingClient _client;
+    private readonly RecipientResolver _resolver;
+    private readonly GovernmentContractsScraperOptions _options;
+    private readonly WorkerOptions _workerOptions;
+    private readonly ErrorReporter _errorReporter;
+
+    public GovernmentContractsImportService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<GovernmentContractsImportService> logger,
+        IUsaSpendingClient client,
+        RecipientResolver resolver,
+        IOptions<GovernmentContractsScraperOptions> options,
+        IOptions<WorkerOptions> workerOptions,
+        ErrorReporter errorReporter
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _client = client;
+        _resolver = resolver;
+        _options = options.Value;
+        _workerOptions = workerOptions.Value;
+        _errorReporter = errorReporter;
+    }
+
+    public async Task Import(CancellationToken cancellationToken)
+    {
+        var recipientLookup = await _resolver.BuildLookup(cancellationToken);
+        if (recipientLookup.Count == 0)
+        {
+            _logger.LogWarning(
+                "Government contracts import: the CommonStock universe is empty; skipping cycle"
+            );
+            return;
+        }
+
+        var startDate = await DetermineStartDate(cancellationToken);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        if (startDate > today)
+        {
+            _logger.LogInformation("Government contracts import: already up to date");
+            return;
+        }
+
+        _logger.LogInformation(
+            "Government contracts import: scanning {Start}..{Today} (>= ${Min:N0}) against {Count} companies",
+            startDate,
+            today,
+            _options.MinimumAwardAmount,
+            recipientLookup.Count
+        );
+
+        var windowDays = Math.Max(1, _options.WindowDays);
+        var totalInserted = 0;
+
+        for (
+            var windowStart = startDate;
+            windowStart <= today;
+            windowStart = windowStart.AddDays(windowDays)
+        )
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var windowEnd = windowStart.AddDays(windowDays - 1);
+            if (windowEnd > today)
+                windowEnd = today;
+
+            try
+            {
+                totalInserted += await ImportWindow(
+                    windowStart,
+                    windowEnd,
+                    recipientLookup,
+                    cancellationToken
+                );
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogError(
+                    ex,
+                    "Government contracts import failed for window {Start}..{End}",
+                    windowStart,
+                    windowEnd
+                );
+                await _errorReporter.Report(
+                    ErrorSource.GovernmentContractsScraper,
+                    "GovernmentContractsImport.ImportWindow",
+                    ex.Message,
+                    ex.StackTrace,
+                    $"window: {windowStart}..{windowEnd}"
+                );
+            }
+        }
+
+        _logger.LogInformation(
+            "Government contracts import complete: {Count} new awards persisted",
+            totalInserted
+        );
+    }
+
+    private async Task<int> ImportWindow(
+        DateOnly windowStart,
+        DateOnly windowEnd,
+        IReadOnlyDictionary<string, Guid> recipientLookup,
+        CancellationToken cancellationToken
+    )
+    {
+        var awards = await _client.GetContractAwards(
+            windowStart,
+            windowEnd,
+            _options.MinimumAwardAmount
+        );
+        if (awards.Count == 0)
+            return 0;
+
+        // Resolve to public companies, map, and de-duplicate within the batch by unique key.
+        var mapped = new Dictionary<string, GovernmentContract>(StringComparer.Ordinal);
+        foreach (var award in awards)
+        {
+            var commonStockId = RecipientResolver.Resolve(award.RecipientName, recipientLookup);
+            if (commonStockId == null)
+                continue;
+
+            var entity = UsaSpendingAwardMapper.Map(award, commonStockId.Value);
+            if (entity != null)
+                mapped[entity.AwardUniqueKey] = entity;
+        }
+
+        if (mapped.Count == 0)
+            return 0;
+
+        var existingKeys = await LoadExistingKeys(mapped.Keys, cancellationToken);
+        var toInsert = mapped.Values.Where(c => !existingKeys.Contains(c.AwardUniqueKey)).ToList();
+        if (toInsert.Count == 0)
+            return 0;
+
+        var inserted = await BatchPersister.Persist<
+            GovernmentContract,
+            GovernmentContractRepository
+        >(toInsert, InsertBatchSize, _scopeFactory);
+
+        _logger.LogDebug(
+            "Government contracts {Start}..{End}: {Inserted} new of {Matched} matched ({Fetched} fetched)",
+            windowStart,
+            windowEnd,
+            inserted,
+            mapped.Count,
+            awards.Count
+        );
+        return inserted;
+    }
+
+    private async Task<HashSet<string>> LoadExistingKeys(
+        IEnumerable<string> keys,
+        CancellationToken cancellationToken
+    )
+    {
+        var keyList = keys.ToList();
+        using var scope = _scopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<GovernmentContractRepository>();
+        return (
+            await repository
+                .GetAll()
+                .Where(c => keyList.Contains(c.AwardUniqueKey))
+                .Select(c => c.AwardUniqueKey)
+                .ToListAsync(cancellationToken)
+        ).ToHashSet(StringComparer.Ordinal);
+    }
+
+    private async Task<DateOnly> DetermineStartDate(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<GovernmentContractRepository>();
+        var latest = await repository
+            .GetAll()
+            .Where(c => c.ActionDate != null)
+            .MaxAsync(c => (DateOnly?)c.ActionDate, cancellationToken);
+
+        return SyncDateResolver.Resolve(latest ?? default, _workerOptions);
+    }
+}

--- a/src/Equibles.GovernmentContracts.HostedService/Services/RecipientNameNormalizer.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/RecipientNameNormalizer.cs
@@ -1,0 +1,67 @@
+using System.Text;
+
+namespace Equibles.GovernmentContracts.HostedService.Services;
+
+/// <summary>
+/// Normalises a company/recipient legal name to a comparable key for exact-match
+/// resolution between USAspending recipients and our <c>CommonStock</c> universe.
+/// Deliberately conservative — it strips punctuation, a leading "THE", and trailing
+/// legal-entity suffixes (CORP/INC/LLC/…) so "Lockheed Martin Corporation" and
+/// "Lockheed Martin Corp" collapse to the same key, but it never fuzzy-matches.
+/// Returns null when nothing meaningful remains.
+/// </summary>
+public static class RecipientNameNormalizer
+{
+    private const int MinimumKeyLength = 4;
+
+    private static readonly HashSet<string> LegalSuffixes = new(StringComparer.Ordinal)
+    {
+        "CORP",
+        "CORPORATION",
+        "INC",
+        "INCORPORATED",
+        "CO",
+        "COMPANY",
+        "LLC",
+        "LP",
+        "LLP",
+        "LTD",
+        "LIMITED",
+        "PLC",
+        "NV",
+        "SA",
+        "AG",
+        "SE",
+        "CV",
+    };
+
+    public static string Normalize(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+
+        var cleaned = new StringBuilder(name.Length);
+        foreach (var c in name.ToUpperInvariant())
+        {
+            if (char.IsLetterOrDigit(c))
+                cleaned.Append(c);
+            else if (char.IsWhiteSpace(c) || c is '.' or ',' or '-' or '/' or '&' or '\'' or '"')
+                cleaned.Append(' ');
+            // any other punctuation is dropped entirely
+        }
+
+        var tokens = cleaned
+            .ToString()
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToList();
+
+        if (tokens.Count > 1 && tokens[0] == "THE")
+            tokens.RemoveAt(0);
+
+        while (tokens.Count > 1 && LegalSuffixes.Contains(tokens[^1]))
+            tokens.RemoveAt(tokens.Count - 1);
+
+        var key = string.Join(' ', tokens);
+        return key.Length >= MinimumKeyLength ? key : null;
+    }
+}

--- a/src/Equibles.GovernmentContracts.HostedService/Services/RecipientResolver.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/RecipientResolver.cs
@@ -1,0 +1,71 @@
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.AutoWiring;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.GovernmentContracts.HostedService.Services;
+
+/// <summary>
+/// Resolves a USAspending recipient name to a public company in our <c>CommonStock</c>
+/// universe via an exact normalised-name match. Builds the lookup once per import cycle.
+/// Names that normalise to the same key for more than one distinct stock are treated as
+/// ambiguous and dropped, so a wrong link is never asserted.
+/// </summary>
+[Service]
+public class RecipientResolver
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public RecipientResolver(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public async Task<IReadOnlyDictionary<string, Guid>> BuildLookup(
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+
+        var stocks = await repository
+            .GetAll()
+            .Where(s => s.Name != null)
+            .Select(s => new { s.Id, s.Name })
+            .ToListAsync(cancellationToken);
+
+        var lookup = new Dictionary<string, Guid>(StringComparer.Ordinal);
+        var ambiguous = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var stock in stocks)
+        {
+            var key = RecipientNameNormalizer.Normalize(stock.Name);
+            if (key == null)
+                continue;
+
+            if (lookup.TryGetValue(key, out var existingId))
+            {
+                if (existingId != stock.Id)
+                    ambiguous.Add(key);
+            }
+            else
+            {
+                lookup[key] = stock.Id;
+            }
+        }
+
+        foreach (var key in ambiguous)
+            lookup.Remove(key);
+
+        return lookup;
+    }
+
+    public static Guid? Resolve(string recipientName, IReadOnlyDictionary<string, Guid> lookup)
+    {
+        var key = RecipientNameNormalizer.Normalize(recipientName);
+        if (key == null)
+            return null;
+
+        return lookup.TryGetValue(key, out var id) ? id : null;
+    }
+}

--- a/src/Equibles.GovernmentContracts.HostedService/Services/UsaSpendingAwardMapper.cs
+++ b/src/Equibles.GovernmentContracts.HostedService/Services/UsaSpendingAwardMapper.cs
@@ -1,0 +1,94 @@
+using System.Globalization;
+using Equibles.GovernmentContracts.Data.Models;
+using Equibles.Integrations.GovernmentContracts.Models;
+
+namespace Equibles.GovernmentContracts.HostedService.Services;
+
+/// <summary>
+/// Maps a USAspending wire record onto a <see cref="GovernmentContract"/> entity for an
+/// already-resolved public company. Pure and side-effect free so it can be unit tested.
+/// </summary>
+public static class UsaSpendingAwardMapper
+{
+    /// <summary>
+    /// Builds the entity, or returns null when the award carries no stable unique
+    /// identifier (neither a generated id nor a PIID) and therefore can't be stored idempotently.
+    /// </summary>
+    public static GovernmentContract Map(UsaSpendingAwardRecord record, Guid commonStockId)
+    {
+        var uniqueKey = FirstNonEmpty(record.GeneratedInternalId, record.AwardId);
+        if (uniqueKey == null)
+            return null;
+
+        return new GovernmentContract
+        {
+            CommonStockId = commonStockId,
+            AwardUniqueKey = Truncate(uniqueKey, 128),
+            AwardId = Truncate(record.AwardId, 128),
+            RecipientName = Truncate(record.RecipientName, 512),
+            RecipientId = Truncate(record.RecipientId, 64),
+            AwardType = MapAwardType(record.ContractAwardType),
+            AwardingAgency = Truncate(record.AwardingAgency, 256),
+            Amount = record.Amount ?? 0m,
+            TotalOutlays = record.TotalOutlays,
+            ActionDate = ParseDate(record.StartDate),
+            EndDate = ParseDate(record.EndDate),
+            LastModifiedDate = ParseDate(record.LastModifiedDate),
+            NaicsCode = LeadingToken(record.Naics, 8),
+            PscCode = LeadingToken(record.Psc, 8),
+            Description = record.Description,
+        };
+    }
+
+    public static GovernmentContractAwardType MapAwardType(string contractAwardType)
+    {
+        if (string.IsNullOrWhiteSpace(contractAwardType))
+            return GovernmentContractAwardType.Unknown;
+
+        return contractAwardType.Trim().ToUpperInvariant() switch
+        {
+            "BPA CALL" => GovernmentContractAwardType.BpaCall,
+            "PURCHASE ORDER" => GovernmentContractAwardType.PurchaseOrder,
+            "DELIVERY ORDER" => GovernmentContractAwardType.DeliveryOrder,
+            "DEFINITIVE CONTRACT" => GovernmentContractAwardType.DefinitiveContract,
+            _ => GovernmentContractAwardType.Unknown,
+        };
+    }
+
+    private static DateOnly? ParseDate(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        return DateOnly.TryParseExact(
+            value.Trim(),
+            "yyyy-MM-dd",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var date
+        )
+            ? date
+            : null;
+    }
+
+    private static string FirstNonEmpty(params string[] candidates) =>
+        candidates.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c))?.Trim();
+
+    // USAspending NAICS/PSC fields carry the bare code; guard against an unexpectedly
+    // long value (e.g. "code | description") by keeping only the leading token.
+    private static string LeadingToken(string value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        var token = value.Trim().Split(' ', '|')[0];
+        return Truncate(token, maxLength);
+    }
+
+    private static string Truncate(string value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        var trimmed = value.Trim();
+        return trimmed.Length <= maxLength ? trimmed : trimmed[..maxLength];
+    }
+}

--- a/src/Equibles.GovernmentContracts.Mcp/Equibles.GovernmentContracts.Mcp.csproj
+++ b/src/Equibles.GovernmentContracts.Mcp/Equibles.GovernmentContracts.Mcp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Mcp\Equibles.Mcp.csproj" />
+    <ProjectReference Include="..\Equibles.GovernmentContracts.Repositories\Equibles.GovernmentContracts.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.CommonStocks.Repositories\Equibles.CommonStocks.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
+    <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.GovernmentContracts.Mcp/Extensions/McpBuilderExtensions.cs
+++ b/src/Equibles.GovernmentContracts.Mcp/Extensions/McpBuilderExtensions.cs
@@ -1,0 +1,12 @@
+using Equibles.GovernmentContracts.Mcp.Tools;
+using Equibles.Mcp;
+
+namespace Equibles.GovernmentContracts.Mcp.Extensions;
+
+public static class McpBuilderExtensions
+{
+    public static EquiblesMcpBuilder AddGovernmentContracts(this EquiblesMcpBuilder builder)
+    {
+        return builder.AddModule<AssemblyMcpModule<GovernmentContractsTools>>();
+    }
+}

--- a/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
+++ b/src/Equibles.GovernmentContracts.Mcp/Tools/GovernmentContractsTools.cs
@@ -1,0 +1,181 @@
+using System.ComponentModel;
+using System.Globalization;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
+using Equibles.GovernmentContracts.Data.Models;
+using Equibles.GovernmentContracts.Repositories;
+using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Equibles.GovernmentContracts.Mcp.Tools;
+
+[McpServerToolType]
+public class GovernmentContractsTools
+{
+    private readonly GovernmentContractRepository _contractRepository;
+    private readonly CommonStockRepository _commonStockRepository;
+    private readonly McpToolRunner _runner;
+
+    public GovernmentContractsTools(
+        GovernmentContractRepository contractRepository,
+        CommonStockRepository commonStockRepository,
+        ErrorManager errorManager,
+        ILogger<GovernmentContractsTools> logger
+    )
+    {
+        _contractRepository = contractRepository;
+        _commonStockRepository = commonStockRepository;
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
+    }
+
+    [McpServerTool(Name = "GetGovernmentContracts")]
+    [Description(
+        "Get federal government contract awards (from USAspending.gov) won by a specific public company. "
+            + "Shows the awarding agency, award amount, period dates, and description — useful for gauging a "
+            + "company's reliance on federal spending."
+    )]
+    public Task<string> GetGovernmentContracts(
+        [Description("Stock ticker symbol (e.g., LMT, RTX, BA)")] string ticker,
+        [Description("Start date in YYYY-MM-DD format (defaults to 1 year ago)")]
+            string startDate = null,
+        [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
+            string endDate = null,
+        [Description("Maximum number of awards to return (default: 50, largest first)")]
+            int maxResults = 50
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
+                if (stockError != null)
+                    return stockError;
+
+                var (start, end) = McpToolExecutor.ParseDateRange(
+                    startDate,
+                    endDate,
+                    McpToolExecutor.UtcYearsAgo(1)
+                );
+                maxResults = McpLimit.Clamp(maxResults);
+
+                var awards = await _contractRepository
+                    .GetByCommonStock(stock)
+                    .Where(c => c.ActionDate >= start && c.ActionDate <= end)
+                    .OrderByDescending(c => c.Amount)
+                    .Take(maxResults)
+                    .ToListAsync();
+
+                return MarkdownTable.Render(
+                    awards,
+                    $"No federal contract awards found for {stock.Ticker} in the specified date range.",
+                    $"Federal contract awards for {stock.Ticker} ({stock.Name}):",
+                    "| Action Date | Agency | Type | Amount | Award ID | Description |",
+                    "|-------------|--------|------|--------|----------|-------------|",
+                    c =>
+                        $"| {Format(c.ActionDate)} | {Escape(c.AwardingAgency)} | {AwardTypeLabel(c.AwardType)} "
+                        + $"| {FormatUsd(c.Amount)} | {Escape(c.AwardId)} | {Escape(Shorten(c.Description, 80))} |"
+                );
+            },
+            "GetGovernmentContracts",
+            $"ticker: {ticker}"
+        );
+    }
+
+    [McpServerTool(Name = "GetTopGovernmentContractors")]
+    [Description(
+        "Rank public companies by total federal contract dollars awarded over a date range (from "
+            + "USAspending.gov). Answers questions like 'which public companies won the most federal contracts "
+            + "last quarter'."
+    )]
+    public Task<string> GetTopGovernmentContractors(
+        [Description("Start date in YYYY-MM-DD format (defaults to 1 year ago)")]
+            string startDate = null,
+        [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
+            string endDate = null,
+        [Description("Maximum number of companies to return (default: 25, largest first)")]
+            int maxResults = 25
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var (start, end) = McpToolExecutor.ParseDateRange(
+                    startDate,
+                    endDate,
+                    McpToolExecutor.UtcYearsAgo(1)
+                );
+                maxResults = McpLimit.Clamp(maxResults);
+
+                var ranked = await _contractRepository
+                    .GetAll()
+                    .Where(c => c.ActionDate >= start && c.ActionDate <= end)
+                    .GroupBy(c => new
+                    {
+                        c.CommonStockId,
+                        c.CommonStock.Ticker,
+                        c.CommonStock.Name,
+                    })
+                    .Select(g => new
+                    {
+                        g.Key.Ticker,
+                        g.Key.Name,
+                        Total = g.Sum(c => c.Amount),
+                        Count = g.Count(),
+                    })
+                    .OrderByDescending(r => r.Total)
+                    .Take(maxResults)
+                    .ToListAsync();
+
+                var rank = 0;
+                return MarkdownTable.Render(
+                    ranked,
+                    "No federal contract awards found in the specified date range.",
+                    $"Top federal contractors ({start:yyyy-MM-dd} to {end:yyyy-MM-dd}):",
+                    "| Rank | Ticker | Company | Total Awarded | Awards |",
+                    "|------|--------|---------|---------------|--------|",
+                    r =>
+                        $"| {++rank} | {Escape(r.Ticker)} | {Escape(r.Name)} | {FormatUsd(r.Total)} | {r.Count} |"
+                );
+            },
+            "GetTopGovernmentContractors",
+            $"range: {startDate}..{endDate}"
+        );
+    }
+
+    private static string AwardTypeLabel(GovernmentContractAwardType type) =>
+        type switch
+        {
+            GovernmentContractAwardType.BpaCall => "BPA Call",
+            GovernmentContractAwardType.PurchaseOrder => "Purchase Order",
+            GovernmentContractAwardType.DeliveryOrder => "Delivery Order",
+            GovernmentContractAwardType.DefinitiveContract => "Definitive Contract",
+            _ => "Unknown",
+        };
+
+    private static string FormatUsd(decimal amount) =>
+        "$" + amount.ToString("N0", CultureInfo.InvariantCulture);
+
+    private static string Format(DateOnly? date) =>
+        date?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "—";
+
+    private static string Shorten(string value, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        var trimmed = value.Trim();
+        return trimmed.Length <= maxLength ? trimmed : trimmed[..maxLength] + "…";
+    }
+
+    // Markdown cells can't contain a raw pipe or newline without breaking the table.
+    private static string Escape(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return "";
+        return value.Replace("|", "\\|").Replace("\r", " ").Replace("\n", " ");
+    }
+}

--- a/src/Equibles.GovernmentContracts.Repositories/Equibles.GovernmentContracts.Repositories.csproj
+++ b/src/Equibles.GovernmentContracts.Repositories/Equibles.GovernmentContracts.Repositories.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.GovernmentContracts.Data\Equibles.GovernmentContracts.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.GovernmentContracts.Repositories/GovernmentContractRepository.cs
+++ b/src/Equibles.GovernmentContracts.Repositories/GovernmentContractRepository.cs
@@ -1,0 +1,21 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.GovernmentContracts.Data.Models;
+
+namespace Equibles.GovernmentContracts.Repositories;
+
+public class GovernmentContractRepository : BaseRepository<GovernmentContract>
+{
+    public GovernmentContractRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<GovernmentContract> GetByCommonStock(CommonStock commonStock)
+    {
+        return GetAll().Where(c => c.CommonStockId == commonStock.Id);
+    }
+
+    public IQueryable<GovernmentContract> GetByAwardUniqueKey(string awardUniqueKey)
+    {
+        return GetAll().Where(c => c.AwardUniqueKey == awardUniqueKey);
+    }
+}

--- a/src/Equibles.Integrations.GovernmentContracts/Contracts/IUsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Contracts/IUsaSpendingClient.cs
@@ -1,0 +1,19 @@
+using Equibles.Integrations.GovernmentContracts.Models;
+
+namespace Equibles.Integrations.GovernmentContracts.Contracts;
+
+public interface IUsaSpendingClient
+{
+    /// <summary>
+    /// Fetches federal procurement contract awards (award types A/B/C/D) whose
+    /// action date falls within <paramref name="startDate"/>..<paramref name="endDate"/>
+    /// and whose award amount is at least <paramref name="minimumAmount"/>, following
+    /// pagination. The window must be narrow enough to stay under the API's
+    /// deep-pagination ceiling; truncation is logged rather than silently dropped.
+    /// </summary>
+    Task<List<UsaSpendingAwardRecord>> GetContractAwards(
+        DateOnly startDate,
+        DateOnly endDate,
+        decimal minimumAmount
+    );
+}

--- a/src/Equibles.Integrations.GovernmentContracts/Equibles.Integrations.GovernmentContracts.csproj
+++ b/src/Equibles.Integrations.GovernmentContracts/Equibles.Integrations.GovernmentContracts.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Equibles.Core.AutoWiring" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Integrations.Common\Equibles.Integrations.Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingAwardRecord.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingAwardRecord.cs
@@ -1,0 +1,55 @@
+using Newtonsoft.Json;
+
+namespace Equibles.Integrations.GovernmentContracts.Models;
+
+/// <summary>
+/// One contract award row as returned by USAspending's
+/// <c>POST /api/v2/search/spending_by_award/</c> endpoint. Field names mirror the
+/// API's display labels verbatim; values are kept as wire strings and mapped to the
+/// domain entity downstream.
+/// </summary>
+public class UsaSpendingAwardRecord
+{
+    /// <summary>The globally-unique award slug used by award-detail URLs.</summary>
+    [JsonProperty("generated_internal_id")]
+    public string GeneratedInternalId { get; set; }
+
+    [JsonProperty("Award ID")]
+    public string AwardId { get; set; }
+
+    [JsonProperty("Recipient Name")]
+    public string RecipientName { get; set; }
+
+    [JsonProperty("recipient_id")]
+    public string RecipientId { get; set; }
+
+    [JsonProperty("Award Amount")]
+    public decimal? Amount { get; set; }
+
+    [JsonProperty("Total Outlays")]
+    public decimal? TotalOutlays { get; set; }
+
+    [JsonProperty("Awarding Agency")]
+    public string AwardingAgency { get; set; }
+
+    [JsonProperty("Contract Award Type")]
+    public string ContractAwardType { get; set; }
+
+    [JsonProperty("Start Date")]
+    public string StartDate { get; set; }
+
+    [JsonProperty("End Date")]
+    public string EndDate { get; set; }
+
+    [JsonProperty("Last Modified Date")]
+    public string LastModifiedDate { get; set; }
+
+    [JsonProperty("NAICS")]
+    public string Naics { get; set; }
+
+    [JsonProperty("PSC")]
+    public string Psc { get; set; }
+
+    [JsonProperty("Description")]
+    public string Description { get; set; }
+}

--- a/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingAwardResponse.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingAwardResponse.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace Equibles.Integrations.GovernmentContracts.Models;
+
+public class UsaSpendingAwardResponse
+{
+    [JsonProperty("results")]
+    public List<UsaSpendingAwardRecord> Results { get; set; } = [];
+
+    [JsonProperty("page_metadata")]
+    public UsaSpendingPageMetadata PageMetadata { get; set; }
+}

--- a/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingPageMetadata.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/Models/UsaSpendingPageMetadata.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace Equibles.Integrations.GovernmentContracts.Models;
+
+public class UsaSpendingPageMetadata
+{
+    [JsonProperty("page")]
+    public int Page { get; set; }
+
+    [JsonProperty("hasNext")]
+    public bool HasNext { get; set; }
+}

--- a/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
+++ b/src/Equibles.Integrations.GovernmentContracts/UsaSpendingClient.cs
@@ -1,0 +1,190 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Equibles.Core.AutoWiring;
+using Equibles.Integrations.Common.RateLimiter;
+using Equibles.Integrations.Common.Retry;
+using Equibles.Integrations.GovernmentContracts.Contracts;
+using Equibles.Integrations.GovernmentContracts.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Equibles.Integrations.GovernmentContracts;
+
+[Service(ServiceLifetime.Scoped, typeof(IUsaSpendingClient))]
+public class UsaSpendingClient : IUsaSpendingClient
+{
+    private const string SearchUrl = "https://api.usaspending.gov/api/v2/search/spending_by_award/";
+    private const int MaxRetries = 3;
+
+    // The API returns at most 100 rows/page and refuses to paginate past the
+    // 10,000th record, so 100 pages is the hard ceiling for a single window.
+    private const int PageSize = 100;
+    private const int MaxPages = 100;
+
+    // Federal procurement contract award types (excludes grants/loans/other assistance).
+    private static readonly string[] ContractAwardTypeCodes = ["A", "B", "C", "D"];
+
+    private static readonly string[] RequestFields =
+    [
+        "Award ID",
+        "Recipient Name",
+        "recipient_id",
+        "Award Amount",
+        "Total Outlays",
+        "Awarding Agency",
+        "Contract Award Type",
+        "Start Date",
+        "End Date",
+        "Last Modified Date",
+        "NAICS",
+        "PSC",
+        "Description",
+    ];
+
+    private static readonly IRateLimiter RateLimiter = new Common.RateLimiter.RateLimiter(
+        maxRequests: 10,
+        timeWindow: TimeSpan.FromSeconds(1)
+    );
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<UsaSpendingClient> _logger;
+
+    public UsaSpendingClient(HttpClient httpClient, ILogger<UsaSpendingClient> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task<List<UsaSpendingAwardRecord>> GetContractAwards(
+        DateOnly startDate,
+        DateOnly endDate,
+        decimal minimumAmount
+    )
+    {
+        var startStr = FormatDate(startDate);
+        var endStr = FormatDate(endDate);
+        var results = new List<UsaSpendingAwardRecord>();
+
+        for (var page = 1; page <= MaxPages; page++)
+        {
+            var body = BuildRequestBody(startStr, endStr, minimumAmount, page);
+            var response = await PostQuery(body);
+            if (response.Results.Count > 0)
+            {
+                results.AddRange(response.Results);
+            }
+
+            if (response.PageMetadata is not { HasNext: true })
+            {
+                return results;
+            }
+
+            if (page == MaxPages)
+            {
+                _logger.LogWarning(
+                    "USAspending window {Start}..{End} (>= ${Min}) exceeded {MaxPages} pages "
+                        + "({Count} awards fetched) and has more results — narrow the window or raise the floor",
+                    startStr,
+                    endStr,
+                    minimumAmount,
+                    MaxPages,
+                    results.Count
+                );
+            }
+        }
+
+        return results;
+    }
+
+    private static object BuildRequestBody(
+        string startDate,
+        string endDate,
+        decimal minimumAmount,
+        int page
+    )
+    {
+        return new
+        {
+            filters = new
+            {
+                award_type_codes = ContractAwardTypeCodes,
+                time_period = new[] { new { start_date = startDate, end_date = endDate } },
+                award_amounts = new[] { new { lower_bound = minimumAmount } },
+            },
+            fields = RequestFields,
+            page,
+            limit = PageSize,
+            sort = "Award Amount",
+            order = "desc",
+            subawards = false,
+        };
+    }
+
+    private async Task<UsaSpendingAwardResponse> PostQuery(object body)
+    {
+        var json = JsonConvert.SerializeObject(body);
+        var content = await SendWithRetry(() =>
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, SearchUrl);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            return _httpClient.SendAsync(request);
+        });
+
+        return JsonConvert.DeserializeObject<UsaSpendingAwardResponse>(content)
+            ?? new UsaSpendingAwardResponse();
+    }
+
+    private async Task<string> SendWithRetry(Func<Task<HttpResponseMessage>> sendRequest)
+    {
+        for (var attempt = 0; attempt <= MaxRetries; attempt++)
+        {
+            await RateLimiter.WaitAsync();
+
+            using var response = await sendRequest();
+
+            if (response.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxRetries)
+            {
+                var delay = ExponentialBackoff(attempt);
+                _logger.LogWarning(
+                    "USAspending rate limited (429), retrying in {Delay}s (attempt {Attempt}/{Max})",
+                    delay.TotalSeconds,
+                    attempt + 1,
+                    MaxRetries
+                );
+                await Task.Delay(delay);
+                continue;
+            }
+
+            if ((int)response.StatusCode >= 500 && attempt < MaxRetries)
+            {
+                var delay = ExponentialBackoff(attempt);
+                _logger.LogWarning(
+                    "USAspending server error ({StatusCode}), retrying in {Delay}s (attempt {Attempt}/{Max})",
+                    (int)response.StatusCode,
+                    delay.TotalSeconds,
+                    attempt + 1,
+                    MaxRetries
+                );
+                await Task.Delay(delay);
+                continue;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        throw new HttpRequestException("Max retries exceeded for USAspending API request");
+    }
+
+    // Thin forwarder so reflection-based backoff tests can find the method.
+    private static TimeSpan ExponentialBackoff(int attempt) => RetryBackoff.Exponential(attempt);
+
+    // USAspending expects Gregorian ISO dates; InvariantCulture keeps the format
+    // stable on non-Gregorian threads.
+    private static string FormatDate(DateOnly date) =>
+        date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+}

--- a/src/Equibles.Migrations/DesignTimeDbContextFactory.cs
+++ b/src/Equibles.Migrations/DesignTimeDbContextFactory.cs
@@ -7,6 +7,7 @@ using Equibles.Errors.Data;
 using Equibles.FdaCatalysts.Data;
 using Equibles.Finra.Data;
 using Equibles.Fred.Data;
+using Equibles.GovernmentContracts.Data;
 using Equibles.Holdings.Data;
 using Equibles.InsiderTrading.Data;
 using Equibles.Media.Data;
@@ -59,6 +60,7 @@ public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<EquiblesFi
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration(),
             new FdaCatalystsModuleConfiguration(),
+            new GovernmentContractsModuleConfiguration(),
             new SecModuleConfiguration(),
             new FinancialFactsModuleConfiguration(),
             new MediaModuleConfiguration(),

--- a/src/Equibles.Migrations/Equibles.Migrations.csproj
+++ b/src/Equibles.Migrations/Equibles.Migrations.csproj
@@ -22,5 +22,6 @@
     <ProjectReference Include="..\Equibles.FdaCatalysts.Data\Equibles.FdaCatalysts.Data.csproj" />
     <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Data\Equibles.Sec.FinancialFacts.Data.csproj" />
+    <ProjectReference Include="..\Equibles.GovernmentContracts.Data\Equibles.GovernmentContracts.Data.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Equibles.Migrations/Migrations/20260613084145_AddGovernmentContracts.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260613084145_AddGovernmentContracts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613084145_AddGovernmentContracts")]
+    partial class AddGovernmentContracts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -251,10 +254,6 @@ namespace Equibles.Migrations.Migrations
                         .HasMaxLength(2000)
                         .HasColumnType("character varying(2000)");
 
-                    b.Property<string>("EntityType")
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
-
                     b.Property<int?>("FiscalYearEndDay")
                         .HasColumnType("integer");
 
@@ -270,9 +269,6 @@ namespace Equibles.Migrations.Migrations
                     b.Property<string>("InvestorRelationsUrl")
                         .HasMaxLength(256)
                         .HasColumnType("character varying(256)");
-
-                    b.Property<DateTime?>("IrContentScrapedAt")
-                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("IrPlatformType")
                         .HasColumnType("integer");
@@ -292,10 +288,6 @@ namespace Equibles.Migrations.Migrations
 
                     b.Property<long>("SharesOutStanding")
                         .HasColumnType("bigint");
-
-                    b.Property<string>("Sic")
-                        .HasMaxLength(8)
-                        .HasColumnType("character varying(8)");
 
                     b.Property<string>("Ticker")
                         .HasMaxLength(16)
@@ -321,6 +313,126 @@ namespace Equibles.Migrations.Migrations
                         .IsUnique();
 
                     b.ToTable("CommonStock");
+                });
+
+            modelBuilder.Entity("Equibles.CommonStocks.Data.Models.EarningsCalendarEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CommonStockId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreationTime")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("FiscalQuarter")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("FiscalYear")
+                        .HasColumnType("integer");
+
+                    b.Property<bool>("IsConfirmed")
+                        .HasColumnType("boolean");
+
+                    b.Property<DateOnly>("ScheduledDate")
+                        .HasColumnType("date");
+
+                    b.Property<int>("Source")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Url")
+                        .HasMaxLength(1024)
+                        .HasColumnType("character varying(1024)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ScheduledDate");
+
+                    b.HasIndex("CommonStockId", "FiscalYear", "FiscalQuarter")
+                        .IsUnique();
+
+                    b.ToTable("EarningsCalendarEntry");
+                });
+
+            modelBuilder.Entity("Equibles.CommonStocks.Data.Models.IrEvent", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CommonStockId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreationTime")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("Source")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTime>("StartDateTime")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Title")
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
+
+                    b.Property<int>("Type")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Url")
+                        .HasMaxLength(1024)
+                        .HasColumnType("character varying(1024)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CommonStockId", "StartDateTime");
+
+                    b.HasIndex("CommonStockId", "StartDateTime", "Title")
+                        .IsUnique();
+
+                    b.ToTable("IrEvent");
+                });
+
+            modelBuilder.Entity("Equibles.CommonStocks.Data.Models.IrNewsItem", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CommonStockId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreationTime")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<DateTime>("PublishedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("Source")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Summary")
+                        .HasMaxLength(4000)
+                        .HasColumnType("character varying(4000)");
+
+                    b.Property<string>("Title")
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
+
+                    b.Property<string>("Url")
+                        .HasMaxLength(1024)
+                        .HasColumnType("character varying(1024)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CommonStockId", "PublishedAt");
+
+                    b.HasIndex("CommonStockId", "Url")
+                        .IsUnique();
+
+                    b.ToTable("IrNewsItem");
                 });
 
             modelBuilder.Entity("Equibles.CommonStocks.Data.Models.Taxonomies.Industry", b =>
@@ -546,60 +658,6 @@ namespace Equibles.Migrations.Migrations
                     b.HasIndex("Source");
 
                     b.ToTable("Errors");
-                });
-
-            modelBuilder.Entity("Equibles.FdaCatalysts.Data.Models.FdaCatalyst", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<int>("CatalystType")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("Center")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<Guid?>("CommonStockId")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreationTime")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<DateOnly?>("EndDate")
-                        .HasColumnType("date");
-
-                    b.Property<DateOnly>("MeetingDate")
-                        .HasColumnType("date");
-
-                    b.Property<string>("SourceReference")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
-
-                    b.Property<string>("SourceUrl")
-                        .HasColumnType("text");
-
-                    b.Property<string>("Summary")
-                        .HasColumnType("text");
-
-                    b.Property<string>("Title")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CommonStockId");
-
-                    b.HasIndex("MeetingDate");
-
-                    b.HasIndex("SourceReference")
-                        .IsUnique();
-
-                    b.HasIndex("CatalystType", "MeetingDate");
-
-                    b.ToTable("FdaCatalyst");
                 });
 
             modelBuilder.Entity("Equibles.Finra.Data.Models.DailyShortVolume", b =>
@@ -1057,45 +1115,6 @@ namespace Equibles.Migrations.Migrations
                     b.ToTable("HolderQuarterlySnapshot");
                 });
 
-            modelBuilder.Entity("Equibles.Holdings.Data.Models.HoldingsReconciliationLog", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreationTime")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Details")
-                        .HasColumnType("text");
-
-                    b.Property<string>("HolderCik")
-                        .HasColumnType("text");
-
-                    b.Property<string>("HolderName")
-                        .HasColumnType("text");
-
-                    b.Property<Guid>("InstitutionalHolderId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int>("Outcome")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("QuartersReingested")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("TriggeredBy")
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CreationTime");
-
-                    b.HasIndex("InstitutionalHolderId");
-
-                    b.ToTable("HoldingsReconciliationLog");
-                });
-
             modelBuilder.Entity("Equibles.Holdings.Data.Models.InstitutionalFiling", b =>
                 {
                     b.Property<Guid>("Id")
@@ -1132,9 +1151,9 @@ namespace Equibles.Migrations.Migrations
                     b.HasIndex("AccessionNumber")
                         .IsUnique();
 
-                    b.HasIndex("InstitutionalHolderId");
+                    b.HasIndex("FilingDate");
 
-                    b.HasIndex("FilingDate", "AccessionNumber");
+                    b.HasIndex("InstitutionalHolderId");
 
                     b.ToTable("InstitutionalFiling");
                 });
@@ -1280,7 +1299,7 @@ namespace Equibles.Migrations.Migrations
 
                     b.HasIndex("InstitutionalHolderId", "ReportDate");
 
-                    NpgsqlIndexBuilderExtensions.IncludeProperties(b.HasIndex("InstitutionalHolderId", "ReportDate"), new[] { "CommonStockId", "Value", "Shares", "FilingDate" });
+                    NpgsqlIndexBuilderExtensions.IncludeProperties(b.HasIndex("InstitutionalHolderId", "ReportDate"), new[] { "CommonStockId", "Value", "Shares" });
 
                     b.HasIndex("ReportDate", "CommonStockId", "InstitutionalHolderId");
 
@@ -1656,9 +1675,6 @@ namespace Equibles.Migrations.Migrations
                         .HasColumnType("boolean");
 
                     b.Property<bool?>("IsPriceValid")
-                        .HasColumnType("boolean");
-
-                    b.Property<bool?>("IsRule10b5One")
                         .HasColumnType("boolean");
 
                     b.PrimitiveCollection<List<string>>("Notes")
@@ -2181,82 +2197,6 @@ namespace Equibles.Migrations.Migrations
                     b.ToTable("FormDRelatedPerson");
                 });
 
-            modelBuilder.Entity("Equibles.Sec.Data.Models.FundSeries", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid?>("CommonStockId")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("ComputedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("FundType")
-                        .HasMaxLength(16)
-                        .HasColumnType("character varying(16)");
-
-                    b.Property<string>("IdentityKey")
-                        .IsRequired()
-                        .HasMaxLength(80)
-                        .HasColumnType("character varying(80)");
-
-                    b.Property<DateOnly>("LatestFilingDate")
-                        .HasColumnType("date");
-
-                    b.Property<DateOnly>("LatestReportPeriodDate")
-                        .HasColumnType("date");
-
-                    b.Property<decimal>("NetAssets")
-                        .HasColumnType("numeric");
-
-                    b.Property<int>("PositionCount")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("RegistrantCik")
-                        .HasMaxLength(16)
-                        .HasColumnType("character varying(16)");
-
-                    b.Property<string>("RegistrantName")
-                        .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
-
-                    b.Property<string>("SeriesId")
-                        .IsRequired()
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
-
-                    b.Property<string>("SeriesName")
-                        .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
-
-                    b.Property<string>("Slug")
-                        .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
-
-                    b.Property<string>("Ticker")
-                        .HasMaxLength(16)
-                        .HasColumnType("character varying(16)");
-
-                    b.Property<decimal>("TotalAssets")
-                        .HasColumnType("numeric");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CommonStockId");
-
-                    b.HasIndex("IdentityKey")
-                        .IsUnique();
-
-                    b.HasIndex("Slug")
-                        .IsUnique();
-
-                    b.HasIndex("RegistrantCik", "SeriesId");
-
-                    b.ToTable("FundSeries");
-                });
-
             modelBuilder.Entity("Equibles.Sec.Data.Models.NCenFiling", b =>
                 {
                     b.Property<Guid>("Id")
@@ -2367,7 +2307,7 @@ namespace Equibles.Migrations.Migrations
                         .HasMaxLength(32)
                         .HasColumnType("character varying(32)");
 
-                    b.Property<Guid?>("CommonStockId")
+                    b.Property<Guid>("CommonStockId")
                         .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreationTime")
@@ -2387,10 +2327,6 @@ namespace Equibles.Migrations.Migrations
 
                     b.Property<int>("ParserVersion")
                         .HasColumnType("integer");
-
-                    b.Property<string>("RegistrantCik")
-                        .HasMaxLength(16)
-                        .HasColumnType("character varying(16)");
 
                     b.Property<string>("RegistrantName")
                         .HasMaxLength(512)
@@ -2431,8 +2367,6 @@ namespace Equibles.Migrations.Migrations
                     b.HasIndex("FilingDate");
 
                     b.HasIndex("ParserVersion");
-
-                    b.HasIndex("RegistrantCik");
 
                     b.HasIndex("CommonStockId", "FilingDate");
 
@@ -2504,31 +2438,9 @@ namespace Equibles.Migrations.Migrations
 
                     b.HasIndex("Cusip");
 
-                    b.HasIndex("NportFilingId", "ValueUsd");
+                    b.HasIndex("NportFilingId");
 
                     b.ToTable("NportHolding");
-                });
-
-            modelBuilder.Entity("Equibles.Sec.Data.Models.ProcessedNportFiling", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("AccessionNumber")
-                        .IsRequired()
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
-
-                    b.Property<DateTime>("CreationTime")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("AccessionNumber")
-                        .IsUnique();
-
-                    b.ToTable("ProcessedNportFiling");
                 });
 
             modelBuilder.Entity("Equibles.Sec.Data.Models.TranscriptCheckStatus", b =>
@@ -2791,6 +2703,39 @@ namespace Equibles.Migrations.Migrations
                         .HasForeignKey("IndustryId");
 
                     b.Navigation("Industry");
+                });
+
+            modelBuilder.Entity("Equibles.CommonStocks.Data.Models.EarningsCalendarEntry", b =>
+                {
+                    b.HasOne("Equibles.CommonStocks.Data.Models.CommonStock", "CommonStock")
+                        .WithMany()
+                        .HasForeignKey("CommonStockId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("CommonStock");
+                });
+
+            modelBuilder.Entity("Equibles.CommonStocks.Data.Models.IrEvent", b =>
+                {
+                    b.HasOne("Equibles.CommonStocks.Data.Models.CommonStock", "CommonStock")
+                        .WithMany()
+                        .HasForeignKey("CommonStockId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("CommonStock");
+                });
+
+            modelBuilder.Entity("Equibles.CommonStocks.Data.Models.IrNewsItem", b =>
+                {
+                    b.HasOne("Equibles.CommonStocks.Data.Models.CommonStock", "CommonStock")
+                        .WithMany()
+                        .HasForeignKey("CommonStockId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("CommonStock");
                 });
 
             modelBuilder.Entity("Equibles.CommonStocks.Data.Models.Taxonomies.Industry", b =>
@@ -3163,7 +3108,9 @@ namespace Equibles.Migrations.Migrations
                 {
                     b.HasOne("Equibles.CommonStocks.Data.Models.CommonStock", "CommonStock")
                         .WithMany()
-                        .HasForeignKey("CommonStockId");
+                        .HasForeignKey("CommonStockId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
                     b.Navigation("CommonStock");
                 });

--- a/src/Equibles.Migrations/Migrations/20260613084145_AddGovernmentContracts.cs
+++ b/src/Equibles.Migrations/Migrations/20260613084145_AddGovernmentContracts.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGovernmentContracts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GovernmentContract",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AwardUniqueKey = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    AwardId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    RecipientName = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    RecipientId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    AwardType = table.Column<int>(type: "integer", nullable: false),
+                    AwardingAgency = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Amount = table.Column<decimal>(type: "numeric", nullable: false),
+                    TotalOutlays = table.Column<decimal>(type: "numeric", nullable: true),
+                    ActionDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    EndDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    LastModifiedDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    NaicsCode = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: true),
+                    PscCode = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: true),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GovernmentContract", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_GovernmentContract_CommonStock_CommonStockId",
+                        column: x => x.CommonStockId,
+                        principalTable: "CommonStock",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GovernmentContract_ActionDate",
+                table: "GovernmentContract",
+                column: "ActionDate");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GovernmentContract_AwardUniqueKey",
+                table: "GovernmentContract",
+                column: "AwardUniqueKey",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GovernmentContract_CommonStockId_ActionDate",
+                table: "GovernmentContract",
+                columns: new[] { "CommonStockId", "ActionDate" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GovernmentContract");
+        }
+    }
+}

--- a/tests/Equibles.FunctionalTests/Fixtures/McpServerAppFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/McpServerAppFixture.cs
@@ -8,6 +8,7 @@ using Equibles.Errors.Data;
 using Equibles.FdaCatalysts.Data;
 using Equibles.Finra.Data;
 using Equibles.Fred.Data;
+using Equibles.GovernmentContracts.Data;
 using Equibles.Holdings.Data;
 using Equibles.InsiderTrading.Data;
 using Equibles.Mcp.Server;
@@ -206,6 +207,7 @@ public class McpServerAppFixture : IAsyncLifetime
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration(),
             new FdaCatalystsModuleConfiguration(),
+            new GovernmentContractsModuleConfiguration(),
             new SecModuleConfiguration(),
             new FinancialFactsModuleConfiguration(),
             new MediaModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
+++ b/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
@@ -88,6 +88,7 @@
     <ProjectReference Include="..\..\src\Equibles.Cboe.Repositories\Equibles.Cboe.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.FdaCatalysts.Data\Equibles.FdaCatalysts.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.FdaCatalysts.Repositories\Equibles.FdaCatalysts.Repositories.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.GovernmentContracts.Data\Equibles.GovernmentContracts.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.Cboe\Equibles.Integrations.Cboe.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.Cftc\Equibles.Integrations.Cftc.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cftc.HostedService\Equibles.Cftc.HostedService.csproj" />

--- a/tests/Equibles.IntegrationTests/Helpers/ParadeDbFixture.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/ParadeDbFixture.cs
@@ -7,6 +7,7 @@ using Equibles.Errors.Data;
 using Equibles.FdaCatalysts.Data;
 using Equibles.Finra.Data;
 using Equibles.Fred.Data;
+using Equibles.GovernmentContracts.Data;
 using Equibles.Holdings.Data;
 using Equibles.InsiderTrading.Data;
 using Equibles.Media.Data;
@@ -129,6 +130,7 @@ public class ParadeDbFixture : IAsyncLifetime
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration(),
             new FdaCatalystsModuleConfiguration(),
+            new GovernmentContractsModuleConfiguration(),
             new SecModuleConfiguration(),
             new FinancialFactsModuleConfiguration(),
             new MediaModuleConfiguration(),

--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -54,6 +54,9 @@
     <ProjectReference Include="..\..\src\Equibles.Media.Data\Equibles.Media.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Media.BusinessLogic\Equibles.Media.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Congress.HostedService\Equibles.Congress.HostedService.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.GovernmentContracts.Data\Equibles.GovernmentContracts.Data.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.GovernmentContracts.HostedService\Equibles.GovernmentContracts.HostedService.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.Integrations.GovernmentContracts\Equibles.Integrations.GovernmentContracts.csproj" />
     <ProjectReference Include="..\..\src\Equibles.InsiderTrading.Repositories\Equibles.InsiderTrading.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.InsiderTrading.BusinessLogic\Equibles.InsiderTrading.BusinessLogic.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Sec.Repositories\Equibles.Sec.Repositories.csproj" />

--- a/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/RecipientNameNormalizerTests.cs
@@ -1,0 +1,46 @@
+using Equibles.GovernmentContracts.HostedService.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+public class RecipientNameNormalizerTests
+{
+    [Theory]
+    [InlineData("Lockheed Martin Corporation", "LOCKHEED MARTIN")]
+    [InlineData("Lockheed Martin Corp", "LOCKHEED MARTIN")]
+    [InlineData("Lockheed Martin Corp.", "LOCKHEED MARTIN")]
+    [InlineData("The Boeing Company", "BOEING")]
+    [InlineData("Raytheon Technologies, Inc.", "RAYTHEON TECHNOLOGIES")]
+    [InlineData("Raytheon Technologies", "RAYTHEON TECHNOLOGIES")]
+    [InlineData("International Business Machines Corporation", "INTERNATIONAL BUSINESS MACHINES")]
+    public void Normalize_strips_suffixes_punctuation_and_leading_the(string input, string expected)
+    {
+        RecipientNameNormalizer.Normalize(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Two_legal_forms_of_the_same_name_collapse_to_one_key()
+    {
+        var a = RecipientNameNormalizer.Normalize("Lockheed Martin Corporation");
+        var b = RecipientNameNormalizer.Normalize("LOCKHEED MARTIN CORP");
+        a.Should().Be(b);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Inc")]
+    [InlineData("Co")]
+    public void Normalize_returns_null_for_empty_or_suffix_only_input(string input)
+    {
+        RecipientNameNormalizer.Normalize(input).Should().BeNull();
+    }
+
+    [Fact]
+    public void Multiple_trailing_suffixes_are_all_stripped()
+    {
+        RecipientNameNormalizer.Normalize("Acme Holdings Co LLC").Should().Be("ACME HOLDINGS");
+    }
+}

--- a/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardMapperTests.cs
+++ b/tests/Equibles.UnitTests/GovernmentContracts/UsaSpendingAwardMapperTests.cs
@@ -1,0 +1,100 @@
+using Equibles.GovernmentContracts.Data.Models;
+using Equibles.GovernmentContracts.HostedService.Services;
+using Equibles.Integrations.GovernmentContracts.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.GovernmentContracts;
+
+public class UsaSpendingAwardMapperTests
+{
+    private static UsaSpendingAwardRecord SampleRecord() =>
+        new()
+        {
+            GeneratedInternalId = "CONT_AWD_ABC123",
+            AwardId = "FA8675309",
+            RecipientName = "Lockheed Martin Corporation",
+            RecipientId = "abc-hash-C",
+            Amount = 1_234_567.89m,
+            TotalOutlays = 500_000m,
+            AwardingAgency = "Department of Defense",
+            ContractAwardType = "DEFINITIVE CONTRACT",
+            StartDate = "2024-03-15",
+            EndDate = "2027-03-14",
+            LastModifiedDate = "2024-04-01",
+            Naics = "336411",
+            Psc = "1510",
+            Description = "AIRCRAFT COMPONENTS",
+        };
+
+    [Fact]
+    public void Map_projects_all_fields_for_a_resolved_company()
+    {
+        var stockId = Guid.NewGuid();
+
+        var entity = UsaSpendingAwardMapper.Map(SampleRecord(), stockId);
+
+        entity.Should().NotBeNull();
+        entity.CommonStockId.Should().Be(stockId);
+        entity.AwardUniqueKey.Should().Be("CONT_AWD_ABC123");
+        entity.AwardId.Should().Be("FA8675309");
+        entity.RecipientName.Should().Be("Lockheed Martin Corporation");
+        entity.AwardType.Should().Be(GovernmentContractAwardType.DefinitiveContract);
+        entity.Amount.Should().Be(1_234_567.89m);
+        entity.TotalOutlays.Should().Be(500_000m);
+        entity.ActionDate.Should().Be(new DateOnly(2024, 3, 15));
+        entity.EndDate.Should().Be(new DateOnly(2027, 3, 14));
+        entity.LastModifiedDate.Should().Be(new DateOnly(2024, 4, 1));
+        entity.NaicsCode.Should().Be("336411");
+        entity.PscCode.Should().Be("1510");
+        entity.Description.Should().Be("AIRCRAFT COMPONENTS");
+    }
+
+    [Fact]
+    public void Map_falls_back_to_award_id_when_generated_id_is_missing()
+    {
+        var record = SampleRecord();
+        record.GeneratedInternalId = null;
+
+        var entity = UsaSpendingAwardMapper.Map(record, Guid.NewGuid());
+
+        entity.Should().NotBeNull();
+        entity.AwardUniqueKey.Should().Be("FA8675309");
+    }
+
+    [Fact]
+    public void Map_returns_null_when_no_stable_identifier_exists()
+    {
+        var record = SampleRecord();
+        record.GeneratedInternalId = null;
+        record.AwardId = null;
+
+        UsaSpendingAwardMapper.Map(record, Guid.NewGuid()).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("BPA CALL", GovernmentContractAwardType.BpaCall)]
+    [InlineData("Purchase Order", GovernmentContractAwardType.PurchaseOrder)]
+    [InlineData("delivery order", GovernmentContractAwardType.DeliveryOrder)]
+    [InlineData("DEFINITIVE CONTRACT", GovernmentContractAwardType.DefinitiveContract)]
+    [InlineData("Cooperative Agreement", GovernmentContractAwardType.Unknown)]
+    [InlineData(null, GovernmentContractAwardType.Unknown)]
+    public void MapAwardType_maps_known_labels_case_insensitively(
+        string label,
+        GovernmentContractAwardType expected
+    )
+    {
+        UsaSpendingAwardMapper.MapAwardType(label).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Map_keeps_only_the_leading_token_of_a_decorated_naics_value()
+    {
+        var record = SampleRecord();
+        record.Naics = "541512 | Computer Systems Design Services";
+
+        var entity = UsaSpendingAwardMapper.Map(record, Guid.NewGuid());
+
+        entity.NaicsCode.Should().Be("541512");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `GovernmentContracts` OSS module that ingests federal procurement contract awards from the public [USAspending.gov](https://api.usaspending.gov) award API and resolves each award to a public company in the `CommonStock` universe. This is the foundation for the commercial-tier government-contracts feature (EquiblesCommercial#2161).

The module follows the existing external-API data-module shape (Cftc/Congress): `Data` + `Repositories` + `Integrations` client + `HostedService` scraper + `Mcp` tools.

## What's included

- **Data** — `GovernmentContract` entity (recipient, awarding agency, amount, period dates, NAICS/PSC, description) keyed to `CommonStock`, an award-type enum (A/B/C/D), module configuration, and the migration.
- **Integrations** — `UsaSpendingClient`, a paginated `POST /api/v2/search/spending_by_award/` client (rate-limited, retrying).
- **HostedService** — an incremental scraper that sweeps awards by action-date window (≥ a configurable material-amount floor), resolves the recipient to a public company via an **exact normalised-name match**, and persists **only** awards that resolve. Ambiguous names (one key → multiple stocks) are dropped, so a wrong link is never asserted.
- **Mcp** — `GetGovernmentContracts` (per company) and `GetTopGovernmentContractors` (leaderboard by total awarded).
- **Tests** — unit coverage for the recipient normalizer and the award→entity mapper.

## Notes

- The module is inert until a host wires it (`AddGovernmentContractsWorker()` / `mcp.AddGovernmentContracts()` / module registration); commercial hosts consume it. No OSS host behaviour changes.
- Recipient resolution is direct-name only for now (subsidiary→parent rollup is a future refinement); it favours precision over recall, in line with the data-accuracy bar.

A.L.V.I.S.
