### PR TITLE
feat(ir-discovery): follow the homepage investor-relations link when path guessing misses

### DIFF
--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsLinkExtractor.cs
@@ -1,0 +1,122 @@
+using HtmlAgilityPack;
+
+namespace Equibles.CommonStocks.HostedService.Services;
+
+/// <summary>
+/// Extracts candidate investor-relations URLs from a company homepage by reading its
+/// anchors — the link whose visible text or href is about investor relations. This catches
+/// IR pages at locations path/subdomain guessing can't reach: a different host (a Q4 / GCS
+/// portal), a regional subdomain, a locale path (<c>/ja/ir/</c>), or a deeper path
+/// (<c>/investor-information</c>, <c>/stock-info/</c>). Pure (no I/O), so it is unit-testable
+/// against fixture HTML.
+/// </summary>
+public static class InvestorRelationsLinkExtractor
+{
+    // Strong IR signals in the anchor text or the href.
+    private static readonly string[] PrimaryKeywords = ["investor", "shareholder"];
+
+    // Weaker signals SPACs / microcaps use instead of an "Investors" link (a SEC-filings or
+    // stock-information link). These are validated downstream, so a false positive costs only a
+    // probe — they are tried after every primary candidate.
+    private static readonly string[] SecondaryKeywords =
+    [
+        "sec filings",
+        "sec-filings",
+        "stock information",
+        "stock-info",
+        "stock quote",
+        "financial reports",
+        "financial-reports",
+        "annual report",
+    ];
+
+    /// <summary>
+    /// Returns absolute IR-link candidates found in <paramref name="html"/>, resolved against
+    /// <paramref name="baseUrl"/>, primary signals first, de-duplicated, capped at
+    /// <paramref name="max"/>. Empty when the HTML has no anchors or the base URL is unparseable.
+    /// </summary>
+    public static IReadOnlyList<string> Extract(string html, string baseUrl, int max = 6)
+    {
+        if (
+            string.IsNullOrWhiteSpace(html)
+            || !Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri)
+        )
+            return [];
+
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+        var anchors = document.DocumentNode.SelectNodes("//a[@href]");
+        if (anchors == null)
+            return [];
+
+        var primary = new List<string>();
+        var secondary = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var anchor in anchors)
+        {
+            if (!TryResolveHref(baseUri, anchor.GetAttributeValue("href", ""), out var absolute))
+                continue;
+            if (!seen.Add(absolute))
+                continue;
+
+            var text = HtmlEntity.DeEntitize(anchor.InnerText ?? "").Trim().ToLowerInvariant();
+            var haystack = text + " " + absolute.ToLowerInvariant();
+
+            if (PrimaryKeywords.Any(haystack.Contains) || HasIrHostOrPath(absolute))
+                primary.Add(absolute);
+            else if (SecondaryKeywords.Any(haystack.Contains))
+                secondary.Add(absolute);
+        }
+
+        return primary.Concat(secondary).Take(max).ToList();
+    }
+
+    // The link's host is an ir. / investor(s). subdomain, or its path carries an "ir" segment
+    // (e.g. a locale-prefixed /ja/ir/) — strong IR signals even when the anchor text isn't English.
+    private static bool HasIrHostOrPath(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return false;
+
+        var host = uri.Host.ToLowerInvariant();
+        if (host.StartsWith("ir.") || host.StartsWith("investor.") || host.StartsWith("investors."))
+            return true;
+
+        return uri
+            .AbsolutePath.ToLowerInvariant()
+            .Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .Contains("ir");
+    }
+
+    private static bool TryResolveHref(Uri baseUri, string href, out string absolute)
+    {
+        absolute = null;
+        if (string.IsNullOrWhiteSpace(href))
+            return false;
+
+        var trimmed = href.Trim();
+        if (
+            trimmed.StartsWith("#")
+            || trimmed.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("tel:", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase)
+        )
+            return false;
+
+        if (
+            !Uri.TryCreate(baseUri, trimmed, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+        )
+            return false;
+
+        // EDGAR is the regulator's site, not a company IR page — filings already come from there.
+        var host = uri.Host.ToLowerInvariant();
+        if (host == "sec.gov" || host.EndsWith(".sec.gov"))
+            return false;
+
+        // Drop the fragment; keep the path and query.
+        absolute = uri.GetLeftPart(UriPartial.Query);
+        return true;
+    }
+}

--- a/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
+++ b/src/Equibles.CommonStocks.HostedService/Services/InvestorRelationsProbeClient.cs
@@ -60,7 +60,11 @@ public class InvestorRelationsProbeClient
                 return resolved;
         }
 
