### PR TITLE
fix(holdings): flag new filers after pagination, not via a per-row subquery

### DIFF
--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -241,8 +241,11 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     // Recent filings feed: one row per 13F filing, read straight from the
     // InstitutionalFiling rollup (maintained at ingestion) instead of grouping the
     // whole holdings table on every request. Joins InstitutionalHolder for filer
-    // metadata and uses a NOT EXISTS subquery to flag first-time filers (no holdings
-    // from any earlier report date). Callers order by FilingDate descending.
+    // metadata. The first-time-filer flag is deliberately NOT computed here: a per-row
+    // correlated NOT EXISTS over the whole InstitutionalHolding table is evaluated far
+    // beyond the page the caller keeps and times the request out (#3474). Callers order
+    // by FilingDate descending, take their page, then call MarkNewFilers to set
+    // IsNewFiler for just that page's filers.
     public IQueryable<RecentFiling> GetRecentFilings()
     {
         return DbContext
@@ -264,14 +267,47 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
                         TotalValue = f.TotalValue,
                         IsAmendment = f.IsAmendment,
                         ImportedAt = f.CreationTime,
-                        IsNewFiler = !DbContext
-                            .Set<InstitutionalHolding>()
-                            .Any(prior =>
-                                prior.InstitutionalHolderId == f.InstitutionalHolderId
-                                && prior.ReportDate < f.ReportDate
-                            ),
                     }
             );
+    }
+
+    // Sets IsNewFiler on a materialised page of recent filings (from GetRecentFilings).
+    // A filer is "new" when no holding was reported before the filing's report date —
+    // equivalently, the filing's report date is at or before the filer's earliest holding
+    // report date. Computed with a single grouped lookup bounded to the page's filers
+    // (served by the (InstitutionalHolderId, ReportDate) index), replacing the per-row
+    // correlated NOT EXISTS over the full holdings table that timed the page out (#3474).
+    public async Task MarkNewFilers(
+        IReadOnlyCollection<RecentFiling> filings,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (filings.Count == 0)
+        {
+            return;
+        }
+
+        var holderIds = filings.Select(f => f.InstitutionalHolderId).Distinct().ToList();
+
+        var earliestReportDateByFiler = await DbContext
+            .Set<InstitutionalHolding>()
+            .Where(h => holderIds.Contains(h.InstitutionalHolderId))
+            .GroupBy(h => h.InstitutionalHolderId)
+            .Select(g => new { HolderId = g.Key, Earliest = g.Min(h => h.ReportDate) })
+            .ToDictionaryAsync(x => x.HolderId, x => x.Earliest, cancellationToken);
+
+        foreach (var filing in filings)
+        {
+            // A filer with no holdings on record (absent from the lookup) has nothing
+            // earlier, so it is new; otherwise it is new only when this filing is at or
+            // before its earliest reported holding.
+            filing.IsNewFiler =
+                !earliestReportDateByFiler.TryGetValue(
+                    filing.InstitutionalHolderId,
+                    out var earliest
+                )
+                || filing.ReportDate <= earliest;
+        }
     }
 
     // Cross-sectional 13F screener. Aggregates per-stock filer-count / total-value /

--- a/src/Equibles.Web/Controllers/HoldingsActivityController.cs
+++ b/src/Equibles.Web/Controllers/HoldingsActivityController.cs
@@ -112,6 +112,10 @@ public class HoldingsActivityController : BaseController
 
         var filings = await query.Page(page, LatestFilingsViewModel.PageSize).ToListAsync();
 
