### PR TITLE
feat(fda-catalysts): parse the FDA.gov advisory-committee calendar

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -171,6 +171,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.Data"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.Repositories", "src\Equibles.FdaCatalysts.Repositories\Equibles.FdaCatalysts.Repositories.csproj", "{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.BusinessLogic", "src\Equibles.FdaCatalysts.BusinessLogic\Equibles.FdaCatalysts.BusinessLogic.csproj", "{50271682-2648-41F7-9B01-292259615318}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1165,6 +1167,18 @@ Global
 		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Release|x64.Build.0 = Release|Any CPU
 		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Release|x86.ActiveCfg = Release|Any CPU
 		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837}.Release|x86.Build.0 = Release|Any CPU
+		{50271682-2648-41F7-9B01-292259615318}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50271682-2648-41F7-9B01-292259615318}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50271682-2648-41F7-9B01-292259615318}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{50271682-2648-41F7-9B01-292259615318}.Debug|x64.Build.0 = Debug|Any CPU
+		{50271682-2648-41F7-9B01-292259615318}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{50271682-2648-41F7-9B01-292259615318}.Debug|x86.Build.0 = Debug|Any CPU
+		{50271682-2648-41F7-9B01-292259615318}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50271682-2648-41F7-9B01-292259615318}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50271682-2648-41F7-9B01-292259615318}.Release|x64.ActiveCfg = Release|Any CPU
+		{50271682-2648-41F7-9B01-292259615318}.Release|x64.Build.0 = Release|Any CPU
+		{50271682-2648-41F7-9B01-292259615318}.Release|x86.ActiveCfg = Release|Any CPU
+		{50271682-2648-41F7-9B01-292259615318}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1252,6 +1266,7 @@ Global
 		{34598F2B-3BFA-46E6-9EE5-63816F78B959} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{50271682-2648-41F7-9B01-292259615318} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.FdaCatalysts.BusinessLogic/Equibles.FdaCatalysts.BusinessLogic.csproj