-        return null;
+        // None of the guessed paths/subdomains validated. Crawl the homepage and follow the
+        // investor-relations link it exposes — the IR page is often at a location guessing can't
+        // reach (a Q4 / GCS host, a regional or locale path, a deeper path), and the homepage URL
+        // itself is sometimes the IR site.
+        return await CrawlHomepage(website, cancellationToken);
     }
 
     private async Task<IrDiscoveryResult> TryResolve(
@@ -68,11 +72,31 @@ public class InvestorRelationsProbeClient
         CancellationToken cancellationToken
     )
     {
-        // Company/IR hosts are mostly bot-protected, so render every candidate through
-        // the stealth sidecar when one is configured. Plain HTTP is only the fallback
-        // for a standalone build with no sidecar.
+        var (html, finalUrl) = await Fetch(url, cancellationToken);
+        if (html == null)
+            return null;
+
+        return BuildResult(html, finalUrl, url);
+    }
+
+    /// <summary>
+    /// Fetches the page's HTML and the URL it actually landed on: rendered through the stealth
+    /// sidecar when one is configured (most company/IR hosts are bot-protected, so plain HTTP
+    /// would be walled), otherwise plain HTTP as the standalone fallback. Returns
+    /// <c>(null, url)</c> on any miss; a single host never fails the discovery batch.
+    /// </summary>
+    private async Task<(string Html, string FinalUrl)> Fetch(
+        string url,
+        CancellationToken cancellationToken
+    )
+    {
         if (_stealthClient.IsEnabled)
-            return await ResolveViaStealth(url, cancellationToken);
+        {
+            // The stealth fetch follows redirects internally, so the requested URL is the best
+            // one we have for the rendered page.
+            var rendered = await _stealthClient.FetchHtml(url, cancellationToken);
+            return (rendered, url);
+        }
 
         try
         {
@@ -88,13 +112,12 @@ public class InvestorRelationsProbeClient
 
             if (response.IsSuccessStatusCode && body != null)
             {
-                // Prefer where the request actually landed after redirects, falling
-                // back to the probed URL when that overruns the column ceiling.
+                // Where the request actually landed after redirects.
                 var finalUrl = response.RequestMessage?.RequestUri?.ToString() ?? url;
-                return BuildResult(body, finalUrl, url);
+                return (body, finalUrl);
             }
 
-            return null;
+            return (null, url);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -105,29 +128,71 @@ public class InvestorRelationsProbeClient
             // A dead host, TLS error, or timeout on a guessed URL is expected and
             // not worth reporting — most candidates won't exist.
             _logger.LogDebug(ex, "Investor relations probe failed for {Url}", url);
-            return null;
+            return (null, url);
         }
     }
 
