### PR TITLE
feat(fda-catalysts): add the GetFdaCatalysts MCP tool

### DIFF
--- a/Equibles.sln
+++ b/Equibles.sln
@@ -175,6 +175,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.Busin
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.HostedService", "src\Equibles.FdaCatalysts.HostedService\Equibles.FdaCatalysts.HostedService.csproj", "{65E4C514-1A49-445F-92E0-D87B37F072A1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Equibles.FdaCatalysts.Mcp", "src\Equibles.FdaCatalysts.Mcp\Equibles.FdaCatalysts.Mcp.csproj", "{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1193,6 +1195,18 @@ Global
 		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Release|x64.Build.0 = Release|Any CPU
 		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Release|x86.ActiveCfg = Release|Any CPU
 		{65E4C514-1A49-445F-92E0-D87B37F072A1}.Release|x86.Build.0 = Release|Any CPU
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Debug|x64.Build.0 = Debug|Any CPU
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Debug|x86.Build.0 = Debug|Any CPU
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Release|x64.ActiveCfg = Release|Any CPU
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Release|x64.Build.0 = Release|Any CPU
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Release|x86.ActiveCfg = Release|Any CPU
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1282,6 +1296,7 @@ Global
 		{5F2ACE60-D60E-4AF3-BBCB-CE5B8E226837} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{50271682-2648-41F7-9B01-292259615318} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{65E4C514-1A49-445F-92E0-D87B37F072A1} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{DA825E79-D731-46F9-BC1E-D1776FD2B1CA} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7473574D-5C8B-494E-9E90-98F9FC10518C}

--- a/src/Equibles.FdaCatalysts.Mcp/Equibles.FdaCatalysts.Mcp.csproj
+++ b/src/Equibles.FdaCatalysts.Mcp/Equibles.FdaCatalysts.Mcp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Equibles.Mcp\Equibles.Mcp.csproj" />
+    <ProjectReference Include="..\Equibles.FdaCatalysts.Repositories\Equibles.FdaCatalysts.Repositories.csproj" />
+    <ProjectReference Include="..\Equibles.Errors.BusinessLogic\Equibles.Errors.BusinessLogic.csproj" />
+    <ProjectReference Include="..\Equibles.Core\Equibles.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Equibles.FdaCatalysts.Mcp/Extensions/McpBuilderExtensions.cs
+++ b/src/Equibles.FdaCatalysts.Mcp/Extensions/McpBuilderExtensions.cs
@@ -1,0 +1,12 @@
+using Equibles.FdaCatalysts.Mcp.Tools;
+using Equibles.Mcp;
+
+namespace Equibles.FdaCatalysts.Mcp.Extensions;
+
+public static class McpBuilderExtensions
+{
+    public static EquiblesMcpBuilder AddFdaCatalysts(this EquiblesMcpBuilder builder)
+    {
+        return builder.AddModule<AssemblyMcpModule<FdaCatalystTools>>();
+    }
+}

--- a/src/Equibles.FdaCatalysts.Mcp/Tools/FdaCatalystTools.cs
+++ b/src/Equibles.FdaCatalysts.Mcp/Tools/FdaCatalystTools.cs
@@ -1,0 +1,81 @@
+using System.ComponentModel;
+using Equibles.Core.Extensions;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.BusinessLogic.Extensions;
+using Equibles.FdaCatalysts.Repositories;
+using Equibles.Mcp;
+using Equibles.Mcp.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+namespace Equibles.FdaCatalysts.Mcp.Tools;
+
+[McpServerToolType]
+public class FdaCatalystTools
+{
+    private readonly FdaCatalystRepository _repository;
+    private readonly McpToolRunner _runner;
+
+    public FdaCatalystTools(
+        FdaCatalystRepository repository,
+        ErrorManager errorManager,
+        ILogger<FdaCatalystTools> logger
+    )
+    {
+        _repository = repository;
+        _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
+    }
+
+    [McpServerTool(Name = "GetFdaCatalysts")]
+    [Description(
+        "Get scheduled FDA advisory-committee (AdComm) meetings — the regulatory catalyst dates that move biotech and pharma stocks. Sourced from the FDA.gov advisory-committee calendar. Defaults to meetings in the next 90 days; pass a date range to look further ahead or back."
+    )]
+    public Task<string> GetFdaCatalysts(
+        [Description("Start date in YYYY-MM-DD format (defaults to today)")]
+            string startDate = null,
+        [Description("End date in YYYY-MM-DD format (defaults to 90 days after the start)")]
+            string endDate = null,
+        [Description("Maximum number of meetings to return (default: 60, soonest first)")]
+            int maxResults = 60
+    )
+    {
+        return _runner.Execute(
+            async () =>
+            {
+                var today = DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = McpToolExecutor.ParseDateOr(startDate, today);
+                var end = McpToolExecutor.ParseDateOr(endDate, start.AddDays(90));
+                if (end < start)
+                    end = start;
+
+                maxResults = McpLimit.Clamp(maxResults);
+
+                var records = await _repository
+                    .GetByDateRange(start, end)
+                    .OrderBy(c => c.MeetingDate)
+                    .ThenBy(c => c.Title)
+                    .Take(maxResults)
+                    .ToListAsync();
+
+                return MarkdownTable.Render(
+                    records,
+                    "No FDA advisory-committee meetings found in the specified date range.",
+                    "FDA Catalyst Calendar (advisory-committee meetings):",
+                    "| Date | Meeting | Center | Type | Through |",
+                    "|------|---------|--------|------|---------|",
+                    c =>
+                        $"| {c.MeetingDate:yyyy-MM-dd} | {Clean(c.Title)} | {Clean(c.Center)} | {c.CatalystType.NameForHumans()} | {(c.EndDate.HasValue ? c.EndDate.Value.ToString("yyyy-MM-dd") : "—")} |"
+                );
+            },
+            "GetFdaCatalysts",
+            $"startDate: {startDate}"
+        );
+    }
+
+    // Free-text columns can contain pipes or newlines that would break the markdown row.
+    private static string Clean(string value) =>
+        string.IsNullOrEmpty(value)
+            ? value
+            : value.Replace("|", "/").Replace("\r", " ").Replace("\n", " ");
+}

--- a/src/Equibles.Mcp.Server/Equibles.Mcp.Server.csproj
+++ b/src/Equibles.Mcp.Server/Equibles.Mcp.Server.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\Equibles.Yahoo.Repositories\Equibles.Yahoo.Repositories.csproj" />
     <ProjectReference Include="..\Equibles.Cftc.Mcp\Equibles.Cftc.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Cboe.Mcp\Equibles.Cboe.Mcp.csproj" />
+    <ProjectReference Include="..\Equibles.FdaCatalysts.Mcp\Equibles.FdaCatalysts.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Congress.Mcp\Equibles.Congress.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Finra.Mcp\Equibles.Finra.Mcp.csproj" />
     <ProjectReference Include="..\Equibles.Yahoo.Mcp\Equibles.Yahoo.Mcp.csproj" />

--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -9,6 +9,7 @@ using Equibles.Core.AutoWiring;
 using Equibles.Data;
 using Equibles.Data.Extensions;
 using Equibles.Errors.Data.Extensions;
+using Equibles.FdaCatalysts.Mcp.Extensions;
 using Equibles.Finra.Data.Extensions;
 using Equibles.Finra.Mcp.Extensions;
 using Equibles.Fred.Data.Extensions;
@@ -88,6 +89,7 @@ public partial class Program
             mcp.AddFinancialFacts();
             mcp.AddCftc();
             mcp.AddCboe();
+            mcp.AddFdaCatalysts();
             mcp.AddCongress();
             mcp.AddShortData();
             mcp.AddStockPrices();

--- a/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
+++ b/tests/Equibles.UnitTests/Equibles.UnitTests.csproj
@@ -82,6 +82,7 @@
     <ProjectReference Include="..\..\src\Equibles.Finra.Mcp\Equibles.Finra.Mcp.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Yahoo.Mcp\Equibles.Yahoo.Mcp.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cboe.Mcp\Equibles.Cboe.Mcp.csproj" />
+    <ProjectReference Include="..\..\src\Equibles.FdaCatalysts.Mcp\Equibles.FdaCatalysts.Mcp.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cftc.Mcp\Equibles.Cftc.Mcp.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cftc.Data\Equibles.Cftc.Data.csproj" />
     <ProjectReference Include="..\..\src\Equibles.Cftc.Repositories\Equibles.Cftc.Repositories.csproj" />

--- a/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/McpModuleTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Equibles.Cboe.Mcp.Tools;
 using Equibles.Cftc.Mcp.Tools;
 using Equibles.Congress.Mcp.Tools;
+using Equibles.FdaCatalysts.Mcp.Tools;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Fred.Mcp.Tools;
 using Equibles.Holdings.Mcp.Tools;
@@ -138,6 +139,7 @@ public class McpModuleInterfaceTests
             typeof(AssemblyMcpModule<RagSearchTools>),
             typeof(AssemblyMcpModule<CboeTools>),
             typeof(AssemblyMcpModule<CftcTools>),
+            typeof(AssemblyMcpModule<FdaCatalystTools>),
             typeof(AssemblyMcpModule<CongressTools>),
             typeof(AssemblyMcpModule<ShortDataTools>),
             typeof(AssemblyMcpModule<StockPriceTools>),
@@ -323,6 +325,7 @@ public class McpModuleToolDiscoveryTests
             typeof(RagSearchTools),
             typeof(CboeTools),
             typeof(CftcTools),
+            typeof(FdaCatalystTools),
             typeof(CongressTools),
             typeof(ShortDataTools),
             typeof(StockPriceTools),
@@ -415,6 +418,7 @@ public class McpModuleToolDiscoveryTests
                 typeof(CftcTools),
                 new[] { "GetCftcPositioning", "GetLatestCftcData", "SearchCftcMarkets" }
             },
