### PR TITLE
fix(finra): backfill historical short-volume, short-interest and off-exchange data

### DIFF
--- a/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
@@ -47,31 +47,46 @@ public class OffExchangeVolumeImportService
 
     public async Task Import(CancellationToken cancellationToken)
     {
-        var startDate = await SyncStartDate.Resolve<OffExchangeVolumeRepository>(
-            _scopeFactory,
-            _workerOptions,
-            repo => repo.GetLatestWeek(),
-            cancellationToken
-        );
+        // Resolve the backfill floor (Worker:MinSyncDate or 2020-01-01) by passing `default`:
+        // the loop below re-derives the forward edge from the stored span, so the full
+        // window is reconsidered every cycle rather than only moving past the latest week.
+        var floor = SyncDateResolver.Resolve(default, _workerOptions);
 
         // FINRA partitions the OTC/ATS Transparency feed by the Monday that starts
         // each reporting week, so iterate Monday-by-Monday rather than day-by-day.
-        var startWeek = ToWeekStart(startDate);
+        var startWeek = ToWeekStart(floor);
         var endWeek = ToWeekStart(DateOnly.FromDateTime(DateTime.UtcNow));
 
         if (startWeek > endWeek)
         {
             _logger.LogInformation(
-                "Off-exchange volume data is up to date (latest week: {Week})",
-                startWeek.AddDays(-7)
+                "Off-exchange volume sync floor {Week} is in the future; nothing to import",
+                startWeek
             );
             return;
         }
 
+        // The weeks already stored span [earliestWeek, latestWeek]; the loop skips that span
+        // and imports the weeks outside it, backfilling history below the earliest stored
+        // week and importing forward past the latest, without re-fetching finished weeks.
+        // The previous implementation only moved forward from the latest stored week, so the
+        // pre-collection history could never load.
+        DateOnly earliestWeek;
+        DateOnly latestWeek;
+        using (var scope = _scopeFactory.CreateScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<OffExchangeVolumeRepository>();
+            earliestWeek = await repo.GetEarliestWeek().FirstOrDefaultAsync(cancellationToken);
+            latestWeek = await repo.GetLatestWeek().FirstOrDefaultAsync(cancellationToken);
+        }
+
+        var hasStored = earliestWeek != default;
+
         _logger.LogInformation(
-            "Importing off-exchange volume from week {Start} to week {End}",
+            "Importing off-exchange volume from week {Start} to week {End}{Skip}",
             startWeek,
-            endWeek
+            endWeek,
+            hasStored ? $" (skipping already-stored {earliestWeek}..{latestWeek})" : null
         );
 
         var tickerMap = await _tickerMapService.Build(
@@ -83,6 +98,14 @@ public class OffExchangeVolumeImportService
         while (currentWeek <= endWeek)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            // Skip any week already inside the stored span.
+            if (hasStored && currentWeek >= earliestWeek && currentWeek <= latestWeek)
+            {
+                currentWeek = currentWeek.AddDays(7);
+                continue;
+            }
+
             await ImportWeek(currentWeek, tickerMap, cancellationToken);
             currentWeek = currentWeek.AddDays(7);
         }

--- a/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
@@ -69,16 +69,41 @@ public class ShortInterestImportService
             knownDates = dates.ToHashSet();
         }
 
