### PR TITLE
fix(fda-catalysts): reshape FdaCatalyst for the FDA.gov calendar source

### DIFF
--- a/src/Equibles.FdaCatalysts.Data/Models/FdaCatalyst.cs
+++ b/src/Equibles.FdaCatalysts.Data/Models/FdaCatalyst.cs
@@ -7,8 +7,9 @@ namespace Equibles.FdaCatalysts.Data.Models;
 /// A scheduled FDA regulatory catalyst for a public company. Today this holds FDA
 /// advisory-committee (AdComm) meetings, with the type discriminator left open for
 /// PDUFA decisions and complete-response follow-ups once an authoritative source for
-/// those exists. AdComm meetings are sourced from the Federal Register, which publishes
-/// FDA advisory-committee meeting notices as structured documents.
+/// those exists. AdComm meetings are sourced from the FDA.gov advisory-committee
+/// calendar, which publishes the meeting schedule as a structured table with explicit
+/// Start Date / End Date / Meeting / Center columns and a stable per-meeting page slug.
 /// </summary>
 [Index(nameof(SourceReference), IsUnique = true)]
 [Index(nameof(CatalystType), nameof(MeetingDate))]
@@ -20,30 +21,39 @@ public class FdaCatalyst
 
     public FdaCatalystType CatalystType { get; set; }
 
+    // The Start Date column of the FDA calendar (the first day of the meeting).
     public DateOnly MeetingDate { get; set; }
 
+    // The End Date column; null when the calendar lists no distinct end (single-day
+    // meetings or rows where the end is not given).
+    public DateOnly? EndDate { get; set; }
+
+    // The FDA calendar's organizational column (e.g. "Center for Drug Evaluation and
+    // Research"). The standalone committee name is not its own column — it appears only
+    // inside the Meeting title prose — so Center is the authoritative org field and the
+    // committee is carried in Title.
     [Required]
-    public string Committee { get; set; }
+    public string Center { get; set; }
 
     [Required]
     public string Title { get; set; }
 
     public string Summary { get; set; }
 
-    // The Federal Register document number — globally unique per notice, so it is the
-    // natural key that keeps re-imports of the same meeting idempotent.
+    // The FDA calendar's per-meeting page slug (e.g.
+    // "july-23-24-2026-meeting-pharmacy-compounding-advisory-committee-07232026") —
+    // globally unique per meeting, so it is the natural key that keeps re-imports of the
+    // same meeting idempotent.
     [Required]
-    [MaxLength(64)]
+    [MaxLength(128)]
     public string SourceReference { get; set; }
 
     public string SourceUrl { get; set; }
 
-    public DateOnly? PublicationDate { get; set; }
-
-    // Resolved to a CommonStock only when the notice's sponsor maps authoritatively
-    // (CIK / ticker), and left null otherwise — many sponsors are private, pre-IPO, or
-    // foreign and fall outside the tracked equity universe, so a soft reference avoids
-    // dropping catalysts we cannot tie to a ticker.
+    // Resolved to a CommonStock only when the meeting names a sponsor that maps
+    // authoritatively (CIK / ticker), and left null otherwise — many meetings concern
+    // private, pre-IPO, or foreign sponsors that fall outside the tracked equity
+    // universe, so a soft reference avoids dropping catalysts we cannot tie to a ticker.
     public Guid? CommonStockId { get; set; }
 
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;

--- a/src/Equibles.Migrations/Migrations/20260614014711_ReshapeFdaCatalystForFdaGovSource.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260614014711_ReshapeFdaCatalystForFdaGovSource.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260614014711_ReshapeFdaCatalystForFdaGovSource")]
+    partial class ReshapeFdaCatalystForFdaGovSource
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260614014711_ReshapeFdaCatalystForFdaGovSource.cs
+++ b/src/Equibles.Migrations/Migrations/20260614014711_ReshapeFdaCatalystForFdaGovSource.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class ReshapeFdaCatalystForFdaGovSource : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "PublicationDate",
+                table: "FdaCatalyst",
+                newName: "EndDate");
+
+            migrationBuilder.RenameColumn(
+                name: "Committee",
+                table: "FdaCatalyst",
+                newName: "Center");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SourceReference",
+                table: "FdaCatalyst",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "EndDate",
+                table: "FdaCatalyst",
+                newName: "PublicationDate");
+
+            migrationBuilder.RenameColumn(
+                name: "Center",
+                table: "FdaCatalyst",
+                newName: "Committee");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SourceReference",
+                table: "FdaCatalyst",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- The `FdaCatalyst` data module was shaped for the Federal Register, but the authoritative meeting-date source is the FDA.gov advisory-committee calendar, whose columns differ. This corrects the entity before any ingestion lands on top of it.
- The table carries no rows yet (no ingestion has shipped), so the corrective migration is a plain rename/alter on an empty table.

## Code changes

- `src/Equibles.FdaCatalysts.Data/Models/FdaCatalyst.cs` — replace the unsourceable `Committee` with `Center` (the calendar's organizational column; the committee name stays in `Title`); repoint `SourceReference` to the per-meeting page slug and widen it to 128 chars (slugs run past the old 64-char cap); add `EndDate`; drop the Federal-Register-only `PublicationDate`; refresh the type doc comment.
- `src/Equibles.Migrations/Migrations/20260614014711_ReshapeFdaCatalystForFdaGovSource.cs` (+ `.Designer.cs`) — rename `PublicationDate`→`EndDate` and `Committee`→`Center`, widen `SourceReference` to `varchar(128)`.
- `src/Equibles.Migrations/Migrations/EquiblesDbContextModelSnapshot.cs` — regenerated snapshot.