### PR TITLE
feat(fda-catalysts): add FDA catalyst data module and migration

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -167,6 +167,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Finra.BusinessLogi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.Integrations.Wikidata", "src\Equibles.Integrations.Wikidata\Equibles.Integrations.Wikidata.csproj", "{34598F2B-3BFA-46E6-9EE5-63816F78B959}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.Data", "src\Equibles.FdaCatalysts.Data\Equibles.FdaCatalysts.Data.csproj", "{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.Repositories", "src\Equibles.FdaCatalysts.Repositories\Equibles.FdaCatalysts.Repositories.csproj", "{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1137,6 +1141,30 @@ Global
 		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Release|x64.Build.0 = Release|Any CPU
 		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Release|x86.ActiveCfg = Release|Any CPU
 		{34598F2B-3BFA-46E6-9EE5-63816F78B959}.Release|x86.Build.0 = Release|Any CPU
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}.Debug|x64.Build.0 = Debug|Any CPU
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}.Debug|x86.Build.0 = Debug|Any CPU
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}.Release|x64.ActiveCfg = Release|Any CPU
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}.Release|x64.Build.0 = Release|Any CPU
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}.Release|x86.ActiveCfg = Release|Any CPU
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A}.Release|x86.Build.0 = Release|Any CPU
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Debug|x64.Build.0 = Debug|Any CPU
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Debug|x86.Build.0 = Debug|Any CPU
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Release|x64.ActiveCfg = Release|Any CPU
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Release|x64.Build.0 = Release|Any CPU
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Release|x86.ActiveCfg = Release|Any CPU
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1222,6 +1250,8 @@ Global
 		{7E757C1B-7801-4110-8C94-ACED64B36CAC} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{93D079ED-711C-47C9-9C12-513ADE703C9C} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{34598F2B-3BFA-46E6-9EE5-63816F78B959} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.FdaCatalysts.Data/Equibles.FdaCatalysts.Data.csproj
+++ b/src/Equibles.FdaCatalysts.Data/Equibles.FdaCatalysts.Data.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Data\Equibles.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.FdaCatalysts.Data/Extensions/ModuleBuilderExtensions.cs
+++ b/src/Equibles.FdaCatalysts.Data/Extensions/ModuleBuilderExtensions.cs
@@ -1,0 +1,11 @@
+using Equibles.Data;
+
+namespace Equibles.FdaCatalysts.Data.Extensions;
+
+public static class ModuleBuilderExtensions
+{
+    public static EquiblesModuleBuilder AddFdaCatalysts(this EquiblesModuleBuilder builder)
+    {
+        return builder.AddModule<FdaCatalystsModuleConfiguration>();
+    }
+}

--- a/src/Equibles.FdaCatalysts.Data/FdaCatalystsModuleConfiguration.cs
+++ b/src/Equibles.FdaCatalysts.Data/FdaCatalystsModuleConfiguration.cs
@@ -1,0 +1,12 @@
+using Equibles.FdaCatalysts.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.FdaCatalysts.Data;
+
+public class FdaCatalystsModuleConfiguration : Equibles.Data.IFinancialModule
+{
+    public void ConfigureEntities(ModelBuilder builder)
+    {
+        builder.Entity<FdaCatalyst>();
+    }
+}

--- a/src/Equibles.FdaCatalysts.Data/Models/FdaCatalyst.cs
+++ b/src/Equibles.FdaCatalysts.Data/Models/FdaCatalyst.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.FdaCatalysts.Data.Models;
+
+/// <summary>
+/// A scheduled FDA regulatory catalyst for a public company. Today this holds FDA
+/// advisory-committee (AdComm) meetings, with the type discriminator left open for
+/// PDUFA decisions and complete-response follow-ups once an authoritative source for
+/// those exists. AdComm meetings are sourced from the Federal Register, which publishes
+/// FDA advisory-committee meeting notices as structured documents.
+/// </summary>
+[Index(nameof(SourceReference), IsUnique = true)]
+[Index(nameof(CatalystType), nameof(MeetingDate))]
+[Index(nameof(MeetingDate))]
+[Index(nameof(CommonStockId))]
+public class FdaCatalyst
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public FdaCatalystType CatalystType { get; set; }
+
+    public DateOnly MeetingDate { get; set; }
+
+    [Required]
+    public string Committee { get; set; }
+
+    [Required]
+    public string Title { get; set; }
+
+    public string Summary { get; set; }
+
+    // The Federal Register document number — globally unique per notice, so it is the
+    // natural key that keeps re-imports of the same meeting idempotent.
+    [Required]
+    [MaxLength(64)]
+    public string SourceReference { get; set; }
+
+    public string SourceUrl { get; set; }
+
+    public DateOnly? PublicationDate { get; set; }
+
+    // Resolved to a CommonStock only when the notice's sponsor maps authoritatively
+    // (CIK / ticker), and left null otherwise — many sponsors are private, pre-IPO, or
+    // foreign and fall outside the tracked equity universe, so a soft reference avoids
+    // dropping catalysts we cannot tie to a ticker.
+    public Guid? CommonStockId { get; set; }
+
+    public DateTime CreationTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/Equibles.FdaCatalysts.Data/Models/FdaCatalystType.cs
+++ b/src/Equibles.FdaCatalysts.Data/Models/FdaCatalystType.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Equibles.FdaCatalysts.Data.Models;
+
+public enum FdaCatalystType
+{
+    [Display(Name = "Advisory Committee Meeting")]
+    AdvisoryCommittee,
+
+    [Display(Name = "PDUFA Decision")]
+    Pdufa,
+
+    [Display(Name = "Complete Response Follow-up")]
+    CompleteResponse,
+}