-    private async Task<IrDiscoveryResult> ResolveViaStealth(
-        string url,
+    /// <summary>
+    /// Fetches the company homepage and either validates it directly as the IR site (when the
+    /// website itself is an investor.* host) or follows the investor-relations link(s) it
+    /// exposes — catching IR pages at locations path/subdomain guessing can't reach.
+    /// </summary>
+    private async Task<IrDiscoveryResult> CrawlHomepage(
+        string website,
         CancellationToken cancellationToken
     )
     {
-        var html = await _stealthClient.FetchHtml(url, cancellationToken);
+        // EDGAR-sourced websites occasionally omit the scheme ("acme.com"); the candidate builder
+        // normalizes for the guessed probes, but the homepage fetch consumes the raw value, so
+        // normalize it here too or HttpClient would reject the non-absolute URL.
+        var homepage = NormalizeWebsite(website);
+        if (homepage == null)
+            return null;
+
+        var (html, finalUrl) = await Fetch(homepage, cancellationToken);
         if (html == null)
             return null;
 
-        // The stealth fetch follows redirects internally, so the candidate is the
-        // best URL we have for the rendered page.
-        var result = BuildResult(html, url, url);
-        if (result != null)
-            _logger.LogInformation(
-                "Investor relations page resolved via stealth fetch for {Url}",
-                url
-            );
+        // The website itself might BE the IR site (e.g. investor.acme.com).
+        var self = BuildResult(html, finalUrl, website);
+        if (self != null)
+            return self;
 
-        return result;
+        foreach (var link in InvestorRelationsLinkExtractor.Extract(html, finalUrl))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var resolved = await TryResolve(link, cancellationToken);
+            if (resolved != null)
+            {
+                _logger.LogInformation(
+                    "Investor relations page resolved via homepage link {Link} for {Website}",
+                    link,
+                    website
+                );
+                return resolved;
+            }
+        }
+
+        return null;
+    }
+
+    // Turns a possibly-scheme-less website into an absolute http(s) URL, or null when it can't be
+    // parsed as one. Mirrors InvestorRelationsCandidateBuilder's normalization.
+    private static string NormalizeWebsite(string website)
+    {
+        if (string.IsNullOrWhiteSpace(website))
+            return null;
+
+        var normalized = website.Trim();
+        if (!normalized.Contains("://"))
+            normalized = "https://" + normalized;
+
+        return
+            Uri.TryCreate(normalized, UriKind.Absolute, out var uri)
+            && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+            ? normalized
+            : null;
     }
 
     /// <summary>

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsLinkExtractorTests.cs
@@ -1,0 +1,79 @@
+using Equibles.CommonStocks.HostedService.Services;
+
+namespace Equibles.UnitTests.CommonStocks;
+
+public class InvestorRelationsLinkExtractorTests
+{
+    [Fact]
+    public void Extract_FindsIrLinksByTextOrHref_PrimaryBeforeSecondary()
+    {
+        const string html =
+            "<html><body><nav>"
+            + "<a href=\"/about\">About us</a>"
+            // primary: anchor text contains "investor", on a third-party host
+            + "<a href=\"https://firstmid.q4ir.com/ir-home\">Investor Relations</a>"
+            // primary: href path carries an "ir" segment (locale-prefixed), non-English text
+            + "<a href=\"/ja/ir/\">株主・投資家</a>"
+            // secondary: a SEC-filings link (SPAC/microcap pattern)
+            + "<a href=\"/sec-filings/\">SEC Filings</a>"
+            + "<a href=\"mailto:ir@acme.com\">Email IR</a>"
+            + "<a href=\"https://www.sec.gov/edgar\">EDGAR</a>"
+            + "<a href=\"#investors\">Skip to investors</a>"
+            + "</nav></body></html>";
+
+        var links = InvestorRelationsLinkExtractor.Extract(html, "https://acme.com");
+
+        links
+            .Should()
+            .ContainInOrder(
+                "https://firstmid.q4ir.com/ir-home",
+                "https://acme.com/ja/ir/",
+                "https://acme.com/sec-filings/"
+            );
+        // mailto, sec.gov, and the in-page fragment are excluded.
+        links.Should().NotContain(l => l.Contains("sec.gov"));
+        links.Should().NotContain(l => l.Contains("mailto") || l.Contains("#"));
+    }
+
+    [Fact]
+    public void Extract_InvestorSubdomainAnchor_IsFound()
+    {
+        var links = InvestorRelationsLinkExtractor.Extract(
+            "<a href=\"https://investors.acme.com/\">Investors</a>",
+            "https://www.acme.com"
+        );
+
+        links.Should().ContainSingle().Which.Should().Be("https://investors.acme.com/");
+    }
+
+    [Fact]
+    public void Extract_NoIrAnchors_ReturnsEmpty()
+    {
+        InvestorRelationsLinkExtractor
+            .Extract("<html><body><a href=\"/about\">About</a></body></html>", "https://acme.com")
+            .Should()
+            .BeEmpty();
+    }
+
+    [Fact]
+    public void Extract_UnparseableBase_ReturnsEmpty()
+    {
+        InvestorRelationsLinkExtractor
+            .Extract("<a href=\"/investors\">Investors</a>", "not-a-url")
+            .Should()
+            .BeEmpty();
+    }
+
+    [Fact]
+    public void Extract_DedupesAndCaps()
+    {
+        var html = string.Concat(
+            Enumerable.Range(0, 10).Select(i => $"<a href=\"/investor-{i}\">Investors {i}</a>")
+        );
+
+        InvestorRelationsLinkExtractor
+            .Extract(html, "https://acme.com", max: 3)
+            .Should()
+            .HaveCount(3);
+    }
+}

--- a/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
+++ b/tests/Equibles.UnitTests/CommonStocks/InvestorRelationsProbeClientTests.cs
@@ -115,11 +115,75 @@ public class InvestorRelationsProbeClientTests
         result.Url.Length.Should().BeLessThanOrEqualTo(256);
     }
 
