### PR TITLE
fix(holdings): compute per-stock quarterly activity over Form 13F only

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsAggregateRefreshService.cs
@@ -450,9 +450,13 @@ public class HoldingsAggregateRefreshService
         // The prior quarter on record. default(DateOnly) when this is the
         // earliest — no holding row carries that date, so every "previous"
         // predicate below is simply false and all current filers count as new.
+        // Form 13F only: Schedule 13D/G rows carry event-driven report dates
+        // clustered around quarter-ends, and would otherwise resolve the prior
+        // quarter to a sparse non-quarter date where almost no stock has a
+        // holding, collapsing every PreviousFilerCount to zero.
         var previousReportDate = await dbContext
             .Set<InstitutionalHolding>()
-            .Where(h => h.ReportDate < reportDate)
+            .Where(h => h.ReportDate < reportDate && h.FilingType == FilingType.Form13F)
             .Select(h => h.ReportDate)
             .OrderByDescending(d => d)
             .FirstOrDefaultAsync(cancellationToken);
@@ -460,7 +464,10 @@ public class HoldingsAggregateRefreshService
 
         var activity = await dbContext
             .Set<InstitutionalHolding>()
-            .Where(h => h.ReportDate == reportDate || h.ReportDate == previousReportDate)
+            .Where(h =>
+                (h.ReportDate == reportDate || h.ReportDate == previousReportDate)
+                && h.FilingType == FilingType.Form13F
+            )
             .GroupBy(h => h.CommonStockId)
             .Select(g => new
             {
@@ -486,7 +493,10 @@ public class HoldingsAggregateRefreshService
         var churn = (
             await dbContext
                 .Set<InstitutionalHolding>()
-                .Where(h => h.ReportDate == reportDate || h.ReportDate == previousReportDate)
+                .Where(h =>
+                    (h.ReportDate == reportDate || h.ReportDate == previousReportDate)
+                    && h.FilingType == FilingType.Form13F
+                )
                 .GroupBy(h => h.CommonStockId)
                 .Select(g => new
                 {
@@ -497,6 +507,7 @@ public class HoldingsAggregateRefreshService
                                 .Set<InstitutionalHolding>()
                                 .Any(p =>
                                     p.ReportDate == previousReportDate
+                                    && p.FilingType == FilingType.Form13F
                                     && p.CommonStockId == h.CommonStockId
                                     && p.InstitutionalHolderId == h.InstitutionalHolderId
                                 )
@@ -510,6 +521,7 @@ public class HoldingsAggregateRefreshService
                                 .Set<InstitutionalHolding>()
                                 .Any(c =>
                                     c.ReportDate == reportDate
+                                    && c.FilingType == FilingType.Form13F
                                     && c.CommonStockId == h.CommonStockId
                                     && c.InstitutionalHolderId == h.InstitutionalHolderId
                                 )

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceStockActivityTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsAggregateRefreshServiceStockActivityTests.cs
@@ -1,0 +1,196 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Models.Taxonomies;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+/// <summary>
+/// Contract for the per-stock slice of <see cref="HoldingsAggregateRefreshService"/>:
+/// <see cref="StockQuarterlyActivity"/> must be computed over Form 13F holdings only.
+/// Schedule 13D/G rows carry event-driven report dates that cluster around quarter-ends;
+/// counting them would resolve the prior quarter to a sparse non-quarter date and collapse
+/// every PreviousFilerCount to zero (#3732).
+/// </summary>
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsAggregateRefreshServiceStockActivityTests : IAsyncLifetime
+{
+    private readonly ParadeDbFixture _fixture;
+    private readonly List<Equibles.Data.EquiblesFinancialDbContext> _contexts = [];
+
+    public HoldingsAggregateRefreshServiceStockActivityTests(ParadeDbFixture fixture) =>
+        _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+            ctx.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private Equibles.Data.EquiblesFinancialDbContext FreshContext()
+    {
+        var ctx = _fixture.CreateDbContext();
+        _contexts.Add(ctx);
+        return ctx;
+    }
+
+    // The real prior 13F quarter, the quarter under refresh, and a 13D/G event
+    // date that falls between them — the date the buggy max(ReportDate) picked.
+    private static readonly DateOnly QPrev = new(2024, 9, 30);
+    private static readonly DateOnly QCur = new(2024, 12, 31);
+    private static readonly DateOnly PollutionDate = new(2024, 12, 18);
+
+    private HoldingsAggregateRefreshService BuildService()
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(_ => CreateScopeFromFixture());
+        return new HoldingsAggregateRefreshService(
+            scopeFactory,
+            NullLogger<HoldingsAggregateRefreshService>.Instance
+        );
+    }
+
+    private IServiceScope CreateScopeFromFixture()
+    {
+        var ctx = FreshContext();
+        var scope = Substitute.For<IServiceScope>();
+        var provider = Substitute.For<IServiceProvider>();
+        provider.GetService(typeof(Equibles.Data.EquiblesFinancialDbContext)).Returns(ctx);
+        scope.ServiceProvider.Returns(provider);
+        return scope;
+    }
+
+    [Fact]
+    public async Task RebuildQuarterAsync_StockActivity_PriorQuarterIsForm13FOnly_Not13DGEventDate()
+    {
+        await using var seed = FreshContext();
+        var industry = await SeedTaxonomy(seed);
+        var aapl = await SeedStock(seed, "AAPL", industry);
+        var holderA = await SeedHolder(seed, "H001");
+        var holderB = await SeedHolder(seed, "H002");
+        var holderC = await SeedHolder(seed, "H003");
+        var holder13D = await SeedHolder(seed, "H004");
+        var holder13G = await SeedHolder(seed, "H005");
+        seed.AddRange(
+            // Prior 13F quarter: two filers.
+            MakeHolding(aapl, holderA, QPrev, 100_000, "acc-a-prev"),
+            MakeHolding(aapl, holderB, QPrev, 100_000, "acc-b-prev"),
+            // Current 13F quarter: holders A and B stay, C is a new filer.
+            MakeHolding(aapl, holderA, QCur, 120_000, "acc-a-cur"),
+            MakeHolding(aapl, holderB, QCur, 120_000, "acc-b-cur"),
+            MakeHolding(aapl, holderC, QCur, 50_000, "acc-c-cur"),
+            // A 13D event-date row between the quarters — the date the buggy
+            // max(ReportDate < QCur) latched onto, zeroing every prior count.
+            MakeHolding(
+                aapl,
+                holder13D,
+                PollutionDate,
+                999_000_000,
+                "acc-13d",
+                filingType: FilingType.Schedule13D
+            ),
+            // A 13G row landing on the current quarter date itself must not be
+            // counted as a 13F filer.
+            MakeHolding(
+                aapl,
+                holder13G,
+                QCur,
+                500_000,
+                "acc-13g",
+                filingType: FilingType.Schedule13G
+            )
+        );
+        await seed.SaveChangesAsync();
+
+        await BuildService().RebuildQuarterAsync(QCur, CancellationToken.None);
+
+        await using var read = FreshContext();
+        var row = await read.Set<StockQuarterlyActivity>()
+            .SingleAsync(s => s.CommonStockId == aapl.Id && s.ReportDate == QCur);
+
+        row.PreviousReportDate.Should()
+            .Be(QPrev, "the prior quarter is the latest Form 13F date, not the 13D/G event date");
+        row.CurrentFilerCount.Should().Be(3, "holders A, B and C filed 13F this quarter");
+        row.PreviousFilerCount.Should()
+            .Be(2, "holders A and B filed 13F last quarter — the 13D/G rows are excluded");
+        row.NewFilerCount.Should()
+            .Be(1, "holder C is the only filer new versus the prior 13F quarter");
+        row.SoldOutFilerCount.Should().Be(0, "no 13F filer left between the quarters");
+    }
+
+    private static async Task<Guid> SeedTaxonomy(Equibles.Data.EquiblesFinancialDbContext ctx)
+    {
+        var sector = new Sector { Name = "Technology" };
+        ctx.Add(sector);
+        await ctx.SaveChangesAsync();
+        var industry = new Industry { Name = "Software", SectorId = sector.Id };
+        ctx.Add(industry);
+        await ctx.SaveChangesAsync();
+        return industry.Id;
+    }
+
+    private static async Task<CommonStock> SeedStock(
+        Equibles.Data.EquiblesFinancialDbContext ctx,
+        string ticker,
+        Guid industryId
+    )
+    {
+        var stock = new CommonStock
+        {
+            Ticker = ticker,
+            Name = $"{ticker} Corp.",
+            Cik = $"C{Guid.NewGuid().GetHashCode() & int.MaxValue:D8}",
+            IndustryId = industryId,
+        };
+        ctx.Add(stock);
+        await ctx.SaveChangesAsync();
+        return stock;
+    }
+
+    private static async Task<InstitutionalHolder> SeedHolder(
+        Equibles.Data.EquiblesFinancialDbContext ctx,
+        string cik
+    )
+    {
+        var holder = new InstitutionalHolder { Cik = cik, Name = $"Holder {cik}" };
+        ctx.Add(holder);
+        await ctx.SaveChangesAsync();
+        return holder;
+    }
+
+    private static InstitutionalHolding MakeHolding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly reportDate,
+        long value,
+        string accession,
+        FilingType filingType = FilingType.Form13F
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            FilingDate = reportDate.AddDays(45),
+            ReportDate = reportDate,
+            Shares = value / 100,
+            Value = value,
+            ShareType = ShareType.Shares,
+            InvestmentDiscretion = InvestmentDiscretion.Sole,
+            AccessionNumber = accession,
+            FilingType = filingType,
+            // CUSIP column is varchar(9); a deterministic per-accession value keeps
+            // the holding-row unique key disambiguated across the seeds.
+            Cusip =
+                $"{stock.Ticker[..Math.Min(4, stock.Ticker.Length)]}{accession.GetHashCode():X8}"[
+                    ..9
+                ],
+        };
+}


### PR DESCRIPTION
## Summary

`HoldingsAggregateRefreshService.UpsertStockActivitySnapshots` built each stock's quarter-over-quarter institutional activity (the conviction heat map and the cross-metric stock screener) over **every** `InstitutionalHolding` row, regardless of `FilingType`. With Schedule 13D/G rows now in the table — they carry event-driven report dates clustered around quarter-ends (e.g. `2026-03-30`, `2026-04-01`, `2024-12-18`) — `previousReportDate = max(ReportDate < reportDate)` resolved to a sparse non-quarter date where almost no stock has a holding, so `PreviousFilerCount` collapsed to 0 for the whole universe and the QoQ filer delta degenerated into the full current filer count. `NewFilerCount`/`SoldOutFilerCount` were skewed the same way.

The sibling `UpsertHolderSnapshots` already guards every query with `FilingType == FilingType.Form13F`; this slice was missed.

Closes #3732.

## Code changes

- **`HoldingsAggregateRefreshService.cs`** — restrict the prior-quarter lookup and the activity/churn aggregations in `UpsertStockActivitySnapshots` to `FilingType.Form13F`, including the two NOT-EXISTS new/sold-out subqueries. The prior quarter now resolves to the real prior 13F report date and all filer counts are 13F-only, consistent with `UpsertHolderSnapshots`.
- **`HoldingsAggregateRefreshServiceStockActivityTests.cs`** — integration test seeding two real 13F quarters plus a polluting 13D/G event date between them, asserting the snapshot's `PreviousReportDate` is the prior 13F quarter (not the 13D/G date) and the current/previous/new/sold-out filer counts exclude 13D/G rows.

## Notes

Existing materialized `StockQuarterlyActivity` rows are already wrong; they correct themselves once the aggregate refresh re-runs for the affected quarters (the daily recent-quarters safety-net, or a full rebuild).