+        var minKnownDate = knownDates.Count > 0 ? knownDates.Min() : default;
         var maxKnownDate = knownDates.Count > 0 ? knownDates.Max() : default;
         var minDate = SyncDateResolver.Resolve(default, _workerOptions);
 
         List<DateOnly> newDates;
         try
         {
-            newDates =
-                maxKnownDate != default
-                    ? await _finraClient.GetShortInterestSettlementDatesAfter(maxKnownDate)
-                    : await _finraClient.GetShortInterestSettlementDates();
+            if (knownDates.Count == 0)
+            {
+                // Empty store: discover every settlement date; the floor filter below bounds it.
+                newDates = await _finraClient.GetShortInterestSettlementDates();
+            }
+            else
+            {
+                // Forward: settlement dates published since the newest stored one.
+                newDates = await _finraClient.GetShortInterestSettlementDatesAfter(maxKnownDate);
+
+                // Backfill: settlement dates between the floor and the oldest stored one. A
+                // fresh deployment starts with only recent data, so without this the years of
+                // FINRA history below the earliest stored date could never be filled. Each
+                // cycle the window shrinks as older dates import; once it bottoms out at
+                // FINRA's earliest available date this is a single empty discovery call
+                // (the date-range filter matches no rows, so paging stops on the first page).
+                if (minKnownDate > minDate)
+                {
+                    var backfillDates = await _finraClient.GetShortInterestSettlementDatesBetween(
+                        minDate,
+                        minKnownDate.AddDays(-1)
+                    );
+                    if (backfillDates is { Count: > 0 })
+                    {
+                        newDates.AddRange(backfillDates);
+                    }
+                }
+            }
         }
         catch (Exception ex)
         {

--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -45,38 +45,59 @@ public class ShortVolumeImportService
 
     public async Task Import(CancellationToken cancellationToken)
     {
-        var startDate = await SyncStartDate.Resolve<DailyShortVolumeRepository>(
-            _scopeFactory,
-            _workerOptions,
-            repo => repo.GetLatestDate(),
-            cancellationToken
-        );
-
+        // Resolve the backfill floor (Worker:MinSyncDate or 2020-01-01) by passing `default`:
+        // we want the floor itself, not "latest stored + 1". The loop below re-derives the
+        // forward edge from the stored span, so the full window is reconsidered every cycle.
+        var floor = SyncDateResolver.Resolve(default, _workerOptions);
         var endDate = DateOnly.FromDateTime(DateTime.UtcNow);
 
-        if (startDate > endDate)
+        if (floor > endDate)
         {
             _logger.LogInformation(
-                "Short volume data is up to date (latest: {Date})",
-                startDate.AddDays(-1)
+                "Short volume sync floor {Floor} is in the future; nothing to import",
+                floor
             );
             return;
         }
 
-        _logger.LogInformation("Importing short volume from {Start} to {End}", startDate, endDate);
+        // The span already stored is [earliest, latest]; the loop skips it and imports the
+        // days outside it. That fills the history below the earliest row (a fresh deployment
+        // starts with only recent FINRA data) AND keeps importing forward past the latest
+        // row, without ever re-fetching a finished day. The previous implementation only
+        // moved forward from the latest row, so the pre-collection history could never load.
+        DateOnly earliest;
+        DateOnly latest;
+        using (var scope = _scopeFactory.CreateScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<DailyShortVolumeRepository>();
+            earliest = await repo.GetEarliestDate().FirstOrDefaultAsync(cancellationToken);
+            latest = await repo.GetLatestDate().FirstOrDefaultAsync(cancellationToken);
+        }
+
+        var hasStored = earliest != default;
+
+        _logger.LogInformation(
+            "Importing short volume from {Start} to {End}{Skip}",
+            floor,
+            endDate,
+            hasStored ? $" (skipping already-stored {earliest}..{latest})" : null
+        );
 
         var tickerMap = await _tickerMapService.Build(
             _workerOptions.TickersToSync,
             cancellationToken
         );
 
-        var currentDate = startDate;
+        var currentDate = floor;
         while (currentDate <= endDate)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Skip weekends
-            if (currentDate.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
+            // Skip weekends and any day already inside the stored span.
+            if (
+                currentDate.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday
+                || (hasStored && currentDate >= earliest && currentDate <= latest)
+            )
             {
                 currentDate = currentDate.AddDays(1);
                 continue;

--- a/src/Equibles.Finra.Repositories/DailyShortVolumeRepository.cs
+++ b/src/Equibles.Finra.Repositories/DailyShortVolumeRepository.cs
@@ -25,6 +25,11 @@ public class DailyShortVolumeRepository : BaseRepository<DailyShortVolume>
         return GetAll().LatestValue(d => d.Date, distinct: true);
     }
 
+    public IQueryable<DateOnly> GetEarliestDate()
+    {
+        return GetAll().Select(d => d.Date).Distinct().OrderBy(d => d).Take(1);
+    }
+
     public IQueryable<DailyShortVolume> GetByDate(DateOnly date)
     {
         return GetAll().Where(d => d.Date == date);

--- a/src/Equibles.Finra.Repositories/OffExchangeVolumeRepository.cs
+++ b/src/Equibles.Finra.Repositories/OffExchangeVolumeRepository.cs
@@ -25,6 +25,11 @@ public class OffExchangeVolumeRepository : BaseRepository<OffExchangeVolume>
         return GetAll().LatestValue(d => d.WeekStartDate, distinct: true);
     }
 
+    public IQueryable<DateOnly> GetEarliestWeek()
+    {
+        return GetAll().Select(d => d.WeekStartDate).Distinct().OrderBy(d => d).Take(1);
+    }
+
     public IQueryable<OffExchangeVolume> GetByWeek(DateOnly weekStartDate)
     {
         return GetAll().Where(d => d.WeekStartDate == weekStartDate);

--- a/src/Equibles.Integrations.Finra/Contracts/IFinraClient.cs
+++ b/src/Equibles.Integrations.Finra/Contracts/IFinraClient.cs
@@ -13,5 +13,9 @@ public interface IFinraClient
     );
     Task<List<DateOnly>> GetShortInterestSettlementDates();
     Task<List<DateOnly>> GetShortInterestSettlementDatesAfter(DateOnly afterDate);
+    Task<List<DateOnly>> GetShortInterestSettlementDatesBetween(
+        DateOnly startDate,
+        DateOnly endDate
+    );
     Task<List<OffExchangeWeeklyRecord>> GetWeeklyOffExchangeVolume(DateOnly weekStartDate);
 }

--- a/src/Equibles.Integrations.Finra/FinraClient.cs
+++ b/src/Equibles.Integrations.Finra/FinraClient.cs
@@ -206,12 +206,41 @@ public class FinraClient : IFinraClient
         return dates.OrderBy(d => d).ToList();
     }
 
-    public async Task<List<DateOnly>> GetShortInterestSettlementDatesAfter(DateOnly afterDate)
+    public Task<List<DateOnly>> GetShortInterestSettlementDatesAfter(DateOnly afterDate)
     {
-        var startDateStr = FormatDate(afterDate.AddDays(1));
-        var endDateStr = FormatDate(DateOnly.FromDateTime(DateTime.UtcNow));
-
         _logger.LogDebug("Discovering settlement dates after {Date}", afterDate);
+        return DiscoverSettlementDatesInRange(
+            afterDate.AddDays(1),
+            DateOnly.FromDateTime(DateTime.UtcNow)
+        );
+    }
+
+    public Task<List<DateOnly>> GetShortInterestSettlementDatesBetween(
+        DateOnly startDate,
+        DateOnly endDate
+    )
+    {
+        _logger.LogDebug(
+            "Discovering settlement dates between {Start} and {End}",
+            startDate,
+            endDate
+        );
+        return DiscoverSettlementDatesInRange(startDate, endDate);
+    }
+
+    // Page the consolidatedShortInterest dataset over a settlement-date window and return
+    // the deduped, ascending set of distinct settlement dates it contains. An empty window
+    // (startDate after endDate) short-circuits without an API call.
+    private async Task<List<DateOnly>> DiscoverSettlementDatesInRange(
+        DateOnly startDate,
+        DateOnly endDate
+    )
+    {
+        if (startDate > endDate)
+            return [];
+
+        var startDateStr = FormatDate(startDate);
+        var endDateStr = FormatDate(endDate);
 
         var dates = await CollectSettlementDates(offset => new
         {
@@ -230,9 +259,10 @@ public class FinraClient : IFinraClient
         });
 
         _logger.LogDebug(
-            "Discovered {Count} new settlement dates after {Date}",
+            "Discovered {Count} settlement dates in {Start}..{End}",
             dates.Count,
-            afterDate
+            startDate,
+            endDate
         );
         return dates.OrderBy(d => d).ToList();
     }

--- a/tests/Equibles.IntegrationTests/Finra/FinraClientSettlementDatesBetweenTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraClientSettlementDatesBetweenTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Text;
+using Equibles.Integrations.Finra;
+using Equibles.Integrations.Finra.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Finra;
+
+/// <summary>
+/// Sibling to <see cref="FinraClientSettlementDatesAfterTests"/>. Pins
+/// <c>GetShortInterestSettlementDatesBetween</c> — the bounded discovery method the scraper
+/// uses to backfill settlement dates below the earliest stored one. Critical contract: the
+/// window bounds are passed through verbatim (no +1 offset, unlike the "After" variant), the
+/// result is HashSet-deduped and sorted ascending, and an inverted window short-circuits
+/// without an API call.
+/// </summary>
+public class FinraClientSettlementDatesBetweenTests
+{
+    [Fact]
+    public async Task GetShortInterestSettlementDatesBetween_FiltersToTheWindow_AndSortsAscending()
+    {
+        var tokenResponse = "{\"access_token\":\"t\",\"expires_in\":3600}";
+        var dataResponse =
+            "[{\"settlementDate\":\"2022-06-30\"},{\"settlementDate\":\"2022-06-15\"}]";
+
+        var handler = new CapturingHandler(tokenResponse, dataResponse);
+        var sut = new FinraClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<FinraClient>>(),
+            Options.Create(new FinraOptions { ClientId = "id", ClientSecret = "secret" })
+        );
+
+        var dates = await sut.GetShortInterestSettlementDatesBetween(
+            new DateOnly(2022, 6, 1),
+            new DateOnly(2022, 6, 30)
+        );
+
+        dates.Should().Equal(new DateOnly(2022, 6, 15), new DateOnly(2022, 6, 30));
+        // The window bounds are passed straight through — no +1 offset (that belongs to the
+        // forward-only "After" variant). A wrong offset would silently drop boundary dates.
+        handler.LastDataRequestBody.Should().Contain("\"startDate\":\"2022-06-01\"");
+        handler.LastDataRequestBody.Should().Contain("\"endDate\":\"2022-06-30\"");
+    }
+
+    [Fact]
+    public async Task GetShortInterestSettlementDatesBetween_StartAfterEnd_ReturnsEmptyWithoutCallingApi()
+    {
+        var handler = new CapturingHandler("{\"access_token\":\"t\",\"expires_in\":3600}", "[]");
+        var sut = new FinraClient(
+            new HttpClient(handler),
+            Substitute.For<ILogger<FinraClient>>(),
+            Options.Create(new FinraOptions { ClientId = "id", ClientSecret = "secret" })
+        );
+
+        // An empty/inverted window (the steady state once backfill has reached the floor)
+        // must not waste an API round-trip.
+        var dates = await sut.GetShortInterestSettlementDatesBetween(
+            new DateOnly(2022, 6, 30),
+            new DateOnly(2022, 6, 1)
+        );
+
+        dates.Should().BeEmpty();
+        handler.LastDataRequestBody.Should().BeNull("an inverted window must not hit the API");
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private readonly string _tokenBody;
+        private readonly string _dataBody;
+        public string LastDataRequestBody { get; private set; }
+
+        public CapturingHandler(string tokenBody, string dataBody)
+        {
+            _tokenBody = tokenBody;
+            _dataBody = dataBody;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var isToken = request.RequestUri!.AbsoluteUri.Contains("oauth2/access_token");
+            string body;
+            if (isToken)
+            {
+                body = _tokenBody;
+            }
+            else
+            {
+                LastDataRequestBody =
+                    request.Content != null
+                        ? await request.Content.ReadAsStringAsync(cancellationToken)
+                        : "";
+                body = _dataBody;
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Finra/FinraImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraImportServiceTests.cs
@@ -226,16 +226,18 @@ public class ShortVolumeImportServiceTests : IDisposable
         volume[0].TotalVolume.Should().Be(2_000_000);
     }
 
-    // ── Skips duplicates ─────────────────────────────────────────────
+    // ── Skips stored days, backfills the rest ────────────────────────
 
     [Fact]
-    public async Task Import_DataAlreadyUpToDate_SkipsWithoutCallingApi()
+    public async Task Import_StoredSpanCoversWholeWindow_SkipsWithoutCallingApi()
     {
         var apple = CreateStock("AAPL", "Apple Inc.");
         await SeedStocks(apple);
 
-        // Seed a volume for today so startDate > today
+        // Floor == today and today's row is already stored, so the only day in the
+        // [floor, today] window is already covered and nothing is fetched.
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        _workerOptions.MinSyncDate = today.ToDateTime(TimeOnly.MinValue);
         await SeedVolume(apple, today);
 
         await _service.Import(CancellationToken.None);
@@ -244,27 +246,42 @@ public class ShortVolumeImportServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Import_ExistingData_FetchesOnlyFromDayAfterLatest()
+    public async Task Import_ExistingData_BackfillsBeforeEarliestAndFetchesForward()
     {
         var apple = CreateStock("AAPL", "Apple Inc.");
         await SeedStocks(apple);
 
-        // Seed data for a recent weekday
         var existingDate = new DateOnly(2026, 3, 25); // Wednesday
         await SeedVolume(apple, existingDate);
 
-        var nextDay = existingDate.AddDays(1); // Thursday
-        var records = CreateVolumeRecords(("AAPL", 100_000, 1_000, 500_000));
-        _finraClient.GetDailyShortVolume(nextDay).Returns(records);
+        // Floor two weekdays before the stored row, so the loop must backfill the gap
+        // below the earliest stored day as well as fetch forward past the latest.
+        _workerOptions.MinSyncDate = new DateTime(2026, 3, 23); // Monday
+
+        var backfillDay = new DateOnly(2026, 3, 24); // Tuesday, below the stored row
+        var forwardDay = existingDate.AddDays(1); // Thursday, above the stored row
+
         _finraClient
-            .GetDailyShortVolume(Arg.Is<DateOnly>(d => d > nextDay))
+            .GetDailyShortVolume(Arg.Any<DateOnly>())
             .Returns(new List<ShortVolumeRecord>());
+        _finraClient
+            .GetDailyShortVolume(backfillDay)
+            .Returns(CreateVolumeRecords(("AAPL", 100_000, 1_000, 500_000)));
+        _finraClient
+            .GetDailyShortVolume(forwardDay)
+            .Returns(CreateVolumeRecords(("AAPL", 200_000, 2_000, 800_000)));
 
         await _service.Import(CancellationToken.None);
 
-        // Should have fetched starting from the day after the existing date, not before
+        // The already-stored day is never re-fetched...
         await _finraClient.DidNotReceive().GetDailyShortVolume(existingDate);
-        await _finraClient.Received().GetDailyShortVolume(nextDay);
+        // ...but both the earlier (backfill) and later (forward) days are.
+        await _finraClient.Received().GetDailyShortVolume(backfillDay);
+        await _finraClient.Received().GetDailyShortVolume(forwardDay);
+
+        var volumes = _volumeRepo.GetAll().ToList();
+        volumes.Should().Contain(v => v.Date == backfillDay && v.ShortVolume == 100_000);
+        volumes.Should().Contain(v => v.Date == forwardDay && v.ShortVolume == 200_000);
     }
 
     // ── Handles empty API response ───────────────────────────────────
@@ -815,6 +832,42 @@ public class ShortInterestImportServiceTests : IDisposable
         await _service.Import(CancellationToken.None);
 
         await _finraClient.DidNotReceive().GetShortInterest(Arg.Any<DateOnly>());
+    }
+
+    [Fact]
+    public async Task Import_StoredDatesAboveFloor_DiscoversAndBackfillsEarlierDates()
+    {
+        var apple = CreateStock("AAPL", "Apple Inc.");
+        await SeedStocks(apple);
+
+        var existingDate = new DateOnly(2026, 3, 15);
+        await SeedInterest(apple, existingDate);
+
+        _workerOptions.MinSyncDate = new DateTime(2026, 1, 1);
+
+        // Nothing new published after the stored date...
+        _finraClient
+            .GetShortInterestSettlementDatesAfter(existingDate)
+            .Returns(new List<DateOnly>());
+        // ...but an earlier settlement date exists in the backfill window below it. Without
+        // the backfill discovery this date could never be found, since the forward-only
+        // "after the newest stored date" query never looks earlier.
+        var backfillDate = new DateOnly(2026, 2, 1);
+        _finraClient
+            .GetShortInterestSettlementDatesBetween(
+                new DateOnly(2026, 1, 1),
+                existingDate.AddDays(-1)
+            )
+            .Returns(new List<DateOnly> { backfillDate });
+        _finraClient
+            .GetShortInterest(backfillDate)
+            .Returns(CreateInterestRecords(("AAPL", 9_000_000, 8_000_000, 1_000_000, null, null)));
+
+        await _service.Import(CancellationToken.None);
+
+        await _finraClient.Received().GetShortInterest(backfillDate);
+        var interests = _interestRepo.GetAll().ToList();
+        interests.Should().Contain(i => i.SettlementDate == backfillDate);
     }
 
     // ── Handles empty API response ───────────────────────────────────

--- a/tests/Equibles.IntegrationTests/Finra/OffExchangeVolumeImportServiceBackfillTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/OffExchangeVolumeImportServiceBackfillTests.cs
@@ -1,0 +1,163 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.Core.Configuration;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Finra.Data;
+using Equibles.Finra.Data.Models;
+using Equibles.Finra.HostedService.Services;
+using Equibles.Finra.Repositories;
+using Equibles.Integrations.Finra.Contracts;
+using Equibles.Integrations.Finra.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Finra;
+
+/// <summary>
+/// Pins the historical-backfill behaviour of <see cref="OffExchangeVolumeImportService.Import"/>:
+/// the importer now scans the whole [floor, current week] window and skips only the weeks
+/// already stored, so a fresh deployment fills weeks below the earliest stored week instead of
+/// only ever moving forward from the latest one.
+/// </summary>
+public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
+{
+    private readonly EquiblesFinancialDbContext _dbContext;
+    private readonly OffExchangeVolumeRepository _volumeRepo;
+    private readonly CommonStockRepository _stockRepo;
+    private readonly IFinraClient _finraClient;
+    private readonly WorkerOptions _workerOptions;
+    private readonly OffExchangeVolumeImportService _service;
+
+    public OffExchangeVolumeImportServiceBackfillTests()
+    {
+        _dbContext = TestDbContextFactory.Create(
+            new CommonStocksModuleConfiguration(),
+            new FinraModuleConfiguration()
+        );
+        _volumeRepo = new OffExchangeVolumeRepository(_dbContext);
+        _stockRepo = new CommonStockRepository(_dbContext);
+        _finraClient = Substitute.For<IFinraClient>();
+        _workerOptions = new WorkerOptions();
+
+        var scopeFactory = ServiceScopeSubstitute.Create(
+            (typeof(OffExchangeVolumeRepository), _volumeRepo),
+            (typeof(CommonStockRepository), _stockRepo)
+        );
+
+        _service = new OffExchangeVolumeImportService(
+            scopeFactory,
+            Substitute.For<ILogger<OffExchangeVolumeImportService>>(),
+            _finraClient,
+            new TickerMapService(scopeFactory),
+            new ErrorReporter(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            Options.Create(_workerOptions)
+        );
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    // Monday that starts the FINRA reporting week containing the given date — mirrors the
+    // private ToWeekStart in the service.
+    private static DateOnly WeekStart(DateOnly date) =>
+        date.AddDays(-(((int)date.DayOfWeek + 6) % 7));
+
+    [Fact]
+    public async Task Import_StoredWeekBetweenFloorAndToday_BackfillsEarlierSkipsStoredAndFetchesForward()
+    {
+        var apple = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Cik = "CIK-AAPL",
+        };
+        _stockRepo.AddRange([apple]);
+        await _stockRepo.SaveChanges();
+
+        var currentWeek = WeekStart(DateOnly.FromDateTime(DateTime.UtcNow));
+        var storedWeek = currentWeek.AddDays(-14); // two weeks back
+        var backfillWeek = currentWeek.AddDays(-21); // below the stored week
+        var forwardWeek = currentWeek.AddDays(-7); // above the stored week
+
+        _dbContext
+            .Set<OffExchangeVolume>()
+            .Add(
+                new OffExchangeVolume
+                {
+                    CommonStockId = apple.Id,
+                    WeekStartDate = storedWeek,
+                    AtsVolume = 1,
+                    NonAtsOtcVolume = 1,
+                }
+            );
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Floor a week below the stored week, so the loop must backfill the earlier week,
+        // skip the stored week, and still import forward past it.
+        _workerOptions.MinSyncDate = backfillWeek.ToDateTime(TimeOnly.MinValue);
+
+        _finraClient
+            .GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>())
+            .Returns(new List<OffExchangeWeeklyRecord>());
+        _finraClient
+            .GetWeeklyOffExchangeVolume(backfillWeek)
+            .Returns(MakeRecords(ats: 5_000, otc: 3_000));
+        _finraClient
+            .GetWeeklyOffExchangeVolume(forwardWeek)
+            .Returns(MakeRecords(ats: 7_000, otc: 2_000));
+
+        await _service.Import(CancellationToken.None);
+
+        // The stored week is never re-fetched...
+        await _finraClient.DidNotReceive().GetWeeklyOffExchangeVolume(storedWeek);
+        // ...but both the earlier (backfill) and later (forward) weeks are.
+        await _finraClient.Received().GetWeeklyOffExchangeVolume(backfillWeek);
+        await _finraClient.Received().GetWeeklyOffExchangeVolume(forwardWeek);
+
+        var rows = _volumeRepo.GetAll().Where(v => v.CommonStockId == apple.Id).ToList();
+        rows.Should().Contain(v => v.WeekStartDate == backfillWeek && v.AtsVolume == 5_000);
+        rows.Should().Contain(v => v.WeekStartDate == forwardWeek && v.AtsVolume == 7_000);
+    }
+
+    private static List<OffExchangeWeeklyRecord> MakeRecords(long ats, long otc) =>
+        [
+            new()
+            {
+                Symbol = "AAPL",
+                SummaryTypeCode = "ATS_W_SMBL",
+                TotalWeeklyShareQuantity = ats,
+                TotalWeeklyTradeCount = 10,
+            },
+            new()
+            {
+                Symbol = "AAPL",
+                SummaryTypeCode = "OTC_W_SMBL",
+                TotalWeeklyShareQuantity = otc,
+                TotalWeeklyTradeCount = 5,
+            },
+        ];
+
+    [Fact]
+    public async Task Import_FloorWeekInFuture_DoesNothing()
+    {
+        _workerOptions.MinSyncDate = new DateTime(2099, 1, 1);
+
+        await _service.Import(CancellationToken.None);
+
+        await _finraClient.DidNotReceive().GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>());
+        _volumeRepo.GetAll().Should().BeEmpty();
+    }
+}

--- a/tests/Equibles.IntegrationTests/Finra/ShortVolumeImportServicePipelineTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortVolumeImportServicePipelineTests.cs
@@ -72,7 +72,12 @@ public class ShortVolumeImportServicePipelineTests : ParadeDbMcpTestBase
                 Substitute.For<IServiceScopeFactory>(),
                 Substitute.For<ILogger<ErrorReporter>>()
             ),
-            Options.Create(new WorkerOptions { TickersToSync = [] })
+            // Floor a week back so the backfill window stays tiny: the seeded "latest" row
+            // is 3 days old, so the loop only fills the few days around it rather than every
+            // weekday since the default 2020 floor.
+            Options.Create(
+                new WorkerOptions { TickersToSync = [], MinSyncDate = DateTime.UtcNow.AddDays(-7) }
+            )
         );
     }
 


