### PR TITLE
feat(fda-catalysts): ingest the FDA.gov advisory-committee calendar

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -173,6 +173,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.Repos
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.BusinessLogic", "src\Equibles.FdaCatalysts.BusinessLogic\Equibles.FdaCatalysts.BusinessLogic.csproj", "{50271682-2648-41F7-9B01-292259615318}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.HostedService", "src\Equibles.FdaCatalysts.HostedService\Equibles.FdaCatalysts.HostedService.csproj", "{65E4C514-1A49-445F-92E0-D87B37F072A1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1179,6 +1181,18 @@ Global
 		{50271682-2648-41F7-9B01-292259615318}.Release|x64.Build.0 = Release|Any CPU
 		{50271682-2648-41F7-9B01-292259615318}.Release|x86.ActiveCfg = Release|Any CPU
 		{50271682-2648-41F7-9B01-292259615318}.Release|x86.Build.0 = Release|Any CPU
+		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Debug|x64.Build.0 = Debug|Any CPU
+		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Debug|x86.Build.0 = Debug|Any CPU
+		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Release|x64.ActiveCfg = Release|Any CPU
+		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Release|x64.Build.0 = Release|Any CPU
+		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Release|x86.ActiveCfg = Release|Any CPU
+		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1267,6 +1281,7 @@ Global
 		{9E50F603-B0E7-4E2F-A2A3-26484BB2C10A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{50271682-2648-41F7-9B01-292259615318} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{65E4C514-1A49-445F-92E0-D87B37F072A1} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.Errors.Data/Models/ErrorSource.cs
+++ b/src/Equibles.Errors.Data/Models/ErrorSource.cs
@@ -27,6 +27,7 @@ public sealed class ErrorSource
         "InvestorRelationsDiscovery"
     );
     public static readonly ErrorSource InvestorRelationsScraper = new("InvestorRelationsScraper");
+    public static readonly ErrorSource FdaCatalystScraper = new("FdaCatalystScraper");
     public static readonly ErrorSource Other = new("Other");
 
     public static IEnumerable<ErrorSource> GetAll() =>
@@ -50,6 +51,7 @@ public sealed class ErrorSource
             WebsiteDiscovery,
             InvestorRelationsDiscovery,
             InvestorRelationsScraper,
+            FdaCatalystScraper,
             Other,
         ];
 

--- a/src/Equibles.FdaCatalysts.HostedService/Configuration/FdaCatalystScraperOptions.cs
+++ b/src/Equibles.FdaCatalysts.HostedService/Configuration/FdaCatalystScraperOptions.cs
@@ -1,0 +1,15 @@
+using Equibles.Worker;
+
+namespace Equibles.FdaCatalysts.HostedService.Configuration;
+
+public class FdaCatalystScraperOptions : ScraperOptions
+{
+    /// <summary>
+    /// The FDA.gov advisory-committee calendar page. Its meeting rows are rendered
+    /// client-side (a Drupal "views" DataTable), so the worker fetches it through the
+    /// headless stealth browser rather than plain HTTP — a plain GET returns only the
+    /// page chrome with no rows.
+    /// </summary>
+    public string CalendarUrl { get; set; } =
+        "https://www.fda.gov/advisory-committees/advisory-committee-calendar";
+}