+++ b/src/Equibles.FdaCatalysts.BusinessLogic/Equibles.FdaCatalysts.BusinessLogic.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.FdaCatalysts.Data\Equibles.FdaCatalysts.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.FdaCatalysts.BusinessLogic/FdaAdvisoryCommitteeCalendarParser.cs
+++ b/src/Equibles.FdaCatalysts.BusinessLogic/FdaAdvisoryCommitteeCalendarParser.cs
@@ -1,0 +1,191 @@
+using System.Globalization;
+using Equibles.FdaCatalysts.Data.Models;
+using HtmlAgilityPack;
+
+namespace Equibles.FdaCatalysts.BusinessLogic;
+
+/// <summary>
+/// Parses the FDA.gov advisory-committee calendar's table into <see cref="FdaCatalyst"/> rows.
+/// The calendar is a client-rendered DataTable, so the caller must supply the rendered DOM
+/// (fetched through the headless browser path), not a plain HTTP response — a plain GET returns
+/// the page chrome with an empty table body.
+///
+/// Every field comes from an explicit calendar column (Start Date, End Date, Meeting, Center) or
+/// the per-meeting anchor's slug, so nothing is recovered from prose. Rows without a parseable
+/// Start Date or without the meeting-page anchor are skipped: they carry no authoritative date to
+/// place on a timeline and no stable natural key.
+/// </summary>
+public static class FdaAdvisoryCommitteeCalendarParser
+{
+    private const string CalendarHost = "https://www.fda.gov";
+
+    public static IReadOnlyList<FdaCatalyst> Parse(string html)
+    {
+        var catalysts = new List<FdaCatalyst>();
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            return catalysts;
+        }
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var table = doc.DocumentNode.SelectSingleNode(
+            "//table[contains(@class, 'lcds-datatable--advisory-committee-calendar')]"
+        );
+        if (table == null)
+        {
+            return catalysts;
+        }
+
+        // Resolve column positions from the header so a reordered table still maps correctly.
+        var headerCells = table.SelectNodes(".//thead//th") ?? table.SelectNodes(".//thead//td");
+        if (headerCells == null)
+        {
+            return catalysts;
+        }
+
+        var columns = headerCells
+            .Select(h => HtmlEntity.DeEntitize(h.InnerText).Trim().ToLowerInvariant())
+            .ToList();
+        var startCol = columns.FindIndex(c => c.Contains("start date"));
+        var endCol = columns.FindIndex(c => c.Contains("end date"));
+        var meetingCol = columns.FindIndex(c => c.Contains("meeting"));
+        var centerCol = columns.FindIndex(c => c.Contains("center"));
+        if (startCol < 0 || meetingCol < 0 || centerCol < 0)
+        {
+            return catalysts;
+        }
+
+        var rows = table.SelectNodes(".//tbody//tr");
+        if (rows == null)
+        {
+            return catalysts;
+        }
+
+        var minCells = Math.Max(startCol, Math.Max(meetingCol, centerCol));
+        var seenSlugs = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            var cells = row.SelectNodes("./td");
+            if (cells == null || cells.Count <= minCells)
+            {
+                continue;
+            }
+
+            // The Meeting cell's anchor carries the authoritative per-meeting slug and title.
+            var link = cells[meetingCol].SelectSingleNode(".//a[@href]");
+            if (link == null)
+            {
+                continue;
+            }
+
+            var href = link.GetAttributeValue("href", string.Empty).Trim();
+            var slug = ExtractSlug(href);
+            if (slug.Length == 0 || !seenSlugs.Add(slug))
+            {
+                continue;
+            }
+
+            var meetingDate = ParseColumnDate(cells[startCol].InnerText);
+            if (meetingDate == null)
+            {
+                continue;
+            }
+
+            var title = HtmlEntity.DeEntitize(link.InnerText).Trim();
+            if (title.Length == 0)
+            {
+                continue;
+            }
+
+            var center = HtmlEntity.DeEntitize(cells[centerCol].InnerText).Trim();
+            if (center.Length == 0)
+            {
+                continue;
+            }
+
+            var endDate =
+                endCol >= 0 && endCol < cells.Count
+                    ? ParseColumnDate(cells[endCol].InnerText)
+                    : null;
+
+            catalysts.Add(
+                new FdaCatalyst
+                {
+                    CatalystType = FdaCatalystType.AdvisoryCommittee,
+                    MeetingDate = meetingDate.Value,
+                    EndDate = endDate,
+                    Center = center,
+                    Title = title,
+                    SourceReference = slug,
+                    SourceUrl = ToAbsoluteUrl(href),
+                }
+            );
+        }
+
+        return catalysts;
+    }
+
+    // Calendar dates render as "MM/dd/yyyy hh:mm tt zzz" (e.g. "07/23/2026 08:00 AM EDT"). The
+    // date is the leading token of the authoritative Start/End Date column, so taking it is a
+    // structured-field read, not a guess pulled from prose.
+    private static DateOnly? ParseColumnDate(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        var token = HtmlEntity
+            .DeEntitize(raw)
+            .Trim()
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault();
+        if (token == null)
+        {
+            return null;
+        }
+
+        return DateOnly.TryParseExact(
+            token,
+            "MM/dd/yyyy",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var date
+        )
+            ? date
+            : null;
+    }
+
+    private static string ExtractSlug(string href)
+    {
+        if (string.IsNullOrWhiteSpace(href))
+        {
+            return string.Empty;
+        }
+
+        var path = href.Split('?', '#')[0].TrimEnd('/');
+        if (path.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        return path[(path.LastIndexOf('/') + 1)..];
+    }
+
+    private static string ToAbsoluteUrl(string href)
+    {
+        if (string.IsNullOrWhiteSpace(href))
+        {
+            return string.Empty;
+        }
+
+        if (href.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+        {
+            return href;
+        }
+
+        return CalendarHost + (href.StartsWith('/') ? href : "/" + href);
+    }
+}

--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -95,5 +95,6 @@
     <ProjectReference Include="..\..\src\Equibles.Search.Abstractions\Equibles.Search.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cboe.HostedService\Equibles.Cboe.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Messaging\Equibles.Messaging.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.FdaCatalysts.BusinessLogic\Equibles.FdaCatalysts.BusinessLogic.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserTests.cs
+++ b/tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Equibles.FdaCatalysts.BusinessLogic;
+using Equibles.FdaCatalysts.Data.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.FdaCatalysts;
+
+public class FdaAdvisoryCommitteeCalendarParserTests
+{
+    private static string FixturePath(string fileName) =>
+        Path.Combine(AppContext.BaseDirectory, "TestAssets", "FdaCatalysts", fileName);
+
+    private static IReadOnlyList<FdaCatalyst> ParseFixture() =>
+        FdaAdvisoryCommitteeCalendarParser.Parse(
+            File.ReadAllText(FixturePath("fda-advisory-committee-calendar.html"))
+        );
+
+    [Fact]
+    public void Parse_RealCalendar_KeepsOnlyRowsWithAnAuthoritativeStartDate()
+    {
+        var catalysts = ParseFixture();
+
+        // Five rows in the fixture; the stale 2016 row has an empty Start Date and is dropped.
+        catalysts.Should().HaveCount(4);
+        catalysts.Should().OnlyContain(c => c.CatalystType == FdaCatalystType.AdvisoryCommittee);
+        catalysts
+            .Should()
+            .NotContain(c =>
+                c.SourceReference
+                == "november-9-10-2016-microbiology-devices-panel-medical-devices-advisory-committee-meeting"
+            );
+    }
+
+    [Fact]
+    public void Parse_MultiDayMeeting_MapsEveryColumnToTheEntity()
+    {
+        var pharmacy = ParseFixture()
+            .Should()
+            .ContainSingle(c => c.Title.Contains("Pharmacy Compounding"))
+            .Subject;
+
+        pharmacy.MeetingDate.Should().Be(new DateOnly(2026, 7, 23));
+        pharmacy.EndDate.Should().Be(new DateOnly(2026, 7, 24));
+        pharmacy.Center.Should().Be("Center for Drug Evaluation and Research");
+        pharmacy
+            .SourceReference.Should()
+            .Be("july-23-24-2026-meeting-pharmacy-compounding-advisory-committee-07232026");
+        pharmacy
+            .SourceUrl.Should()
+            .Be(
+                "https://www.fda.gov/advisory-committees/advisory-committee-calendar/july-23-24-2026-meeting-pharmacy-compounding-advisory-committee-07232026"
+            );
+    }
+
+    [Fact]
+    public void Parse_SingleDayMeeting_SetsEndDateEqualToStart()
+    {
+        var tobacco = ParseFixture()
+            .Should()
+            .ContainSingle(c => c.Center == "Center for Tobacco Products")
+            .Subject;
+
+        tobacco.MeetingDate.Should().Be(new DateOnly(2026, 1, 22));
+        tobacco.EndDate.Should().Be(new DateOnly(2026, 1, 22));
+    }
+
+    [Fact]
+    public void Parse_TakesSlugFromTheMeetingAnchor()
+    {
+        var catalysts = ParseFixture();
+
+        catalysts
+            .Should()
+            .Contain(c =>
+                c.SourceReference
+                    == "vaccines-and-related-biological-products-advisory-committee-june-18-2026-meeting-announcement"
+                && c.MeetingDate == new DateOnly(2026, 6, 18)
+            );
+    }
+
+    [Fact]
+    public void Parse_EmptyOrTablelessHtml_ReturnsEmpty()
+    {
+        FdaAdvisoryCommitteeCalendarParser.Parse("").Should().BeEmpty();
+        FdaAdvisoryCommitteeCalendarParser
+            .Parse("<html><body><p>no table here</p></body></html>")
+            .Should()
+            .BeEmpty();
+    }
+}

--- a/tests/Equibles.UnitTests/TestAssets/FdaCatalysts/fda-advisory-committee-calendar.html
+++ b/tests/Equibles.UnitTests/TestAssets/FdaCatalysts/fda-advisory-committee-calendar.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Advisory Committee Calendar | FDA</title>
+  </head>
+  <body>
+    <div class="region region-content">
+      <table class="lcds-datatable--advisory-committee-calendar table table-bordered">
+        <thead>
+          <tr role="row"><th tabindex="0" class="sorting_desc" aria-controls="DataTables_Table_0" rowspan="1" colspan="1" aria-label="Start Date: activate to sort column ascending" aria-sort="descending">Start Date</th><th tabindex="0" class="sorting" aria-controls="DataTables_Table_0" rowspan="1" colspan="1" aria-label="End Date: activate to sort column ascending">End Date</th><th tabindex="0" class="sorting" aria-controls="DataTables_Table_0" rowspan="1" colspan="1" aria-label="Meeting: activate to sort column ascending">Meeting</th><th tabindex="0" class="sorting" aria-controls="DataTables_Table_0" rowspan="1" colspan="1" aria-label="Center: activate to sort column ascending">Center</th></tr>
+        </thead>
+        <tbody>
+          <tr role="row" class="odd"><td class="sorting_1" tabindex="0">07/23/2026 08:00 AM EDT</td><td>07/24/2026 03:50 PM EDT</td><td><a href="/advisory-committees/advisory-committee-calendar/july-23-24-2026-meeting-pharmacy-compounding-advisory-committee-07232026" hreflang="en">July 23-24, 2026: Meeting of the Pharmacy Compounding Advisory Committee - 07/23/2026</a></td><td>Center for Drug Evaluation and Research</td></tr>
+          <tr role="row" class="even"><td class="sorting_1" tabindex="0">06/18/2026 08:30 AM EDT</td><td>06/18/2026 04:00 PM EDT</td><td><a href="/advisory-committees/advisory-committee-calendar/vaccines-and-related-biological-products-advisory-committee-june-18-2026-meeting-announcement" hreflang="en">Vaccines and Related Biological Products Advisory Committee June 18, 2026 Meeting Announcement - 06/18/2026</a></td><td>Center for Biologics Evaluation and Research</td></tr>
+          <tr role="row" class="even"><td class="sorting_1" tabindex="0">01/22/2026 09:00 AM EST</td><td>01/22/2026 04:30 PM EST</td><td><a href="/advisory-committees/advisory-committee-calendar/january-22-2026-tobacco-products-scientific-advisory-committee-meeting-01222026" hreflang="en">January 22, 2026: Tobacco Products Scientific Advisory Committee Meeting - 01/22/2026</a></td><td>Center for Tobacco Products</td></tr>
+          <tr role="row" class="odd"><td class="sorting_1" tabindex="0">12/10/2025 09:00 AM EST</td><td>12/10/2025 03:30 PM EST</td><td><a href="/advisory-committees/advisory-committee-calendar/updated-meeting-time-and-public-participation-information-december-10-2025-general-hospital-and" hreflang="en">UPDATED MEETING TIME AND PUBLIC PARTICIPATION INFORMATION: December 10, 2025: General Hospital and Personal Use Devices Panel Meeting Announcement - 12/10/2025</a></td><td>Center for Devices and Radiological Health</td></tr>
+          <tr role="row" class="odd"><td class="sorting_1" tabindex="0"></td><td></td><td><a href="/advisory-committees/advisory-committee-calendar/november-9-10-2016-microbiology-devices-panel-medical-devices-advisory-committee-meeting" hreflang="en">November 9-10, 2016: Microbiology Devices Panel of the Medical Devices Advisory Committee Meeting Announcement -</a></td><td>Center for Drug Evaluation and Research</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `FdaAdvisoryCommitteeCalendarParser`, the authoritative parsing core for the FDA catalyst calendar: it turns the FDA.gov advisory-committee calendar's rendered table into `FdaCatalyst` rows.
- Every field is read from an explicit calendar column (Start Date, End Date, Meeting, Center) or the per-meeting anchor's slug — nothing is recovered from prose — and column positions are resolved from the header so a reordered table still maps correctly.
- Rows without a parseable Start Date or a meeting-page anchor are dropped (no date to place on a timeline, no stable natural key).

## Code changes

- `src/Equibles.FdaCatalysts.BusinessLogic/` — new project housing the static `FdaAdvisoryCommitteeCalendarParser`. Uses HtmlAgilityPack; references the `Equibles.FdaCatalysts.Data` models.
- `tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserTests.cs` — 5 tests over a captured fixture of the real calendar table.
- `tests/Equibles.UnitTests/TestAssets/FdaCatalysts/fda-advisory-committee-calendar.html` — captured fixture: multi-day and single-day meetings across four FDA centers, plus a stale row with empty dates that must be dropped.
- `Equibles.sln`, `tests/Equibles.UnitTests/Equibles.UnitTests.csproj` — wire in the new project and test reference.

The ingestion worker that fetches the rendered calendar (headless path) and persists/resolves these rows lands in a follow-up.