### PR TITLE
feat(insider-trading): capture the Form 4 Rule 10b5-1 checkbox

### DIFF
--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
@@ -37,11 +37,17 @@ public static class InsiderFilingParser
         var transactions = new List<InsiderTransaction>();
         var footnotes = BuildFootnotes(root);
 
+        // The Rule 10b5-1 affirmative-defense checkbox is a single document-level
+        // element, so it applies to every row this filing contributes — stamp it
+        // on each as they are added.
+        var rule10b5One = ParseRule10b5One(root);
+
         void AddParsed(InsiderTransaction tx)
         {
             if (tx == null)
                 return;
             tx.TransactionOrder = transactions.Count;
+            tx.IsRule10b5One = rule10b5One;
             transactions.Add(tx);
         }
 
@@ -113,6 +119,17 @@ public static class InsiderFilingParser
     // holds none of the issuer's securities; both ownership tables are then empty.
     internal static bool DeclaresNoSecuritiesOwned(XElement root) =>
         ParseBool(root.Element("noSecuritiesOwned")?.Value);
+
+    // The Rule 10b5-1(c) affirmative-defense checkbox (<aff10b5One>), added to the
+    // ownership schema in EDGAR 23.1 (2023). A direct value element on the document
+    // root — not wrapped in <value> like the transaction fields. Tri-state: absent
+    // (pre-2023 schema) returns null so "unknown" stays distinct from an explicit
+    // unchecked box (0 → false).
+    internal static bool? ParseRule10b5One(XElement root)
+    {
+        var element = root.Element("aff10b5One");
+        return element == null ? null : ParseBool(element.Value);
+    }
 
     // The 0-shares row recorded for a noSecuritiesOwned Form 3 — the owner's zero
     // baseline. No security exists to classify, so SecurityKind stays Unknown; the

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -24,9 +24,10 @@ public class InsiderTransaction
     /// History: v1 added SecurityKind; v2 added <see cref="Notes"/> (footnotes);
     /// v3 restates per-ADS prices on ADS/ADR rows to per-ordinary so Shares ×
     /// PricePerShare is a real value (re-evaluated from the footnotes — see
-    /// <see cref="ReportedPricePerShare"/>).
+    /// <see cref="ReportedPricePerShare"/>); v4 captures the Rule 10b5-1
+    /// affirmative-defense checkbox into <see cref="IsRule10b5One"/>.
     /// </summary>
-    public const int CurrentParserVersion = 3;
+    public const int CurrentParserVersion = 4;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 
@@ -101,6 +102,24 @@ public class InsiderTransaction
     /// Empty when the filing annotated nothing. Stored as a Postgres array.
     /// </summary>
     public List<string> Notes { get; set; } = [];
+
+    /// <summary>
+    /// Whether this transaction was made pursuant to a Rule 10b5-1(c) trading
+    /// plan, from the affirmative-defense checkbox the SEC added to Form 4/5 in
+    /// 2023 (the <c>aff10b5One</c> element). The checkbox is a single
+    /// document-level flag — one Form 4 can report several transactions, and the
+    /// box asserts the affirmative defense for the filing as a whole — so every
+    /// row parsed from the same filing carries the same value; the per-trade
+    /// detail lives in the footnotes, which are not machine-classified.
+    /// <list type="bullet">
+    /// <item><c>true</c> — the box is checked: a pre-planned, automatic trade.</item>
+    /// <item><c>false</c> — the box is present and unchecked.</item>
+    /// <item><c>null</c> — the filing predates the checkbox (schema older than
+    /// EDGAR 23.1) or otherwise omits the element, so pre-planned status is
+    /// unknown rather than negative.</item>
+    /// </list>
+    /// </summary>
+    public bool? IsRule10b5One { get; set; }
 
     /// <summary>
     /// Tri-state price-plausibility flag, cross-checked against the Yahoo