+            { typeof(FdaCatalystTools), new[] { "GetFdaCatalysts" } },
             {
                 typeof(CongressTools),
                 new[]
@@ -464,6 +468,7 @@ public class McpModuleToolDiscoveryTests
             typeof(RagSearchTools),
             typeof(CboeTools),
             typeof(CftcTools),
+            typeof(FdaCatalystTools),
             typeof(CongressTools),
             typeof(ShortDataTools),
             typeof(StockPriceTools),


### PR DESCRIPTION
## Summary

- Adds an `Equibles.FdaCatalysts.Mcp` module exposing a `GetFdaCatalysts` tool over the FDA advisory-committee calendar, mirroring the other per-dataset MCP modules (Cboe/Cftc/etc.). Consumed by daniel3303/EquiblesCommercial#3658.
- Wired into the standalone MCP server and pinned in the module tests. Defaults to meetings in the next 90 days; accepts an optional date range and result cap.

## Code changes

- `src/Equibles.FdaCatalysts.Mcp/` — new module: `FdaCatalystTools` (`GetFdaCatalysts`, day-ordered, free-text cells sanitized), the `AddFdaCatalysts` builder extension, and the project file.
- `src/Equibles.Mcp.Server/` — register `AddFdaCatalysts()` and reference the new module.
- `tests/Equibles.UnitTests/Mcp/McpModuleTests.cs` — add `FdaCatalystTools` to the module/tool-discovery/uniqueness data (expects exactly `GetFdaCatalysts`).
- `Equibles.sln` — add the new project.