+    [Theory]
+    [InlineData("https://acme.com")]
+    [InlineData("acme.com")] // EDGAR data often omits the scheme; the crawl must still run.
+    public async Task Discover_NoSidecar_GuessedPathsMiss_FollowsHomepageIrLink(string website)
+    {
+        // The guessed paths/subdomains don't validate, but the homepage links to the real IR
+        // page at a non-guessed location (/en-us/investors) — the homepage crawl follows it.
+        const string homepage =
+            "<html><head><title>Acme Corp</title></head><body>"
+            + "<a href=\"/en-us/investors\">Investors</a></body></html>";
+        const string irPage =
+            "<html><head><title>Investor Relations - Acme</title></head>"
+            + "<body><h1>Quarterly results</h1></body></html>";
+        const string notIr =
+            "<html><head><title>Page not found</title></head><body>404</body></html>";
+
+        var handler = new RoutingHandler(uri =>
+        {
+            var key = uri.Host + uri.AbsolutePath;
+            return key == "acme.com/" ? homepage
+                : key == "acme.com/en-us/investors" ? irPage
+                : notIr;
+        });
+        var client = new InvestorRelationsProbeClient(
+            new HttpClient(handler),
+            DisabledStealth(),
+            NullLogger<InvestorRelationsProbeClient>.Instance
+        );
+
+        var result = await client.Discover(
+            website,
+            ["investors", "ir"],
+            ["ir"],
+            CancellationToken.None
+        );
+
+        result.Should().NotBeNull();
+        result!.Url.Should().Be("https://acme.com/en-us/investors");
+    }
+
     private static IStealthBrowserClient DisabledStealth()
     {
         var stealth = Substitute.For<IStealthBrowserClient>();
         stealth.IsEnabled.Returns(false);
         return stealth;
+    }
+
+    // Serves a body chosen per request URL, echoing the request as the final URL.
+    private sealed class RoutingHandler : HttpMessageHandler
+    {
+        private readonly Func<Uri, string> _bodyFor;
+
+        public RoutingHandler(Func<Uri, string> bodyFor) => _bodyFor = bodyFor;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        ) =>
+            Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        _bodyFor(request.RequestUri!),
+                        Encoding.UTF8,
+                        "text/html"
+                    ),
+                    RequestMessage = request,
+                }
+            );
     }
 
     // Fails the test if plain HTTP is used — proves the sidecar path never falls through


### PR DESCRIPTION
## Summary

Discovery only probed a handful of **guessed** candidates — a few paths (`/investors`, `/ir`, …) and `ir.`/`investors.` subdomains. An audit of 24 companies that have a website but **no** discovered IR URL found the IR link is on the homepage **22 of 24** times, but often at a location guessing can't reach: a third-party IR host (a Q4 / GCS portal), a regional subdomain, a locale path (`/ja/ir/`), or a deeper path (`/investor-information`, `/sec-filings/`). Those were missed forever.

This adds a **homepage crawl** that runs only after every guessed candidate fails: fetch the homepage once (through the stealth sidecar when configured), validate it directly in case the website itself **is** the IR site (e.g. `investor.acme.com`), then follow the investor-relations link(s) it exposes.

## Code changes

- **New** `InvestorRelationsLinkExtractor` (HtmlAgilityPack, pure) — returns absolute IR-link candidates from a homepage: anchor text/href carrying `investor`/`shareholder`, an `ir.`/`investors.` host, or an `/ir/` path segment (primary); `sec filings` / `stock information` / … (secondary, tried after). Resolves relative hrefs, excludes `sec.gov` and `mailto:`/`tel:`/`javascript:`/`#`, dedups, caps.
- `InvestorRelationsProbeClient` — factored a `Fetch()` helper (stealth-first / plain-HTTP fallback, **behaviour unchanged** from the post-sidecar version) and added `CrawlHomepage()`. `Discover()` calls it after the guessed candidates. Each extracted link is still gated by `InvestorRelationsPageValidator`, so a junk link costs only one rate-limited probe. Scheme-less websites (EDGAR data) are normalized before the crawl.

## Cost

The crawl adds **one homepage fetch + up to a few link probes per MISSED stock only** — a stock that resolves on a guessed candidate returns early and pays nothing.

## Verification

- `csharpier check` clean; `Equibles.Worker.Host` builds; all **161** CommonStocks unit tests pass (new `InvestorRelationsLinkExtractorTests` covering third-party host, locale `/ja/ir/`, secondary `/sec-filings/`, `sec.gov`/`mailto`/`#` exclusion, primary-before-secondary order, dedup+cap; homepage-crawl probe test covering both scheme-qualified and scheme-less websites).
- code-reviewer: APPROVE after fixing one High (scheme-less website skipped the crawl) — now normalized + covered.

## Context

Pairs with the always-sidecar change (#3716): with the sidecar deployed, the homepage fetch + IR-link probes render through stealth, so bot-walled homepages are also crawled. Largest single coverage lever remains deploying the sidecar so the existing checked-but-missed cohort is re-probed.