--- a/src/Equibles.FdaCatalysts.HostedService/Equibles.FdaCatalysts.HostedService.csproj
+++ b/src/Equibles.FdaCatalysts.HostedService/Equibles.FdaCatalysts.HostedService.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Equibles.Core.AutoWiring" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
+    <ProjectReference Include="..\Equibles.FdaCatalysts.Repositories\Equibles.FdaCatalysts.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.FdaCatalysts.BusinessLogic\Equibles.FdaCatalysts.BusinessLogic.csproj" />
+    <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
+    <ProjectReference Include="..\Equibles.Worker\Equibles.Worker.csproj" />
+    <!-- IStealthBrowserClient lives here: the FDA.gov calendar is client-rendered, so it
+         is fetched through the same headless stealth browser the IR discovery uses. -->
+    <ProjectReference Include="..\Equibles.CommonStocks.HostedService\Equibles.CommonStocks.HostedService.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.FdaCatalysts.HostedService/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Equibles.FdaCatalysts.HostedService/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+using Equibles.Core.AutoWiring;
+using Equibles.FdaCatalysts.HostedService.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.FdaCatalysts.HostedService.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddFdaCatalystWorker(this IServiceCollection services)
+    {
+        services.AutoWireServicesFrom<FdaAdvisoryCommitteeCalendarImportService>();
+        services.AddHostedService<FdaCatalystScraperWorker>();
+        return services;
+    }
+}

--- a/src/Equibles.FdaCatalysts.HostedService/FdaCatalystScraperWorker.cs
+++ b/src/Equibles.FdaCatalysts.HostedService/FdaCatalystScraperWorker.cs
@@ -1,0 +1,33 @@
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.FdaCatalysts.HostedService.Configuration;
+using Equibles.FdaCatalysts.HostedService.Services;
+using Equibles.Worker;
+
+namespace Equibles.FdaCatalysts.HostedService;
+
+/// <summary>
+/// Periodically reconciles the FDA advisory-committee calendar into the
+/// <c>FdaCatalyst</c> table. A single cycle re-reads the whole calendar and upserts by
+/// the per-meeting slug, so there is no incremental state to keep.
+/// </summary>
+public class FdaCatalystScraperWorker : BaseScraperWorker
+{
+    protected override string WorkerName => "FDA catalyst scraper";
+    protected override TimeSpan SleepInterval { get; }
+    protected override ErrorSource ErrorSource => ErrorSource.FdaCatalystScraper;
+
+    public FdaCatalystScraperWorker(
+        ILogger<FdaCatalystScraperWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        ErrorReporter errorReporter,
+        IOptions<FdaCatalystScraperOptions> options
+    )
+        : base(logger, scopeFactory, errorReporter)
+    {
+        SleepInterval = TimeSpan.FromHours(options.Value.SleepIntervalHours);
+    }
+
+    protected override Task DoWork(CancellationToken stoppingToken) =>
+        RunImport<FdaAdvisoryCommitteeCalendarImportService>(stoppingToken);
+}