--- a/src/Equibles.Migrations/Migrations/20260613140204_AddInsiderTransactionRule10b5One.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260613140204_AddInsiderTransactionRule10b5One.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613140204_AddInsiderTransactionRule10b5One")]
+    partial class AddInsiderTransactionRule10b5One
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260613140204_AddInsiderTransactionRule10b5One.cs
+++ b/src/Equibles.Migrations/Migrations/20260613140204_AddInsiderTransactionRule10b5One.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInsiderTransactionRule10b5One : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsRule10b5One",
+                table: "InsiderTransaction",
+                type: "boolean",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsRule10b5One",
+                table: "InsiderTransaction");
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserRule10b5OneTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingParserRule10b5OneTests.cs
@@ -1,0 +1,105 @@
+using System.Xml.Linq;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+// The Rule 10b5-1(c) affirmative-defense checkbox the SEC added to Form 4/5 in 2023
+// is the document-level <aff10b5One> element. It is a single per-filing flag, so every
+// row a filing contributes must carry the same value, and an absent element (pre-2023
+// schema) must stay null so "unknown" is distinct from an explicit unchecked box.
+public class InsiderFilingParserRule10b5OneTests
+{
+    private static List<InsiderTransaction> ParseAll(XElement root)
+    {
+        var owner = new InsiderOwner { OwnerCik = "0000000001", Name = "Owner" };
+        var filing = new FilingData
+        {
+            AccessionNumber = "0000000000-26-000001",
+            Form = "4",
+            FilingDate = new DateOnly(2026, 1, 5),
+            ReportDate = new DateOnly(2026, 1, 2),
+        };
+        return InsiderFilingParser.ParseTransactions(root, owner, Guid.NewGuid(), filing, false);
+    }
+
+    private static XElement Transaction(string code) =>
+        new(
+            "nonDerivativeTransaction",
+            new XElement("securityTitle", new XElement("value", "Common Stock")),
+            new XElement("transactionDate", new XElement("value", "2026-01-02")),
+            new XElement("transactionCoding", new XElement("transactionCode", code)),
+            new XElement(
+                "transactionAmounts",
+                new XElement("transactionShares", new XElement("value", "1000")),
+                new XElement("transactionPricePerShare", new XElement("value", "10"))
+            )
+        );
+
+    [Fact]
+    public void ParseTransactions_RealFilingWithBoxChecked_FlagsEveryRowTrue()
+    {
+        // A real Form 4 (Dutch Bros, accession 0001866581-25-000077) with the Rule
+        // 10b5-1 box checked and 14 plan sales — locks the element name and position
+        // against the live ownership schema, not a hand-built approximation.
+        var xml = File.ReadAllText(
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "TestAssets",
+                "InsiderTrading",
+                "form4-rule10b5one-checked.xml"
+            )
+        );
+        var root = InsiderFilingParser.TryGetOwnershipRoot(xml);
+
+        var transactions = ParseAll(root);
+
+        transactions.Should().HaveCount(14);
+        transactions.Should().OnlyContain(t => t.IsRule10b5One == true);
+    }
+
+    [Fact]
+    public void ParseTransactions_BoxPresentUnchecked_FlagsRowsFalse()
+    {
+        var root = new XElement(
+            "ownershipDocument",
+            new XElement("nonDerivativeTable", Transaction("S")),
+            new XElement("aff10b5One", "0")
+        );
+
+        var transactions = ParseAll(root);
+
+        transactions.Should().ContainSingle();
+        transactions[0].IsRule10b5One.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseTransactions_BoxAbsent_FlagIsNull()
+    {
+        var root = new XElement(
+            "ownershipDocument",
+            new XElement("nonDerivativeTable", Transaction("P"))
+        );
+
+        var transactions = ParseAll(root);
+
+        transactions.Should().ContainSingle();
+        transactions[0].IsRule10b5One.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseTransactions_BoxChecked_AppliesToEveryRowInTheFiling()
+    {
+        var root = new XElement(
+            "ownershipDocument",
+            new XElement("nonDerivativeTable", Transaction("S"), Transaction("S")),
+            new XElement("aff10b5One", "1")
+        );
+
+        var transactions = ParseAll(root);
+
+        transactions.Should().HaveCount(2);
+        transactions.Should().OnlyContain(t => t.IsRule10b5One == true);
+    }
+}

--- a/tests/Equibles.UnitTests/TestAssets/InsiderTrading/form4-rule10b5one-checked.xml
+++ b/tests/Equibles.UnitTests/TestAssets/InsiderTrading/form4-rule10b5one-checked.xml
@@ -1,0 +1,627 @@
+<?xml version="1.0"?>
+<ownershipDocument>
+
+    <schemaVersion>X0508</schemaVersion>
+
+    <documentType>4</documentType>
+
+    <periodOfReport>2025-02-25</periodOfReport>
+
+    <notSubjectToSection16>0</notSubjectToSection16>
+
+    <issuer>
+        <issuerCik>0001866581</issuerCik>
+        <issuerName>Dutch Bros Inc.</issuerName>
+        <issuerTradingSymbol>BROS</issuerTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0001883154</rptOwnerCik>
+            <rptOwnerName>Boersma Travis</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerStreet1>C/O DUTCH BROS INC.</rptOwnerStreet1>
+            <rptOwnerStreet2>PO BOX 1929</rptOwnerStreet2>
+            <rptOwnerCity>GRANTS PASS</rptOwnerCity>
+            <rptOwnerState>OR</rptOwnerState>
+            <rptOwnerZipCode>97528</rptOwnerZipCode>
+            <rptOwnerStateDescription></rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>1</isDirector>
+            <isOfficer>1</isOfficer>
+            <isTenPercentOwner>1</isTenPercentOwner>
+            <isOther>0</isOther>
+            <officerTitle>Executive Chairman of Board</officerTitle>
+            <otherText></otherText>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <aff10b5One>1</aff10b5One>
+
+    <nonDerivativeTable>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-25</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F1"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>177098</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>72.854</value>
+                    <footnoteId id="F2"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>4022003</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Trust Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-25</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F1"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>43073</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>73.5652</value>
+                    <footnoteId id="F4"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>3978930</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Trust Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-25</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F1"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>14448</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>74.7161</value>
+                    <footnoteId id="F5"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>3964482</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Trust Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-25</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F1"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>432</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>75.2289</value>
+                    <footnoteId id="F6"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>3964050</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Trust Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-25</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F7"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>111376</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>72.854</value>
+                    <footnoteId id="F2"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>2529403</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Individual Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-25</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F7"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>27087</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>73.5652</value>
+                    <footnoteId id="F4"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>2502316</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Individual Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-25</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F7"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>9087</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>74.716</value>
+                    <footnoteId id="F5"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>2493229</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Individual Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-25</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F7"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>272</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>75.229</value>
+                    <footnoteId id="F6"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>2492957</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Individual Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-26</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F1"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>56147</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>74.9862</value>
+                    <footnoteId id="F8"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>3907903</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Trust Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-26</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F1"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>109646</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>75.5356</value>
+                    <footnoteId id="F9"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>3798257</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Trust Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-26</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F1"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>123802</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>76.6714</value>
+                    <footnoteId id="F10"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>3674455</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Trust Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-26</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F7"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>35310</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>74.9862</value>
+                    <footnoteId id="F8"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>2457647</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Individual Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-26</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F7"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>68956</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>75.5356</value>
+                    <footnoteId id="F9"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>2388691</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Individual Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Class A Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2025-02-26</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+                <footnoteId id="F7"/>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>77857</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>76.6714</value>
+                    <footnoteId id="F10"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>2310834</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By DM Individual Aggregator, LLC</value>
+                    <footnoteId id="F3"/>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+    </nonDerivativeTable>
+
+    <derivativeTable></derivativeTable>
+
+    <footnotes>
+        <footnote id="F1">As indicated by the checkbox above, this transaction was effected automatically pursuant to a Rule 10b5-1 trading plan adopted by DM Trust Aggregator, LLC on November 22, 2024.</footnote>
+        <footnote id="F2">Represents the weighted average sale price. These shares were sold in multiple transactions at prices ranging from $72.1600 to $73.1500 inclusive. The reporting person undertakes to provide the Issuer, any security holder of the Issuer, or the staff of the Securities and Exchange Commission, upon request, full information regarding the number of shares sold at each separate price within the range set forth above.</footnote>
+        <footnote id="F3">The Reporting Person is the manager of DM Trust Aggregator, LLC and DM Individual Aggregator, LLC (the &quot;DM Trusts&quot;). Multiple members hold ownership interests in the DM Trusts, including the Reporting Person. The Reporting Person disclaims beneficial ownership of the reported securities except to the extent of his pecuniary interest therein, if any, and the inclusion of the reported securities in this report shall not be deemed an admission of beneficial ownership of all of the reported securities for purposes of Section 16 of the Securities Exchange Act of 1934, as amended, or any other purpose.</footnote>
+        <footnote id="F4">Represents the weighted average sale price. These shares were sold in multiple transactions at prices ranging from $73.1600 to $74.1500 inclusive. The reporting person undertakes to provide the Issuer, any security holder of the Issuer, or the staff of the Securities and Exchange Commission, upon request, full information regarding the number of shares sold at each separate price within the range set forth above.</footnote>
+        <footnote id="F5">Represents the weighted average sale price. These shares were sold in multiple transactions at prices ranging from $74.1800 to $75.1250 inclusive. The reporting person undertakes to provide the Issuer, any security holder of the Issuer, or the staff of the Securities and Exchange Commission, upon request, full information regarding the number of shares sold at each separate price within the range set forth above.</footnote>
+        <footnote id="F6">Represents the weighted average sale price. These shares were sold in multiple transactions at prices ranging from $75.2000 to $75.3000 inclusive. The reporting person undertakes to provide the Issuer, any security holder of the Issuer, or the staff of the Securities and Exchange Commission, upon request, full information regarding the number of shares sold at each separate price within the range set forth above.</footnote>
+        <footnote id="F7">As indicated by the checkbox above, this transaction was effected automatically pursuant to a Rule 10b5-1 trading plan adopted by DM Individual Aggregator, LLC on November 22, 2024.</footnote>
+        <footnote id="F8">Represents the weighted average sale price. These shares were sold in multiple transactions at prices ranging from $74.2500 to $75.2450 inclusive. The reporting person undertakes to provide the Issuer, any security holder of the Issuer, or the staff of the Securities and Exchange Commission, upon request, full information regarding the number of shares sold at each separate price within the range set forth above.</footnote>
+        <footnote id="F9">Represents the weighted average sale price. These shares were sold in multiple transactions at prices ranging from $75.2500 to $76.2400 inclusive. The reporting person undertakes to provide the Issuer, any security holder of the Issuer, or the staff of the Securities and Exchange Commission, upon request, full information regarding the number of shares sold at each separate price within the range set forth above.</footnote>
+        <footnote id="F10">Represents the weighted average sale price. These shares were sold in multiple transactions at prices ranging from $76.2500 to $77.1500 inclusive. The reporting person undertakes to provide the Issuer, any security holder of the Issuer, or the staff of the Securities and Exchange Commission, upon request, full information regarding the number of shares sold at each separate price within the range set forth above.</footnote>
+    </footnotes>
+
+    <remarks></remarks>
+
+    <ownerSignature>
+        <signatureName>/s/ Thomas P. Conaghan, Attorney-in-Fact for Travis Boersma</signatureName>
+        <signatureDate>2025-02-27</signatureDate>
+    </ownerSignature>
+</ownershipDocument>


### PR DESCRIPTION
## Summary

Form 4/5 gained a Rule 10b5-1(c) affirmative-defense checkbox in the 2023 ownership-schema update (EDGAR 23.1), but the parser never read it, so pre-planned automatic trades couldn't be told apart from organic open-market activity. This captures that checkbox.

The element is `<aff10b5One>` — a single document-level child of `ownershipDocument` (a sibling of `reportingOwner`/`nonDerivativeTable`), `1` when checked and `0` when present-and-unchecked. Because it is one per filing, every row a filing contributes carries the same value; the per-trade narrative lives in the footnotes, which are not machine-classified. Filings on a pre-2023 schema omit the element, so the new flag is a nullable `bool?` and stays `null` there — keeping "unknown" distinct from an explicit unchecked box.

I verified the element name and position against a real post-2023 Form 4 (Dutch Bros, accession 0001866581-25-000077, schemaVersion X0508) rather than the schema doc alone, and checked that filing in as a parser fixture.

Part of the commercial insider-sentiment follow-up daniel3303/EquiblesCommercial#3313 (excluding pre-planned trades from the sentiment score).

## Code changes

- `InsiderTransaction` — new nullable `IsRule10b5One` flag; `CurrentParserVersion` 3 → 4 so the existing version-driven reprocess re-reads it over the cached filing XML.
- `InsiderFilingParser` — `ParseRule10b5One(root)` reads the document-level `aff10b5One` (tri-state; absent → null), stamped onto every parsed row/holding.
- Migration — additive nullable `boolean` column on `InsiderTransaction`.
- Tests — a real-filing cassette (14 plan sales, all flagged) plus constructed unchecked → false and absent → null cases.