### PR DESCRIPTION
## Summary

The FINRA short-volume, short-interest and off-exchange-volume importers only ever synced **forward** from the latest stored date (`SyncDateResolver` returns `latestStored + 1`). Once any data existed, dates earlier than the earliest stored row could never be filled — so a per-stock short-volume page showed only the weeks since collection began, even when the user selected a 5Y or All range. FINRA's source history is intact (daily files go back years), so the gap was purely our forward-only sync logic.

This makes the three forward-only importers scan the full `[floor, today]` window (floor = `Worker:MinSyncDate`, default `2020-01-01`) and skip only the already-stored span, so a deployment **backfills history and keeps syncing forward**, without re-fetching stored dates.

## Code changes

- **`ShortVolumeImportService` / `OffExchangeVolumeImportService`** — resolve the floor (not `latest + 1`), read the stored `[earliest, latest]` span, iterate the whole window and skip days/weeks inside that span. New `DailyShortVolumeRepository.GetEarliestDate()` and `OffExchangeVolumeRepository.GetEarliestWeek()`.
- **`ShortInterestImportService`** — settlement-date discovery is API-driven, so it additionally discovers a converging backfill window `[floor, earliestKnown-1]`. Once FINRA's history is exhausted this is a single empty query per cycle (paging stops on the first empty page).
- **`IFinraClient` / `FinraClient`** — new `GetShortInterestSettlementDatesBetween(start, end)`; `GetShortInterestSettlementDatesAfter` refactored to delegate to a shared `DiscoverSettlementDatesInRange` (which short-circuits an inverted window with no API call). The `afterDate + 1` cursor contract is preserved.
- **Tests** — rewrote two short-volume tests that pinned the old forward-only behavior, added short-interest and off-exchange backfill tests, a `GetShortInterestSettlementDatesBetween` client test, and bounded one pipeline test's floor. 38 unit + 89 integration FINRA tests pass; csharpier-clean.

## Notes

- No schema change or migration; repository queries and importer logic only.
- First run after deploy walks the full window once (resumable across restarts as the stored span grows); subsequent cycles only fetch the trailing edge.
- Intra-span gap-filling is unchanged from prior behavior (the skip is span-level, matching the previous forward-only limitation).