--- a/src/Equibles.FdaCatalysts.Repositories/Equibles.FdaCatalysts.Repositories.csproj
+++ b/src/Equibles.FdaCatalysts.Repositories/Equibles.FdaCatalysts.Repositories.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.FdaCatalysts.Data\Equibles.FdaCatalysts.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.FdaCatalysts.Repositories/FdaCatalystRepository.cs
+++ b/src/Equibles.FdaCatalysts.Repositories/FdaCatalystRepository.cs
@@ -1,0 +1,31 @@
+using Equibles.Data;
+using Equibles.Data.Extensions;
+using Equibles.FdaCatalysts.Data.Models;
+
+namespace Equibles.FdaCatalysts.Repositories;
+
+public class FdaCatalystRepository : BaseRepository<FdaCatalyst>
+{
+    public FdaCatalystRepository(EquiblesFinancialDbContext dbContext)
+        : base(dbContext) { }
+
+    public IQueryable<FdaCatalyst> GetUpcoming(DateOnly from)
+    {
+        return GetAll().Where(c => c.MeetingDate >= from);
+    }
+
+    public IQueryable<FdaCatalyst> GetByDateRange(DateOnly startDate, DateOnly endDate)
+    {
+        return GetAll().Where(c => c.MeetingDate >= startDate && c.MeetingDate <= endDate);
+    }
+
+    public IQueryable<FdaCatalyst> GetByStock(Guid commonStockId)
+    {
+        return GetAll().Where(c => c.CommonStockId == commonStockId);
+    }
+
+    public IQueryable<DateOnly> GetLatestMeetingDate()
+    {
+        return GetAll().LatestValue(c => c.MeetingDate);
+    }
+}

--- a/src/Equibles.Migrations/DesignTimeDbContextFactory.cs
+++ b/src/Equibles.Migrations/DesignTimeDbContextFactory.cs
@@ -4,6 +4,7 @@ using Equibles.CommonStocks.Data;
 using Equibles.Congress.Data;
 using Equibles.Data;
 using Equibles.Errors.Data;
+using Equibles.FdaCatalysts.Data;
 using Equibles.Finra.Data;
 using Equibles.Fred.Data;
 using Equibles.Holdings.Data;
@@ -57,6 +58,7 @@ public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<EquiblesFi
             new YahooModuleConfiguration(),
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration(),
+            new FdaCatalystsModuleConfiguration(),
             new SecModuleConfiguration(),
             new FinancialFactsModuleConfiguration(),
             new MediaModuleConfiguration(),

--- a/src/Equibles.Migrations/Equibles.Migrations.csproj
+++ b/src/Equibles.Migrations/Equibles.Migrations.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\Equibles.Yahoo.Data\Equibles.Yahoo.Data.csproj" />
     <ProjectReference Include="..\Equibles.Cftc.Data\Equibles.Cftc.Data.csproj" />
     <ProjectReference Include="..\Equibles.Cboe.Data\Equibles.Cboe.Data.csproj" />
+    <ProjectReference Include="..\Equibles.FdaCatalysts.Data\Equibles.FdaCatalysts.Data.csproj" />
     <ProjectReference Include="..\Equibles.Messaging\Equibles.Messaging.csproj" />
     <ProjectReference Include="..\Equibles.Sec.FinancialFacts.Data\Equibles.Sec.FinancialFacts.Data.csproj" />
   </ItemGroup>

