### PR TITLE
fix(congress): skip reprinted PTR column headers in the House parser

### DIFF
--- a/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
+++ b/src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs
@@ -319,13 +319,41 @@ public partial class HouseDisclosureClient
     }
 
     // Lines that continue the current row's asset name or amount: not the next
-    // transaction, not a field-label line, not the footer note.
+    // transaction, not a field-label line, not the footer note, not a reprinted header.
     private static bool IsContinuationLine(string line)
     {
-        if (string.IsNullOrWhiteSpace(line) || line.Contains(':') || line.StartsWith('*'))
+        if (
+            string.IsNullOrWhiteSpace(line)
+            || line.Contains(':')
+            || line.StartsWith('*')
+            || IsTableHeaderFragment(line)
+        )
             return false;
         return !TransactionAnchorRegex().IsMatch(line);
     }
+
+    // Distinctive PTR column labels. A real asset/amount continuation line never carries
+    // several of them together, so their co-occurrence flags a reprinted header.
+    private static readonly string[] PtrHeaderTokens =
+    [
+        "Owner",
+        "Asset",
+        "Transaction",
+        "Notification",
+        "Amount",
+        "Gains",
+    ];
+
+    // At a page break the House PTR reprints its column-header block ("ID Owner Asset
+    // Transaction Date Notification Amount Cap. Gains > $200? ..."). PdfPig's geometry turns
+    // that into a line with no colon, asterisk or transaction anchor, so it would otherwise be
+    // mistaken for a continuation and spliced into the preceding trade — appending the header
+    // words to the asset name and pulling the "$200" cap-gains threshold into the amount,
+    // yielding inverted ranges like "$50,001-$200" (#3378). Skip any line carrying several of
+    // the column labels.
+    private static bool IsTableHeaderFragment(string line) =>
+        PtrHeaderTokens.Count(token => line.Contains(token, StringComparison.OrdinalIgnoreCase))
+        >= 3;
 
     // A continuation line holds asset text, a wrapped amount ("$5,000,000"), or
     // both; the amount is always the trailing "$…" run.

--- a/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTableHeaderContinuationTests.cs
+++ b/tests/Equibles.UnitTests/Congress/HouseDisclosureClientTableHeaderContinuationTests.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using Equibles.Congress.HostedService.Services;
+
+namespace Equibles.UnitTests.Congress;
+
+/// <summary>
+/// A page break reprints the PTR column-header block. PdfPig renders it as a line with no
+/// colon, asterisk or transaction anchor, so <c>IsContinuationLine</c> used to classify it as
+/// a continuation and splice it into the preceding trade — appending the header words to the
+/// asset name and pulling the "Cap. Gains &gt; $200?" threshold into the amount, producing
+/// inverted ranges like "$50,001-$200" (#3378). The reprinted header must not be a continuation,
+/// while a genuine wrapped asset line still must be.
+/// </summary>
+public class HouseDisclosureClientTableHeaderContinuationTests
+{
+    private static bool IsContinuationLine(string line) =>
+        (bool)
+            typeof(HouseDisclosureClient)
+                .GetMethod("IsContinuationLine", BindingFlags.NonPublic | BindingFlags.Static)!
+                .Invoke(null, [line])!;
+
+    [Fact]
+    public void IsContinuationLine_ReprintedPtrColumnHeader_NotTreatedAsContinuation()
+    {
+        const string header =
+            "ID Owner Asset Transaction Date Notification Amount Cap. Type Date Gains >";
+
+        IsContinuationLine(header)
+            .Should()
+            .BeFalse("a reprinted PTR column header must not be spliced into the preceding trade");
+    }
+
+    [Fact]
+    public void IsContinuationLine_WrappedAssetName_StillContinuation()
+    {
+        // A genuine continuation carries at most one header-ish word and must keep flowing
+        // into the preceding trade's asset name.
+        IsContinuationLine("Class A Common Stock").Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- At a page break the House PTR reprints its column-header block. PdfPig's geometry renders it as a line with no colon, asterisk or transaction anchor, so `IsContinuationLine` treated it as a continuation and spliced it into the preceding trade — appending the header words to the asset name and pulling the `Cap. Gains > $200?` threshold into the amount, producing inverted ranges like `$50,001-$200` (e.g. Pelosi TEM 2026-01-16) — daniel3303/EquiblesCommercial#3378.
- Detect a reprinted header by the co-occurrence of ≥3 distinctive column labels (no real asset/amount continuation carries that many) and exclude it from continuation lines.

## Code changes

- `src/Equibles.Congress.HostedService/Services/HouseDisclosureClient.cs` — add `IsTableHeaderFragment` (+ `PtrHeaderTokens`); `IsContinuationLine` now returns false for it.
- `tests/Equibles.UnitTests/Congress/HouseDisclosureClientTableHeaderContinuationTests.cs` (new) — reprinted header → not a continuation (red→green on the existing method); a genuine wrapped asset line still is.

Refs daniel3303/EquiblesCommercial#3378