+        // Flag first-time filers for just this page, off the holdings table's
+        // (InstitutionalHolderId, ReportDate) index — see MarkNewFilers (#3474).
+        await _holdingRepository.MarkNewFilers(filings);
+
         return View(
             new LatestFilingsViewModel
             {

--- a/tests/Equibles.FunctionalTests/Tests/HoldingsLatestFilingsSeededTests.cs
+++ b/tests/Equibles.FunctionalTests/Tests/HoldingsLatestFilingsSeededTests.cs
@@ -198,8 +198,9 @@ public class HoldingsLatestFilingsSeededTests
             .Expect(row1.Locator(".badge").Filter(new() { HasTextString = "New" }))
             .ToHaveCountAsync(0);
 
-        // Row 2: Filer A Q1 — oldest import. Still not new (Q1 is their first quarter,
-        // but IsNewFiler checks prior.ReportDate < f.ReportDate — Q1 has no prior)
+        // Row 2: Filer A Q1 — oldest import. The row asserts only the filer name, not the
+        // new-filer badge; IsNewFiler is now set by MarkNewFilers from each filer's earliest
+        // holding report date (#3474) rather than a per-row NOT EXISTS subquery.
         var row2 = rows.Nth(2);
         await Assertions.Expect(row2).ToContainTextAsync("Alpha Capital");
     }

--- a/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryRecentFilingsTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryRecentFilingsTests.cs
@@ -8,9 +8,10 @@ namespace Equibles.IntegrationTests.Holdings;
 
 /// <summary>
 /// Coverage for <c>GetRecentFilings()</c>, which reads one row per filing from the
-/// <see cref="InstitutionalFiling"/> rollup (not a live GROUP BY over holdings):
-/// the NOT EXISTS <c>IsNewFiler</c> subquery must still correlate to the right
-/// holder, the projection must surface the rollup's counts/values, and the
+/// <see cref="InstitutionalFiling"/> rollup (not a live GROUP BY over holdings): the
+/// projection must surface the rollup's counts/values, <c>MarkNewFilers</c> must flag
+/// first-time filers from each filer's earliest holding report date (the bounded
+/// replacement for the per-row NOT EXISTS that timed the page out, #3474), and the
 /// migration's one-time backfill SQL must collapse holdings into that rollup.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
@@ -49,9 +50,10 @@ public class InstitutionalHoldingRepositoryRecentFilingsTests : IAsyncLifetime
         // Contract: IsNewFiler is true when no holdings exist for the filer at
         // any ReportDate strictly earlier than this filing's ReportDate. A
         // returning filer (Q3 + Q4) must be false; a first-time filer (Q4 only)
-        // must be true. The NOT EXISTS subquery inside the Join result selector
-        // must correlate with the correct InstitutionalHolderId — a broken
-        // correlation would flag both or neither.
+        // must be true. GetRecentFilings no longer computes the flag (the per-row
+        // NOT EXISTS timed the page out, #3474); MarkNewFilers sets it for the
+        // materialised page from each filer's earliest holding report date, keyed
+        // on the correct InstitutionalHolderId — a broken key would flag both or neither.
         await using var seed = FreshContext();
         var stock = await SeedStock(seed, "AAPL");
         var returningFiler = await SeedHolder(seed, "returning");
@@ -70,6 +72,7 @@ public class InstitutionalHoldingRepositoryRecentFilingsTests : IAsyncLifetime
         var sut = new InstitutionalHoldingRepository(read);
 
         var filings = await sut.GetRecentFilings().ToListAsync();
+        await sut.MarkNewFilers(filings);
 
         var returningFiling = filings.Single(f => f.FilerCik == "returning" && f.ReportDate == Q4);
         var newFiling = filings.Single(f => f.FilerCik == "firsttime");
@@ -89,9 +92,9 @@ public class InstitutionalHoldingRepositoryRecentFilingsTests : IAsyncLifetime
         var stock = await SeedStock(seed, "MSFT");
         var holder = await SeedHolder(seed, "rollup");
 
-        // One holding exists so the IsNewFiler subquery has something to resolve...
+        // A holding exists for this accession, but the rollup independently claims 3
+        // positions worth 900k — the read path must surface the rollup, not the holdings.
         seed.Add(MakeHolding(stock, holder, Q4, accession: "acc-roll"));
-        // ...but the rollup independently claims 3 positions worth 900k.
         seed.Add(MakeFiling(holder, Q4, "acc-roll", positionCount: 3, totalValue: 900_000));
         await seed.SaveChangesAsync();
 
@@ -104,7 +107,6 @@ public class InstitutionalHoldingRepositoryRecentFilingsTests : IAsyncLifetime
         filing.PositionCount.Should().Be(3);
         filing.TotalValue.Should().Be(900_000);
         filing.FilerCik.Should().Be("rollup");
-        filing.IsNewFiler.Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `InstitutionalHoldingRepository.GetRecentFilings()` computed `IsNewFiler` with a per-row correlated `NOT EXISTS` over the whole `InstitutionalHolding` table, baked into the composable `IQueryable`. The planner evaluated it far beyond the ~50-row page the caller keeps, so the Latest 13F filings page exceeded the 30s command timeout. The `(InstitutionalHolderId, ReportDate)` index already exists — this was a query-plan problem, not a missing index.
- Drop the subquery from `GetRecentFilings`; add `MarkNewFilers(filings)`, run by callers on a materialised page. It sets `IsNewFiler` from each filer's earliest holding report date via one bounded `GROUP BY MIN(ReportDate)` over only the page's filers (served by that index) — identical semantics (`!exists(prior < f.ReportDate)` ⟺ `f.ReportDate <= earliest`; a filer with no holdings is new).

## Code changes

- `src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs` — `GetRecentFilings` no longer projects `IsNewFiler`; new `MarkNewFilers(IReadOnlyCollection<RecentFiling>, CancellationToken)`.
- `src/Equibles.Web/Controllers/HoldingsActivityController.cs` — `LatestFilings` calls `MarkNewFilers` after pagination.
- `tests/Equibles.IntegrationTests/Holdings/InstitutionalHoldingRepositoryRecentFilingsTests.cs` — updated to mark the page then assert; pins the new-filer contract on real Postgres (ParadeDb).
- `tests/Equibles.FunctionalTests/Tests/HoldingsLatestFilingsSeededTests.cs` — comment refresh.

Refs daniel3303/EquiblesCommercial#3474