### PR TITLE
fix(holdings): prune stale fund scores when the window is too short to annualize

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
+++ b/src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs
@@ -79,13 +79,14 @@ public class FundScoringManager
         );
         if (result == null || result.Points.Count == 0 || !IsStorable(result))
         {
-            // Prune the stored score only when the filer structurally has nothing to score
-            // (no 13F snapshots for the window — e.g. a Schedule 13D/G-only filer), or the
-            // alpha leaderboard keeps ranking it on a result that can never be recomputed.
-            // Transient failures (a benchmark price gap, a non-finite simulation) keep the
-            // previous score: deleting on those would wipe the whole leaderboard over a
-            // one-cycle data hiccup.
-            if (!has13FSnapshots)
+            // Prune the stored score when the filer structurally can't be scored: it has no
+            // 13F snapshots for the window (e.g. a Schedule 13D/G-only filer), or its window
+            // is below the annualization floor so CAGR is null — leaving that stale row lets a
+            // pre-floor artifact (a ~19-day window annualized to +96,699%) dominate the alpha
+            // leaderboard (#3407). Transient failures (a benchmark price gap, a non-finite /
+            // out-of-range simulation) keep the previous score: deleting on those would wipe
+            // the whole leaderboard over a one-cycle data hiccup.
+            if (ShouldDeleteStaleScore(result, has13FSnapshots))
                 await DeleteExistingScore(holder, windowYears, benchmarkTicker);
             return null;
         }
@@ -235,6 +236,21 @@ public class FundScoringManager
                     .ToList(),
             })
             .ToList();
+
+    // Whether an unstorable result should also evict the existing stored score. Prune when
+    // the filer has no 13F snapshots to score, OR the window is too short to annualize (CAGR
+    // null) — both are structural and won't recompute into a real score, so a stale annualized
+    // artifact must not linger on the leaderboard (#3407). A merely out-of-range / non-finite
+    // result is treated as transient and keeps the previous score.
+    private static bool ShouldDeleteStaleScore(BacktestResult result, bool has13FSnapshots) =>
+        !has13FSnapshots || IsTooShortToAnnualize(result);
+
+    // The backtest ran (produced points) but the scored portfolio's own series was below
+    // HoldingsBacktestCalculator.MinAnnualizationDays, so its CAGR could not be computed.
+    // Keyed on the PORTFOLIO CAGR only: a null benchmark CAGR with a real portfolio CAGR is a
+    // benchmark price gap (transient), which must keep the previous score, not prune it.
+    private static bool IsTooShortToAnnualize(BacktestResult result) =>
+        result is { Points.Count: > 0 } && result.PortfolioSummary.CagrPercent is null;
 
     // A null CAGR means the simulated window was too short to annualize
     // (HoldingsBacktestCalculator.MinAnnualizationDays) — such a score is not meaningful.