--- a/src/Equibles.FdaCatalysts.HostedService/Services/FdaAdvisoryCommitteeCalendarImportService.cs
+++ b/src/Equibles.FdaCatalysts.HostedService/Services/FdaAdvisoryCommitteeCalendarImportService.cs
@@ -1,0 +1,170 @@
+using Equibles.CommonStocks.HostedService.Services;
+using Equibles.Core.AutoWiring;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data.Models;
+using Equibles.FdaCatalysts.BusinessLogic;
+using Equibles.FdaCatalysts.Data.Models;
+using Equibles.FdaCatalysts.HostedService.Configuration;
+using Equibles.FdaCatalysts.Repositories;
+using Equibles.Worker;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.FdaCatalysts.HostedService.Services;
+
+/// <summary>
+/// Imports FDA advisory-committee meetings from the FDA.gov advisory-committee
+/// calendar. The calendar table is rendered client-side, so the page is fetched
+/// through the headless stealth browser; the rendered HTML is then handed to the
+/// authoritative-column parser and the resulting rows are upserted by their stable
+/// per-meeting slug (<see cref="FdaCatalyst.SourceReference"/>). The whole calendar is
+/// re-read every cycle and reconciled — there is no watermark, because the calendar
+/// only carries a short forward window and meetings can be rescheduled in place.
+/// </summary>
+[Service]
+public class FdaAdvisoryCommitteeCalendarImportService : IImporter
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IStealthBrowserClient _stealthBrowser;
+    private readonly ErrorReporter _errorReporter;
+    private readonly ILogger<FdaAdvisoryCommitteeCalendarImportService> _logger;
+    private readonly FdaCatalystScraperOptions _options;
+
+    public FdaAdvisoryCommitteeCalendarImportService(
+        IServiceScopeFactory scopeFactory,
+        IStealthBrowserClient stealthBrowser,
+        ErrorReporter errorReporter,
+        ILogger<FdaAdvisoryCommitteeCalendarImportService> logger,
+        IOptions<FdaCatalystScraperOptions> options
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _stealthBrowser = stealthBrowser;
+        _errorReporter = errorReporter;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    public async Task Import(CancellationToken cancellationToken)
+    {
+        if (!_stealthBrowser.IsEnabled)
+        {
+            // The calendar is client-rendered, so without a stealth/render engine there
+            // is no way to read its rows — degrade to a no-op rather than scraping chrome.
+            _logger.LogWarning(
+                "FDA advisory-committee import skipped: no stealth browser configured "
+                    + "(InvestorRelationsDiscovery:StealthFetch:SidecarUrl)."
+            );
+            return;
+        }
+
+        var html = await _stealthBrowser.FetchHtml(_options.CalendarUrl, cancellationToken);
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            _logger.LogWarning(
+                "FDA advisory-committee calendar render returned no HTML from {Url}",
+                _options.CalendarUrl
+            );
+            return;
+        }
+
+        var parsed = FdaAdvisoryCommitteeCalendarParser.Parse(html);
+        if (parsed.Count == 0)
+        {
+            // A render that yields zero rows is more likely a markup change than a genuinely
+            // empty calendar, so surface it as an error rather than a silent success.
+            await _errorReporter.Report(
+                ErrorSource.FdaCatalystScraper,
+                "FdaAdvisoryCommitteeCalendarImportService.Import",
+                $"Parsed zero rows from the FDA advisory-committee calendar at {_options.CalendarUrl}",
+                null
+            );
+            return;
+        }
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var repository = scope.ServiceProvider.GetRequiredService<FdaCatalystRepository>();
+
+        var slugs = parsed.Select(c => c.SourceReference).ToList();
+        var existing = await repository
+            .GetAll()
+            .Where(c => slugs.Contains(c.SourceReference))
+            .ToListAsync(cancellationToken);
+        var bySlug = existing.ToDictionary(c => c.SourceReference);
+
+        var inserted = 0;
+        var updated = 0;
+        foreach (var catalyst in parsed)
+        {
+            if (bySlug.TryGetValue(catalyst.SourceReference, out var row))
+            {
+                if (Apply(catalyst, row))
+                {
+                    repository.Update(row);
+                    updated++;
+                }
+            }
+            else
+            {
+                repository.Add(catalyst);
+                inserted++;
+            }
+        }
+
+        await repository.SaveChanges();
+
+        _logger.LogInformation(
+            "FDA advisory-committee import complete: {Inserted} new, {Updated} updated, "
+                + "{Total} on the calendar.",
+            inserted,
+            updated,
+            parsed.Count
+        );
+    }
+
+    /// <summary>
+    /// Refreshes the mutable, calendar-sourced fields of an existing catalyst from a
+    /// freshly parsed row, preserving the stored <c>Id</c>, <c>CreationTime</c>, and any
+    /// resolved <c>CommonStockId</c>. Returns true only when something actually changed,
+    /// so a row is marked dirty only on a real update.
+    /// </summary>
+    private static bool Apply(FdaCatalyst source, FdaCatalyst target)
+    {
+        var changed = false;
+        if (target.CatalystType != source.CatalystType)
+        {
+            target.CatalystType = source.CatalystType;
+            changed = true;
+        }
+        if (target.MeetingDate != source.MeetingDate)
+        {
+            target.MeetingDate = source.MeetingDate;
+            changed = true;
+        }
+        if (target.EndDate != source.EndDate)
+        {
+            target.EndDate = source.EndDate;
+            changed = true;
+        }
+        if (target.Center != source.Center)
+        {
+            target.Center = source.Center;
+            changed = true;
+        }
+        if (target.Title != source.Title)
+        {
+            target.Title = source.Title;
+            changed = true;
+        }
+        if (target.Summary != source.Summary)
+        {
+            target.Summary = source.Summary;
+            changed = true;
+        }
+        if (target.SourceUrl != source.SourceUrl)
+        {
+            target.SourceUrl = source.SourceUrl;
+            changed = true;
+        }
+        return changed;
+    }
+}

