### PR TITLE
test(fda-catalysts): pin parser strips query, fragment, and trailing slash from the meeting slug

### DIFF
--- a/tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserSlugHrefCleanupTests.cs
+++ b/tests/Equibles.UnitTests/FdaCatalysts/FdaAdvisoryCommitteeCalendarParserSlugHrefCleanupTests.cs
@@ -1,0 +1,40 @@
+using System;
+using Equibles.FdaCatalysts.BusinessLogic;
+using FluentAssertions;
+using Xunit;
+
+namespace Equibles.UnitTests.FdaCatalysts;
+
+public class FdaAdvisoryCommitteeCalendarParserSlugHrefCleanupTests
+{
+    // Contract: the slug (SourceReference) is the stable per-meeting natural key that makes
+    // re-imports idempotent, so a query string, a fragment, and a trailing slash on the meeting
+    // link must all be stripped — none may leak into the key, or the same meeting would re-import
+    // as a duplicate. Existing slug coverage only exercises a clean path-only href.
+    [Fact]
+    public void Parse_MeetingHrefWithQueryFragmentAndTrailingSlash_YieldsCleanSlug()
+    {
+        const string html =
+            @"<table class='lcds-datatable--advisory-committee-calendar'>
+  <thead><tr><th>Start Date</th><th>End Date</th><th>Meeting</th><th>Center</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>10/22/2026 08:00 AM EDT</td>
+      <td></td>
+      <td><a href='/advisory-committees/advisory-committee-calendar/october-22-2026-cardiovascular-and-renal-drugs-advisory-committee-meeting/?utm_source=newsletter#agenda'>October 22, 2026: Cardiovascular and Renal Drugs Advisory Committee</a></td>
+      <td>Center for Drug Evaluation and Research</td>
+    </tr>
+  </tbody>
+</table>";
+
+        var catalyst = FdaAdvisoryCommitteeCalendarParser
+            .Parse(html)
+            .Should()
+            .ContainSingle()
+            .Subject;
+
+        catalyst
+            .SourceReference.Should()
+            .Be("october-22-2026-cardiovascular-and-renal-drugs-advisory-committee-meeting");
+    }
+}


### PR DESCRIPTION
## Code changes

Adds one adversarial unit test for `FdaAdvisoryCommitteeCalendarParser.Parse` covering the URL-cleanup branch of `ExtractSlug`.

The slug (`SourceReference`) is the stable per-meeting natural key that keeps re-imports idempotent. Existing slug coverage only exercises a clean path-only href, leaving the query/fragment/trailing-slash stripping unexercised. This test feeds a meeting link carrying `?utm_source=newsletter`, `#agenda`, and a trailing slash and asserts the slug is the bare meeting segment — guarding against any of those leaking into the key, which would re-import the same meeting as a duplicate.

Pure test addition — no production code touched.