--- a/tests/Equibles.UnitTests/Holdings/FundScoringManagerShouldDeleteStaleScoreTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/FundScoringManagerShouldDeleteStaleScoreTests.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Repositories.Models;
+
+namespace Equibles.UnitTests.Holdings;
+
+// ShouldDeleteStaleScore is ScoreHolder's prune gate when a backtest result can't be stored.
+// It must evict the existing stored score when the filer's window is too short to annualize
+// (CAGR null) EVEN THOUGH it still has 13F snapshots — otherwise a pre-floor annualized
+// artifact (a ~19-day window annualized to +96,699%) keeps dominating the alpha leaderboard
+// (#3407). A transient out-of-range/non-finite result (CAGR present but huge) keeps the
+// previous score so a one-cycle data hiccup never wipes the leaderboard.
+public class FundScoringManagerShouldDeleteStaleScoreTests
+{
+    private static readonly MethodInfo Method = typeof(FundScoringManager).GetMethod(
+        "ShouldDeleteStaleScore",
+        BindingFlags.NonPublic | BindingFlags.Static
+    );
+
+    private static bool ShouldDelete(BacktestResult result, bool has13FSnapshots) =>
+        (bool)Method.Invoke(null, [result, has13FSnapshots]);
+
+    [Fact]
+    public void TooShortToAnnualize_WithSnapshots_DeletesStaleScore()
+    {
+        // Below the annualization floor: the backtest produced points but CAGR is null.
+        var tooShort = new BacktestResult
+        {
+            Points = [new BacktestPoint()],
+            PortfolioSummary = new BacktestStrategySummary { CagrPercent = null },
+            BenchmarkSummary = new BacktestStrategySummary { CagrPercent = null },
+        };
+
+        ShouldDelete(tooShort, has13FSnapshots: true)
+            .Should()
+            .BeTrue("a too-short window leaves a stale annualized artifact that must be pruned");
+    }
+
+    [Fact]
+    public void OutOfRangeButAnnualized_WithSnapshots_KeepsScore()
+    {
+        // CAGRs are present (the window did annualize) but out of range — treated as a
+        // transient hiccup, so the previous score is kept.
+        var outOfRange = new BacktestResult
+        {
+            Points = [new BacktestPoint()],
+            PortfolioSummary = new BacktestStrategySummary { CagrPercent = decimal.MaxValue },
+            BenchmarkSummary = new BacktestStrategySummary { CagrPercent = 9m },
+        };
+
+        ShouldDelete(outOfRange, has13FSnapshots: true)
+            .Should()
+            .BeFalse(
+                "an out-of-range but annualized result is transient and must not wipe the score"
+            );
+    }
+
+    [Fact]
+    public void BenchmarkCagrNullButPortfolioAnnualized_WithSnapshots_KeepsScore()
+    {
+        // Portfolio annualized fine but the benchmark CAGR is null (e.g. SPY prices lagged the
+        // window). That is a transient benchmark data gap, not a too-short portfolio — pruning
+        // here would wipe the leaderboard whenever the price feed lags, so the score is kept.
+        var benchmarkGap = new BacktestResult
+        {
+            Points = [new BacktestPoint()],
+            PortfolioSummary = new BacktestStrategySummary { CagrPercent = 12m },
+            BenchmarkSummary = new BacktestStrategySummary { CagrPercent = null },
+        };
+
+        ShouldDelete(benchmarkGap, has13FSnapshots: true)
+            .Should()
+            .BeFalse("a null benchmark CAGR with a real portfolio CAGR is a transient gap");
+    }
+
+    [Fact]
+    public void NoSnapshots_DeletesStaleScore()
+    {
+        ShouldDelete(new BacktestResult(), has13FSnapshots: false)
+            .Should()
+            .BeTrue("a filer with no 13F snapshots structurally can't be scored");
+    }
+}


### PR DESCRIPTION
## Summary

- The manager-performance leaderboard ranks on stored `FundScore` rows. When a filer's clone window is below `HoldingsBacktestCalculator.MinAnnualizationDays`, the recomputed score has a null CAGR and isn't stored — but `ScoreHolder` only pruned the existing row when the filer had **no 13F snapshots**. A filer that still has snapshots kept a stale pre-floor row (a ~19-day window annualized to +96,699%), dominating the leaderboard (daniel3303/EquiblesCommercial#3407).
- Now also prune when the result is **too short to annualize** (portfolio CAGR null), keyed on the *portfolio* CAGR so a null *benchmark* CAGR (a transient price-feed gap) still keeps the previous score. The scoring worker clears the artifacts on its next cycle — no reimport.

## Code changes

- `src/Equibles.Holdings.BusinessLogic/FundScoringManager.cs` — `ShouldDeleteStaleScore(result, has13FSnapshots)` = `!has13FSnapshots || IsTooShortToAnnualize(result)`; `IsTooShortToAnnualize` = points produced but `PortfolioSummary.CagrPercent is null`. `ScoreHolder`'s prune branch uses it.
- `tests/Equibles.UnitTests/Holdings/FundScoringManagerShouldDeleteStaleScoreTests.cs` (new) — too-short+snapshots → prune; out-of-range annualized → keep; **benchmark-CAGR-null + portfolio annualized → keep** (guards the transient-gap case); no-snapshots → prune.

Refs daniel3303/EquiblesCommercial#3407