--- a/src/Equibles.Worker.Host/Equibles.Worker.Host.csproj
+++ b/src/Equibles.Worker.Host/Equibles.Worker.Host.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\Equibles.Congress.HostedService\Equibles.Congress.HostedService.csproj" />
     <ProjectReference Include="..\Equibles.Finra.HostedService\Equibles.Finra.HostedService.csproj" />
     <ProjectReference Include="..\Equibles.Fred.HostedService\Equibles.Fred.HostedService.csproj" />
+    <ProjectReference Include="..\Equibles.FdaCatalysts.HostedService\Equibles.FdaCatalysts.HostedService.csproj" />
     <ProjectReference Include="..\Equibles.Integrations.Yahoo\Equibles.Integrations.Yahoo.csproj" />
     <ProjectReference Include="..\Equibles.Yahoo.HostedService\Equibles.Yahoo.HostedService.csproj" />
     <ProjectReference Include="..\Equibles.Cftc.HostedService\Equibles.Cftc.HostedService.csproj" />

--- a/src/Equibles.Worker.Host/Program.cs
+++ b/src/Equibles.Worker.Host/Program.cs
@@ -11,6 +11,8 @@ using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
 using Equibles.Data.Extensions;
 using Equibles.Errors.Data.Extensions;
+using Equibles.FdaCatalysts.HostedService.Configuration;
+using Equibles.FdaCatalysts.HostedService.Extensions;
 using Equibles.Finra.Data.Extensions;
 using Equibles.Finra.HostedService.Extensions;
 using Equibles.Fred.Data.Extensions;
