### PR TITLE
test(fda-catalysts): pin advisory-committee parser dedups a repeated meeting slug

### DIFF
--- a/tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserDuplicateSlugTests.cs
+++ b/tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserDuplicateSlugTests.cs
@@ -1,0 +1,43 @@
+using Equibles.FdaCatalysts.BusinessLogic;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.FdaCatalysts;
+
+public class FdaAdvisoryCommitteeCalendarParserDuplicateSlugTests
+{
+    // The per-meeting slug is the natural key the worker upserts on, so the parser must dedup it
+    // within a single page: a calendar that lists the same meeting twice (here the second row's
+    // anchor differs only by a tracking query string the slug extractor strips) must yield one
+    // catalyst, not a duplicate pair, so the same render cannot insert the meeting twice.
+    [Fact]
+    public void Parse_DuplicateMeetingSlug_KeepsOnlyTheFirstOccurrence()
+    {
+        const string html =
+            @"<table class='lcds-datatable--advisory-committee-calendar'>
+  <thead><tr><th>Start Date</th><th>End Date</th><th>Meeting</th><th>Center</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>03/10/2026 08:00 AM EDT</td>
+      <td>03/10/2026 04:00 PM EDT</td>
+      <td><a href='/advisory-committees/advisory-committee-calendar/march-10-2026-oncologic-drugs-advisory-committee-meeting'>March 10, 2026: Oncologic Drugs Advisory Committee</a></td>
+      <td>Center for Drug Evaluation and Research</td>
+    </tr>
+    <tr>
+      <td>03/10/2026 08:00 AM EDT</td>
+      <td>03/10/2026 04:00 PM EDT</td>
+      <td><a href='/advisory-committees/advisory-committee-calendar/march-10-2026-oncologic-drugs-advisory-committee-meeting?utm=dup'>March 10, 2026: Oncologic Drugs Advisory Committee (duplicate listing)</a></td>
+      <td>Center for Drug Evaluation and Research</td>
+    </tr>
+  </tbody>
+</table>";
+
+        var catalysts = FdaAdvisoryCommitteeCalendarParser.Parse(html);
+
+        catalysts
+            .Should()
+            .ContainSingle()
+            .Which.SourceReference.Should()
+            .Be("march-10-2026-oncologic-drugs-advisory-committee-meeting");
+    }
+}


### PR DESCRIPTION
## Summary

- The per-meeting slug is the natural key the import worker upserts on, and `FdaAdvisoryCommitteeCalendarParser` dedups it within a single page, but that guard had no test.
- Adds one unit test: a calendar listing the same meeting twice (the duplicate row's anchor differs only by a tracking query string the slug extractor strips) yields a single catalyst, so one render cannot insert the meeting twice.

## Code changes

- `tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserDuplicateSlugTests.cs` — new unit test pinning the duplicate-slug dedup path.