### PR TITLE
test(fda-catalysts): pin advisory-committee parser skips a row with no meeting anchor

### DIFF
--- a/tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserAnchorlessRowTests.cs
+++ b/tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserAnchorlessRowTests.cs
@@ -1,0 +1,43 @@
+using Equibles.FdaCatalysts.BusinessLogic;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.FdaCatalysts;
+
+public class FdaAdvisoryCommitteeCalendarParserAnchorlessRowTests
+{
+    // The per-meeting anchor carries the slug (the upsert natural key) and the title, so the
+    // parser documents that a row without it is skipped even when its other columns parse. A row
+    // whose Meeting cell is plain text (no link) must be dropped, not turned into a slug-less,
+    // title-less catalyst — otherwise the worker would upsert on an empty key.
+    [Fact]
+    public void Parse_RowWithStartDateButNoMeetingAnchor_IsSkipped()
+    {
+        const string html =
+            @"<table class='lcds-datatable--advisory-committee-calendar'>
+  <thead><tr><th>Start Date</th><th>End Date</th><th>Meeting</th><th>Center</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>04/15/2026 08:00 AM EDT</td>
+      <td>04/15/2026 04:00 PM EDT</td>
+      <td>Pending Advisory Committee Meeting (details to follow)</td>
+      <td>Center for Drug Evaluation and Research</td>
+    </tr>
+    <tr>
+      <td>05/20/2026 08:00 AM EDT</td>
+      <td>05/20/2026 04:00 PM EDT</td>
+      <td><a href='/advisory-committees/advisory-committee-calendar/may-20-2026-cardiovascular-and-renal-drugs-advisory-committee-meeting'>May 20, 2026: Cardiovascular and Renal Drugs Advisory Committee</a></td>
+      <td>Center for Drug Evaluation and Research</td>
+    </tr>
+  </tbody>
+</table>";
+
+        var catalysts = FdaAdvisoryCommitteeCalendarParser.Parse(html);
+
+        catalysts
+            .Should()
+            .ContainSingle("the anchor-less row carries no slug or title and is dropped")
+            .Which.SourceReference.Should()
+            .Be("may-20-2026-cardiovascular-and-renal-drugs-advisory-committee-meeting");
+    }
+}


### PR DESCRIPTION
## Summary

- The advisory-committee calendar parser documents that a row without the meeting-page anchor is skipped — the anchor carries the per-meeting slug (the upsert natural key) and the title, so a row missing it has no stable key.
- Existing parser tests cover the missing-start-date skip but never a row that has a valid start date and center yet a plain-text Meeting cell with no link. This pins that contract so such a row can never become a slug-less, title-less catalyst.

## Code changes

- `tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserAnchorlessRowTests.cs` — new unit test: a two-row table where the first Meeting cell is plain text yields a single catalyst, the anchored row.