@@ -112,6 +114,9 @@ builder.Services.Configure<InvestorRelationsDiscoveryOptions>(
 builder.Services.Configure<Equibles.CommonStocks.HostedService.Configuration.StealthFetchOptions>(
     builder.Configuration.GetSection("InvestorRelationsDiscovery:StealthFetch")
 );
+builder.Services.Configure<FdaCatalystScraperOptions>(
+    builder.Configuration.GetSection("FdaCatalystScraper")
+);
 
 // Without this bind, IOptions<EmbeddingConfig> is always default (Enabled=false),
 // so GenerateEmbeddingBatch short-circuits and no embeddings are ever produced —
@@ -141,6 +146,10 @@ builder.Services.AddCboeWorker();
 builder.Services.AddCongressWorker();
 builder.Services.AddHoldingsWorker();
 builder.Services.AddCommonStocksWorker();
+
+// Reads the stealth browser registered by AddCommonStocksWorker above to render the
+// client-side FDA.gov advisory-committee calendar.
+builder.Services.AddFdaCatalystWorker();
 
 var host = builder.Build();
 host.Run();

--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -96,5 +96,7 @@
     <ProjectReference Include="..\..\src\Equibles.Cboe.HostedService\Equibles.Cboe.HostedService.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Messaging\Equibles.Messaging.csproj" />
     <ProjectReference Include="..\..\src\Equibles.FdaCatalysts.BusinessLogic\Equibles.FdaCatalysts.BusinessLogic.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.FdaCatalysts.Repositories\Equibles.FdaCatalysts.Repositories.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.FdaCatalysts.HostedService\Equibles.FdaCatalysts.HostedService.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarImportServiceTests.cs
+++ b/tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarImportServiceTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equibles.CommonStocks.HostedService.Services;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.FdaCatalysts.Data;
+using Equibles.FdaCatalysts.Data.Models;
+using Equibles.FdaCatalysts.HostedService.Configuration;
+using Equibles.FdaCatalysts.HostedService.Services;
+using Equibles.FdaCatalysts.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Equibles.UnitTests.FdaCatalysts;
+
+/// <summary>
+/// Contract: <c>FdaAdvisoryCommitteeCalendarImportService.Import</c> renders the
+/// FDA.gov advisory-committee calendar through the stealth browser, parses the
+/// authoritative columns, and upserts the meetings by their per-meeting slug — so a
+/// re-run reconciles in place rather than duplicating, and a row whose calendar fields
+/// changed is refreshed. With no stealth engine configured it is a clean no-op.
+/// </summary>
+public class FdaAdvisoryCommitteeCalendarImportServiceTests
+{
+    private static string FixtureHtml() =>
+        File.ReadAllText(
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "TestAssets",
+                "FdaCatalysts",
+                "fda-advisory-committee-calendar.html"
+            )
+        );
+
+    private static DbContextOptions<EquiblesFinancialDbContext> NewDbOptions() =>
+        new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), new InMemoryDatabaseRoot())
+            .EnableServiceProviderCaching(false)
+            .Options;
+
+    private static EquiblesFinancialDbContext NewContext(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var ctx = new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[] { new FdaCatalystsModuleConfiguration() }
+        );
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+
+    private static IServiceScopeFactory ScopeFactory(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => NewContext(options));
+        services.AddScoped<FdaCatalystRepository>();
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+
+    private static FdaAdvisoryCommitteeCalendarImportService BuildSut(
+        DbContextOptions<EquiblesFinancialDbContext> options,
+        string html,
+        bool stealthEnabled = true
+    )
+    {
+        var stealth = Substitute.For<IStealthBrowserClient>();
+        stealth.IsEnabled.Returns(stealthEnabled);
+        stealth
+            .FetchHtml(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(html));
+
+        return new FdaAdvisoryCommitteeCalendarImportService(
+            ScopeFactory(options),
+            stealth,
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Substitute.For<ILogger<FdaAdvisoryCommitteeCalendarImportService>>(),
+            Options.Create(new FdaCatalystScraperOptions())
+        );
+    }
+
+    private static async Task<System.Collections.Generic.List<FdaCatalyst>> AllRows(
+        DbContextOptions<EquiblesFinancialDbContext> options
+    )
+    {
+        using var ctx = NewContext(options);
+        return await ctx.Set<FdaCatalyst>().ToListAsync();
+    }
+
+    [Fact]
+    public async Task Import_PersistsEveryParsedAdvisoryCommitteeMeeting()
+    {
+        var options = NewDbOptions();
+
+        await BuildSut(options, FixtureHtml()).Import(CancellationToken.None);
+
+        var rows = await AllRows(options);
+        // The fixture has five meeting rows; the stale 2016 row with no Start Date is
+        // dropped by the parser, leaving four.
+        rows.Should().HaveCount(4);
+        rows.Should().OnlyContain(c => c.CatalystType == FdaCatalystType.AdvisoryCommittee);
+        rows.Should().OnlyContain(c => !string.IsNullOrWhiteSpace(c.SourceReference));
+        rows.Should().OnlyContain(c => !string.IsNullOrWhiteSpace(c.Center));
+    }
+
+    [Fact]
+    public async Task Import_IsIdempotent_ReRunDoesNotDuplicate()
+    {
+        var options = NewDbOptions();
+        var html = FixtureHtml();
+
+        await BuildSut(options, html).Import(CancellationToken.None);
+        await BuildSut(options, html).Import(CancellationToken.None);
+
+        (await AllRows(options)).Should().HaveCount(4);
+    }
+
+    [Fact]
+    public async Task Import_RefreshesAnExistingRow_FromTheCalendarWithoutDuplicating()
+    {
+        var options = NewDbOptions();
+        var html = FixtureHtml();
+
+        // Seed one row whose slug matches a parsed meeting but whose title is stale, then
+        // import: the row must be refreshed in place, not duplicated.
+        var parsed = Equibles
+            .FdaCatalysts.BusinessLogic.FdaAdvisoryCommitteeCalendarParser.Parse(html)
+            .First();
+        using (var ctx = NewContext(options))
+        {
+            ctx.Set<FdaCatalyst>()
+                .Add(
+                    new FdaCatalyst
+                    {
+                        CatalystType = FdaCatalystType.AdvisoryCommittee,
+                        MeetingDate = new DateOnly(2000, 1, 1),
+                        Center = "stale center",
+                        Title = "stale title",
+                        SourceReference = parsed.SourceReference,
+                    }
+                );
+            await ctx.SaveChangesAsync();
+        }
+
+        await BuildSut(options, html).Import(CancellationToken.None);
+
+        var rows = await AllRows(options);
+        rows.Should().HaveCount(4);
+        var refreshed = rows.Single(c => c.SourceReference == parsed.SourceReference);
+        refreshed.Title.Should().Be(parsed.Title);
+        refreshed.MeetingDate.Should().Be(parsed.MeetingDate);
+        refreshed.Center.Should().Be(parsed.Center);
+    }
+
+    [Fact]
+    public async Task Import_WithoutAStealthBrowser_DoesNothing()
+    {
+        var options = NewDbOptions();
+
+        await BuildSut(options, FixtureHtml(), stealthEnabled: false)
+            .Import(CancellationToken.None);
+
+        (await AllRows(options)).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Adds the ingestion worker that fills the `FdaCatalyst` table from the FDA.gov advisory-committee calendar — slice 4 of the FDA catalyst calendar feature (tracking issue daniel3303/EquiblesCommercial#2238). The data module, the FDA.gov entity reshape, and the calendar parser landed in #3712, #3717, and #3718; this slice is the worker that drives the parser on a schedule and persists the results.

The calendar's meeting rows are rendered client-side (a Drupal "views" DataTable), so a plain HTTP GET returns only page chrome. The worker therefore fetches the page through the existing headless stealth browser (`IStealthBrowserClient`, the same engine IR discovery uses) and hands the rendered HTML to `FdaAdvisoryCommitteeCalendarParser`. Meetings are upserted by their stable per-meeting slug (`SourceReference`), so each cycle reconciles the calendar in place rather than duplicating. There is no watermark — the calendar only carries a short forward window and meetings can be rescheduled in place, so the whole table is re-read and reconciled every cycle.

With no stealth engine configured the worker is a clean no-op (the calendar can't be read without rendering). A render that parses to zero rows is surfaced under a new `FdaCatalystScraper` error source rather than passing as a silent success, since that points at a markup change.

## Code changes

- **`src/Equibles.FdaCatalysts.HostedService/`** (new project)
  - `FdaAdvisoryCommitteeCalendarImportService` — `IImporter` that renders the calendar, parses it, and upserts by slug (insert new, refresh changed fields in place, leave `Id`/`CreationTime`/`CommonStockId` untouched).
  - `FdaCatalystScraperWorker` — `BaseScraperWorker` running the importer on the configured interval (default daily).
  - `FdaCatalystScraperOptions` — `SleepIntervalHours` + the calendar URL.
  - `AddFdaCatalystWorker()` DI extension.
- **`ErrorSource`** — new `FdaCatalystScraper` value (string-stored smart enum; no migration).
- **`Equibles.Worker.Host`** — binds `FdaCatalystScraper` config and registers the worker after the common-stocks worker (which provides the stealth browser).
- **Tests** — `FdaAdvisoryCommitteeCalendarImportServiceTests`: persists every parsed meeting, idempotent re-run, in-place refresh without duplication, and the no-stealth no-op.

No schema change — the table and migrations already exist from the earlier slices.