--- a/src/Equibles.Migrations/Migrations/20260613215330_AddFdaCatalysts.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260613215330_AddFdaCatalysts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613215330_AddFdaCatalysts")]
+    partial class AddFdaCatalysts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260613215330_AddFdaCatalysts.cs
+++ b/src/Equibles.Migrations/Migrations/20260613215330_AddFdaCatalysts.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFdaCatalysts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FdaCatalyst",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CatalystType = table.Column<int>(type: "integer", nullable: false),
+                    MeetingDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    Committee = table.Column<string>(type: "text", nullable: false),
+                    Title = table.Column<string>(type: "text", nullable: false),
+                    Summary = table.Column<string>(type: "text", nullable: true),
+                    SourceReference = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    SourceUrl = table.Column<string>(type: "text", nullable: true),
+                    PublicationDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    CommonStockId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FdaCatalyst", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FdaCatalyst_CatalystType_MeetingDate",
+                table: "FdaCatalyst",
+                columns: new[] { "CatalystType", "MeetingDate" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FdaCatalyst_CommonStockId",
+                table: "FdaCatalyst",
+                column: "CommonStockId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FdaCatalyst_MeetingDate",
+                table: "FdaCatalyst",
+                column: "MeetingDate");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FdaCatalyst_SourceReference",
+                table: "FdaCatalyst",
+                column: "SourceReference",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FdaCatalyst");
+        }
+    }
+}

--- a/tests/Equibles.FunctionalTests/Fixtures/McpServerAppFixture.cs
+++ b/tests/Equibles.FunctionalTests/Fixtures/McpServerAppFixture.cs
@@ -5,6 +5,7 @@ using Equibles.CommonStocks.Data;
 using Equibles.Congress.Data;
 using Equibles.Data;
 using Equibles.Errors.Data;
+using Equibles.FdaCatalysts.Data;
 using Equibles.Finra.Data;
 using Equibles.Fred.Data;
 using Equibles.Holdings.Data;
@@ -204,6 +205,7 @@ public class McpServerAppFixture : IAsyncLifetime
             new YahooModuleConfiguration(),
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration(),
+            new FdaCatalystsModuleConfiguration(),
             new SecModuleConfiguration(),
             new FinancialFactsModuleConfiguration(),
             new MediaModuleConfiguration(),

--- a/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
+++ b/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
@@ -86,6 +86,8 @@
     <ProjectReference Include="..\..\src\Equibles.Cftc.Repositories\Equibles.Cftc.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cboe.Data\Equibles.Cboe.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cboe.Repositories\Equibles.Cboe.Repositories.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.FdaCatalysts.Data\Equibles.FdaCatalysts.Data.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.FdaCatalysts.Repositories\Equibles.FdaCatalysts.Repositories.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.Cboe\Equibles.Integrations.Cboe.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Integrations.Cftc\Equibles.Integrations.Cftc.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cftc.HostedService\Equibles.Cftc.HostedService.csproj" />

--- a/tests/Equibles.IntegrationTests/Helpers/ParadeDbFixture.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/ParadeDbFixture.cs
@@ -4,6 +4,7 @@ using Equibles.CommonStocks.Data;
 using Equibles.Congress.Data;
 using Equibles.Data;
 using Equibles.Errors.Data;
+using Equibles.FdaCatalysts.Data;
 using Equibles.Finra.Data;
 using Equibles.Fred.Data;
 using Equibles.Holdings.Data;
@@ -127,6 +128,7 @@ public class ParadeDbFixture : IAsyncLifetime
             new YahooModuleConfiguration(),
             new CftcModuleConfiguration(),
             new CboeModuleConfiguration(),
+            new FdaCatalystsModuleConfiguration(),
             new SecModuleConfiguration(),
             new FinancialFactsModuleConfiguration(),
             new MediaModuleConfiguration(),


### PR DESCRIPTION
## Summary

Slice 1 of 6 for the FDA / biotech catalyst calendar (daniel3303/EquiblesCommercial#2238) — does **not** close the issue.

Adds the `Equibles.FdaCatalysts` data + repositories module:

- **`FdaCatalyst`** entity — advisory-committee (AdComm) meetings now; the `FdaCatalystType` discriminator is left open for PDUFA and complete-response follow-ups once an authoritative source is chosen. `SourceReference` (Federal Register document number) is the unique natural key for idempotent re-imports; `CommonStockId` is a soft nullable reference (sponsors outside the tracked equity universe stay null).
- **`IFinancialModule`** registration + `AddFdaCatalysts` builder extension (auto-discovered by `AddAllModules`), and explicit registration in the design-time factory.
- **`FdaCatalystRepository`** — upcoming / date-range / per-stock / latest-meeting-date queries.
- **`AddFdaCatalysts`** migration — new `FdaCatalyst` table + indexes only.

No ingestion yet — the worker that imports FDA advisory-committee meeting notices from the Federal Register (authoritative, free) lands in the next slice.

Build green, csharpier clean.